### PR TITLE
Implement `AnimationNodeSub2` to `AnimationTree` and allow less or greater value in mathematical `AnimationNode`

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Base resource for [AnimationTree] nodes. In general, it's not used directly, but you can create custom ones with custom blending formulas.
-		Inherit this when creating nodes mainly for use in [AnimationNodeBlendTree], otherwise [AnimationRootNode] should be used instead.
+		Inherit this when creating animation nodes mainly for use in [AnimationNodeBlendTree], otherwise [AnimationRootNode] should be used instead.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
@@ -14,46 +14,46 @@
 		<method name="_get_caption" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to override the text caption for this node.
+				When inheriting from [AnimationRootNode], implement this virtual method to override the text caption for this animation node.
 			</description>
 		</method>
 		<method name="_get_child_by_name" qualifiers="virtual const">
 			<return type="AnimationNode" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return a child node by its [param name].
+				When inheriting from [AnimationRootNode], implement this virtual method to return a child animation node by its [param name].
 			</description>
 		</method>
 		<method name="_get_child_nodes" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return all children nodes in order as a [code]name: node[/code] dictionary.
+				When inheriting from [AnimationRootNode], implement this virtual method to return all children animation nodes in order as a [code]name: node[/code] dictionary.
 			</description>
 		</method>
 		<method name="_get_parameter_default_value" qualifiers="virtual const">
 			<return type="Variant" />
 			<param index="0" name="parameter" type="StringName" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return the default value of a [param parameter]. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
+				When inheriting from [AnimationRootNode], implement this virtual method to return the default value of a [param parameter]. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
 		<method name="_get_parameter_list" qualifiers="virtual const">
 			<return type="Array" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return a list of the properties on this node. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees. Format is similar to [method Object.get_property_list].
