### PR TITLE
Add GDExtension compatibility methods

### DIFF
--- a/core/extension/gdextension.compat.inc
+++ b/core/extension/gdextension.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  gdextension.compat.inc                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "gdextension.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Error GDExtension::open_library_compat_76406(const String &p_path, const String &p_entry_symbol) {
+	return open_library(p_path, p_entry_symbol, true);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void GDExtension::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library_compat_76406);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "gdextension.h"
+#include "gdextension.compat.inc"
+
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/object/class_db.h"
@@ -486,10 +488,6 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 	}
 }
 
-Error GDExtension::open_library_compat_76406(const String &p_path, const String &p_entry_symbol) {
-	return open_library(p_path, p_entry_symbol, true);
-}
-
 void GDExtension::close_library() {
 	ERR_FAIL_COND(library == nullptr);
 	OS::get_singleton()->close_dynamic_library(library);
@@ -526,7 +524,6 @@ void GDExtension::deinitialize_library(InitializationLevel p_level) {
 
 void GDExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol", "use_legacy_interface"), &GDExtension::open_library, DEFVAL(false));
-	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library_compat_76406);
 	ClassDB::bind_method(D_METHOD("close_library"), &GDExtension::close_library);
 	ClassDB::bind_method(D_METHOD("is_library_open"), &GDExtension::is_library_open);
 

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -65,6 +65,10 @@ class GDExtension : public Resource {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Error open_library_compat_76406(const String &p_path, const String &p_entry_symbol);
+#endif
 
 public:
 	HashMap<String, String> class_icon_paths;
@@ -73,7 +77,6 @@ public:
 	static String find_extension_library(const String &p_path, Ref<ConfigFile> p_config, std::function<bool(String)> p_has_feature, PackedStringArray *r_tags = nullptr);
 
 	Error open_library(const String &p_path, const String &p_entry_symbol, bool p_use_legacy_interface = false);
-	Error open_library_compat_76406(const String &p_path, const String &p_entry_symbol);
 	void close_library();
 
 	enum InitializationLevel {

--- a/core/object/object.compat.inc
+++ b/core/object/object.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  object.compat.inc                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "object.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
+#include "core/object/class_db.h"
+#include "core/variant/typed_array.h"
 
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Vector<String> Object::_get_meta_list_bind_compat_76418() const {
+	return Variant(_get_meta_list_bind()).operator Vector<String>();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void Object::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_meta_list"), &Object::_get_meta_list_bind_compat_76418);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "object.h"
+#include "object.compat.inc"
 
 #include "core/core_string_names.h"
 #include "core/io/resource.h"
@@ -1395,6 +1396,9 @@ void Object::initialize_class() {
 	}
 	ClassDB::_add_class<Object>();
 	_bind_methods();
+#ifndef DISABLE_DEPRECATED
+	_bind_compatibility_methods();
+#endif
 	initialized = true;
 }
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -430,6 +430,9 @@ protected:                                                                      
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                        \
 		return &m_class::_bind_methods;                                                                                                          \
 	}                                                                                                                                            \
+	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {                                                                          \
+		return &m_class::_bind_compatibility_methods;                                                                                            \
+	}                                                                                                                                            \
                                                                                                                                                  \
 public:                                                                                                                                          \
 	static void initialize_class() {                                                                                                             \
@@ -441,6 +444,9 @@ public:                                                                         
 		::ClassDB::_add_class<m_class>();                                                                                                        \
 		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                   \
 			_bind_methods();                                                                                                                     \
+		}                                                                                                                                        \
+		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) {                                       \
+			_bind_compatibility_methods();                                                                                                       \
 		}                                                                                                                                        \
 		initialized = true;                                                                                                                      \
 	}                                                                                                                                            \
@@ -674,6 +680,11 @@ protected:
 	virtual void _notificationv(int p_notification, bool p_reversed) {}
 
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+#else
+	static void _bind_compatibility_methods() {}
+#endif
 	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
 	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
 	void _get_property_list(List<PropertyInfo> *p_list) const {};
@@ -684,6 +695,9 @@ protected:
 
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {
 		return &Object::_bind_methods;
+	}
+	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {
+		return &Object::_bind_compatibility_methods;
 	}
 	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &r_ret) const {
 		return &Object::_get;
@@ -721,6 +735,9 @@ protected:
 	}
 
 	TypedArray<StringName> _get_meta_list_bind() const;
