### PR TITLE
GDScript: Allow quoteless strings as arguments in some annotations

### DIFF
--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -138,10 +138,10 @@
 			Used with [method Node.rpc_config] to disable a method or property for all RPC calls, making it unavailable. Default for all methods.
 		</constant>
 		<constant name="RPC_MODE_ANY_PEER" value="1" enum="RPCMode">
-			Used with [method Node.rpc_config] to set a method to be callable remotely by any peer. Analogous to the [code]@rpc("any_peer")[/code] annotation. Calls are accepted from all remote peers, no matter if they are node's authority or not.
+			Used with [method Node.rpc_config] to set a method to be callable remotely by any peer. Analogous to the [code]@rpc(any_peer)[/code] annotation. Calls are accepted from all remote peers, no matter if they are node's authority or not.
 		</constant>
 		<constant name="RPC_MODE_AUTHORITY" value="2" enum="RPCMode">
-			Used with [method Node.rpc_config] to set a method to be callable remotely only by the current multiplayer authority (which is the server by default). Analogous to the [code]@rpc("authority")[/code] annotation. See [method Node.set_multiplayer_authority].
+			Used with [method Node.rpc_config] to set a method to be callable remotely only by the current multiplayer authority (which is the server by default). Analogous to the [code]@rpc(authority)[/code] annotation. See [method Node.set_multiplayer_authority].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -679,7 +679,7 @@
 				    channel = 0,
 				}
 				[/codeblock]
-				See [enum MultiplayerAPI.RPCMode] and [enum MultiplayerPeer.TransferMode]. An alternative is annotating methods and properties with the corresponding [annotation @GDScript.@rpc] annotation ([code]@rpc("any_peer")[/code], [code]@rpc("authority")[/code]). By default, methods are not exposed to networking (and RPCs).
+				See [enum MultiplayerAPI.RPCMode] and [enum MultiplayerPeer.TransferMode]. An alternative is annotating methods and properties with the corresponding [annotation @GDScript.@rpc] annotation ([code]@rpc(any_peer)[/code], [code]@rpc(authority)[/code]). By default, methods are not exposed to networking (and RPCs).
 			</description>
 		</method>
 		<method name="rpc_id" qualifiers="vararg">

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -271,7 +271,7 @@ void ScriptTextEditor::_warning_clicked(Variant p_line) {
 			} else {
 				annotation_indent = String(" ").repeat(text_editor->get_indent_size() * indent);
 			}
