### PR TITLE
Unify setting tooltips for items in `SceneTreeEditor`

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -357,33 +357,22 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		}
 	}
 
-	// Display the node name in all tooltips so that long node names can be previewed
-	// without having to rename them.
-	if (p_node == get_scene_node() && p_node->get_scene_inherited_state().is_valid()) {
-		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+	{
+		// Display the node name in all tooltips so that long node names can be previewed
+		// without having to rename them.
+		String tooltip = String(p_node->get_name());
 
-		String tooltip = String(p_node->get_name()) + "\n" + TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (!p_node->get_editor_description().is_empty()) {
-			tooltip += "\n\n" + p_node->get_editor_description();
+		if (p_node == get_scene_node() && p_node->get_scene_inherited_state().is_valid()) {
+			item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+			tooltip += String("\n" + TTR("Inherits:") + " " + p_node->get_scene_inherited_state()->get_path());
+		} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
+			item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+			tooltip += String("\n" + TTR("Instance:") + " " + p_node->get_scene_file_path());
 		}
 
-		item->set_tooltip_text(0, tooltip);
-	} else if (p_node != get_scene_node() && !p_node->get_scene_file_path().is_empty() && can_open_instance) {
-		item->add_button(0, get_theme_icon(SNAME("InstanceOptions"), SNAME("EditorIcons")), BUTTON_SUBSCENE, false, TTR("Open in Editor"));
+		StringName custom_type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
+		tooltip += String("\n" + TTR("Type:") + " " + (custom_type != StringName() ? String(custom_type) : p_node->get_class()));
 
-		String tooltip = String(p_node->get_name()) + "\n" + TTR("Instance:") + " " + p_node->get_scene_file_path() + "\n" + TTR("Type:") + " " + p_node->get_class();
-		if (!p_node->get_editor_description().is_empty()) {
-			tooltip += "\n\n" + p_node->get_editor_description();
-		}
-
-		item->set_tooltip_text(0, tooltip);
-	} else {
-		StringName type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
-		if (type == StringName()) {
-			type = p_node->get_class();
-		}
-
-		String tooltip = String(p_node->get_name()) + "\n" + TTR("Type:") + " " + type;
 		if (!p_node->get_editor_description().is_empty()) {
 			tooltip += "\n\n" + p_node->get_editor_description();
 		}


### PR DESCRIPTION
Makes only the tooltip parts specific for different cases (inherited scene / instanced scene) be generated separately, the rest of the tooltip is now handled the same way for every case.

Fixes #76663.

|Before|After|
|-|-|
|![Godot_v4 0 2-stable_win64_gDLhdn3QcJ](https://user-images.githubusercontent.com/9283098/235641722-4618f3b6-aa4b-4e02-a8c9-a8a4c49ff6dc.png)|![WVrTvZmpgU](https://user-images.githubusercontent.com/9283098/235642063-ea1c9ff3-debc-405f-baf2-fa9a204973f3.png)|
|![h3CHl4R7up](https://user-images.githubusercontent.com/9283098/235642231-6bd9429b-1710-45f0-b457-0997b27033e0.png)|![t71oCHLSqw](https://user-images.githubusercontent.com/9283098/235642058-149faac5-72b0-4fb4-871e-2ea7f3a937d5.png)|
|![dpcnQErCkl](https://user-images.githubusercontent.com/9283098/235641725-1001950a-3f49-446d-877a-a7264f7d0442.png)|![lO2965bvK3](https://user-images.githubusercontent.com/9283098/235642269-6a16f0b9-37f8-42cd-936c-1c3f3bf1642a.png)|