+#ifndef DISABLE_DEPRECATED
+	Vector<String> _get_meta_list_bind_compat_76418() const;
+#endif
 	TypedArray<Dictionary> _get_property_list_bind() const;
 	TypedArray<Dictionary> _get_method_list_bind() const;
 

--- a/core/object/worker_thread_pool.compat.inc
+++ b/core/object/worker_thread_pool.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  worker_thread_pool.compat.inc                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "worker_thread_pool.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void WorkerThreadPool::wait_for_task_completion_compat_77143(TaskID p_group) {
+	wait_for_group_task_completion(p_group);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void WorkerThreadPool::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("wait_for_task_completion", "task_id"), &WorkerThreadPool::wait_for_task_completion_compat_77143);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "worker_thread_pool.h"
+#include "worker_thread_pool.compat.inc"
 
 #include "core/os/os.h"
 

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -161,6 +161,10 @@ private:
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void wait_for_task_completion_compat_77143(TaskID p_task_id);
+#endif
 
 public:
 	template <class C, class M, class U>

--- a/editor/editor_interface.compat.inc
+++ b/editor/editor_interface.compat.inc
@@ -1,0 +1,95 @@
+/**************************************************************************/
+/*  editor_interface.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "editor_interface.h"
+
+#include "editor/editor_data.h"
+#include "editor/editor_paths.h"
+#include "editor/editor_resource_preview.h"
+#include "editor/editor_settings.h"
+#include "editor/filesystem_dock.h"
+#include "scene/main/node.h"
+
+EditorFileSystem *EditorInterface::get_resource_file_system_compat_76176() {
+	return get_resource_file_system();
+}
+
+EditorPaths *EditorInterface::get_editor_paths_compat_76176() {
+	return get_editor_paths();
+}
+
+EditorResourcePreview *EditorInterface::get_resource_previewer_compat_76176() {
+	return get_resource_previewer();
+}
+
+EditorSelection *EditorInterface::get_selection_compat_76176() {
+	return get_selection();
+}
+
+Ref<EditorSettings> EditorInterface::get_editor_settings_compat_76176() {
+	return get_editor_settings();
+}
+
+Control *EditorInterface::get_base_control_compat_76176() {
+	return get_base_control();
+}
+
+VBoxContainer *EditorInterface::get_editor_main_screen_compat_76176() {
+	return get_editor_main_screen();
+}
+
+ScriptEditor *EditorInterface::get_script_editor_compat_76176() {
+	return get_script_editor();
+}
+
+FileSystemDock *EditorInterface::get_file_system_dock_compat_76176() {
+	return get_file_system_dock();
+}
+
+Node *EditorInterface::get_edited_scene_root_compat_76176() {
+	return get_edited_scene_root();
+}
+
+void EditorInterface::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_selection"), &EditorInterface::get_selection_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_base_control"), &EditorInterface::get_base_control_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock_compat_76176);
+	ClassDB::bind_compatibility_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root_compat_76176);
+}
+
+#endif

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "editor_interface.h"
+#include "editor_interface.compat.inc"
 
 #include "editor/editor_command_palette.h"
 #include "editor/editor_node.h"

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -64,6 +64,19 @@ class EditorInterface : public Object {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	EditorFileSystem *get_resource_file_system_compat_76176();
+	EditorPaths *get_editor_paths_compat_76176();
+	EditorResourcePreview *get_resource_previewer_compat_76176();
+	EditorSelection *get_selection_compat_76176();
+	Ref<EditorSettings> get_editor_settings_compat_76176();
+	Control *get_base_control_compat_76176();
+	VBoxContainer *get_editor_main_screen_compat_76176();
+	ScriptEditor *get_script_editor_compat_76176();
+	FileSystemDock *get_file_system_dock_compat_76176();
+	Node *get_edited_scene_root_compat_76176();
+#endif
 
 public:
 	static EditorInterface *get_singleton() { return singleton; }

--- a/editor/editor_script.compat.inc
+++ b/editor/editor_script.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  editor_script.compat.inc                                              */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifndef DISABLE_DEPRECATED
+
 #include "editor_script.h"
-#include "editor_script.compat.inc"
 
 #include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "scene/main/node.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Node *EditorScript::get_scene_compat_76026() {
