### PR TITLE
Fix for infinite loop in Build2DFaces::_find_edge_intersections

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -315,61 +315,6 @@ public:
 		}
 	};
 
-	struct EnumDoc {
-		String name = "@unnamed_enum";
-		bool is_bitfield = false;
-		String description;
-		Vector<DocData::ConstantDoc> values;
-		static EnumDoc from_dict(const Dictionary &p_dict) {
-			EnumDoc doc;
-
-			if (p_dict.has("name")) {
-				doc.name = p_dict["name"];
-			}
-
-			if (p_dict.has("is_bitfield")) {
-				doc.is_bitfield = p_dict["is_bitfield"];
-			}
-
-			if (p_dict.has("description")) {
-				doc.description = p_dict["description"];
-			}
-
-			Array values;
-			if (p_dict.has("values")) {
-				values = p_dict["values"];
-			}
-			for (int i = 0; i < values.size(); i++) {
-				doc.values.push_back(ConstantDoc::from_dict(values[i]));
-			}
-
-			return doc;
-		}
-		static Dictionary to_dict(const EnumDoc &p_doc) {
-			Dictionary dict;
-
-			if (!p_doc.name.is_empty()) {
-				dict["name"] = p_doc.name;
-			}
-
-			dict["is_bitfield"] = p_doc.is_bitfield;
-
-			if (!p_doc.description.is_empty()) {
-				dict["description"] = p_doc.description;
-			}
-
-			if (!p_doc.values.is_empty()) {
-				Array values;
-				for (int i = 0; i < p_doc.values.size(); i++) {
-					values.push_back(ConstantDoc::to_dict(p_doc.values[i]));
-				}
-				dict["values"] = values;
-			}
-
-			return dict;
-		}
-	};
-
 	struct PropertyDoc {
 		String name;
 		String type;

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -178,7 +178,7 @@ class EditorHelp : public VBoxContainer {
 	void _class_desc_resized(bool p_force_update_theme);
 	int display_margin = 0;
 
-	Error _goto_desc(const String &p_class, int p_vscr = -1);
+	Error _goto_desc(const String &p_class);
 	//void _update_history_buttons();
 	void _update_method_list(const Vector<DocData::MethodDoc> p_methods);
 	void _update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, const String &p_method_type);
@@ -210,7 +210,7 @@ public:
 	static String get_cache_full_path();
 
 	void go_to_help(const String &p_help);
-	void go_to_class(const String &p_class, int p_scroll = 0);
+	void go_to_class(const String &p_class);
 	void update_doc();
 
 	Vector<Pair<String, int>> get_sections();

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3316,7 +3316,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 	eh->set_name(p_class);
 	tab_container->add_child(eh);
 	_go_to_tab(tab_container->get_tab_count() - 1);
-	eh->go_to_class(p_class, 0);
+	eh->go_to_class(p_class);
 	eh->connect("go_to_help", callable_mp(this, &ScriptEditor::_help_class_goto));
 	_add_recent_script(p_class);
 	_sort_list_on_update = true;

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -1,0 +1,271 @@
+/**************************************************************************/
+/*  gdscript_docgen.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_docgen.h"
+#include "../gdscript.h"
+
+using GDP = GDScriptParser;
+using GDType = GDP::DataType;
+
+static String _get_script_path(const String &p_path) {
+	return vformat(R"("%s")", p_path.get_slice("://", 1));
+}
+
+static String _get_class_name(const GDP::ClassNode &p_class) {
+	const GDP::ClassNode *curr_class = &p_class;
+	if (!curr_class->identifier) { // All inner classes have a identifier, so this is the outer class
+		return _get_script_path(curr_class->fqcn);
+	}
+
+	String full_name = curr_class->identifier->name;
+	while (curr_class->outer) {
+		curr_class = curr_class->outer;
+		if (!curr_class->identifier) { // All inner classes have a identifier, so this is the outer class
+			return vformat("%s.%s", _get_script_path(curr_class->fqcn), full_name);
+		}
+		full_name = vformat("%s.%s", curr_class->identifier->name, full_name);
+	}
+	return full_name;
+}
+
+static PropertyInfo _property_info_from_datatype(const GDType &p_type) {
+	PropertyInfo pi;
+	pi.type = p_type.builtin_type;
+	if (p_type.kind == GDType::CLASS) {
+		pi.class_name = _get_class_name(*p_type.class_type);
+	} else if (p_type.kind == GDType::ENUM && p_type.enum_type != StringName()) {
+		pi.type = Variant::INT; // Only int types are recognized as enums by the EditorHelp
+		pi.usage |= PROPERTY_USAGE_CLASS_IS_ENUM;
+		// Replace :: from enum's use of fully qualified class names with regular .
+		pi.class_name = String(p_type.native_type).replace("::", ".");
+	} else if (p_type.kind == GDType::NATIVE) {
+		pi.class_name = p_type.native_type;
+	}
+	return pi;
+}
+
+void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_class) {
+	p_script->_clear_doc();
+
+	DocData::ClassDoc &doc = p_script->doc;
+
+	doc.script_path = _get_script_path(p_script->get_script_path());
+	if (p_script->name.is_empty()) {
+		doc.name = doc.script_path;
+	} else {
+		doc.name = p_script->name;
+	}
+
+	if (p_script->_owner) {
+		doc.name = p_script->_owner->doc.name + "." + doc.name;
+		doc.script_path = doc.script_path + "." + doc.name;
+	}
+
+	doc.is_script_doc = true;
+
+	if (p_script->base.is_valid() && p_script->base->is_valid()) {
+		if (!p_script->base->doc.name.is_empty()) {
+			doc.inherits = p_script->base->doc.name;
+		} else {
+			doc.inherits = p_script->base->get_instance_base_type();
+		}
+	} else if (p_script->native.is_valid()) {
+		doc.inherits = p_script->native->get_name();
+	}
+
+	doc.brief_description = p_class->doc_brief_description;
+	doc.description = p_class->doc_description;
+	for (const Pair<String, String> &p : p_class->doc_tutorials) {
+		DocData::TutorialDoc td;
+		td.title = p.first;
+		td.link = p.second;
+		doc.tutorials.append(td);
+	}
+
+	for (const GDP::ClassNode::Member &member : p_class->members) {
+		switch (member.type) {
+			case GDP::ClassNode::Member::CLASS: {
+				const GDP::ClassNode *inner_class = member.m_class;
+				const StringName &class_name = inner_class->identifier->name;
+
+				p_script->member_lines[class_name] = inner_class->start_line;
+
+				// Recursively generate inner class docs
+				// Needs inner GDScripts to exist: previously generated in GDScriptCompiler::make_scripts()
+				GDScriptDocGen::generate_docs(*p_script->subclasses[class_name], inner_class);
+			} break;
+
+			case GDP::ClassNode::Member::CONSTANT: {
+				const GDP::ConstantNode *m_const = member.constant;
+				const StringName &const_name = member.constant->identifier->name;
+
+				p_script->member_lines[const_name] = m_const->start_line;
+
+				DocData::ConstantDoc const_doc;
+				DocData::constant_doc_from_variant(const_doc, const_name, m_const->initializer->reduced_value, m_const->doc_description);
+				doc.constants.push_back(const_doc);
+			} break;
+
+			case GDP::ClassNode::Member::FUNCTION: {
+				const GDP::FunctionNode *m_func = member.function;
+				const StringName &func_name = m_func->identifier->name;
+
+				p_script->member_lines[func_name] = m_func->start_line;
+
+				MethodInfo mi;
+				mi.name = func_name;
+
+				if (m_func->return_type) {
+					mi.return_val = _property_info_from_datatype(m_func->return_type->get_datatype());
+				}
+				for (const GDScriptParser::ParameterNode *p : m_func->parameters) {
+					PropertyInfo pi = _property_info_from_datatype(p->get_datatype());
+					pi.name = p->identifier->name;
+					mi.arguments.push_back(pi);
+				}
+
+				DocData::MethodDoc method_doc;
+				DocData::method_doc_from_methodinfo(method_doc, mi, m_func->doc_description);
+				doc.methods.push_back(method_doc);
+			} break;
+
+			case GDP::ClassNode::Member::SIGNAL: {
+				const GDP::SignalNode *m_signal = member.signal;
+				const StringName &signal_name = m_signal->identifier->name;
+
+				p_script->member_lines[signal_name] = m_signal->start_line;
+
+				MethodInfo mi;
+				mi.name = signal_name;
+				for (const GDScriptParser::ParameterNode *p : m_signal->parameters) {
+					PropertyInfo pi = _property_info_from_datatype(p->get_datatype());
+					pi.name = p->identifier->name;
+					mi.arguments.push_back(pi);
+				}
+
+				DocData::MethodDoc signal_doc;
+				DocData::signal_doc_from_methodinfo(signal_doc, mi, m_signal->doc_description);
+				doc.signals.push_back(signal_doc);
+			} break;
+
+			case GDP::ClassNode::Member::VARIABLE: {
+				const GDP::VariableNode *m_var = member.variable;
+				const StringName &var_name = m_var->identifier->name;
+
+				p_script->member_lines[var_name] = m_var->start_line;
+
+				DocData::PropertyDoc prop_doc;
+
+				prop_doc.name = var_name;
+				prop_doc.description = m_var->doc_description;
+
+				GDType dt = m_var->get_datatype();
+				switch (dt.kind) {
+					case GDType::CLASS:
+						prop_doc.type = _get_class_name(*dt.class_type);
+						break;
+					case GDType::VARIANT:
+						prop_doc.type = "Variant";
+						break;
+					case GDType::ENUM:
+						prop_doc.type = Variant::get_type_name(dt.builtin_type);
+						// Replace :: from enum's use of fully qualified class names with regular .
+						prop_doc.enumeration = String(dt.native_type).replace("::", ".");
+						break;
+					case GDType::NATIVE:;
+						prop_doc.type = dt.native_type;
+						break;
+					case GDType::BUILTIN:
+						prop_doc.type = Variant::get_type_name(dt.builtin_type);
+						break;
+					default:
+						// SCRIPT: can be preload()'d and perhaps used as types directly?
+						// RESOLVING & UNRESOLVED should never happen since docgen requires analyzing w/o errors
+						break;
+				}
+
+				if (m_var->property == GDP::VariableNode::PROP_SETGET) {
+					if (m_var->setter_pointer != nullptr) {
+						prop_doc.setter = m_var->setter_pointer->name;
+					}
+					if (m_var->getter_pointer != nullptr) {
+						prop_doc.getter = m_var->getter_pointer->name;
+					}
+				}
+
+				if (m_var->initializer && m_var->initializer->is_constant) {
+					prop_doc.default_value = m_var->initializer->reduced_value.get_construct_string().replace("\n", "");
+				}
+
+				prop_doc.overridden = false;
+
+				doc.properties.push_back(prop_doc);
+			} break;
+
+			case GDP::ClassNode::Member::ENUM: {
+				const GDP::EnumNode *m_enum = member.m_enum;
+				StringName name = m_enum->identifier->name;
+
+				p_script->member_lines[name] = m_enum->start_line;
+
+				for (const GDP::EnumNode::Value &val : m_enum->values) {
+					DocData::ConstantDoc const_doc;
+					const_doc.name = val.identifier->name;
+					const_doc.value = String(Variant(val.value));
+					const_doc.description = val.doc_description;
+					const_doc.enumeration = name;
+
+					doc.enums[const_doc.name] = const_doc.description;
+					doc.constants.push_back(const_doc);
+				}
+
+			} break;
+
+			case GDP::ClassNode::Member::ENUM_VALUE: {
+				const GDP::EnumNode::Value &m_enum_val = member.enum_value;
+				const StringName &name = m_enum_val.identifier->name;
+
+				p_script->member_lines[name] = m_enum_val.identifier->start_line;
+
+				DocData::ConstantDoc constant_doc;
+				constant_doc.enumeration = "@unnamed_enums";
+				DocData::constant_doc_from_variant(constant_doc, name, m_enum_val.value, m_enum_val.doc_description);
+				doc.constants.push_back(constant_doc);
+			} break;
+			case GDP::ClassNode::Member::GROUP:
+			case GDP::ClassNode::Member::UNDEFINED:
+			default:
+				break;
+		}
+	}
+
+	// Add doc to the outer-most class.
+	p_script->_add_doc(doc);
+}

--- a/modules/gdscript/editor/gdscript_docgen.h
+++ b/modules/gdscript/editor/gdscript_docgen.h
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  gdscript_docgen.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_DOCGEN_H
+#define GDSCRIPT_DOCGEN_H
+
+#include "../gdscript_parser.h"
+#include "core/doc_data.h"
+
+class GDScriptDocGen {
+public:
+	static void generate_docs(GDScript *p_script, const GDScriptParser::ClassNode *p_class);
+};
+
+#endif // GDSCRIPT_DOCGEN_H

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -83,6 +83,7 @@ class GDScript : public Script {
 	friend class GDScriptFunction;
 	friend class GDScriptAnalyzer;
 	friend class GDScriptCompiler;
+	friend class GDScriptDocGen;
 	friend class GDScriptLanguage;
 	friend struct GDScriptUtilityFunctionsDefinitions;
 
@@ -113,16 +114,7 @@ class GDScript : public Script {
 
 	DocData::ClassDoc doc;
 	Vector<DocData::ClassDoc> docs;
-	String doc_brief_description;
-	String doc_description;
-	Vector<DocData::TutorialDoc> doc_tutorials;
-	HashMap<String, String> doc_functions;
-	HashMap<String, String> doc_variables;
-	HashMap<String, String> doc_constants;
-	HashMap<String, String> doc_signals;
-	HashMap<String, DocData::EnumDoc> doc_enums;
 	void _clear_doc();
-	void _update_doc();
 	void _add_doc(const DocData::ClassDoc &p_inner_class);
 
 #endif

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2145,12 +2145,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 
 	if (p_func) {
 		codegen.generator->set_initial_line(p_func->start_line);
-#ifdef TOOLS_ENABLED
-		if (!p_for_lambda) {
-			p_script->member_lines[func_name] = p_func->start_line;
-			p_script->doc_functions[func_name] = p_func->doc_description;
-		}
-#endif
 	} else {
 		codegen.generator->set_initial_line(0);
 	}
@@ -2219,23 +2213,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 	parsing_classes.insert(p_script);
 
 	p_script->clearing = true;
-#ifdef TOOLS_ENABLED
-	p_script->doc_functions.clear();
-	p_script->doc_variables.clear();
-	p_script->doc_constants.clear();
-	p_script->doc_enums.clear();
-	p_script->doc_signals.clear();
-	p_script->doc_tutorials.clear();
-
-	p_script->doc_brief_description = p_class->doc_brief_description;
-	p_script->doc_description = p_class->doc_description;
-	for (int i = 0; i < p_class->doc_tutorials.size(); i++) {
-		DocData::TutorialDoc td;
-		td.title = p_class->doc_tutorials[i].first;
-		td.link = p_class->doc_tutorials[i].second;
-		p_script->doc_tutorials.append(td);
-	}
-#endif
 
 	p_script->native = Ref<GDScriptNativeClass>();
 	p_script->base = Ref<GDScript>();
@@ -2379,9 +2356,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				} else {
 					prop_info.usage = PROPERTY_USAGE_SCRIPT_VARIABLE;
 				}
-#ifdef TOOLS_ENABLED
-				p_script->doc_variables[name] = variable->doc_description;
-#endif
 
 				p_script->member_info[name] = prop_info;
 				p_script->member_indices[name] = minfo;
@@ -2394,7 +2368,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				} else {
 					p_script->member_default_values.erase(name);
 				}
-				p_script->member_lines[name] = variable->start_line;
 #endif
 			} break;
 
@@ -2403,12 +2376,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				StringName name = constant->identifier->name;
 
 				p_script->constants.insert(name, constant->initializer->reduced_value);
-#ifdef TOOLS_ENABLED
-				p_script->member_lines[name] = constant->start_line;
-				if (!constant->doc_description.is_empty()) {
-					p_script->doc_constants[name] = constant->doc_description;
-				}
-#endif
 			} break;
 
 			case GDScriptParser::ClassNode::Member::ENUM_VALUE: {
@@ -2416,18 +2383,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				StringName name = enum_value.identifier->name;
 
 				p_script->constants.insert(name, enum_value.value);
-#ifdef TOOLS_ENABLED
-				p_script->member_lines[name] = enum_value.identifier->start_line;
-				if (!p_script->doc_enums.has("@unnamed_enums")) {
-					p_script->doc_enums["@unnamed_enums"] = DocData::EnumDoc();
-					p_script->doc_enums["@unnamed_enums"].name = "@unnamed_enums";
-				}
-				DocData::ConstantDoc const_doc;
-				const_doc.name = enum_value.identifier->name;
-				const_doc.value = Variant(enum_value.value).operator String(); // TODO-DOC: enum value currently is int.
-				const_doc.description = enum_value.doc_description;
-				p_script->doc_enums["@unnamed_enums"].values.push_back(const_doc);
-#endif
 			} break;
 
 			case GDScriptParser::ClassNode::Member::SIGNAL: {
@@ -2440,11 +2395,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 					parameters_names.write[j] = signal->parameters[j]->identifier->name;
 				}
 				p_script->_signals[name] = parameters_names;
-#ifdef TOOLS_ENABLED
-				if (!signal->doc_description.is_empty()) {
-					p_script->doc_signals[name] = signal->doc_description;
-				}
-#endif
 			} break;
 
 			case GDScriptParser::ClassNode::Member::ENUM: {
@@ -2452,19 +2402,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				StringName name = enum_n->identifier->name;
 
 				p_script->constants.insert(name, enum_n->dictionary);
-#ifdef TOOLS_ENABLED
-				p_script->member_lines[name] = enum_n->start_line;
-				p_script->doc_enums[name] = DocData::EnumDoc();
-				p_script->doc_enums[name].name = name;
-				p_script->doc_enums[name].description = enum_n->doc_description;
-				for (int j = 0; j < enum_n->values.size(); j++) {
-					DocData::ConstantDoc const_doc;
-					const_doc.name = enum_n->values[j].identifier->name;
-					const_doc.value = Variant(enum_n->values[j].value).operator String();
-					const_doc.description = enum_n->values[j].doc_description;
-					p_script->doc_enums[name].values.push_back(const_doc);
-				}
-#endif
 			} break;
 
 			case GDScriptParser::ClassNode::Member::GROUP: {
@@ -2512,9 +2449,6 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 			}
 		}
 
-#ifdef TOOLS_ENABLED
-		p_script->member_lines[name] = inner_class->start_line;
-#endif
 		p_script->constants.insert(name, subclass); //once parsed, goes to the list of constants
 	}
 
@@ -2607,7 +2541,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 						//well, tough luck, not gonna do anything here
 					}
 				}
-#endif
+#endif // TOOLS_ENABLED
 			} else {
 				GDScriptInstance *gi = static_cast<GDScriptInstance *>(si);
 				gi->reload_members();
@@ -2616,7 +2550,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 			E = N;
 		}
 	}
-#endif
+#endif //DEBUG_ENABLED
 
 	for (int i = 0; i < p_class->members.size(); i++) {
 		if (p_class->members[i].type != GDScriptParser::ClassNode::Member::CLASS) {
@@ -2715,10 +2649,6 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	if (err) {
 		return err;
 	}
-
-#ifdef TOOLS_ENABLED
-	p_script->_update_doc();
-#endif
 
 	return GDScriptCache::finish_compiling(main_script->get_path());
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1480,7 +1480,7 @@ private:
 #ifdef TOOLS_ENABLED
 	// Doc comments.
 	int class_doc_line = 0x7FFFFFFF;
-	bool has_comment(int p_line);
+	bool has_comment(int p_line, bool p_must_be_doc = false);
 	String get_doc_comment(int p_line, bool p_single_line = false);
 	void get_class_doc_comment(int p_line, String &p_brief, String &p_desc, Vector<Pair<String, String>> &p_tutorials, bool p_inner_class);
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
This PR solves issue #73927 in which _find_edge_intersections could loop infinitely while creating new faces from edge intersections by keeping track of which edges we have already processed and skipping edges with the same points and uvs that come up in subsequent loops.

Had some concern about the glitchy faces that appear in subtract mode, but that appears to also occur in the most recent master post- https://github.com/godotengine/godot/pull/74771 so I'm not sure they really need to be covered in this fix, or if its even related.

This branch working:
https://user-images.githubusercontent.com/6236852/234983317-df6c0734-25f3-4790-80c6-24844062dde8.mp4

Most recent Master branch crashing, also exhibiting similar geometry wonkiness:
https://user-images.githubusercontent.com/6236852/234984769-620a2f24-968e-4a08-9a56-f4cc383c6d27.mp4

Also this is my first time touching both the Godot source and C++ so uh... don't hold back :D