### PR TITLE
Fix formatting function not used when printing run arguments

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -264,7 +264,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 	if (OS::get_singleton()->is_stdout_verbose()) {
 		print_line(vformat("Running: %s", exec));
 		for (const String &E : args) {
-			print_line(" %s", E);
+			print_line(vformat(" %s", E));
 		}
 	}
 


### PR DESCRIPTION
Otherwise, the relevant output looks like this:
```
Running: C:/godot/bin/godot.windows.editor.dev.x86_64.exe
 %s --disable-crash-handler
 %s --verbose
 %s --path
 %s C:/G/tests-4/godot-reflection-voxelgi
 %s --remote-debug
 %s tcp://127.0.0.1:6007
 %s --editor-pid
 %s 61640
 %s --position
 %s 1144,376
 %s res://reflection/reflection.tscn
```

It seems the cause is just an overlook when doing a pass of upgrading prints.