### PR TITLE
Fix wrongly removing prefix when generating in-editor documentation

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -115,7 +115,13 @@ static String _contextualize_class_specifier(const String &p_class_specifier, co
 		return p_class_specifier.substr(rfind + 1);
 	}
 
-	// Remove prefix
+	// They share a _name_ prefix but not a _class specifier_ prefix, e.g. Tree & TreeItem
+	// begins_with + lengths being different implies p_class_specifier.length() > p_edited_class.length() so this is safe
+	if (p_class_specifier[p_edited_class.length()] != '.') {
+		return p_class_specifier;
+	}
+
+	// Remove class specifier prefix
 	return p_class_specifier.substr(p_edited_class.length() + 1);
 }
 


### PR DESCRIPTION
Fixes a regression introduced by #72095 where for example `Tree` was considered being a class specifier prefix of `TreeItem` when that really only ought to be the case for something like `Tree.TreeItem`. We now check whether there's the necessary class specifier separator `.` there.

Found and essentially fixed by @dalexeev which I added as co-author of this PR :)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
