### PR TITLE
Respect "compress_binary_resources" editor setting on scene import

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -33,6 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
+#include "editor/editor_settings.h"
 #include "editor/import/scene_import_settings.h"
 #include "scene/3d/area_3d.h"
 #include "scene/3d/collision_shape_3d.h"
@@ -2528,6 +2529,11 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	progress.step(TTR("Saving..."), 104);
 
+	int flags = 0;
+	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+
 	if (animation_importer) {
 		Ref<AnimationLibrary> library;
 		for (int i = 0; i < scene->get_child_count(); i++) {
@@ -2546,15 +2552,15 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 			library.instantiate(); // Will be empty
 		}
 
-		print_verbose("Saving animation to: " + p_save_path + ".scn");
-		err = ResourceSaver::save(library, p_save_path + ".res"); //do not take over, let the changed files reload themselves
+		print_verbose("Saving animation to: " + p_save_path + ".res");
+		err = ResourceSaver::save(library, p_save_path + ".res", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
 
 	} else {
 		Ref<PackedScene> packer = memnew(PackedScene);
 		packer->pack(scene);
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
-		err = ResourceSaver::save(packer, p_save_path + ".scn"); //do not take over, let the changed files reload themselves
+		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
 	}
 


### PR DESCRIPTION
`ResourceImporterScene::import()` did not check the `filesystem/on_save/compress_binary_resources` editor setting to set `FLAG_COMPRESS` when saving after import, while `EditorNode::save_resource_in_path()` did, causing imported scenes (e.g. from gLTF files) to be larger than scenes created by manually saving in the editor.

Closes #71538 