### PR TITLE
[3.x] Fix inconsistent file dialog settings usage

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -557,6 +557,10 @@ void EditorNode::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			scene_tabs->set_tab_close_display_policy((bool(EDITOR_GET("interface/scene_tabs/always_show_close_button")) ? Tabs::CLOSE_BUTTON_SHOW_ALWAYS : Tabs::CLOSE_BUTTON_SHOW_ACTIVE_ONLY));
+			FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
+			EditorFileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
+			EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EditorSettings::get_singleton()->get("filesystem/file_dialog/display_mode").operator int());
+
 			theme = create_custom_theme(theme_base->get_theme());
 
 			theme_base->set_theme(theme);


### PR DESCRIPTION
`3.x` version of #76421

Note that project manager here is still using `FileDialog` instead of `EditorFileDialog`, so display mode is not relevant.