### PR TITLE
Corrected the GDScript and C# examples for the MeshDataTool class reference documentation

### DIFF
--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -19,7 +19,7 @@
 		    vertex += mdt.get_vertex_normal(i)
 		    # Save your change.
 		    mdt.set_vertex(i, vertex)
-		mesh.surface_remove(0)
+		mesh.clear_surfaces()
 		mdt.commit_to_surface(mesh)
 		var mi = MeshInstance.new()
 		mi.mesh = mesh
@@ -38,7 +38,7 @@
 		    // Save your change.
 		    mdt.SetVertex(i, vertex);
 		}
-		mesh.SurfaceRemove(0);
+		mesh.ClearSurfaces();
 		mdt.CommitToSurface(mesh);
 		var mi = new MeshInstance();
 		mi.Mesh = mesh;


### PR DESCRIPTION
Resolves: [#7176 ](https://github.com/godotengine/godot-docs/issues/7176)

These changes simply correct the GDScript and C# code examples within the MeshDataTool documentation. The GDScript example was using `mesh.surface_remove(0)` and the C# example was using `mesh.SurfaceRemove(0)`. This method does not exist under the ArrayMesh class reference documentation. Under the advice of @clayjohn in issue [#7176](https://github.com/godotengine/godot-docs/issues/7176), I have changed the GDScript example to use `mesh.clear_surfaces()` and the C# example to use `mesh.ClearSurfaces()`.