### PR TITLE
Make it easier to build a working mono-enabled Godot from scons

### DIFF
--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
+import os
 import build_scripts.mono_configure as mono_configure
+import build_scripts.build_assemblies as build_assemblies
+from methods import glob_recursive, get_cmdline_bool
 
 Import("env")
 Import("env_modules")
@@ -27,3 +30,41 @@ if env["platform"] in ["macos", "ios"]:
 if env.editor_build:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
     SConscript("editor/script_templates/SCsub")
+
+    if env["build_csharp"]:
+        env["build_assemblies"] = get_cmdline_bool("build_assemblies", env["build_csharp"])
+        env["generate_mono_glue"] = get_cmdline_bool("generate_mono_glue", env["build_csharp"])
+
+    if env["build_assemblies"] or env["generate_mono_glue"]:
+        gd = os.path.join(env.Dir("#bin").abspath, "godot" + env["PROGSUFFIX"])
+
+        if env["generate_mono_glue"]:
+            env["BUILDERS"]["CSharpGlue"] = Builder(action=gd + " --headless --generate-mono-glue modules/mono/glue")
+
+            # the only generated files with fixed names are these
+            glue_targets = [
+                "glue/GodotSharp/GodotSharp/Generated/GD_constants.cs",
+                "glue/GodotSharp/GodotSharp/Generated/GD_extensions.cs",
+                "glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props",
+                "glue/GodotSharp/GodotSharp/Generated/NativeCalls.cs",
+                "glue/GodotSharp/GodotSharpEditor/Generated/EditorNativeCalls.cs",
+                "glue/GodotSharp/GodotSharpEditor/Generated/GeneratedIncludes.props",
+            ]
+
+            glue_sources = [gd]
+            env.Alias("generate_mono_glue", [env.CSharpGlue(glue_targets, glue_sources)])
+
+        if env["build_assemblies"]:
+            env["BUILDERS"]["CSharpBuildAssemblies"] = Builder(
+                action=env.Run(build_assemblies.make_assemblies, "Building C# assemblies.")
+            )
+
+            assemblies_targets = []
+            for build_config in ["Debug", "Release"]:
+                editor_api_dir = os.path.join("#bin", "GodotSharp", "Api", build_config)
+                assemblies_targets += [
+                    os.path.join(editor_api_dir, filename) for filename in build_assemblies.target_filenames
+                ]
+
+            assemblies_sources = glob_recursive("**/*.cs", "glue")
+            env.Alias("build_assemblies", [env.CSharpBuildAssemblies(assemblies_targets, assemblies_sources)])

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -36,3 +36,13 @@ def get_doc_path():
 def is_enabled():
     # The module is disabled by default. Use module_mono_enabled=yes to enable it.
     return False
+
+
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("generate_mono_glue", "Generate C# glue", False),
+        BoolVariable("build_assemblies", "Build C# assemblies", False),
+        BoolVariable("build_csharp", "Generate and build C# bindings", False),
+    ]


### PR DESCRIPTION
Building a mono-enabled Godot from source currently requires a bunch of manual steps ~~, including having a separate Godot installation available to bootstrap the build~~. The current multi-step bootstrap+build process makes it harder for new users to do their own builds. It would be nice to be able to just do `scons target=editor module_mono_enabled=yes` and end up with a fully working Godot+Mono build, without extra steps. 

This PR adds `generate_mono_glue` and `build_assemblies` options to scons.

Having these as part of the build means that building a mono-enabled godot will create all the necessary bits to run it without having to do extra manual steps. It also means that changes to the native code that might change scripting API will automatically trigger regenerating the C# glue bindings and a rebuild of the assemblies, as part of the normal build process. The `build_assemblies.py` can still be run manually from the command line as before.

## Notes

~~The one thing this PR doesn't do is pass in the `--push-nupkgs-local` flag to `build_assemblies`, because that assumes that a dotnet nuget source has already been configured. Which teeeechnically means that game projects will not be fully buildable and users still need to do extra steps for a fully working installation.~~

~~In this scenario, my personal preference would be for the build to also configure a nuget source pointing to the `#bin/GodotSharp/Tools/nupkgs` build output folder, so the packages get consumed directly from the build and not pushed to somewhere else. Users can then optionally push their nupkgs if they want to distribute them/once they're happy with them, but by default they don't have to do anything, and all binaries and packages are consumed from the bin folder directly. Thoughts?~~

- The glue generator initialization fix has been moved to https://github.com/godotengine/godot/pull/76659
- This now adds/updates a `GodotSourceBuild` nuget source pointing to `#bin/GodotSharp/Tools/nupkgs`, so nuget packages built from source are automatically picked up. It also cleans any cached nuget packages.
