### PR TITLE
Add `Control::grab_focus_no_signal()`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -579,6 +579,13 @@
 			<description>
 				Steal the focus from another control and become the focused control (see [member focus_mode]).
 				[b]Note:[/b] Using this method together with [method Callable.call_deferred] makes it more reliable, especially when called inside [method Node._ready].
+				[b]Note:[/b] This method emits [signal Control.focus_entered]. See [method Control.grab_focus_no_signal] if you need to grab the focus without emitting the signal.
+			</description>
+		</method>
+		<method name="grab_focus_no_signal">
+			<return type="void" />
+			<description>
+				Steal the focus from another control and become the focused control without notifying. See also [method grab_focus].
 			</description>
 		</method>
 		<method name="has_focus" qualifiers="const">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2003,7 +2003,7 @@ void Control::grab_focus() {
 		return;
 	}
 
-	get_viewport()->_gui_control_grab_focus(this);
+	get_viewport()->_gui_control_grab_focus(this, true);
 }
 
 void Control::grab_click_focus() {
@@ -2022,6 +2022,17 @@ void Control::release_focus() {
 	}
 
 	get_viewport()->gui_release_focus();
+}
+
+void Control::grab_focus_no_signal() {
+	ERR_FAIL_COND(!is_inside_tree());
+
+	if (data.focus_mode == FOCUS_NONE) {
+		WARN_PRINT("This control can't grab focus. Use set_focus_mode() to allow a control to get focus.");
+		return;
+	}
+
+	get_viewport()->_gui_control_grab_focus(this, false);
 }
 
 static Control *_next_control(Control *p_from) {
@@ -3466,6 +3477,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_clipping_contents"), &Control::is_clipping_contents);
 
 	ClassDB::bind_method(D_METHOD("grab_click_focus"), &Control::grab_click_focus);
+	ClassDB::bind_method(D_METHOD("grab_focus_no_signal"), &Control::grab_focus_no_signal);
 
 	ClassDB::bind_method(D_METHOD("set_drag_forwarding", "drag_func", "can_drop_func", "drop_func"), &Control::set_drag_forwarding);
 	ClassDB::bind_method(D_METHOD("set_drag_preview", "control"), &Control::set_drag_preview);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -524,6 +524,7 @@ public:
 	void grab_focus();
 	void grab_click_focus();
 	void release_focus();
+	void grab_focus_no_signal();
 
 	Control *find_next_valid_focus() const;
 	Control *find_prev_valid_focus() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2466,7 +2466,7 @@ bool Viewport::_gui_control_has_focus(const Control *p_control) {
 	return gui.key_focus == p_control;
 }
 
-void Viewport::_gui_control_grab_focus(Control *p_control) {
+void Viewport::_gui_control_grab_focus(Control *p_control, bool p_emit_signal) {
 	if (gui.key_focus && gui.key_focus == p_control) {
 		// No need for change.
 		return;
@@ -2475,7 +2475,9 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		emit_signal(SNAME("gui_focus_changed"), p_control);
-		p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
+		if (p_emit_signal) {
+			p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);
+		}
 		p_control->queue_redraw();
 	}
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -436,7 +436,7 @@ private:
 	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_unfocus_control(Control *p_control);
 	bool _gui_control_has_focus(const Control *p_control);
-	void _gui_control_grab_focus(Control *p_control);
+	void _gui_control_grab_focus(Control *p_control, bool p_emit_signal);
 	void _gui_grab_click_focus(Control *p_control);
 	void _post_gui_grab_click_focus();
 	void _gui_accept_event();


### PR DESCRIPTION
This PR adds a `grab_focus_no_signal` function that works similarly to `grab_focus()` without calling `focus_entered` and its counterpart notification (e.g. it may avoid to play a sound - when you call `grab_focus()` directly, which may not be ideal for the majority of games):

```gdscript
extends Control


func _ready():
        $A.grab_focus_no_signal()


func focused_a():
        print("focused A")


func focused_b():
        print("focused B")
```

It won't print `focused A` automatically once you run the scene, but it does when pressing down and up arrow keys sequentially or clicking the button with the mouse left button:

![image](https://user-images.githubusercontent.com/33421921/234349910-1f1f5cb3-aa86-44aa-8796-7634457ee893.png)

Proposal: https://github.com/godotengine/godot-proposals/issues/5699

_This is my first contribution to Godot via code, so please, let me know if there's anything that can be improved!_

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/5699_