### PR TITLE
Rework GDExtension interface from a struct to loading function pointers

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -34,6 +34,13 @@
 #include "core/object/class_db.h"
 #include "core/object/method_bind.h"
 #include "core/os/os.h"
+#include "core/version.h"
+
+extern void gdextension_setup_interface();
+extern void *gdextension_get_legacy_interface();
+extern GDExtensionInterfaceFunctionPtr gdextension_get_proc_address(const char *p_name);
+
+typedef GDExtensionBool (*GDExtensionLegacyInitializationFunction)(void *p_interface, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
 
 String GDExtension::get_extension_list_config_file() {
 	return ProjectSettings::get_singleton()->get_project_data_path().path_join("extension_list.cfg");
@@ -275,8 +282,6 @@ public:
 	}
 };
 
-static GDExtensionInterface gdextension_interface;
-
 void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo *p_extension_funcs) {
 	GDExtension *self = reinterpret_cast<GDExtension *>(p_library);
 
@@ -431,7 +436,20 @@ void GDExtension::_get_library_path(GDExtensionClassLibraryPtr p_library, GDExte
 	memnew_placement(r_path, String(self->library_path));
 }
 
-Error GDExtension::open_library(const String &p_path, const String &p_entry_symbol) {
+HashMap<StringName, GDExtensionInterfaceFunctionPtr> gdextension_interface_functions;
+
+void GDExtension::register_interface_function(StringName p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer) {
+	ERR_FAIL_COND_MSG(gdextension_interface_functions.has(p_function_name), "Attempt to register interface function '" + p_function_name + "', which appears to be already registered.");
+	gdextension_interface_functions.insert(p_function_name, p_function_pointer);
+}
+
+GDExtensionInterfaceFunctionPtr GDExtension::get_interface_function(StringName p_function_name) {
+	GDExtensionInterfaceFunctionPtr *function = gdextension_interface_functions.getptr(p_function_name);
+	ERR_FAIL_COND_V_MSG(function == nullptr, nullptr, "Attempt to get non-existent interface function: " + p_function_name);
+	return *function;
+}
+
+Error GDExtension::open_library(const String &p_path, const String &p_entry_symbol, bool p_use_legacy_interface) {
 	Error err = OS::get_singleton()->open_dynamic_library(p_path, library, true, &library_path);
 	if (err != OK) {
 		ERR_PRINT("GDExtension dynamic library not found: " + p_path);
@@ -448,15 +466,27 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 		return err;
 	}
 
-	GDExtensionInitializationFunction initialization_function = (GDExtensionInitializationFunction)entry_funcptr;
+	GDExtensionBool ret = 0;
+	if (p_use_legacy_interface) {
+		GDExtensionLegacyInitializationFunction initialization_function = (GDExtensionLegacyInitializationFunction)entry_funcptr;
+		ret = initialization_function(gdextension_get_legacy_interface(), this, &initialization);
 
-	if (initialization_function(&gdextension_interface, this, &initialization)) {
+	} else {
+		GDExtensionInitializationFunction initialization_function = (GDExtensionInitializationFunction)entry_funcptr;
+		ret = initialization_function(&gdextension_get_proc_address, this, &initialization);
+	}
+
+	if (ret) {
 		level_initialized = -1;
 		return OK;
 	} else {
 		ERR_PRINT("GDExtension initialization function '" + p_entry_symbol + "' returned an error.");
 		return FAILED;
 	}
+}
+
+Error GDExtension::open_library_compat_76406(const String &p_path, const String &p_entry_symbol) {
+	return open_library(p_path, p_entry_symbol, true);
 }
 
 void GDExtension::close_library() {
@@ -494,7 +524,8 @@ void GDExtension::deinitialize_library(InitializationLevel p_level) {
 }
 
 void GDExtension::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library);
+	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol", "use_legacy_interface"), &GDExtension::open_library);
+	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library_compat_76406);
 	ClassDB::bind_method(D_METHOD("close_library"), &GDExtension::close_library);
 	ClassDB::bind_method(D_METHOD("is_library_open"), &GDExtension::is_library_open);
 
@@ -516,20 +547,18 @@ GDExtension::~GDExtension() {
 	}
 }
 
-extern void gdextension_setup_interface(GDExtensionInterface *p_interface);
-
 void GDExtension::initialize_gdextensions() {
-	gdextension_setup_interface(&gdextension_interface);
+	gdextension_setup_interface();
 
-	gdextension_interface.classdb_register_extension_class = _register_extension_class;
-	gdextension_interface.classdb_register_extension_class_method = _register_extension_class_method;
-	gdextension_interface.classdb_register_extension_class_integer_constant = _register_extension_class_integer_constant;
-	gdextension_interface.classdb_register_extension_class_property = _register_extension_class_property;
-	gdextension_interface.classdb_register_extension_class_property_group = _register_extension_class_property_group;
-	gdextension_interface.classdb_register_extension_class_property_subgroup = _register_extension_class_property_subgroup;
-	gdextension_interface.classdb_register_extension_class_signal = _register_extension_class_signal;
-	gdextension_interface.classdb_unregister_extension_class = _unregister_extension_class;
-	gdextension_interface.get_library_path = _get_library_path;
+	register_interface_function("classdb_register_extension_class", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class);
+	register_interface_function("classdb_register_extension_class_method", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_method);
+	register_interface_function("classdb_register_extension_class_integer_constant", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_integer_constant);
+	register_interface_function("classdb_register_extension_class_property", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_property);
+	register_interface_function("classdb_register_extension_class_property_group", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_property_group);
+	register_interface_function("classdb_register_extension_class_property_subgroup", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_property_subgroup);
+	register_interface_function("classdb_register_extension_class_signal", (GDExtensionInterfaceFunctionPtr)&GDExtension::_register_extension_class_signal);
+	register_interface_function("classdb_unregister_extension_class", (GDExtensionInterfaceFunctionPtr)&GDExtension::_unregister_extension_class);
+	register_interface_function("get_library_path", (GDExtensionInterfaceFunctionPtr)&GDExtension::_get_library_path);
 }
 
 Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
@@ -557,6 +586,39 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 
 	String entry_symbol = config->get_value("configuration", "entry_symbol");
 
+	uint32_t compatibility_minimum[3] = { 0, 0, 0 };
+	if (config->has_section_key("configuration", "compatibility_minimum")) {
+		String compat_string = config->get_value("configuration", "compatibility_minimum");
+		Vector<int> parts = compat_string.split_ints(".");
+		for (int i = 0; i < parts.size(); i++) {
+			if (i >= 3) {
+				break;
+			}
+			if (parts[i] >= 0) {
+				compatibility_minimum[i] = parts[i];
+			}
+		}
+	}
+	if (compatibility_minimum[0] < 4) {
+		compatibility_minimum[0] = 4;
+	}
+
+	bool compatible = true;
+	if (VERSION_MAJOR < compatibility_minimum[0]) {
+		compatible = false;
+	} else if (VERSION_MINOR < compatibility_minimum[1]) {
+		compatible = false;
+	} else if (VERSION_PATCH < compatibility_minimum[2]) {
+		compatible = false;
+	}
+	if (!compatible) {
+		if (r_error) {
+			*r_error = ERR_INVALID_DATA;
+		}
+		ERR_PRINT(vformat("GDExtension only compatible with Godot version %d.%d.%d or later: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
+		return Ref<Resource>();
+	}
+
 	String library_path = GDExtension::find_extension_library(p_path, config, [](String p_feature) { return OS::get_singleton()->has_feature(p_feature); });
 
 	if (library_path.is_empty()) {
@@ -572,10 +634,12 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 		library_path = p_path.get_base_dir().path_join(library_path);
 	}
 
+	bool use_legacy_interface = compatibility_minimum[0] == 4 && compatibility_minimum[1] == 0;
+
 	Ref<GDExtension> lib;
 	lib.instantiate();
 	String abs_path = ProjectSettings::get_singleton()->globalize_path(library_path);
-	err = lib->open_library(abs_path, entry_symbol);
+	err = lib->open_library(abs_path, entry_symbol, use_legacy_interface);
 
 	if (r_error) {
 		*r_error = err;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -72,7 +72,8 @@ public:
 	static String get_extension_list_config_file();
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 
-	Error open_library(const String &p_path, const String &p_entry_symbol);
+	Error open_library(const String &p_path, const String &p_entry_symbol, bool p_use_legacy_interface = false);
+	Error open_library_compat_76406(const String &p_path, const String &p_entry_symbol);
 	void close_library();
 
 	enum InitializationLevel {
@@ -88,7 +89,10 @@ public:
 	void initialize_library(InitializationLevel p_level);
 	void deinitialize_library(InitializationLevel p_level);
 
+	static void register_interface_function(StringName p_function_name, GDExtensionInterfaceFunctionPtr p_function_pointer);
+	static GDExtensionInterfaceFunctionPtr get_interface_function(StringName p_function_name);
 	static void initialize_gdextensions();
+
 	GDExtension();
 	~GDExtension();
 };

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -31,6 +31,7 @@
 #include "gdextension_interface.h"
 
 #include "core/config/engine.h"
+#include "core/extension/gdextension.h"
 #include "core/io/file_access.h"
 #include "core/io/xml_parser.h"
 #include "core/object/class_db.h"
@@ -40,16 +41,28 @@
 #include "core/variant/variant.h"
 #include "core/version.h"
 
+// Core interface functions.
+GDExtensionInterfaceFunctionPtr gdextension_get_proc_address(const char *p_name) {
+	return GDExtension::get_interface_function(p_name);
+}
+
+static void gdextension_get_godot_version(GDExtensionGodotVersion *r_godot_version) {
+	r_godot_version->major = VERSION_MAJOR;
+	r_godot_version->minor = VERSION_MINOR;
+	r_godot_version->patch = VERSION_PATCH;
+	r_godot_version->string = VERSION_FULL_NAME;
+}
+
 // Memory Functions
-static void *gdextension_alloc(size_t p_size) {
+static void *gdextension_mem_alloc(size_t p_size) {
 	return memalloc(p_size);
 }
 
-static void *gdextension_realloc(void *p_mem, size_t p_size) {
+static void *gdextension_mem_realloc(void *p_mem, size_t p_size) {
 	return memrealloc(p_mem, p_size);
 }
 
-static void gdextension_free(void *p_mem) {
+static void gdextension_mem_free(void *p_mem) {
 	memfree(p_mem);
 }
 
@@ -397,7 +410,7 @@ static GDExtensionVariantFromTypeConstructorFunc gdextension_get_variant_from_ty
 	ERR_FAIL_V_MSG(nullptr, "Getting Variant conversion function with invalid type");
 }
 
-static GDExtensionTypeFromVariantConstructorFunc gdextension_get_type_from_variant_constructor(GDExtensionVariantType p_type) {
+static GDExtensionTypeFromVariantConstructorFunc gdextension_get_variant_to_type_constructor(GDExtensionVariantType p_type) {
 	switch (p_type) {
 		case GDEXTENSION_VARIANT_TYPE_BOOL:
 			return VariantTypeConstructor<bool>::type_from_variant;
@@ -1045,204 +1058,452 @@ static void *gdextension_classdb_get_class_tag(GDExtensionConstStringNamePtr p_c
 	return class_info ? class_info->class_ptr : nullptr;
 }
 
-void gdextension_setup_interface(GDExtensionInterface *p_interface) {
-	GDExtensionInterface &gde_interface = *p_interface;
+#define REGISTER_INTERFACE_FUNC(m_name) GDExtension::register_interface_function(#m_name, (GDExtensionInterfaceFunctionPtr)&gdextension_##m_name)
 
-	gde_interface.version_major = VERSION_MAJOR;
-	gde_interface.version_minor = VERSION_MINOR;
-#if VERSION_PATCH
-	gde_interface.version_patch = VERSION_PATCH;
-#else
-	gde_interface.version_patch = 0;
-#endif
-	gde_interface.version_string = VERSION_FULL_NAME;
-
-	/* GODOT CORE */
-
-	gde_interface.mem_alloc = gdextension_alloc;
-	gde_interface.mem_realloc = gdextension_realloc;
-	gde_interface.mem_free = gdextension_free;
-
-	gde_interface.print_error = gdextension_print_error;
-	gde_interface.print_error_with_message = gdextension_print_error_with_message;
-	gde_interface.print_warning = gdextension_print_warning;
-	gde_interface.print_warning_with_message = gdextension_print_warning_with_message;
-	gde_interface.print_script_error = gdextension_print_script_error;
-	gde_interface.print_script_error_with_message = gdextension_print_script_error_with_message;
-
-	gde_interface.get_native_struct_size = gdextension_get_native_struct_size;
-
-	/* GODOT VARIANT */
-
-	// variant general
-	gde_interface.variant_new_copy = gdextension_variant_new_copy;
-	gde_interface.variant_new_nil = gdextension_variant_new_nil;
-	gde_interface.variant_destroy = gdextension_variant_destroy;
-
-	gde_interface.variant_call = gdextension_variant_call;
-	gde_interface.variant_call_static = gdextension_variant_call_static;
-	gde_interface.variant_evaluate = gdextension_variant_evaluate;
-	gde_interface.variant_set = gdextension_variant_set;
-	gde_interface.variant_set_named = gdextension_variant_set_named;
-	gde_interface.variant_set_keyed = gdextension_variant_set_keyed;
-	gde_interface.variant_set_indexed = gdextension_variant_set_indexed;
-	gde_interface.variant_get = gdextension_variant_get;
-	gde_interface.variant_get_named = gdextension_variant_get_named;
-	gde_interface.variant_get_keyed = gdextension_variant_get_keyed;
-	gde_interface.variant_get_indexed = gdextension_variant_get_indexed;
-	gde_interface.variant_iter_init = gdextension_variant_iter_init;
-	gde_interface.variant_iter_next = gdextension_variant_iter_next;
-	gde_interface.variant_iter_get = gdextension_variant_iter_get;
-	gde_interface.variant_hash = gdextension_variant_hash;
-	gde_interface.variant_recursive_hash = gdextension_variant_recursive_hash;
-	gde_interface.variant_hash_compare = gdextension_variant_hash_compare;
-	gde_interface.variant_booleanize = gdextension_variant_booleanize;
-	gde_interface.variant_duplicate = gdextension_variant_duplicate;
-	gde_interface.variant_stringify = gdextension_variant_stringify;
-
-	gde_interface.variant_get_type = gdextension_variant_get_type;
-	gde_interface.variant_has_method = gdextension_variant_has_method;
-	gde_interface.variant_has_member = gdextension_variant_has_member;
-	gde_interface.variant_has_key = gdextension_variant_has_key;
-	gde_interface.variant_get_type_name = gdextension_variant_get_type_name;
-	gde_interface.variant_can_convert = gdextension_variant_can_convert;
-	gde_interface.variant_can_convert_strict = gdextension_variant_can_convert_strict;
-
-	gde_interface.get_variant_from_type_constructor = gdextension_get_variant_from_type_constructor;
-	gde_interface.get_variant_to_type_constructor = gdextension_get_type_from_variant_constructor;
-
-	// ptrcalls.
-
-	gde_interface.variant_get_ptr_operator_evaluator = gdextension_variant_get_ptr_operator_evaluator;
-	gde_interface.variant_get_ptr_builtin_method = gdextension_variant_get_ptr_builtin_method;
-	gde_interface.variant_get_ptr_constructor = gdextension_variant_get_ptr_constructor;
-	gde_interface.variant_get_ptr_destructor = gdextension_variant_get_ptr_destructor;
-	gde_interface.variant_construct = gdextension_variant_construct;
-	gde_interface.variant_get_ptr_setter = gdextension_variant_get_ptr_setter;
-	gde_interface.variant_get_ptr_getter = gdextension_variant_get_ptr_getter;
-	gde_interface.variant_get_ptr_indexed_setter = gdextension_variant_get_ptr_indexed_setter;
-	gde_interface.variant_get_ptr_indexed_getter = gdextension_variant_get_ptr_indexed_getter;
-	gde_interface.variant_get_ptr_keyed_setter = gdextension_variant_get_ptr_keyed_setter;
-	gde_interface.variant_get_ptr_keyed_getter = gdextension_variant_get_ptr_keyed_getter;
-	gde_interface.variant_get_ptr_keyed_checker = gdextension_variant_get_ptr_keyed_checker;
-	gde_interface.variant_get_constant_value = gdextension_variant_get_constant_value;
-	gde_interface.variant_get_ptr_utility_function = gdextension_variant_get_ptr_utility_function;
-
-	// extra utilities
-
-	gde_interface.string_new_with_latin1_chars = gdextension_string_new_with_latin1_chars;
-	gde_interface.string_new_with_utf8_chars = gdextension_string_new_with_utf8_chars;
-	gde_interface.string_new_with_utf16_chars = gdextension_string_new_with_utf16_chars;
-	gde_interface.string_new_with_utf32_chars = gdextension_string_new_with_utf32_chars;
-	gde_interface.string_new_with_wide_chars = gdextension_string_new_with_wide_chars;
-	gde_interface.string_new_with_latin1_chars_and_len = gdextension_string_new_with_latin1_chars_and_len;
-	gde_interface.string_new_with_utf8_chars_and_len = gdextension_string_new_with_utf8_chars_and_len;
-	gde_interface.string_new_with_utf16_chars_and_len = gdextension_string_new_with_utf16_chars_and_len;
-	gde_interface.string_new_with_utf32_chars_and_len = gdextension_string_new_with_utf32_chars_and_len;
-	gde_interface.string_new_with_wide_chars_and_len = gdextension_string_new_with_wide_chars_and_len;
-	gde_interface.string_to_latin1_chars = gdextension_string_to_latin1_chars;
-	gde_interface.string_to_utf8_chars = gdextension_string_to_utf8_chars;
-	gde_interface.string_to_utf16_chars = gdextension_string_to_utf16_chars;
-	gde_interface.string_to_utf32_chars = gdextension_string_to_utf32_chars;
-	gde_interface.string_to_wide_chars = gdextension_string_to_wide_chars;
-	gde_interface.string_operator_index = gdextension_string_operator_index;
-	gde_interface.string_operator_index_const = gdextension_string_operator_index_const;
-	gde_interface.string_operator_plus_eq_string = gdextension_string_operator_plus_eq_string;
-	gde_interface.string_operator_plus_eq_char = gdextension_string_operator_plus_eq_char;
-	gde_interface.string_operator_plus_eq_cstr = gdextension_string_operator_plus_eq_cstr;
-	gde_interface.string_operator_plus_eq_wcstr = gdextension_string_operator_plus_eq_wcstr;
-	gde_interface.string_operator_plus_eq_c32str = gdextension_string_operator_plus_eq_c32str;
-
-	/*  XMLParser extra utilities */
-
-	gde_interface.xml_parser_open_buffer = gdextension_xml_parser_open_buffer;
-
-	/*  FileAccess extra utilities */
-
-	gde_interface.file_access_store_buffer = gdextension_file_access_store_buffer;
-	gde_interface.file_access_get_buffer = gdextension_file_access_get_buffer;
-
-	/*  WorkerThreadPool extra utilities */
-
-	gde_interface.worker_thread_pool_add_native_group_task = gdextension_worker_thread_pool_add_native_group_task;
-	gde_interface.worker_thread_pool_add_native_task = gdextension_worker_thread_pool_add_native_task;
-
-	/* Packed array functions */
-
-	gde_interface.packed_byte_array_operator_index = gdextension_packed_byte_array_operator_index;
-	gde_interface.packed_byte_array_operator_index_const = gdextension_packed_byte_array_operator_index_const;
-
-	gde_interface.packed_color_array_operator_index = gdextension_packed_color_array_operator_index;
-	gde_interface.packed_color_array_operator_index_const = gdextension_packed_color_array_operator_index_const;
-
-	gde_interface.packed_float32_array_operator_index = gdextension_packed_float32_array_operator_index;
-	gde_interface.packed_float32_array_operator_index_const = gdextension_packed_float32_array_operator_index_const;
-	gde_interface.packed_float64_array_operator_index = gdextension_packed_float64_array_operator_index;
-	gde_interface.packed_float64_array_operator_index_const = gdextension_packed_float64_array_operator_index_const;
-
-	gde_interface.packed_int32_array_operator_index = gdextension_packed_int32_array_operator_index;
-	gde_interface.packed_int32_array_operator_index_const = gdextension_packed_int32_array_operator_index_const;
-	gde_interface.packed_int64_array_operator_index = gdextension_packed_int64_array_operator_index;
-	gde_interface.packed_int64_array_operator_index_const = gdextension_packed_int64_array_operator_index_const;
-
-	gde_interface.packed_string_array_operator_index = gdextension_packed_string_array_operator_index;
-	gde_interface.packed_string_array_operator_index_const = gdextension_packed_string_array_operator_index_const;
-
-	gde_interface.packed_vector2_array_operator_index = gdextension_packed_vector2_array_operator_index;
-	gde_interface.packed_vector2_array_operator_index_const = gdextension_packed_vector2_array_operator_index_const;
-	gde_interface.packed_vector3_array_operator_index = gdextension_packed_vector3_array_operator_index;
-	gde_interface.packed_vector3_array_operator_index_const = gdextension_packed_vector3_array_operator_index_const;
-
-	gde_interface.array_operator_index = gdextension_array_operator_index;
-	gde_interface.array_operator_index_const = gdextension_array_operator_index_const;
-	gde_interface.array_ref = gdextension_array_ref;
-	gde_interface.array_set_typed = gdextension_array_set_typed;
-
-	/* Dictionary functions */
-
-	gde_interface.dictionary_operator_index = gdextension_dictionary_operator_index;
-	gde_interface.dictionary_operator_index_const = gdextension_dictionary_operator_index_const;
-
-	/* OBJECT */
-
-	gde_interface.object_method_bind_call = gdextension_object_method_bind_call;
-	gde_interface.object_method_bind_ptrcall = gdextension_object_method_bind_ptrcall;
-	gde_interface.object_destroy = gdextension_object_destroy;
-	gde_interface.global_get_singleton = gdextension_global_get_singleton;
-	gde_interface.object_get_instance_binding = gdextension_object_get_instance_binding;
-	gde_interface.object_set_instance_binding = gdextension_object_set_instance_binding;
-	gde_interface.object_set_instance = gdextension_object_set_instance;
-
-	gde_interface.object_cast_to = gdextension_object_cast_to;
-	gde_interface.object_get_instance_from_id = gdextension_object_get_instance_from_id;
-	gde_interface.object_get_instance_id = gdextension_object_get_instance_id;
-
-	/* REFERENCE */
-
-	gde_interface.ref_get_object = gdextension_ref_get_object;
-	gde_interface.ref_set_object = gdextension_ref_set_object;
-
-	/* SCRIPT INSTANCE */
-
-	gde_interface.script_instance_create = gdextension_script_instance_create;
-
-	/* CLASSDB */
-
-	gde_interface.classdb_construct_object = gdextension_classdb_construct_object;
-	gde_interface.classdb_get_method_bind = gdextension_classdb_get_method_bind;
-	gde_interface.classdb_get_class_tag = gdextension_classdb_get_class_tag;
-
-	/* CLASSDB EXTENSION */
-
-	//these are filled by implementation, since it will want to keep track of registered classes
-	gde_interface.classdb_register_extension_class = nullptr;
-	gde_interface.classdb_register_extension_class_method = nullptr;
-	gde_interface.classdb_register_extension_class_integer_constant = nullptr;
-	gde_interface.classdb_register_extension_class_property = nullptr;
-	gde_interface.classdb_register_extension_class_property_group = nullptr;
-	gde_interface.classdb_register_extension_class_property_subgroup = nullptr;
-	gde_interface.classdb_register_extension_class_signal = nullptr;
-	gde_interface.classdb_unregister_extension_class = nullptr;
-
-	gde_interface.get_library_path = nullptr;
+void gdextension_setup_interface() {
+	REGISTER_INTERFACE_FUNC(get_godot_version);
+	REGISTER_INTERFACE_FUNC(mem_alloc);
+	REGISTER_INTERFACE_FUNC(mem_realloc);
+	REGISTER_INTERFACE_FUNC(mem_free);
+	REGISTER_INTERFACE_FUNC(print_error);
+	REGISTER_INTERFACE_FUNC(print_error_with_message);
+	REGISTER_INTERFACE_FUNC(print_warning);
+	REGISTER_INTERFACE_FUNC(print_warning_with_message);
+	REGISTER_INTERFACE_FUNC(print_script_error);
+	REGISTER_INTERFACE_FUNC(print_script_error_with_message);
+	REGISTER_INTERFACE_FUNC(get_native_struct_size);
+	REGISTER_INTERFACE_FUNC(variant_new_copy);
+	REGISTER_INTERFACE_FUNC(variant_new_nil);
+	REGISTER_INTERFACE_FUNC(variant_destroy);
+	REGISTER_INTERFACE_FUNC(variant_call);
+	REGISTER_INTERFACE_FUNC(variant_call_static);
+	REGISTER_INTERFACE_FUNC(variant_evaluate);
+	REGISTER_INTERFACE_FUNC(variant_set);
+	REGISTER_INTERFACE_FUNC(variant_set_named);
+	REGISTER_INTERFACE_FUNC(variant_set_keyed);
+	REGISTER_INTERFACE_FUNC(variant_set_indexed);
+	REGISTER_INTERFACE_FUNC(variant_get);
+	REGISTER_INTERFACE_FUNC(variant_get_named);
+	REGISTER_INTERFACE_FUNC(variant_get_keyed);
+	REGISTER_INTERFACE_FUNC(variant_get_indexed);
+	REGISTER_INTERFACE_FUNC(variant_iter_init);
+	REGISTER_INTERFACE_FUNC(variant_iter_next);
+	REGISTER_INTERFACE_FUNC(variant_iter_get);
+	REGISTER_INTERFACE_FUNC(variant_hash);
+	REGISTER_INTERFACE_FUNC(variant_recursive_hash);
+	REGISTER_INTERFACE_FUNC(variant_hash_compare);
+	REGISTER_INTERFACE_FUNC(variant_booleanize);
+	REGISTER_INTERFACE_FUNC(variant_duplicate);
+	REGISTER_INTERFACE_FUNC(variant_stringify);
+	REGISTER_INTERFACE_FUNC(variant_get_type);
+	REGISTER_INTERFACE_FUNC(variant_has_method);
+	REGISTER_INTERFACE_FUNC(variant_has_member);
+	REGISTER_INTERFACE_FUNC(variant_has_key);
+	REGISTER_INTERFACE_FUNC(variant_get_type_name);
+	REGISTER_INTERFACE_FUNC(variant_can_convert);
+	REGISTER_INTERFACE_FUNC(variant_can_convert_strict);
+	REGISTER_INTERFACE_FUNC(get_variant_from_type_constructor);
+	REGISTER_INTERFACE_FUNC(get_variant_to_type_constructor);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_operator_evaluator);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_builtin_method);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_constructor);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_destructor);
+	REGISTER_INTERFACE_FUNC(variant_construct);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_setter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_getter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_indexed_setter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_indexed_getter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_keyed_setter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_keyed_getter);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_keyed_checker);
+	REGISTER_INTERFACE_FUNC(variant_get_constant_value);
+	REGISTER_INTERFACE_FUNC(variant_get_ptr_utility_function);
+	REGISTER_INTERFACE_FUNC(string_new_with_latin1_chars);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf8_chars);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf16_chars);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf32_chars);
+	REGISTER_INTERFACE_FUNC(string_new_with_wide_chars);
+	REGISTER_INTERFACE_FUNC(string_new_with_latin1_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf8_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf16_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_utf32_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_new_with_wide_chars_and_len);
+	REGISTER_INTERFACE_FUNC(string_to_latin1_chars);
+	REGISTER_INTERFACE_FUNC(string_to_utf8_chars);
+	REGISTER_INTERFACE_FUNC(string_to_utf16_chars);
+	REGISTER_INTERFACE_FUNC(string_to_utf32_chars);
+	REGISTER_INTERFACE_FUNC(string_to_wide_chars);
+	REGISTER_INTERFACE_FUNC(string_operator_index);
+	REGISTER_INTERFACE_FUNC(string_operator_index_const);
+	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_string);
+	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_char);
+	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_cstr);
+	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_wcstr);
+	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_c32str);
+	REGISTER_INTERFACE_FUNC(xml_parser_open_buffer);
+	REGISTER_INTERFACE_FUNC(file_access_store_buffer);
+	REGISTER_INTERFACE_FUNC(file_access_get_buffer);
+	REGISTER_INTERFACE_FUNC(worker_thread_pool_add_native_group_task);
+	REGISTER_INTERFACE_FUNC(worker_thread_pool_add_native_task);
+	REGISTER_INTERFACE_FUNC(packed_byte_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_byte_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_color_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_color_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_float32_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_float32_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_float64_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_float64_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_int32_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_int32_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_int64_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_int64_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_string_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_string_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_vector2_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_vector2_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(packed_vector3_array_operator_index);
+	REGISTER_INTERFACE_FUNC(packed_vector3_array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(array_operator_index);
+	REGISTER_INTERFACE_FUNC(array_operator_index_const);
+	REGISTER_INTERFACE_FUNC(array_ref);
+	REGISTER_INTERFACE_FUNC(array_set_typed);
+	REGISTER_INTERFACE_FUNC(dictionary_operator_index);
+	REGISTER_INTERFACE_FUNC(dictionary_operator_index_const);
+	REGISTER_INTERFACE_FUNC(object_method_bind_call);
+	REGISTER_INTERFACE_FUNC(object_method_bind_ptrcall);
+	REGISTER_INTERFACE_FUNC(object_destroy);
+	REGISTER_INTERFACE_FUNC(global_get_singleton);
+	REGISTER_INTERFACE_FUNC(object_get_instance_binding);
+	REGISTER_INTERFACE_FUNC(object_set_instance_binding);
+	REGISTER_INTERFACE_FUNC(object_set_instance);
+	REGISTER_INTERFACE_FUNC(object_cast_to);
+	REGISTER_INTERFACE_FUNC(object_get_instance_from_id);
+	REGISTER_INTERFACE_FUNC(object_get_instance_id);
+	REGISTER_INTERFACE_FUNC(ref_get_object);
+	REGISTER_INTERFACE_FUNC(ref_set_object);
+	REGISTER_INTERFACE_FUNC(script_instance_create);
+	REGISTER_INTERFACE_FUNC(classdb_construct_object);
+	REGISTER_INTERFACE_FUNC(classdb_get_method_bind);
+	REGISTER_INTERFACE_FUNC(classdb_get_class_tag);
 }
+
+#undef REGISTER_INTERFACE_FUNCTION
+
+/*
+ * Handle legacy GDExtension interface from Godot 4.0.
+ */
+
+typedef struct {
+	uint32_t version_major;
+	uint32_t version_minor;
+	uint32_t version_patch;
+	const char *version_string;
+
+	GDExtensionInterfaceMemAlloc mem_alloc;
+	GDExtensionInterfaceMemRealloc mem_realloc;
+	GDExtensionInterfaceMemFree mem_free;
+
+	GDExtensionInterfacePrintError print_error;
+	GDExtensionInterfacePrintErrorWithMessage print_error_with_message;
+	GDExtensionInterfacePrintWarning print_warning;
+	GDExtensionInterfacePrintWarningWithMessage print_warning_with_message;
+	GDExtensionInterfacePrintScriptError print_script_error;
+	GDExtensionInterfacePrintScriptErrorWithMessage print_script_error_with_message;
+
+	GDExtensionInterfaceGetNativeStructSize get_native_struct_size;
+
+	GDExtensionInterfaceVariantNewCopy variant_new_copy;
+	GDExtensionInterfaceVariantNewNil variant_new_nil;
+	GDExtensionInterfaceVariantDestroy variant_destroy;
+
+	GDExtensionInterfaceVariantCall variant_call;
+	GDExtensionInterfaceVariantCallStatic variant_call_static;
+	GDExtensionInterfaceVariantEvaluate variant_evaluate;
+	GDExtensionInterfaceVariantSet variant_set;
+	GDExtensionInterfaceVariantSetNamed variant_set_named;
+	GDExtensionInterfaceVariantSetKeyed variant_set_keyed;
+	GDExtensionInterfaceVariantSetIndexed variant_set_indexed;
+	GDExtensionInterfaceVariantGet variant_get;
+	GDExtensionInterfaceVariantGetNamed variant_get_named;
+	GDExtensionInterfaceVariantGetKeyed variant_get_keyed;
+	GDExtensionInterfaceVariantGetIndexed variant_get_indexed;
+	GDExtensionInterfaceVariantIterInit variant_iter_init;
+	GDExtensionInterfaceVariantIterNext variant_iter_next;
+	GDExtensionInterfaceVariantIterGet variant_iter_get;
+	GDExtensionInterfaceVariantHash variant_hash;
+	GDExtensionInterfaceVariantRecursiveHash variant_recursive_hash;
+	GDExtensionInterfaceVariantHashCompare variant_hash_compare;
+	GDExtensionInterfaceVariantBooleanize variant_booleanize;
+	GDExtensionInterfaceVariantDuplicate variant_duplicate;
+	GDExtensionInterfaceVariantStringify variant_stringify;
+
+	GDExtensionInterfaceVariantGetType variant_get_type;
+	GDExtensionInterfaceVariantHasMethod variant_has_method;
+	GDExtensionInterfaceVariantHasMember variant_has_member;
+	GDExtensionInterfaceVariantHasKey variant_has_key;
+	GDExtensionInterfaceVariantGetTypeName variant_get_type_name;
+	GDExtensionInterfaceVariantCanConvert variant_can_convert;
+	GDExtensionInterfaceVariantCanConvertStrict variant_can_convert_strict;
+
+	GDExtensionInterfaceGetVariantFromTypeConstructor get_variant_from_type_constructor;
+	GDExtensionInterfaceGetVariantToTypeConstructor get_variant_to_type_constructor;
+	GDExtensionInterfaceVariantGetPtrOperatorEvaluator variant_get_ptr_operator_evaluator;
+	GDExtensionInterfaceVariantGetPtrBuiltinMethod variant_get_ptr_builtin_method;
+	GDExtensionInterfaceVariantGetPtrConstructor variant_get_ptr_constructor;
+	GDExtensionInterfaceVariantGetPtrDestructor variant_get_ptr_destructor;
+	GDExtensionInterfaceVariantConstruct variant_construct;
+	GDExtensionInterfaceVariantGetPtrSetter variant_get_ptr_setter;
+	GDExtensionInterfaceVariantGetPtrGetter variant_get_ptr_getter;
+	GDExtensionInterfaceVariantGetPtrIndexedSetter variant_get_ptr_indexed_setter;
+	GDExtensionInterfaceVariantGetPtrIndexedGetter variant_get_ptr_indexed_getter;
+	GDExtensionInterfaceVariantGetPtrKeyedSetter variant_get_ptr_keyed_setter;
+	GDExtensionInterfaceVariantGetPtrKeyedGetter variant_get_ptr_keyed_getter;
+	GDExtensionInterfaceVariantGetPtrKeyedChecker variant_get_ptr_keyed_checker;
+	GDExtensionInterfaceVariantGetConstantValue variant_get_constant_value;
+	GDExtensionInterfaceVariantGetPtrUtilityFunction variant_get_ptr_utility_function;
+
+	GDExtensionInterfaceStringNewWithLatin1Chars string_new_with_latin1_chars;
+	GDExtensionInterfaceStringNewWithUtf8Chars string_new_with_utf8_chars;
+	GDExtensionInterfaceStringNewWithUtf16Chars string_new_with_utf16_chars;
+	GDExtensionInterfaceStringNewWithUtf32Chars string_new_with_utf32_chars;
+	GDExtensionInterfaceStringNewWithWideChars string_new_with_wide_chars;
+	GDExtensionInterfaceStringNewWithLatin1CharsAndLen string_new_with_latin1_chars_and_len;
+	GDExtensionInterfaceStringNewWithUtf8CharsAndLen string_new_with_utf8_chars_and_len;
+	GDExtensionInterfaceStringNewWithUtf16CharsAndLen string_new_with_utf16_chars_and_len;
+	GDExtensionInterfaceStringNewWithUtf32CharsAndLen string_new_with_utf32_chars_and_len;
+	GDExtensionInterfaceStringNewWithWideCharsAndLen string_new_with_wide_chars_and_len;
+	GDExtensionInterfaceStringToLatin1Chars string_to_latin1_chars;
+	GDExtensionInterfaceStringToUtf8Chars string_to_utf8_chars;
+	GDExtensionInterfaceStringToUtf16Chars string_to_utf16_chars;
+	GDExtensionInterfaceStringToUtf32Chars string_to_utf32_chars;
+	GDExtensionInterfaceStringToWideChars string_to_wide_chars;
+	GDExtensionInterfaceStringOperatorIndex string_operator_index;
+	GDExtensionInterfaceStringOperatorIndexConst string_operator_index_const;
+
+	GDExtensionInterfaceStringOperatorPlusEqString string_operator_plus_eq_string;
+	GDExtensionInterfaceStringOperatorPlusEqChar string_operator_plus_eq_char;
+	GDExtensionInterfaceStringOperatorPlusEqCstr string_operator_plus_eq_cstr;
+	GDExtensionInterfaceStringOperatorPlusEqWcstr string_operator_plus_eq_wcstr;
+	GDExtensionInterfaceStringOperatorPlusEqC32str string_operator_plus_eq_c32str;
+
+	GDExtensionInterfaceXmlParserOpenBuffer xml_parser_open_buffer;
+
+	GDExtensionInterfaceFileAccessStoreBuffer file_access_store_buffer;
+	GDExtensionInterfaceFileAccessGetBuffer file_access_get_buffer;
+
+	GDExtensionInterfaceWorkerThreadPoolAddNativeGroupTask worker_thread_pool_add_native_group_task;
+	GDExtensionInterfaceWorkerThreadPoolAddNativeTask worker_thread_pool_add_native_task;
+
+	GDExtensionInterfacePackedByteArrayOperatorIndex packed_byte_array_operator_index;
+	GDExtensionInterfacePackedByteArrayOperatorIndexConst packed_byte_array_operator_index_const;
+	GDExtensionInterfacePackedColorArrayOperatorIndex packed_color_array_operator_index;
+	GDExtensionInterfacePackedColorArrayOperatorIndexConst packed_color_array_operator_index_const;
+	GDExtensionInterfacePackedFloat32ArrayOperatorIndex packed_float32_array_operator_index;
+	GDExtensionInterfacePackedFloat32ArrayOperatorIndexConst packed_float32_array_operator_index_const;
+	GDExtensionInterfacePackedFloat64ArrayOperatorIndex packed_float64_array_operator_index;
+	GDExtensionInterfacePackedFloat64ArrayOperatorIndexConst packed_float64_array_operator_index_const;
+	GDExtensionInterfacePackedInt32ArrayOperatorIndex packed_int32_array_operator_index;
+	GDExtensionInterfacePackedInt32ArrayOperatorIndexConst packed_int32_array_operator_index_const;
+	GDExtensionInterfacePackedInt64ArrayOperatorIndex packed_int64_array_operator_index;
+	GDExtensionInterfacePackedInt64ArrayOperatorIndexConst packed_int64_array_operator_index_const;
+	GDExtensionInterfacePackedStringArrayOperatorIndex packed_string_array_operator_index;
+	GDExtensionInterfacePackedStringArrayOperatorIndexConst packed_string_array_operator_index_const;
+	GDExtensionInterfacePackedVector2ArrayOperatorIndex packed_vector2_array_operator_index;
+	GDExtensionInterfacePackedVector2ArrayOperatorIndexConst packed_vector2_array_operator_index_const;
+	GDExtensionInterfacePackedVector3ArrayOperatorIndex packed_vector3_array_operator_index;
+	GDExtensionInterfacePackedVector3ArrayOperatorIndexConst packed_vector3_array_operator_index_const;
+	GDExtensionInterfaceArrayOperatorIndex array_operator_index;
+	GDExtensionInterfaceArrayOperatorIndexConst array_operator_index_const;
+	GDExtensionInterfaceArrayRef array_ref;
+	GDExtensionInterfaceArraySetTyped array_set_typed;
+
+	GDExtensionInterfaceDictionaryOperatorIndex dictionary_operator_index;
+	GDExtensionInterfaceDictionaryOperatorIndexConst dictionary_operator_index_const;
+
+	GDExtensionInterfaceObjectMethodBindCall object_method_bind_call;
+	GDExtensionInterfaceObjectMethodBindPtrcall object_method_bind_ptrcall;
+	GDExtensionInterfaceObjectDestroy object_destroy;
+	GDExtensionInterfaceGlobalGetSingleton global_get_singleton;
+	GDExtensionInterfaceObjectGetInstanceBinding object_get_instance_binding;
+	GDExtensionInterfaceObjectSetInstanceBinding object_set_instance_binding;
+	GDExtensionInterfaceObjectSetInstance object_set_instance;
+	GDExtensionInterfaceObjectCastTo object_cast_to;
+	GDExtensionInterfaceObjectGetInstanceFromId object_get_instance_from_id;
+	GDExtensionInterfaceObjectGetInstanceId object_get_instance_id;
+
+	GDExtensionInterfaceRefGetObject ref_get_object;
+	GDExtensionInterfaceRefSetObject ref_set_object;
+
+	GDExtensionInterfaceScriptInstanceCreate script_instance_create;
+
+	GDExtensionInterfaceClassdbConstructObject classdb_construct_object;
+	GDExtensionInterfaceClassdbGetMethodBind classdb_get_method_bind;
+	GDExtensionInterfaceClassdbGetClassTag classdb_get_class_tag;
+
+	GDExtensionInterfaceClassdbRegisterExtensionClass classdb_register_extension_class;
+	GDExtensionInterfaceClassdbRegisterExtensionClassMethod classdb_register_extension_class_method;
+	GDExtensionInterfaceClassdbRegisterExtensionClassIntegerConstant classdb_register_extension_class_integer_constant;
+	GDExtensionInterfaceClassdbRegisterExtensionClassProperty classdb_register_extension_class_property;
+	GDExtensionInterfaceClassdbRegisterExtensionClassPropertyGroup classdb_register_extension_class_property_group;
+	GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup classdb_register_extension_class_property_subgroup;
+	GDExtensionInterfaceClassdbRegisterExtensionClassSignal classdb_register_extension_class_signal;
+	GDExtensionInterfaceClassdbUnregisterExtensionClass classdb_unregister_extension_class;
+
+	GDExtensionInterfaceGetLibraryPath get_library_path;
+
+} LegacyGDExtensionInterface;
+
+static LegacyGDExtensionInterface *legacy_gdextension_interface = nullptr;
+
+#define SETUP_LEGACY_FUNC(m_name, m_type) legacy_gdextension_interface->m_name = (m_type)GDExtension::get_interface_function(#m_name)
+
+void *gdextension_get_legacy_interface() {
+	if (legacy_gdextension_interface != nullptr) {
+		return legacy_gdextension_interface;
+	}
+
+	legacy_gdextension_interface = memnew(LegacyGDExtensionInterface);
+
+	// Force to 4.0.999 to make it easier to detect this structure.
+	legacy_gdextension_interface->version_major = 4;
+	legacy_gdextension_interface->version_minor = 0;
+	legacy_gdextension_interface->version_patch = 999;
+	legacy_gdextension_interface->version_string = "Godot Engine v4.0.999.stable.official [000000000]";
+
+	SETUP_LEGACY_FUNC(mem_alloc, GDExtensionInterfaceMemAlloc);
+	SETUP_LEGACY_FUNC(mem_realloc, GDExtensionInterfaceMemRealloc);
+	SETUP_LEGACY_FUNC(mem_free, GDExtensionInterfaceMemFree);
+	SETUP_LEGACY_FUNC(print_error, GDExtensionInterfacePrintError);
+	SETUP_LEGACY_FUNC(print_error_with_message, GDExtensionInterfacePrintErrorWithMessage);
+	SETUP_LEGACY_FUNC(print_warning, GDExtensionInterfacePrintWarning);
+	SETUP_LEGACY_FUNC(print_warning_with_message, GDExtensionInterfacePrintWarningWithMessage);
+	SETUP_LEGACY_FUNC(print_script_error, GDExtensionInterfacePrintScriptError);
+	SETUP_LEGACY_FUNC(print_script_error_with_message, GDExtensionInterfacePrintScriptErrorWithMessage);
+	SETUP_LEGACY_FUNC(get_native_struct_size, GDExtensionInterfaceGetNativeStructSize);
+	SETUP_LEGACY_FUNC(variant_new_copy, GDExtensionInterfaceVariantNewCopy);
+	SETUP_LEGACY_FUNC(variant_new_nil, GDExtensionInterfaceVariantNewNil);
+	SETUP_LEGACY_FUNC(variant_destroy, GDExtensionInterfaceVariantDestroy);
+	SETUP_LEGACY_FUNC(variant_call, GDExtensionInterfaceVariantCall);
+	SETUP_LEGACY_FUNC(variant_call_static, GDExtensionInterfaceVariantCallStatic);
+	SETUP_LEGACY_FUNC(variant_evaluate, GDExtensionInterfaceVariantEvaluate);
+	SETUP_LEGACY_FUNC(variant_set, GDExtensionInterfaceVariantSet);
+	SETUP_LEGACY_FUNC(variant_set_named, GDExtensionInterfaceVariantSetNamed);
+	SETUP_LEGACY_FUNC(variant_set_keyed, GDExtensionInterfaceVariantSetKeyed);
+	SETUP_LEGACY_FUNC(variant_set_indexed, GDExtensionInterfaceVariantSetIndexed);
+	SETUP_LEGACY_FUNC(variant_get, GDExtensionInterfaceVariantGet);
+	SETUP_LEGACY_FUNC(variant_get_named, GDExtensionInterfaceVariantGetNamed);
+	SETUP_LEGACY_FUNC(variant_get_keyed, GDExtensionInterfaceVariantGetKeyed);
+	SETUP_LEGACY_FUNC(variant_get_indexed, GDExtensionInterfaceVariantGetIndexed);
+	SETUP_LEGACY_FUNC(variant_iter_init, GDExtensionInterfaceVariantIterInit);
+	SETUP_LEGACY_FUNC(variant_iter_next, GDExtensionInterfaceVariantIterNext);
+	SETUP_LEGACY_FUNC(variant_iter_get, GDExtensionInterfaceVariantIterGet);
+	SETUP_LEGACY_FUNC(variant_hash, GDExtensionInterfaceVariantHash);
+	SETUP_LEGACY_FUNC(variant_recursive_hash, GDExtensionInterfaceVariantRecursiveHash);
+	SETUP_LEGACY_FUNC(variant_hash_compare, GDExtensionInterfaceVariantHashCompare);
+	SETUP_LEGACY_FUNC(variant_booleanize, GDExtensionInterfaceVariantBooleanize);
+	SETUP_LEGACY_FUNC(variant_duplicate, GDExtensionInterfaceVariantDuplicate);
+	SETUP_LEGACY_FUNC(variant_stringify, GDExtensionInterfaceVariantStringify);
+	SETUP_LEGACY_FUNC(variant_get_type, GDExtensionInterfaceVariantGetType);
+	SETUP_LEGACY_FUNC(variant_has_method, GDExtensionInterfaceVariantHasMethod);
+	SETUP_LEGACY_FUNC(variant_has_member, GDExtensionInterfaceVariantHasMember);
+	SETUP_LEGACY_FUNC(variant_has_key, GDExtensionInterfaceVariantHasKey);
+	SETUP_LEGACY_FUNC(variant_get_type_name, GDExtensionInterfaceVariantGetTypeName);
+	SETUP_LEGACY_FUNC(variant_can_convert, GDExtensionInterfaceVariantCanConvert);
+	SETUP_LEGACY_FUNC(variant_can_convert_strict, GDExtensionInterfaceVariantCanConvertStrict);
+	SETUP_LEGACY_FUNC(get_variant_from_type_constructor, GDExtensionInterfaceGetVariantFromTypeConstructor);
+	SETUP_LEGACY_FUNC(get_variant_to_type_constructor, GDExtensionInterfaceGetVariantToTypeConstructor);
+	SETUP_LEGACY_FUNC(variant_get_ptr_operator_evaluator, GDExtensionInterfaceVariantGetPtrOperatorEvaluator);
+	SETUP_LEGACY_FUNC(variant_get_ptr_builtin_method, GDExtensionInterfaceVariantGetPtrBuiltinMethod);
+	SETUP_LEGACY_FUNC(variant_get_ptr_constructor, GDExtensionInterfaceVariantGetPtrConstructor);
+	SETUP_LEGACY_FUNC(variant_get_ptr_destructor, GDExtensionInterfaceVariantGetPtrDestructor);
+	SETUP_LEGACY_FUNC(variant_construct, GDExtensionInterfaceVariantConstruct);
+	SETUP_LEGACY_FUNC(variant_get_ptr_setter, GDExtensionInterfaceVariantGetPtrSetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_getter, GDExtensionInterfaceVariantGetPtrGetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_indexed_setter, GDExtensionInterfaceVariantGetPtrIndexedSetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_indexed_getter, GDExtensionInterfaceVariantGetPtrIndexedGetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_keyed_setter, GDExtensionInterfaceVariantGetPtrKeyedSetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_keyed_getter, GDExtensionInterfaceVariantGetPtrKeyedGetter);
+	SETUP_LEGACY_FUNC(variant_get_ptr_keyed_checker, GDExtensionInterfaceVariantGetPtrKeyedChecker);
+	SETUP_LEGACY_FUNC(variant_get_constant_value, GDExtensionInterfaceVariantGetConstantValue);
+	SETUP_LEGACY_FUNC(variant_get_ptr_utility_function, GDExtensionInterfaceVariantGetPtrUtilityFunction);
+	SETUP_LEGACY_FUNC(string_new_with_latin1_chars, GDExtensionInterfaceStringNewWithLatin1Chars);
+	SETUP_LEGACY_FUNC(string_new_with_utf8_chars, GDExtensionInterfaceStringNewWithUtf8Chars);
+	SETUP_LEGACY_FUNC(string_new_with_utf16_chars, GDExtensionInterfaceStringNewWithUtf16Chars);
+	SETUP_LEGACY_FUNC(string_new_with_utf32_chars, GDExtensionInterfaceStringNewWithUtf32Chars);
+	SETUP_LEGACY_FUNC(string_new_with_wide_chars, GDExtensionInterfaceStringNewWithWideChars);
+	SETUP_LEGACY_FUNC(string_new_with_latin1_chars_and_len, GDExtensionInterfaceStringNewWithLatin1CharsAndLen);
+	SETUP_LEGACY_FUNC(string_new_with_utf8_chars_and_len, GDExtensionInterfaceStringNewWithUtf8CharsAndLen);
+	SETUP_LEGACY_FUNC(string_new_with_utf16_chars_and_len, GDExtensionInterfaceStringNewWithUtf16CharsAndLen);
+	SETUP_LEGACY_FUNC(string_new_with_utf32_chars_and_len, GDExtensionInterfaceStringNewWithUtf32CharsAndLen);
+	SETUP_LEGACY_FUNC(string_new_with_wide_chars_and_len, GDExtensionInterfaceStringNewWithWideCharsAndLen);
+	SETUP_LEGACY_FUNC(string_to_latin1_chars, GDExtensionInterfaceStringToLatin1Chars);
+	SETUP_LEGACY_FUNC(string_to_utf8_chars, GDExtensionInterfaceStringToUtf8Chars);
+	SETUP_LEGACY_FUNC(string_to_utf16_chars, GDExtensionInterfaceStringToUtf16Chars);
+	SETUP_LEGACY_FUNC(string_to_utf32_chars, GDExtensionInterfaceStringToUtf32Chars);
+	SETUP_LEGACY_FUNC(string_to_wide_chars, GDExtensionInterfaceStringToWideChars);
+	SETUP_LEGACY_FUNC(string_operator_index, GDExtensionInterfaceStringOperatorIndex);
+	SETUP_LEGACY_FUNC(string_operator_index_const, GDExtensionInterfaceStringOperatorIndexConst);
+	SETUP_LEGACY_FUNC(string_operator_plus_eq_string, GDExtensionInterfaceStringOperatorPlusEqString);
+	SETUP_LEGACY_FUNC(string_operator_plus_eq_char, GDExtensionInterfaceStringOperatorPlusEqChar);
+	SETUP_LEGACY_FUNC(string_operator_plus_eq_cstr, GDExtensionInterfaceStringOperatorPlusEqCstr);
+	SETUP_LEGACY_FUNC(string_operator_plus_eq_wcstr, GDExtensionInterfaceStringOperatorPlusEqWcstr);
+	SETUP_LEGACY_FUNC(string_operator_plus_eq_c32str, GDExtensionInterfaceStringOperatorPlusEqC32str);
+	SETUP_LEGACY_FUNC(xml_parser_open_buffer, GDExtensionInterfaceXmlParserOpenBuffer);
+	SETUP_LEGACY_FUNC(file_access_store_buffer, GDExtensionInterfaceFileAccessStoreBuffer);
+	SETUP_LEGACY_FUNC(file_access_get_buffer, GDExtensionInterfaceFileAccessGetBuffer);
+	SETUP_LEGACY_FUNC(worker_thread_pool_add_native_group_task, GDExtensionInterfaceWorkerThreadPoolAddNativeGroupTask);
+	SETUP_LEGACY_FUNC(worker_thread_pool_add_native_task, GDExtensionInterfaceWorkerThreadPoolAddNativeTask);
+	SETUP_LEGACY_FUNC(packed_byte_array_operator_index, GDExtensionInterfacePackedByteArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_byte_array_operator_index_const, GDExtensionInterfacePackedByteArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_color_array_operator_index, GDExtensionInterfacePackedColorArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_color_array_operator_index_const, GDExtensionInterfacePackedColorArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_float32_array_operator_index, GDExtensionInterfacePackedFloat32ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_float32_array_operator_index_const, GDExtensionInterfacePackedFloat32ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_float64_array_operator_index, GDExtensionInterfacePackedFloat64ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_float64_array_operator_index_const, GDExtensionInterfacePackedFloat64ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_int32_array_operator_index, GDExtensionInterfacePackedInt32ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_int32_array_operator_index_const, GDExtensionInterfacePackedInt32ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_int64_array_operator_index, GDExtensionInterfacePackedInt64ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_int64_array_operator_index_const, GDExtensionInterfacePackedInt64ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_string_array_operator_index, GDExtensionInterfacePackedStringArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_string_array_operator_index_const, GDExtensionInterfacePackedStringArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_vector2_array_operator_index, GDExtensionInterfacePackedVector2ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_vector2_array_operator_index_const, GDExtensionInterfacePackedVector2ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(packed_vector3_array_operator_index, GDExtensionInterfacePackedVector3ArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(packed_vector3_array_operator_index_const, GDExtensionInterfacePackedVector3ArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(array_operator_index, GDExtensionInterfaceArrayOperatorIndex);
+	SETUP_LEGACY_FUNC(array_operator_index_const, GDExtensionInterfaceArrayOperatorIndexConst);
+	SETUP_LEGACY_FUNC(array_ref, GDExtensionInterfaceArrayRef);
+	SETUP_LEGACY_FUNC(array_set_typed, GDExtensionInterfaceArraySetTyped);
+	SETUP_LEGACY_FUNC(dictionary_operator_index, GDExtensionInterfaceDictionaryOperatorIndex);
+	SETUP_LEGACY_FUNC(dictionary_operator_index_const, GDExtensionInterfaceDictionaryOperatorIndexConst);
+	SETUP_LEGACY_FUNC(object_method_bind_call, GDExtensionInterfaceObjectMethodBindCall);
+	SETUP_LEGACY_FUNC(object_method_bind_ptrcall, GDExtensionInterfaceObjectMethodBindPtrcall);
+	SETUP_LEGACY_FUNC(object_destroy, GDExtensionInterfaceObjectDestroy);
+	SETUP_LEGACY_FUNC(global_get_singleton, GDExtensionInterfaceGlobalGetSingleton);
+	SETUP_LEGACY_FUNC(object_get_instance_binding, GDExtensionInterfaceObjectGetInstanceBinding);
+	SETUP_LEGACY_FUNC(object_set_instance_binding, GDExtensionInterfaceObjectSetInstanceBinding);
+	SETUP_LEGACY_FUNC(object_set_instance, GDExtensionInterfaceObjectSetInstance);
+	SETUP_LEGACY_FUNC(object_cast_to, GDExtensionInterfaceObjectCastTo);
+	SETUP_LEGACY_FUNC(object_get_instance_from_id, GDExtensionInterfaceObjectGetInstanceFromId);
+	SETUP_LEGACY_FUNC(object_get_instance_id, GDExtensionInterfaceObjectGetInstanceId);
+	SETUP_LEGACY_FUNC(ref_get_object, GDExtensionInterfaceRefGetObject);
+	SETUP_LEGACY_FUNC(ref_set_object, GDExtensionInterfaceRefSetObject);
+	SETUP_LEGACY_FUNC(script_instance_create, GDExtensionInterfaceScriptInstanceCreate);
+	SETUP_LEGACY_FUNC(classdb_construct_object, GDExtensionInterfaceClassdbConstructObject);
+	SETUP_LEGACY_FUNC(classdb_get_method_bind, GDExtensionInterfaceClassdbGetMethodBind);
+	SETUP_LEGACY_FUNC(classdb_get_class_tag, GDExtensionInterfaceClassdbGetClassTag);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class, GDExtensionInterfaceClassdbRegisterExtensionClass);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_method, GDExtensionInterfaceClassdbRegisterExtensionClassMethod);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_integer_constant, GDExtensionInterfaceClassdbRegisterExtensionClassIntegerConstant);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_property, GDExtensionInterfaceClassdbRegisterExtensionClassProperty);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_property_group, GDExtensionInterfaceClassdbRegisterExtensionClassPropertyGroup);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_property_subgroup, GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup);
+	SETUP_LEGACY_FUNC(classdb_register_extension_class_signal, GDExtensionInterfaceClassdbRegisterExtensionClassSignal);
+	SETUP_LEGACY_FUNC(classdb_unregister_extension_class, GDExtensionInterfaceClassdbUnregisterExtensionClass);
+	SETUP_LEGACY_FUNC(get_library_path, GDExtensionInterfaceGetLibraryPath);
+
+	return legacy_gdextension_interface;
+}
+
+#undef SETUP_LEGACY_FUNC

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -422,214 +422,6 @@ typedef struct {
 
 } GDExtensionScriptInstanceInfo;
 
