### PR TITLE
Fix crashes due to stack overflow when painting a large area in tile map

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -312,6 +312,11 @@ void UndoRedo::commit_action(bool p_execute) {
 }
 
 void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
+	const int PREALLOCATE_ARGS_COUNT = 16;
+
+	LocalVector<const Variant *> args;
+	args.reserve(PREALLOCATE_ARGS_COUNT);
+
 	for (; E; E = E->next()) {
 		Operation &op = E->get();
 
@@ -347,12 +352,13 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E) {
 					if (binds.is_empty()) {
 						method_callback(method_callback_ud, obj, op.name, nullptr, 0);
 					} else {
-						const Variant **args = (const Variant **)alloca(sizeof(const Variant **) * binds.size());
+						args.clear();
+
 						for (int i = 0; i < binds.size(); i++) {
-							args[i] = (const Variant *)&binds[i];
+							args.push_back(&binds[i]);
 						}
 
-						method_callback(method_callback_ud, obj, op.name, args, binds.size());
+						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds.size());
 					}
 				}
 			} break;


### PR DESCRIPTION
Fixes #76473.

This PR takes `alloca` out of the loop, reuses previous allocations whenever possible to reduce the chance of using up too much stack space.

**Cause**
the crash described in linked issue is most likely (almost certain) caused by the stack overflow.

filling a large area of tiles at once will create a long list of operations for Undo/Redo to record, which gets processed by the for loop inside `UndoRedo::_process_operation_list` function, which uses `alloca` inside. memory obtained from `alloca` gets freed after you leave the function scope.
given long enough list and right condition (which can be achieved by using a CTRL+SHIFT fill on tile map), `alloca` can exhaust the stack and cause a stack overflow, resulting in crash.

Valgrind report
![Screenshot from 2023-04-28 22-49-01](https://user-images.githubusercontent.com/70929713/235170573-f0d9c6ea-be51-4ed1-a244-dc0ac2456bf0.png)

each call allocates around 40 bytes (8 bytes for pointer * 5 arguments), resulting in roughly 6.6 MB before the crash
![Screenshot from 2023-04-28 22-53-48](https://user-images.githubusercontent.com/70929713/235170578-b455a700-d1e0-4785-a858-23f838c0ac92.png)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

