### PR TITLE
Fix ShaderMaterial uniform type changes (reverted)

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -279,10 +279,28 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				groups["<None>"]["<None>"].push_back(info);
 			}
 
+			const bool is_uniform_cached = param_cache.has(E->get().name);
+			bool is_uniform_type_changing = false;
+
+			if (is_uniform_cached) {
+				// Check if the uniform Variant type changed, for example vec3 to vec4.
+				const Variant &cached = param_cache.get(E->get().name);
+				is_uniform_type_changing = E->get().type != cached.get_type();
+
+				if (!is_uniform_type_changing && E->get().type == Variant::OBJECT && cached.get_type() == Variant::OBJECT) {
+					// Check if the Object class (hint string) changed, for example Texture2D sampler to Texture3D.
+					// Allow inheritance, for example Texture2D type sampler should also accept CompressedTexture2D.
+					Object *cached_obj = cached;
+					if (!cached_obj->is_class(E->get().hint_string)) {
+						is_uniform_type_changing = true;
+					}
+				}
+			}
+
 			PropertyInfo info = E->get();
 			info.name = "shader_parameter/" + info.name;
-			if (!param_cache.has(E->get().name)) {
-				// Property has never been edited, retrieve with default value.
+			if (!is_uniform_cached || is_uniform_type_changing) {
+				// Property has never been edited or its type changed, retrieve with default value.
 				Variant default_value = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), E->get().name);
 				param_cache.insert(E->get().name, default_value);
 				remap_cache.insert(info.name, E->get().name);


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/63064
* Fixes https://github.com/godotengine/godot/issues/74680

Fixes data handling issues when user changes the type of a shader uniform that is used by a ShaderMaterial. For example, changing a `vec3` to `vec2`. Currently uniform data is cached temporarily in ShaderMaterial to make sure uniforms don't lose their values when user for example cuts and pastes a uniform while refactoring or accidentally renames an uniform. However, this cache works a bit too well and causes the uniform data and type to get "stuck" when you try to change the uniform type.

This PR adds a type comparison between the cached type and new type. If they are different, cached data is discarded.

There are still some issues left with some uniform types (like invalid initialization values etc.), but most of those should be fixed by https://github.com/godotengine/godot/pull/74937.