### PR TITLE
import: Fix Silhouette used incorrect index.

### DIFF
--- a/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
@@ -669,7 +669,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 						StringName bn = skin->get_bind_name(i);
 						int bone_idx = src_skeleton->find_bone(bn);
 						if (bone_idx >= 0) {
-							Transform3D new_rest = silhouette_diff[i] * src_skeleton->get_bone_global_rest(bone_idx);
+							Transform3D new_rest = silhouette_diff[bone_idx] * src_skeleton->get_bone_global_rest(bone_idx);
 							skin->set_bind_pose(i, new_rest.inverse() * ibm_diff[bone_idx]);
 						}
 					}


### PR DESCRIPTION
PostImportPluginSkeletonRestFixer: Fixes bind pose mistake from using i (mesh skin index) instead of bone_idx (skeleton bone index).
Fixes #76448

![image showing properly t-posed skeleton](https://user-images.githubusercontent.com/39946030/234809162-47813c80-1ffa-4acb-bf11-cadeaf162b3b.png)