### PR TITLE
Add Linear SRGB and OKLab color spaces to Gradient.

### DIFF
--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -80,8 +80,12 @@
 		<member name="colors" type="PackedColorArray" setter="set_colors" getter="get_colors" default="PackedColorArray(0, 0, 0, 1, 1, 1, 1, 1)">
 			Gradient's colors returned as a [PackedColorArray].
 		</member>
+		<member name="interpolation_color_space" type="int" setter="set_interpolation_color_space" getter="get_interpolation_color_space" enum="Gradient.ColorSpace" default="0">
+			The color space used to interpolate between points of the gradient. It does not affect the returned colors, which will always be in sRGB space. See [enum ColorSpace] for available modes.
+			[b]Note:[/b] This setting has no effect when [member interpolation_mode] is set to [constant GRADIENT_INTERPOLATE_CONSTANT].
+		</member>
 		<member name="interpolation_mode" type="int" setter="set_interpolation_mode" getter="get_interpolation_mode" enum="Gradient.InterpolationMode" default="0">
-			Defines how the colors between points of the gradient are interpolated. See [enum InterpolationMode] for available modes.
+			The algorithm used to interpolate between points of the gradient. See [enum InterpolationMode] for available modes.
 		</member>
 		<member name="offsets" type="PackedFloat32Array" setter="set_offsets" getter="get_offsets" default="PackedFloat32Array(0, 1)">
 			Gradient's offsets returned as a [PackedFloat32Array].
@@ -96,6 +100,15 @@
 		</constant>
 		<constant name="GRADIENT_INTERPOLATE_CUBIC" value="2" enum="InterpolationMode">
 			Cubic interpolation.
