### PR TITLE
Fix for "off-by-1" bug when sampling "baked" curve data towards the end of the curve.

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -452,7 +452,7 @@ void Curve::bake() {
 	_baked_cache.resize(_bake_resolution);
 
 	for (int i = 1; i < _bake_resolution - 1; ++i) {
-		real_t x = i / static_cast<real_t>(_bake_resolution);
+		real_t x = i / static_cast<real_t>(_bake_resolution - 1);
 		real_t y = sample(x);
 		_baked_cache.write[i] = y;
 	}
@@ -489,7 +489,7 @@ real_t Curve::sample_baked(real_t p_offset) const {
 	}
 
 	// Get interpolation index
-	real_t fi = p_offset * _baked_cache.size();
+	real_t fi = p_offset * (_baked_cache.size() - 1);
 	int i = Math::floor(fi);
 	if (i < 0) {
 		i = 0;

--- a/tests/scene/test_curve.h
+++ b/tests/scene/test_curve.h
@@ -62,6 +62,7 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 	curve->add_point(Vector2(0.25, 1));
 	curve->add_point(Vector2(0.5, 0));
 	curve->add_point(Vector2(0.75, 1));
+	curve->set_bake_resolution(11);
 
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->get_point_left_tangent(0)),
@@ -82,41 +83,41 @@ TEST_CASE("[Curve] Custom curve with free tangents") {
 
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->sample(-0.1)),
-			"Custom free curve should return the expected value at offset 0.1.");
+			"Custom free curve should return the expected value at offset -0.1.");
 	CHECK_MESSAGE(
 			curve->sample(0.1) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected value at offset 0.1.");
 	CHECK_MESSAGE(
 			curve->sample(0.4) == doctest::Approx((real_t)0.352),
-			"Custom free curve should return the expected value at offset 0.1.");
+			"Custom free curve should return the expected value at offset 0.4.");
 	CHECK_MESSAGE(
 			curve->sample(0.7) == doctest::Approx((real_t)0.896),
-			"Custom free curve should return the expected value at offset 0.1.");
+			"Custom free curve should return the expected value at offset 0.7.");
 	CHECK_MESSAGE(
 			curve->sample(1) == doctest::Approx(1),
-			"Custom free curve should return the expected value at offset 0.1.");
+			"Custom free curve should return the expected value at offset 1.");
 	CHECK_MESSAGE(
 			curve->sample(2) == doctest::Approx(1),
-			"Custom free curve should return the expected value at offset 0.1.");
+			"Custom free curve should return the expected value at offset 2.");
 
 	CHECK_MESSAGE(
 			Math::is_zero_approx(curve->sample_baked(-0.1)),
-			"Custom free curve should return the expected baked value at offset 0.1.");
+			"Custom free curve should return the expected baked value at offset -0.1.");
 	CHECK_MESSAGE(
 			curve->sample_baked(0.1) == doctest::Approx((real_t)0.352),
 			"Custom free curve should return the expected baked value at offset 0.1.");
 	CHECK_MESSAGE(
 			curve->sample_baked(0.4) == doctest::Approx((real_t)0.352),
-			"Custom free curve should return the expected baked value at offset 0.1.");
+			"Custom free curve should return the expected baked value at offset 0.4.");
 	CHECK_MESSAGE(
 			curve->sample_baked(0.7) == doctest::Approx((real_t)0.896),
-			"Custom free curve should return the expected baked value at offset 0.1.");
+			"Custom free curve should return the expected baked value at offset 0.7.");
 	CHECK_MESSAGE(
 			curve->sample_baked(1) == doctest::Approx(1),
-			"Custom free curve should return the expected baked value at offset 0.1.");
+			"Custom free curve should return the expected baked value at offset 1.");
 	CHECK_MESSAGE(
 			curve->sample_baked(2) == doctest::Approx(1),
-			"Custom free curve should return the expected baked value at offset 0.1.");
+			"Custom free curve should return the expected baked value at offset 2.");
 
 	curve->remove_point(1);
 	CHECK_MESSAGE(
@@ -216,6 +217,16 @@ TEST_CASE("[Curve] Custom curve with linear tangents") {
 	CHECK_MESSAGE(
 			curve->sample_baked(0.7) == doctest::Approx((real_t)0.8),
 			"Custom free curve should return the expected baked value at offset 0.7 after removing point at invalid index 10.");
+}
+
+TEST_CASE("[Curve] Straight line offset test") {
+	Ref<Curve> curve = memnew(Curve);
+	curve->add_point(Vector2(0, 0));
+	curve->add_point(Vector2(1, 1));
+
+	CHECK_MESSAGE(
+			curve->sample_baked(1.0 - (0.5 / curve->get_bake_resolution())) != curve->sample_baked(1),
+			"Straight line curve should return different baked values at offset 1 vs offset (1 - 0.5 / bake resolution) .");
 }
 
 TEST_CASE("[Curve2D] Linear sampling should return exact value") {


### PR DESCRIPTION
I noticed that when using `Curve::sample()` & `Curve::sample_baked()`, I was getting different results for the same curve, when sampling an offset close to 1. 

By setting a simple, rising curve's `bake_resolution` to a low value (e.g. 10) and plotting the sample values on a line, the error can be seen quite clearly.

Using `Curve::sample()`, the curve appears as expected:
<img width="516" alt="CurveSampleLine" src="https://user-images.githubusercontent.com/20951891/235358589-96990cc2-a6d6-4df3-89c1-20d91262cc7d.png">
Using `Curve::sample_baked()` for the same curve results in a strange "kink" followed by a horizontal, flat section towards the end (top right) of the curve:
<img width="516" alt="CurveBakedSampleLine" src="https://user-images.githubusercontent.com/20951891/235358590-2a965df9-4761-4a30-a4d1-4f1fa4fd910d.png">

This was tracked down to a small math error in `Curve::bake()`. Note the original function below from `curve.cpp`

``` c++
void Curve::bake() {
	_baked_cache.clear();

	_baked_cache.resize(_bake_resolution);

	for (int i = 1; i < _bake_resolution - 1; ++i) {
		real_t x = i / static_cast<real_t>(_bake_resolution);
		real_t y = sample(x);
		_baked_cache.write[i] = y;
	}

	if (_points.size() != 0) {
		_baked_cache.write[0] = _points[0].position.y;
		_baked_cache.write[_baked_cache.size() - 1] = _points[_points.size() - 1].position.y;
	}

	_baked_cache_dirty = false;
}
```

Since the first and last baked points will be set to be equal to the first and last points of the curve itself, the loop part is essentially used to "cut" the curve into $n-1$ equally sized intervals with $n-2$ values baked between each interval (resulting in $n$ baked points in total once the first & last points are also added). To illustrate the situation more concretely, the error occurs because if we are to create, say, 10 "baked points", that will _actually_ result in only $9$ _sections_ or "intervals" (and $8$ "middle" baked points) so the length of each section should be $\frac{1}{9}$ instead of $\frac{1}{10}$.

In other words, this line was assuming the intervals between each baked point would be $\frac{1}{n}$:
``` c++
real_t x = i / static_cast<real_t>(_bake_resolution);
```

But if we have $n-1$ intervals, the length of each should in fact be $\frac{1}{n-1}$, so the line just needs to be changed to:
``` c++
real_t x = i / static_cast<real_t>(_bake_resolution - 1);
```

This will ensure that each of the "middle" baked points is in fact equally spaced between the "start" and "end" baked points.

Similarly, a corresponding change needs to be made to `Curve::sample_baked()`, changing:
``` c++
real_t fi = p_offset * _baked_cache.size();
```

to:
``` c++
real_t fi = p_offset * (_baked_cache.size() - 1);
```

Making the 2 small changes in this pull request results in `Curve::sample_baked()` returning the correct and expected values 

Fixes #76623