### PR TITLE
[3.x] Fix size error in `BitMap.opaque_to_polygons`

### DIFF
--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -318,7 +318,7 @@ Vector<Vector2> BitMap::_march_square(const Rect2i &rect, const Point2i &start) 
 		prevx = stepx;
 		prevy = stepy;
 
-		ERR_FAIL_COND_V((int)count > width * height, _points);
+		ERR_FAIL_COND_V((int)count > 2 * (width * height + 1), _points);
 	} while (curx != startx || cury != starty);
 	return _points;
 }


### PR DESCRIPTION
Previous estimate of upper limit on size was incorrect

For 4.x version: #76536

See there for elaboration on the reasoning 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