+				When inheriting from [AnimationRootNode], implement this virtual method to return a list of the properties on this animation node. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees. Format is similar to [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="_has_filter" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return whether the blend tree editor should display filter editing on this node.
+				When inheriting from [AnimationRootNode], implement this virtual method to return whether the blend tree editor should display filter editing on this animation node.
 			</description>
 		</method>
 		<method name="_is_parameter_read_only" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="parameter" type="StringName" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to return whether the [param parameter] is read-only. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
+				When inheriting from [AnimationRootNode], implement this virtual method to return whether the [param parameter] is read-only. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
 		<method name="_process" qualifiers="virtual const">
@@ -63,7 +63,7 @@
 			<param index="2" name="is_external_seeking" type="bool" />
 			<param index="3" name="test_only" type="bool" />
 			<description>
-				When inheriting from [AnimationRootNode], implement this virtual method to run some code when this node is processed. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute.
+				When inheriting from [AnimationRootNode], implement this virtual method to run some code when this animation node is processed. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute.
 				Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions. You can also use [method get_parameter] and [method set_parameter] to modify local memory.
 				This function should return the time left for the current animation to finish (if unsure, pass the value from the main blend being called).
 			</description>
@@ -72,7 +72,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
-				Adds an input to the node. This is only useful for nodes created for use in an [AnimationNodeBlendTree]. If the addition fails, returns [code]false[/code].
+				Adds an input to the animation node. This is only useful for animation nodes created for use in an [AnimationNodeBlendTree]. If the addition fails, returns [code]false[/code].
 			</description>
 		</method>
 		<method name="blend_animation">
@@ -100,7 +100,7 @@
 			<param index="6" name="sync" type="bool" default="true" />
 			<param index="7" name="test_only" type="bool" default="false" />
 			<description>
-				Blend an input. This is only useful for nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
+				Blend an input. This is only useful for animation nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
 			</description>
 		</method>
 		<method name="blend_node">
@@ -115,7 +115,7 @@
 			<param index="7" name="sync" type="bool" default="true" />
 			<param index="8" name="test_only" type="bool" default="false" />
 			<description>
-				Blend another animation node (in case this node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your node for addition.
+				Blend another animation node (in case this animation node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your animation node for addition.
 			</description>
 		</method>
 		<method name="find_input" qualifiers="const">
@@ -128,7 +128,7 @@
 		<method name="get_input_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Amount of inputs in this node, only useful for nodes that go into [AnimationNodeBlendTree].
+				Amount of inputs in this animation node, only useful for animation nodes that go into [AnimationNodeBlendTree].
 			</description>
 		</method>
 		<method name="get_input_name" qualifiers="const">
@@ -142,7 +142,7 @@
 			<return type="Variant" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Gets the value of a parameter. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
+				Gets the value of a parameter. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
 		<method name="is_path_filtered" qualifiers="const">
@@ -194,7 +194,7 @@
 			<param index="0" name="object_id" type="int" />
 			<param index="1" name="name" type="String" />
 			<description>
-				Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes removes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
+				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation nodes removes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>
 		</signal>
 		<signal name="animation_node_renamed">
@@ -202,12 +202,12 @@
 			<param index="1" name="old_name" type="String" />
 			<param index="2" name="new_name" type="String" />
 			<description>
-				Emitted by nodes that inherit from this class and that have an internal tree when one of their node names changes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
+				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation node names changes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>
 		</signal>
 		<signal name="tree_changed">
 			<description>
-				Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes changes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], [AnimationNodeBlendTree] and [AnimationNodeTransition].
+				Emitted by nodes that inherit from this class and that have an internal tree when one of their animation nodes changes. The animation nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], [AnimationNodeBlendTree] and [AnimationNodeTransition].
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/AnimationNodeAdd2.xml
+++ b/doc/classes/AnimationNodeAdd2.xml
@@ -4,7 +4,9 @@
 		Blends two animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
-		A resource to add to an [AnimationNodeBlendTree]. Blends two animations additively based on an amount value in the [code][0.0, 1.0][/code] range.
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations additively based on the amount value.
+		If the amount is greater than [code]1.0[/code], the animation connected to "in" port is blended with the amplified animation connected to "add" port.
+		If the amount is less than [code]0.0[/code], the animation connected to "in" port is blended with the inverted animation connected to "add" port.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeAdd3.xml
+++ b/doc/classes/AnimationNodeAdd3.xml
@@ -4,11 +4,12 @@
 		Blends two of three animations additively inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
-		A resource to add to an [AnimationNodeBlendTree]. Blends two animations together additively out of three based on a value in the [code][-1.0, 1.0][/code] range.
-		This node has three inputs:
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations out of three additively out of three based on the amounmt value.
+		This animation node has three inputs:
 		- The base animation to add to
-		- A -add animation to blend with when the blend amount is in the [code][-1.0, 0.0][/code] range.
-		- A +add animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
+		- A "-add" animation to blend with when the blend amount is negative
+		- A "+add" animation to blend with when the blend amount is positive
+		If the absolute value of the amount is greater than [code]1.0[/code], the animation connected to "in" port is blended with the amplified animation connected to "-add"/"+add" port.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeBlend2.xml
+++ b/doc/classes/AnimationNodeBlend2.xml
@@ -4,7 +4,8 @@
 		Blends two animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
-		A resource to add to an [AnimationNodeBlendTree]. Blends two animations linearly based on an amount value in the [code][0.0, 1.0][/code] range.
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations linearly based on the amount value.
+		In general, the blend value should be in the [code][0.0, 1.0][/code] range. Values outside of this range can blend amplified or inverted animations, however, [AnimationNodeAdd2] works better for this purpose.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeBlend3.xml
+++ b/doc/classes/AnimationNodeBlend3.xml
@@ -4,11 +4,12 @@
 		Blends two of three animations linearly inside of an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
-		A resource to add to an [AnimationNodeBlendTree]. Blends two animations together linearly out of three based on a value in the [code][-1.0, 1.0][/code] range.
-		This node has three inputs:
-		- The base animation
-		- A -blend animation to blend with when the blend amount is in the [code][-1.0, 0.0][/code] range.
-		- A +blend animation to blend with when the blend amount is in the [code][0.0, 1.0][/code] range
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations out of three linearly out of three based on the amounmt value.
+		This animation node has three inputs:
+		- The base animation to blend with
+		- A "-blend" animation to blend with when the blend amount is negative value
+		- A "+blend" animation to blend with when the blend amount is positive value
+		In general, the blend value should be in the [code][-1.0, 1.0][/code] range. Values outside of this range can blend amplified animations, however, [AnimationNodeAdd3] works better for this purpose.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -91,7 +91,7 @@
 			The interpolation between animations is linear.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
-			The blend space plays the animation of the node the blending position is closest to. Useful for frame-by-frame 2D animations.
+			The blend space plays the animation of the animation node which blending position is closest to. Useful for frame-by-frame 2D animations.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
 			Similar to [constant BLEND_MODE_DISCRETE], but starts the new animation at the last animation's playback position.

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -136,7 +136,7 @@
 			The interpolation between animations is linear.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE" value="1" enum="BlendMode">
-			The blend space plays the animation of the node the blending position is closest to. Useful for frame-by-frame 2D animations.
+			The blend space plays the animation of the animation node which blending position is closest to. Useful for frame-by-frame 2D animations.
 		</constant>
 		<constant name="BLEND_MODE_DISCRETE_CARRY" value="2" enum="BlendMode">
 			Similar to [constant BLEND_MODE_DISCRETE], but starts the new animation at the last animation's playback position.

--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AnimationNodeBlendTree" inherits="AnimationRootNode" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A sub-tree of blend type [AnimationNode]s used for complex animations. Used by [AnimationTree].
+		A sub-tree of many type [AnimationNode]s used for complex animations. Used by [AnimationTree].
 	</brief_description>
 	<description>
-		This node may contain a sub-tree of any other blend type nodes, such as [AnimationNodeTransition], [AnimationNodeBlend2], [AnimationNodeBlend3], [AnimationNodeOneShot], etc. This is one of the most commonly used animation node roots.
+		This animation node may contain a sub-tree of any other type animation nodes, such as [AnimationNodeTransition], [AnimationNodeBlend2], [AnimationNodeBlend3], [AnimationNodeOneShot], etc. This is one of the most commonly used animation node roots.
 		An [AnimationNodeOutput] node named [code]output[/code] is created by default.
 	</description>
 	<tutorials>
@@ -17,7 +17,7 @@
 			<param index="1" name="node" type="AnimationNode" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Adds an [AnimationNode] at the given [param position]. The [param name] is used to identify the created sub-node later.
+				Adds an [AnimationNode] at the given [param position]. The [param name] is used to identify the created sub animation node later.
 			</description>
 		</method>
 		<method name="connect_node">
@@ -34,35 +34,35 @@
 			<param index="0" name="input_node" type="StringName" />
 			<param index="1" name="input_index" type="int" />
 			<description>
-				Disconnects the node connected to the specified input.
+				Disconnects the animation node connected to the specified input.
 			</description>
 		</method>
 		<method name="get_node" qualifiers="const">
 			<return type="AnimationNode" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the sub-node with the specified [param name].
+				Returns the sub animation node with the specified [param name].
 			</description>
 		</method>
 		<method name="get_node_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the position of the sub-node with the specified [param name].
+				Returns the position of the sub animation node with the specified [param name].
 			</description>
 		</method>
 		<method name="has_node" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if a sub-node with specified [param name] exists.
+				Returns [code]true[/code] if a sub animation node with specified [param name] exists.
 			</description>
 		</method>
 		<method name="remove_node">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Removes a sub-node.
+				Removes a sub animation node.
 			</description>
 		</method>
 		<method name="rename_node">
@@ -70,7 +70,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="new_name" type="StringName" />
 			<description>
-				Changes the name of a sub-node.
+				Changes the name of a sub animation node.
 			</description>
 		</method>
 		<method name="set_node_position">
@@ -78,13 +78,13 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Modifies the position of a sub-node.
+				Modifies the position of a sub animation node.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
-			The global offset of all sub-nodes.
+			The global offset of all sub animation nodes.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -4,7 +4,7 @@
 		Plays an animation once in an [AnimationNodeBlendTree].
 	</brief_description>
 	<description>
-		A resource to add to an [AnimationNodeBlendTree]. This node will execute a sub-animation and return once it finishes. Blend times for fading in and out can be customized, as well as filters.
+		A resource to add to an [AnimationNodeBlendTree]. This animation node will execute a sub-animation and return once it finishes. Blend times for fading in and out can be customized, as well as filters.
 		After setting the request and changing the animation playback, the one-shot node automatically clears the request on the next process frame by setting its [code]request[/code] value to [constant ONE_SHOT_REQUEST_NONE].
 		[codeblocks]
 		[gdscript]

--- a/doc/classes/AnimationNodeStateMachine.xml
+++ b/doc/classes/AnimationNodeStateMachine.xml
@@ -4,7 +4,7 @@
 		A state machine with multiple [AnimationRootNode]s, used by [AnimationTree].
 	</brief_description>
 	<description>
-		Contains multiple [AnimationRootNode]s representing animation states, connected in a graph. Node transitions can be configured to happen automatically or via code, using a shortest-path algorithm. Retrieve the [AnimationNodeStateMachinePlayback] object from the [AnimationTree] node to control it programmatically.
+		Contains multiple [AnimationRootNode]s representing animation states, connected in a graph. State transitions can be configured to happen automatically or via code, using a shortest-path algorithm. Retrieve the [AnimationNodeStateMachinePlayback] object from the [AnimationTree] node to control it programmatically.
 		[b]Example:[/b]
 		[codeblocks]
 		[gdscript]
@@ -27,7 +27,7 @@
 			<param index="1" name="node" type="AnimationNode" />
 			<param index="2" name="position" type="Vector2" default="Vector2(0, 0)" />
 			<description>
-				Adds a new node to the graph. The [param position] is used for display in the editor.
+				Adds a new animation node to the graph. The [param position] is used for display in the editor.
 			</description>
 		</method>
 		<method name="add_transition">
@@ -36,7 +36,7 @@
 			<param index="1" name="to" type="StringName" />
 			<param index="2" name="transition" type="AnimationNodeStateMachineTransition" />
 			<description>
-				Adds a transition between the given nodes.
+				Adds a transition between the given animation nodes.
 			</description>
 		</method>
 		<method name="get_graph_offset" qualifiers="const">
@@ -63,7 +63,7 @@
 			<return type="Vector2" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns the given node's coordinates. Used for display in the editor.
+				Returns the given animation node's coordinates. Used for display in the editor.
 			</description>
 		</method>
 		<method name="get_transition" qualifiers="const">
@@ -97,7 +97,7 @@
 			<return type="bool" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the graph contains the given node.
+				Returns [code]true[/code] if the graph contains the given animation node.
 			</description>
 		</method>
 		<method name="has_transition" qualifiers="const">
@@ -105,14 +105,14 @@
 			<param index="0" name="from" type="StringName" />
 			<param index="1" name="to" type="StringName" />
 			<description>
-				Returns [code]true[/code] if there is a transition between the given nodes.
+				Returns [code]true[/code] if there is a transition between the given animation nodes.
 			</description>
 		</method>
 		<method name="remove_node">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Deletes the given node from the graph.
+				Deletes the given animation node from the graph.
 			</description>
 		</method>
 		<method name="remove_transition">
@@ -120,7 +120,7 @@
 			<param index="0" name="from" type="StringName" />
 			<param index="1" name="to" type="StringName" />
 			<description>
-				Deletes the transition between the two specified nodes.
+				Deletes the transition between the two specified animation nodes.
 			</description>
 		</method>
 		<method name="remove_transition_by_index">
@@ -135,7 +135,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="new_name" type="StringName" />
 			<description>
-				Renames the given node.
+				Renames the given animation node.
 			</description>
 		</method>
 		<method name="replace_node">
@@ -157,7 +157,7 @@
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the node's coordinates. Used for display in the editor.
+				Sets the animation node's coordinates. Used for display in the editor.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/AnimationNodeSub2.xml
+++ b/doc/classes/AnimationNodeSub2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodeSub2" inherits="AnimationNodeSync" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Blends two animations subtractively inside of an [AnimationNodeBlendTree].
+	</brief_description>
+	<description>
+		A resource to add to an [AnimationNodeBlendTree]. Blends two animations subtractively based on the amount value.
+		This animation node is usually used for pre-calculation to cancel out any extra poses from the animation for the "add" animation source in [AnimationNodeAdd2] or [AnimationNodeAdd3].
+		In general, the blend value should be in the [code][0.0, 1.0][/code] range, but values outside of this range can be used for amplified or inverted animations.
+		[b]Note:[/b] This calculation is different from using a negative value in [AnimationNodeAdd2], since the transformation matrices do not satisfy the commutative law. [AnimationNodeSub2] multiplies the transformation matrix of the inverted animation from the left side, while negative [AnimationNodeAdd2] multiplies it from the right side.
+	</description>
+	<tutorials>
+		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
+	</tutorials>
+</class>

--- a/doc/classes/AnimationNodeTimeSeek.xml
+++ b/doc/classes/AnimationNodeTimeSeek.xml
@@ -4,7 +4,7 @@
 		A time-seeking animation node used in [AnimationTree].
 	</brief_description>
 	<description>
-		This node can be used to cause a seek command to happen to any sub-children of the animation graph. Use this node type to play an [Animation] from the start or a certain playback position inside the [AnimationNodeBlendTree].
+		This animation node can be used to cause a seek command to happen to any sub-children of the animation graph. Use to play an [Animation] from the start or a certain playback position inside the [AnimationNodeBlendTree].
 		After setting the time and changing the animation playback, the time seek node automatically goes into sleep mode on the next process frame by setting its [code]seek_request[/code] value to [code]-1.0[/code].
 		[codeblocks]
 		[gdscript]

--- a/doc/classes/AnimationNodeTransition.xml
+++ b/doc/classes/AnimationNodeTransition.xml
@@ -20,7 +20,7 @@
 		animation_tree["parameters/Transition/current_state"]
 
 		# Get current state index (read-only).
-		animation_tree.get("parameters/Transition/current_index"))
+		animation_tree.get("parameters/Transition/current_index")
 		# Alternative syntax (same result as above).
 		animation_tree["parameters/Transition/current_index"]
 		[/gdscript]
