### PR TITLE
[3.x] MessageQueue - Fix max usage performance statistic

### DIFF
--- a/core/message_queue.cpp
+++ b/core/message_queue.cpp
@@ -251,8 +251,7 @@ void MessageQueue::statistics() {
 }
 
 int MessageQueue::get_max_buffer_usage() const {
-	// Note this may be better read_buffer, or a combination, depending when this is read.
-	return buffers[write_buffer].data.size();
+	return _buffer_size_monitor.max_size_overall;
 }
 
 void MessageQueue::_call_function(Object *p_target, const StringName &p_func, const Variant *p_args, int p_argcount, bool p_show_error) {
@@ -392,6 +391,7 @@ void MessageQueue::flush() {
 		_THREAD_SAFE_LOCK_
 		// keep track of the maximum used size, so we can downsize buffers when appropriate
 		_buffer_size_monitor.max_size = MAX(buffer_data_size, _buffer_size_monitor.max_size);
+		_buffer_size_monitor.max_size_overall = MAX(buffer_data_size, _buffer_size_monitor.max_size_overall);
 
 		// flip buffers, this is the only part that requires a lock
 		SWAP(read_buffer, write_buffer);

--- a/core/message_queue.h
+++ b/core/message_queue.h
@@ -70,6 +70,9 @@ class MessageQueue {
 	struct BufferSizeMonitor {
 		uint32_t max_size = 0;
 		uint32_t flush_count = 0;
+
+		// Only used for performance statistics.
+		uint32_t max_size_overall = 0;
 	} _buffer_size_monitor;
 
 	void _call_function(Object *p_target, const StringName &p_func, const Variant *p_args, int p_argcount, bool p_show_error);
@@ -97,6 +100,7 @@ public:
 	bool is_flushing() const;
 
 	int get_max_buffer_usage() const;
+	int get_current_buffer_usage() const;
 
 	MessageQueue();
 	~MessageQueue();


### PR DESCRIPTION
Fixes to keep track of the maximum usage over time, rather than current usage.

Fixes #76518
Regression from #75527

## Notes
* Now the queue is growable / shrinkable, the more interesting statistic is now the current allocated size, but this is left for another PR.
* The statistic here is in theory useful to know you are nowhere near blowing the message queue, but the defaults limits are far higher now after #75527 , so this is unlikely to happen.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
