### PR TITLE
Add graphics quality getter methods to RenderingServer

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1013,6 +1013,13 @@
 				This is the internal equivalent of the [Environment] resource.
 			</description>
 		</method>
+		<method name="environment_get_ssao_quality" qualifiers="const">
+			<return type="int" enum="RenderingServer.EnvironmentSSAOQuality" />
+			<description>
+				Returns the quality of the screen-space ambient occlusion setting, which is set globally (and not on a per-[Environment] basis). See also [method environment_set_ssao_quality].
+				[b]Note:[/b] Calling this method forces synchronization between the CPU and GPU, which is slow and can cause stuttering. Do not call this method every frame or on regular intervals to avoid performance issues.
+			</description>
+		</method>
 		<method name="environment_glow_set_use_bicubic_upscale">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
@@ -1192,7 +1199,7 @@
 			<param index="4" name="fadeout_from" type="float" />
 			<param index="5" name="fadeout_to" type="float" />
 			<description>
-				Sets the quality level of the screen-space ambient occlusion (SSAO) post-process effect. See [Environment] for more details.
+				Sets the quality level of the screen-space ambient occlusion (SSAO) post-process effect. See [Environment] for more details. See also [method environment_get_ssao_quality].
 			</description>
 		</method>
 		<method name="environment_set_ssil_quality">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1091,6 +1091,10 @@ void RasterizerSceneGLES3::environment_set_ssr_roughness_quality(RS::Environment
 void RasterizerSceneGLES3::environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) {
 }
 
+RS::EnvironmentSSAOQuality RasterizerSceneGLES3::environment_get_ssao_quality() const {
+	return ssao_quality;
+}
+
 void RasterizerSceneGLES3::environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) {
 }
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -614,6 +614,7 @@ public:
 	void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override;
 
 	void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override;
+	RS::EnvironmentSSAOQuality environment_get_ssao_quality() const override;
 
 	void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override;
 

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -117,6 +117,7 @@ public:
 	void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override {}
 
 	void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override {}
+	RS::EnvironmentSSAOQuality environment_get_ssao_quality() const override { return RS::ENV_SSAO_QUALITY_MEDIUM; }
 
 	void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override {}
 

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -968,6 +968,10 @@ void SSEffects::ssao_set_quality(RS::EnvironmentSSAOQuality p_quality, bool p_ha
 	ssao_fadeout_to = p_fadeout_to;
 }
 
+RS::EnvironmentSSAOQuality SSEffects::ssao_get_quality() const {
+	return ssao_quality;
+}
+
 void SSEffects::gather_ssao(RD::ComputeListID p_compute_list, const RID *p_ao_slices, const SSAOSettings &p_settings, bool p_adaptive_base_pass, RID p_gather_uniform_set, RID p_importance_map_uniform_set) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);

--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -111,6 +111,7 @@ public:
 
 	/* SSAO */
 	void ssao_set_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to);
+	RS::EnvironmentSSAOQuality ssao_get_quality() const;
 
 	struct SSAORenderBuffers {
 		bool half_size = false;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3298,6 +3298,10 @@ void RenderForwardClustered::environment_set_ssao_quality(RS::EnvironmentSSAOQua
 	ss_effects->ssao_set_quality(p_quality, p_half_size, p_adaptive_target, p_blur_passes, p_fadeout_from, p_fadeout_to);
 }
 
+RS::EnvironmentSSAOQuality RenderForwardClustered::environment_get_ssao_quality() const {
+	return ss_effects->ssao_get_quality();
+}
+
 void RenderForwardClustered::environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) {
 	ss_effects->ssil_set_quality(p_quality, p_half_size, p_adaptive_target, p_blur_passes, p_fadeout_from, p_fadeout_to);
 }

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -609,6 +609,8 @@ protected:
 	virtual RID _render_buffers_get_velocity_texture(Ref<RenderSceneBuffersRD> p_render_buffers) override;
 
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override;
+	virtual RS::EnvironmentSSAOQuality environment_get_ssao_quality() const override;
+
 	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override;
 	virtual void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override;
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -361,6 +361,8 @@ protected:
 	virtual RID _render_buffers_get_velocity_texture(Ref<RenderSceneBuffersRD> p_render_buffers) override;
 
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override{};
+	virtual RS::EnvironmentSSAOQuality environment_get_ssao_quality() const override { return RS::ENV_SSAO_QUALITY_MEDIUM; };
+
 	virtual void environment_set_ssil_quality(RS::EnvironmentSSILQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) override{};
 	virtual void environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) override{};
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1203,6 +1203,7 @@ public:
 	PASS1RC(float, environment_get_ssao_ao_channel_affect, RID)
 
 	PASS6(environment_set_ssao_quality, RS::EnvironmentSSAOQuality, bool, float, int, float, float)
