### PR TITLE
Provide an example on how to use ImmediateMesh

### DIFF
--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -49,6 +49,7 @@
 		[/codeblocks]
 	</description>
 	<tutorials>
+		<link title="Evaluating Expressions">$DOCS_URL/tutorials/scripting/evaluating_expressions.html</link>
 	</tutorials>
 	<methods>
 		<method name="execute">

--- a/doc/classes/ImmediateMesh.xml
+++ b/doc/classes/ImmediateMesh.xml
@@ -4,9 +4,20 @@
 		Mesh optimized for creating geometry manually.
 	</brief_description>
 	<description>
-		Mesh optimized for creating geometry manually, similar to OpenGL1.x immediate mode.
+		A mesh type optimized for creating geometry manually, similar to OpenGL 1.x immediate mode.
+		Here's a sample on how to generate a triangular face:
+		[codeblocks]
+		var mesh = ImmediateMesh.new()
+		mesh.surface_begin(Mesh.PRIMITIVE_TRIANGLES)
+		mesh.surface_add_vertex(Vector3.LEFT)
+		mesh.surface_add_vertex(Vector3.FORWARD)
+		mesh.surface_add_vertex(Vector3.ZERO)
+		mesh.surface_end()
+		[/codeblocks]
+		[b]Note:[/b] Generating complex geometries with [ImmediateMesh] is highly inefficient. Instead, it is designed to generate simple geometry that changes often.
 	</description>
 	<tutorials>
+		<link title="Using ImmediateMesh">$DOCS_URL/tutorials/3d/procedural_geometry/immediatemesh.html</link>
 	</tutorials>
 	<methods>
 		<method name="clear_surfaces">


### PR DESCRIPTION
Adds a small code snippet on how to use ImmediateMesh and links to our tutorial for further information. Also links the Expression class to its tutorial.