### PR TITLE
Print CPU and GPU usage statistics after Movie Maker is finished

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3305,10 +3305,7 @@ bool Main::iteration() {
 	}
 
 	if (movie_writer) {
-		RID main_vp_rid = RenderingServer::get_singleton()->viewport_find_from_screen_attachment(DisplayServer::MAIN_WINDOW_ID);
-		RID main_vp_texture = RenderingServer::get_singleton()->viewport_get_texture(main_vp_rid);
-		Ref<Image> vp_tex = RenderingServer::get_singleton()->texture_2d_get(main_vp_texture);
-		movie_writer->add_frame(vp_tex);
+		movie_writer->add_frame();
 	}
 
 	if ((quit_after > 0) && (Engine::get_singleton()->_process_frames >= quit_after)) {

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -42,6 +42,9 @@ class MovieWriter : public Object {
 	uint64_t mix_rate = 0;
 	uint32_t audio_channels = 0;
 
+	float cpu_time = 0.0f;
+	float gpu_time = 0.0f;
+
 	String project_name;
 
 	LocalVector<int32_t> audio_mix_buffer;
@@ -80,7 +83,7 @@ public:
 	static MovieWriter *find_writer_for_file(const String &p_file);
 
 	void begin(const Size2i &p_movie_size, uint32_t p_fps, const String &p_base_path);
-	void add_frame(const Ref<Image> &p_image);
+	void add_frame();
 
 	static void set_extensions_hint();
 


### PR DESCRIPTION
Example output:

```
----------------
Done recording movie at path: /tmp/a.avi
300 frames at 30 FPS (movie length: 00:00:10), recorded in 00:00:12 (83% of real-time speed).
CPU time: 0.29 seconds (avg 0.97 ms/frame)
GPU time: 3.57 seconds (avg 11.89 ms/frame)
----------------
```