### PR TITLE
Fix voxel GI issues

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -452,6 +452,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="sampler_is_format_supported_for_filter" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="format" type="int" enum="RenderingDevice.DataFormat" />
+			<param index="1" name="sampler_filter" type="int" enum="RenderingDevice.SamplerFilter" />
+			<description>
+				Returns [code]true[/code] if implementation supports using a texture of [param format] with the given [param sampler_filter].
+			</description>
+		</method>
 		<method name="screen_get_framebuffer_format" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4305,6 +4305,18 @@ RID RenderingDeviceVulkan::sampler_create(const SamplerState &p_state) {
 	return id;
 }
 
+bool RenderingDeviceVulkan::sampler_is_format_supported_for_filter(DataFormat p_format, SamplerFilter p_sampler_filter) const {
+	ERR_FAIL_INDEX_V(p_format, DATA_FORMAT_MAX, false);
+
+	_THREAD_SAFE_METHOD_
+
+	// Validate that this image is supported for the intended filtering.
+	VkFormatProperties properties;
+	vkGetPhysicalDeviceFormatProperties(context->get_physical_device(), vulkan_formats[p_format], &properties);
+
+	return p_sampler_filter == RD::SAMPLER_FILTER_NEAREST || (p_sampler_filter == RD::SAMPLER_FILTER_LINEAR && (properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT));
+}
+
 /**********************/
 /**** VERTEX ARRAY ****/
 /**********************/

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1084,6 +1084,7 @@ public:
 	/*****************/
 
 	virtual RID sampler_create(const SamplerState &p_state);
+	virtual bool sampler_is_format_supported_for_filter(DataFormat p_format, SamplerFilter p_sampler_filter) const;
 
 	/**********************/
 	/**** VERTEX ARRAY ****/

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -301,10 +301,25 @@ public:
 		RID emissive_map;
 
 		RID fog_uniform_set;
-		RID copy_uniform_set;
-		RID process_uniform_set_density;
-		RID process_uniform_set;
-		RID process_uniform_set2;
+
+		struct {
+			bool valid = false;
+			RID copy_uniform_set;
+			RID process_uniform_set_density;
+			RID process_uniform_set;
+			RID process_uniform_set2;
+
+#ifdef DEV_ENABLED
+			void assert_actual_validity() {
+				// It's all-or-nothing, or something else has changed that requires dev attention.
+				DEV_ASSERT(valid == RD::get_singleton()->uniform_set_is_valid(copy_uniform_set));
+				DEV_ASSERT(valid == RD::get_singleton()->uniform_set_is_valid(process_uniform_set_density));
+				DEV_ASSERT(valid == RD::get_singleton()->uniform_set_is_valid(process_uniform_set));
+				DEV_ASSERT(valid == RD::get_singleton()->uniform_set_is_valid(process_uniform_set2));
+			}
+#endif
+		} gi_dependent_sets;
+
 		RID sdfgi_uniform_set;
 		RID sky_uniform_set;
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3695,14 +3695,16 @@ void GI::setup_voxel_gi_instances(RenderDataRD *p_render_data, Ref<RenderSceneBu
 		if (p_render_buffers->has_custom_data(RB_SCOPE_FOG)) {
 			Ref<Fog::VolumetricFog> fog = p_render_buffers->get_custom_data(RB_SCOPE_FOG);
 
-			if (RD::get_singleton()->uniform_set_is_valid(fog->fog_uniform_set)) {
-				RD::get_singleton()->free(fog->fog_uniform_set);
-				RD::get_singleton()->free(fog->process_uniform_set);
-				RD::get_singleton()->free(fog->process_uniform_set2);
+#ifdef DEV_ENABLED
+			fog->gi_dependent_sets.assert_actual_validity();
+#endif
+			if (fog->gi_dependent_sets.valid) {
+				RD::get_singleton()->free(fog->gi_dependent_sets.copy_uniform_set);
+				RD::get_singleton()->free(fog->gi_dependent_sets.process_uniform_set_density);
+				RD::get_singleton()->free(fog->gi_dependent_sets.process_uniform_set);
+				RD::get_singleton()->free(fog->gi_dependent_sets.process_uniform_set2);
+				fog->gi_dependent_sets.valid = false;
 			}
-			fog->fog_uniform_set = RID();
-			fog->process_uniform_set = RID();
-			fog->process_uniform_set2 = RID();
 		}
 	}
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3493,6 +3493,9 @@ void GI::init(SkyRD *p_sky) {
 		if (RendererSceneRenderRD::get_singleton()->is_vrs_supported()) {
 			defines += "\n#define USE_VRS\n";
 		}
+		if (!RD::get_singleton()->sampler_is_format_supported_for_filter(RD::DATA_FORMAT_R8G8_UINT, RD::SAMPLER_FILTER_LINEAR)) {
+			defines += "\n#define SAMPLE_VOXEL_GI_NEAREST\n";
+		}
 
 		Vector<String> gi_modes;
 
@@ -3931,7 +3934,6 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 				u.append_id(material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED));
 				uniforms.push_back(u);
 			}
