### PR TITLE
Fix right click in selection of additional caret

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1805,20 +1805,26 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 		int col = pos.x;
 
 		tx->set_move_caret_on_right_click_enabled(EDITOR_GET("text_editor/behavior/navigation/move_caret_on_right_click"));
+		int caret_clicked = -1;
 		if (tx->is_move_caret_on_right_click_enabled()) {
-			tx->remove_secondary_carets();
 			if (tx->has_selection()) {
-				int from_line = tx->get_selection_from_line();
-				int to_line = tx->get_selection_to_line();
-				int from_column = tx->get_selection_from_column();
-				int to_column = tx->get_selection_to_column();
+				for (int i = 0; i < tx->get_caret_count(); i++) {
+					int from_line = tx->get_selection_from_line(i);
+					int to_line = tx->get_selection_to_line(i);
+					int from_column = tx->get_selection_from_column(i);
+					int to_column = tx->get_selection_to_column(i);
 
-				if (row < from_line || row > to_line || (row == from_line && col < from_column) || (row == to_line && col > to_column)) {
-					// Right click is outside the selected text
-					tx->deselect();
+					if (row >= from_line && row <= to_line && (row != from_line || col >= from_column) && (row != to_line || col <= to_column)) {
+						// Right click in one of the selected text
+						caret_clicked = i;
+						break;
+					}
 				}
 			}
-			if (!tx->has_selection()) {
+			if (!caret_clicked) {
+				tx->deselect();
+				tx->remove_secondary_carets();
+				caret_clicked = 0;
 				tx->set_caret_line(row, false, false);
 				tx->set_caret_column(col);
 			}
@@ -1826,10 +1832,10 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 
 		String word_at_pos = tx->get_word_at_pos(local_pos);
 		if (word_at_pos.is_empty()) {
-			word_at_pos = tx->get_word_under_caret(0);
+			word_at_pos = tx->get_word_under_caret(caret_clicked);
 		}
 		if (word_at_pos.is_empty()) {
-			word_at_pos = tx->get_selected_text(0);
+			word_at_pos = tx->get_selected_text(caret_clicked);
 		}
 
 		bool has_color = (word_at_pos == "Color");

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1851,23 +1851,28 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				Point2i pos = get_line_column_at_pos(mpos);
 				int row = pos.y;
 				int col = pos.x;
-				int caret = carets.size() - 1;
 
+				bool selection_clicked = false;
 				if (is_move_caret_on_right_click_enabled()) {
-					if (has_selection(caret)) {
-						int from_line = get_selection_from_line(caret);
-						int to_line = get_selection_to_line(caret);
-						int from_column = get_selection_from_column(caret);
-						int to_column = get_selection_to_column(caret);
+					if (has_selection()) {
+						for (int i = 0; i < get_caret_count(); i++) {
+							int from_line = get_selection_from_line(i);
+							int to_line = get_selection_to_line(i);
+							int from_column = get_selection_from_column(i);
+							int to_column = get_selection_to_column(i);
 
-						if (row < from_line || row > to_line || (row == from_line && col < from_column) || (row == to_line && col > to_column)) {
-							// Right click is outside the selected text.
-							deselect(caret);
+							if (row >= from_line && row <= to_line && (row != from_line || col >= from_column) && (row != to_line || col <= to_column)) {
+								// Right click in one of the selected text
+								selection_clicked = true;
+								break;
+							}
 						}
 					}
-					if (!has_selection(caret)) {
-						set_caret_line(row, true, false, 0, caret);
-						set_caret_column(col, true, caret);
+					if (!selection_clicked) {
+						deselect();
+						remove_secondary_carets();
+						set_caret_line(row, false, false);
+						set_caret_column(col);
 					}
 					merge_overlapping_carets();
 				}


### PR DESCRIPTION
Fix #76417

# Issue description

Right click in the selection of any secondary caret discard all selections and show context menu has is there was no selection.

# Investigations

In ``ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev)`` multicaret is not managed when checking if click was in a selection. It only check the main caret selection. If it's outside the main caret selection, it discards all secondary caret and all selections.

# Fix proposal
(modified version after taking comments into account)

Managed multicarret in ``ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev)`` : iterate throw each caret selection to check if right click is in any of the caret selections. Keep all selection.

Same modification in ``void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input)`` : only one caret selection was checked. Iterates throw all selections and keep it all.

# Before

![mutlicaret](https://user-images.githubusercontent.com/3649998/234554658-508f2c54-ab89-4c5e-a56a-039387ebfee7.gif)

# After

![fixed](https://user-images.githubusercontent.com/3649998/235364323-daba968e-36a8-4531-9c17-ca9840c8acfb.gif)

