### PR TITLE
GDScript: Reorganize and unify warnings

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1545,7 +1545,11 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		resolve_parameter(p_function->parameters[i]);
 #ifdef DEBUG_ENABLED
 		if (p_function->parameters[i]->usages == 0 && !String(p_function->parameters[i]->identifier->name).begins_with("_")) {
-			parser->push_warning(p_function->parameters[i]->identifier, GDScriptWarning::UNUSED_PARAMETER, function_name, p_function->parameters[i]->identifier->name);
+			String visible_name = function_name;
+			if (function_name == StringName()) {
+				visible_name = p_is_lambda ? "<anonymous lambda>" : "<unknown function>";
+			}
+			parser->push_warning(p_function->parameters[i]->identifier, GDScriptWarning::UNUSED_PARAMETER, visible_name, p_function->parameters[i]->identifier->name);
 		}
 		is_shadowing(p_function->parameters[i]->identifier, "function parameter");
 #endif // DEBUG_ENABLED
@@ -3173,7 +3177,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			String base_name = is_self && !p_call->is_super ? "self" : base_type.to_string();
 #ifdef SUGGEST_GODOT4_RENAMES
 			String rename_hint = String();
-			if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GD4_HINT)).booleanize()) {
+			if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GODOT_4_HINT)).booleanize()) {
 				const char *renamed_function_name = check_for_renamed_identifier(p_call->function_name, p_call->type);
 				if (renamed_function_name) {
 					rename_hint = " " + vformat(R"(Did you mean to use "%s"?)", String(renamed_function_name) + "()");
@@ -3374,7 +3378,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 			} else if (base.is_hard_type()) {
 #ifdef SUGGEST_GODOT4_RENAMES
 				String rename_hint = String();
-				if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GD4_HINT)).booleanize()) {
+				if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GODOT_4_HINT)).booleanize()) {
 					const char *renamed_identifier_name = check_for_renamed_identifier(name, p_identifier->type);
 					if (renamed_identifier_name) {
 						rename_hint = " " + vformat(R"(Did you mean to use "%s"?)", renamed_identifier_name);
@@ -3414,7 +3418,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					if (base.is_hard_type()) {
 #ifdef SUGGEST_GODOT4_RENAMES
 						String rename_hint = String();
-						if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GD4_HINT)).booleanize()) {
+						if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GODOT_4_HINT)).booleanize()) {
 							const char *renamed_identifier_name = check_for_renamed_identifier(name, p_identifier->type);
 							if (renamed_identifier_name) {
 								rename_hint = " " + vformat(R"(Did you mean to use "%s"?)", renamed_identifier_name);
@@ -3803,7 +3807,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	} else {
 #ifdef SUGGEST_GODOT4_RENAMES
 		String rename_hint = String();
-		if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GD4_HINT)).booleanize()) {
+		if (GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(GDScriptWarning::Code::RENAMED_IN_GODOT_4_HINT)).booleanize()) {
 			const char *renamed_identifier_name = check_for_renamed_identifier(name, p_identifier->type);
 			if (renamed_identifier_name) {
 				rename_hint = " " + vformat(R"(Did you mean to use "%s"?)", renamed_identifier_name);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -38,156 +38,115 @@ String GDScriptWarning::get_message() const {
 #define CHECK_SYMBOLS(m_amount) ERR_FAIL_COND_V(symbols.size() < m_amount, String());
 
 	switch (code) {
-		case UNASSIGNED_VARIABLE_OP_ASSIGN: {
+		case UNASSIGNED_VARIABLE:
 			CHECK_SYMBOLS(1);
-			return "Using assignment with operation but the variable '" + symbols[0] + "' was not previously assigned a value.";
-		} break;
-		case UNASSIGNED_VARIABLE: {
+			return vformat(R"(The variable "%s" was used but never assigned a value.)", symbols[0]);
+		case UNASSIGNED_VARIABLE_OP_ASSIGN:
 			CHECK_SYMBOLS(1);
-			return "The variable '" + symbols[0] + "' was used but never assigned a value.";
-		} break;
-		case UNUSED_VARIABLE: {
+			return vformat(R"(Using assignment with operation but the variable "%s" was not previously assigned a value.)", symbols[0]);
+		case UNUSED_VARIABLE:
 			CHECK_SYMBOLS(1);
-			return "The local variable '" + symbols[0] + "' is declared but never used in the block. If this is intended, prefix it with an underscore: '_" + symbols[0] + "'";
-		} break;
-		case UNUSED_LOCAL_CONSTANT: {
+			return vformat(R"(The local variable "%s" is declared but never used in the block. If this is intended, prefix it with an underscore: "_%s".)", symbols[0], symbols[0]);
+		case UNUSED_LOCAL_CONSTANT:
 			CHECK_SYMBOLS(1);
-			return "The local constant '" + symbols[0] + "' is declared but never used in the block. If this is intended, prefix it with an underscore: '_" + symbols[0] + "'";
-		} break;
-		case SHADOWED_VARIABLE: {
+			return vformat(R"(The local constant "%s" is declared but never used in the block. If this is intended, prefix it with an underscore: "_%s".)", symbols[0], symbols[0]);
+		case UNUSED_PRIVATE_CLASS_VARIABLE:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The class variable "%s" is declared but never used in the script.)", symbols[0]);
+		case UNUSED_PARAMETER:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The parameter "%s" is never used in the function "%s()". If this is intended, prefix it with an underscore: "_%s".)*", symbols[1], symbols[0], symbols[1]);
+		case UNUSED_SIGNAL:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The signal "%s" is declared but never emitted.)", symbols[0]);
+		case SHADOWED_VARIABLE:
 			CHECK_SYMBOLS(4);
 			return vformat(R"(The local %s "%s" is shadowing an already-declared %s at line %s.)", symbols[0], symbols[1], symbols[2], symbols[3]);
-		} break;
-		case SHADOWED_VARIABLE_BASE_CLASS: {
+		case SHADOWED_VARIABLE_BASE_CLASS:
 			CHECK_SYMBOLS(4);
 			return vformat(R"(The local %s "%s" is shadowing an already-declared %s at the base class "%s".)", symbols[0], symbols[1], symbols[2], symbols[3]);
-		} break;
-		case UNUSED_PRIVATE_CLASS_VARIABLE: {
-			CHECK_SYMBOLS(1);
-			return "The class variable '" + symbols[0] + "' is declared but never used in the script.";
-		} break;
-		case UNUSED_PARAMETER: {
-			CHECK_SYMBOLS(2);
-			return "The parameter '" + symbols[1] + "' is never used in the function '" + symbols[0] + "'. If this is intended, prefix it with an underscore: '_" + symbols[1] + "'";
-		} break;
-		case UNREACHABLE_CODE: {
-			CHECK_SYMBOLS(1);
-			return "Unreachable code (statement after return) in function '" + symbols[0] + "()'.";
-		} break;
-		case UNREACHABLE_PATTERN: {
-			return "Unreachable pattern (pattern after wildcard or bind).";
-		} break;
-		case STANDALONE_EXPRESSION: {
-			return "Standalone expression (the line has no effect).";
-		} break;
-		case NARROWING_CONVERSION: {
-			return "Narrowing conversion (float is converted to int and loses precision).";
-		} break;
-		case INCOMPATIBLE_TERNARY: {
-			return "Values of the ternary conditional are not mutually compatible.";
-		} break;
-		case UNUSED_SIGNAL: {
-			CHECK_SYMBOLS(1);
-			return "The signal '" + symbols[0] + "' is declared but never emitted.";
-		} break;
-		case RETURN_VALUE_DISCARDED: {
-			CHECK_SYMBOLS(1);
-			return "The function '" + symbols[0] + "()' returns a value that will be discarded if not used.";
-		} break;
-		case PROPERTY_USED_AS_FUNCTION: {
-			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a property with the same name. Did you mean to access it?";
-		} break;
-		case CONSTANT_USED_AS_FUNCTION: {
-			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "()' was not found in base '" + symbols[1] + "' but there's a constant with the same name. Did you mean to access it?";
-		} break;
-		case FUNCTION_USED_AS_PROPERTY: {
-			CHECK_SYMBOLS(2);
-			return "The property '" + symbols[0] + "' was not found in base '" + symbols[1] + "' but there's a method with the same name. Did you mean to call it?";
-		} break;
-		case INTEGER_DIVISION: {
-			return "Integer division, decimal part will be discarded.";
-		} break;
-		case UNSAFE_PROPERTY_ACCESS: {
-			CHECK_SYMBOLS(2);
-			return "The property '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
-		} break;
-		case UNSAFE_METHOD_ACCESS: {
-			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "' is not present on the inferred type '" + symbols[1] + "' (but may be present on a subtype).";
-		} break;
-		case UNSAFE_CAST: {
-			CHECK_SYMBOLS(1);
-			return "The value is cast to '" + symbols[0] + "' but has an unknown type.";
-		} break;
-		case UNSAFE_CALL_ARGUMENT: {
-			CHECK_SYMBOLS(4);
-			return "The argument '" + symbols[0] + "' of the function '" + symbols[1] + "' requires a the subtype '" + symbols[2] + "' but the supertype '" + symbols[3] + "' was provided";
-		} break;
-		case UNSAFE_VOID_RETURN: {
-			CHECK_SYMBOLS(2);
-			return "The method '" + symbols[0] + "()' returns 'void' but it's trying to return a call to '" + symbols[1] + "()' that can't be ensured to also be 'void'.";
-		} break;
-		case DEPRECATED_KEYWORD: {
-			CHECK_SYMBOLS(2);
-			return "The '" + symbols[0] + "' keyword is deprecated and will be removed in a future release, please replace its uses by '" + symbols[1] + "'.";
-		} break;
-		case STANDALONE_TERNARY: {
-			return "Standalone ternary conditional operator: the return value is being discarded.";
-		}
-		case ASSERT_ALWAYS_TRUE: {
-			return "Assert statement is redundant because the expression is always true.";
-		}
-		case ASSERT_ALWAYS_FALSE: {
-			return "Assert statement will raise an error because the expression is always false.";
-		}
-		case REDUNDANT_AWAIT: {
-			return R"("await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.)";
-		}
-		case EMPTY_FILE: {
-			return "Empty script file.";
-		}
-		case SHADOWED_GLOBAL_IDENTIFIER: {
+		case SHADOWED_GLOBAL_IDENTIFIER:
 			CHECK_SYMBOLS(3);
-			return vformat(R"(The %s '%s' has the same name as a %s.)", symbols[0], symbols[1], symbols[2]);
-		}
-		case INT_AS_ENUM_WITHOUT_CAST: {
+			return vformat(R"(The %s "%s" has the same name as a %s.)", symbols[0], symbols[1], symbols[2]);
+		case UNREACHABLE_CODE:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(Unreachable code (statement after return) in function "%s()".)*", symbols[0]);
+		case UNREACHABLE_PATTERN:
+			return "Unreachable pattern (pattern after wildcard or bind).";
+		case STANDALONE_EXPRESSION:
+			return "Standalone expression (the line has no effect).";
+		case STANDALONE_TERNARY:
+			return "Standalone ternary conditional operator: the return value is being discarded.";
+		case INCOMPATIBLE_TERNARY:
+			return "Values of the ternary conditional are not mutually compatible.";
+		case PROPERTY_USED_AS_FUNCTION:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The method "%s()" was not found in base "%s" but there's a property with the same name. Did you mean to access it?)*", symbols[0], symbols[1]);
+		case CONSTANT_USED_AS_FUNCTION:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The method "%s()" was not found in base "%s" but there's a constant with the same name. Did you mean to access it?)*", symbols[0], symbols[1]);
+		case FUNCTION_USED_AS_PROPERTY:
+			CHECK_SYMBOLS(2);
+			return vformat(R"(The property "%s" was not found in base "%s" but there's a method with the same name. Did you mean to call it?)", symbols[0], symbols[1]);
+		case UNSAFE_PROPERTY_ACCESS:
+			CHECK_SYMBOLS(2);
+			return vformat(R"(The property "%s" is not present on the inferred type "%s" (but may be present on a subtype).)", symbols[0], symbols[1]);
+		case UNSAFE_METHOD_ACCESS:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The method "%s()" is not present on the inferred type "%s" (but may be present on a subtype).)*", symbols[0], symbols[1]);
+		case UNSAFE_CAST:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(The value is cast to "%s" but has an unknown type.)", symbols[0]);
+		case UNSAFE_CALL_ARGUMENT:
+			CHECK_SYMBOLS(4);
+			return vformat(R"*(The argument %s of the function "%s()" requires a the subtype "%s" but the supertype "%s" was provided.)*", symbols[0], symbols[1], symbols[2], symbols[3]);
+		case UNSAFE_VOID_RETURN:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The method "%s()" returns "void" but it's trying to return a call to "%s()" that can't be ensured to also be "void".)*", symbols[0], symbols[1]);
+		case RETURN_VALUE_DISCARDED:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(The function "%s()" returns a value that will be discarded if not used.)*", symbols[0]);
+		case STATIC_CALLED_ON_INSTANCE:
+			CHECK_SYMBOLS(2);
+			return vformat(R"*(The function "%s()" is a static function but was called from an instance. Instead, it should be directly called from the type: "%s.%s()".)*", symbols[0], symbols[1], symbols[0]);
+		case REDUNDANT_STATIC_UNLOAD:
+			return R"(The "@static_unload" annotation is redundant because the file does not have a class with static variables.)";
+		case REDUNDANT_AWAIT:
+			return R"("await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.)";
+		case ASSERT_ALWAYS_TRUE:
+			return "Assert statement is redundant because the expression is always true.";
+		case ASSERT_ALWAYS_FALSE:
+			return "Assert statement will raise an error because the expression is always false.";
+		case INTEGER_DIVISION:
+			return "Integer division, decimal part will be discarded.";
+		case NARROWING_CONVERSION:
+			return "Narrowing conversion (float is converted to int and loses precision).";
+		case INT_AS_ENUM_WITHOUT_CAST:
 			return "Integer used when an enum value is expected. If this is intended cast the integer to the enum type.";