+	PASS0RC(RS::EnvironmentSSAOQuality, environment_get_ssao_quality)
 
 	// SSIL
 	PASS6(environment_set_ssil, RID, bool, float, float, float, float)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -186,6 +186,7 @@ public:
 	float environment_get_ssao_ao_channel_affect(RID p_env) const;
 
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) = 0;
+	virtual RS::EnvironmentSSAOQuality environment_get_ssao_quality() const = 0;
 
 	// SSIL
 	void environment_set_ssil(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_sharpness, float p_normal_rejection);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -231,6 +231,7 @@ public:
 	virtual float environment_get_ssao_ao_channel_affect(RID p_env) const = 0;
 
 	virtual void environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) = 0;
+	virtual RS::EnvironmentSSAOQuality environment_get_ssao_quality() const = 0;
 
 	// SSIL
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -693,6 +693,7 @@ public:
 
 	FUNC10(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, float)
 	FUNC6(environment_set_ssao_quality, EnvironmentSSAOQuality, bool, float, int, float, float)
+	FUNC0RC(EnvironmentSSAOQuality, environment_get_ssao_quality)
 
 	FUNC6(environment_set_ssil, RID, bool, float, float, float, float)
 	FUNC6(environment_set_ssil_quality, EnvironmentSSILQuality, bool, float, int, float, float)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2363,6 +2363,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_bicubic_upscale", "enable"), &RenderingServer::environment_glow_set_use_bicubic_upscale);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr_roughness_quality", "quality"), &RenderingServer::environment_set_ssr_roughness_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao_quality", "quality", "half_size", "adaptive_target", "blur_passes", "fadeout_from", "fadeout_to"), &RenderingServer::environment_set_ssao_quality);
+	ClassDB::bind_method(D_METHOD("environment_get_ssao_quality"), &RenderingServer::environment_get_ssao_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_ssil_quality", "quality", "half_size", "adaptive_target", "blur_passes", "fadeout_from", "fadeout_to"), &RenderingServer::environment_set_ssil_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_ray_count", "ray_count"), &RenderingServer::environment_set_sdfgi_ray_count);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_frames_to_converge", "frames"), &RenderingServer::environment_set_sdfgi_frames_to_converge);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1078,6 +1078,7 @@ public:
 	};
 
 	virtual void environment_set_ssao_quality(EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) = 0;
+	virtual EnvironmentSSAOQuality environment_get_ssao_quality() const = 0;
 
 	virtual void environment_set_ssil(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_sharpness, float p_normal_rejection) = 0;
 


### PR DESCRIPTION
This is useful for add-ons that wish to display graphics quality settings chosen at run-time by other scripts, as project settings are only defined when the project starts.

For context, I'm working on an add-on to address https://github.com/godotengine/godot-proposals/issues/63 which will make use of this feature to display the current graphics settings on screen. Since the add-on aims to be fully self-contained, it can't know whether other scripts have changed rendering quality settings at run-time.

So far, this PR only includes a getter for SSAO quality. I'll probably add a method per setting (which means there will be more setter methods than getter methods) for better type safety, rather than returning arrays to match the setter methods that accept more than one argument. Let me know if the design is good and I'll continue with other environment settings and directional shadow size :slightly_smiling_face:
