### PR TITLE
Improve reliability of editor docs cache

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -53,6 +53,7 @@ MethodDefinition D_METHODP(const char *p_name, const char *const **p_args, uint3
 #endif
 
 ClassDB::APIType ClassDB::current_api = API_CORE;
+HashMap<ClassDB::APIType, uint64_t> ClassDB::api_hashes_cache;
 
 void ClassDB::set_current_api(APIType p_api) {
 	current_api = p_api;
@@ -164,6 +165,10 @@ ClassDB::APIType ClassDB::get_api_type(const StringName &p_class) {
 uint64_t ClassDB::get_api_hash(APIType p_api) {
 	OBJTYPE_RLOCK;
 #ifdef DEBUG_METHODS_ENABLED
+
+	if (api_hashes_cache.has(p_api)) {
+		return api_hashes_cache[p_api];
+	}
 
 	uint64_t hash = hash_murmur3_one_64(HashMapHasherDefault::hash(VERSION_FULL_CONFIG));
 
@@ -290,7 +295,9 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 		}
 	}
 
-	return hash_fmix32(hash);
+	hash = hash_fmix32(hash);
+	api_hashes_cache[p_api] = hash;
+	return hash;
 #else
 	return 0;
 #endif

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -154,6 +154,7 @@ public:
 #endif
 
 	static APIType current_api;
+	static HashMap<APIType, uint64_t> api_hashes_cache;
 
 	static void _add_class2(const StringName &p_class, const StringName &p_inherits);
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -374,6 +374,11 @@ void DocTools::generate(bool p_basic_types) {
 				classes.pop_front();
 				continue;
 			}
+			if (ClassDB::get_api_type(name) != ClassDB::API_CORE && ClassDB::get_api_type(name) != ClassDB::API_EDITOR) {
+				print_verbose(vformat("Class '%s' belongs neither to core nor editor, skipping.", name));
+				classes.pop_front();
+				continue;
+			}
 
 			String cname = name;
 			// Property setters and getters do not get exposed as individual methods.


### PR DESCRIPTION
This PR follows up on what #76288 did and also makes some extra improvements that the initial implementation failed to include.

- Instead of the awkward whitelisting of classes used if the first attempt is not enough, the proper already existing filter is used for it; namely, ignoring `API_TYPE_NONE`. In the code, that is reflected as letting the inner doc generation exclude classes not belonging to either core or editor, in addition to the non-exposed ones. (Extension API types are not relevant at that point of execution.)
- The hash used to determine if the cache is outdated is upgraded from being the Git commit hash to a concatenation of the core and editor API hashes, which is more robust. Since a single Godot session now will query those hashes at least twice (startup verbose prints, cache validity check and cache store), they are cached.