+		</constant>
+		<constant name="GRADIENT_COLOR_SPACE_SRGB" value="0" enum="ColorSpace">
+			sRGB color space.
+		</constant>
+		<constant name="GRADIENT_COLOR_SPACE_LINEAR_SRGB" value="1" enum="ColorSpace">
+			Linear sRGB color space.
+		</constant>
+		<constant name="GRADIENT_COLOR_SPACE_OKLAB" value="2" enum="ColorSpace">
+			[url=https://bottosson.github.io/posts/oklab/]Oklab[/url] color space. This color space provides a smooth and uniform-looking transition between colors.
 		</constant>
 	</constants>
 </class>

--- a/editor/plugins/gradient_editor.cpp
+++ b/editor/plugins/gradient_editor.cpp
@@ -41,6 +41,7 @@ void GradientEditor::set_gradient(const Ref<Gradient> &p_gradient) {
 	gradient->connect("changed", callable_mp(this, &GradientEditor::_gradient_changed));
 	set_points(gradient->get_points());
 	set_interpolation_mode(gradient->get_interpolation_mode());
+	set_interpolation_color_space(gradient->get_interpolation_color_space());
 }
 
 void GradientEditor::reverse_gradient() {
@@ -93,6 +94,7 @@ void GradientEditor::_gradient_changed() {
 	Vector<Gradient::Point> grad_points = gradient->get_points();
 	set_points(grad_points);
 	set_interpolation_mode(gradient->get_interpolation_mode());
+	set_interpolation_color_space(gradient->get_interpolation_color_space());
 	queue_redraw();
 	editing = false;
 }
@@ -104,9 +106,11 @@ void GradientEditor::_ramp_changed() {
 	undo_redo->add_do_method(gradient.ptr(), "set_offsets", get_offsets());
 	undo_redo->add_do_method(gradient.ptr(), "set_colors", get_colors());
 	undo_redo->add_do_method(gradient.ptr(), "set_interpolation_mode", get_interpolation_mode());
+	undo_redo->add_do_method(gradient.ptr(), "set_interpolation_color_space", get_interpolation_color_space());
 	undo_redo->add_undo_method(gradient.ptr(), "set_offsets", gradient->get_offsets());
 	undo_redo->add_undo_method(gradient.ptr(), "set_colors", gradient->get_colors());
 	undo_redo->add_undo_method(gradient.ptr(), "set_interpolation_mode", gradient->get_interpolation_mode());
+	undo_redo->add_undo_method(gradient.ptr(), "set_interpolation_color_space", gradient->get_interpolation_color_space());
 	undo_redo->commit_action();
 	editing = false;
 }
@@ -169,6 +173,14 @@ void GradientEditor::set_interpolation_mode(Gradient::InterpolationMode p_interp
 
 Gradient::InterpolationMode GradientEditor::get_interpolation_mode() {
 	return interpolation_mode;
+}
+
+void GradientEditor::set_interpolation_color_space(Gradient::ColorSpace p_color_space) {
+	interpolation_color_space = p_color_space;
+}
+
+Gradient::ColorSpace GradientEditor::get_interpolation_color_space() {
+	return interpolation_color_space;
 }
 
 ColorPicker *GradientEditor::get_picker() {
@@ -385,6 +397,7 @@ void GradientEditor::_notification(int p_what) {
 			// Draw color ramp.
 			gradient_cache->set_points(points);
 			gradient_cache->set_interpolation_mode(interpolation_mode);
+			gradient_cache->set_interpolation_color_space(interpolation_color_space);
 			preview_texture->set_gradient(gradient_cache);
 			draw_texture_rect(preview_texture, Rect2(handle_width / 2, 0, total_w, h));
 

--- a/editor/plugins/gradient_editor.h
+++ b/editor/plugins/gradient_editor.h
@@ -45,6 +45,7 @@ class GradientEditor : public Control {
 	int grabbed = -1;
 	Vector<Gradient::Point> points;
 	Gradient::InterpolationMode interpolation_mode = Gradient::GRADIENT_INTERPOLATE_LINEAR;
+	Gradient::ColorSpace interpolation_color_space = Gradient::GRADIENT_COLOR_SPACE_SRGB;
 
 	bool editing = false;
 	Ref<Gradient> gradient;
@@ -83,6 +84,9 @@ public:
 
 	void set_interpolation_mode(Gradient::InterpolationMode p_interp_mode);
 	Gradient::InterpolationMode get_interpolation_mode();
+
+	void set_interpolation_color_space(Gradient::ColorSpace p_color_space);
+	Gradient::ColorSpace get_interpolation_color_space();
 
 	ColorPicker *get_picker();
 	PopupPanel *get_popup();

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -69,7 +69,12 @@ void Gradient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_interpolation_mode", "interpolation_mode"), &Gradient::set_interpolation_mode);
 	ClassDB::bind_method(D_METHOD("get_interpolation_mode"), &Gradient::get_interpolation_mode);
 
+	ClassDB::bind_method(D_METHOD("set_interpolation_color_space", "interpolation_color_space"), &Gradient::set_interpolation_color_space);
+	ClassDB::bind_method(D_METHOD("get_interpolation_color_space"), &Gradient::get_interpolation_color_space);
+
+	ADD_GROUP("Interpolation", "interpolation_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "interpolation_mode", PROPERTY_HINT_ENUM, "Linear,Constant,Cubic"), "set_interpolation_mode", "get_interpolation_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "interpolation_color_space", PROPERTY_HINT_ENUM, "sRGB,Linear sRGB,Oklab"), "set_interpolation_color_space", "get_interpolation_color_space");
 
 	ADD_GROUP("Raw Data", "");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "offsets"), "set_offsets", "get_offsets");
@@ -78,6 +83,16 @@ void Gradient::_bind_methods() {
 	BIND_ENUM_CONSTANT(GRADIENT_INTERPOLATE_LINEAR);
 	BIND_ENUM_CONSTANT(GRADIENT_INTERPOLATE_CONSTANT);
 	BIND_ENUM_CONSTANT(GRADIENT_INTERPOLATE_CUBIC);
+
+	BIND_ENUM_CONSTANT(GRADIENT_COLOR_SPACE_SRGB);
+	BIND_ENUM_CONSTANT(GRADIENT_COLOR_SPACE_LINEAR_SRGB);
+	BIND_ENUM_CONSTANT(GRADIENT_COLOR_SPACE_OKLAB);
+}
+
+void Gradient::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "interpolation_color_space" && interpolation_mode == GRADIENT_INTERPOLATE_CONSTANT) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
 }
 
 Vector<float> Gradient::get_offsets() const {
@@ -101,10 +116,20 @@ Vector<Color> Gradient::get_colors() const {
 void Gradient::set_interpolation_mode(Gradient::InterpolationMode p_interp_mode) {
 	interpolation_mode = p_interp_mode;
 	emit_signal(CoreStringNames::get_singleton()->changed);
+	notify_property_list_changed();
 }
 
 Gradient::InterpolationMode Gradient::get_interpolation_mode() {
 	return interpolation_mode;
+}
+
+void Gradient::set_interpolation_color_space(Gradient::ColorSpace p_color_space) {
+	interpolation_color_space = p_color_space;
+	emit_signal(CoreStringNames::get_singleton()->changed);
+}
+
+Gradient::ColorSpace Gradient::get_interpolation_color_space() {
+	return interpolation_color_space;
 }
 
 void Gradient::set_offsets(const Vector<float> &p_offsets) {


### PR DESCRIPTION
Implements godotengine/godot-proposals#6702

Here's some screenshot of the new color spaces:

![image](https://user-images.githubusercontent.com/10124534/235167711-fb705ea4-5f80-4e56-b631-f0d05f4915d2.png)

In order, SRGB, Linear SRGB and OKLab
![image](https://user-images.githubusercontent.com/10124534/235167859-c8494cda-97c0-4d7a-a167-e7694ed099e5.png)


I have a couple questions about my implementation: 

First, the main logic for gradient sampling is in the header file instead of the cpp. I added 2 utility methods to avoid code duplication, is it alright that it all stays in the header? Should I move code somewhere else?

Edit: Clayjohn confirmed on RocketChat that this is ok.

Second, to avoid duplicating the whole `get_color_at_offset` method, just replacing  godot's Color by oklab's color, I instead ''hijacked'' the Color struct and used it to temporarily hold the Lab values for interpolation. Please tell me if this approach is not acceptable and what should I do instead :)

Edit: Clayjohn agreed on RocketChat to keep using Color but change the access from r/g/b fields to array accessors to avoid confusion.
