### PR TITLE
Don't autocomplete parenthesis if `Callable` is expected.

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.h
+++ b/modules/gdscript/editor/gdscript_docgen.h
@@ -33,10 +33,12 @@
 
 #include "../gdscript_parser.h"
 #include "core/doc_data.h"
+#include "core/object/object.h"
 
 class GDScriptDocGen {
 public:
 	static void generate_docs(GDScript *p_script, const GDScriptParser::ClassNode *p_class);
+	static MethodInfo method_info_from_node(const GDScriptParser::Node &p_func);
 };
 
 #endif // GDSCRIPT_DOCGEN_H


### PR DESCRIPTION
Fixes: godotengine/godot-proposals#6728
Fixes: #68146
Should be thoroughly tested. I may have broken some things in the autocompletion that I am not aware of.