+	return get_scene();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
-}
-
-EditorInterface *EditorScript::get_editor_interface() const {
+EditorInterface *EditorScript::get_editor_interface_compat_76026() {
 	return EditorInterface::get_singleton();
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
+void EditorScript::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_scene"), &EditorScript::get_scene_compat_76026);
+	ClassDB::bind_compatibility_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface_compat_76026);
 }
 
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/editor/editor_script.h
+++ b/editor/editor_script.h
@@ -43,6 +43,11 @@ class EditorScript : public RefCounted {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Node *get_scene_compat_76026();
+	EditorInterface *get_editor_interface_compat_76026();
+#endif
 
 	GDVIRTUAL0(_run)
 

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -9,7 +9,6 @@ should instead be used to justify these changes and describe how users should wo
 GH-77757
 --------
 Validate extension JSON: Error: Field 'classes/Viewport/methods/gui_get_focus_owner': is_const changed value in new API, from false to true.
-Validate extension JSON: Error: Hash changed for 'classes/Viewport/methods/gui_get_focus_owner', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
 
 This method does not affect the state of Viewport so it should be const.
 
@@ -113,16 +112,6 @@ Unsure where these come from; when dumping the interface, these do actually stil
 
 GH-76176
 --------
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_base_control', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_edited_scene_root', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_main_screen', from 36955D8D to 65B2D3B5. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_paths', from FA334A57 to 5F1D5DC4. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_settings', from 932B4D2E to F399A3EB. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_file_system_dock', from 217210BD to DF93E7E7. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_resource_filesystem', from 1D5C1A47 to 2E802B7E. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_resource_previewer', from 5E161783 to 383C77ED. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_script_editor', from EB48A7D4 to 056A8923. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_selection', from 0302AF0B to A05A4D13. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_base_control': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_edited_scene_root': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_editor_main_screen': is_const changed value in new API, from false to true.
@@ -139,8 +128,6 @@ Functions were made `const`. No adjustments should be necessary.
 
 GH-76026
 --------
-Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_editor_interface', from FBC1084A to 75D179CC. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_scene', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/EditorScript/methods/get_editor_interface': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/EditorScript/methods/get_scene': is_const changed value in new API, from false to true.
 
@@ -149,15 +136,10 @@ Functions were made `const`. No adjustments should be necessary.
 
 GH-76418
 --------
-Validate extension JSON: Error: Hash changed for 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Object/methods/get_meta_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/RDShaderFile/methods/get_version_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/RenderingServer/methods/global_shader_parameter_get_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
 Validate extension JSON: Error: Field 'classes/Object/methods/get_meta_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
 Validate extension JSON: Error: Field 'classes/RDShaderFile/methods/get_version_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
 Validate extension JSON: Error: Field 'classes/RenderingServer/methods/global_shader_parameter_get_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
-
 Validate extension JSON: Error: Field 'classes/Geometry3D/methods/segment_intersects_convex/arguments/2': type changed value in new API, from "Array" to "typedarray::Plane".
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': type changed value in new API, from "Array" to "typedarray::RID".
 Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/add_triangle_fan/arguments/5': default_value changed value in new API, from "[]" to "Array[Plane]([])".
@@ -168,10 +150,6 @@ Return types change, fixed some internal type issues and unnecessarily changed t
 
 GH-72749
 --------
-Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/set_priority', from 1647D661 to 4CAD1009. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Area3D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Area3D/methods/set_priority', from 1647D661 to 4CAD1009. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/Area2D/methods/get_priority/return_value': meta changed value in new API, from "float" to "int32".
 Validate extension JSON: Error: Field 'classes/Area2D/methods/get_priority/return_value': type changed value in new API, from "float" to "int".
 Validate extension JSON: Error: Field 'classes/Area2D/methods/set_priority/arguments/0': meta changed value in new API, from "float" to "int32".
@@ -186,7 +164,6 @@ Type changed from `float` to `int`. Previously the `float` values were internall
 
 GH-72152
 --------
-Validate extension JSON: Error: Hash changed for 'classes/MeshInstance3D/methods/create_multiple_convex_collisions', from BFDD6D64 to 257A91A5. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/MeshInstance3D/methods/create_multiple_convex_collisions': arguments
 
 Added an optional parameter with a default value. No adjustments should be necessary.
@@ -194,8 +171,6 @@ Added an optional parameter with a default value. No adjustments should be neces
 
 GH-75759
 --------
-Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_input', from 5162412C to A178F700. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_node', from 1263CBA5 to 0FB30106. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/AnimationNode/methods/_process/arguments': size changed value in new API, from 3 to 4.
 Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_input/arguments': size changed value in new API, from 7 to 8.
 Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_node/arguments': size changed value in new API, from 8 to 9.
@@ -206,7 +181,6 @@ Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_node/
 
 GH-75017
 --------
-Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_list', from 8593DF77 to F0951C19. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 3 to 4.
 
 Added an optional parameter with a default value. No adjustments should be necessary.
@@ -214,7 +188,6 @@ Added an optional parameter with a default value. No adjustments should be neces
 
 GH-76794
 --------
-Validate extension JSON: Error: Hash changed for 'classes/Tree/methods/edit_selected', from 859196D4 to 9AB67ACD. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Tree/methods/edit_selected': arguments
 
 Added an optional parameter with a default value. No adjustments should be necessary.
@@ -222,24 +195,20 @@ Added an optional parameter with a default value. No adjustments should be neces
 
 GH-75777
 --------
-Validate extension JSON: Error: Hash changed for 'classes/SyntaxHighlighter/methods/get_text_edit', from 8248B40D to 70D54D11. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/SyntaxHighlighter/methods/get_text_edit': is_const changed value in new API, from false to true.
 
 Function was made `const`. No adjustments should be necessary.
 
 
-
 GH-75250 & GH-76401
 -------------------
-Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_paragraph', from 3DD1D1C2 to BFDC71FE. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 4 to 6.
 
-Added a optional parameters with default values. No adjustments should be necessary.
+Added optional parameters with default values. No adjustments should be necessary.
 
 
 GH-77143
 --------
-Validate extension JSON: Error: Hash changed for 'classes/WorkerThreadPool/methods/wait_for_task_completion', from 4CAD1009 to 32573865. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/WorkerThreadPool/methods/wait_for_task_completion': return_value
 
 Changed the return value from `void` to `Error`. No adjustments should be necessary.
@@ -292,8 +261,6 @@ GH-76082
 --------
 Validate extension JSON: Error: Hash changed for 'builtin_classes/Basis/methods/looking_at', from 19076B74 to DE3FF159. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'builtin_classes/Transform3D/methods/looking_at', from 3018C31C to 056ADC36. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Node3D/methods/look_at', from 3BC64EA6 to BA2B4FA9. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash changed for 'classes/Node3D/methods/look_at_from_position', from 2BD0F953 to F2739FA7. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'builtin_classes/Basis/methods/looking_at/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'builtin_classes/Transform3D/methods/looking_at/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/Node3D/methods/look_at/arguments': size changed value in new API, from 2 to 3.

--- a/scene/2d/area_2d.compat.inc
+++ b/scene/2d/area_2d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  area_2d.compat.inc                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "area_2d.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void Area2D::set_priority_compat_72749(float p_priority) {
+	set_priority(p_priority);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+float Area2D::get_priority_compat_72749() const {
+	return get_priority();
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
+void Area2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_priority", "priority"), &Area2D::set_priority_compat_72749);
+	ClassDB::bind_compatibility_method(D_METHOD("get_priority"), &Area2D::get_priority_compat_72749);
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "area_2d.h"
+#include "area_2d.compat.inc"
 
 #include "scene/scene_string_names.h"
 #include "servers/audio_server.h"

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -135,6 +135,11 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void set_priority_compat_72749(float p_priority);
+	float get_priority_compat_72749() const;
+#endif
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/3d/area_3d.compat.inc
+++ b/scene/3d/area_3d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  area_3d.compat.inc                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "area_3d.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void Area3D::set_priority_compat_72749(float p_priority) {
+	set_priority(p_priority);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+float Area3D::get_priority_compat_72749() const {
+	return get_priority();
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
+void Area3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_priority", "priority"), &Area3D::set_priority_compat_72749);
+	ClassDB::bind_compatibility_method(D_METHOD("get_priority"), &Area3D::get_priority_compat_72749);
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "area_3d.h"
+#include "area_3d.compat.inc"
 
 #include "scene/scene_string_names.h"
 #include "servers/audio_server.h"

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -146,6 +146,11 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void set_priority_compat_72749(float p_priority);
+	float get_priority_compat_72749() const;
+#endif
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/3d/mesh_instance_3d.compat.inc
+++ b/scene/3d/mesh_instance_3d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  mesh_instance_3d.compat.inc                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "mesh_instance_3d.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void MeshInstance3D::create_multiple_convex_collisions_compat_72152() {
+	create_multiple_convex_collisions();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void MeshInstance3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("create_multiple_convex_collisions"), &MeshInstance3D::create_multiple_convex_collisions_compat_72152);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "mesh_instance_3d.h"
+#include "mesh_instance_3d.compat.inc"
 
 #include "collision_shape_3d.h"
 #include "core/core_string_names.h"

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -61,6 +61,11 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void create_multiple_convex_collisions_compat_72152();
+
+#endif
 
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);

--- a/scene/3d/node_3d.compat.inc
+++ b/scene/3d/node_3d.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  node_3d.compat.inc                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "node_3d.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void Node3D::look_at_compat_76082(const Vector3 &p_target, const Vector3 &p_up) {
+	look_at(p_target, p_up);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void Node3D::look_at_from_position_compat_76082(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
+	look_at_from_position(p_pos, p_target, p_up);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
+void Node3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("look_at", "target", "up"), &Node3D::look_at_compat_76082, DEFVAL(Vector3(0, 1, 0)));
+	ClassDB::bind_compatibility_method(D_METHOD("look_at_from_position", "position", "target", "up"), &Node3D::look_at_from_position_compat_76082, DEFVAL(Vector3(0, 1, 0)));
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "node_3d.h"
+#include "node_3d.compat.inc"
 
 #include "core/object/message_queue.h"
 #include "scene/3d/visual_instance_3d.h"

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -153,6 +153,11 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void look_at_compat_76082(const Vector3 &p_target, const Vector3 &p_up);
+	void look_at_from_position_compat_76082(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up);
+#endif
 
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/animation/animation_node_state_machine.compat.inc
+++ b/scene/animation/animation_node_state_machine.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  animation_node_state_machine.compat.inc                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "animation_node_state_machine.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Vector<String> AnimationNodeStateMachinePlayback::_get_travel_path_compat_76418() const {
+	return Variant(get_travel_path()).operator Vector<String>();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void AnimationNodeStateMachinePlayback::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_travel_path"), &AnimationNodeStateMachinePlayback::_get_travel_path_compat_76418);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "animation_node_state_machine.h"
+#include "animation_node_state_machine.compat.inc"
+
 #include "scene/main/window.h"
 
 /////////////////////////////////////////////////

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -318,6 +318,10 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 protected:
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Vector<String> _get_travel_path_compat_76418() const;
+#endif
 
 public:
 	void travel(const StringName &p_state, bool p_reset_on_teleport = true);

--- a/scene/animation/animation_tree.compat.inc
+++ b/scene/animation/animation_tree.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  animation_tree.compat.inc                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "animation_tree.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+double AnimationNode::blend_input_compat_75759(int p_input, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync) {
+	return blend_input(p_input, p_time, p_seek, p_is_external_seeking, p_blend, p_filter, p_sync, false);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+double AnimationNode::blend_node_compat_75759(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync) {
+	return blend_node(p_sub_path, p_node, p_time, p_seek, p_is_external_seeking, p_blend, p_filter, p_sync, false);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
+void AnimationNode::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("blend_node", "name", "node", "time", "seek", "is_external_seeking", "blend", "filter", "sync"), &AnimationNode::blend_node_compat_75759, DEFVAL(FILTER_IGNORE), DEFVAL(true));
+	ClassDB::bind_compatibility_method(D_METHOD("blend_input", "input_index", "time", "seek", "is_external_seeking", "blend", "filter", "sync"), &AnimationNode::blend_input_compat_75759, DEFVAL(FILTER_IGNORE), DEFVAL(true));
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "animation_tree.h"
+#include "animation_tree.compat.inc"
 
 #include "animation_blend_tree.h"
 #include "core/config/engine.h"

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -118,6 +118,11 @@ protected:
 	AnimationTree *get_animation_tree() const;
 
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	double blend_input_compat_75759(int p_input, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync);
+	double blend_node_compat_75759(const StringName &p_sub_path, Ref<AnimationNode> p_node, double p_time, bool p_seek, bool p_is_external_seeking, real_t p_blend, FilterAction p_filter, bool p_sync);
+#endif
 
 	void _validate_property(PropertyInfo &p_property) const;
 

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  rich_text_label.compat.inc                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,25 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "rich_text_label.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+void RichTextLabel::push_list_compat_75017(int p_level, ListType p_list, bool p_capitalize) {
+	push_list(p_level, p_list, p_capitalize);
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void RichTextLabel::push_paragraph_compat_75250(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser) {
+	push_paragraph(p_alignment, p_direction, p_language, p_st_parser);
+}
+void RichTextLabel::push_paragraph_compat_76401(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser, BitField<TextServer::JustificationFlag> p_jst_flags) {
+	push_paragraph(p_alignment, p_direction, p_language, p_st_parser, p_jst_flags);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
+void RichTextLabel::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("push_list", "level", "type", "capitalize"), &RichTextLabel::push_list_compat_75017);
+	ClassDB::bind_compatibility_method(D_METHOD("push_paragraph", "alignment", "base_direction", "language", "st_parser"), &RichTextLabel::push_paragraph_compat_75250, DEFVAL(TextServer::DIRECTION_AUTO), DEFVAL(""), DEFVAL(TextServer::STRUCTURED_TEXT_DEFAULT));
+	ClassDB::bind_compatibility_method(D_METHOD("push_paragraph", "alignment", "base_direction", "language", "st_parser", "justification_flags"), &RichTextLabel::push_paragraph_compat_76401, DEFVAL(TextServer::DIRECTION_AUTO), DEFVAL(""), DEFVAL(TextServer::STRUCTURED_TEXT_DEFAULT), DEFVAL(TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE));
 }
 
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "rich_text_label.h"
+#include "rich_text_label.compat.inc"
 
 #include "core/input/input_map.h"
 #include "core/math/math_defs.h"

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -97,6 +97,12 @@ protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	void push_list_compat_75017(int p_level, ListType p_list, bool p_capitalize);
+	void push_paragraph_compat_75250(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser);
+	void push_paragraph_compat_76401(HorizontalAlignment p_alignment, Control::TextDirection p_direction, const String &p_language, TextServer::StructuredTextParser p_st_parser, BitField<TextServer::JustificationFlag> p_jst_flags);
+#endif
 
 private:
 	struct Item;

