### PR TITLE
Change Node `set_name` to use StringName, slightly improves performance

### DIFF
--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -90,3 +90,10 @@ Validate extension JSON: API was removed: classes/RenderingServer/methods/instan
 Validate extension JSON: API was removed: classes/RenderingServer/methods/instance_reset_physics_interpolation
 
 Functionality moved out of server.
+
+
+GH-76560
+--------
+Validate extension JSON: Error: Field 'classes/Node/methods/set_name/arguments/0': type changed value in new API, from "String" to "StringName".
+
+Change Node `set_name` to use StringName to improve performance. Compatibility method registered.

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2732,11 +2732,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	if (getter && setter) {
 		const ArgumentInterface &setter_first_arg = setter->arguments.back()->get();
 		if (getter->return_type.cname != setter_first_arg.type.cname) {
-			// Special case for Node::set_name
-			bool whitelisted = getter->return_type.cname == name_cache.type_StringName &&
-					setter_first_arg.type.cname == name_cache.type_String;
-
-			ERR_FAIL_COND_V_MSG(!whitelisted, ERR_BUG,
+			ERR_FAIL_V_MSG(ERR_BUG,
 					"Return type from getter doesn't match first argument of setter for property: '" +
 							p_itype.name + "." + String(p_iprop.cname) + "'.");
 		}

--- a/scene/main/node.compat.inc
+++ b/scene/main/node.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  node.compat.inc                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void Node::_set_name_bind_compat_76560(const String &p_name) {
+	set_name(p_name);
+}
+
+void Node::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_name", "name"), &Node::_set_name_bind_compat_76560);
+}
+
+#endif

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -410,6 +410,11 @@ protected:
 	GDVIRTUAL0RC(RID, _get_focused_accessibility_element)
 	GDVIRTUAL1RC(String, _get_accessibility_container_name, const Node *)
 
+#ifndef DISABLE_DEPRECATED
+	void _set_name_bind_compat_76560(const String &p_name);
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	enum {
 		// You can make your own, but don't use the same numbers as other notifications in other nodes.
@@ -473,7 +478,7 @@ public:
 
 	StringName get_name() const;
 	String get_description() const;
-	void set_name(const String &p_name);
+	void set_name(const StringName &p_name);
 
 	InternalMode get_internal_mode() const;
 

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -359,11 +359,7 @@ void validate_property(const Context &p_context, const ExposedClass &p_class, co
 	if (getter && setter) {
 		const ArgumentData &setter_first_arg = setter->arguments.back()->get();
 		if (getter->return_type.name != setter_first_arg.type.name) {
-			// Special case for Node::set_name
-			bool whitelisted = getter->return_type.name == p_context.names_cache.string_name_type &&
-					setter_first_arg.type.name == p_context.names_cache.string_type;
-
-			TEST_FAIL_COND(!whitelisted,
+			TEST_FAIL(
 					"Return type from getter doesn't match first argument of setter, for property: '", p_class.name, ".", String(p_prop.name), "'.");
 		}
 	}


### PR DESCRIPTION
This PR changes the `Node::set_name()` method to use StringName. This code skips StringName construction in the case where the desired name is already a valid node name. This improves performance by about 15% to 20% in my testing in the case where the desired name is already valid (the common case, the happy code path).

The code has been split up into multiple methods. `invalid_node_name_index()` finds the index of the first character that would be invalid for a node name. Then this is passed to `validate_node_name_internal()` which starts replacing the invalid characters from that index. The same logic used to exist combined into one method, but having it be separate allows us to speed up `Node::set_name()`. The logic in `invalid_node_name_index()` is even slightly simpler because it doesn't have to keep track of `bool valid`, it just returns if invalid. However, the existing `validate_node_name()` is still present as a wrapper, for being exposed to GDScript and is also used in many other parts of the codebase. I also renamed some local variables for readability. I'm open to any suggestions if this can be improved further.

Test and benchmarking code:

```gdscript
func _ready():
	var nodes: Array = []
	for i in range(1000000):
		nodes.append(Node.new())
	var start_time = Time.get_ticks_usec()
	for i in range(1000000):
		nodes[i].set_name(&"MyStringName")
	var end_time = Time.get_ticks_usec()
	print("Time elapsed: " + str(end_time - start_time))
```

Results:

Without calling set_name, just accessing the array:  
Time elapsed: 28971 (varies between about 25k and 30k)

This PR with valid name, skips StringName construction:  
Time elapsed: 132565 (varies between about 120k and 140k)

This PR with invalid name:  
Time elapsed: 220087 (varies between about 200k and 230k)

Current master with valid name:  
Time elapsed: 160325 (varies between about 150k and 170k)

Current master with invalid name:  
Time elapsed: 213259 (varies between about 190k and 220k)

I also did some testing with longer StringNames and the speed improvement gets more significant as length increases.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/96805*