### PR TITLE
Create an "Editor-only" section in the online class reference

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Documentation checks
         run: |
-          doc/tools/make_rst.py --dry-run --color doc/classes modules platforms
+          doc/tools/make_rst.py --dry-run --color doc/classes modules platform
 
       - name: Style checks via clang-format (clang_format.sh)
         run: |

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -33,6 +33,7 @@ BASE_STRINGS = [
     "Globals",
     "Nodes",
     "Resources",
+    "Editor-only",
     "Other objects",
     "Variant types",
     "Description",
@@ -74,13 +75,23 @@ CLASS_GROUPS: Dict[str, str] = {
     "node": "Nodes",
     "resource": "Resources",
     "object": "Other objects",
+    "editor": "Editor-only",
     "variant": "Variant types",
 }
 CLASS_GROUPS_BASE: Dict[str, str] = {
     "node": "Node",
     "resource": "Resource",
     "object": "Object",
+    "variant": "Variant",
 }
+# Sync with editor\register_editor_types.cpp
+EDITOR_CLASSES: List[str] = [
+    "AnimationTrackEditPlugin",
+    "FileSystemDock",
+    "ScriptCreateDialog",
+    "ScriptEditor",
+    "ScriptEditorBase",
+]
 
 
 class State:
@@ -635,6 +646,11 @@ def main() -> None:
             grouped_classes[group_name] = []
         grouped_classes[group_name].append(class_name)
 
+        if is_editor_class(class_def):
+            if "editor" not in grouped_classes:
+                grouped_classes["editor"] = []
+            grouped_classes["editor"].append(class_name)
+
     print("")
     print("Generating the index file...")
 
@@ -722,6 +738,17 @@ def get_class_group(class_def: ClassDef, state: State) -> str:
                 break
 
     return group_name
+
+
+def is_editor_class(class_def: ClassDef) -> bool:
+    class_name = class_def.name
+
+    if class_name.startswith("Editor"):
+        return True
+    if class_name in EDITOR_CLASSES:
+        return True
+
+    return False
 
 
 # Generator methods.
@@ -1472,6 +1499,9 @@ def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_
                 f.write(f"    class_{CLASS_GROUPS_BASE[group_name].lower()}\n")
 
             for class_name in grouped_classes[group_name]:
+                if group_name in CLASS_GROUPS_BASE and CLASS_GROUPS_BASE[group_name].lower() == class_name.lower():
+                    continue
+
                 f.write(f"    class_{class_name.lower()}\n")
 
             f.write("\n")

--- a/misc/hooks/pre-commit-make-rst
+++ b/misc/hooks/pre-commit-make-rst
@@ -9,4 +9,4 @@ if [[ "$py_ver" != "3" ]]; then
   PYTHON+=3
 fi
 
-$PYTHON doc/tools/make_rst.py doc/classes modules --dry-run --color
+$PYTHON doc/tools/make_rst.py doc/classes modules platform --dry-run --color


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/76251.

Adding a dedicated section helps to find editor-specific classes without digging through the rest of the class reference. Still, the new group is only added for convenience and the same classes can still be found in your normal "Node" and "Resources" groups.

This also fixes a typo and a missed case from https://github.com/godotengine/godot/pull/76251.

-----

I also added support for new folders to the docs repo, though I also originally made the same typo, so it's two commits: https://github.com/godotengine/godot-docs/commit/6d289e52532a5679b6874447253152edc79674b0 and https://github.com/godotengine/godot-docs/commit/67400139a28338188cd1453318c26d3285d1200a. 🙃 

-----

The main part of this PR can be backported to 3.x (but not 3.5, as the base PR synching changes to `make_rst` hasn't been cherry-picked yet). The list of editor-specific classes, that don't start with "Editor" may need adjustments.