### PR TITLE
Fix ColorPicker position changing on theme update bug

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -68,11 +68,9 @@ void ColorPicker::_notification(int p_what) {
 			for (int i = 0; i < SLIDER_COUNT; i++) {
 				labels[i]->set_custom_minimum_size(Size2(theme_cache.label_width, 0));
 				sliders[i]->add_theme_constant_override(SNAME("center_grabber"), theme_cache.center_slider_grabbers);
-				set_offset((Side)i, get_offset((Side)i) + theme_cache.content_margin);
 			}
 			alpha_label->set_custom_minimum_size(Size2(theme_cache.label_width, 0));
 			alpha_label->add_theme_constant_override(SNAME("center_grabber"), theme_cache.center_slider_grabbers);
-			set_offset((Side)0, get_offset((Side)0) + theme_cache.content_margin);
 
 			for (int i = 0; i < MODE_BUTTON_COUNT; i++) {
 				mode_btns[i]->add_theme_style_override("pressed", theme_cache.mode_button_pressed);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #62937 by no longer adding `theme_override_constants/margin` to side offsets. It didn't seem to be working correctly anyway, only changing position in unexpected ways. It didn't even increase the space a ColorPicker takes up in a container (ex. HBoxContainer). Inside a container, it will still cause `position` to change, which can lead to the ColorPicker moving outside of the container's rectangle entirely.

Maybe `theme_override_constants/margin` should be removed entirely, not sure about how compatibility breaking it would be.