### PR TITLE
Overhaul the top sections of the class reference (Core classes)

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AABB" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Axis-Aligned Bounding Box.
+		A 3D axis-aligned bounding box.
 	</brief_description>
 	<description>
 		[AABB] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.

--- a/doc/classes/AESContext.xml
+++ b/doc/classes/AESContext.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AESContext" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Interface to low level AES encryption features.
+		Provides access to AES encryption/decryption of raw data.
 	</brief_description>
 	<description>
-		This class provides access to AES encryption/decryption of raw data. Both AES-ECB and AES-CBC mode are supported.
+		This class holds the context information required for encryption and decryption operations with AES (Advanced Encryption Standard). Both AES-ECB and AES-CBC modes are supported.
 		[codeblocks]
 		[gdscript]
 		extends Node

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Array" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A generic array datatype.
+		A built-in data structure that holds a sequence of elements.
 	</brief_description>
 	<description>
-		A generic array that can contain several elements of any type, accessible by a numerical index starting at 0. Negative indices can be used to count from the back, like in Python (-1 is the last element, -2 is the second to last, etc.).
+		An array data structure that can contain a sequence of elements of any type. Elements are accessed by a numerical index starting at 0. Negative indices are used to count from the back (-1 is the last element, -2 is the second to last, etc.).
 		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
@@ -38,7 +38,6 @@
 		GD.Print(array1 + array2); // Prints [One, 2, 3, Four]
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Concatenating with the [code]+=[/code] operator will create a new array, which has a cost. If you want to append another array to an existing array, [method append_array] is more efficient.
 		[b]Note:[/b] Arrays are always passed by reference. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
 		[b]Note:[/b] Erasing elements while iterating over arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Basis" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		3×3 matrix datatype.
+		A 3×3 matrix for representing 3D rotation and scale.
 	</brief_description>
 	<description>
-		3×3 matrix used for 3D rotation and scale. Almost always used as an orthogonal basis for a [Transform3D].
+		A 3×3 matrix used for representing 3D rotation and scale. Usually used as an orthogonal basis for a [Transform3D].
 		Contains 3 vector fields X, Y and Z as its columns, which are typically interpreted as the local basis vectors of a transformation. For such use, it is composed of a scaling and a rotation matrix, in that order (M = R.S).
-		Can also be accessed as array of 3D vectors. These vectors are normally orthogonal to each other, but are not necessarily normalized (due to scaling).
+		Basis can also be accessed as an array of 3D vectors. These vectors are usually orthogonal to each other, but are not necessarily normalized (due to scaling).
 		For more information, read the "Matrices and transforms" documentation article.
 	</description>
 	<tutorials>
@@ -110,13 +110,13 @@
 			<return type="bool" />
 			<param index="0" name="b" type="Basis" />
 			<description>
-				Returns [code]true[/code] if this basis and [param b] are approximately equal, by calling [code]is_equal_approx[/code] on each component.
+				Returns [code]true[/code] if this basis and [param b] are approximately equal, by calling [method @GlobalScope.is_equal_approx] on all vector components.
 			</description>
 		</method>
 		<method name="is_finite" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if this basis is finite, by calling [method @GlobalScope.is_finite] on each component.
+				Returns [code]true[/code] if this basis is finite, by calling [method @GlobalScope.is_finite] on all vector components.
 			</description>
 		</method>
 		<method name="looking_at" qualifiers="static">

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Callable" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Built-in type representing a method in an object instance or a standalone function.
+		A built-in type representing a method or a standalone function.
 	</brief_description>
 	<description>
 		[Callable] is a built-in [Variant] type that represents a function. It can either be a method within an [Object] instance, or a standalone function not related to any object, like a lambda function. Like all [Variant] types, it can be stored in variables and passed to other functions. It is most commonly used for signal callbacks.

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ClassDB" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Class information repository.
+		A class information repository.
 	</brief_description>
 	<description>
 		Provides access to metadata stored for every available class.

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Color" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Color built-in type, in RGBA format.
+		A color represented in RGBA format.
 	</brief_description>
 	<description>
