### PR TITLE
GDScript: Don't fail when freed object is returned

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1651,10 +1651,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						bool was_freed = false;
 						Object *obj = ret->get_validated_object_with_check(was_freed);
 
-						if (was_freed) {
-							err_text = "Got a freed object as a result of the call.";
-							OPCODE_BREAK;
-						}
 						if (obj && obj->is_class_ptr(GDScriptFunctionState::get_class_ptr_static())) {
 							err_text = R"(Trying to call an async function without "await".)";
 							OPCODE_BREAK;

--- a/modules/gdscript/tests/scripts/runtime/features/getter_with_freed_object.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/getter_with_freed_object.gd
@@ -1,0 +1,15 @@
+# https://github.com/godotengine/godot/issues/68184
+
+var node: Node:
+	get:
+		return node
+	set(n):
+		node = n
+
+
+func test():
+	node = Node.new()
+	node.free()
+
+	if !is_instance_valid(node):
+		print("It is freed")

--- a/modules/gdscript/tests/scripts/runtime/features/getter_with_freed_object.out
+++ b/modules/gdscript/tests/scripts/runtime/features/getter_with_freed_object.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+It is freed


### PR DESCRIPTION
This is check is a bit too eager. The user should be able to handle the return value even if it's a freed object.

Fix #68184
Fix #62790

_Bugfix squad: add fix to #62790_