### PR TITLE
Fix MeshLibrary and GridMap change notifications

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -228,6 +228,11 @@
 				Emitted when [member cell_size] changes.
 			</description>
 		</signal>
+		<signal name="mesh_library_changed">
+			<description>
+				Emitted when the assigned [member mesh_library] changes.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="INVALID_CELL_ITEM" value="-1">

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -915,8 +915,13 @@ void GridMapEditor::update_palette() {
 }
 
 void GridMapEditor::edit(GridMap *p_gridmap) {
-	if (node && node->is_connected("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids))) {
-		node->disconnect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
+	if (node) {
+		if (node->is_connected(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids))) {
+			node->disconnect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+		}
+		if (node->is_connected(SNAME("mesh_library_changed"), callable_mp(this, &GridMapEditor::update_palette))) {
+			node->disconnect(SNAME("mesh_library_changed"), callable_mp(this, &GridMapEditor::update_palette));
+		}
 	}
 
 	node = p_gridmap;
@@ -949,7 +954,12 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	_draw_grids(node->get_cell_size());
 	update_grid();
 
-	node->connect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
+	if (!node->is_connected(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids))) {
+		node->connect(SNAME("cell_size_changed"), callable_mp(this, &GridMapEditor::_draw_grids));
+	}
+	if (!node->is_connected(SNAME("mesh_library_changed"), callable_mp(this, &GridMapEditor::update_palette))) {
+		node->connect(SNAME("mesh_library_changed"), callable_mp(this, &GridMapEditor::update_palette));
+	}
 }
 
 void GridMapEditor::update_grid() {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -1007,6 +1007,7 @@ void GridMap::clear() {
 
 void GridMap::resource_changed(const Ref<Resource> &p_res) {
 	_recreate_octant_data();
+	emit_signal(SNAME("mesh_library_changed"));
 }
 
 void GridMap::_update_octants_callback() {
@@ -1119,6 +1120,7 @@ void GridMap::_bind_methods() {
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
 	ADD_SIGNAL(MethodInfo("cell_size_changed", PropertyInfo(Variant::VECTOR3, "cell_size")));
+	ADD_SIGNAL(MethodInfo("mesh_library_changed"));
 }
 
 void GridMap::set_cell_scale(float p_scale) {

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -132,12 +132,15 @@ void MeshLibrary::create_item(int p_item) {
 	ERR_FAIL_COND(p_item < 0);
 	ERR_FAIL_COND(item_map.has(p_item));
 	item_map[p_item] = Item();
+	notify_change_to_owners();
+	emit_changed();
 	notify_property_list_changed();
 }
 
 void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].name = p_name;
+	notify_change_to_owners();
 	emit_changed();
 }
 
@@ -193,6 +196,7 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].preview = p_preview;
+	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }


### PR DESCRIPTION
Fixes MeshLibrary and GridMap change notifications.

Fixes a part of https://github.com/godotengine/godot/issues/76429.

Properly other older bug reports that had issues with Editor GridMap palette updates as well.
