### PR TITLE
Remove quotes in string autocompletes from language server

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2474,7 +2474,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type = p_base.type;
 
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
-	const bool is_external_editor = EDITOR_GET("text_editor/external/use_external_editor");;
+	const bool is_external_editor = EDITOR_GET("text_editor/external/use_external_editor");
 
 	while (base_type.is_set() && !base_type.is_variant()) {
 		switch (base_type.kind) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2474,6 +2474,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type = p_base.type;
 
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const bool is_external_editor = EDITOR_GET("text_editor/external/use_external_editor");;
 
 	while (base_type.is_set() && !base_type.is_variant()) {
 		switch (base_type.kind) {
@@ -2510,6 +2511,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 								if (opt.is_quoted()) {
 									opt = opt.unquote();
 								}
+								
+								if(!is_external_editor) {
+									opt = opt.quote(quote_style);
+								}
+
 								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 								r_result.insert(option.display, option);
 							}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2508,7 +2508,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 							obj->get_argument_options(p_method, p_argidx, &options);
 							for (String &opt : options) {
 								if (opt.is_quoted()) {
-									opt = opt.unquote().quote(quote_style); // Handle user preference.
+									opt = opt.unquote();
 								}
 								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 								r_result.insert(option.display, option);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2474,7 +2474,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	GDScriptParser::DataType base_type = p_base.type;
 
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
-	const bool is_external_editor = EDITOR_GET("text_editor/external/use_external_editor");;
+	const bool is_external_editor = EDITOR_GET("text_editor/external/use_external_editor");
 
 	while (base_type.is_set() && !base_type.is_variant()) {
 		switch (base_type.kind) {
@@ -2511,8 +2511,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 								if (opt.is_quoted()) {
 									opt = opt.unquote();
 								}
-								
-								if(!is_external_editor) {
+
+								if (!is_external_editor) {
 									opt = opt.quote(quote_style);
 								}
 


### PR DESCRIPTION
Potential fix for #48436 

This may go too far or not far enough, but it is a fix for a long-standing issue with the language server's handling of string autocompletes.

https://user-images.githubusercontent.com/58610593/234543656-bc25e419-edc7-40d7-9a96-a824664d114a.mp4

