### PR TITLE
Fix size error in `BitMap.opaque_to_polygons`

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -354,7 +354,7 @@ Vector<Vector<Vector2>> BitMap::_march_square(const Rect2i &p_rect, const Point2
 		prevx = stepx;
 		prevy = stepy;
 
-		ERR_FAIL_COND_V((int)count > width * height, Vector<Vector<Vector2>>());
+		ERR_FAIL_COND_V((int)count > 2 * (width * height + 1), Vector<Vector<Vector2>>());
 	} while (curx != startx || cury != starty);
 
 	// Add remaining points to result.


### PR DESCRIPTION
Previous estimate of upper limit on size was incorrect

I am not sure if the check is still needed based on my previous additions, but keeping it in case there is some edge case that causes getting stuck in an infinite loop, this shouldn't introduce any errors as the condition is there to detect if the list of vertices grows unbounded in that case, the exact value of the limit shouldn't matter as long as it's not too low, only matters in how fast it fails.

3.x version: #76544

Fixes #76531
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
