### PR TITLE
Add `AudioServer::get_buses()`

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -110,6 +110,11 @@
 				Returns the volume of the bus at index [param bus_idx] in dB.
 			</description>
 		</method>
+		<method name="get_buses" qualifiers="const">
+			<return type="PackedStringArray" />
+			<description>
+			</description>
+		</method>
 		<method name="get_input_device_list">
 			<return type="PackedStringArray" />
 			<description>

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -897,6 +897,16 @@ void AudioServer::set_bus_name(int p_bus, const String &p_name) {
 	emit_signal(SNAME("bus_layout_changed"));
 }
 
+PackedStringArray AudioServer::get_buses() const {
+	PackedStringArray ret;
+
+	for (int i = 0; i < buses.size(); ++i) {
+		ret.push_back(buses[i]->name);
+	}
+
+	return ret;
+}
+
 String AudioServer::get_bus_name(int p_bus) const {
 	ERR_FAIL_INDEX_V(p_bus, buses.size(), String());
 	return buses[p_bus]->name;
@@ -1685,6 +1695,7 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bus_name", "bus_idx", "name"), &AudioServer::set_bus_name);
 	ClassDB::bind_method(D_METHOD("get_bus_name", "bus_idx"), &AudioServer::get_bus_name);
 	ClassDB::bind_method(D_METHOD("get_bus_index", "bus_name"), &AudioServer::get_bus_index);
+	ClassDB::bind_method(D_METHOD("get_buses"), &AudioServer::get_buses);
 
 	ClassDB::bind_method(D_METHOD("get_bus_channels", "bus_idx"), &AudioServer::get_bus_channels);
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -334,6 +334,7 @@ public:
 
 	void set_bus_name(int p_bus, const String &p_name);
 	String get_bus_name(int p_bus) const;
+	PackedStringArray get_buses() const;
 	int get_bus_index(const StringName &p_bus_name) const;
 
 	int get_bus_channels(int p_bus) const;


### PR DESCRIPTION
This PR adds a `get_buses` method for the `AudioServer` singleton, so users are able to query a `PackedStringArray` containing all buses' names. Maybe we could rename it to `AudioServer::get_bus_list()` in order to match `AudioServer::get_input_device_list()` and `AudioServer::get_output_device_list()`?

Example:
```gdscript
extends Node


func _ready():
	print(AudioServer.get_buses())
```

Example output:
```gdscript
["Master", "New Bus", "New Bus 2", "New Bus 3"]
```