### PR TITLE
Add API for HSL conversion (reverted)

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -188,6 +188,32 @@ float Color::get_v() const {
 	return max;
 }
 
+float Color::get_hsl_h() const {
+	return get_h();
+}
+
+float Color::get_hsl_s() const {
+	float min = MIN(MIN(r, g), b);
+	float max = MAX(MAX(r, g), b);
+
+	float mid = (min + max) / 2.0f;
+
+	if (mid == 0.0f || mid == 1.0f) {
+		return 0.0f;
+	}
+
+	float delta = max - min;
+
+	return delta / (1.0f - Math::abs(2.0f * mid - 1.0f));
+}
+
+float Color::get_hsl_l() const {
+	float min = MIN(MIN(r, g), b);
+	float max = MAX(MAX(r, g), b);
+
+	return (min + max) / 2.0f;
+}
+
 void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	int i;
 	float f, p, q, t;
@@ -238,6 +264,59 @@ void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 			r = p_v;
 			g = p;
 			b = q;
+			break;
+	}
+}
+
+void Color::set_hsl(float p_h, float p_s, float p_l, float p_alpha) {
+	a = p_alpha;
+
+	if (p_s == 0.0f) {
+		// Achromatic (gray)
+		r = g = b = p_l;
+		return;
+	}
+
+	p_h *= 6.0f;
+	p_h = Math::fmod(p_h, 6.0f);
+
+	float c = (1.0f - Math::abs(2.0f * p_l - 1.0f)) * p_s;
+	float x = c * (1.0f - Math::abs(Math::fmod(p_h, 2.0f) - 1.0f));
+	float m = p_l - c / 2.0f;
+
+	c += m;
+	x += m;
+
+	switch ((int)p_h) {
+		case 0: // Red is the dominant color
+			r = c;
+			g = x;
+			b = m;
+			break;
+		case 1: // Green is the dominant color
+			r = x;
+			g = c;
+			b = m;
+			break;
+		case 2:
+			r = m;
+			g = c;
+			b = x;
+			break;
+		case 3: // Blue is the dominant color
+			r = m;
+			g = x;
+			b = c;
+			break;
+		case 4:
+			r = x;
+			g = m;
+			b = c;
+			break;
+		default: // (5) Red is the dominant color
+			r = c;
+			g = m;
+			b = x;
 			break;
 	}
 }
