### PR TITLE
Add documentation for TubeTrailMesh and RibbonTrailMesh

### DIFF
--- a/doc/classes/RibbonTrailMesh.xml
+++ b/doc/classes/RibbonTrailMesh.xml
@@ -1,29 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RibbonTrailMesh" inherits="PrimitiveMesh" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Represents a straight ribbon-shaped [PrimitiveMesh] with variable width.
 	</brief_description>
 	<description>
+		[RibbonTrailMesh] represents a straight ribbon-shaped mesh with variable width. The ribbon is composed of a number of flat or cross-shaped sections, each with the same [member section_length] and number of [member section_segments]. A [member curve] is sampled along the total length of the ribbon, meaning that the curve determines the size of the ribbon along its length.
+		This primitive mesh is usually used for particle trails.
 	</description>
 	<tutorials>
+		<link title="3D Particle trails">$DOCS_URL/tutorials/3d/particles/trails.html</link>
+		<link title="Particle systems (3D)">$DOCS_URL/tutorials/3d/particles/index.html</link>
 	</tutorials>
 	<members>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
+			Determines the size of the ribbon along its length. The size of a particular section segment is obtained by multiplying the baseline [member size] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted.
 		</member>
 		<member name="section_length" type="float" setter="set_section_length" getter="get_section_length" default="0.2">
+			The length of a section of the ribbon.
 		</member>
 		<member name="section_segments" type="int" setter="set_section_segments" getter="get_section_segments" default="3">
+			The number of segments in a section. The [member curve] is sampled on each segment to determine its size. Higher values result in a more detailed ribbon at the cost of performance.
 		</member>
 		<member name="sections" type="int" setter="set_sections" getter="get_sections" default="5">
+			The total number of sections on the ribbon.
 		</member>
 		<member name="shape" type="int" setter="set_shape" getter="get_shape" enum="RibbonTrailMesh.Shape" default="1">
+			Determines the shape of the ribbon.
 		</member>
 		<member name="size" type="float" setter="set_size" getter="get_size" default="1.0">
+			The baseline size of the ribbon. The size of a particular section segment is obtained by multiplying this size by the value of the [member curve] at the given distance.
 		</member>
 	</members>
 	<constants>
 		<constant name="SHAPE_FLAT" value="0" enum="Shape">
+			Gives the mesh a single flat face.
 		</constant>
 		<constant name="SHAPE_CROSS" value="1" enum="Shape">
+			Gives the mesh two perpendicular flat faces, making a cross shape.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/TubeTrailMesh.xml
+++ b/doc/classes/TubeTrailMesh.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TubeTrailMesh" inherits="PrimitiveMesh" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Represents a straight tube-shaped [PrimitiveMesh] with variable width.
 	</brief_description>
 	<description>
+		[TubeTrailMesh] represents a straight tube-shaped mesh with variable width. The tube is composed of a number of cylindrical sections, each with the same [member section_length] and number of [member section_rings]. A [member curve] is sampled along the total length of the tube, meaning that the curve determines the radius of the tube along its length.
+		This primitive mesh is usually used for particle trails.
 	</description>
 	<tutorials>
+		<link title="3D Particle trails">$DOCS_URL/tutorials/3d/particles/trails.html</link>
+		<link title="Particle systems (3D)">$DOCS_URL/tutorials/3d/particles/index.html</link>
 	</tutorials>
 	<members>
 		<member name="cap_bottom" type="bool" setter="set_cap_bottom" getter="is_cap_bottom" default="true">
@@ -14,16 +19,22 @@
 			If [code]true[/code], generates a cap at the top of the tube. This can be set to [code]false[/code] to speed up generation and rendering when the cap is never seen by the camera.
 		</member>
 		<member name="curve" type="Curve" setter="set_curve" getter="get_curve">
+			Determines the radius of the tube along its length. The radius of a particular section ring is obtained by multiplying the baseline [member radius] by the value of this curve at the given distance. For values smaller than [code]0[/code], the faces will be inverted.
 		</member>
 		<member name="radial_steps" type="int" setter="set_radial_steps" getter="get_radial_steps" default="8">
+			The number of sides on the tube. For example, a value of [code]5[/code] means the tube will be pentagonal. Higher values result in a more detailed tube at the cost of performance.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
+			The baseline radius of the tube. The radius of a particular section ring is obtained by multiplying this radius by the value of the [member curve] at the given distance.
 		</member>
 		<member name="section_length" type="float" setter="set_section_length" getter="get_section_length" default="0.2">
+			The length of a section of the tube.
 		</member>
 		<member name="section_rings" type="int" setter="set_section_rings" getter="get_section_rings" default="3">
+			The number of rings in a section. The [member curve] is sampled on each ring to determine its radius. Higher values result in a more detailed tube at the cost of performance.
 		</member>
 		<member name="sections" type="int" setter="set_sections" getter="get_sections" default="5">
+			The total number of sections on the tube.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Brings class reference documentation up from 87% to 87.2% or something idk it's neverending.