### PR TITLE
[WIP] Added `orthonormalization_forced` property to Camera3D

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -190,6 +190,10 @@
 		<member name="near" type="float" setter="set_near" getter="get_near" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis.
 		</member>
+		<member name="orthonormalization_forced" type="bool" setter="set_orthonormalization_forced" getter="is_orthonormalization_forced" default="true">
+			Forces orthonormalization of this camera's global transform. 
+			Set this to [code]false[/code] to allow non-orthonormalized basis.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera3D.ProjectionType" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -163,6 +163,7 @@
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
+			<param index="2" name="orthonormalize" type="bool" default="true" />
 			<description>
 				Sets [Transform3D] of camera.
 			</description>

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -64,6 +64,7 @@ private:
 
 	ProjectionType mode = PROJECTION_PERSPECTIVE;
 
+	bool orthonormalization_forced = true;
 	real_t fov = 75.0;
 	real_t size = 1.0;
 	Vector2 frustum_offset;
@@ -123,6 +124,7 @@ public:
 
 	RID get_camera() const;
 
+	bool is_orthonormalization_forced() const;
 	real_t get_fov() const;
 	real_t get_size() const;
 	real_t get_far() const;
@@ -131,6 +133,7 @@ public:
 
 	ProjectionType get_projection() const;
 
+	void set_orthonormalization_forced(bool p_force);
 	void set_fov(real_t p_fov);
 	void set_size(real_t p_size);
 	void set_far(real_t p_far);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -75,10 +75,13 @@ void RendererSceneCull::camera_set_frustum(RID p_camera, float p_size, Vector2 p
 	camera->zfar = p_z_far;
 }
 
-void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform) {
+void RendererSceneCull::camera_set_transform(RID p_camera, const Transform3D &p_transform, bool p_orthonormalize) {
 	Camera *camera = camera_owner.get_or_null(p_camera);
 	ERR_FAIL_COND(!camera);
-	camera->transform = p_transform.orthonormalized();
+	if (p_orthonormalize)
+		camera->transform = p_transform.orthonormalized();
+	else
+		camera->transform = p_transform;
 }
 
 void RendererSceneCull::camera_set_cull_mask(RID p_camera, uint32_t p_layers) {
@@ -2517,6 +2520,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 	if (p_xr_interface.is_null()) {
 		// Normal camera
 		Transform3D transform = camera->transform;
+
 		Projection projection;
 		bool vaspect = camera->vaspect;
 		bool is_orthogonal = false;
@@ -2550,6 +2554,12 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 						camera->vaspect);
 			} break;
 		}
+
+		Transform3D ortho = transform.orthonormalized();
+		Transform3D diff = ortho.affine_inverse() * transform;
+
+		transform = ortho;
+		projection = projection * diff.affine_inverse();
 
 		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, camera->visible_layers);
 	} else {

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -100,7 +100,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
-	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
+	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform, bool p_orthonormalize = true);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);
 	virtual void camera_set_camera_attributes(RID p_camera, RID p_attributes);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -43,7 +43,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
-	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
+	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform, bool p_orthonormalize = true) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_camera_attributes(RID p_camera, RID p_attributes) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -568,7 +568,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
-	FUNC2(camera_set_transform, RID, const Transform3D &)
+	FUNC3(camera_set_transform, RID, const Transform3D &, bool)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)
 	FUNC2(camera_set_camera_attributes, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2175,7 +2175,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
-	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
+	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform", "orthonormalize"), &RenderingServer::camera_set_transform, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);
 	ClassDB::bind_method(D_METHOD("camera_set_camera_attributes", "camera", "effects"), &RenderingServer::camera_set_camera_attributes);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -769,7 +769,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
-	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
+	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform, bool p_orthonormalize = true) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;
 	virtual void camera_set_camera_attributes(RID p_camera, RID p_camera_attributes) = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
(Draft in-progress)
References godotengine/godot-proposals#2713

This PR aims to allow non-orthonormalized camera transform, that means you can do some crazy things to the camera's transform's basis, like scaling and skewing.
Basically, it adds a new property `orthonormalization_forced` which defaults to `true` (current behaviour), which when set to `false` allows you to modify the transform's basis without orthonormalizing it. It's really usefull for some camera projections, like oblique orthogonal and it can be combined to any other projection mode.
(Need to add some usage examples, but can't right now)