### PR TITLE
Improve error message when a GDScript instance fails to be constructed

### DIFF
--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -87,9 +87,12 @@ public:
 	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true) const;
 	void reverse();
 
-	int find(const Variant &p_value, int p_from = 0) const;
-	int rfind(const Variant &p_value, int p_from = -1) const;
-	int count(const Variant &p_value) const;
+	int find(const Variant& p_value, int p_from = 0) const;
+	int first_custom(const Callable& p_callable, int p_from = 0) const;
+	int rfind(const Variant& p_value, int p_from = -1) const;
+	int last_custom(const Callable& p_callable, int p_from = -1) const;
+	int count(const Variant& p_value) const;
+	int count_custom(const Callable& p_callable) const;
 	bool has(const Variant &p_value) const;
 
 	void erase(const Variant &p_value);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -158,13 +158,14 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 
 	_super_implicit_constructor(this, instance, r_error);
 	if (r_error.error != Callable::CallError::CALL_OK) {
+		String error_text = Variant::get_call_error_text(instance->owner, "@implicit_new", nullptr, 0, r_error);
 		instance->script = Ref<GDScript>();
 		instance->owner->set_script_instance(nullptr);
 		{
 			MutexLock lock(GDScriptLanguage::singleton->mutex);
 			instances.erase(p_owner);
 		}
-		ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance.");
+		ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance: " + error_text);
 	}
 
 	if (p_argcount < 0) {
@@ -175,13 +176,14 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	if (initializer != nullptr) {
 		initializer->call(instance, p_args, p_argcount, r_error);
 		if (r_error.error != Callable::CallError::CALL_OK) {
+			String error_text = Variant::get_call_error_text(instance->owner, "_init", p_args, p_argcount, r_error);
 			instance->script = Ref<GDScript>();
 			instance->owner->set_script_instance(nullptr);
 			{
 				MutexLock lock(GDScriptLanguage::singleton->mutex);
 				instances.erase(p_owner);
 			}
-			ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance.");
+			ERR_FAIL_V_MSG(nullptr, "Error constructing a GDScriptInstance: " + error_text);
 		}
 	}
 	//@TODO make thread safe


### PR DESCRIPTION
I changed this error message to have a clearer cause ,since this line seems to be caused by godot attempting to initialize a script when the constructor takes more than one argument. Having a clearer message here would have saved me a lot of time.

Changes error message from a terse "Error constructing a GDScriptInstance." to "Error constructing a GDScriptInstance: {error}", where the error matches the error messages given when calling a function improperly in normal GDscript. 

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/5899.*