### PR TITLE
Fix Popups when using SubViewports with embedded subwindows

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -273,7 +273,15 @@ void PopupMenu::_parent_focused() {
 			window_parent = Object::cast_to<Window>(window_parent->get_parent()->get_viewport());
 		}
 
-		Rect2 safe_area = DisplayServer::get_singleton()->window_get_popup_safe_rect(get_window_id());
+		Rect2 safe_area;
+		DisplayServer::WindowID wid = get_window_id();
+		if (wid != DisplayServer::INVALID_WINDOW_ID) {
+			safe_area = DisplayServer::get_singleton()->window_get_popup_safe_rect(wid);
+		} else {
+			Popup::_parent_focused();
+			return;
+		}
+
 		Point2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
 		if (safe_area == Rect2i() || !safe_area.has_point(pos)) {
 			Popup::_parent_focused();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -290,6 +290,9 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 		}
 
 		Window *this_window = Object::cast_to<Window>(this);
+		if (!this_window && get_window_id() == DisplayServer::INVALID_WINDOW_ID) {
+			this_window = get_window();
+		}
 		if (this_window) {
 			this_window->_event_callback(DisplayServer::WINDOW_EVENT_FOCUS_IN);
 		}
@@ -318,6 +321,9 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 		gui.subwindow_drag = SUB_WINDOW_DRAG_DISABLED;
 	} else {
 		Window *this_window = Object::cast_to<Window>(this);
+		if (!this_window && get_window_id() == DisplayServer::INVALID_WINDOW_ID) {
+			this_window = get_window();
+		}
 		if (this_window) {
 			this_window->_event_callback(DisplayServer::WINDOW_EVENT_FOCUS_OUT);
 		}


### PR DESCRIPTION
This PR fixes some issues where it was assumed to always be a Viewport and not a `SubViewport` which behaves slightly different. Also, there were some problems with `SubViewports` with embedded subwindows. I explained in detail in this comment: https://github.com/godotengine/godot/issues/76390#issuecomment-1524052314

In short, to display a 2D GUI in a 3D world, you want to use a `SubViewport` and get its texture to then display it in some mesh, but there are some `Control` nodes that spawn `Popup`s and can't be displayed this way. The solution is to enable `gui_embed_subwindows` in the `SubViewport`, but this creates a series of other issues, like:

- In the case of `ColorPickerButton`, the Popup it spawns cannot be closed
- In the case of `OptionButton` and `MenuButton`, after selecting an option and clicking outside, the Popup will open again

Fixes #76390 and fixes #71612 