### PR TITLE
Add tree filtering to Advanced Import Settings

### DIFF
--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -67,6 +67,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	HSplitContainer *tree_split = nullptr;
 	HSplitContainer *property_split = nullptr;
+	LineEdit *tree_filter_edit = nullptr;
 	TabContainer *data_mode = nullptr;
 	Tree *scene_tree = nullptr;
 	Tree *mesh_tree = nullptr;
@@ -157,6 +158,9 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	String selected_type;
 	String selected_id;
+	String tree_filter;
+
+	Tree *current_tree = nullptr;
 
 	bool selecting = false;
 
@@ -176,6 +180,12 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	void _cleanup();
 
 	void _viewport_input(const Ref<InputEvent> &p_input);
+
+	void _tree_filter_edit_changed(const String &p_filter);
+	void _tree_tab_changed(int p_tab_id);
+	bool _update_tree_filter(TreeItem *p_parent, bool p_scroll_to_selected);
+
+	bool _item_matches_all_terms(TreeItem *p_item, PackedStringArray p_terms);
 
 	HashMap<StringName, Variant> defaults;
 


### PR DESCRIPTION
implements node filtering in the scene import settings dialog

Updates
scene_import_settings.cpp
scene_import_settings.h

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/6764.*
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