-			text_editor->insert_line_at(line, annotation_indent + "@warning_ignore(" + code.quote(quote_style) + ")");
+			text_editor->insert_line_at(line, annotation_indent + "@warning_ignore(" + code + ")");
 		}
 
 		_validate_script();

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -870,14 +870,14 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 	valid = valid && test_conversion_with_regex("\texport_dialog", "\texport_dialog", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex("export", "@export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex(" export", " export", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid && test_conversion_with_regex("\n\nremote func", "\n\n@rpc(\"any_peer\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid && test_conversion_with_regex("\n\nremotesync func", "\n\n@rpc(\"any_peer\", \"call_local\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid && test_conversion_with_regex("\n\nsync func", "\n\n@rpc(\"any_peer\", \"call_local\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nremote func", "\n\n@rpc(any_peer) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nremotesync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nsync func", "\n\n@rpc(any_peer, call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex("\n\nslave func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex("\n\npuppet func", "\n\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid && test_conversion_with_regex("\n\npuppetsync func", "\n\n@rpc(\"call_local\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\npuppetsync func", "\n\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 	valid = valid && test_conversion_with_regex("\n\nmaster func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
-	valid = valid && test_conversion_with_regex("\n\nmastersync func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc(\"call_local\") func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
+	valid = valid && test_conversion_with_regex("\n\nmastersync func", "\n\nThe master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n@rpc(call_local) func", &ProjectConverter3To4::rename_gdscript_keywords, "gdscript keyword", reg_container);
 
 	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget set_function, get_function", "var size: Vector2 = Vector2(): get = get_function, set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
 	valid = valid && test_conversion_gdscript_builtin("var size: Vector2 = Vector2() setget set_function, ", "var size: Vector2 = Vector2(): set = set_function", &ProjectConverter3To4::rename_gdscript_functions, "custom rename", reg_container, false);
@@ -2461,13 +2461,13 @@ void ProjectConverter3To4::rename_gdscript_keywords(Vector<SourceLine> &source_l
 				line = reg_container.keyword_gdscript_onready.sub(line, "@onready", true);
 			}
 			if (line.contains("remote")) {
-				line = reg_container.keyword_gdscript_remote.sub(line, "@rpc(\"any_peer\") func", true);
+				line = reg_container.keyword_gdscript_remote.sub(line, "@rpc(any_peer) func", true);
 			}
 			if (line.contains("remote")) {
-				line = reg_container.keyword_gdscript_remotesync.sub(line, "@rpc(\"any_peer\", \"call_local\") func", true);
+				line = reg_container.keyword_gdscript_remotesync.sub(line, "@rpc(any_peer, call_local) func", true);
 			}
 			if (line.contains("sync")) {
-				line = reg_container.keyword_gdscript_sync.sub(line, "@rpc(\"any_peer\", \"call_local\") func", true);
+				line = reg_container.keyword_gdscript_sync.sub(line, "@rpc(any_peer, call_local) func", true);
 			}
 			if (line.contains("slave")) {
 				line = reg_container.keyword_gdscript_slave.sub(line, "@rpc func", true);
@@ -2476,13 +2476,13 @@ void ProjectConverter3To4::rename_gdscript_keywords(Vector<SourceLine> &source_l
 				line = reg_container.keyword_gdscript_puppet.sub(line, "@rpc func", true);
 			}
 			if (line.contains("puppet")) {
-				line = reg_container.keyword_gdscript_puppetsync.sub(line, "@rpc(\"call_local\") func", true);
+				line = reg_container.keyword_gdscript_puppetsync.sub(line, "@rpc(call_local) func", true);
 			}
 			if (line.contains("master")) {
 				line = reg_container.keyword_gdscript_master.sub(line, error_message + "@rpc func", true);
 			}
 			if (line.contains("master")) {
-				line = reg_container.keyword_gdscript_mastersync.sub(line, error_message + "@rpc(\"call_local\") func", true);
+				line = reg_container.keyword_gdscript_mastersync.sub(line, error_message + "@rpc(call_local) func", true);
 			}
 		}
 	}
@@ -2530,25 +2530,25 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_keywords(Vector<S
 
 			if (line.contains("remote")) {
 				old = line;
-				line = reg_container.keyword_gdscript_remote.sub(line, "@rpc(\"any_peer\") func", true);
+				line = reg_container.keyword_gdscript_remote.sub(line, "@rpc(any_peer) func", true);
 				if (old != line) {
-					found_renames.append(line_formatter(current_line, "remote func", "@rpc(\"any_peer\") func", line));
+					found_renames.append(line_formatter(current_line, "remote func", "@rpc(any_peer) func", line));
 				}
 			}
 
 			if (line.contains("remote")) {
 				old = line;
-				line = reg_container.keyword_gdscript_remotesync.sub(line, "@rpc(\"any_peer\", \"call_local\")) func", true);
+				line = reg_container.keyword_gdscript_remotesync.sub(line, "@rpc(any_peer, call_local)) func", true);
 				if (old != line) {
-					found_renames.append(line_formatter(current_line, "remotesync func", "@rpc(\"any_peer\", \"call_local\")) func", line));
+					found_renames.append(line_formatter(current_line, "remotesync func", "@rpc(any_peer, call_local)) func", line));
 				}
 			}
 
 			if (line.contains("sync")) {
 				old = line;
-				line = reg_container.keyword_gdscript_sync.sub(line, "@rpc(\"any_peer\", \"call_local\")) func", true);
+				line = reg_container.keyword_gdscript_sync.sub(line, "@rpc(any_peer, call_local)) func", true);
 				if (old != line) {
-					found_renames.append(line_formatter(current_line, "sync func", "@rpc(\"any_peer\", \"call_local\")) func", line));
+					found_renames.append(line_formatter(current_line, "sync func", "@rpc(any_peer, call_local)) func", line));
 				}
 			}
 
@@ -2570,9 +2570,9 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_keywords(Vector<S
 
 			if (line.contains("puppet")) {
 				old = line;
-				line = reg_container.keyword_gdscript_puppetsync.sub(line, "@rpc(\"call_local\") func", true);
+				line = reg_container.keyword_gdscript_puppetsync.sub(line, "@rpc(call_local) func", true);
 				if (old != line) {
-					found_renames.append(line_formatter(current_line, "puppetsync func", "@rpc(\"call_local\") func", line));
+					found_renames.append(line_formatter(current_line, "puppetsync func", "@rpc(call_local) func", line));
 				}
 			}
 
@@ -2586,9 +2586,9 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_keywords(Vector<S
 
 			if (line.contains("master")) {
 				old = line;
-				line = reg_container.keyword_gdscript_master.sub(line, "@rpc(\"call_local\") func", true);
+				line = reg_container.keyword_gdscript_master.sub(line, "@rpc(call_local) func", true);
 				if (old != line) {
-					found_renames.append(line_formatter(current_line, "mastersync func", "@rpc(\"call_local\") func", line));
+					found_renames.append(line_formatter(current_line, "mastersync func", "@rpc(call_local) func", line));
 				}
 			}
 		}

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -520,7 +520,7 @@
 				Export a [NodePath] property with a filter for allowed node types.
 				See also [constant PROPERTY_HINT_NODE_PATH_VALID_TYPES].
 				[codeblock]
-				@export_node_path("Button", "TouchScreenButton") var some_button
+				@export_node_path(Button, TouchScreenButton) var some_button
 				[/codeblock]
 			</description>
 		</annotation>
@@ -614,10 +614,10 @@
 				@rpc
 				func fn(): pass
 
-				@rpc("any_peer", "unreliable_ordered")
+				@rpc(any_peer, unreliable_ordered)
 				func fn_update_pos(): pass
 
-				@rpc("authority", "call_remote", "unreliable", 0) # Equivalent to @rpc
+				@rpc(authority, call_remote, unreliable, 0) # Equivalent to @rpc
 				func fn_default(): pass
 				[/codeblock]
 			</description>
@@ -642,7 +642,7 @@
 				func test():
 				    print("hello")
 				    return
-				    @warning_ignore("unreachable_code")
+				    @warning_ignore(unreachable_code)
 				    print("unreachable")
 				[/codeblock]
 			</description>

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -92,7 +92,7 @@ class GDScriptAnalyzer {
 	void reduce_cast(GDScriptParser::CastNode *p_cast);
 	void reduce_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
 	void reduce_get_node(GDScriptParser::GetNodeNode *p_get_node);
-	void reduce_identifier(GDScriptParser::IdentifierNode *p_identifier, bool can_be_builtin = false);
+	void reduce_identifier(GDScriptParser::IdentifierNode *p_identifier, bool p_can_be_builtin = false, bool p_can_be_not_found = false);
 	void reduce_identifier_from_base(GDScriptParser::IdentifierNode *p_identifier, GDScriptParser::DataType *p_base = nullptr);
 	void reduce_lambda(GDScriptParser::LambdaNode *p_lambda);
 	void reduce_literal(GDScriptParser::LiteralNode *p_literal);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -790,22 +790,30 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 		}
 	} else if (p_annotation->name == SNAME("@export_node_path")) {
 		ScriptLanguage::CodeCompletionOption node("Node", ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
-		node.insert_text = node.display.quote(p_quote_style);
 		r_result.insert(node.display, node);
 		List<StringName> node_types;
-		ClassDB::get_inheriters_from_class("Node", &node_types);
+		StringName node_class = SNAME("Node");
+		ClassDB::get_inheriters_from_class(node_class, &node_types);
 		for (const StringName &E : node_types) {
 			if (!ClassDB::is_class_exposed(E)) {
 				continue;
 			}
 			ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
-			option.insert_text = option.display.quote(p_quote_style);
+			r_result.insert(option.display, option);
+		}
+
+		List<StringName> global_script_classes;
+		ScriptServer::get_global_class_list(&global_script_classes);
+		for (const StringName &E : global_script_classes) {
+			if (!ClassDB::is_parent_class(ScriptServer::get_global_class_native_base(E), node_class)) {
+				continue;
+			}
+			ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
 			r_result.insert(option.display, option);
 		}
 	} else if (p_annotation->name == SNAME("@warning_ignore")) {
 		for (int warning_code = 0; warning_code < GDScriptWarning::WARNING_MAX; warning_code++) {
 			ScriptLanguage::CodeCompletionOption warning(GDScriptWarning::get_name_from_code((GDScriptWarning::Code)warning_code).to_lower(), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
-			warning.insert_text = warning.display.quote(p_quote_style);
 			r_result.insert(warning.display, warning);
 		}
 	} else if (p_annotation->name == SNAME("@rpc")) {
@@ -813,7 +821,6 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			static const char *options[7] = { "call_local", "call_remote", "any_peer", "authority", "reliable", "unreliable", "unreliable_ordered" };
 			for (int i = 0; i < 7; i++) {
 				ScriptLanguage::CodeCompletionOption option(options[i], ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
-				option.insert_text = option.display.quote(p_quote_style);
 				r_result.insert(option.display, option);
 			}
 		}

--- a/modules/gdscript/tests/scripts/analyzer/features/assymetric_assignment_good.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/assymetric_assignment_good.gd
@@ -3,7 +3,7 @@ const const_color: Color = 'red'
 func func_color(arg_color: Color = 'blue') -> bool:
 	return arg_color == Color.BLUE
 
-@warning_ignore("assert_always_true")
+@warning_ignore(assert_always_true)
 func test():
 	assert(const_color == Color.RED)
 

--- a/modules/gdscript/tests/scripts/analyzer/features/await_type_inference.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/await_type_inference.gd
@@ -1,5 +1,5 @@
 func coroutine() -> int:
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	await 0
 	return 1
 
@@ -8,8 +8,8 @@ func not_coroutine() -> int:
 
 func test():
 	var a := await coroutine()
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	var b := await not_coroutine()
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	var c := await 3
 	prints(a, b, c)

--- a/modules/gdscript/tests/scripts/analyzer/features/const_conversions.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/const_conversions.gd
@@ -5,7 +5,7 @@ const const_float_cast: float = 76 as float
 const const_packed_empty: PackedFloat64Array = []
 const const_packed_ints: PackedFloat64Array = [52]
 
-@warning_ignore("assert_always_true")
+@warning_ignore(assert_always_true)
 func test():
 	assert(typeof(const_float_int) == TYPE_FLOAT)
 	assert(str(const_float_int) == '19')

--- a/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/hard_variants.gd
@@ -2,18 +2,18 @@ func variant() -> Variant: return null
 
 var member_weak = variant()
 var member_typed: Variant = variant()
-@warning_ignore("inference_on_variant")
+@warning_ignore(inference_on_variant)
 var member_inferred := variant()
 
 func param_weak(param = variant()) -> void: print(param)
 func param_typed(param: Variant = variant()) -> void: print(param)
-@warning_ignore("inference_on_variant")
+@warning_ignore(inference_on_variant)
 func param_inferred(param := variant()) -> void: print(param)
 
 func return_untyped(): return variant()
 func return_typed() -> Variant: return variant()
 
-@warning_ignore("unused_variable", "inference_on_variant")
+@warning_ignore(unused_variable, inference_on_variant)
 func test() -> void:
 	var weak = variant()
 	var typed: Variant = variant()

--- a/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/ternary_hard_infer.gd
@@ -4,11 +4,11 @@ func test():
 	var result_hard_int := left_hard_int if true else right_hard_int
 	assert(result_hard_int == 1)
 
-	@warning_ignore("inference_on_variant")
+	@warning_ignore(inference_on_variant)
 	var left_hard_variant := 1 as Variant
-	@warning_ignore("inference_on_variant")
+	@warning_ignore(inference_on_variant)
 	var right_hard_variant := 2.0 as Variant
-	@warning_ignore("inference_on_variant")
+	@warning_ignore(inference_on_variant)
 	var result_hard_variant := left_hard_variant if true else right_hard_variant
 	assert(result_hard_variant == 1)
 

--- a/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/type_test_usage.gd
@@ -4,7 +4,7 @@ class A extends RefCounted:
 class B extends A:
 	pass
 
-@warning_ignore("assert_always_true")
+@warning_ignore(assert_always_true)
 func test():
 	var builtin: Variant = 3
 	assert((builtin is Variant) == true)

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_usage.gd
@@ -21,9 +21,9 @@ class Members:
 		return true
 
 
-@warning_ignore("unsafe_method_access")
-@warning_ignore("assert_always_true")
-@warning_ignore("return_value_discarded")
+@warning_ignore(unsafe_method_access)
+@warning_ignore(assert_always_true)
+@warning_ignore(return_value_discarded)
 func test():
 	var untyped_basic = [459]
 	assert(str(untyped_basic) == '[459]')

--- a/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/vararg_call.gd
@@ -1,6 +1,6 @@
 signal ok()
 
-@warning_ignore("return_value_discarded")
+@warning_ignore(return_value_discarded)
 func test():
 	ok.connect(func(): print('ok'))
 	emit_signal(&'ok')

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
@@ -1,12 +1,12 @@
-@warning_ignore("unused_private_class_variable")
+@warning_ignore(unused_private_class_variable)
 var _unused = 2
 
-@warning_ignore("unused_variable")
+@warning_ignore(unused_variable)
 func test():
 	print("test")
 	var unused = 3
 
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	print(await regular_func())
 
 	print("done")

--- a/modules/gdscript/tests/scripts/analyzer/warnings/redundant_await.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/redundant_await.gd
@@ -7,7 +7,7 @@ func test_signals():
 	await t
 
 func coroutine() -> void:
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	await 0
 
 func not_coroutine_variant():

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
@@ -1,6 +1,6 @@
 var member: int = 0
 
-@warning_ignore("unused_variable")
+@warning_ignore(unused_variable)
 func test():
 	var Array := 'Array'
 	var Node := 'Node'

--- a/modules/gdscript/tests/scripts/parser/features/annotations.gd
+++ b/modules/gdscript/tests/scripts/parser/features/annotations.gd
@@ -22,20 +22,20 @@ var a4: int
 var a5: int
 
 @export() var a6: int
-@warning_ignore("onready_with_export") @onready @export var a7: int
-@warning_ignore("onready_with_export") @onready() @export() var a8: int
+@warning_ignore(onready_with_export) @onready @export var a7: int
+@warning_ignore(onready_with_export) @onready() @export() var a8: int
 
-@warning_ignore("onready_with_export")
+@warning_ignore(onready_with_export)
 @onready
 @export
 var a9: int
 
-@warning_ignore("onready_with_export")
+@warning_ignore(onready_with_export)
 @onready()
 @export()
 var a10: int
 
-@warning_ignore("onready_with_export")
+@warning_ignore(onready_with_export)
 @onready()
 @export()
 

--- a/modules/gdscript/tests/scripts/parser/features/arrays_dictionaries_nested_const.gd
+++ b/modules/gdscript/tests/scripts/parser/features/arrays_dictionaries_nested_const.gd
@@ -1,6 +1,6 @@
 # https://github.com/godotengine/godot/issues/50285
 
-@warning_ignore("unused_local_constant")
+@warning_ignore(unused_local_constant)
 func test():
 	const CONST_INNER_DICTIONARY = { "key": true }
 	const CONST_NESTED_DICTIONARY_OLD_WORKAROUND = {

--- a/modules/gdscript/tests/scripts/parser/features/export_variable.gd
+++ b/modules/gdscript/tests/scripts/parser/features/export_variable.gd
@@ -5,7 +5,7 @@
 
 @export var color: Color
 @export_color_no_alpha var color_no_alpha: Color
-@export_node_path("Sprite2D", "Sprite3D", "Control", "Node") var nodepath := ^"hello"
+@export_node_path(Sprite2D, Sprite3D, Control, Node) var nodepath := ^"hello"
 
 
 func test():

--- a/modules/gdscript/tests/scripts/runtime/features/assign_operator.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/assign_operator.gd
@@ -1,6 +1,6 @@
 # https://github.com/godotengine/godot/issues/75832
 
-@warning_ignore("narrowing_conversion")
+@warning_ignore(narrowing_conversion)
 func test():
 	var hf := 2.0
 	var sf = 2.0

--- a/modules/gdscript/tests/scripts/runtime/features/await_on_void.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/await_on_void.gd
@@ -2,6 +2,6 @@ func wait() -> void:
 	pass
 
 func test():
-	@warning_ignore("redundant_await")
+	@warning_ignore(redundant_await)
 	await wait()
 	print("end")

--- a/modules/gdscript/tests/scripts/runtime/features/constants_are_read_only.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/constants_are_read_only.gd
@@ -1,7 +1,7 @@
 const array: Array = [0]
 const dictionary := {1: 2}
 
-@warning_ignore("assert_always_true")
+@warning_ignore(assert_always_true)
 func test():
 	assert(array.is_read_only() == true)
 	assert(str(array) == '[0]')

--- a/modules/gdscript/tests/scripts/runtime/features/does_not_override_temp_values.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/does_not_override_temp_values.gd
@@ -7,11 +7,11 @@ func test():
 
 func builtin_method():
 	var pba := PackedByteArray()
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	pba.resize(1) # Built-in validated.
 
 
 func builtin_method_static():
 	var _pba := PackedByteArray()
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	Vector2.from_angle(PI) # Static built-in validated.

--- a/modules/gdscript/tests/scripts/runtime/features/gdscript.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/gdscript.gd
@@ -11,10 +11,10 @@ class InnerClass:
 	func _init() -> void:
 		prints("Inner")
 '''
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	gdscr.reload()
 
 	var inst = gdscr.new()
 
-	@warning_ignore("unsafe_method_access")
+	@warning_ignore(unsafe_method_access)
 	inst.test()

--- a/modules/gdscript/tests/scripts/runtime/features/standalone-calls-do-not-write-to-nil.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/standalone-calls-do-not-write-to-nil.gd
@@ -20,26 +20,26 @@ func test_utility(v, f):
 	assert(not f) # Test unary operator reading from `nil`.
 
 func test_builtin_call(v, f):
-	@warning_ignore("unsafe_method_access")
+	@warning_ignore(unsafe_method_access)
 	v.angle() # Built-in method call.
 	assert(not f) # Test unary operator reading from `nil`.
 
 func test_builtin_call_validated(v: Vector2, f):
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	v.abs() # Built-in method call validated.
 	assert(not f) # Test unary operator reading from `nil`.
 
 func test_object_call(v, f):
-	@warning_ignore("unsafe_method_access")
+	@warning_ignore(unsafe_method_access)
 	v.get_reference_count() # Native type method call.
 	assert(not f) # Test unary operator reading from `nil`.
 
 func test_object_call_method_bind(v: Resource, f):
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	v.duplicate() # Native type method call with MethodBind.
 	assert(not f) # Test unary operator reading from `nil`.
 
 func test_object_call_ptrcall(v: RefCounted, f):
-	@warning_ignore("return_value_discarded")
+	@warning_ignore(return_value_discarded)
 	v.get_reference_count() # Native type method call with ptrcall.
 	assert(not f) # Test unary operator reading from `nil`.

--- a/modules/gdscript/tests/scripts/runtime/features/use_conversion_assign_with_variant_value.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/use_conversion_assign_with_variant_value.gd
@@ -1,7 +1,7 @@
 # https://github.com/godotengine/godot/issues/71172
 
 func test():
-	@warning_ignore("narrowing_conversion")
+	@warning_ignore(narrowing_conversion)
 	var foo: int = 0.0
 	print(typeof(foo) == TYPE_INT)
 	var dict: Dictionary = {"a": 0.0}


### PR DESCRIPTION
For some annotation, strings arguments are validated. In such cases, we allow not found or not constant identifiers to be used as a string, because invalid values will raise error messages removing the problem of typos.

It also allows type names to be used as strings if the argument supports it.

This commit applies it to `@rpc`, `@warning_ignore`, and `@export_node_path` (the latter now validated the arguments to be valid Node types).

Incidentally, this also improve completion for `@export_node_path` by
also adding custom nodes to the list.

