### PR TITLE
[GDScript] Perform update-and-assign operations in place when possible.

### DIFF
--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -841,8 +841,9 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*r_ret = Array();
-		_add_arrays(*VariantGetInternalPtr<Array>::get_ptr(r_ret), *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
+		Array sum;
+		_add_arrays(sum, *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
+		*r_ret = sum;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Array ret;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1165,8 +1165,18 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				bool has_operation = assignment->operation != GDScriptParser::AssignmentNode::OP_NONE;
 				if (has_operation) {
 					// Perform operation.
-					GDScriptCodeGenerator::Address op_result = codegen.add_temporary(_gdtype_from_datatype(assignment->get_datatype(), codegen.script));
 					GDScriptCodeGenerator::Address og_value = _parse_expression(codegen, r_error, assignment->assignee);
+					GDScriptDataType assignment_type = _gdtype_from_datatype(assignment->get_datatype(), codegen.script);
+					if (!has_setter && !assignment->use_conversion_assign && assignment_type.kind == GDScriptDataType::BUILTIN && og_value.type.kind == GDScriptDataType::BUILTIN && assignment_type.builtin_type == og_value.type.builtin_type) {
+						// If there's nothing special about the assignment, perform the assignment as part of the operator
+						gen->write_binary_operator(target, assignment->variant_op, og_value, assigned_value);
+						if (assigned_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+							gen->pop_temporary(); // Pop assigned value if not done before.
+						}
+						return GDScriptCodeGenerator::Address();
+					}
+
+					GDScriptCodeGenerator::Address op_result = codegen.add_temporary(assignment_type);
 					gen->write_binary_operator(op_result, assignment->variant_op, og_value, assigned_value);
 					to_assign = op_result;
 


### PR DESCRIPTION
This turns two bytecode operations into one by using the assignment destination directly as the output of the binary operator. This manifests in operations like `+=`.

This updated version contains fixes for the bugs previously exposed. It does so by:

* Restricting the transformation to only those scenarios where no stack slots will change type.
* Updating the ArrayAdd validated operator not to destroy the destination up front.