### PR TITLE
Fix calculation bug with `TextEdit::get_line_height()`

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -347,7 +347,8 @@
 		<method name="get_line_height" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the height of a largest line.
+				Returns the maximum value of the line height among all lines.
+				[b]Note:[/b] The return value is influenced by [theme_item line_spacing] and [theme_item font_size]. And it will not be less than [code]1[/code].
 			</description>
 		</method>
 		<method name="get_line_width" qualifiers="const">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3005,6 +3005,9 @@ void TextEdit::_update_theme_item_cache() {
 	theme_cache.outline_color = get_theme_color(SNAME("font_outline_color"));
 
 	theme_cache.line_spacing = get_theme_constant(SNAME("line_spacing"));
+	if (text.get_line_height() + theme_cache.line_spacing < 1) {
+		WARN_PRINT("Line height is too small, please increase font_size and/or line_spacing");
+	}
 
 	theme_cache.background_color = get_theme_color(SNAME("background_color"));
 	theme_cache.current_line_color = get_theme_color(SNAME("current_line_color"));
@@ -3476,7 +3479,7 @@ int TextEdit::get_line_width(int p_line, int p_wrap_index) const {
 }
 
 int TextEdit::get_line_height() const {
-	return text.get_line_height() + theme_cache.line_spacing;
+	return MAX(text.get_line_height() + theme_cache.line_spacing, 1);
 }
 
 int TextEdit::get_indent_level(int p_line) const {


### PR DESCRIPTION
When `get_line_height()` is not greater than `0`, there is no visible text.

In these cases, the user is required to increase `line_spacing` and/or `font_size` to obtain a reasonably positive `line_height`.

There are many cases where the return value of `get_line_height()` is used for calculation, and in some cases the final result is allowed to be negative. So limit the return result of `get_line_height()` to **not less** than `0`. Print an error if `get_line_height()` is `0` and used as the denominator.

Fix #69209.



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