@@ -78,7 +78,7 @@
 			If [code]true[/code], allows transition to the self state. When the reset option is enabled in input, the animation is restarted. If [code]false[/code], nothing happens on the transition to the self state.
 		</member>
 		<member name="input_count" type="int" setter="set_input_count" getter="get_input_count" default="0">
-			The number of enabled input ports for this node.
+			The number of enabled input ports for this animation node.
 		</member>
 		<member name="xfade_curve" type="Curve" setter="set_xfade_curve" getter="get_xfade_curve">
 			Determines how cross-fading between animations is eased. If empty, the transition will be linear.

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1109,6 +1109,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("Add3", "AnimationNodeAdd3", 3));
 	add_options.push_back(AddOption("Blend2", "AnimationNodeBlend2", 2));
 	add_options.push_back(AddOption("Blend3", "AnimationNodeBlend3", 3));
+	add_options.push_back(AddOption("Sub2", "AnimationNodeSub2", 2));
 	add_options.push_back(AddOption("TimeSeek", "AnimationNodeTimeSeek", 1));
 	add_options.push_back(AddOption("TimeScale", "AnimationNodeTimeScale", 1));
 	add_options.push_back(AddOption("Transition", "AnimationNodeTransition"));

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -527,7 +527,7 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 ////////////////////////////////////////////////
 
 void AnimationNodeAdd2::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "0,1,0.01"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
 
 Variant AnimationNodeAdd2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -561,7 +561,7 @@ AnimationNodeAdd2::AnimationNodeAdd2() {
 ////////////////////////////////////////////////
 
 void AnimationNodeAdd3::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "-1,1,0.01"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"));
 }
 
 Variant AnimationNodeAdd3::get_parameter_default_value(const StringName &p_parameter) const {
@@ -597,7 +597,7 @@ AnimationNodeAdd3::AnimationNodeAdd3() {
 /////////////////////////////////////////////
 
 void AnimationNodeBlend2::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "0,1,0.01"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
 }
 
 Variant AnimationNodeBlend2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -632,7 +632,7 @@ AnimationNodeBlend2::AnimationNodeBlend2() {
 //////////////////////////////////////
 
 void AnimationNodeBlend3::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "-1,1,0.01"));
