### PR TITLE
Unexpose `AnimationTrackEditPlugin` as not implemented

### DIFF
--- a/doc/classes/AnimationTrackEditPlugin.xml
+++ b/doc/classes/AnimationTrackEditPlugin.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationTrackEditPlugin" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<tutorials>
-	</tutorials>
-</class>

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -86,7 +86,6 @@ CLASS_GROUPS_BASE: Dict[str, str] = {
 }
 # Sync with editor\register_editor_types.cpp
 EDITOR_CLASSES: List[str] = [
-    "AnimationTrackEditPlugin",
     "FileSystemDock",
     "ScriptCreateDialog",
     "ScriptEditor",

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -30,7 +30,6 @@
 
 #include "register_editor_types.h"
 
-#include "editor/animation_track_editor.h"
 #include "editor/debugger/debug_adapter/debug_adapter_server.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_feature_profile.h"
@@ -144,7 +143,6 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorInspector);
 	GDREGISTER_CLASS(EditorInspectorPlugin);
 	GDREGISTER_CLASS(EditorProperty);
-	GDREGISTER_CLASS(AnimationTrackEditPlugin);
 	GDREGISTER_CLASS(ScriptCreateDialog);
 	GDREGISTER_CLASS(EditorFeatureProfile);
 	GDREGISTER_CLASS(EditorSpinSlider);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -860,7 +860,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 	// Find next and see when to transition.
 	_transition_to_next_recursive(tree, p_state_machine, p_test_only);
 
-	// Predict reamin time.
+	// Predict remaining time.
 	double remain = rem; // If we can't predict the end of state machine, the time remaining must be INFINITY.
 
 	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_NESTED) {


### PR DESCRIPTION
I noticed we have this class, that has no description, no properties, and no methods, virtual or otherwise. It was added with https://github.com/godotengine/godot/commit/b659fd6d7442701284cbb8763fb712be36d17ed0, but there doesn't seem to be a reason for it. Perhaps the plan was to allow such user plugins at some point, but 5 years later, there is nothing and it does nothing. So it should be removed.

And if at a later date the idea is revived, it can be properly exposed in some form.
