### PR TITLE
[Android] Fix dynamic Variant params stack constructions in JNI callbacks

### DIFF
--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -120,7 +120,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 
 	for (int i = 0; i < count; i++) {
 		jobject j_param = env->GetObjectArrayElement(j_signal_params, i);
-		variant_params[i] = _jobject_to_variant(env, j_param);
+		ERR_FAIL_NULL(j_param);
+		memnew_placement(&variant_params[i], Variant(_jobject_to_variant(env, j_param)));
 		args[i] = &variant_params[i];
 		env->DeleteLocalRef(j_param);
 	}


### PR DESCRIPTION
Emitting signals with params from Android plugins could crash due to object assignment with uninitialised mem.
Instead, use *memnew_placement* to construct into stack addresses.

This appears to be introduced in godot 4.0 from [refactoring](https://github.com/godotengine/godot/commit/21637dfc2535a00f531b8b664c1e66ba34d11eb0#diff-4169b5dca5f1b41a90f9c366a5247cb51555d9d5231fdf95c8e3051832ed12ac) so not applicable for 3.x.

**Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitSignal** was main issue and whilst appeared to run fine with Armv8 ABI for me, consistently crashed when running Armv7.

**Java_org_godotengine_godot_GodotLib_callobject** was not affected due to constructing a nil Variant to the stack addresses before assignment.

**Java_org_godotengine_godot_GodotLib_calldeferred** looked to have same issue but not sure if actually used.

I've updated the above three calls for consistency.

Not sure the circumstances that *GetObjectArrayElement* could return null (out of java refs/mem?) but was being tested in some funcs.  I've changed to an ERR_FAIL_NULL as I believe it better to abort the call than continue with partially converted params.

JNI *Push/PopLocalFrame* calls have been removed from call funcs as seem somewhat redundant here and could interfere with early return.  May reduce local java refs capacity by a couple.

Fixes #75754.
Probably Fixes #69297.

Thanks to @Ajrarn777 for assistance in tracking this down.