--- a/scene/gui/tree.compat.inc
+++ b/scene/gui/tree.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  tree.compat.inc                                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "tree.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+bool Tree::edit_selected_compat_76794() {
+	return edit_selected();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void Tree::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("edit_selected"), &Tree::edit_selected_compat_76794);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "tree.h"
+#include "tree.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -659,6 +659,10 @@ protected:
 	virtual void _update_theme_item_cache() override;
 
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	bool edit_selected_compat_76794();
+#endif
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;

--- a/scene/main/viewport.compat.inc
+++ b/scene/main/viewport.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  viewport.compat.inc                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "viewport.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Control *Viewport::gui_get_focus_owner_compat_77757() {
+	return gui_get_focus_owner();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void Viewport::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner_compat_77757);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "viewport.h"
+#include "viewport.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -488,6 +488,10 @@ protected:
 	void _notification(int p_what);
 	void _process_picking();
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Control *gui_get_focus_owner_compat_77757();
+#endif
 
 public:
 	void canvas_parent_mark_dirty(Node *p_node);

--- a/scene/resources/syntax_highlighter.compat.inc
+++ b/scene/resources/syntax_highlighter.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  syntax_highlighter.compat.inc                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "syntax_highlighter.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
+#include "core/object/script_language.h"
+#include "scene/gui/text_edit.h"
 
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+TextEdit *SyntaxHighlighter::get_text_edit_compat_75777() {
+	return get_text_edit();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void SyntaxHighlighter::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_text_edit"), &SyntaxHighlighter::get_text_edit_compat_75777);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "syntax_highlighter.h"
+#include "syntax_highlighter.compat.inc"
 
 #include "core/object/script_language.h"
 #include "scene/gui/text_edit.h"

--- a/scene/resources/syntax_highlighter.h
+++ b/scene/resources/syntax_highlighter.h
@@ -49,6 +49,10 @@ protected:
 	TextEdit *text_edit = nullptr;
 
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	TextEdit *get_text_edit_compat_75777();
+#endif
 
 	GDVIRTUAL1RC(Dictionary, _get_line_syntax_highlighting, int)
 	GDVIRTUAL0(_clear_highlighting_cache)

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -435,6 +435,15 @@ protected:
 		ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_versions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_versions", "_get_versions");
 		ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_error"), "set_base_error", "get_base_error");
 	}
