### PR TITLE
[GDScript] Opportunistically elide array allocations when performing += on Array

### DIFF
--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -835,12 +835,25 @@ public:
 	static void evaluate(const Variant &p_left, const Variant &p_right, Variant *r_ret, bool &r_valid) {
 		const Array &array_a = *VariantGetInternalPtr<Array>::get_ptr(&p_left);
 		const Array &array_b = *VariantGetInternalPtr<Array>::get_ptr(&p_right);
+		if (r_ret == &p_left) {
+			Array &array_ret = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
+			array_ret.append_array(array_b);
+			r_valid = true;
+			return;
+		}
+
 		Array sum;
 		_add_arrays(sum, array_a, array_b);
 		*r_ret = sum;
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		if (r_ret == left) {
+			Array &array_ret = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
+			array_ret.append_array(*VariantGetInternalPtr<Array>::get_ptr(right));
+			return;
+		}
+
 		Array sum;
 		_add_arrays(sum, *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
 		*r_ret = sum;

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -841,8 +841,9 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
-		*r_ret = Array();
-		_add_arrays(*VariantGetInternalPtr<Array>::get_ptr(r_ret), *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
+		Array sum;
+		_add_arrays(sum, *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
+		*r_ret = sum;
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
 		Array ret;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1165,8 +1165,18 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				bool has_operation = assignment->operation != GDScriptParser::AssignmentNode::OP_NONE;
 				if (has_operation) {
 					// Perform operation.
-					GDScriptCodeGenerator::Address op_result = codegen.add_temporary(_gdtype_from_datatype(assignment->get_datatype(), codegen.script));
 					GDScriptCodeGenerator::Address og_value = _parse_expression(codegen, r_error, assignment->assignee);
+					GDScriptDataType assignment_type = _gdtype_from_datatype(assignment->get_datatype(), codegen.script);
+					if (!has_setter && !assignment->use_conversion_assign && assignment_type.kind == GDScriptDataType::BUILTIN && og_value.type.kind == GDScriptDataType::BUILTIN && assignment_type.builtin_type == og_value.type.builtin_type) {
+						// If there's nothing special about the assignment, perform the assignment as part of the operator
+						gen->write_binary_operator(target, assignment->variant_op, og_value, assigned_value);
+						if (assigned_value.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+							gen->pop_temporary(); // Pop assigned value if not done before.
+						}
+						return GDScriptCodeGenerator::Address();
+					}
+
+					GDScriptCodeGenerator::Address op_result = codegen.add_temporary(assignment_type);
 					gen->write_binary_operator(op_result, assignment->variant_op, og_value, assigned_value);
 					to_assign = op_result;
 


### PR DESCRIPTION
This builds on top of the stack slot elision introduced in https://github.com/godotengine/godot/pull/76496 