### PR TITLE
Revert "Fix ShaderMaterial uniform type changes"

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -279,28 +279,10 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				groups["<None>"]["<None>"].push_back(info);
 			}
 
-			const bool is_uniform_cached = param_cache.has(E->get().name);
-			bool is_uniform_type_changing = false;
-
-			if (is_uniform_cached) {
-				// Check if the uniform Variant type changed, for example vec3 to vec4.
-				const Variant &cached = param_cache.get(E->get().name);
-				is_uniform_type_changing = E->get().type != cached.get_type();
-
-				if (!is_uniform_type_changing && E->get().type == Variant::OBJECT && cached.get_type() == Variant::OBJECT) {
-					// Check if the Object class (hint string) changed, for example Texture2D sampler to Texture3D.
-					// Allow inheritance, for example Texture2D type sampler should also accept CompressedTexture2D.
-					Object *cached_obj = cached;
-					if (!cached_obj->is_class(E->get().hint_string)) {
-						is_uniform_type_changing = true;
-					}
-				}
-			}
-
 			PropertyInfo info = E->get();
 			info.name = "shader_parameter/" + info.name;
-			if (!is_uniform_cached || is_uniform_type_changing) {
-				// Property has never been edited or its type changed, retrieve with default value.
+			if (!param_cache.has(E->get().name)) {
+				// Property has never been edited, retrieve with default value.
 				Variant default_value = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), E->get().name);
 				param_cache.insert(E->get().name, default_value);
 				remap_cache.insert(info.name, E->get().name);


### PR DESCRIPTION
Reverts https://github.com/godotengine/godot/pull/76438 and re-opens the issues.

That PR itself should be fine, but as currently some uniforms are created with a wrong type, that PR also clears a few valid type combinations when saving a ShaderMaterial.

I'll create that PR again after https://github.com/godotengine/godot/pull/74937 is merged, which should fix most incorrect uniform types. There might be also some need for a few backwards compatibility hacks, but I'll have to investigate that more. I might even have to combine both PR's so that all type updates happen at the same commit so that any fixups will work, too.