+
+#ifndef DISABLE_DEPRECATED
+	Vector<String> get_version_list_compat_76418() const {
+		return Variant(get_version_list()).operator Vector<String>();
+	}
+	static void _bind_compatibility_methods() {
+		ClassDB::bind_compatibility_method(D_METHOD("get_version_list"), &RDShaderFile::get_version_list_compat_76418);
+	}
+#endif
 };
 
 class RDUniform : public RefCounted {

--- a/servers/rendering_server.compat.inc
+++ b/servers/rendering_server.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_script.cpp                                                     */
+/*  rendering_server.compat.inc                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,49 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "editor_script.h"
-#include "editor_script.compat.inc"
+#ifndef DISABLE_DEPRECATED
 
-#include "editor/editor_interface.h"
-#include "editor/editor_node.h"
+#include "rendering_server.h"
 
-void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("There is an edited scene already."));
-		return;
-	}
-
-	//editor->set_edited_scene(p_node);
+Vector<String> RenderingServer::_global_shader_parameter_get_list_compat_76418() const {
+	return Variant(global_shader_parameter_get_list()).operator Vector<String>();
 }
 
-Node *EditorScript::get_scene() const {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
-		return nullptr;
-	}
-
-	return EditorNode::get_singleton()->get_edited_scene();
+void RenderingServer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("global_shader_parameter_get_list"), &RenderingServer::_global_shader_parameter_get_list_compat_76418);
 }
 
-EditorInterface *EditorScript::get_editor_interface() const {
-	return EditorInterface::get_singleton();
-}
-
-void EditorScript::run() {
-	if (!GDVIRTUAL_CALL(_run)) {
-		EditorNode::add_io_error(TTR("Couldn't run editor script, did you forget to override the '_run' method?"));
-	}
-}
-
-void EditorScript::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
-	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
-	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
-
-	GDVIRTUAL_BIND(_run);
-}
+#endif

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "rendering_server.h"
+#include "rendering_server.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/object/worker_thread_pool.h"

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -70,6 +70,10 @@ protected:
 
 	static RenderingServer *(*create_func)();
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+	Vector<String> _global_shader_parameter_get_list_compat_76418() const;
+#endif
 
 public:
 	static RenderingServer *get_singleton();


### PR DESCRIPTION
Requires #76446. ~~Split into many commit to make it possible to cherry pick only the relevant bits (assuming that #76446 gets backported). I will add a commit with compat bindings for https://github.com/godotengine/godot/issues/75779, if that becomes possible.~~ looks like that's not happening (for now)

---

Compared to 4.0.2 this leaved one reported issue:
```
Validate extension JSON: API was removed: classes/AnimationTrackEditPlugin
```
Which was completely useless and intentionally removed.

Compared to 4.0.1 a whole bunch of additional issues appear, that are all the hash changes that can't have compat methods atm:
```
Validate extension JSON: Error: Hash mismatch for 'classes/AnimatedSprite2D/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/AnimatedSprite3D/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Animation/methods/compress'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/AnimationPlayer/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer2D/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer3D/methods/play'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/CanvasItem/methods/draw_set_transform'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/sample_baked'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/sample_baked_with_rotation'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/tessellate_even_length'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/sample_baked'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/sample_baked_with_rotation'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/tessellate_even_length'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/DisplayServer/methods/tts_speak'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Font/methods/find_variation'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/GridMap/methods/make_baked_meshes'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/save_jpg_to_buffer'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/save_webp_to_buffer'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/bump_map_to_normal_map'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody2D/methods/move_and_collide'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody3D/methods/move_and_collide'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody3D/methods/test_move'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/RandomNumberGenerator/methods/randfn'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/environment_set_ambient_light'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/canvas_item_set_canvas_group_mode'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/force_draw'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Window/methods/popup_centered_ratio'. This means that the function has changed and no compatibility function was provided.
Validate extension JSON: Error: Hash mismatch for 'classes/Window/methods/popup_centered_clamped'. This means that the function has changed and no compatibility function was provided.
```

And finally 4.0.0 has a few more changes where no compat code can be created:
```
Validate extension JSON: Error: Field 'classes/MenuBar/properties/start_index': type changed value in new API, from "bool" to "int".
Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionMotionCollision': format changed value in new API, from "Vector3 position;Vector3 normal;Vector3 collider_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape" to "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape".
Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionMotionResult': format changed value in new API, from "Vector3 travel;Vector3 remainder;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count" to "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count".
```

---

~~Additionally a bunch of virtual methods have changes between 4.0 and 4.1 but they are currently not validated.~~
Check `misc/extension_api_validation/*.expected` for up to date details.