### PR TITLE
Dump API docs from inline GDScript comments using --doctool --gdscript-docs PATH

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -165,6 +165,7 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 void DocData::constant_doc_from_variant(DocData::ConstantDoc &p_const, const StringName &p_name, const Variant &p_value, const String &p_desc) {
 	p_const.name = p_name;
 	p_const.value = p_value;
+	p_const.is_value_valid = (p_value.get_type() != Variant::OBJECT);
 	p_const.description = p_desc;
 }
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1406,7 +1406,7 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 				if (!m.return_enum.is_empty()) {
 					enum_text = " enum=\"" + m.return_enum + "\"";
 				}
-				_write_string(f, 3, "<return type=\"" + m.return_type + "\"" + enum_text + " />");
+				_write_string(f, 3, "<return type=\"" + m.return_type.xml_escape(true) + "\"" + enum_text + " />");
 			}
 			if (m.errors_returned.size() > 0) {
 				for (int j = 0; j < m.errors_returned.size(); j++) {
@@ -1423,9 +1423,9 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 				}
 
 				if (!a.default_value.is_empty()) {
-					_write_string(f, 3, "<param index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " default=\"" + a.default_value.xml_escape(true) + "\" />");
+					_write_string(f, 3, "<param index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape(true) + "\"" + enum_text + " default=\"" + a.default_value.xml_escape(true) + "\" />");
 				} else {
-					_write_string(f, 3, "<param index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape() + "\"" + enum_text + " />");
+					_write_string(f, 3, "<param index=\"" + itos(j) + "\" name=\"" + a.name.xml_escape() + "\" type=\"" + a.type.xml_escape(true) + "\"" + enum_text + " />");
 				}
 			}
 
@@ -1440,7 +1440,7 @@ static void _write_method_doc(Ref<FileAccess> f, const String &p_name, Vector<Do
 	}
 }
 
-Error DocTools::save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path) {
+Error DocTools::save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_include_xml_schema) {
 	for (KeyValue<String, DocData::ClassDoc> &E : class_list) {
 		DocData::ClassDoc &c = E.value;
 
@@ -1452,16 +1452,16 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 		}
 
 		Error err;
-		String save_file = save_path.path_join(c.name + ".xml");
+		String save_file = save_path.path_join(c.name.replace("\"", "").replace("/", "--") + ".xml");
 		Ref<FileAccess> f = FileAccess::open(save_file, FileAccess::WRITE, &err);
 
 		ERR_CONTINUE_MSG(err != OK, "Can't write doc file: " + save_file + ".");
 
 		_write_string(f, 0, "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
 
-		String header = "<class name=\"" + c.name + "\"";
+		String header = "<class name=\"" + c.name.xml_escape(true) + "\"";
 		if (!c.inherits.is_empty()) {
-			header += " inherits=\"" + c.inherits + "\"";
+			header += " inherits=\"" + c.inherits.xml_escape(true) + "\"";
 			if (c.is_deprecated) {
 				header += " is_deprecated=\"true\"";
 			}
@@ -1470,12 +1470,15 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 			}
 		}
 		header += String(" version=\"") + VERSION_BRANCH + "\"";
-		// Reference the XML schema so editors can provide error checking.
-		// Modules are nested deep, so change the path to reference the same schema everywhere.
-		const String schema_path = save_path.find("modules/") != -1 ? "../../../doc/class.xsd" : "../class.xsd";
-		header += vformat(
-				R"( xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="%s">)",
-				schema_path);
+		if (p_include_xml_schema) {
+			// Reference the XML schema so editors can provide error checking.
+			// Modules are nested deep, so change the path to reference the same schema everywhere.
+			const String schema_path = save_path.find("modules/") != -1 ? "../../../doc/class.xsd" : "../class.xsd";
+			header += vformat(
+					R"( xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="%s")",
+					schema_path);
+		}
+		header += ">";
 		_write_string(f, 0, header);
 
 		_write_string(f, 1, "<brief_description>");
@@ -1521,9 +1524,9 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 				const DocData::PropertyDoc &p = c.properties[i];
 
 				if (c.properties[i].overridden) {
-					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\" overrides=\"" + p.overrides + "\"" + additional_attributes + " />");
+					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type.xml_escape(true) + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\" overrides=\"" + p.overrides + "\"" + additional_attributes + " />");
 				} else {
-					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\"" + additional_attributes + ">");
+					_write_string(f, 2, "<member name=\"" + p.name + "\" type=\"" + p.type.xml_escape(true) + "\" setter=\"" + p.setter + "\" getter=\"" + p.getter + "\"" + additional_attributes + ">");
 					_write_string(f, 3, _translate_doc_string(p.description).strip_edges().xml_escape());
 					_write_string(f, 2, "</member>");
 				}
@@ -1549,12 +1552,12 @@ Error DocTools::save_classes(const String &p_default_path, const HashMap<String,
 				if (k.is_value_valid) {
 					if (!k.enumeration.is_empty()) {
 						if (k.is_bitfield) {
-							_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\" is_bitfield=\"true\"" + additional_attributes + ">");
+							_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value.xml_escape(true) + "\" enum=\"" + k.enumeration + "\" is_bitfield=\"true\"" + additional_attributes + ">");
 						} else {
-							_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\" enum=\"" + k.enumeration + "\"" + additional_attributes + ">");
+							_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value.xml_escape(true) + "\" enum=\"" + k.enumeration + "\"" + additional_attributes + ">");
 						}
 					} else {
-						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value + "\"" + additional_attributes + ">");
+						_write_string(f, 2, "<constant name=\"" + k.name + "\" value=\"" + k.value.xml_escape(true) + "\"" + additional_attributes + ">");
 					}
 				} else {
 					if (!k.enumeration.is_empty()) {

--- a/editor/doc_tools.h
+++ b/editor/doc_tools.h
@@ -47,7 +47,7 @@ public:
 	bool has_doc(const String &p_class_name);
 	void generate(bool p_basic_types = false);
 	Error load_classes(const String &p_dir);
-	Error save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path);
+	Error save_classes(const String &p_default_path, const HashMap<String, String> &p_class_path, bool p_include_xml_schema = true);
 
 	Error _load(Ref<XMLParser> parser);
 	Error load_compressed(const uint8_t *p_data, int p_compressed_size, int p_uncompressed_size);

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -239,6 +239,7 @@ void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_c
 					DocData::ConstantDoc const_doc;
 					const_doc.name = val.identifier->name;
 					const_doc.value = String(Variant(val.value));
+					const_doc.is_value_valid = true;
 					const_doc.description = val.doc_description;
 					const_doc.enumeration = name;
 


### PR DESCRIPTION
Godot is now parsing inline API documentation in GDScript, in order to show it in the editor's integrated help system.

This PR allows dumping this as XML by passing `--doctool --gdscript-docs PATH` on the command-line, using the same XML format as `--doctool` normally does for the engine API documentation.

This could allow addon authors to further process the XML, for example, to create an online API reference.

I'm not 100% sure that having this in the engine is a good idea. It wouldn't be that hard to create an external tool that parsed GDScript's inline API documentation (like https://github.com/GDQuest/gdscript-docs-maker). The advantage to having it in engine is that it will exactly match what shows up in the editor's help system.

What do you think?