### PR TITLE
Updated Object's class reference documentation

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -656,6 +656,7 @@
 			<description>
 				Returns [code]true[/code] if a metadata entry is found with the given [param name]. See also [method get_meta], [method set_meta] and [method remove_meta].
 				[b]Note:[/b] Metadata that has a [param name] starting with an underscore ([code]_[/code]) is considered editor-only. Editor-only metadata is not displayed in the Inspector and should not be edited, although it can still be found by this method.
+				[b]Note:[/b] A metadata’s [param name] must be a valid identifier. A valid identifier cannot start with a number.
 			</description>
 		</method>
 		<method name="has_method" qualifiers="const">


### PR DESCRIPTION
Resolves: https://github.com/godotengine/godot/issues/70141

This change simply adds another Note: under the class reference documentation of Object's set_meta(String name, Variant value) method that indicates the "name" parameter must be a valid identifier (i.e., the String cannot begin with a number).