-
 			{
 				RD::Uniform u;
 				u.uniform_type = RD::UNIFORM_TYPE_IMAGE;

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -4,6 +4,10 @@
 
 #VERSION_DEFINES
 
+#ifdef SAMPLE_VOXEL_GI_NEAREST
+#extension GL_EXT_samplerless_texture_functions : enable
+#endif
+
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 #define M_PI 3.141592
@@ -625,7 +629,11 @@ void process_gi(ivec2 pos, vec3 vertex, inout vec4 ambient_light, inout vec4 ref
 
 #ifdef USE_VOXEL_GI_INSTANCES
 		{
+#ifdef SAMPLE_VOXEL_GI_NEAREST
+			uvec2 voxel_gi_tex = texelFetch(voxel_gi_buffer, pos, 0).rg;
+#else
 			uvec2 voxel_gi_tex = texelFetch(usampler2D(voxel_gi_buffer, linear_sampler), pos, 0).rg;
+#endif
 			roughness *= roughness;
 			//find arbitrary tangent and bitangent, then build a matrix
 			vec3 v0 = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -723,6 +723,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("framebuffer_is_valid", "framebuffer"), &RenderingDevice::framebuffer_is_valid);
 
 	ClassDB::bind_method(D_METHOD("sampler_create", "state"), &RenderingDevice::_sampler_create);
+	ClassDB::bind_method(D_METHOD("sampler_is_format_supported_for_filter", "format", "sampler_filter"), &RenderingDevice::sampler_is_format_supported_for_filter);
 
 	ClassDB::bind_method(D_METHOD("vertex_buffer_create", "size_bytes", "data", "use_as_storage"), &RenderingDevice::vertex_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("vertex_format_create", "vertex_descriptions"), &RenderingDevice::_vertex_format_create);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -653,6 +653,7 @@ public:
 	};
 
 	virtual RID sampler_create(const SamplerState &p_state) = 0;
+	virtual bool sampler_is_format_supported_for_filter(DataFormat p_format, SamplerFilter p_sampler_filter) const = 0;
 
 	/**********************/
 	/**** VERTEX ARRAY ****/


### PR DESCRIPTION
**UPDATE:** To avoid multiple 'update' notices throughout, just know that the full text has been revised after enhancing the fixes.

---

Changes kept in two commits because, even if related, they address different issues:

- Commit 1: _Fix breakages of volumetric fog on voxel GI changes_

   Fixes the book-keeping of related uniforms. Without this change, some of them could fail to be created when needed and some others could be pointing to outdated voxel GI buffers. For the uniform sets related to GI instances, a minor sets group idiom is introduced, that helps tracking validity and saves some checks, while also assisting developers in detecting bugs.

   Fixes #69565.
   Fixes #76243.

- Commit 2: _Fix unsupported sampler filter used for voxel GI_

   Fixes a validation error* about an R8G8 texture being sampled linearly when the driver reports no support for that.
   
*:
```
drivers\vulkan\vulkan_context.cpp:267 - VALIDATION - Message Id Number: 188609398 | Message Id Name: VUID-vkCmdDispatch-magFilter-04553
Validation Error: [ VUID-vkCmdDispatch-magFilter-04553 ] Object 0: handle = 0x8f7057000000562c, name = RID:505478996034037, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0xa182620000000079, name = RID:163208757251, type = VK_OBJECT_TYPE_SAMPLER; Object 2: handle = 0xf325e500000055e3, name = RenderBuffer forward_clustered/voxel_gi View, type = VK_OBJECT_TYPE_IMAGE_VIEW; | MessageID = 0xb3df376 | Descriptor set VkDescriptorSet 0x8f7057000000562c[RID:505478996034037] encountered the following validation error at vkCmdDispatch time: Sampler (VkSampler 0xa182620000000079[RID:163208757251]) is set to use VK_FILTER_LINEAR with compareEnable is set to VK_FALSE, but image view's (VkImageView 0xf325e500000055e3[RenderBuffer forward_clustered/voxel_gi View]) format (VK_FORMAT_R8G8_UINT) does not contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features. The Vulkan spec states: If a VkSampler created with magFilter or minFilter equal to VK_FILTER_LINEAR and compareEnable equal to VK_FALSE is used to sample a VkImageView as a result of this command, then the image view's format features must contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT (https://vulkan.lunarg.com/doc/view/1.3.216.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDispatch-magFilter-04553)
	Objects - 3
		Object[0] - VK_OBJECT_TYPE_DESCRIPTOR_SET, Handle -8110887271382624724, Name "RID:505478996034037"
		Object[1] - VK_OBJECT_TYPE_SAMPLER, Handle -6808771934491246471, Name "RID:163208757251"
		Object[2] - VK_OBJECT_TYPE_IMAGE_VIEW, Handle -926082360191986205, Name "RenderBuffer forward_clustered/voxel_gi View"
   ```
