### PR TITLE
Skip initializing the C# runtime when generating glue bindings

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -93,6 +93,12 @@ String CSharpLanguage::get_extension() const {
 }
 
 void CSharpLanguage::init() {
+#ifdef TOOLS_ENABLED
+	if (OS::get_singleton()->get_cmdline_args().find("--generate-mono-glue")) {
+		print_verbose(".NET: Skipping runtime initialization because glue generation is enabled.");
+		return;
+	}
+#endif
 #ifdef DEBUG_METHODS_ENABLED
 	if (OS::get_singleton()->get_cmdline_args().find("--class-db-json")) {
 		class_db_api_to_json("user://class_db_api.json", ClassDB::API_CORE);


### PR DESCRIPTION
Fixes #75152

This splits out the glue generator initialization fix from #76542 into its own PR.

The bindings generator doesn't require the C# runtime in order to generate the glue, and when it the glue generation runs, it exits immediately afterwards, so we can skip this initialization when the `--generate-mono-glue` flag is passed in.

In some platforms, like on macos M1 arm, trying to run the godot+mono binary on an incomplete installation crashes during the hostfx initialization, so #75152 is a bit more serious than just an annoying popup.