-		}
-		case INT_AS_ENUM_WITHOUT_MATCH: {
+		case INT_AS_ENUM_WITHOUT_MATCH:
 			CHECK_SYMBOLS(3);
 			return vformat(R"(Cannot %s %s as Enum "%s": no enum member has matching value.)", symbols[0], symbols[1], symbols[2]);
-		} break;
-		case STATIC_CALLED_ON_INSTANCE: {
+		case EMPTY_FILE:
+			return "Empty script file.";
+		case DEPRECATED_KEYWORD:
 			CHECK_SYMBOLS(2);
-			return vformat(R"(The function '%s()' is a static function but was called from an instance. Instead, it should be directly called from the type: '%s.%s()'.)", symbols[0], symbols[1], symbols[0]);
-		}
-		case CONFUSABLE_IDENTIFIER: {
+			return vformat(R"(The "%s" keyword is deprecated and will be removed in a future release, please replace its uses by "%s".)", symbols[0], symbols[1]);
+		case RENAMED_IN_GODOT_4_HINT:
+			break; // Renamed identifier hint is taken care of by the GDScriptAnalyzer. No message needed here.
+		case CONFUSABLE_IDENTIFIER:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The identifier "%s" has misleading characters and might be confused with something else.)", symbols[0]);
-		}
-		case RENAMED_IN_GD4_HINT: {
-			break; // Renamed identifier hint is taken care of by the GDScriptAnalyzer. No message needed here.
-		}
-		case INFERENCE_ON_VARIANT: {
+		case INFERENCE_ON_VARIANT:
 			CHECK_SYMBOLS(1);
 			return vformat("The %s type is being inferred from a Variant value, so it will be typed as Variant.", symbols[0]);
-		}
-		case NATIVE_METHOD_OVERRIDE: {
+		case NATIVE_METHOD_OVERRIDE:
 			CHECK_SYMBOLS(2);
-			return vformat(R"(The method "%s" overrides a method from native class "%s". This won't be called by the engine and may not work as expected.)", symbols[0], symbols[1]);
-		}
-		case GET_NODE_DEFAULT_WITHOUT_ONREADY: {
+			return vformat(R"*(The method "%s()" overrides a method from native class "%s". This won't be called by the engine and may not work as expected.)*", symbols[0], symbols[1]);
+		case GET_NODE_DEFAULT_WITHOUT_ONREADY:
 			CHECK_SYMBOLS(1);
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
-		}
-		case ONREADY_WITH_EXPORT: {
+		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
-		}
-		case REDUNDANT_STATIC_UNLOAD: {
-			return R"(The "@static_unload" annotation is redundant because the file does not have a class with static variables.)";
-		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -203,7 +162,7 @@ int GDScriptWarning::get_default_value(Code p_code) {
 
 PropertyInfo GDScriptWarning::get_property_info(Code p_code) {
 	// Making this a separate function in case a warning needs different PropertyInfo in the future.
-	if (p_code == Code::RENAMED_IN_GD4_HINT) {
+	if (p_code == Code::RENAMED_IN_GODOT_4_HINT) {
 		return PropertyInfo(Variant::BOOL, get_settings_path_from_code(p_code));
 	}
 	return PropertyInfo(Variant::INT, get_settings_path_from_code(p_code), PROPERTY_HINT_ENUM, "Ignore,Warn,Error");
@@ -221,43 +180,43 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"UNASSIGNED_VARIABLE_OP_ASSIGN",
 		"UNUSED_VARIABLE",
 		"UNUSED_LOCAL_CONSTANT",
-		"SHADOWED_VARIABLE",
-		"SHADOWED_VARIABLE_BASE_CLASS",
 		"UNUSED_PRIVATE_CLASS_VARIABLE",
 		"UNUSED_PARAMETER",
+		"UNUSED_SIGNAL",
+		"SHADOWED_VARIABLE",
+		"SHADOWED_VARIABLE_BASE_CLASS",
+		"SHADOWED_GLOBAL_IDENTIFIER",
 		"UNREACHABLE_CODE",
 		"UNREACHABLE_PATTERN",
 		"STANDALONE_EXPRESSION",
-		"NARROWING_CONVERSION",
+		"STANDALONE_TERNARY",
 		"INCOMPATIBLE_TERNARY",
-		"UNUSED_SIGNAL",
-		"RETURN_VALUE_DISCARDED",
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",
 		"FUNCTION_USED_AS_PROPERTY",
-		"INTEGER_DIVISION",
 		"UNSAFE_PROPERTY_ACCESS",
 		"UNSAFE_METHOD_ACCESS",
 		"UNSAFE_CAST",
 		"UNSAFE_CALL_ARGUMENT",
 		"UNSAFE_VOID_RETURN",
-		"DEPRECATED_KEYWORD",
-		"STANDALONE_TERNARY",
+		"RETURN_VALUE_DISCARDED",
+		"STATIC_CALLED_ON_INSTANCE",
+		"REDUNDANT_STATIC_UNLOAD",
+		"REDUNDANT_AWAIT",
 		"ASSERT_ALWAYS_TRUE",
 		"ASSERT_ALWAYS_FALSE",
-		"REDUNDANT_AWAIT",
-		"EMPTY_FILE",
-		"SHADOWED_GLOBAL_IDENTIFIER",
+		"INTEGER_DIVISION",
+		"NARROWING_CONVERSION",
 		"INT_AS_ENUM_WITHOUT_CAST",
 		"INT_AS_ENUM_WITHOUT_MATCH",
-		"STATIC_CALLED_ON_INSTANCE",
-		"CONFUSABLE_IDENTIFIER",
+		"EMPTY_FILE",
+		"DEPRECATED_KEYWORD",
 		"RENAMED_IN_GODOT_4_HINT",
+		"CONFUSABLE_IDENTIFIER",
 		"INFERENCE_ON_VARIANT",
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
-		"REDUNDANT_STATIC_UNLOAD",
 	};
 
 	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -50,43 +50,43 @@ public:
 		UNASSIGNED_VARIABLE_OP_ASSIGN, // Variable never assigned but used in an assignment operation (+=, *=, etc).
 		UNUSED_VARIABLE, // Local variable is declared but never used.
 		UNUSED_LOCAL_CONSTANT, // Local constant is declared but never used.
-		SHADOWED_VARIABLE, // Variable name shadowed by other variable in same class.
-		SHADOWED_VARIABLE_BASE_CLASS, // Variable name shadowed by other variable in some base class.
 		UNUSED_PRIVATE_CLASS_VARIABLE, // Class variable is declared private ("_" prefix) but never used in the file.
 		UNUSED_PARAMETER, // Function parameter is never used.
+		UNUSED_SIGNAL, // Signal is defined but never emitted.
+		SHADOWED_VARIABLE, // Variable name shadowed by other variable in same class.
+		SHADOWED_VARIABLE_BASE_CLASS, // Variable name shadowed by other variable in some base class.
+		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
 		UNREACHABLE_CODE, // Code after a return statement.
 		UNREACHABLE_PATTERN, // Pattern in a match statement after a catch all pattern (wildcard or bind).
 		STANDALONE_EXPRESSION, // Expression not assigned to a variable.
-		NARROWING_CONVERSION, // Float value into an integer slot, precision is lost.
+		STANDALONE_TERNARY, // Return value of ternary expression is discarded.
 		INCOMPATIBLE_TERNARY, // Possible values of a ternary if are not mutually compatible.
-		UNUSED_SIGNAL, // Signal is defined but never emitted.
-		RETURN_VALUE_DISCARDED, // Function call returns something but the value isn't used.
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
 		FUNCTION_USED_AS_PROPERTY, // Property not found, but there's a function with the same name.
-		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
 		UNSAFE_PROPERTY_ACCESS, // Property not found in the detected type (but can be in subtypes).
 		UNSAFE_METHOD_ACCESS, // Function not found in the detected type (but can be in subtypes).
 		UNSAFE_CAST, // Cast used in an unknown type.
-		UNSAFE_CALL_ARGUMENT, // Function call argument is of a supertype of the require argument.
+		UNSAFE_CALL_ARGUMENT, // Function call argument is of a supertype of the required type.
 		UNSAFE_VOID_RETURN, // Function returns void but returned a call to a function that can't be type checked.
-		DEPRECATED_KEYWORD, // The keyword is deprecated and should be replaced.
-		STANDALONE_TERNARY, // Return value of ternary expression is discarded.
+		RETURN_VALUE_DISCARDED, // Function call returns something but the value isn't used.
+		STATIC_CALLED_ON_INSTANCE, // A static method was called on an instance of a class instead of on the class itself.
+		REDUNDANT_STATIC_UNLOAD, // The `@static_unload` annotation is used but the class does not have static data.
+		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
 		ASSERT_ALWAYS_TRUE, // Expression for assert argument is always true.
 		ASSERT_ALWAYS_FALSE, // Expression for assert argument is always false.
-		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
-		EMPTY_FILE, // A script file is empty.
-		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
+		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
+		NARROWING_CONVERSION, // Float value into an integer slot, precision is lost.
 		INT_AS_ENUM_WITHOUT_CAST, // An integer value was used as an enum value without casting.
 		INT_AS_ENUM_WITHOUT_MATCH, // An integer value was used as an enum value without matching enum member.
-		STATIC_CALLED_ON_INSTANCE, // A static method was called on an instance of a class instead of on the class itself.
+		EMPTY_FILE, // A script file is empty.
+		DEPRECATED_KEYWORD, // The keyword is deprecated and should be replaced.
+		RENAMED_IN_GODOT_4_HINT, // A variable or function that could not be found has been renamed in Godot 4.
 		CONFUSABLE_IDENTIFIER, // The identifier contains misleading characters that can be confused. E.g. "usеr" (has Cyrillic "е" instead of Latin "e").
-		RENAMED_IN_GD4_HINT, // A variable or function that could not be found has been renamed in Godot 4
 		INFERENCE_ON_VARIANT, // The declaration uses type inference but the value is typed as Variant.
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
-		REDUNDANT_STATIC_UNLOAD, // The `@static_unload` annotation is used but the class does not have static data.
 		WARNING_MAX,
 	};
 
@@ -95,43 +95,43 @@ public:
 		WARN, // UNASSIGNED_VARIABLE_OP_ASSIGN
 		WARN, // UNUSED_VARIABLE
 		WARN, // UNUSED_LOCAL_CONSTANT
-		WARN, // SHADOWED_VARIABLE
-		WARN, // SHADOWED_VARIABLE_BASE_CLASS
 		WARN, // UNUSED_PRIVATE_CLASS_VARIABLE
 		WARN, // UNUSED_PARAMETER
+		WARN, // UNUSED_SIGNAL
+		WARN, // SHADOWED_VARIABLE
+		WARN, // SHADOWED_VARIABLE_BASE_CLASS
+		WARN, // SHADOWED_GLOBAL_IDENTIFIER
 		WARN, // UNREACHABLE_CODE
 		WARN, // UNREACHABLE_PATTERN
 		WARN, // STANDALONE_EXPRESSION
-		WARN, // NARROWING_CONVERSION
+		WARN, // STANDALONE_TERNARY
 		WARN, // INCOMPATIBLE_TERNARY
-		WARN, // UNUSED_SIGNAL
-		IGNORE, // RETURN_VALUE_DISCARDED // Too spammy by default on common cases (connect, Tween, etc.).
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION
 		WARN, // FUNCTION_USED_AS_PROPERTY
-		WARN, // INTEGER_DIVISION
 		IGNORE, // UNSAFE_PROPERTY_ACCESS // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_METHOD_ACCESS // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_CAST // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_CALL_ARGUMENT // Too common in untyped scenarios.
 		WARN, // UNSAFE_VOID_RETURN
-		WARN, // DEPRECATED_KEYWORD
-		WARN, // STANDALONE_TERNARY
+		IGNORE, // RETURN_VALUE_DISCARDED // Too spammy by default on common cases (connect, Tween, etc.).
+		WARN, // STATIC_CALLED_ON_INSTANCE
+		WARN, // REDUNDANT_STATIC_UNLOAD
+		WARN, // REDUNDANT_AWAIT
 		WARN, // ASSERT_ALWAYS_TRUE
 		WARN, // ASSERT_ALWAYS_FALSE
-		WARN, // REDUNDANT_AWAIT
-		WARN, // EMPTY_FILE
-		WARN, // SHADOWED_GLOBAL_IDENTIFIER
+		WARN, // INTEGER_DIVISION
+		WARN, // NARROWING_CONVERSION
 		WARN, // INT_AS_ENUM_WITHOUT_CAST
 		WARN, // INT_AS_ENUM_WITHOUT_MATCH
-		WARN, // STATIC_CALLED_ON_INSTANCE
+		WARN, // EMPTY_FILE
+		WARN, // DEPRECATED_KEYWORD
+		WARN, // RENAMED_IN_GODOT_4_HINT
 		WARN, // CONFUSABLE_IDENTIFIER
-		WARN, // RENAMED_IN_GD4_HINT
 		ERROR, // INFERENCE_ON_VARIANT // Most likely done by accident, usually inference is trying for a particular type.
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
-		WARN, // REDUNDANT_STATIC_UNLOAD
 	};
 
 	static_assert((sizeof(default_warning_levels) / sizeof(default_warning_levels[0])) == WARNING_MAX, "Amount of default levels does not match the amount of warnings.");

--- a/modules/gdscript/tests/scripts/analyzer/features/allow_void_function_to_return_void.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/allow_void_function_to_return_void.out
@@ -2,7 +2,7 @@ GDTEST_OK
 >> WARNING
 >> Line: 20
 >> UNSAFE_VOID_RETURN
->> The method 'return_side_effect()' returns 'void' but it's trying to return a call to 'side_effect()' that can't be ensured to also be 'void'.
+>> The method "return_side_effect()" returns "void" but it's trying to return a call to "side_effect()" that can't be ensured to also be "void".
 hello
 effect
 effect

--- a/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/auto_inferred_type_dont_error.out
@@ -2,5 +2,5 @@ GDTEST_OK
 >> WARNING
 >> Line: 6
 >> UNSAFE_METHOD_ACCESS
->> The method 'free' is not present on the inferred type 'Variant' (but may be present on a subtype).
+>> The method "free()" is not present on the inferred type "Variant" (but may be present on a subtype).
 Ok

--- a/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/lambda_unused_arg.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_PARAMETER
->> The parameter 'unused' is never used in the function ''. If this is intended, prefix it with an underscore: '_unused'
+>> The parameter "unused" is never used in the function "<anonymous lambda>()". If this is intended, prefix it with an underscore: "_unused".

--- a/modules/gdscript/tests/scripts/analyzer/warnings/overriding_native_method.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/overriding_native_method.out
@@ -2,5 +2,5 @@ GDTEST_OK
 >> WARNING
 >> Line: 4
 >> NATIVE_METHOD_OVERRIDE
->> The method "get" overrides a method from native class "Object". This won't be called by the engine and may not work as expected.
+>> The method "get()" overrides a method from native class "Object". This won't be called by the engine and may not work as expected.
 warn

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
@@ -2,19 +2,19 @@ GDTEST_OK
 >> WARNING
 >> Line: 5
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable 'Array' has the same name as a built-in type.
+>> The variable "Array" has the same name as a built-in type.
 >> WARNING
 >> Line: 6
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable 'Node' has the same name as a global class.
+>> The variable "Node" has the same name as a global class.
 >> WARNING
 >> Line: 7
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable 'is_same' has the same name as a built-in function.
+>> The variable "is_same" has the same name as a built-in function.
 >> WARNING
 >> Line: 8
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable 'sqrt' has the same name as a built-in function.
+>> The variable "sqrt" has the same name as a built-in function.
 >> WARNING
 >> Line: 9
 >> SHADOWED_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/features/constants.out
+++ b/modules/gdscript/tests/scripts/parser/features/constants.out
@@ -2,32 +2,32 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_TEST' is declared but never used in the block. If this is intended, prefix it with an underscore: '__TEST'
+>> The local constant "_TEST" is declared but never used in the block. If this is intended, prefix it with an underscore: "__TEST".
 >> WARNING
 >> Line: 3
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_STRING' is declared but never used in the block. If this is intended, prefix it with an underscore: '__STRING'
+>> The local constant "_STRING" is declared but never used in the block. If this is intended, prefix it with an underscore: "__STRING".
 >> WARNING
 >> Line: 4
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_VECTOR' is declared but never used in the block. If this is intended, prefix it with an underscore: '__VECTOR'
+>> The local constant "_VECTOR" is declared but never used in the block. If this is intended, prefix it with an underscore: "__VECTOR".
 >> WARNING
 >> Line: 5
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_ARRAY' is declared but never used in the block. If this is intended, prefix it with an underscore: '__ARRAY'
+>> The local constant "_ARRAY" is declared but never used in the block. If this is intended, prefix it with an underscore: "__ARRAY".
 >> WARNING
 >> Line: 6
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_DICTIONARY' is declared but never used in the block. If this is intended, prefix it with an underscore: '__DICTIONARY'
+>> The local constant "_DICTIONARY" is declared but never used in the block. If this is intended, prefix it with an underscore: "__DICTIONARY".
 >> WARNING
 >> Line: 9
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_HELLO' is declared but never used in the block. If this is intended, prefix it with an underscore: '__HELLO'
+>> The local constant "_HELLO" is declared but never used in the block. If this is intended, prefix it with an underscore: "__HELLO".
 >> WARNING
 >> Line: 10
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INFINITY' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INFINITY'
+>> The local constant "_INFINITY" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INFINITY".
 >> WARNING
 >> Line: 11
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_NOT_A_NUMBER' is declared but never used in the block. If this is intended, prefix it with an underscore: '__NOT_A_NUMBER'
+>> The local constant "_NOT_A_NUMBER" is declared but never used in the block. If this is intended, prefix it with an underscore: "__NOT_A_NUMBER".

--- a/modules/gdscript/tests/scripts/parser/features/match_bind_unused.out
+++ b/modules/gdscript/tests/scripts/parser/features/match_bind_unused.out
@@ -2,5 +2,5 @@ GDTEST_OK
 >> WARNING
 >> Line: 9
 >> UNUSED_VARIABLE
->> The local variable 'value' is declared but never used in the block. If this is intended, prefix it with an underscore: '_value'
+>> The local variable "value" is declared but never used in the block. If this is intended, prefix it with an underscore: "_value".
 value

--- a/modules/gdscript/tests/scripts/parser/features/static_typing.out
+++ b/modules/gdscript/tests/scripts/parser/features/static_typing.out
@@ -2,20 +2,20 @@ GDTEST_OK
 >> WARNING
 >> Line: 11
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INTEGER' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER'
+>> The local constant "_INTEGER" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INTEGER".
 >> WARNING
 >> Line: 12
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INTEGER_REDUNDANT_TYPED' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_TYPED'
+>> The local constant "_INTEGER_REDUNDANT_TYPED" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INTEGER_REDUNDANT_TYPED".
 >> WARNING
 >> Line: 13
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INTEGER_REDUNDANT_TYPED2' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_TYPED2'
+>> The local constant "_INTEGER_REDUNDANT_TYPED2" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INTEGER_REDUNDANT_TYPED2".
 >> WARNING
 >> Line: 14
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INTEGER_REDUNDANT_INFERRED' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_INFERRED'
+>> The local constant "_INTEGER_REDUNDANT_INFERRED" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INTEGER_REDUNDANT_INFERRED".
 >> WARNING
 >> Line: 15
 >> UNUSED_LOCAL_CONSTANT
->> The local constant '_INTEGER_REDUNDANT_INFERRED2' is declared but never used in the block. If this is intended, prefix it with an underscore: '__INTEGER_REDUNDANT_INFERRED2'
+>> The local constant "_INTEGER_REDUNDANT_INFERRED2" is declared but never used in the block. If this is intended, prefix it with an underscore: "__INTEGER_REDUNDANT_INFERRED2".

--- a/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/return_value_discarded.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 6
 >> RETURN_VALUE_DISCARDED
->> The function 'i_return_int()' returns a value that will be discarded if not used.
+>> The function "i_return_int()" returns a value that will be discarded if not used.

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_constant.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_constant.out
@@ -2,7 +2,7 @@ GDTEST_OK
 >> WARNING
 >> Line: 8
 >> UNUSED_LOCAL_CONSTANT
->> The local constant 'TEST' is declared but never used in the block. If this is intended, prefix it with an underscore: '_TEST'
+>> The local constant "TEST" is declared but never used in the block. If this is intended, prefix it with an underscore: "_TEST".
 >> WARNING
 >> Line: 8
 >> SHADOWED_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_global_identifier.out
@@ -2,8 +2,8 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_VARIABLE
->> The local variable 'abs' is declared but never used in the block. If this is intended, prefix it with an underscore: '_abs'
+>> The local variable "abs" is declared but never used in the block. If this is intended, prefix it with an underscore: "_abs".
 >> WARNING
 >> Line: 2
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable 'abs' has the same name as a built-in function.
+>> The variable "abs" has the same name as a built-in function.

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_variable_class.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_variable_class.out
@@ -2,7 +2,7 @@ GDTEST_OK
 >> WARNING
 >> Line: 8
 >> UNUSED_VARIABLE
->> The local variable 'foo' is declared but never used in the block. If this is intended, prefix it with an underscore: '_foo'
+>> The local variable "foo" is declared but never used in the block. If this is intended, prefix it with an underscore: "_foo".
 >> WARNING
 >> Line: 8
 >> SHADOWED_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/warnings/shadowed_variable_function.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/shadowed_variable_function.out
@@ -2,7 +2,7 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_VARIABLE
->> The local variable 'test' is declared but never used in the block. If this is intended, prefix it with an underscore: '_test'
+>> The local variable "test" is declared but never used in the block. If this is intended, prefix it with an underscore: "_test".
 >> WARNING
 >> Line: 2
 >> SHADOWED_VARIABLE

--- a/modules/gdscript/tests/scripts/parser/warnings/static_called_on_instance.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/static_called_on_instance.out
@@ -2,6 +2,6 @@ GDTEST_OK
 >> WARNING
 >> Line: 11
 >> STATIC_CALLED_ON_INSTANCE
->> The function 'num_uint64()' is a static function but was called from an instance. Instead, it should be directly called from the type: 'String.num_uint64()'.
+>> The function "num_uint64()" is a static function but was called from an instance. Instead, it should be directly called from the type: "String.num_uint64()".
 8589934592
 8589934592

--- a/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNASSIGNED_VARIABLE
->> The variable '__' was used but never assigned a value.
+>> The variable "__" was used but never assigned a value.

--- a/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable_op_assign.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unassigned_variable_op_assign.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 4
 >> UNASSIGNED_VARIABLE_OP_ASSIGN
->> Using assignment with operation but the variable '__' was not previously assigned a value.
+>> Using assignment with operation but the variable "__" was not previously assigned a value.

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 7
 >> UNREACHABLE_CODE
->> Unreachable code (statement after return) in function 'test()'.
+>> Unreachable code (statement after return) in function "test()".

--- a/modules/gdscript/tests/scripts/parser/warnings/unused_argument.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unused_argument.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_PARAMETER
->> The parameter 'p_arg2' is never used in the function 'function_with_unused_argument'. If this is intended, prefix it with an underscore: '_p_arg2'
+>> The parameter "p_arg2" is never used in the function "function_with_unused_argument()". If this is intended, prefix it with an underscore: "_p_arg2".

--- a/modules/gdscript/tests/scripts/parser/warnings/unused_variable.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unused_variable.out
@@ -2,4 +2,4 @@ GDTEST_OK
 >> WARNING
 >> Line: 2
 >> UNUSED_VARIABLE
->> The local variable 'unused' is declared but never used in the block. If this is intended, prefix it with an underscore: '_unused'
+>> The local variable "unused" is declared but never used in the block. If this is intended, prefix it with an underscore: "_unused".


### PR DESCRIPTION
* Use double quotes, trailing dots, and `()` after function names.
* Use `vformat` and R-strings instead of concatenation.
* Don't use `{}` and `break` in the `switch` as every `case` ends with `return` or `break`.
* Rename `RENAMED_IN_GD4_HINT` to `RENAMED_IN_GODOT_4_HINT`. It does **not** break compatibility since it's an internal name, but I don't think there's any reason for it to be different from the public name.
* Changed the order of warnings so that similar ones are located next to each other.