### PR TITLE
Add filter for `AnimationNodeBlend3`

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -567,11 +567,15 @@ String AnimationNodeBlend3::get_caption() const {
 
 double AnimationNodeBlend3::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	double amount = get_parameter(blend_amount);
-	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_IGNORE, sync, p_test_only);
-	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, 1.0 - ABS(amount), FILTER_IGNORE, sync, p_test_only);
-	double rem2 = blend_input(2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_IGNORE, sync, p_test_only);
+	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_PASS, sync, p_test_only);
+	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, 1.0 - ABS(amount), FILTER_BLEND, sync, p_test_only);
+	double rem2 = blend_input(2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_PASS, sync, p_test_only);
 
 	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); // Hacky but good enough.
+}
+
+bool AnimationNodeBlend3::has_filter() const {
+	return true;
 }
 
 void AnimationNodeBlend3::_bind_methods() {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -232,6 +232,8 @@ public:
 	virtual String get_caption() const override;
 
 	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+
+	virtual bool has_filter() const override;
 	AnimationNodeBlend3();
 };
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->


Befor:

https://user-images.githubusercontent.com/61624558/234867370-7a5786eb-7c46-43f2-8a70-fa6530f5710b.mp4

After:


https://user-images.githubusercontent.com/61624558/234867386-bbaf7a38-18c3-45f4-966d-74afbbea7b5f.mp4



Refer to this [discussion](https://github.com/godotengine/godot/pull/27571#issuecomment-517682942).