### PR TITLE
Fix Skeleton3D & PhysicalBone3D editor errors

### DIFF
--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -96,8 +96,9 @@ void PhysicalBone3DEditorPlugin::make_visible(bool p_visible) {
 }
 
 void PhysicalBone3DEditorPlugin::edit(Object *p_node) {
-	selected = static_cast<PhysicalBone3D *>(p_node); // Trust it
-	ERR_FAIL_COND(!selected);
-
-	physical_bone_editor.set_selected(selected);
+	PhysicalBone3D *bone = Object::cast_to<PhysicalBone3D>(p_node);
+	if (bone) {
+		selected = bone;
+		physical_bone_editor.set_selected(selected);
+	}
 }

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -832,8 +832,8 @@ void Skeleton3DEditor::create_editors() {
 void Skeleton3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			create_editors();
 			update_joint_tree();
-			update_editors();
 
 			joint_tree->connect("item_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_selection_changed));
 			joint_tree->connect("item_mouse_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_rmb_select));
@@ -946,8 +946,6 @@ void fragment() {
 	handles_mesh_instance->set_cast_shadows_setting(GeometryInstance3D::SHADOW_CASTING_SETTING_OFF);
 	handles_mesh.instantiate();
 	handles_mesh_instance->set_mesh(handles_mesh);
-
-	create_editors();
 }
 
 void Skeleton3DEditor::update_bone_original() {


### PR DESCRIPTION
I was looking at a separate issue, but I run into 2 errors with 3d skeleton and physical bones.
3d skeleton was the "attempting to load..." theme error because the editor was created in construction.
Physical bone 3d was never updated and did not correctly handle calls from EditorNode::_plugin_over_edit

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
