### PR TITLE
Fix Sprite3D to utilize 3D space by default

### DIFF
--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -44,7 +44,7 @@
 		<member name="alpha_antialiasing_mode" type="int" setter="set_alpha_antialiasing" getter="get_alpha_antialiasing" enum="BaseMaterial3D.AlphaAntiAliasing" default="0">
 			The type of alpha antialiasing to apply. See [enum BaseMaterial3D.AlphaAntiAliasing].
 		</member>
-		<member name="alpha_cut" type="int" setter="set_alpha_cut_mode" getter="get_alpha_cut_mode" enum="SpriteBase3D.AlphaCutMode" default="0">
+		<member name="alpha_cut" type="int" setter="set_alpha_cut_mode" getter="get_alpha_cut_mode" enum="SpriteBase3D.AlphaCutMode" default="2">
 			The alpha cutting mode to use for the sprite. See [enum AlphaCutMode] for possible values.
 		</member>
 		<member name="alpha_hash_scale" type="float" setter="set_alpha_hash_scale" getter="get_alpha_hash_scale" default="1.0">

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -86,7 +86,7 @@ private:
 	RID last_texture;
 
 	bool flags[FLAG_MAX] = {};
-	AlphaCutMode alpha_cut = ALPHA_CUT_DISABLED;
+	AlphaCutMode alpha_cut = ALPHA_CUT_OPAQUE_PREPASS;
 	float alpha_scissor_threshold = 0.5;
 	float alpha_hash_scale = 1.0;
 	StandardMaterial3D::AlphaAntiAliasing alpha_antialiasing_mode = StandardMaterial3D::ALPHA_ANTIALIASING_OFF;


### PR DESCRIPTION
Changes Sprite3D to use the depth prepass by default instead of render order. This makes Sprite3D more in line with its usage as a helper "to display a 2D texture in a 3D environment".

IMO, alpha cut mode should be the most exhaustive mode by default, and adjusting it for better performance should be left to the user. This also addresses concerns with Sprite3D covering up Gizmos in the editor.

See https://github.com/godotengine/godot/issues/17567, https://github.com/godotengine/godot/issues/24069