### PR TITLE
Use DXT1 when compressing PNGs with RGB format

### DIFF
--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -66,7 +66,7 @@ EtcpakType _determine_dxt_type(Image::UsedChannels p_channels) {
 		case Image::USED_CHANNELS_RG:
 			return EtcpakType::ETCPAK_TYPE_DXT5_RA_AS_RG;
 		case Image::USED_CHANNELS_RGB:
-			return EtcpakType::ETCPAK_TYPE_DXT5;
+			return EtcpakType::ETCPAK_TYPE_DXT1;
 		case Image::USED_CHANNELS_RGBA:
 			return EtcpakType::ETCPAK_TYPE_DXT5;
 		default:


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/58012

This now roughly matches the behaviour of Godot 3. We switched to DXT5 for RGB textures in https://github.com/godotengine/godot/pull/47370 and it's not clear why the change was made. My guess is it was just a typo.

This PR only changes the RGB format. R format is left as DXT5. Originally it used FORMAT_RGTC_R. Since I'm not sure why and I'm not sure what the tradeoffs involved are, I'd prefer to leave this PR as just fixing up the obviously broken case of RGB texture imports. 

There is a quality difference between DXT5 and DXT1. Notably the DXT5 option appears slightly smoother, but comes nowhere close to the quality of BPTC with the same file size

_Before_
![Screenshot from 2023-04-27 11-01-12](https://user-images.githubusercontent.com/16521339/234952616-fa20a8c2-1a44-45d7-a557-8bdfd2a158b3.png)

_After_
![Screenshot from 2023-04-27 11-01-17](https://user-images.githubusercontent.com/16521339/234952614-73c8beb1-a016-477b-84b8-8a4b2ac1fcd2.png)

_BPTC for reference_
![Screenshot from 2023-04-27 11-04-35](https://user-images.githubusercontent.com/16521339/234953085-08192bab-ad97-4acb-81d3-6c8414bba2a0.png)

_Original for reference_
![Screenshot from 2023-04-27 11-05-18](https://user-images.githubusercontent.com/16521339/234953275-3cd44ea6-d931-462f-89fd-ab62ff2ed5ea.png)