-/* INTERFACE */
-
-typedef struct {
-	uint32_t version_major;
-	uint32_t version_minor;
-	uint32_t version_patch;
-	const char *version_string;
-
-	/* GODOT CORE */
-
-	void *(*mem_alloc)(size_t p_bytes);
-	void *(*mem_realloc)(void *p_ptr, size_t p_bytes);
-	void (*mem_free)(void *p_ptr);
-
-	void (*print_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-	void (*print_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-	void (*print_warning_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-	void (*print_script_error_with_message)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
-
-	uint64_t (*get_native_struct_size)(GDExtensionConstStringNamePtr p_name);
-
-	/* GODOT VARIANT */
-
-	/* variant general */
-	void (*variant_new_copy)(GDExtensionUninitializedVariantPtr r_dest, GDExtensionConstVariantPtr p_src);
-	void (*variant_new_nil)(GDExtensionUninitializedVariantPtr r_dest);
-	void (*variant_destroy)(GDExtensionVariantPtr p_self);
-
-	/* variant type */
-	void (*variant_call)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
-	void (*variant_call_static)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
-	void (*variant_evaluate)(GDExtensionVariantOperator p_op, GDExtensionConstVariantPtr p_a, GDExtensionConstVariantPtr p_b, GDExtensionUninitializedVariantPtr r_return, GDExtensionBool *r_valid);
-	void (*variant_set)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
-	void (*variant_set_named)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
-	void (*variant_set_keyed)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
-	void (*variant_set_indexed)(GDExtensionVariantPtr p_self, GDExtensionInt p_index, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
-	void (*variant_get)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
-	void (*variant_get_named)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
-	void (*variant_get_keyed)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
-	void (*variant_get_indexed)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_index, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
-	GDExtensionBool (*variant_iter_init)(GDExtensionConstVariantPtr p_self, GDExtensionUninitializedVariantPtr r_iter, GDExtensionBool *r_valid);
-	GDExtensionBool (*variant_iter_next)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionBool *r_valid);
-	void (*variant_iter_get)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
-	GDExtensionInt (*variant_hash)(GDExtensionConstVariantPtr p_self);
-	GDExtensionInt (*variant_recursive_hash)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_recursion_count);
-	GDExtensionBool (*variant_hash_compare)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_other);
-	GDExtensionBool (*variant_booleanize)(GDExtensionConstVariantPtr p_self);
-	void (*variant_duplicate)(GDExtensionConstVariantPtr p_self, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool p_deep);
-	void (*variant_stringify)(GDExtensionConstVariantPtr p_self, GDExtensionUninitializedStringPtr r_ret);
-
-	GDExtensionVariantType (*variant_get_type)(GDExtensionConstVariantPtr p_self);
-	GDExtensionBool (*variant_has_method)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_method);
-	GDExtensionBool (*variant_has_member)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
-	GDExtensionBool (*variant_has_key)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionBool *r_valid);
-	void (*variant_get_type_name)(GDExtensionVariantType p_type, GDExtensionUninitializedStringPtr r_name);
-	GDExtensionBool (*variant_can_convert)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
-	GDExtensionBool (*variant_can_convert_strict)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
-
-	/* ptrcalls */
-	GDExtensionVariantFromTypeConstructorFunc (*get_variant_from_type_constructor)(GDExtensionVariantType p_type);
-	GDExtensionTypeFromVariantConstructorFunc (*get_variant_to_type_constructor)(GDExtensionVariantType p_type);
-	GDExtensionPtrOperatorEvaluator (*variant_get_ptr_operator_evaluator)(GDExtensionVariantOperator p_operator, GDExtensionVariantType p_type_a, GDExtensionVariantType p_type_b);
-	GDExtensionPtrBuiltInMethod (*variant_get_ptr_builtin_method)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, GDExtensionInt p_hash);
-	GDExtensionPtrConstructor (*variant_get_ptr_constructor)(GDExtensionVariantType p_type, int32_t p_constructor);
-	GDExtensionPtrDestructor (*variant_get_ptr_destructor)(GDExtensionVariantType p_type);
-	void (*variant_construct)(GDExtensionVariantType p_type, GDExtensionUninitializedVariantPtr r_base, const GDExtensionConstVariantPtr *p_args, int32_t p_argument_count, GDExtensionCallError *r_error);
-	GDExtensionPtrSetter (*variant_get_ptr_setter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
-	GDExtensionPtrGetter (*variant_get_ptr_getter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
-	GDExtensionPtrIndexedSetter (*variant_get_ptr_indexed_setter)(GDExtensionVariantType p_type);
-	GDExtensionPtrIndexedGetter (*variant_get_ptr_indexed_getter)(GDExtensionVariantType p_type);
-	GDExtensionPtrKeyedSetter (*variant_get_ptr_keyed_setter)(GDExtensionVariantType p_type);
-	GDExtensionPtrKeyedGetter (*variant_get_ptr_keyed_getter)(GDExtensionVariantType p_type);
-	GDExtensionPtrKeyedChecker (*variant_get_ptr_keyed_checker)(GDExtensionVariantType p_type);
-	void (*variant_get_constant_value)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_constant, GDExtensionUninitializedVariantPtr r_ret);
-	GDExtensionPtrUtilityFunction (*variant_get_ptr_utility_function)(GDExtensionConstStringNamePtr p_function, GDExtensionInt p_hash);
-
-	/*  extra utilities */
-	void (*string_new_with_latin1_chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
-	void (*string_new_with_utf8_chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
-	void (*string_new_with_utf16_chars)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents);
-	void (*string_new_with_utf32_chars)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents);
-	void (*string_new_with_wide_chars)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents);
-	void (*string_new_with_latin1_chars_and_len)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
-	void (*string_new_with_utf8_chars_and_len)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
-	void (*string_new_with_utf16_chars_and_len)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_size);
-	void (*string_new_with_utf32_chars_and_len)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_size);
-	void (*string_new_with_wide_chars_and_len)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents, GDExtensionInt p_size);
-	/* Information about the following functions:
-	 * - The return value is the resulting encoded string length.
-	 * - The length returned is in characters, not in bytes. It also does not include a trailing zero.
-	 * - These functions also do not write trailing zero, If you need it, write it yourself at the position indicated by the length (and make sure to allocate it).
-	 * - Passing NULL in r_text means only the length is computed (again, without including trailing zero).
-	 * - p_max_write_length argument is in characters, not bytes. It will be ignored if r_text is NULL.
-	 * - p_max_write_length argument does not affect the return value, it's only to cap write length.
-	 */
-	GDExtensionInt (*string_to_latin1_chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
-	GDExtensionInt (*string_to_utf8_chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
-	GDExtensionInt (*string_to_utf16_chars)(GDExtensionConstStringPtr p_self, char16_t *r_text, GDExtensionInt p_max_write_length);
-	GDExtensionInt (*string_to_utf32_chars)(GDExtensionConstStringPtr p_self, char32_t *r_text, GDExtensionInt p_max_write_length);
-	GDExtensionInt (*string_to_wide_chars)(GDExtensionConstStringPtr p_self, wchar_t *r_text, GDExtensionInt p_max_write_length);
-	char32_t *(*string_operator_index)(GDExtensionStringPtr p_self, GDExtensionInt p_index);
-	const char32_t *(*string_operator_index_const)(GDExtensionConstStringPtr p_self, GDExtensionInt p_index);
-
-	void (*string_operator_plus_eq_string)(GDExtensionStringPtr p_self, GDExtensionConstStringPtr p_b);
-	void (*string_operator_plus_eq_char)(GDExtensionStringPtr p_self, char32_t p_b);
-	void (*string_operator_plus_eq_cstr)(GDExtensionStringPtr p_self, const char *p_b);
-	void (*string_operator_plus_eq_wcstr)(GDExtensionStringPtr p_self, const wchar_t *p_b);
-	void (*string_operator_plus_eq_c32str)(GDExtensionStringPtr p_self, const char32_t *p_b);
-
-	/*  XMLParser extra utilities */
-
-	GDExtensionInt (*xml_parser_open_buffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size);
-
-	/*  FileAccess extra utilities */
-
-	void (*file_access_store_buffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length);
-	uint64_t (*file_access_get_buffer)(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length);
-
-	/*  WorkerThreadPool extra utilities */
-
-	int64_t (*worker_thread_pool_add_native_group_task)(GDExtensionObjectPtr p_instance, void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
-	int64_t (*worker_thread_pool_add_native_task)(GDExtensionObjectPtr p_instance, void (*p_func)(void *), void *p_userdata, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
-
-	/* Packed array functions */
-
-	uint8_t *(*packed_byte_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedByteArray
-	const uint8_t *(*packed_byte_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedByteArray
-
-	GDExtensionTypePtr (*packed_color_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedColorArray, returns Color ptr
-	GDExtensionTypePtr (*packed_color_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedColorArray, returns Color ptr
-
-	float *(*packed_float32_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedFloat32Array
-	const float *(*packed_float32_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedFloat32Array
-	double *(*packed_float64_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedFloat64Array
-	const double *(*packed_float64_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedFloat64Array
-
-	int32_t *(*packed_int32_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedInt32Array
-	const int32_t *(*packed_int32_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedInt32Array
-	int64_t *(*packed_int64_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedInt32Array
-	const int64_t *(*packed_int64_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedInt32Array
-
-	GDExtensionStringPtr (*packed_string_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedStringArray
-	GDExtensionStringPtr (*packed_string_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedStringArray
-
-	GDExtensionTypePtr (*packed_vector2_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedVector2Array, returns Vector2 ptr
-	GDExtensionTypePtr (*packed_vector2_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedVector2Array, returns Vector2 ptr
-	GDExtensionTypePtr (*packed_vector3_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedVector3Array, returns Vector3 ptr
-	GDExtensionTypePtr (*packed_vector3_array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedVector3Array, returns Vector3 ptr
-
-	GDExtensionVariantPtr (*array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
-	GDExtensionVariantPtr (*array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
-	void (*array_ref)(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from); // p_self should be an Array ptr
-	void (*array_set_typed)(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script); // p_self should be an Array ptr
-
-	/* Dictionary functions */
-
-	GDExtensionVariantPtr (*dictionary_operator_index)(GDExtensionTypePtr p_self, GDExtensionConstVariantPtr p_key); // p_self should be an Dictionary ptr
-	GDExtensionVariantPtr (*dictionary_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionConstVariantPtr p_key); // p_self should be an Dictionary ptr
-
-	/* OBJECT */
-
-	void (*object_method_bind_call)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_arg_count, GDExtensionUninitializedVariantPtr r_ret, GDExtensionCallError *r_error);
-	void (*object_method_bind_ptrcall)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
-	void (*object_destroy)(GDExtensionObjectPtr p_o);
-	GDExtensionObjectPtr (*global_get_singleton)(GDExtensionConstStringNamePtr p_name);
-
-	void *(*object_get_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
-	void (*object_set_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
-
-	void (*object_set_instance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
-
-	GDExtensionObjectPtr (*object_cast_to)(GDExtensionConstObjectPtr p_object, void *p_class_tag);
-	GDExtensionObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);
-	GDObjectInstanceID (*object_get_instance_id)(GDExtensionConstObjectPtr p_object);
-
-	/* REFERENCE */
-
-	GDExtensionObjectPtr (*ref_get_object)(GDExtensionConstRefPtr p_ref);
-	void (*ref_set_object)(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object);
-
-	/* SCRIPT INSTANCE */
-
-	GDExtensionScriptInstancePtr (*script_instance_create)(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
-
-	/* CLASSDB */
-
-	GDExtensionObjectPtr (*classdb_construct_object)(GDExtensionConstStringNamePtr p_classname); /* The passed class must be a built-in godot class, or an already-registered extension class. In both case, object_set_instance should be called to fully initialize the object. */
-	GDExtensionMethodBindPtr (*classdb_get_method_bind)(GDExtensionConstStringNamePtr p_classname, GDExtensionConstStringNamePtr p_methodname, GDExtensionInt p_hash);
-	void *(*classdb_get_class_tag)(GDExtensionConstStringNamePtr p_classname);
-
-	/* CLASSDB EXTENSION */
-
-	/* Provided parameters for `classdb_register_extension_*` can be safely freed once the function returns. */
-	void (*classdb_register_extension_class)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo *p_extension_funcs);
-	void (*classdb_register_extension_class_method)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassMethodInfo *p_method_info);
-	void (*classdb_register_extension_class_integer_constant)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_enum_name, GDExtensionConstStringNamePtr p_constant_name, GDExtensionInt p_constant_value, GDExtensionBool p_is_bitfield);
-	void (*classdb_register_extension_class_property)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionPropertyInfo *p_info, GDExtensionConstStringNamePtr p_setter, GDExtensionConstStringNamePtr p_getter);
-	void (*classdb_register_extension_class_property_group)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_group_name, GDExtensionConstStringPtr p_prefix);
-	void (*classdb_register_extension_class_property_subgroup)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_subgroup_name, GDExtensionConstStringPtr p_prefix);
-	void (*classdb_register_extension_class_signal)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_signal_name, const GDExtensionPropertyInfo *p_argument_info, GDExtensionInt p_argument_count);
-	void (*classdb_unregister_extension_class)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name); /* Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first. */
-
-	void (*get_library_path)(GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringPtr r_path);
-
-} GDExtensionInterface;
-
 /* INITIALIZATION */
 
 typedef enum {
@@ -651,12 +443,1690 @@ typedef struct {
 	void (*deinitialize)(void *userdata, GDExtensionInitializationLevel p_level);
 } GDExtensionInitialization;
 
-/* Define a C function prototype that implements the function below and expose it to dlopen() (or similar).
- * This is the entry point of the GDExtension library and will be called on initialization.
- * It can be used to set up different init levels, which are called during various stages of initialization/shutdown.
- * The function name must be a unique one specified in the .gdextension config file.
+typedef void (*GDExtensionInterfaceFunctionPtr)();
+typedef GDExtensionInterfaceFunctionPtr (*GDExtensionInterfaceGetProcAddress)(const char *p_function_name);
+
+/*
+ * Each GDExtension should define a C function that matches the signature of GDExtensionInitializationFunction,
+ * and export it so that it can be loaded via dlopen() or equivalent for the given platform.
+ *
+ * For example:
+ *
+ *   GDExtensionBool my_extension_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
+ *
+ * This function's name must be specified as the 'entry_symbol' in the .gdextension file.
+ *
+ * This makes it the entry point of the GDExtension and will be called on initialization.
+ *
+ * The GDExtension can then modify the r_initialization structure, setting the minimum initialization level,
+ * and providing pointers to functions that will be called at various stages of initialization/shutdown.
+ *
+ * The rest of the GDExtension's interface to Godot consists of function pointers that can be loaded
+ * by calling p_get_proc_address("...") with the name of the function.
+ *
+ * For example:
+ *
+ *   GDExtensionInterfaceGetGodotVersion *get_godot_version = (GDExtensionInterfaceGetGodotVersion)p_get_proc_address("get_godot_version");
+ *
+ * You can then call it like a normal function:
+ *
+ *   GDExtensionGodotVersion godot_version;
+ *   get_godot_version(&godot_version);
+ *   printf("Godot v%d.%d.%d\n", godot_version.major, godot_version.minor, godot_version.patch);
+ *
+ * All of these interface functions are described below, together with the name that's used to load it,
+ * and the function pointer typedef that shows its signature.
  */
-typedef GDExtensionBool (*GDExtensionInitializationFunction)(const GDExtensionInterface *p_interface, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
+typedef GDExtensionBool (*GDExtensionInitializationFunction)(GDExtensionInterfaceGetProcAddress p_get_proc_address, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization);
+
+/* INTERFACE */
+
+typedef struct {
+	uint32_t major;
+	uint32_t minor;
+	uint32_t patch;
+	const char *string;
+} GDExtensionGodotVersion;
+
+/**
+ * @name get_godot_version
+ *
+ * Gets the Godot version that the GDExtension was loaded into.
+ *
+ * @param r_godot_version A pointer to the structure to write the version information into.
+ */
+typedef void (*GDExtensionInterfaceGetGodotVersion)(GDExtensionGodotVersion *r_godot_version);
+
+/* INTERFACE: Memory */
+
+/**
+ * @name mem_alloc
+ *
+ * Allocates memory.
+ *
+ * @param p_bytes The amount of memory to allocate in bytes.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemAlloc)(size_t p_bytes);
+
+/**
+ * @name mem_realloc
+ *
+ * Reallocates memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ * @param p_bytes The number of bytes to resize the memory block to.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
+
+/**
+ * @name mem_free
+ *
+ * Frees memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ */
+typedef void (*GDExtensionInterfaceMemFree)(void *p_ptr);
+
+/* INTERFACE: Godot Core */
+
+/**
+ * @name print_error
+ *
+ * Logs an error to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintError)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_error_with_message
+ *
+ * Logs an error with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the error.
+ * @param p_message The message to show along with the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintErrorWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_warning
+ *
+ * Logs a warning to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the warning.
+ * @param p_function The function name where the warning occurred.
+ * @param p_file The file where the warning occurred.
+ * @param p_line The line where the warning occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintWarning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_warning_with_message
+ *
+ * Logs a warning with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the warning.
+ * @param p_message The message to show along with the warning.
+ * @param p_function The function name where the warning occurred.
+ * @param p_file The file where the warning occurred.
+ * @param p_line The line where the warning occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintWarningWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_script_error
+ *
+ * Logs a script error to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintScriptError)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name print_script_error_with_message
+ *
+ * Logs a script error with a message to Godot's built-in debugger and to the OS terminal.
+ *
+ * @param p_description The code trigging the error.
+ * @param p_message The message to show along with the error.
+ * @param p_function The function name where the error occurred.
+ * @param p_file The file where the error occurred.
+ * @param p_line The line where the error occurred.
+ * @param p_editor_notify Whether or not to notify the editor.
+ */
+typedef void (*GDExtensionInterfacePrintScriptErrorWithMessage)(const char *p_description, const char *p_message, const char *p_function, const char *p_file, int32_t p_line, GDExtensionBool p_editor_notify);
+
+/**
+ * @name get_native_struct_size
+ *
+ * Gets the size of a native struct (ex. ObjectID) in bytes.
+ *
+ * @param p_name A pointer to a StringName identifying the struct name.
+ *
+ * @return The size in bytes.
+ */
+typedef uint64_t (*GDExtensionInterfaceGetNativeStructSize)(GDExtensionConstStringNamePtr p_name);
+
+/* INTERFACE: Variant */
+
+/**
+ * @name variant_new_copy
+ *
+ * Copies one Variant into a another.
+ *
+ * @param r_dest A pointer to the destination Variant.
+ * @param p_src A pointer to the source Variant.
+ */
+typedef void (*GDExtensionInterfaceVariantNewCopy)(GDExtensionUninitializedVariantPtr r_dest, GDExtensionConstVariantPtr p_src);
+
+/**
+ * @name variant_new_nil
+ *
+ * Creates a new Variant containing nil.
+ *
+ * @param r_dest A pointer to the destination Variant.
+ */
+typedef void (*GDExtensionInterfaceVariantNewNil)(GDExtensionUninitializedVariantPtr r_dest);
+
+/**
+ * @name variant_destroy
+ *
+ * Destroys a Variant.
+ *
+ * @param p_self A pointer to the Variant to destroy.
+ */
+typedef void (*GDExtensionInterfaceVariantDestroy)(GDExtensionVariantPtr p_self);
+
+/**
+ * @name variant_call
+ *
+ * Calls a method on a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_method A pointer to a StringName identifying the method.
+ * @param p_args A pointer to a C array of Variant.
+ * @param p_argument_count The number of arguments.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_error A pointer the structure which will hold error information.
+ *
+ * @see Variant::callp()
+ */
+typedef void (*GDExtensionInterfaceVariantCall)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_call_static
+ *
+ * Calls a static method on a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_method A pointer to a StringName identifying the method.
+ * @param p_args A pointer to a C array of Variant.
+ * @param p_argument_count The number of arguments.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_error A pointer the structure which will be updated with error information.
+ *
+ * @see Variant::call_static()
+ */
+typedef void (*GDExtensionInterfaceVariantCallStatic)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionUninitializedVariantPtr r_return, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_evaluate
+ *
+ * Evaluate an operator on two Variants.
+ *
+ * @param p_op The operator to evaluate.
+ * @param p_a The first Variant.
+ * @param p_b The second Variant.
+ * @param r_return A pointer a Variant which will be assigned the return value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::evaluate()
+ */
+typedef void (*GDExtensionInterfaceVariantEvaluate)(GDExtensionVariantOperator p_op, GDExtensionConstVariantPtr p_a, GDExtensionConstVariantPtr p_b, GDExtensionUninitializedVariantPtr r_return, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set
+ *
+ * Sets a key on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set()
+ */
+typedef void (*GDExtensionInterfaceVariantSet)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_named
+ *
+ * Sets a named key on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a StringName representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set_named()
+ */
+typedef void (*GDExtensionInterfaceVariantSetNamed)(GDExtensionVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_keyed
+ *
+ * Sets a keyed property on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::set_keyed()
+ */
+typedef void (*GDExtensionInterfaceVariantSetKeyed)(GDExtensionVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_set_indexed
+ *
+ * Sets an index on a Variant to a value.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_index The index.
+ * @param p_value A pointer to a Variant representing the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ * @param r_oob A pointer to a boolean which will be set to true if the index is out of bounds.
+ */
+typedef void (*GDExtensionInterfaceVariantSetIndexed)(GDExtensionVariantPtr p_self, GDExtensionInt p_index, GDExtensionConstVariantPtr p_value, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
+
+/**
+ * @name variant_get
+ *
+ * Gets the value of a key from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGet)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_named
+ *
+ * Gets the value of a named key from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a StringName representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGetNamed)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_keyed
+ *
+ * Gets the value of a keyed property from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ */
+typedef void (*GDExtensionInterfaceVariantGetKeyed)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_indexed
+ *
+ * Gets the value of an index from a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_index The index.
+ * @param r_ret A pointer to a Variant which will be assigned the value.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ * @param r_oob A pointer to a boolean which will be set to true if the index is out of bounds.
+ */
+typedef void (*GDExtensionInterfaceVariantGetIndexed)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_index, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid, GDExtensionBool *r_oob);
+
+/**
+ * @name variant_iter_init
+ *
+ * Initializes an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @return true if the operation is valid; otherwise false.
+ *
+ * @see Variant::iter_init()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantIterInit)(GDExtensionConstVariantPtr p_self, GDExtensionUninitializedVariantPtr r_iter, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_iter_next
+ *
+ * Gets the next value for an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @return true if the operation is valid; otherwise false.
+ *
+ * @see Variant::iter_next()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantIterNext)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_iter_get
+ *
+ * Gets the next value for an iterator over a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_iter A pointer to a Variant which will be assigned the iterator.
+ * @param r_ret A pointer to a Variant which will be assigned false if the operation is invalid.
+ * @param r_valid A pointer to a boolean which will be set to false if the operation is invalid.
+ *
+ * @see Variant::iter_get()
+ */
+typedef void (*GDExtensionInterfaceVariantIterGet)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_iter, GDExtensionUninitializedVariantPtr r_ret, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_hash
+ *
+ * Gets the hash of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::hash()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceVariantHash)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_recursive_hash
+ *
+ * Gets the recursive hash of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_recursion_count The number of recursive loops so far.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::recursive_hash()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceVariantRecursiveHash)(GDExtensionConstVariantPtr p_self, GDExtensionInt p_recursion_count);
+
+/**
+ * @name variant_hash_compare
+ *
+ * Compares two Variants by their hash.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_other A pointer to the other Variant to compare it to.
+ *
+ * @return The hash value.
+ *
+ * @see Variant::hash_compare()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHashCompare)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_other);
+
+/**
+ * @name variant_booleanize
+ *
+ * Converts a Variant to a boolean.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The boolean value of the Variant.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantBooleanize)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_duplicate
+ *
+ * Duplicates a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_ret A pointer to a Variant to store the duplicated value.
+ * @param p_deep Whether or not to duplicate deeply (when supported by the Variant type).
+ */
+typedef void (*GDExtensionInterfaceVariantDuplicate)(GDExtensionConstVariantPtr p_self, GDExtensionVariantPtr r_ret, GDExtensionBool p_deep);
+
+/**
+ * @name variant_stringify
+ *
+ * Converts a Variant to a string.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param r_ret A pointer to a String to store the resulting value.
+ */
+typedef void (*GDExtensionInterfaceVariantStringify)(GDExtensionConstVariantPtr p_self, GDExtensionStringPtr r_ret);
+
+/**
+ * @name variant_get_type
+ *
+ * Gets the type of a Variant.
+ *
+ * @param p_self A pointer to the Variant.
+ *
+ * @return The variant type.
+ */
+typedef GDExtensionVariantType (*GDExtensionInterfaceVariantGetType)(GDExtensionConstVariantPtr p_self);
+
+/**
+ * @name variant_has_method
+ *
+ * Checks if a Variant has the given method.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_method A pointer to a StringName with the method name.
+ *
+ * @return
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasMethod)(GDExtensionConstVariantPtr p_self, GDExtensionConstStringNamePtr p_method);
+
+/**
+ * @name variant_has_member
+ *
+ * Checks if a type of Variant has the given member.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasMember)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_has_key
+ *
+ * Checks if a Variant has a key.
+ *
+ * @param p_self A pointer to the Variant.
+ * @param p_key A pointer to a Variant representing the key.
+ * @param r_valid A pointer to a boolean which will be set to false if the key doesn't exist.
+ *
+ * @return true if the key exists; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantHasKey)(GDExtensionConstVariantPtr p_self, GDExtensionConstVariantPtr p_key, GDExtensionBool *r_valid);
+
+/**
+ * @name variant_get_type_name
+ *
+ * Gets the name of a Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param r_name A pointer to a String to store the Variant type name.
+ */
+typedef void (*GDExtensionInterfaceVariantGetTypeName)(GDExtensionVariantType p_type, GDExtensionUninitializedStringPtr r_name);
+
+/**
+ * @name variant_can_convert
+ *
+ * Checks if Variants can be converted from one type to another.
+ *
+ * @param p_from The Variant type to convert from.
+ * @param p_to The Variant type to convert to.
+ *
+ * @return true if the conversion is possible; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvert)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
+
+/**
+ * @name variant_can_convert_strict
+ *
+ * Checks if Variant can be converted from one type to another using stricter rules.
+ *
+ * @param p_from The Variant type to convert from.
+ * @param p_to The Variant type to convert to.
+ *
+ * @return true if the conversion is possible; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvertStrict)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
+
+/**
+ * @name get_variant_from_type_constructor
+ *
+ * Gets a pointer to a function that can create a Variant of the given type from a raw value.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can create a Variant of the given type from a raw value.
+ */
+typedef GDExtensionVariantFromTypeConstructorFunc (*GDExtensionInterfaceGetVariantFromTypeConstructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name get_variant_to_type_constructor
+ *
+ * Gets a pointer to a function that can get the raw value from a Variant of the given type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get the raw value from a Variant of the given type.
+ */
+typedef GDExtensionTypeFromVariantConstructorFunc (*GDExtensionInterfaceGetVariantToTypeConstructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_operator_evaluator
+ *
+ * Gets a pointer to a function that can evaluate the given Variant operator on the given Variant types.
+ *
+ * @param p_operator The variant operator.
+ * @param p_type_a The type of the first Variant.
+ * @param p_type_b The type of the second Variant.
+ *
+ * @return A pointer to a function that can evaluate the given Variant operator on the given Variant types.
+ */
+typedef GDExtensionPtrOperatorEvaluator (*GDExtensionInterfaceVariantGetPtrOperatorEvaluator)(GDExtensionVariantOperator p_operator, GDExtensionVariantType p_type_a, GDExtensionVariantType p_type_b);
+
+/**
+ * @name variant_get_ptr_builtin_method
+ *
+ * Gets a pointer to a function that can call a builtin method on a type of Variant.
+ *
+ * @param p_type The Variant type.
+ * @param p_method A pointer to a StringName with the method name.
+ * @param p_hash A hash representing the method signature.
+ *
+ * @return A pointer to a function that can call a builtin method on a type of Variant.
+ */
+typedef GDExtensionPtrBuiltInMethod (*GDExtensionInterfaceVariantGetPtrBuiltinMethod)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_method, GDExtensionInt p_hash);
+
+/**
+ * @name variant_get_ptr_constructor
+ *
+ * Gets a pointer to a function that can call one of the constructors for a type of Variant.
+ *
+ * @param p_type The Variant type.
+ * @param p_constructor The index of the constructor.
+ *
+ * @return A pointer to a function that can call one of the constructors for a type of Variant.
+ */
+typedef GDExtensionPtrConstructor (*GDExtensionInterfaceVariantGetPtrConstructor)(GDExtensionVariantType p_type, int32_t p_constructor);
+
+/**
+ * @name variant_get_ptr_destructor
+ *
+ * Gets a pointer to a function than can call the destructor for a type of Variant.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function than can call the destructor for a type of Variant.
+ */
+typedef GDExtensionPtrDestructor (*GDExtensionInterfaceVariantGetPtrDestructor)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_construct
+ *
+ * Constructs a Variant of the given type, using the first constructor that matches the given arguments.
+ *
+ * @param p_type The Variant type.
+ * @param p_base A pointer to a Variant to store the constructed value.
+ * @param p_args A pointer to a C array of Variant pointers representing the arguments for the constructor.
+ * @param p_argument_count The number of arguments to pass to the constructor.
+ * @param r_error A pointer the structure which will be updated with error information.
+ */
+typedef void (*GDExtensionInterfaceVariantConstruct)(GDExtensionVariantType p_type, GDExtensionUninitializedVariantPtr r_base, const GDExtensionConstVariantPtr *p_args, int32_t p_argument_count, GDExtensionCallError *r_error);
+
+/**
+ * @name variant_get_ptr_setter
+ *
+ * Gets a pointer to a function that can call a member's setter on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return A pointer to a function that can call a member's setter on the given Variant type.
+ */
+typedef GDExtensionPtrSetter (*GDExtensionInterfaceVariantGetPtrSetter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_get_ptr_getter
+ *
+ * Gets a pointer to a function that can call a member's getter on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_member A pointer to a StringName with the member name.
+ *
+ * @return A pointer to a function that can call a member's getter on the given Variant type.
+ */
+typedef GDExtensionPtrGetter (*GDExtensionInterfaceVariantGetPtrGetter)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_member);
+
+/**
+ * @name variant_get_ptr_indexed_setter
+ *
+ * Gets a pointer to a function that can set an index on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can set an index on the given Variant type.
+ */
+typedef GDExtensionPtrIndexedSetter (*GDExtensionInterfaceVariantGetPtrIndexedSetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_indexed_getter
+ *
+ * Gets a pointer to a function that can get an index on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get an index on the given Variant type.
+ */
+typedef GDExtensionPtrIndexedGetter (*GDExtensionInterfaceVariantGetPtrIndexedGetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_setter
+ *
+ * Gets a pointer to a function that can set a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can set a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedSetter (*GDExtensionInterfaceVariantGetPtrKeyedSetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_getter
+ *
+ * Gets a pointer to a function that can get a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can get a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedGetter (*GDExtensionInterfaceVariantGetPtrKeyedGetter)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_ptr_keyed_checker
+ *
+ * Gets a pointer to a function that can check a key on the given Variant type.
+ *
+ * @param p_type The Variant type.
+ *
+ * @return A pointer to a function that can check a key on the given Variant type.
+ */
+typedef GDExtensionPtrKeyedChecker (*GDExtensionInterfaceVariantGetPtrKeyedChecker)(GDExtensionVariantType p_type);
+
+/**
+ * @name variant_get_constant_value
+ *
+ * Gets the value of a constant from the given Variant type.
+ *
+ * @param p_type The Variant type.
+ * @param p_constant A pointer to a StringName with the constant name.
+ * @param r_ret A pointer to a Variant to store the value.
+ */
+typedef void (*GDExtensionInterfaceVariantGetConstantValue)(GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_constant, GDExtensionUninitializedVariantPtr r_ret);
+
+/**
+ * @name variant_get_ptr_utility_function
+ *
+ * Gets a pointer to a function that can call a Variant utility function.
+ *
+ * @param p_function A pointer to a StringName with the function name.
+ * @param p_hash A hash representing the function signature.
+ *
+ * @return A pointer to a function that can call a Variant utility function.
+ */
+typedef GDExtensionPtrUtilityFunction (*GDExtensionInterfaceVariantGetPtrUtilityFunction)(GDExtensionConstStringNamePtr p_function, GDExtensionInt p_hash);
+
+/* INTERFACE: String Utilities */
+
+/**
+ * @name string_new_with_latin1_chars
+ *
+ * Creates a String from a Latin-1 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a Latin-1 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithLatin1Chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
+
+/**
+ * @name string_new_with_utf8_chars
+ *
+ * Creates a String from a UTF-8 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf8Chars)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents);
+
+/**
+ * @name string_new_with_utf16_chars
+ *
+ * Creates a String from a UTF-16 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf16Chars)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents);
+
+/**
+ * @name string_new_with_utf32_chars
+ *
+ * Creates a String from a UTF-32 encoded C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-32 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf32Chars)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents);
+
+/**
+ * @name string_new_with_wide_chars
+ *
+ * Creates a String from a wide C string.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a wide C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringNewWithWideChars)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents);
+
+/**
+ * @name string_new_with_latin1_chars_and_len
+ *
+ * Creates a String from a Latin-1 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a Latin-1 encoded C string.
+ * @param p_size The number of characters.
+ */
+typedef void (*GDExtensionInterfaceStringNewWithLatin1CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf8_chars_and_len
+ *
+ * Creates a String from a UTF-8 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of characters.
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf8CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf16_chars_and_len
+ *
+ * Creates a String from a UTF-16 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-16 encoded C string.
+ * @param p_size The number of characters.
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf16CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_utf32_chars_and_len
+ *
+ * Creates a String from a UTF-32 encoded C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a UTF-32 encoded C string.
+ * @param p_size The number of characters.
+ */
+typedef void (*GDExtensionInterfaceStringNewWithUtf32CharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_new_with_wide_chars_and_len
+ *
+ * Creates a String from a wide C string with the given length.
+ *
+ * @param r_dest A pointer to a Variant to hold the newly created String.
+ * @param p_contents A pointer to a wide C string.
+ * @param p_size The number of characters.
+ */
+typedef void (*GDExtensionInterfaceStringNewWithWideCharsAndLen)(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents, GDExtensionInt p_size);
+
+/**
+ * @name string_to_latin1_chars
+ *
+ * Converts a String to a Latin-1 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToLatin1Chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf8_chars
+ *
+ * Converts a String to a UTF-8 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf8Chars)(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf16_chars
+ *
+ * Converts a String to a UTF-16 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf16Chars)(GDExtensionConstStringPtr p_self, char16_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_utf32_chars
+ *
+ * Converts a String to a UTF-32 encoded C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToUtf32Chars)(GDExtensionConstStringPtr p_self, char32_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_to_wide_chars
+ *
+ * Converts a String to a wide C string.
+ *
+ * It doesn't write a null terminator.
+ *
+ * @param p_self A pointer to the String.
+ * @param r_text A pointer to the buffer to hold the resulting data. If NULL is passed in, only the length will be computed.
+ * @param p_max_write_length The maximum number of characters that can be written to r_text. It has no affect on the return value.
+ *
+ * @return The resulting encoded string length in characters (not bytes), not including a null terminator.
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceStringToWideChars)(GDExtensionConstStringPtr p_self, wchar_t *r_text, GDExtensionInt p_max_write_length);
+
+/**
+ * @name string_operator_index
+ *
+ * Gets a pointer to the character at the given index from a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_index The index.
+ *
+ * @return A pointer to the requested character.
+ */
+typedef char32_t *(*GDExtensionInterfaceStringOperatorIndex)(GDExtensionStringPtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name string_operator_index_const
+ *
+ * Gets a const pointer to the character at the given index from a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_index The index.
+ *
+ * @return A const pointer to the requested character.
+ */
+typedef const char32_t *(*GDExtensionInterfaceStringOperatorIndexConst)(GDExtensionConstStringPtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name string_operator_plus_eq_string
+ *
+ * Appends another String to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to the other String to append.
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqString)(GDExtensionStringPtr p_self, GDExtensionConstStringPtr p_b);
+
+/**
+ * @name string_operator_plus_eq_char
+ *
+ * Appends a character to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to the character to append.
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqChar)(GDExtensionStringPtr p_self, char32_t p_b);
+
+/**
+ * @name string_operator_plus_eq_cstr
+ *
+ * Appends a Latin-1 encoded C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a Latin-1 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqCstr)(GDExtensionStringPtr p_self, const char *p_b);
+
+/**
+ * @name string_operator_plus_eq_wcstr
+ *
+ * Appends a wide C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a wide C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqWcstr)(GDExtensionStringPtr p_self, const wchar_t *p_b);
+
+/**
+ * @name string_operator_plus_eq_c32str
+ *
+ * Appends a UTF-32 encoded C string to a String.
+ *
+ * @param p_self A pointer to the String.
+ * @param p_b A pointer to a UTF-32 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionInterfaceStringOperatorPlusEqC32str)(GDExtensionStringPtr p_self, const char32_t *p_b);
+
+/* INTERFACE: XMLParser Utilities */
+
+/**
+ * @name xml_parser_open_buffer
+ *
+ * Opens a raw XML buffer on an XMLParser instance.
+ *
+ * @param p_instance A pointer to an XMLParser object.
+ * @param p_buffer A pointer to the buffer.
+ * @param p_size The size of the buffer.
+ *
+ * @return A Godot error code (ex. OK, ERR_INVALID_DATA, etc).
+ *
+ * @see XMLParser::open_buffer()
+ */
+typedef GDExtensionInt (*GDExtensionInterfaceXmlParserOpenBuffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size);
+
+/* INTERFACE: FileAccess Utilities */
+
+/**
+ * @name file_access_store_buffer
+ *
+ * Stores the given buffer using an instance of FileAccess.
+ *
+ * @param p_instance A pointer to a FileAccess object.
+ * @param p_src A pointer to the buffer.
+ * @param p_length The size of the buffer.
+ *
+ * @see FileAccess::store_buffer()
+ */
+typedef void (*GDExtensionInterfaceFileAccessStoreBuffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length);
+
+/**
+ * @name file_access_get_buffer
+ *
+ * Reads the next p_length bytes into the given buffer using an instance of FileAccess.
+ *
+ * @param p_instance A pointer to a FileAccess object.
+ * @param p_dst A pointer to the buffer to store the data.
+ * @param p_length The requested number of bytes to read.
+ *
+ * @return The actual number of bytes read (may be less than requested).
+ */
+typedef uint64_t (*GDExtensionInterfaceFileAccessGetBuffer)(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length);
+
+/* INTERFACE: WorkerThreadPool Utilities */
+
+/**
+ * @name worker_thread_pool_add_native_group_task
+ *
+ * Adds a group task to an instance of WorkerThreadPool.
+ *
+ * @param p_instance A pointer to a WorkerThreadPool object.
+ * @param p_func A pointer to a function to run in the thread pool.
+ * @param p_userdata A pointer to arbitrary data which will be passed to p_func.
+ * @param p_tasks The number of tasks needed in the group.
+ * @param p_high_priority Whether or not this is a high priority task.
+ * @param p_description A pointer to a String with the task description.
+ *
+ * @return The task group ID.
+ *
+ * @see WorkerThreadPool::add_group_task()
+ */
+typedef int64_t (*GDExtensionInterfaceWorkerThreadPoolAddNativeGroupTask)(GDExtensionObjectPtr p_instance, void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+
+/**
+ * @name worker_thread_pool_add_native_task
+ *
+ * Adds a task to an instance of WorkerThreadPool.
+ *
+ * @param p_instance A pointer to a WorkerThreadPool object.
+ * @param p_func A pointer to a function to run in the thread pool.
+ * @param p_userdata A pointer to arbitrary data which will be passed to p_func.
+ * @param p_high_priority Whether or not this is a high priority task.
+ * @param p_description A pointer to a String with the task description.
+ *
+ * @return The task ID.
+ */
+typedef int64_t (*GDExtensionInterfaceWorkerThreadPoolAddNativeTask)(GDExtensionObjectPtr p_instance, void (*p_func)(void *), void *p_userdata, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+
+/* INTERFACE: Packed Array */
+
+/**
+ * @name packed_byte_array_operator_index
+ *
+ * Gets a pointer to a byte in a PackedByteArray.
+ *
+ * @param p_self A pointer to a PackedByteArray object.
+ * @param p_index The index of the byte to get.
+ *
+ * @return A pointer to the requested byte.
+ */
+typedef uint8_t *(*GDExtensionInterfacePackedByteArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_byte_array_operator_index_const
+ *
+ * Gets a const pointer to a byte in a PackedByteArray.
+ *
+ * @param p_self A const pointer to a PackedByteArray object.
+ * @param p_index The index of the byte to get.
+ *
+ * @return A const pointer to the requested byte.
+ */
+typedef const uint8_t *(*GDExtensionInterfacePackedByteArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_color_array_operator_index
+ *
+ * Gets a pointer to a color in a PackedColorArray.
+ *
+ * @param p_self A pointer to a PackedColorArray object.
+ * @param p_index The index of the Color to get.
+ *
+ * @return A pointer to the requested Color.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedColorArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_color_array_operator_index_const
+ *
+ * Gets a const pointer to a color in a PackedColorArray.
+ *
+ * @param p_self A const pointer to a const PackedColorArray object.
+ * @param p_index The index of the Color to get.
+ *
+ * @return A const pointer to the requested Color.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedColorArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float32_array_operator_index
+ *
+ * Gets a pointer to a 32-bit float in a PackedFloat32Array.
+ *
+ * @param p_self A pointer to a PackedFloat32Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A pointer to the requested 32-bit float.
+ */
+typedef float *(*GDExtensionInterfacePackedFloat32ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float32_array_operator_index_const
+ *
+ * Gets a const pointer to a 32-bit float in a PackedFloat32Array.
+ *
+ * @param p_self A const pointer to a PackedFloat32Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A const pointer to the requested 32-bit float.
+ */
+typedef const float *(*GDExtensionInterfacePackedFloat32ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float64_array_operator_index
+ *
+ * Gets a pointer to a 64-bit float in a PackedFloat64Array.
+ *
+ * @param p_self A pointer to a PackedFloat64Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A pointer to the requested 64-bit float.
+ */
+typedef double *(*GDExtensionInterfacePackedFloat64ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_float64_array_operator_index_const
+ *
+ * Gets a const pointer to a 64-bit float in a PackedFloat64Array.
+ *
+ * @param p_self A const pointer to a PackedFloat64Array object.
+ * @param p_index The index of the float to get.
+ *
+ * @return A const pointer to the requested 64-bit float.
+ */
+typedef const double *(*GDExtensionInterfacePackedFloat64ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int32_array_operator_index
+ *
+ * Gets a pointer to a 32-bit integer in a PackedInt32Array.
+ *
+ * @param p_self A pointer to a PackedInt32Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A pointer to the requested 32-bit integer.
+ */
+typedef int32_t *(*GDExtensionInterfacePackedInt32ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int32_array_operator_index_const
+ *
+ * Gets a const pointer to a 32-bit integer in a PackedInt32Array.
+ *
+ * @param p_self A const pointer to a PackedInt32Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A const pointer to the requested 32-bit integer.
+ */
+typedef const int32_t *(*GDExtensionInterfacePackedInt32ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int64_array_operator_index
+ *
+ * Gets a pointer to a 64-bit integer in a PackedInt64Array.
+ *
+ * @param p_self A pointer to a PackedInt64Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A pointer to the requested 64-bit integer.
+ */
+typedef int64_t *(*GDExtensionInterfacePackedInt64ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_int64_array_operator_index_const
+ *
+ * Gets a const pointer to a 64-bit integer in a PackedInt64Array.
+ *
+ * @param p_self A const pointer to a PackedInt64Array object.
+ * @param p_index The index of the integer to get.
+ *
+ * @return A const pointer to the requested 64-bit integer.
+ */
+typedef const int64_t *(*GDExtensionInterfacePackedInt64ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_string_array_operator_index
+ *
+ * Gets a pointer to a string in a PackedStringArray.
+ *
+ * @param p_self A pointer to a PackedStringArray object.
+ * @param p_index The index of the String to get.
+ *
+ * @return A pointer to the requested String.
+ */
+typedef GDExtensionStringPtr (*GDExtensionInterfacePackedStringArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_string_array_operator_index_const
+ *
+ * Gets a const pointer to a string in a PackedStringArray.
+ *
+ * @param p_self A const pointer to a PackedStringArray object.
+ * @param p_index The index of the String to get.
+ *
+ * @return A const pointer to the requested String.
+ */
+typedef GDExtensionStringPtr (*GDExtensionInterfacePackedStringArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector2_array_operator_index
+ *
+ * Gets a pointer to a Vector2 in a PackedVector2Array.
+ *
+ * @param p_self A pointer to a PackedVector2Array object.
+ * @param p_index The index of the Vector2 to get.
+ *
+ * @return A pointer to the requested Vector2.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector2ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector2_array_operator_index_const
+ *
+ * Gets a const pointer to a Vector2 in a PackedVector2Array.
+ *
+ * @param p_self A const pointer to a PackedVector2Array object.
+ * @param p_index The index of the Vector2 to get.
+ *
+ * @return A const pointer to the requested Vector2.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector2ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector3_array_operator_index
+ *
+ * Gets a pointer to a Vector3 in a PackedVector3Array.
+ *
+ * @param p_self A pointer to a PackedVector3Array object.
+ * @param p_index The index of the Vector3 to get.
+ *
+ * @return A pointer to the requested Vector3.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector3ArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name packed_vector3_array_operator_index_const
+ *
+ * Gets a const pointer to a Vector3 in a PackedVector3Array.
+ *
+ * @param p_self A const pointer to a PackedVector3Array object.
+ * @param p_index The index of the Vector3 to get.
+ *
+ * @return A const pointer to the requested Vector3.
+ */
+typedef GDExtensionTypePtr (*GDExtensionInterfacePackedVector3ArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_operator_index
+ *
+ * Gets a pointer to a Variant in an Array.
+ *
+ * @param p_self A pointer to an Array object.
+ * @param p_index The index of the Variant to get.
+ *
+ * @return A pointer to the requested Variant.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceArrayOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_operator_index_const
+ *
+ * Gets a const pointer to a Variant in an Array.
+ *
+ * @param p_self A const pointer to an Array object.
+ * @param p_index The index of the Variant to get.
+ *
+ * @return A const pointer to the requested Variant.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceArrayOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index);
+
+/**
+ * @name array_ref
+ *
+ * Sets an Array to be a reference to another Array object.
+ *
+ * @param p_self A pointer to the Array object to update.
+ * @param p_from A pointer to the Array object to reference.
+ */
+typedef void (*GDExtensionInterfaceArrayRef)(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from);
+
+/**
+ * @name array_set_typed
+ *
+ * Makes an Array into a typed Array.
+ *
+ * @param p_self A pointer to the Array.
+ * @param p_type The type of Variant the Array will store.
+ * @param p_class_name A pointer to a StringName with the name of the object (if p_type is GDEXTENSION_VARIANT_TYPE_OBJECT).
+ * @param p_script A pointer to a Script object (if p_type is GDEXTENSION_VARIANT_TYPE_OBJECT and the base class is extended by a script).
+ */
+typedef void (*GDExtensionInterfaceArraySetTyped)(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script);
+
+/* INTERFACE: Dictionary */
+
+/**
+ * @name dictionary_operator_index
+ *
+ * Gets a pointer to a Variant in a Dictionary with the given key.
+ *
+ * @param p_self A pointer to a Dictionary object.
+ * @param p_key A pointer to a Variant representing the key.
+ *
+ * @return A pointer to a Variant representing the value at the given key.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceDictionaryOperatorIndex)(GDExtensionTypePtr p_self, GDExtensionConstVariantPtr p_key);
+
+/**
+ * @name dictionary_operator_index_const
+ *
+ * Gets a const pointer to a Variant in a Dictionary with the given key.
+ *
+ * @param p_self A const pointer to a Dictionary object.
+ * @param p_key A pointer to a Variant representing the key.
+ *
+ * @return A const pointer to a Variant representing the value at the given key.
+ */
+typedef GDExtensionVariantPtr (*GDExtensionInterfaceDictionaryOperatorIndexConst)(GDExtensionConstTypePtr p_self, GDExtensionConstVariantPtr p_key);
+
+/* INTERFACE: Object */
+
+/**
+ * @name object_method_bind_call
+ *
+ * Calls a method on an Object.
+ *
+ * @param p_method_bind A pointer to the MethodBind representing the method on the Object's class.
+ * @param p_instance A pointer to the Object.
+ * @param p_args A pointer to a C array of Variants representing the arguments.
+ * @param p_arg_count The number of arguments.
+ * @param r_ret A pointer to Variant which will receive the return value.
+ * @param r_error A pointer to a GDExtensionCallError struct that will receive error information.
+ */
+typedef void (*GDExtensionInterfaceObjectMethodBindCall)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_arg_count, GDExtensionUninitializedVariantPtr r_ret, GDExtensionCallError *r_error);
+
+/**
+ * @name object_method_bind_ptrcall
+ *
+ * Calls a method on an Object (using a "ptrcall").
+ *
+ * @param p_method_bind A pointer to the MethodBind representing the method on the Object's class.
+ * @param p_instance A pointer to the Object.
+ * @param p_args A pointer to a C array representing the arguments.
+ * @param r_ret A pointer to the Object that will receive the return value.
+ */
+typedef void (*GDExtensionInterfaceObjectMethodBindPtrcall)(GDExtensionMethodBindPtr p_method_bind, GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
+
+/**
+ * @name object_destroy
+ *
+ * Destroys an Object.
+ *
+ * @param p_o A pointer to the Object.
+ */
+typedef void (*GDExtensionInterfaceObjectDestroy)(GDExtensionObjectPtr p_o);
+
+/**
+ * @name global_get_singleton
+ *
+ * Gets a global singleton by name.
+ *
+ * @param p_name A pointer to a StringName with the singleton name.
+ *
+ * @return A pointer to the singleton Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceGlobalGetSingleton)(GDExtensionConstStringNamePtr p_name);
+
+/**
+ * @name object_get_instance_binding
+ *
+ * Gets a pointer representing an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_library A token the library received by the GDExtension's entry point function.
+ * @param p_callbacks A pointer to a GDExtensionInstanceBindingCallbacks struct.
+ *
+ * @return
+ */
+typedef void *(*GDExtensionInterfaceObjectGetInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+
+/**
+ * @name object_set_instance_binding
+ *
+ * Sets an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_library A token the library received by the GDExtension's entry point function.
+ * @param p_binding A pointer to the instance binding.
+ * @param p_callbacks A pointer to a GDExtensionInstanceBindingCallbacks struct.
+ */
+typedef void (*GDExtensionInterfaceObjectSetInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+
+/**
+ * @name object_set_instance
+ *
+ * Sets an extension class instance on a Object.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_classname A pointer to a StringName with the registered extension class's name.
+ * @param p_instance A pointer to the extension class instance.
+ */
+typedef void (*GDExtensionInterfaceObjectSetInstance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
+
+/**
+ * @name object_cast_to
+ *
+ * Casts an Object to a different type.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_class_tag A pointer uniquely identifying a built-in class in the ClassDB.
+ *
+ * @return Returns a pointer to the Object, or NULL if it can't be cast to the requested type.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceObjectCastTo)(GDExtensionConstObjectPtr p_object, void *p_class_tag);
+
+/**
+ * @name object_get_instance_from_id
+ *
+ * Gets an Object by its instance ID.
+ *
+ * @param p_instance_id The instance ID.
+ *
+ * @return A pointer to the Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceObjectGetInstanceFromId)(GDObjectInstanceID p_instance_id);
+
+/**
+ * @name object_get_instance_id
+ *
+ * Gets the instance ID from an Object.
+ *
+ * @param p_object A pointer to the Object.
+ *
+ * @return The instance ID.
+ */
+typedef GDObjectInstanceID (*GDExtensionInterfaceObjectGetInstanceId)(GDExtensionConstObjectPtr p_object);
+
+/* INTERFACE: Reference */
+
+/**
+ * @name ref_get_object
+ *
+ * Gets the Object from a reference.
+ *
+ * @param p_ref A pointer to the reference.
+ *
+ * @return A pointer to the Object from the reference or NULL.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceRefGetObject)(GDExtensionConstRefPtr p_ref);
+
+/**
+ * @name ref_set_object
+ *
+ * Sets the Object referred to by a reference.
+ *
+ * @param p_ref A pointer to the reference.
+ * @param p_object A pointer to the Object to refer to.
+ */
+typedef void (*GDExtensionInterfaceRefSetObject)(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object);
+
+/* INTERFACE: Script Instance */
+
+/**
+ * @name script_instance_create
+ *
+ * Creates a script instance that contains the given info and instance data.
+ *
+ * @param p_info A pointer to a GDExtensionScriptInstanceInfo struct.
+ * @param p_instance_data A pointer to a data representing the script instance in the GDExtension. This will be passed to all the function pointers on p_info.
+ *
+ * @return A pointer to a ScriptInstanceExtension object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfaceScriptInstanceCreate)(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
+
+/* INTERFACE: ClassDB */
+
+/**
+ * @name classdb_construct_object
+ *
+ * Constructs an Object of the requested class.
+ *
+ * The passed class must be a built-in godot class, or an already-registered extension class. In both cases, object_set_instance() should be called to fully initialize the object.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer to the newly created Object.
+ */
+typedef GDExtensionObjectPtr (*GDExtensionInterfaceClassdbConstructObject)(GDExtensionConstStringNamePtr p_classname);
+
+/**
+ * @name classdb_get_method_bind
+ *
+ * Gets a pointer to the MethodBind in ClassDB for the given class, method and hash.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ * @param p_methodname A pointer to a StringName with the method name.
+ * @param p_hash A hash representing the function signature.
+ *
+ * @return A pointer to the MethodBind from ClassDB.
+ */
+typedef GDExtensionMethodBindPtr (*GDExtensionInterfaceClassdbGetMethodBind)(GDExtensionConstStringNamePtr p_classname, GDExtensionConstStringNamePtr p_methodname, GDExtensionInt p_hash);
+
+/**
+ * @name classdb_get_class_tag
+ *
+ * Gets a pointer uniquely identifying the given built-in class in the ClassDB.
+ *
+ * @param p_classname A pointer to a StringName with the class name.
+ *
+ * @return A pointer uniquely identifying the built-in class in the ClassDB.
+ */
+typedef void *(*GDExtensionInterfaceClassdbGetClassTag)(GDExtensionConstStringNamePtr p_classname);
+
+/* INTERFACE: ClassDB Extension */
+
+/**
+ * @name classdb_register_extension_class
+ *
+ * Registers an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_parent_class_name A pointer to a StringName with the parent class name.
+ * @param p_extension_funcs A pointer to a GDExtensionClassCreationInfo struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClass)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_parent_class_name, const GDExtensionClassCreationInfo *p_extension_funcs);
+
+/**
+ * @name classdb_register_extension_class_method
+ *
+ * Registers a method on an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_method_info A pointer to a GDExtensionClassMethodInfo struct.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassMethod)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassMethodInfo *p_method_info);
+
+/**
+ * @name classdb_register_extension_class_integer_constant
+ *
+ * Registers an integer constant on an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_enum_name A pointer to a StringName with the enum name.
+ * @param p_constant_name A pointer to a StringName with the constant name.
+ * @param p_constant_value The constant value.
+ * @param p_is_bitfield Whether or not this is a bit field.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassIntegerConstant)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_enum_name, GDExtensionConstStringNamePtr p_constant_name, GDExtensionInt p_constant_value, GDExtensionBool p_is_bitfield);
+
+/**
+ * @name classdb_register_extension_class_property
+ *
+ * Registers a property on an extension class in the ClassDB.
+ *
+ * Provided struct can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_info A pointer to a GDExtensionPropertyInfo struct.
+ * @param p_setter A pointer to a StringName with the name of the setter method.
+ * @param p_getter A pointer to a StringName with the name of the getter method.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassProperty)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionPropertyInfo *p_info, GDExtensionConstStringNamePtr p_setter, GDExtensionConstStringNamePtr p_getter);
+
+/**
+ * @name classdb_register_extension_class_property_group
+ *
+ * Registers a property group on an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_group_name A pointer to a String with the group name.
+ * @param p_prefix A pointer to a String with the prefix used by properties in this group.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassPropertyGroup)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_group_name, GDExtensionConstStringPtr p_prefix);
+
+/**
+ * @name classdb_register_extension_class_property_subgroup
+ *
+ * Registers a property subgroup on an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_subgroup_name A pointer to a String with the subgroup name.
+ * @param p_prefix A pointer to a String with the prefix used by properties in this subgroup.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringPtr p_subgroup_name, GDExtensionConstStringPtr p_prefix);
+
+/**
+ * @name classdb_register_extension_class_signal
+ *
+ * Registers a signal on an extension class in the ClassDB.
+ *
+ * Provided structs can be safely freed once the function returns.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ * @param p_signal_name A pointer to a StringName with the signal name.
+ * @param p_argument_info A pointer to a GDExtensionPropertyInfo struct.
+ * @param p_argument_count The number of arguments the signal receives.
+ */
+typedef void (*GDExtensionInterfaceClassdbRegisterExtensionClassSignal)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstStringNamePtr p_signal_name, const GDExtensionPropertyInfo *p_argument_info, GDExtensionInt p_argument_count);
+
+/**
+ * @name classdb_unregister_extension_class
+ *
+ * Unregisters an extension class in the ClassDB.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param p_class_name A pointer to a StringName with the class name.
+ */
+typedef void (*GDExtensionInterfaceClassdbUnregisterExtensionClass)(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name); /* Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first. */
+
+/**
+ * @name get_library_path
+ *
+ * Gets the path to the current GDExtension library.
+ *
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param r_path A pointer to a String which will receive the path.
+ */
+typedef void (*GDExtensionInterfaceGetLibraryPath)(GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringPtr r_path);
 
 #ifdef __cplusplus
 }

--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -32,6 +32,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="entry_symbol" type="String" />
+			<param index="2" name="use_legacy_interface" type="bool" />
 			<description>
 			</description>
 		</method>


### PR DESCRIPTION
At the GDExtension meeting on 2023-04-14, we were discussing (among other things) how to allow us to add new methods to the `GDExtensionInterface` struct without breaking the ABI. (There is at least one GDExtension bug that requires a new method to be added in order to fix it.)

We discussed a few possibilities, including just adding new pointers to the end of the struct, or adding a `void *next` pointer to the end of the struct (so that could point to a new struct with new methods, similar to how we did it in GDNative).

@vnen had the idea of having a "low-level ClassDB" where we could register these functions, rather than putting them in a big struct. And @BastiaanOlij brought up how many APIs (like OpenGL, OpenXR and Vulkan) do exactly that, where you're given a `void *GetProcAddress(const char *p_name)` function and then load each of the function pointers individually.

So, this PR is attempting to implement that!

Here's an overview:

- The `GDExtensionInterface` struct no longer exists in `gdextension_interface.h`, and is replaced by a bunch of function pointer `typedef`s, and the initialization function in each GDExtension is now passed a `GDExtensionInterfaceGetProcAddress` function pointer instead
- In the XXX.gdextension file, you can set a `compatibility_minimum` property (came from a discussion on RocketChat with @mhilbrunner in the gdextension channel) to denote the minimum Godot version that a given GDExtension needs
- Any GDExtension without `comptability_minimum` or where it's set to `4.0` will still get passed the "legacy" structure, so GDExtensions made for Godot 4.0 should still work with Godot 4.1+, but extensions made for Godot 4.1+ won't work with Godot 4.0 _(Its on the agenda for the next GDExtension meeting to discuss if this sort of forward-but-not-backward compatibility is OK)_
- The companion PR for godot-cpp (https://github.com/godotengine/godot-cpp/pull/1095) also does some work to ensure that a newer GDExtension that uses this new interface won't be loaded by Godot 4.0, with a nice message rather than a crash

~~This is currently a draft for discussion! If the overall approach looks good, there's a bunch of little bits of clean-up I'd like to do (in addition to whatever comes up in review)~~

UPDATE: No longer a draft!