### PR TITLE
Preserve scene unique names when saving branch as scene.

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -276,6 +276,8 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base)
 		return;
 	}
 
+	instantiated_scene->set_unique_name_in_owner(base->is_unique_name_in_owner());
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Replace with Branch Scene"));
 


### PR DESCRIPTION
Fixes: #76614

When saving a branch as scene it did loose its unique scene name within the original scene. Now it is preserved so that scripts in the original scene don't break when splitting a scene up.