### PR TITLE
[iOS] Fix loading of GDExtension dylibs auto converted to framework.

### DIFF
--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -240,8 +240,18 @@ Error OS_IOS::open_dynamic_library(const String p_path, void *&p_library_handle,
 	}
 
 	if (!FileAccess::exists(path)) {
+		// Load .dylib converted to framework from within the executable path.
+		path = get_framework_executable(get_executable_path().get_base_dir().path_join(p_path.get_file().get_basename() + ".framework"));
+	}
+
+	if (!FileAccess::exists(path)) {
 		// Load .dylib or framework from a standard iOS location.
 		path = get_framework_executable(get_executable_path().get_base_dir().path_join("Frameworks").path_join(p_path.get_file()));
+	}
+
+	if (!FileAccess::exists(path)) {
+		// Load .dylib converted to framework from a standard iOS location.
+		path = get_framework_executable(get_executable_path().get_base_dir().path_join("Frameworks").path_join(p_path.get_file().get_basename() + ".framework"));
 	}
 
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);


### PR DESCRIPTION
It's possible to build GDExtension as `dylib`, which can't be directly loaded on iOS device, so Godot will convert them to `framework`s during export. But the library can be still referenced by original name, this PR adds extra checks to load converted `dylib`s using original name.