### PR TITLE
Fix `SurfaceTool::create_from_blend_shape()`

### DIFF
--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -985,9 +985,21 @@ void SurfaceTool::create_from_blend_shape(const Ref<Mesh> &p_existing, int p_sur
 	}
 	ERR_FAIL_COND(shape_idx == -1);
 	ERR_FAIL_COND(shape_idx >= arr.size());
-	Array mesh = arr[shape_idx];
-	ERR_FAIL_COND(mesh.size() != RS::ARRAY_MAX);
-	_create_list_from_arrays(arr[shape_idx], &vertex_array, &index_array, format);
+	Array blendshape_mesh_arrays = arr[shape_idx];
+	ERR_FAIL_COND(blendshape_mesh_arrays.size() != RS::ARRAY_MAX);
+
+	Array source_mesh_arrays = p_existing->surface_get_arrays(p_surface);
+	ERR_FAIL_COND(source_mesh_arrays.size() != RS::ARRAY_MAX);
+
+	// Copy BlendShape vertex data over while keeping e.g. bones, weights, index from existing mesh intact.
+	source_mesh_arrays[RS::ARRAY_VERTEX] = blendshape_mesh_arrays[RS::ARRAY_VERTEX];
+	source_mesh_arrays[RS::ARRAY_NORMAL] = blendshape_mesh_arrays[RS::ARRAY_NORMAL];
+	source_mesh_arrays[RS::ARRAY_TANGENT] = blendshape_mesh_arrays[RS::ARRAY_TANGENT];
+
+	_create_list_from_arrays(source_mesh_arrays, &vertex_array, &index_array, format);
+
+	material = p_existing->surface_get_material(p_surface);
+	format = p_existing->surface_get_format(p_surface);
 
 	for (int j = 0; j < RS::ARRAY_CUSTOM_COUNT; j++) {
 		if (format & custom_mask[j]) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76320

The issue was that `SurfaceTool::create_from_blend_shape()` compared to the similar `SurfaceTool::create_from()` function (that copies all mesh arrays) was only using the BlendShape mask arrays (Vertex, Normal and Tangent). Other important mesh arrays from the source mesh like e.g. bones, weight, index arrays or custom data were ignored.

![create_blendshape_mesh_02](https://user-images.githubusercontent.com/52464204/235613403-6dc176ab-2d8f-49bd-855b-1162cb60f7d9.png)


This in turn would break any mesh using an index array. Also all meshes animated with a skeleton would break due to the lack of bone and weight data on the new mesh created by the SurfaceTool. The function was also not applying the source mesh format or material for the SurfaceTool to make a proper mesh copy.

![create_blendshape_mesh_01](https://user-images.githubusercontent.com/52464204/235598956-75de500e-5445-4b94-86a0-dcca75788212.gif)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