@@ -465,6 +544,12 @@ Color Color::from_string(const String &p_string, const Color &p_default) {
 Color Color::from_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	Color c;
 	c.set_hsv(p_h, p_s, p_v, p_alpha);
+	return c;
+}
+
+Color Color::from_hsl(float p_h, float p_s, float p_l, float p_alpha) {
+	Color c;
+	c.set_hsl(p_h, p_s, p_l, p_alpha);
 	return c;
 }
 

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -57,6 +57,10 @@ struct _NO_DISCARD_ Color {
 	float get_s() const;
 	float get_v() const;
 	void set_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
+	float get_hsl_h() const;
+	float get_hsl_s() const;
+	float get_hsl_l() const;
+	void set_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	float get_ok_hsl_h() const;
 	float get_ok_hsl_s() const;
 	float get_ok_hsl_l() const;
@@ -198,6 +202,7 @@ struct _NO_DISCARD_ Color {
 	static Color get_named_color(int p_idx);
 	static Color from_string(const String &p_string, const Color &p_default);
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
+	static Color from_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_rgbe9995(uint32_t p_rgbe);
 
@@ -217,6 +222,9 @@ struct _NO_DISCARD_ Color {
 	_FORCE_INLINE_ void set_h(float p_h) { set_hsv(p_h, get_s(), get_v(), a); }
 	_FORCE_INLINE_ void set_s(float p_s) { set_hsv(get_h(), p_s, get_v(), a); }
 	_FORCE_INLINE_ void set_v(float p_v) { set_hsv(get_h(), get_s(), p_v, a); }
+	_FORCE_INLINE_ void set_hsl_h(float p_h) { set_hsl(p_h, get_hsl_s(), get_hsl_l(), a); }
+	_FORCE_INLINE_ void set_hsl_s(float p_s) { set_hsl(get_hsl_h(), p_s, get_hsl_l(), a); }
+	_FORCE_INLINE_ void set_hsl_l(float p_l) { set_hsl(get_hsl_h(), get_hsl_s(), p_l, a); }
 	_FORCE_INLINE_ void set_ok_hsl_h(float p_h) { set_ok_hsl(p_h, get_ok_hsl_s(), get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2000,6 +2000,7 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Color, html_is_valid, sarray("color"), varray());
 	bind_static_method(Color, from_string, sarray("str", "default"), varray());
 	bind_static_method(Color, from_hsv, sarray("h", "s", "v", "alpha"), varray(1.0));
+	bind_static_method(Color, from_hsl, sarray("h", "s", "l", "alpha"), varray(1.0));
 	bind_static_method(Color, from_ok_hsl, sarray("h", "s", "l", "alpha"), varray(1.0));
 
 	bind_static_method(Color, from_rgbe9995, sarray("rgbe"), varray());

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -139,6 +139,10 @@ void register_named_setters_getters() {
 	REGISTER_MEMBER(Color, h);
 	REGISTER_MEMBER(Color, s);
 	REGISTER_MEMBER(Color, v);
+
+	REGISTER_MEMBER(Color, hsl_h);
+	REGISTER_MEMBER(Color, hsl_s);
+	REGISTER_MEMBER(Color, hsl_l);
 }
 
 void unregister_named_setters_getters() {

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -344,6 +344,10 @@ SETGET_NUMBER_STRUCT_FUNC(Color, double, h, set_h, get_h)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, s, set_s, get_s)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, v, set_v, get_v)
 
+SETGET_NUMBER_STRUCT_FUNC(Color, double, hsl_h, set_hsl_h, get_hsl_h)
+SETGET_NUMBER_STRUCT_FUNC(Color, double, hsl_s, set_hsl_s, get_hsl_s)
+SETGET_NUMBER_STRUCT_FUNC(Color, double, hsl_l, set_hsl_l, get_hsl_l)
+
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_h, set_ok_hsl_h, get_ok_hsl_h)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_s, set_ok_hsl_s, get_ok_hsl_s)
 SETGET_NUMBER_STRUCT_FUNC(Color, double, ok_hsl_l, set_ok_hsl_l, get_ok_hsl_l)

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -141,6 +141,24 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="from_hsl" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="h" type="float" />
+			<param index="1" name="s" type="float" />
+			<param index="2" name="l" type="float" />
+			<param index="3" name="alpha" type="float" default="1.0" />
+			<description>
+				Constructs a color from an [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSL profile[/url]. The hue ([param h]), saturation ([param s]), and lightness ([param l]) are typically between 0.0 and 1.0.
+				[codeblocks]
+				[gdscript]
+				var color = Color.from_hsl(0.58, 0.5, 0.79, 0.8)
+				[/gdscript]
+				[csharp]
+				var color = Color.FromHsl(0.58f, 0.5f, 0.79f, 0.8f);
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="from_hsv" qualifiers="static">
 			<return type="Color" />
 			<param index="0" name="h" type="float" />
@@ -492,6 +510,15 @@
 		</member>
 		<member name="h" type="float" setter="" getter="" default="0.0">
 			The HSV hue of this color, on the range 0 to 1.
+		</member>
+		<member name="hsl_h" type="float" setter="" getter="" default="0.0">
+			The HSL hue of this color, on the range 0 to 1.
+		</member>
+		<member name="hsl_l" type="float" setter="" getter="" default="0.0">
+			The HSL lightness of this color, on the range 0 to 1.
+		</member>
+		<member name="hsl_s" type="float" setter="" getter="" default="0.0">
+			The HSL saturation of this color, on the range 0 to 1.
 		</member>
 		<member name="r" type="float" setter="" getter="" default="0.0">
 			The color's red component, typically on the range of 0 to 1.

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -63,10 +63,14 @@ TEST_CASE("[Color] Constructor methods") {
 
 	const Color green_rgba = Color(0, 1, 0, 0.25);
 	const Color green_hsva = Color(0, 0, 0).from_hsv(120 / 360.0, 1, 1, 0.25);
+	const Color green_hsla = Color(0, 0, 0).from_hsl(120 / 360.0, 1, 0.5, 0.25);
 
 	CHECK_MESSAGE(
 			green_rgba.is_equal_approx(green_hsva),
 			"Creation with HSV notation should result in components approximately equal to the default constructor.");
+	CHECK_MESSAGE(
+			green_rgba.is_equal_approx(green_hsla),
+			"Creation with HSL notation should result in components approximately equal to the default constructor.");
 }
 
 TEST_CASE("[Color] Operators") {
@@ -109,6 +113,16 @@ TEST_CASE("[Color] Reading methods") {
 	CHECK_MESSAGE(
 			dark_blue.get_v() == doctest::Approx(0.5f),
 			"The returned HSV value should match the expected value.");
+
+	CHECK_MESSAGE(
+			dark_blue.get_hsl_h() == doctest::Approx(240.0f / 360.0f),
+			"The returned HSL hue should match the expected value.");
+	CHECK_MESSAGE(
+			dark_blue.get_hsl_s() == doctest::Approx(1.0f),
+			"The returned HSL saturation should match the expected value.");
+	CHECK_MESSAGE(
+			dark_blue.get_hsl_l() == doctest::Approx(0.25f),
+			"The returned HSL lightness should match the expected value.");
 }
 
 TEST_CASE("[Color] Conversion methods") {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-proposals/issues/6794

Math ported pretty much 1:1 from https://en.wikipedia.org/wiki/HSL_and_HSV
Style doesn't match the existing HSV code exactly, but should be close enough.

Here's a demo project: [Color Demo.zip](https://github.com/godotengine/godot/files/11378101/Color.Demo.zip)
![Color Demo](https://user-images.githubusercontent.com/43251584/235798597-acecb361-e05f-43be-841d-2052ebbd7134.gif)