### PR TITLE
Allow negative line spacing for the script editor in Editor Settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1292,7 +1292,7 @@
 			If [code]true[/code], draws tab characters as chevrons.
 		</member>
 		<member name="text_editor/appearance/whitespace/line_spacing" type="int" setter="" getter="">
-			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying fewer lines on screen.
+			The space to add between lines (in pixels). Greater line spacing can help improve readability at the cost of displaying fewer lines on screen. Negative values allow for even more compact text, but may look broken with certain fonts.
 		</member>
 		<member name="text_editor/behavior/documentation/enable_tooltips" type="bool" setter="" getter="">
 			If [code]true[/code], documentation tooltips will appear when hovering over a symbol.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -770,7 +770,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Appearance: Whitespace
 	_initial_set("text_editor/appearance/whitespace/draw_tabs", true, true);
 	_initial_set("text_editor/appearance/whitespace/draw_spaces", false, true);
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/whitespace/line_spacing", 4, "0,50,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/whitespace/line_spacing", 4, "-10,50,1")
 
 	// Behavior
 	// Behavior: General


### PR DESCRIPTION
This can be used to make text even more compact with certain fonts.

In the meantime, you can edit `editor_settings-4.tres` while the editor is closed and manually input a negative value for `text_editor/appearance/whitespace/line_spacing` (add that line if it's not present in your configuration file).

- This closes https://github.com/godotengine/godot/issues/76385.