+	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"));
 }
 
 Variant AnimationNodeBlend3::get_parameter_default_value(const StringName &p_parameter) const {
@@ -659,6 +659,39 @@ AnimationNodeBlend3::AnimationNodeBlend3() {
 	add_input("-blend");
 	add_input("in");
 	add_input("+blend");
+}
+
+////////////////////////////////////////////////
+
+void AnimationNodeSub2::get_parameter_list(List<PropertyInfo> *r_list) const {
+	r_list->push_back(PropertyInfo(Variant::FLOAT, sub_amount, PROPERTY_HINT_RANGE, "0,1,0.01,or_less,or_greater"));
+}
+
+Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_parameter) const {
+	return 0;
+}
+
+String AnimationNodeSub2::get_caption() const {
+	return "Sub2";
+}
+
+bool AnimationNodeSub2::has_filter() const {
+	return true;
+}
+
+double AnimationNodeSub2::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(sub_amount);
+	// Out = Sub.Transform3D^(-1) * In.Transform3D
+	blend_input(1, p_time, p_seek, p_is_external_seeking, -amount, FILTER_PASS, sync, p_test_only);
+	return blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+}
+
+void AnimationNodeSub2::_bind_methods() {
+}
+
+AnimationNodeSub2::AnimationNodeSub2() {
+	add_input("in");
+	add_input("sub");
 }
 
 /////////////////////////////////

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -246,6 +246,26 @@ public:
 	AnimationNodeBlend3();
 };
 
