### PR TITLE
Fix renaming a node to the name of its siblings causing exported `NodePath` to point to the wrong node

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -988,6 +988,7 @@ void SceneTreeEditor::_rename_node(Node *p_node, const String &p_name) {
 	}
 	// Trim leading/trailing whitespace to prevent node names from containing accidental whitespace, which would make it more difficult to get the node via `get_node()`.
 	new_name = new_name.strip_edges();
+	new_name = p_node->get_parent()->validate_child_name(p_node, new_name);
 
 	if (!is_scene_tree_dock) {
 		p_node->set_name(new_name);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1188,6 +1188,11 @@ String Node::validate_child_name(Node *p_child) {
 	_generate_serial_child_name(p_child, name);
 	return name;
 }
+
+String Node::validate_child_name(Node *p_child, StringName p_name) {
+	_generate_serial_child_name(p_child, p_name);
+	return p_name;
+}
 #endif
 
 String Node::adjust_name_casing(const String &p_name) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -609,6 +609,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);
+	String validate_child_name(Node *p_child, StringName p_name);
 #endif
 	static String adjust_name_casing(const String &p_name);
 


### PR DESCRIPTION
Once text editing is complete, the method `void SceneTreeEditor::_renamed()` is triggered, followed by `void SceneTreeDock::_node_prerenamed(Node *p_node, const String &p_new_name)`. Afterward, the method `void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims)` is called, which ultimately leads to line 1707 where the method `p_base->set(propertyname, updated_variant);` modifies the previously set value with the new Node's name. Next, the method `void SceneTreeEditor::_rename_node(ObjectID p_node, const String &p_name)` is triggered to update the TreeItem in SceneTreeEditor and the Node's name. However, the problem arises in line 962: `n->set_name(p_name);` when the Node's name is validated using `data.parent->_validate_child_name(this, true);`. It is then discovered that the new name conflicts with a sibling's name, prompting `_generate_serial_child_name(p_child, name);` to append a number to the renaming Node's name. Unfortunately, the value of the exported variable is not updated, causing the bug.

Fixes: #76192
Fixes: #76680