-		A color represented in RGBA format by red ([member r]), green ([member g]), blue ([member b]), and alpha ([member a]) components. Each component is a 16-bit floating-point value, usually ranging from 0 to 1. Some properties (such as [member CanvasItem.modulate]) may support values greater than 1, for overbright or High Dynamic Range colors. If you want to supply values in a range of 0 to 255, you should use [method @GDScript.Color8].
-		Colors can also be created by name from a set of standardized colors, through the [String] constructor, [method from_string], or by directly fetching the color constants documented here. The standardized color set is based on the [url=https://en.wikipedia.org/wiki/X11_color_names]X11 color names[/url], with the addition of [constant TRANSPARENT].
-		[b]Note:[/b] In a boolean context, a Color will evaluate to [code]false[/code] if it's equal to [code]Color(0, 0, 0, 1)[/code] (opaque black). Otherwise, a Color will always evaluate to [code]true[/code].
+		A color represented in RGBA format by a red ([member r]), green ([member g]), blue ([member b]), and alpha ([member a]) component. Each component is a 16-bit floating-point value, usually ranging from [code]0.0[/code] to [code]1.0[/code]. Some properties (such as [member CanvasItem.modulate]) may support values greater than [code]1.0[/code], for overbright or HDR (High Dynamic Range) colors.
+		Colors can be created in various ways: By the various [Color] constructors, by static methods such as [method from_hsv], and by using a name from the set of standardized colors based on [url=https://en.wikipedia.org/wiki/X11_color_names]X11 color names[/url] with the addition of [constant TRANSPARENT]. GDScript also provides [method @GDScript.Color8], which uses integers from [code]0[/code] to [code]255[/code] and doesn't support overbright colors.
+		[b]Note:[/b] In a boolean context, a Color will evaluate to [code]false[/code] if it is equal to [code]Color(0, 0, 0, 1)[/code] (opaque black). Otherwise, a Color will always evaluate to [code]true[/code].
 		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/color_constants.png]Color constants cheatsheet[/url]
 	</description>
 	<tutorials>

--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Crypto" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Access to advanced cryptographic functionalities.
+		Provides access to advanced cryptographic functionalities.
 	</brief_description>
 	<description>
-		The Crypto class allows you to access some more advanced cryptographic functionalities in Godot.
-		For now, this includes generating cryptographically secure random bytes, RSA keys and self-signed X509 certificates generation, asymmetric key encryption/decryption, and signing/verification.
+		The Crypto class provides access to advanced cryptographic functionalities.
+		Currently, this includes asymmetric key encryption/decryption, signing/verification, and generating cryptographically secure random bytes, RSA keys, HMAC digests, and self-signed [X509Certificate]s.
 		[codeblocks]
 		[gdscript]
 		extends Node

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Dictionary" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Dictionary type.
+		A built-in data structure that holds key-value pairs.
 	</brief_description>
 	<description>
-		Dictionary type. Associative container, which contains values referenced by unique keys. Dictionaries are composed of pairs of keys (which must be unique) and values. Dictionaries will preserve the insertion order when adding new entries. In other programming languages, this data structure is sometimes referred to as a hash map or associative array.
-		You can define a dictionary by placing a comma-separated list of [code]key: value[/code] pairs in curly braces [code]{}[/code].
-		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
+		Dictionaries are associative containers that contain values referenced by unique keys. Dictionaries will preserve the insertion order when adding new entries. In other programming languages, this data structure is often referred to as a hash map or an associative array.
+		You can define a dictionary by placing a comma-separated list of [code]key: value[/code] pairs inside curly braces [code]{}[/code].
 		Creating a dictionary:
 		[codeblocks]
 		[gdscript]
@@ -134,6 +133,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
 		[b]Note:[/b] Erasing elements while iterating over dictionaries is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="DirAccess" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Type used to handle the filesystem.
+		Provides methods for managing directories and their content.
 	</brief_description>
 	<description>
-		Directory type. It is used to manage directories and their content (not restricted to the project folder).
+		This class is used to manage directories and their content, even outside of the project folder.
 		[DirAccess] can't be instantiated directly. Instead it is created with a static method that takes a path for which it will be opened.
 		Most of the methods have a static alternative that can be used without creating a [DirAccess]. Static methods only support absolute paths (including [code]res://[/code] and [code]user://[/code]).
 		[codeblock]

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Engine" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Access to engine properties.
+		Provides access to engine properties.
 	</brief_description>
 	<description>
 		The [Engine] singleton allows you to query and modify the project's run-time parameters, such as frames per second, time scale, and others.

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="FileAccess" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Type to handle file reading and writing operations.
+		Provides methods for file reading and writing operations.
 	</brief_description>
 	<description>
-		File type. This is used to permanently store data into the user device's file system and to read from it. This can be used to store game save data or player configuration files, for example.
+		This class can be used to permanently store data in the user device's file system and to read from it. This is useful for store game save data or player configuration files.
 		Here's a sample on how to write and read from a file:
 		[codeblocks]
 		[gdscript]
@@ -33,7 +33,7 @@
 		[/csharp]
 		[/codeblocks]
 		In the example above, the file will be saved in the user data folder as specified in the [url=$DOCS_URL/tutorials/io/data_paths.html]Data paths[/url] documentation.
-		[FileAccess] will close when it's freed, which happens when it goes out of scope or when it gets assigned with [code]null[/code]. In C# the reference must be disposed after we are done using it, this can be done with the [code]using[/code] statement or calling the [code]Dispose[/code] method directly.
+		[FileAccess] will close when it's freed, which happens when it goes out of scope or when it gets assigned with [code]null[/code]. In C# the reference must be disposed manually, which can be done with the [code]using[/code] statement or by calling the [code]Dispose[/code] method directly.
 		[codeblocks]
 		[gdscript]
 		var file = FileAccess.open("res://something") # File is opened and locked for use.
@@ -44,7 +44,7 @@
 		// The using statement calls Dispose when going out of scope.
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of the [FileAccess] API, as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
+		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of [FileAccess], as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
 		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [b]Alt + F4[/b]). If you stop the project execution by pressing [b]F8[/b] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
 	</description>
 	<tutorials>

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Geometry2D" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Helper node to calculate generic geometry operations in 2D space.
+		Provides methods for some common 2D geometric operations.
 	</brief_description>
 	<description>
-		Geometry2D provides users with a set of helper functions to create geometric shapes, compute intersections between shapes, and process various other geometric operations.
+		Provides a set of helper functions to create geometric shapes, compute intersections between shapes, and process various other geometric operations in 2D.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Geometry3D" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Helper node to calculate generic geometry operations in 3D space.
+		Provides methods for some common 3D geometric operations.
 	</brief_description>
 	<description>
-		Geometry3D provides users with a set of helper functions to create geometric shapes, compute intersections between shapes, and process various other geometric operations.
+		Provides a set of helper functions to create geometric shapes, compute intersections between shapes, and process various other geometric operations in 3D.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HashingContext.xml
+++ b/doc/classes/HashingContext.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="HashingContext" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Context to compute cryptographic hashes over multiple iterations.
+		Provides functionality for computing cryptographic hashes chunk by chunk.
 	</brief_description>
 	<description>
-		The HashingContext class provides an interface for computing cryptographic hashes over multiple iterations. This is useful for example when computing hashes of big files (so you don't have to load them all in memory), network streams, and data streams in general (so you don't have to hold buffers).
+		The HashingContext class provides an interface for computing cryptographic hashes over multiple iterations. Useful for computing hashes of big files (so you don't have to load them all in memory), network streams, and data streams in general (so you don't have to hold buffers).
 		The [enum HashType] enum shows the supported hashing algorithms.
 		[codeblocks]
 		[gdscript]

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Input" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A singleton that deals with inputs.
+		A singleton for handling inputs.
 	</brief_description>
 	<description>
-		A singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
-		[b]Note:[/b] The methods here reflect the global input state and are not affected by [method Control.accept_event] or [method Viewport.set_input_as_handled], which only deal with the way input is propagated in the [SceneTree].
+		The [Input] singleton handles key presses, mouse buttons and movement, gamepads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
+		[b]Note:[/b] [Input]'s methods reflect the global input state and are not affected by [method Control.accept_event] or [method Viewport.set_input_as_handled], as those methods only deal with the way input is propagated in the [SceneTree].
 	</description>
 	<tutorials>
 		<link title="Inputs documentation index">$DOCS_URL/tutorials/inputs/index.html</link>

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEvent" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Generic input event.
+		Abstract base class for input events.
 	</brief_description>
 	<description>
-		Base class of all sort of input event. See [method Node._input].
+		Abstract base class of all types of input events. See [method Node._input].
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 		<link title="Viewport and canvas transforms">$DOCS_URL/tutorials/2d/2d_transforms.html</link>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>

--- a/doc/classes/InputEventAction.xml
+++ b/doc/classes/InputEventAction.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventAction" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for actions.
+		An input event type for actions.
 	</brief_description>
 	<description>
-		Contains a generic action which can be targeted from several types of inputs. Actions can be created from the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b] menu. See [method Node._input].
+		Contains a generic action which can be targeted from several types of inputs. Actions and their events can be set in the [b]Input Map[/b] tab in [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
 		[b]Note:[/b] Unlike the other [InputEvent] subclasses which map to unique physical events, this virtual one is not emitted by the engine. This class is useful to emit actions manually with [method Input.parse_input_event], which are then received in [method Node._input]. To check if a physical event matches an action from the Input Map, use [method InputEvent.is_action] and [method InputEvent.is_action_pressed].
 	</description>
 	<tutorials>
-		<link title="InputEvent: Actions">$DOCS_URL/tutorials/inputs/inputevent.html#actions</link>
+		<link title="Using InputEvent: Actions">$DOCS_URL/tutorials/inputs/inputevent.html#actions</link>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/515</link>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>

--- a/doc/classes/InputEventFromWindow.xml
+++ b/doc/classes/InputEventFromWindow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventFromWindow" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for [Viewport]-based input events.
+		Abstract base class for [Viewport]-based input events.
 	</brief_description>
 	<description>
 		InputEventFromWindow represents events specifically received by windows. This includes mouse events, keyboard events in focused windows or touch screen actions.

--- a/doc/classes/InputEventGesture.xml
+++ b/doc/classes/InputEventGesture.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventGesture" inherits="InputEventWithModifiers" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for touch control gestures.
+		Abstract base class for touch gestures.
 	</brief_description>
 	<description>
-		InputEventGesture is sent when a user performs a supported gesture on a touch screen. Gestures can't be emulated using mouse, because they typically require multi-touch.
+		InputEventGestures are sent when a user performs a supported gesture on a touch screen. Gestures can't be emulated using mouse, because they typically require multi-touch.
 	</description>
 	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventJoypadButton" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event for gamepad buttons.
+		Represents a gamepad button being pressed or released.
 	</brief_description>
 	<description>
 		Input event type for gamepad buttons. For gamepad analog sticks and joysticks, see [InputEventJoypadMotion].
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" enum="JoyButton" default="0">

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventJoypadMotion" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for gamepad joysticks and other motions. For buttons, see [code]InputEventJoypadButton[/code].
+		Represents axis motions (such as joystick or analog triggers) from a gamepad.
 	</brief_description>
 	<description>
-		Stores information about joystick motions. One [InputEventJoypadMotion] represents one axis at a time.
+		Stores information about joystick motions. One [InputEventJoypadMotion] represents one axis at a time. For gamepad buttons, see [InputEventJoypadButton].
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="JoyAxis" default="0">

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventKey" inherits="InputEventWithModifiers" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for keyboard events.
+		Represents a key on a keyboard being pressed or released.
 	</brief_description>
 	<description>
-		Stores key presses on the keyboard. Supports key presses, key releases and [member echo] events.
+		An input event for keys on a keyboard. Supports key presses, key releases and [member echo] events. It can also be received in [method Node._unhandled_key_input].
 		[b]Note:[/b] Events received from the keyboard usually have all properties set. Event mappings should have only one of the [member keycode], [member physical_keycode] or [member unicode] set.
-		When events are compared, properties are checked in the following priority - [member keycode], [member physical_keycode] and [member unicode], events with the first matching value will be considered equal.
+		When events are compared, properties are checked in the following priority - [member keycode], [member physical_keycode] and [member unicode]. Events with the first matching value will be considered equal.
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 		<method name="as_text_key_label" qualifiers="const">

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventMIDI" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event for MIDI inputs.
+		Represents an input event from a MIDI device, such as a piano.
 	</brief_description>
 	<description>
-		InputEventMIDI allows receiving input events from MIDI devices such as a piano. MIDI stands for Musical Instrument Digital Interface.
+		InputEventMIDI allows receiving input events from MIDI (Musical Instrument Digital Interface) devices such as a piano.
 		MIDI signals can be sent over a 5-pin MIDI connector or over USB, if your device supports both be sure to check the settings in the device to see which output it's using.
 		To receive input events from MIDI devices, you need to call [method OS.open_midi_inputs]. You can check which devices are detected using [method OS.get_connected_midi_inputs].
 		[codeblocks]

--- a/doc/classes/InputEventMagnifyGesture.xml
+++ b/doc/classes/InputEventMagnifyGesture.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventMagnifyGesture" inherits="InputEventGesture" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		[InputEvent] that represents a magnifying touch gesture.
+		Represents a magnifying touch gesture.
 	</brief_description>
 	<description>
-		Magnify gesture is performed when the user pinches the touch screen. It's typically used for zooming.
+		Stores the factor of a magnifying touch gesture. This is usually performed when the user pinches the touch screen and used for zooming in/out.
 	</description>
 	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="factor" type="float" setter="set_factor" getter="get_factor" default="1.0">
-			The amount (or delta) of the event. This value is higher the faster the gesture is performed.
+			The amount (or delta) of the event. This value is closer to [code]1.0[/code] the slower the gesture is performed.
 		</member>
 	</members>
 </class>

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -4,10 +4,10 @@
 		Base input event type for mouse events.
 	</brief_description>
 	<description>
-		Stores general mouse events information.
+		Stores general information about mouse events.
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButtonMask" default="0">

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventMouseButton" inherits="InputEventMouse" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for mouse button events.
+		Represents a mouse button being pressed or released.
 	</brief_description>
 	<description>
-		Contains mouse click information. See [method Node._input].
+		Stores information about mouse click events. See [method Node._input].
 	</description>
 	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 		<link title="Mouse and input coordinates">$DOCS_URL/tutorials/inputs/mouse_and_input_coordinates.html</link>
 	</tutorials>
 	<members>

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventMouseMotion" inherits="InputEventMouse" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for mouse motion events.
+		Represents a mouse or a pen movement.
 	</brief_description>
 	<description>
-		Contains mouse and pen motion information. Supports relative, absolute positions and velocity. See [method Node._input].
+		Stores information about a mouse or a pen motion. This includes relative position, absolute position, and velocity. See [method Node._input].
 		[b]Note:[/b] By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, set [member Input.use_accumulated_input] to [code]false[/code] to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 	</description>
 	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 		<link title="Mouse and input coordinates">$DOCS_URL/tutorials/inputs/mouse_and_input_coordinates.html</link>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>

--- a/doc/classes/InputEventPanGesture.xml
+++ b/doc/classes/InputEventPanGesture.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventPanGesture" inherits="InputEventGesture" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		[InputEvent] that represents a panning touch gesture.
+		Represents a panning touch gesture.
 	</brief_description>
 	<description>
-		Pan gesture is performed when the user swipes the touch screen with two fingers. It's typically used for panning/scrolling.
+		Stores information about pan gestures. A pan gesture is performed when the user swipes the touch screen with two fingers. It's typically used for panning/scrolling.
 	</description>
 	<tutorials>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="delta" type="Vector2" setter="set_delta" getter="get_delta" default="Vector2(0, 0)">

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventScreenDrag" inherits="InputEventFromWindow" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for screen drag events. Only available on mobile devices.
+		Represents a screen drag event.
 	</brief_description>
 	<description>
-		Contains screen drag information. See [method Node._input].
+		Stores information about screen drag events. See [method Node._input].
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventScreenTouch" inherits="InputEventFromWindow" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Input event type for screen touch events.
-		(only available on mobile devices)
+		Represents a screen touch event.
 	</brief_description>
 	<description>
-		Stores multi-touch press/release information. Supports touch press, touch release and [member index] for multi-touch count and order.
+		Stores information about multi-touch press/release input events. Supports touch press, touch release and [member index] for multi-touch count and order.
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
 		<member name="canceled" type="bool" setter="set_canceled" getter="is_canceled" default="false">

--- a/doc/classes/InputEventShortcut.xml
+++ b/doc/classes/InputEventShortcut.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventShortcut" inherits="InputEvent" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		[InputEvent] that signifies a triggered keyboard [Shortcut].
+		Represents a triggered keyboard [Shortcut].
 	</brief_description>
 	<description>
-		InputEventShortcut is a special event that can be received in [method Node._unhandled_key_input]. It's typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_unhandled_input].
+		InputEventShortcut is a special event that can be received in [method Node._unhandled_key_input]. It is typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_unhandled_input].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputEventWithModifiers" inherits="InputEventFromWindow" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for keys events with modifiers.
+		Abstract base class for input events affected by modifier keys like [kbd]Shift[/kbd] and [kbd]Alt[/kbd].
 	</brief_description>
 	<description>
