### PR TITLE
Move convert_indent into CodeEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -126,6 +126,15 @@
 				Inserts the selected entry into the text. If [param replace] is true, any existing text is replaced rather then merged.
 			</description>
 		</method>
+		<method name="convert_indent">
+			<return type="void" />
+			<param index="0" name="from_line" type="int" default="-1" />
+			<param index="1" name="to_line" type="int" default="-1" />
+			<description>
+				Converts the indents of lines between [param from_line] and [param to_line] to tabs or spaces as set by [member indent_use_spaces].
+				Values of [code]-1[/code] convert the entire text.
+			</description>
+		</method>
 		<method name="do_indent">
 			<return type="void" />
 			<description>

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -222,9 +222,6 @@ public:
 	void trim_trailing_whitespace();
 	void insert_final_newline();
 
-	void convert_indent_to_spaces();
-	void convert_indent_to_tabs();
-
 	enum CaseStyle {
 		UPPER,
 		LOWER,

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -944,11 +944,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 		se->insert_final_newline();
 
 		if (convert_indent_on_save) {
-			if (use_space_indentation) {
-				se->convert_indent_to_spaces();
-			} else {
-				se->convert_indent_to_tabs();
-			}
+			se->convert_indent();
 		}
 
 		Ref<TextFile> text_file = scr;
@@ -1299,11 +1295,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				current->insert_final_newline();
 
 				if (convert_indent_on_save) {
-					if (use_space_indentation) {
-						current->convert_indent_to_spaces();
-					} else {
-						current->convert_indent_to_tabs();
-					}
+					current->convert_indent();
 				}
 
 				Ref<Resource> resource = current->get_edited_resource();
@@ -2451,11 +2443,7 @@ void ScriptEditor::save_current_script() {
 	current->insert_final_newline();
 
 	if (convert_indent_on_save) {
-		if (use_space_indentation) {
-			current->convert_indent_to_spaces();
-		} else {
-			current->convert_indent_to_tabs();
-		}
+		current->convert_indent();
 	}
 
 	Ref<Resource> resource = current->get_edited_resource();
@@ -2499,11 +2487,7 @@ void ScriptEditor::save_all_scripts() {
 		}
 
 		if (convert_indent_on_save) {
-			if (use_space_indentation) {
-				se->convert_indent_to_spaces();
-			} else {
-				se->convert_indent_to_tabs();
-			}
+			se->convert_indent();
 		}
 
 		if (trim_trailing_whitespace_on_save) {
@@ -2730,7 +2714,6 @@ void ScriptEditor::_editor_settings_changed() {
 
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
-	use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
 
 	members_overview_enabled = EDITOR_GET("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EDITOR_GET("text_editor/help/show_help_index");
@@ -4081,7 +4064,6 @@ ScriptEditor::ScriptEditor() {
 	edit_pass = 0;
 	trim_trailing_whitespace_on_save = EDITOR_GET("text_editor/behavior/files/trim_trailing_whitespace_on_save");
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
-	use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
 
 	ScriptServer::edit_request_func = _open_script_request;
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -169,8 +169,7 @@ public:
 	virtual void clear_executing_line() = 0;
 	virtual void trim_trailing_whitespace() = 0;
 	virtual void insert_final_newline() = 0;
-	virtual void convert_indent_to_spaces() = 0;
-	virtual void convert_indent_to_tabs() = 0;
+	virtual void convert_indent() = 0;
 	virtual void ensure_focus() = 0;
 	virtual void tag_saved_version() = 0;
 	virtual void reload(bool p_soft) {}
@@ -390,7 +389,6 @@ class ScriptEditor : public PanelContainer {
 
 	bool open_textfile_after_create = true;
 	bool trim_trailing_whitespace_on_save;
-	bool use_space_indentation;
 	bool convert_indent_on_save;
 
 	void _goto_script_line2(int p_line);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -378,12 +378,8 @@ void ScriptTextEditor::insert_final_newline() {
 	code_editor->insert_final_newline();
 }
 
-void ScriptTextEditor::convert_indent_to_spaces() {
-	code_editor->convert_indent_to_spaces();
-}
-
-void ScriptTextEditor::convert_indent_to_tabs() {
-	code_editor->convert_indent_to_tabs();
+void ScriptTextEditor::convert_indent() {
+	code_editor->get_text_editor()->convert_indent();
 }
 
 void ScriptTextEditor::tag_saved_version() {
@@ -1282,10 +1278,12 @@ void ScriptTextEditor::_edit_option(int p_op) {
 			trim_trailing_whitespace();
 		} break;
 		case EDIT_CONVERT_INDENT_TO_SPACES: {
-			convert_indent_to_spaces();
+			tx->set_indent_using_spaces(true);
+			convert_indent();
 		} break;
 		case EDIT_CONVERT_INDENT_TO_TABS: {
-			convert_indent_to_tabs();
+			tx->set_indent_using_spaces(false);
+			convert_indent();
 		} break;
 		case EDIT_PICK_COLOR: {
 			color_panel->popup();

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -222,8 +222,7 @@ public:
 	virtual void ensure_focus() override;
 	virtual void trim_trailing_whitespace() override;
 	virtual void insert_final_newline() override;
-	virtual void convert_indent_to_spaces() override;
-	virtual void convert_indent_to_tabs() override;
+	virtual void convert_indent() override;
 	virtual void tag_saved_version() override;
 
 	virtual void goto_line(int p_line, bool p_with_error = false) override;

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -288,12 +288,8 @@ void TextEditor::insert_final_newline() {
 	code_editor->insert_final_newline();
 }
 
-void TextEditor::convert_indent_to_spaces() {
-	code_editor->convert_indent_to_spaces();
-}
-
-void TextEditor::convert_indent_to_tabs() {
-	code_editor->convert_indent_to_tabs();
+void TextEditor::convert_indent() {
+	code_editor->get_text_editor()->convert_indent();
 }
 
 void TextEditor::tag_saved_version() {
@@ -419,10 +415,12 @@ void TextEditor::_edit_option(int p_op) {
 			trim_trailing_whitespace();
 		} break;
 		case EDIT_CONVERT_INDENT_TO_SPACES: {
-			convert_indent_to_spaces();
+			tx->set_indent_using_spaces(true);
+			convert_indent();
 		} break;
 		case EDIT_CONVERT_INDENT_TO_TABS: {
-			convert_indent_to_tabs();
+			tx->set_indent_using_spaces(false);
+			convert_indent();
 		} break;
 		case EDIT_TO_UPPERCASE: {
 			_convert_case(CodeTextEditor::UPPER);

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -131,8 +131,7 @@ public:
 	virtual void clear_executing_line() override;
 	virtual void trim_trailing_whitespace() override;
 	virtual void insert_final_newline() override;
-	virtual void convert_indent_to_spaces() override;
-	virtual void convert_indent_to_tabs() override;
+	virtual void convert_indent() override;
 	virtual void ensure_focus() override;
 	virtual void tag_saved_version() override;
 	virtual void update_settings() override;

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -314,6 +314,8 @@ public:
 	void indent_lines();
 	void unindent_lines();
 
+	void convert_indent(int p_from_line = -1, int p_to_line = -1);
+
 	/* Auto brace completion */
 	void set_auto_brace_completion_enabled(bool p_enabled);
 	bool is_auto_brace_completion_enabled() const;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2314,6 +2314,143 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		}
 	}
 
+	SUBCASE("[CodeEdit] convert indent to tabs") {
+		code_edit->set_indent_size(4);
+		code_edit->set_indent_using_spaces(false);
+
+		// Only line.
+		code_edit->insert_text_at_caret("        test");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(8);
+		code_edit->select(0, 8, 0, 9);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(0) == "\t\ttest");
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_from_column() == 2);
+		CHECK(code_edit->get_selection_to_column() == 3);
+
+		// First line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("        test\n");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(8);
+		code_edit->select(0, 8, 0, 9);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(0) == "\t\ttest");
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_from_column() == 2);
+		CHECK(code_edit->get_selection_to_column() == 3);
+
+		// Middle line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\n        test\n");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(8);
+		code_edit->select(1, 8, 1, 9);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(1) == "\t\ttest");
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_from_column() == 2);
+		CHECK(code_edit->get_selection_to_column() == 3);
+
+		// End line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\n        test");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(8);
+		code_edit->select(1, 8, 1, 9);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(1) == "\t\ttest");
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_from_column() == 2);
+		CHECK(code_edit->get_selection_to_column() == 3);
+
+		// Within provided range.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("    test\n        test\n");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(8);
+		code_edit->select(1, 8, 1, 9);
+		code_edit->convert_indent(1, 1);
+		CHECK(code_edit->get_line(0) == "    test");
+		CHECK(code_edit->get_line(1) == "\t\ttest");
+		CHECK(code_edit->get_caret_column() == 2);
+		CHECK(code_edit->get_selection_from_column() == 2);
+		CHECK(code_edit->get_selection_to_column() == 3);
+	}
+
+	SUBCASE("[CodeEdit] convert indent to spaces") {
+		code_edit->set_indent_size(4);
+		code_edit->set_indent_using_spaces(true);
+
+		// Only line.
+		code_edit->insert_text_at_caret("\t\ttest");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(2);
+		code_edit->select(0, 2, 0, 3);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(0) == "        test");
+		CHECK(code_edit->get_caret_column() == 8);
+		CHECK(code_edit->get_selection_from_column() == 8);
+		CHECK(code_edit->get_selection_to_column() == 9);
+
+		// First line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\t\ttest\n");
+		code_edit->set_caret_line(0);
+		code_edit->set_caret_column(2);
+		code_edit->select(0, 2, 0, 3);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(0) == "        test");
+		CHECK(code_edit->get_caret_column() == 8);
+		CHECK(code_edit->get_selection_from_column() == 8);
+		CHECK(code_edit->get_selection_to_column() == 9);
+
+		// Middle line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\n\t\ttest\n");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->select(1, 2, 1, 3);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(1) == "        test");
+		CHECK(code_edit->get_caret_column() == 8);
+		CHECK(code_edit->get_selection_from_column() == 8);
+		CHECK(code_edit->get_selection_to_column() == 9);
+
+		// End line.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\n\t\ttest");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->select(1, 2, 1, 3);
+		code_edit->convert_indent();
+		CHECK(code_edit->get_line(1) == "        test");
+		CHECK(code_edit->get_caret_column() == 8);
+		CHECK(code_edit->get_selection_from_column() == 8);
+		CHECK(code_edit->get_selection_to_column() == 9);
+
+		// Within provided range.
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("\ttest\n\t\ttest\n");
+		code_edit->set_caret_line(1);
+		code_edit->set_caret_column(2);
+		code_edit->select(1, 2, 1, 3);
+		code_edit->convert_indent(1, 1);
+		CHECK(code_edit->get_line(0) == "\ttest");
+		CHECK(code_edit->get_line(1) == "        test");
+		CHECK(code_edit->get_caret_column() == 8);
+		CHECK(code_edit->get_selection_from_column() == 8);
+		CHECK(code_edit->get_selection_to_column() == 9);
+
+		// Outside of range.
+		ERR_PRINT_OFF;
+		code_edit->convert_indent(0, 4);
+		code_edit->convert_indent(4, 5);
+		code_edit->convert_indent(4, 1);
+		ERR_PRINT_ON;
+	}
+
 	memdelete(code_edit);
 }
 


### PR DESCRIPTION
Moved `convert_indent_to_[space|tabs]` methods from `CodeTextEditor`, into a single `convert_indent` method in `CodeEdit`. The new method is exposed to the API.

Now there is a single place for this information moved control away from the editor, into `CodeEdit`. The editor will now allow you to temporarily set it to a different indent type from that set in the settings. This is a step to supporting automatically detecting the indent. To make this clearer added the current indent type to the status bar.

Lastly, `convert_indent`, should also now properly handle carets and selections columns.

