### PR TITLE
Fix wait for thread not started

### DIFF
--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -339,7 +339,9 @@ void AudioDriverALSA::finish_output_device() {
 
 void AudioDriverALSA::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 
 	finish_output_device();
 }

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -207,7 +207,9 @@ Error MIDIDriverALSAMidi::open() {
 
 void MIDIDriverALSAMidi::close() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 
 	for (int i = 0; i < connected_inputs.size(); i++) {
 		snd_rawmidi_t *midi_in = connected_inputs[i].rawmidi_ptr;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -676,7 +676,9 @@ void AudioDriverPulseAudio::finish() {
 	}
 
 	exit_thread.set();
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 
 	finish_output_device();
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -930,7 +930,9 @@ void AudioDriverWASAPI::unlock() {
 
 void AudioDriverWASAPI::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 
 	finish_input_device();
 	finish_output_device();

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -151,7 +151,9 @@ void AudioDriverXAudio2::unlock() {
 
 void AudioDriverXAudio2::finish() {
 	exit_thread.set();
-	thread.wait_to_finish();
+	if (thread.is_started()) {
+		thread.wait_to_finish();
+	}
 
 	if (source_voice) {
 		source_voice->Stop(0);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1256,7 +1256,9 @@ void EditorFileSystem::_notification(int p_what) {
 					if (scanning_changes_done) {
 						set_process(false);
 
-						thread_sources.wait_to_finish();
+						if (thread_sources.is_started()) {
+							thread_sources.wait_to_finish();
+						}
 						bool changed = _update_scan_actions();
 						_update_pending_script_classes();
 						if (changed) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2371,9 +2371,6 @@ void EditorHelp::update_doc() {
 
 void EditorHelp::cleanup_doc() {
 	_wait_for_thread();
-	if (doc_gen_use_threads) {
-		thread.wait_to_finish();
-	}
 	memdelete(doc);
 }
 

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -44,7 +44,9 @@ NoiseTexture2D::~NoiseTexture2D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}
-	noise_thread.wait_to_finish();
+	if (noise_thread.is_started()) {
+		noise_thread.wait_to_finish();
+	}
 }
 
 void NoiseTexture2D::_bind_methods() {

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -604,7 +604,9 @@ RaycastOcclusionCull::~RaycastOcclusionCull() {
 	for (KeyValue<RID, Scenario> &K : scenarios) {
 		Scenario &scenario = K.value;
 		if (scenario.commit_thread) {
-			scenario.commit_thread->wait_to_finish();
+			if (scenario.commit_thread->is_started()) {
+				scenario.commit_thread->wait_to_finish();
+			}
 			memdelete(scenario.commit_thread);
 		}
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1984,6 +1984,8 @@ EditorExportPlatformIOS::EditorExportPlatformIOS() {
 EditorExportPlatformIOS::~EditorExportPlatformIOS() {
 #ifndef ANDROID_ENABLED
 	quit_request.set();
-	check_for_changes_thread.wait_to_finish();
+	if (check_for_changes_thread.is_started()) {
+		check_for_changes_thread.wait_to_finish();
+	}
 #endif
 }

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -687,5 +687,7 @@ EditorExportPlatformWeb::~EditorExportPlatformWeb() {
 		server->stop();
 	}
 	server_quit = true;
-	server_thread.wait_to_finish();
+	if (server_thread.is_started()) {
+		server_thread.wait_to_finish();
+	}
 }

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -270,7 +270,9 @@ void NavigationRegion3D::bake_navigation_mesh(bool p_on_thread) {
 
 void NavigationRegion3D::_bake_finished(Ref<NavigationMesh> p_nav_mesh) {
 	set_navigation_mesh(p_nav_mesh);
-	bake_thread.wait_to_finish();
+	if (bake_thread.is_started()) {
+		bake_thread.wait_to_finish();
+	}
 	emit_signal(SNAME("bake_finished"));
 }
 

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -190,7 +190,9 @@ void HTTPRequest::cancel_request() {
 		set_process_internal(false);
 	} else {
 		thread_request_quit.set();
-		thread.wait_to_finish();
+		if (thread.is_started()) {
+			thread.wait_to_finish();
+		}
 	}
 
 	file.unref();

--- a/servers/audio/audio_driver_dummy.cpp
+++ b/servers/audio/audio_driver_dummy.cpp
@@ -136,7 +136,9 @@ void AudioDriverDummy::mix_audio(int p_frames, int32_t *p_buffer) {
 void AudioDriverDummy::finish() {
 	if (use_threads) {
 		exit_thread.set();
-		thread.wait_to_finish();
+		if (thread.is_started()) {
+			thread.wait_to_finish();
+		}
 	}
 
 	if (samples_in) {

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -120,7 +120,9 @@ void AudioEffectRecordInstance::init() {
 }
 
 void AudioEffectRecordInstance::finish() {
-	io_thread.wait_to_finish();
+	if (io_thread.is_started()) {
+		io_thread.wait_to_finish();
+	}
 }
 
 AudioEffectRecordInstance::~AudioEffectRecordInstance() {

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -237,7 +237,9 @@ void RenderingServerDefault::init() {
 void RenderingServerDefault::finish() {
 	if (create_thread) {
 		command_queue.push(this, &RenderingServerDefault::_thread_exit);
-		thread.wait_to_finish();
+		if (thread.is_started()) {
+			thread.wait_to_finish();
+		}
 	} else {
 		_finish();
 	}


### PR DESCRIPTION
At least the one I could find. Noise and AudioDriverDummy was happening for me on Win11, a couple where reported and iOS didn't match the android counterpart.

Fix https://github.com/godotengine/godot/issues/76456
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