-		Contains keys events information with modifiers support like [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See [method Node._input].
+		Stores information about mouse, keyboard, and touch gesture input events. This includes information about which modifier keys are pressed, such as [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See [method Node._input].
 	</description>
 	<tutorials>
-		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
+		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_modifiers_mask" qualifiers="const">

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="InputMap" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Singleton that manages [InputEventAction].
+		A singleton that manages all [InputEventAction]s.
 	</brief_description>
 	<description>
 		Manages all [InputEventAction] which can be created/modified from the project settings menu [b]Project &gt; Project Settings &gt; Input Map[/b] or in code with [method add_action] and [method action_add_event]. See [method Node._input].
 	</description>
 	<tutorials>
-		<link title="InputEvent: InputMap">$DOCS_URL/tutorials/inputs/inputevent.html#inputmap</link>
+		<link title="Using InputEvent: InputMap">$DOCS_URL/tutorials/inputs/inputevent.html#inputmap</link>
 	</tutorials>
 	<methods>
 		<method name="action_add_event">

--- a/doc/classes/MissingNode.xml
+++ b/doc/classes/MissingNode.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MissingNode" inherits="Node" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		This is an internal editor class intended for keeping data of nodes of unknown type.
+		An internal editor class intended for keeping the data of unrecognized nodes.
 	</brief_description>
 	<description>
 		This is an internal editor class intended for keeping data of nodes of unknown type (most likely this type was supplied by an extension that is no longer loaded). It can't be manually instantiated or placed in the scene. Ignore it if you don't know what it is.
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="original_class" type="String" setter="set_original_class" getter="get_original_class">
+			Returns the name of the type this node was originally.
 		</member>
 		<member name="recording_properties" type="bool" setter="set_recording_properties" getter="is_recording_properties">
 		</member>

--- a/doc/classes/MissingResource.xml
+++ b/doc/classes/MissingResource.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="MissingResource" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		This is an internal editor class intended for keeping data of resources of unknown type.
+		An internal editor class intended for keeping the data of unrecognized resources.
 	</brief_description>
 	<description>
 		This is an internal editor class intended for keeping data of resources of unknown type (most likely this type was supplied by an extension that is no longer loaded). It can't be manually instantiated or placed in the scene. Ignore it if you don't know what it is.
@@ -10,6 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="original_class" type="String" setter="set_original_class" getter="get_original_class">
+			Returns the name of the class this resource was originally.
 		</member>
 		<member name="recording_properties" type="bool" setter="set_recording_properties" getter="is_recording_properties">
 		</member>

--- a/doc/classes/Mutex.xml
+++ b/doc/classes/Mutex.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Mutex" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A synchronization mutex (mutual exclusion).
+		A binary [Semaphore] for synchronization of multiple [Thread]s.
 	</brief_description>
 	<description>
-		A synchronization mutex (mutual exclusion). This is used to synchronize multiple [Thread]s, and is equivalent to a binary [Semaphore]. It guarantees that only one thread can ever acquire the lock at a time. A mutex can be used to protect a critical section; however, be careful to avoid deadlocks.
-		It's of the recursive kind, so it can be locked multiple times by one thread, provided it also unlocks it as many times.
-		[b]Warning:[/b]
-		To guarantee that the operating system is able to perform proper cleanup (no crashes, no deadlocks), these conditions must be met:
-		- By the time a [Mutex]'s reference count reaches zero and therefore it is destroyed, no threads (including the one on which the destruction will happen) must have it locked.
-		- By the time a [Thread]'s reference count reaches zero and therefore it is destroyed, it must not have any mutex locked.
+		A synchronization mutex (mutual exclusion). This is used to synchronize multiple [Thread]s, and is equivalent to a binary [Semaphore]. It guarantees that only one thread can access a critical section at a time.
+		This is a reentrant mutex, meaning that it can be locked multiple times by one thread, provided it also unlocks it as many times.
+		[b]Warning:[/b] Mutexes must be used carefully to avoid deadlocks.
+		[b]Warning:[/b] To ensure proper cleanup without crashes or deadlocks, the following conditions must be met:
+		- When a [Mutex]'s reference count reaches zero and it is therefore destroyed, no threads (including the one on which the destruction will happen) must have it locked.
+		- When a [Thread]'s reference count reaches zero and it is therefore destroyed, it must not have any mutex locked.
 	</description>
 	<tutorials>
 		<link title="Using multiple threads">$DOCS_URL/tutorials/performance/using_multiple_threads.html</link>
+		<link title="Thread-safe APIs">$DOCS_URL/tutorials/performance/thread_safe_apis.html</link>
 	</tutorials>
 	<methods>
 		<method name="lock">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Node" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for all [i]scene[/i] objects.
+		Base class for all scene objects.
 	</brief_description>
 	<description>
 		Nodes are Godot's building blocks. They can be assigned as the child of another node, resulting in a tree arrangement. A given node can contain any number of nodes as children with the requirement that all siblings (direct children of a node) should have unique names.

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="NodePath" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Pre-parsed scene tree path.
+		A pre-parsed scene tree path.
 	</brief_description>
 	<description>
 		A pre-parsed relative or absolute path in a scene tree, for use with [method Node.get_node] and similar functions. It can reference a node, a resource within a node, or a property of a node or resource. For example, [code]"Path2D/PathFollow2D/Sprite2D:texture:size"[/code] would refer to the [code]size[/code] property of the [code]texture[/code] resource on the node named [code]"Sprite2D"[/code] which is a child of the other named nodes in the path.
@@ -22,6 +22,7 @@
 		[/codeblock]
 		See also [StringName], which is a similar concept for general-purpose string interning.
 		[b]Note:[/b] In the editor, [NodePath] properties are automatically updated when moving, renaming or deleting a node in the scene tree, but they are never updated at runtime.
+		[b]Note:[/b] In a boolean context, a [NodePath] will evaluate to [code]false[/code] if it is empty ([code]NodePath("")[/code]). Otherwise, a [NodePath] will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>
 		<link title="2D Role Playing Game Demo">https://godotengine.org/asset-library/asset/520</link>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OS" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Operating System functions.
+		Provides access to common operating system functionalities.
 	</brief_description>
 	<description>
-		Operating System functions. [OS] wraps the most common functionality to communicate with the host operating system, such as the video driver, delays, environment variables, execution of binaries, command line, etc.
+		This class wraps the most common functionalities for communicating with the host operating system, such as the video driver, delays, environment variables, execution of binaries, command line, etc.
 		[b]Note:[/b] In Godot 4, [OS] functions related to window management were moved to the [DisplayServer] singleton.
 	</description>
 	<tutorials>

--- a/doc/classes/PackedDataContainerRef.xml
+++ b/doc/classes/PackedDataContainerRef.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedDataContainerRef" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Internal class used by [PackedDataContainer].
+		An internal class used by [PackedDataContainer] to pack nested arrays and dictionaries.
 	</brief_description>
 	<description>
 		When packing nested containers using [PackedDataContainer], they are recursively packed into [PackedDataContainerRef] (only applies to [Array] and [Dictionary]). Their data can be retrieved the same way as from [PackedDataContainer].

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Plane" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Plane in hessian form.
+		A plane in Hessian normal form.
 	</brief_description>
 	<description>
-		Plane represents a normalized plane equation. Basically, "normal" is the normal of the plane (a,b,c normalized), and "d" is the distance from the origin to the plane (in the direction of "normal"). "Over" or "Above" the plane is considered the side of the plane towards where the normal is pointing.
+		Represents a normalized plane equation. [member normal] is the normal of the plane (a, b, c normalized), and [member d] is the distance from the origin to the plane (in the direction of "normal"). "Over" or "Above" the plane is considered the side of the plane towards where the normal is pointing.
 	</description>
 	<tutorials>
 		<link title="Math documentation index">$DOCS_URL/tutorials/math/index.html</link>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ProjectSettings" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Contains global variables accessible from everywhere.
+		Stores globally-accessible variables.
 	</brief_description>
 	<description>
-		Contains global variables accessible from everywhere. Use [method get_setting], [method set_setting] or [method has_setting] to access them. Variables stored in [code]project.godot[/code] are also loaded into ProjectSettings, making this object very useful for reading custom game configuration options.
+		Stores variables that can be accessed from everywhere. Use [method get_setting], [method set_setting] or [method has_setting] to access them. Variables stored in [code]project.godot[/code] are also loaded into [ProjectSettings], making this object very useful for reading custom game configuration options.
 		When naming a Project Settings property, use the full path to the setting including the category. For example, [code]"application/config/name"[/code] for the project name. Category and property names can be viewed in the Project Settings dialog.
 		[b]Feature tags:[/b] Project settings can be overridden for specific platforms and configurations (debug, release, ...) using [url=$DOCS_URL/tutorials/export/feature_tags.html]feature tags[/url].
 		[b]Overriding:[/b] Any project setting can be overridden by creating a file named [code]override.cfg[/code] in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [url=$DOCS_URL/tutorials/export/feature_tags.html]feature tags[/url] in account. Therefore, make sure to [i]also[/i] override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Projection" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		3D projection (4x4 matrix).
+		A 4×4 matrix for 3D projective transformations.
 	</brief_description>
 	<description>
 		A 4x4 matrix used for 3D projective transformations. It can represent transformations such as translation, rotation, scaling, shearing, and perspective division. It consists of four [Vector4] columns.
-		For purely linear transformations (translation, rotation, and scale), it is recommended to use [Transform3D], as it is more performant and has a lower memory footprint.
+		For purely linear transformations (translation, rotation, and scale), it is recommended to use [Transform3D], as it is more performant and requires less memory.
 		Used internally as [Camera3D]'s projection matrix.
 	</description>
 	<tutorials>

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RID" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Handle for a [Resource]'s unique ID.
+		A handle for a [Resource]'s unique identifier.
 	</brief_description>
 	<description>
 		The RID [Variant] type is used to access a low-level resource by its unique ID. RIDs are opaque, which means they do not grant access to the resource by themselves. They are used by the low-level server classes, such as [DisplayServer], [RenderingServer], [TextServer], etc.

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RandomNumberGenerator" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A class for generating pseudo-random numbers.
+		Provides methods for generating pseudo-random numbers.
 	</brief_description>
 	<description>
 		RandomNumberGenerator is a class for generating pseudo-random numbers. It currently uses [url=https://www.pcg-random.org/]PCG32[/url].
-		[b]Note:[/b] The underlying algorithm is an implementation detail. As a result, it should not be depended upon for reproducible random streams across Godot versions.
+		[b]Note:[/b] The underlying algorithm is an implementation detail and should not be depended upon.
 		To generate a random float number (within a given range) based on a time-dependant seed:
 		[codeblock]
 		var rng = RandomNumberGenerator.new()
 		func _ready():
 		    var my_random_number = rng.randf_range(-10.0, 10.0)
 		[/codeblock]
-		[b]Note:[/b] The default values of [member seed] and [member state] properties are pseudo-random, and change when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
 	</description>
 	<tutorials>
 		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>
@@ -66,6 +65,7 @@
 			Initializes the random number generator state based on the given seed value. A given seed will give a reproducible sequence of pseudo-random numbers.
 			[b]Note:[/b] The RNG does not have an avalanche effect, and can output similar random streams given similar seeds. Consider using a hash function to improve your seed quality if they're sourced externally.
 			[b]Note:[/b] Setting this property produces a side effect of changing the internal [member state], so make sure to initialize the seed [i]before[/i] modifying the [member state]:
+			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
 			[codeblock]
 			var rng = RandomNumberGenerator.new()
 			rng.seed = hash("Godot")
@@ -83,6 +83,7 @@
 			print(rng.randf()) # Prints the same value as in previous.
 			[/codeblock]
 			[b]Note:[/b] Do not set state to arbitrary values, since the random number generator requires the state to have certain qualities to behave properly. It should only be set to values that came from the state property itself. To initialize the random number generator with arbitrary input, use [member seed] instead.
+			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.
 		</member>
 	</members>
 </class>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Rect2" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		2D axis-aligned bounding box using floating point coordinates.
+		A 2D axis-aligned bounding box using floating-point coordinates.
 	</brief_description>
 	<description>
 		[Rect2] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Rect2i" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		2D axis-aligned bounding box using integer coordinates.
+		A 2D axis-aligned bounding box using integer coordinates.
 	</brief_description>
 	<description>
 		[Rect2i] consists of a position, a size, and several utility functions. It is typically used for fast overlap tests.

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Resource" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for all resources.
+		Base class for serializable objects.
 	</brief_description>
 	<description>
 		Resource is the base class for all Godot-specific resource types, serving primarily as data containers. Since they inherit from [RefCounted], resources are reference-counted and freed when no longer in use. They can also be nested within other resources, and saved on disk. Once loaded from disk, further attempts to load a resource by [member resource_path] returns the same reference. [PackedScene], one of the most common [Object]s in a Godot project, is also a resource, uniquely capable of storing and instantiating the [Node]s it contains as many times as desired.

--- a/doc/classes/ResourceImporter.xml
+++ b/doc/classes/ResourceImporter.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporter" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Base class for the implementation of core resource importers.
+		Base class for resource importers.
 	</brief_description>
 	<description>
-		This is the base class for the resource importers implemented in core. To implement your own resource importers using editor plugins, see [EditorImportPlugin].
+		This is the base class for Godot's resource importers. To implement your own resource importers using editor plugins, see [EditorImportPlugin].
 	</description>
 	<tutorials>
 		<link title="Import plugins">$DOCS_URL/tutorials/plugins/editor/import_plugins.html</link>

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceLoader" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Singleton used to load resource files.
+		A singleton for loading resource files.
 	</brief_description>
 	<description>
-		Singleton used to load resource files from the filesystem.
+		A singleton used to load resource files from the filesystem.
 		It uses the many [ResourceFormatLoader] classes registered in the engine (either built-in or from a plugin) to load files into memory and convert them to a format that can be used by the engine.
 		[b]Note:[/b] You have to import the files into the engine first to load them using [method load]. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 	</description>

--- a/doc/classes/ResourcePreloader.xml
+++ b/doc/classes/ResourcePreloader.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourcePreloader" inherits="Node" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Preloads a list of resources inside a scene.
+		A node used to preload sub-resources inside a scene.
 	</brief_description>
 	<description>
 		This node is used to preload sub-resources inside a scene, so when the scene is loaded, all the resources are ready to use and can be retrieved from the preloader. You can add the resources using the ResourcePreloader tab when the node is selected.

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceSaver" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Singleton for saving Godot-specific resource types.
+		A singleton for saving [Resource]s to the filesystem.
 	</brief_description>
 	<description>
-		Singleton for saving Godot-specific resource types to the filesystem.
-		It uses the many [ResourceFormatSaver] classes registered in the engine (either built-in or from a plugin) to save engine-specific resource data to text-based (e.g. [code].tres[/code] or [code].tscn[/code]) or binary files (e.g. [code].res[/code] or [code].scn[/code]).
+		A singleton for saving resource types to the filesystem.
+		It uses the many [ResourceFormatSaver] classes registered in the engine (either built-in or from a plugin) to save resource data to text-based (e.g. [code].tres[/code] or [code].tscn[/code]) or binary files (e.g. [code].res[/code] or [code].scn[/code]).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ResourceUID.xml
+++ b/doc/classes/ResourceUID.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceUID" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Singleton for managing a cache of resource UIDs within a project.
+		A singleton that manages the unique identifiers of all resources within a project.
 	</brief_description>
 	<description>
-		Resources can not only be referenced using their resource paths [code]res://[/code], but alternatively through a unique identifier specified via [code]uid://[/code].
-		Using UIDs allows for the engine to keep references between resources intact, even if the files get renamed or moved.
-		This singleton is responsible for keeping track of all registered resource UIDs of a project, generating new UIDs and converting between the string and integer representation.
+		Resource UIDs (Unique IDentifiers) allow the engine to keep references between resources intact, even if files can renamed or moved. They can be accessed with [code]uid://[/code].
+		[ResourceUID] keeps track of all registered resource UIDs in a project, generates new UIDs, and converts between their string and integer representations.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SceneState" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A script interface to a scene file's data.
+		Provides access to a scene file's information.
 	</brief_description>
 	<description>
-		Maintains a list of resources, nodes, exported, and overridden properties, and built-in scripts associated with a scene.
+		Maintains a list of resources, nodes, exported and overridden properties, and built-in scripts associated with a scene. They cannot be modified from a [SceneState], only accessed. Useful for peeking into what a [PackedScene] contains without instantiating it.
 		This class cannot be instantiated directly, it is retrieved for a given scene as the result of [method PackedScene.get_state].
 	</description>
 	<tutorials>

--- a/doc/classes/Semaphore.xml
+++ b/doc/classes/Semaphore.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Semaphore" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A synchronization semaphore.
+		A synchronization mechanism used to control access to a shared resource by [Thread]s.
 	</brief_description>
 	<description>
-		A synchronization semaphore which can be used to synchronize multiple [Thread]s. Initialized to zero on creation. Be careful to avoid deadlocks. For a binary version, see [Mutex].
-		[b]Warning:[/b]
-		To guarantee that the operating system is able to perform proper cleanup (no crashes, no deadlocks), these conditions must be met:
-		- By the time a [Semaphore]'s reference count reaches zero and therefore it is destroyed, no threads must be waiting on it.
-		- By the time a [Thread]'s reference count reaches zero and therefore it is destroyed, it must not be waiting on any semaphore.
+		A synchronization semaphore that can be used to synchronize multiple [Thread]s. Initialized to zero on creation. For a binary version, see [Mutex].
+		[b]Warning:[/b] Semaphores must be used carefully to avoid deadlocks.
+		[b]Warning:[/b] To guarantee that the operating system is able to perform proper cleanup (no crashes, no deadlocks), these conditions must be met:
+		- When a [Semaphore]'s reference count reaches zero and it is therefore destroyed, no threads must be waiting on it.
+		- When a [Thread]'s reference count reaches zero and it is therefore destroyed, it must not be waiting on any semaphore.
 	</description>
 	<tutorials>
 		<link title="Using multiple threads">$DOCS_URL/tutorials/performance/using_multiple_threads.html</link>
+		<link title="Thread-safe APIs">$DOCS_URL/tutorials/performance/thread_safe_apis.html</link>
 	</tutorials>
 	<methods>
 		<method name="post">

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Signal" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Built-in type representing a signal defined in an object.
+		A built-in type representing a signal of an [Object].
 	</brief_description>
 	<description>
 		[Signal] is a built-in [Variant] type that represents a signal of an [Object] instance. Like all [Variant] types, it can be stored in variables and passed to functions. Signals allow all connected [Callable]s (and by extension their respective objects) to listen and react to events, without directly referencing one another. This keeps the code flexible and easier to manage.

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeer" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Abstraction and base class for stream-based protocols.
+		Abstract base class for interacting with streams.
 	</brief_description>
 	<description>
-		StreamPeer is an abstraction and base class for stream-based protocols (such as TCP). It provides an API for sending and receiving data through streams as raw data or strings.
+		StreamPeer is an abstract base class mostly used for stream-based protocols (such as TCP). It provides an API for sending and receiving data through streams as raw data or strings.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>

--- a/doc/classes/StreamPeerBuffer.xml
+++ b/doc/classes/StreamPeerBuffer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerBuffer" inherits="StreamPeer" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Data buffer stream peer.
+		A stream peer used to handle binary data streams.
 	</brief_description>
 	<description>
-		Data buffer stream peer that uses a byte array as the stream. This object can be used to handle binary data from network sessions. To handle binary data stored in files, [FileAccess] can be used directly.
+		A data buffer stream peer that uses a byte array as the stream. This object can be used to handle binary data from network sessions. To handle binary data stored in files, [FileAccess] can be used directly.
 		A [StreamPeerBuffer] object keeps an internal cursor which is the offset in bytes to the start of the buffer. Get and put operations are performed at the cursor position and will move the cursor accordingly.
 	</description>
 	<tutorials>

--- a/doc/classes/StreamPeerGZIP.xml
+++ b/doc/classes/StreamPeerGZIP.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerGZIP" inherits="StreamPeer" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Stream peer handling GZIP and deflate compression/decompresison.
+		A stream peer that handles GZIP and deflate compression/decompression.
 	</brief_description>
 	<description>
-		This class allows to compress or decompress data using GZIP/deflate in a streaming fashion. This is particularly useful when compressing or decompressing files that has to be sent through the network without having to allocate them all in memory.
+		This class allows to compress or decompress data using GZIP/deflate in a streaming fashion. This is particularly useful when compressing or decompressing files that have to be sent through the network without needing to allocate them all in memory.
 		After starting the stream via [method start_compression] (or [method start_decompression]), calling [method StreamPeer.put_partial_data] on this stream will compress (or decompress) the data, writing it to the internal buffer. Calling [method StreamPeer.get_available_bytes] will return the pending bytes in the internal buffer, and [method StreamPeer.get_partial_data] will retrieve the compressed (or decompressed) bytes from it. When the stream is over, you must call [method finish] to ensure the internal buffer is properly flushed (make sure to call [method StreamPeer.get_available_bytes] on last time to check if more data needs to be read after that).
 	</description>
 	<tutorials>

--- a/doc/classes/StreamPeerTCP.xml
+++ b/doc/classes/StreamPeerTCP.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerTCP" inherits="StreamPeer" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		TCP stream peer.
+		A stream peer that handles TCP connections.
 	</brief_description>
 	<description>
-		TCP stream peer. This object can be used to connect to TCP servers, or also is returned by a TCP server.
+		A stream peer that handles TCP connections. This object can be used to connect to TCP servers, or also is returned by a TCP server.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>

--- a/doc/classes/StreamPeerTLS.xml
+++ b/doc/classes/StreamPeerTLS.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StreamPeerTLS" inherits="StreamPeer" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		TLS stream peer.
+		A stream peer that handles TLS connections.
 	</brief_description>
 	<description>
-		TLS stream peer. This object can be used to connect to a TLS server or accept a single TLS client connection.
+		A stream peer that handles TLS connections. This object can be used to connect to a TLS server or accept a single TLS client connection.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="String" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Built-in string Variant type.
+		A built-in type for strings.
 	</brief_description>
 	<description>
 		This is the built-in string Variant type (and the one used by GDScript). Strings may contain any number of Unicode characters, and expose methods useful for manipulating and generating strings. Strings are reference-counted and use a copy-on-write approach (every modification to a string returns a new [String]), so passing them around is cheap in resources.

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="StringName" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		An optimized string type for unique names.
+		A built-in type for unique strings.
 	</brief_description>
 	<description>
-		[StringName]s are immutable strings designed for general-purpose representation of unique names (also called "string interning"). [StringName] ensures that only one instance of a given name exists (so two [StringName]s with the same value are the same object). Comparing them is much faster than with regular [String]s, because only the pointers are compared, not the whole strings.
+		[StringName]s are immutable strings designed for general-purpose representation of unique names (also called "string interning"). Two [StringName]s with the same value are the same object. Comparing them is extremely fast compared to regular [String]s.
 		You will usually just pass a [String] to methods expecting a [StringName] and it will be automatically converted, but you may occasionally want to construct a [StringName] ahead of time with the [StringName] constructor or, in GDScript, the literal syntax [code]&amp;"example"[/code].
-		See also [NodePath], which is a similar concept specifically designed to store pre-parsed node paths.
-		Some string methods have corresponding variations. Variations suffixed with [code]n[/code] ([method countn], [method findn], [method replacen], etc.) are [b]case-insensitive[/b] (they make no distinction between uppercase and lowercase letters). Method variations prefixed with [code]r[/code] ([method rfind], [method rsplit], etc.) are reversed, and start from the end of the string, instead of the beginning.
+		See also [NodePath], which is a similar concept specifically designed to store pre-parsed scene tree paths.
+		All of [String]'s methods are available in this class too. They convert the [StringName] into a string, and they also return a string. This is highly inefficient and should only be used if the string is desired.
 		[b]Note:[/b] In a boolean context, a [StringName] will evaluate to [code]false[/code] if it is empty ([code]StringName("")[/code]). Otherwise, a [StringName] will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -7,7 +7,7 @@
 		A unit of execution in a process. Can run methods on [Object]s simultaneously. The use of synchronization via [Mutex] or [Semaphore] is advised if working with shared objects.
 		[b]Note:[/b] Breakpoints won't break on code if it's running in a thread. This is a current limitation of the GDScript debugger.
 		[b]Warning:[/b]
-		To guarantee that the operating system is able to perform proper cleanup (no crashes, no deadlocks), these conditions must be met by the time a [Thread]'s reference count reaches zero and therefore it is destroyed:
+		To ensure proper cleanup without crashes or deadlocks, when a [Thread]'s reference count reaches zero and it is therefore destroyed, the following conditions must be met:
 		- It must not have any [Mutex] objects locked.
 		- It must not be waiting on any [Semaphore] objects.
 		- [method wait_to_finish] should have been called on it.

--- a/doc/classes/Time.xml
+++ b/doc/classes/Time.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Time" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Time singleton for working with time.
+		A singleton for working with time data.
 	</brief_description>
 	<description>
 		The Time singleton allows converting time between various formats and also getting time information from the system.

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Transform2D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		2D transformation (2×3 matrix).
+		A 2×3 matrix representing a 2D transformation.
 	</brief_description>
 	<description>
-		2×3 matrix (2 rows, 3 columns) used for 2D linear transformations. It can represent transformations such as translation, rotation, or scaling. It consists of three [Vector2] values: [member x], [member y], and the [member origin].
+		A 2×3 matrix (2 rows, 3 columns) used for 2D linear transformations. It can represent transformations such as translation, rotation, and scaling. It consists of three [Vector2] values: [member x], [member y], and the [member origin].
 		For more information, read the "Matrices and transforms" documentation article.
 	</description>
 	<tutorials>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Transform3D" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		3D transformation (3×4 matrix).
+		A 3×4 matrix representing a 3D transformation.
 	</brief_description>
 	<description>
-		3×4 matrix (3 rows, 4 columns) used for 3D linear transformations. It can represent transformations such as translation, rotation, or scaling. It consists of a [member basis] (first 3 columns) and a [Vector3] for the [member origin] (last column).
+		A 3×4 matrix (3 rows, 4 columns) used for 3D linear transformations. It can represent transformations such as translation, rotation, and scaling. It consists of a [member basis] (first 3 columns) and a [Vector3] for the [member origin] (last column).
 		For more information, read the "Matrices and transforms" documentation article.
 	</description>
 	<tutorials>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector2" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 2D math using floating point coordinates.
+		A 2D vector using floating point coordinates.
 	</brief_description>
 	<description>
-		2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
+		A 2-element structure that can be used to represent 2D coordinates or any other pair of numeric values.
 		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector2i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector2 will evaluate to [code]false[/code] if it's equal to [code]Vector2(0, 0)[/code]. Otherwise, a Vector2 will always evaluate to [code]true[/code].

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector2i" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 2D math using integer coordinates.
+		A 2D vector using integer coordinates.
 	</brief_description>
 	<description>
-		2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
+		A 2-element structure that can be used to represent 2D grid coordinates or any other pair of integers.
 		It uses integer coordinates and is therefore preferable to [Vector2] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector2] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
 		[b]Note:[/b] In a boolean context, a Vector2i will evaluate to [code]false[/code] if it's equal to [code]Vector2i(0, 0)[/code]. Otherwise, a Vector2i will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector3" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 3D math using floating point coordinates.
+		A 3D vector using floating point coordinates.
 	</brief_description>
 	<description>
-		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
+		A 3-element structure that can be used to represent 3D coordinates or any other triplet of numeric values.
 		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector3i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector3 will evaluate to [code]false[/code] if it's equal to [code]Vector3(0, 0, 0)[/code]. Otherwise, a Vector3 will always evaluate to [code]true[/code].

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector3i" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 3D math using integer coordinates.
+		A 3D vector using integer coordinates.
 	</brief_description>
 	<description>
-		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
+		A 3-element structure that can be used to represent 3D grid coordinates or any other triplet of integers.
 		It uses integer coordinates and is therefore preferable to [Vector3] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector3] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
 		[b]Note:[/b] In a boolean context, a Vector3i will evaluate to [code]false[/code] if it's equal to [code]Vector3i(0, 0, 0)[/code]. Otherwise, a Vector3i will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector4" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 4D math using floating point coordinates.
+		A 4D vector using floating point coordinates.
 	</brief_description>
 	<description>
-		4-element structure that can be used to represent any quadruplet of numeric values.
+		A 4-element structure that can be used to represent 4D coordinates or any other quadruplet of numeric values.
 		It uses floating-point coordinates. By default, these floating-point values use 32-bit precision, unlike [float] which is always 64-bit. If double precision is needed, compile the engine with the option [code]precision=double[/code].
 		See [Vector4i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector4 will evaluate to [code]false[/code] if it's equal to [code]Vector4(0, 0, 0, 0)[/code]. Otherwise, a Vector4 will always evaluate to [code]true[/code].

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Vector4i" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Vector used for 4D math using integer coordinates.
+		A 4D vector using integer coordinates.
 	</brief_description>
 	<description>
-		4-element structure that can be used to represent 4D grid coordinates or sets of integers.
+		A 4-element structure that can be used to represent 4D grid coordinates or any other quadruplet of integers.
 		It uses integer coordinates and is therefore preferable to [Vector4] when exact precision is required. Note that the values are limited to 32 bits, and unlike [Vector4] this cannot be configured with an engine build option. Use [int] or [PackedInt64Array] if 64-bit values are needed.
+		[b]Note:[/b] In a boolean context, a Vector4i will evaluate to [code]false[/code] if it's equal to [code]Vector4i(0, 0, 0, 0)[/code]. Otherwise, a Vector3i will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/WeakRef.xml
+++ b/doc/classes/WeakRef.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WeakRef" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Holds an [Object], but does not contribute to the reference count if the object is a reference.
+		Holds an [Object]. If the object is [RefCounted], it doesn't update the reference count.
 	</brief_description>
 	<description>
-		A weakref can hold a [RefCounted], without contributing to the reference counter. A weakref can be created from an [Object] using [method @GlobalScope.weakref]. If this object is not a reference, weakref still works, however, it does not have any effect on the object. Weakrefs are useful in cases where multiple classes have variables that refer to each other. Without weakrefs, using these classes could lead to memory leaks, since both references keep each other from being released. Making part of the variables a weakref can prevent this cyclic dependency, and allows the references to be released.
+		A weakref can hold a [RefCounted] without contributing to the reference counter. A weakref can be created from an [Object] using [method @GlobalScope.weakref]. If this object is not a reference, weakref still works, however, it does not have any effect on the object. Weakrefs are useful in cases where multiple classes have variables that refer to each other. Without weakrefs, using these classes could lead to memory leaks, since both references keep each other from being released. Making part of the variables a weakref can prevent this cyclic dependency, and allows the references to be released.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="World2D" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Class that has everything pertaining to a 2D world.
+		A resource that holds all components of a 2D world, such as a canvas and a physics space.
 	</brief_description>
 	<description>
-		Class that has everything pertaining to a 2D world. A physics space, a visual scenario and a sound space. 2D nodes register their resources into the current 2D world.
+		Class that has everything pertaining to a 2D world: A physics space, a canvas, and a sound space. 2D nodes register their resources into the current 2D world.
 	</description>
 	<tutorials>
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="World3D" inherits="Resource" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Class that has everything pertaining to a world.
+		A resource that holds all components of a 3D world, such as a visual scenario and a physics space.
 	</brief_description>
 	<description>
-		Class that has everything pertaining to a world. A physics space, a visual scenario and a sound space. Node3D nodes register their resources into the current world.
+		Class that has everything pertaining to a world: A physics space, a visual scenario, and a sound space. 3D nodes register their resources into the current 3D world.
 	</description>
 	<tutorials>
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="XMLParser" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Provides a low-level interface for creating parsers for XML files.
 		Low-level class for creating parsers for [url=https://en.wikipedia.org/wiki/XML]XML[/url] files.
 	</brief_description>
 	<description>
-		This class can serve as base to make custom XML parsers. Since XML is a very flexible standard, this interface is low-level so it can be applied to any possible schema.
+		Provides a low-level interface for creating parsers for [url=https://en.wikipedia.org/wiki/XML]XML[/url] files. This class can serve as base to make custom XML parsers.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -1,90 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="bool" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Boolean built-in type.
+		A built-in boolean type.
 	</brief_description>
 	<description>
-		Boolean is a built-in type. There are two boolean values: [code]true[/code] and [code]false[/code]. You can think of it as a switch with on or off (1 or 0) setting. Booleans are used in programming for logic in condition statements, like [code]if[/code] statements.
-		Booleans can be directly used in [code]if[/code] statements. The code below demonstrates this on the [code]if can_shoot:[/code] line. You don't need to use [code]== true[/code], you only need [code]if can_shoot:[/code]. Similarly, use [code]if not can_shoot:[/code] rather than [code]== false[/code].
+		A [bool] is always one of two values: [code]true[/code] or [code]false[/code], similar to a switch that is either on or off. Booleans are used in programming for logic in condition statements.
+		Booleans can be directly used in [code]if[/code] and [code]elif[/code] statements. You don't need to add [code]== true[/code] or [code]== false[/code]:
 		[codeblocks]
 		[gdscript]
-		var _can_shoot = true
-
-		func shoot():
-		    if _can_shoot:
-		        pass # Perform shooting actions here.
+		if can_shoot:
+		    launch_bullet()
 		[/gdscript]
 		[csharp]
-		private bool _canShoot = true;
-
-		public void Shoot()
+		if (canShoot)
 		{
-		    if (_canShoot)
-		    {
-		        // Perform shooting actions here.
-		    }
+		    launchBullet();
 		}
 		[/csharp]
 		[/codeblocks]
-		The following code will only create a bullet if both conditions are met: action "shoot" is pressed and if [code]can_shoot[/code] is [code]true[/code].
-		[b]Note:[/b] [code]Input.is_action_pressed("shoot")[/code] is also a boolean that is [code]true[/code] when "shoot" is pressed and [code]false[/code] when "shoot" isn't pressed.
+		Many common methods and operations return [bool]s, for example, [code]shooting_cooldown &lt;= 0.0[/code] may evaluate to [code]true[/code] or [code]false[/code] depending on the number's value.
+		[bool]s are usually used with the logical operators [code]and[/code], [code]or[/code], and [code]not[/code] to create complex conditions:
 		[codeblocks]
 		[gdscript]
-		var _can_shoot = true
+		if bullets &gt; 0 and not is_reloading:
+		    launch_bullet()
 
-		func shoot():
-		    if _can_shoot and Input.is_action_pressed("shoot"):
-		        create_bullet()
+		if bullets == 0 or is_reloading:
+		    play_clack_sound()
 		[/gdscript]
 		[csharp]
-		private bool _canShoot = true;
-
-		public void Shoot()
+		if (bullets &gt; 0 &amp;&amp; !isReloading)
 		{
-		    if (_canShoot &amp;&amp; Input.IsActionPressed("shoot"))
-		    {
-		        CreateBullet();
-		    }
-		}
-		[/csharp]
-		[/codeblocks]
-		The following code will set [code]can_shoot[/code] to [code]false[/code] and start a timer. This will prevent player from shooting until the timer runs out. Next [code]can_shoot[/code] will be set to [code]true[/code] again allowing player to shoot once again.
-		[codeblocks]
-		[gdscript]
-		var _can_shoot = true
-		@onready var _cool_down = $CoolDownTimer
-
-		func shoot():
-		    if _can_shoot and Input.is_action_pressed("shoot"):
-		        create_bullet()
-		        _can_shoot = false
-		        _cool_down.start()
-
-		func _on_cool_down_timer_timeout():
-		    _can_shoot = true
-		[/gdscript]
-		[csharp]
-		private bool _canShoot = true;
-		private Timer _coolDown;
-
-		public override void _Ready()
-		{
-		    _coolDown = GetNode&lt;Timer&gt;("CoolDownTimer");
+		    launchBullet();
 		}
 
-		public void Shoot()
+		if (bullets == 0 || isReloading)
 		{
-		    if (_canShoot &amp;&amp; Input.IsActionPressed("shoot"))
-		    {
-		        CreateBullet();
-		        _canShoot = false;
-		        _coolDown.Start();
-		    }
-		}
-
-		public void OnCoolDownTimerTimeout()
-		{
-		    _canShoot = true;
+		    playClackSound();
 		}
 		[/csharp]
 		[/codeblocks]
@@ -109,14 +61,14 @@
 			<return type="bool" />
 			<param index="0" name="from" type="float" />
 			<description>
-				Cast a [float] value to a boolean value, this method will return [code]false[/code] if [code]0.0[/code] is passed in, and [code]true[/code] for all other floats.
+				Cast a [float] value to a boolean value. This method will return [code]false[/code] if [code]0.0[/code] is passed in, and [code]true[/code] for all other values.
 			</description>
 		</constructor>
 		<constructor name="bool">
 			<return type="bool" />
 			<param index="0" name="from" type="int" />
 			<description>
-				Cast an [int] value to a boolean value, this method will return [code]false[/code] if [code]0[/code] is passed in, and [code]true[/code] for all other ints.
+				Cast an [int] value to a boolean value. This method will return [code]false[/code] if [code]0[/code] is passed in, and [code]true[/code] for all other values.
 			</description>
 		</constructor>
 	</constructors>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="float" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Float built-in type.
+		A built-in type for floating point numbers.
 	</brief_description>
 	<description>
-		The [float] built-in type is a 64-bit double-precision floating-point number, equivalent to [code]double[/code] in C++. This type has 14 reliable decimal digits of precision. The [float] type can be stored in [Variant], which is the generic type used by the engine. The maximum value of [float] is approximately [code]1.79769e308[/code], and the minimum is approximately [code]-1.79769e308[/code].
+		The [float] built-in type is a 64-bit double-precision floating-point number, equivalent to [code]double[/code] in C++. This type has 14 reliable decimal digits of precision. The maximum value of [float] is approximately [code]1.79769e308[/code], and the minimum is approximately [code]-1.79769e308[/code].
 		Many methods and properties in the engine use 32-bit single-precision floating-point numbers instead, equivalent to [code]float[/code] in C++, which have 6 reliable decimal digits of precision. For data structures such as [Vector2] and [Vector3], Godot uses 32-bit floating-point numbers by default, but it can be changed to use 64-bit doubles if Godot is compiled with the [code]precision=double[/code] option.
-		Math done using the [float] type is not guaranteed to be exact or deterministic, and will often result in small errors. You should usually use the [method @GlobalScope.is_equal_approx] and [method @GlobalScope.is_zero_approx] methods instead of [code]==[/code] to compare [float] values for equality.
+		Math done using the [float] type is not guaranteed to be exact and will often result in small errors. You should usually use the [method @GlobalScope.is_equal_approx] and [method @GlobalScope.is_zero_approx] methods instead of [code]==[/code] to compare [float] values for equality.
 	</description>
 	<tutorials>
 		<link title="Wikipedia: Double-precision floating-point format">https://en.wikipedia.org/wiki/Double-precision_floating-point_format</link>
@@ -67,7 +67,7 @@
 			<return type="Color" />
 			<param index="0" name="right" type="Color" />
 			<description>
-				Multiplies each component of the [Color] by the given [float].
+				Multiplies each component of the [Color], including the alpha, by the given [float].
 				[codeblock]
 				print(1.5 * Color(0.5, 0.5, 0.5)) # Color(0.75, 0.75, 0.75)
 				[/codeblock]

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="int" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Built-in integer Variant type.
+		A built-in type for integers.
 	</brief_description>
 	<description>
 		Signed 64-bit integer type. This means that it can take values from [code]-2^63[/code] to [code]2^63 - 1[/code], i.e. from [code]-9223372036854775808[/code] to [code]9223372036854775807[/code]. When it exceeds these bounds, it will wrap around.

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="@GDScript" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Built-in GDScript functions.
+		Built-in GDScript constants, functions, and annotations.
 	</brief_description>
 	<description>
 		A list of GDScript-specific utility functions and annotations accessible from any script.


### PR DESCRIPTION
The top sections of classes are often one of the first things users read about them, so they are important to get right.

After I recently fixed Quaternion's description (which was "Quaternion.") I thought it would be a good idea to nip in the bud any need for such corrections in the near future. After all, Node2D still thinks it holds the Z-index property, some GPU Particles' colliders think they are attractors, the 2D world boundary thinks it's a plane, and what's "law of cosigns"? And so, SO many descriptions are circular - I get that a PinJoint2D is "A pin joint for 2D", but what is it?

^ I'm already working on more PRs that will address all the issues raised above - this is just the one dedicated to the core team.

I mostly touched up the short descriptions and occasionally the full descriptions and the tutorials sections. But I also overhauled bool's documentation and tweaked and filled up a little bit of documentation to the side.
StreamPeerExtension remains undocumented. KoBeWi took care of documenting PackedDataContainer (finally!). I also wrote documentation for WorkerThreadPool, but I separated it.

<details>
<summary>Rules for brief descriptions</summary>

**I'm abiding by a set of rules for consistency. I had them in mind when writing all descriptions, but violated them intentionally sometimes.**

- Use the articles "a" and "an". This is helpful for words that can be multiple things, i.e. "light" which can be a noun, an adjective, and a verb. This, and the fact it's grammatically correct, helps with reading comprehension in many cases.

- Use a single sentence with punctuation. If two sentences are needed, don't use newline.

- Never use text formatting (i.e. italics) or external links.

- Don't use capitalization for normal words. If referring to a class, use a reference.

- For nodes, always answer "What is this?". For non-node objects, it's also OK to answer "What does this do?"

- Avoid self-referencing, such as "*Popup:* Popup is a [...]"

- Avoid circular reasoning such as "CanvasLayer: Canvas drawing layer."
    - Exception 1: It's something common folk are familiar with, i.e. "Timer: A countdown timer."
    - Exception 2: The class can't be used by people who don't know the term, i.e. it's okay to say "XML" in XMLParser.

- When a class is abstract, start with "Abstract base class for [...]".

- I often used "Holds X" and "Stores X" to replace "Contains X" - I think it improves clarity that X is the main thing, not just one of the things the resource holds.

- Try to stay under 120 characters without compromising the quality of writing. (Sometimes it's impossible, in that case, go on for a bit longer)
</details>

<details>
<summary>A long list of brief description changes</summary>

**Classes not on here are ones I thought to be already excellent, or ones that I didn't realize were "core". This list might be a slightly outdated (like, by 1%).**

**@GDScript:** Built-in GDScript constants and functions.
**AABB:** A 3D axis-aligned bounding box.
**AESContext:** Provides functionality for AES encryption/decryption of raw data.
**Array:** A built-in data structure that stores a sequence of elements.
**Basis:** A 3×3 matrix for representing 3D rotation and scale.
**ClassDB:** A class information repository.
**Crypto:** Provides access to advanced cryptographic functionalities.
**bool**: A built-in boolean type.
**Callable:** A built-in type representing a method or a standalone function.
**Color:** A color represented in RGBA format.
**Dictionary:** A built-in data structure that stores key-value pairs.
**DirAccess:** Provides methods for managing directories and their content.
**Engine:** Provides access to engine properties.
**FileAccess:** Provides reading and writing operations for files.
**float:** A built-in type for a floating point numbers.
**Geometry2D:** Provides methods for some common 2D geometric operations.
**Geometry3D:** Provides methods for some common 3D geometric operations.
**HashingContext:** Provides functionality for computing cryptographic hashes chunk by chunk.
**Input:** A singleton for handling inputs.
**InputEvent:** Abstract base class for input events.
**InputEventFromWindow:** Abstract base class for [Viewport]-based input events.
**InputEventGesture:** Abstract base class for touch gestures.
**InputEventJoypadButton:** Represents a button on a gamepad being pressed or released.
**InputEventJoypadMotion:** Represents axis motions (such as joystick or analog triggers) from a gamepad.
**InputEventKey:** Represents a key on a keyboard being pressed or released.
**InputEventMagnifyGesture:** Represents a magnifying touch gesture.
**InputEventMIDI:** Represents an input event from a MIDI device, such as a piano.
**InputEventMouse:** Abstract base class for mouse input events.
**InputEventMouseButton:** Represents a mouse button being pressed or released.
**InputEventMouseMotion:** Represents a mouse movement.
**InputEventPanGesture:** Represents a panning touch gesture.
**InputEventScreenDrag:** Represents a screen drag event.
**InputEventScreenTouch:** Represents a screen touch event. {Remove outdated note}
**InputEventWithModifiers:** Abstract base class for input events affected by modifier keys like [code]Shift[/code] and [code]Alt[/code].
**InputEventShortcut:** Represents a triggered keyboard [Shortcut].
**InputMap:** A singleton that manages all [InputEventAction]s.
**int:** A built-in type for integers.
**Mutex:** A binary [Semaphore] for synchronization of multiple [Thread]s.
**MissingNode:** An internal editor class intended for keeping the data of unrecognized nodes.
**MissingResource:** An internal editor class intended for keeping the data of unrecognized resources.
**Node:** Base class for all scene objects.
**NodePath:** A pre-parsed scene tree path.
**Object:** Base class for all other classes in the engine.
**OS:** Provides access to common operating system functionalities.
*PackedDataContainer*
**PackedDataContainerRef:** A reference-counted [PackedDataContainer].
**Plane:** A plane in Hessian normal form.
**Projection:** A 4×4 matrix for 3D projective transformations.
**ProjectSettings:** Stores globally-accessible variables.
**RandomNumberGenerator:** Provides methods for generating pseudo-random numbers.
**Rect2:** A 2D axis-aligned bounding box using floating-point coordinates.
**Rect2i:** A 2D axis-aligned bounding box using integer coordinates.
**ResourceLoader:** A singleton for loading resource files.
**ResourcePreloader:** A node used to preload sub-resources inside a scene.
**ResourceSaver:** A singleton for saving [Resource]s to the filesystem. {FIX DESC}
**RID:** A handle for a [Resource]'s unique ID.
**SceneState:** Provides access to a scene file's information. {It can not be used to change the state, only to access it. Often used to peek into what a [PackedScene] contains without instantiating it.}
**Semaphore:** A synchronization mechanism used to control access to a shared resource by [Thread]s. {Add thread-safe APIs.}
**Signal:** A built-in type representing a signal defined in an [Object].
**StreamPeer:** Abstract base class for interacting with streams.
**StreamPeerBuffer:** A stream peer that handles binary data streams.
**StreamPeerGZIP:** A stream peer that handles GZIP and deflate compression/decompression.
**StreamPeerTCP:** A stream peer that handles TCP connections.
**StreamPeerTLS:** A stream peer that handles TLS connections.
**String: ** A built-in type for strings.
**StringName:** A built-in type for unique strings.
**Thread:** A thread used for simultaneous execution of code. {Allows to offload work from the [MainLoop].}
**Time:** A singleton for working with time data.
**Transform2D:** A 2×3 matrix representing a 2D transformation.
**Transform3D:** A 3×4 matrix representing a 3D transformation.
**Vector2:** A 2D vector using floating point coordinates.
**Vector2i:** A 2D vector using integer coordinates.
**Vector3:** A 3D vector using floating point coordinates.
**Vector3i:** A 3D vector using integer coordinates.
**Vector4:** A 4D vector using floating point coordinates.
**Vector4i:** A 4D vector using integer coordinates.
**WeakRef:** Holds an [Object]. If the object is [RefCounted], it doesn't update the reference count.
**World2D:** A resource that holds all components of a 2D world, such as a canvas and a physics space.
**World3D:** A resource that holds all components of a 3D world, such as a visual scenario and a physics space.

</details>

Thank you to the many people that helped with and reviewed some of these changes in advance: Winston, KoBeWi, SlugFiller, Estel, and others.