+class AnimationNodeSub2 : public AnimationNodeSync {
+	GDCLASS(AnimationNodeSub2, AnimationNodeSync);
+
+	StringName sub_amount = PNAME("sub_amount");
+
+protected:
+	static void _bind_methods();
+
+public:
+	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+
+	virtual String get_caption() const override;
+
+	virtual bool has_filter() const override;
+	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+
+	AnimationNodeSub2();
+};
+
 class AnimationNodeTimeScale : public AnimationNode {
 	GDCLASS(AnimationNodeTimeScale, AnimationNode);
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -281,7 +281,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 	if (r_max) {
 		*r_max = 0;
 		for (int i = 0; i < blend_count; i++) {
-			*r_max = MAX(*r_max, blendw[i]);
+			*r_max = MAX(*r_max, Math::abs(blendw[i]));
 		}
 	}
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -465,6 +465,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeAdd3);
 	GDREGISTER_CLASS(AnimationNodeBlend2);
 	GDREGISTER_CLASS(AnimationNodeBlend3);
+	GDREGISTER_CLASS(AnimationNodeSub2);
 	GDREGISTER_CLASS(AnimationNodeTimeScale);
 	GDREGISTER_CLASS(AnimationNodeTimeSeek);
 	GDREGISTER_CLASS(AnimationNodeTransition);


### PR DESCRIPTION
If you want to use NodeAdd2 to blend animation, the difference from rest will be added unless the animation of the `in` port is rest. Also see https://github.com/godotengine/godot-proposals/issues/2700 and https://github.com/godotengine/godot/pull/76310 for more information.

![image](https://user-images.githubusercontent.com/61938263/235359089-d1964d18-999b-4d82-aa59-e8be10867d7a.png)

This can make the animation too exaggerated, so add a NodeSub2 to cancel the extra pose in advance and extract the delta animation. This improves the flexibility of NodeAdd2/Add3.

![image](https://user-images.githubusercontent.com/61938263/235359871-e6eb89a1-6dd5-4dec-966a-bdcd5680c5b2.png)

Test for calculation consistency. The following results are equivalent:

![image](https://user-images.githubusercontent.com/61938263/235358998-9fca1c28-84fd-44aa-b80b-dd775c304697.png)