### PR TITLE
Add get_descendants, get_descendant_count, get_ancestors and get_ancestor_count to Node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -280,6 +280,22 @@
 				If [param include_internal] is [code]false[/code], the returned array won't include internal children (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
+		<method name="get_descendant_count" qualifiers="const">
+			<return type="Node[]" />
+			<param index="0" name="include_internal" type="bool" default="false" />
+			<description>
+				Returns the number of descendant nodes.
+				If [param include_internal] is [code]false[/code], the returned array won't include internal descendants (see [code]internal[/code] parameter in [method add_child]).
+			</description>
+		</method>
+		<method name="get_descendants" qualifiers="const">
+			<return type="Node[]" />
+			<param index="0" name="include_internal" type="bool" default="false" />
+			<description>
+				Returns an array of references to node's descendants.
+				If [param include_internal] is [code]false[/code], the returned array won't include internal descendants (see [code]internal[/code] parameter in [method add_child]).
+			</description>
+		</method>
 		<method name="get_groups" qualifiers="const">
 			<return type="StringName[]" />
 			<description>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -253,6 +253,18 @@
 				[b]Note:[/b] As this method walks upwards in the scene tree, it can be slow in large, deeply nested scene trees. Whenever possible, consider using [method get_node] with unique names instead (see [member unique_name_in_owner]), or caching the node references into variable.
 			</description>
 		</method>
+		<method name="get_ancestor_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of ancestor nodes.
+			</description>
+		</method>
+		<method name="get_ancestors" qualifiers="const">
+			<return type="Node[]" />
+			<description>
+				Returns an array of references to node's ancestors.
+			</description>
+		</method>
 		<method name="get_child" qualifiers="const">
 			<return type="Node" />
 			<param index="0" name="idx" type="int" />
@@ -294,18 +306,6 @@
 			<description>
 				Returns an array of references to node's descendants.
 				If [param include_internal] is [code]false[/code], the returned array won't include internal descendants (see [code]internal[/code] parameter in [method add_child]).
-			</description>
-		</method>
-		<method name="get_ancestor_count" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the number of ancestor nodes.
-			</description>
-		</method>
-		<method name="get_ancestors" qualifiers="const">
-			<return type="Node[]" />
-			<description>
-				Returns an array of references to node's ancestors.
 			</description>
 		</method>
 		<method name="get_groups" qualifiers="const">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -296,6 +296,18 @@
 				If [param include_internal] is [code]false[/code], the returned array won't include internal descendants (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
+		<method name="get_ancestor_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of ancestor nodes.
+			</description>
+		</method>
+		<method name="get_ancestors" qualifiers="const">
+			<return type="Node[]" />
+			<description>
+				Returns an array of references to node's ancestors.
+			</description>
+		</method>
 		<method name="get_groups" qualifiers="const">
 			<return type="StringName[]" />
 			<description>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -281,7 +281,7 @@
 			</description>
 		</method>
 		<method name="get_descendant_count" qualifiers="const">
-			<return type="Node[]" />
+			<return type="int" />
 			<param index="0" name="include_internal" type="bool" default="false" />
 			<description>
 				Returns the number of descendant nodes.

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1302,12 +1302,14 @@ int Node::get_descendant_count(bool p_include_internal) const {
 	return count;
 }
 
-TypedArray<Node> Node::get_ancestors() const {
-	TypedArray<Node> res;
-	const Node* current_node = this;
-	while (current_node->get_parent() != nullptr){
-		res.append(current_node);
-		current_node = current_node->get_parent();
+TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
+	TypedArray<Node> res = get_children(p_include_internal);
+	TypedArray<Node> children = get_children(p_include_internal);
+	for (int i = 0; i < children.size(); i++) {
+		Node *node = Object::cast_to<Node>(children[i]);
+		if (node->get_child_count(p_include_internal) > 0) {
+			res.append_array(node->get_descendants(p_include_internal));
+		}
 	}
 	return res;
 }
@@ -1322,14 +1324,12 @@ int Node::get_ancestor_count() const {
 	return count;
 }
 
-TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
-	TypedArray<Node> res = get_children(p_include_internal);
-	TypedArray<Node> children = get_children(p_include_internal);
-	for (int i = 0; i < children.size(); i++) {
-		Node *node = Object::cast_to<Node>(children[i]);
-		if (node->get_child_count(p_include_internal) > 0) {
-			res.append_array(node->get_descendants(p_include_internal));
-		}
+TypedArray<Node> Node::get_ancestors() const {
+	TypedArray<Node> res;
+	const Node* current_node = this;
+	while (current_node->get_parent() != nullptr){
+		res.append(current_node);
+		current_node = current_node->get_parent();
 	}
 	return res;
 }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1301,6 +1301,7 @@ int Node::get_descendant_count(bool p_include_internal) const {
 	}
 	return count;
 }
+
 TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
 	TypedArray<Node> res = get_children(p_include_internal);
 	TypedArray<Node> children = get_children(p_include_internal);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1290,26 +1290,26 @@ Node *Node::_get_child_by_name(const StringName &p_name) const {
 }
 
 int Node::get_descendant_count(bool p_include_internal) const {
-    int count = 0;
-    TypedArray<Node> children = get_children(p_include_internal);
-    count += children.size();
-    for (int i = 0; i < children.size(); i++) {
-        Node *node = Object::cast_to<Node>(children[i]);
-        if (node->get_child_count(p_include_internal) > 0) {
-            count += node->get_descendant_count(p_include_internal);
-        }
-    }
-    return count;
+	int count = 0;
+	TypedArray<Node> children = get_children(p_include_internal);
+	count += children.size();
+	for (int i = 0; i < children.size(); i++) {
+		Node *node = Object::cast_to<Node>(children[i]);
+		if (node->get_child_count(p_include_internal) > 0) {
+			count += node->get_descendant_count(p_include_internal);
+		}
+	}
+	return count;
 }
 TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
-    TypedArray<Node> res = get_children(p_include_internal);
-    TypedArray<Node> children = get_children(p_include_internal);
-    for (int i = 0; i < children.size(); i++) {
-        Node *node = Object::cast_to<Node>(children[i]);
-        if (node->get_child_count(p_include_internal) > 0) {
-            res.append_array(node->get_descendants(p_include_internal));
-        }
-    }
+	TypedArray<Node> res = get_children(p_include_internal);
+	TypedArray<Node> children = get_children(p_include_internal);
+	for (int i = 0; i < children.size(); i++) {
+		Node *node = Object::cast_to<Node>(children[i]);
+		if (node->get_child_count(p_include_internal) > 0) {
+			res.append_array(node->get_descendants(p_include_internal));
+		}
+	}
 }
 
 Node *Node::get_node_or_null(const NodePath &p_path) const {
@@ -2880,8 +2880,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_child_count", "include_internal"), &Node::get_child_count, DEFVAL(false)); // Note that the default value bound for include_internal is false, while the method is declared with true. This is because internal nodes are irrelevant for GDSCript.
 	ClassDB::bind_method(D_METHOD("get_children", "include_internal"), &Node::get_children, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
-    ClassDB::bind_method(D_METHOD("get_descendants", "include_internal"), &Node::get_descendants, DEFVAL(false));
-    ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_descendants", "include_internal"), &Node::get_descendants, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_node_or_null", "path"), &Node::get_node_or_null);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1311,7 +1311,7 @@ TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
 			res.append_array(node->get_descendants(p_include_internal));
 		}
 	}
-    return res;
+	return res;
 }
 
 Node *Node::get_node_or_null(const NodePath &p_path) const {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1293,26 +1293,23 @@ int Node::get_descendant_count(bool p_include_internal) const {
     int count = 0;
     TypedArray<Node> children = get_children(p_include_internal);
     count += children.size();
-    for(int i = 0; i < children.size(); i++) {
+    for (int i = 0; i < children.size(); i++) {
         Node *node = Object::cast_to<Node>(children[i]);
-        if(node->get_child_count(p_include_internal)>0){
-            count+= node->get_descendant_count(p_include_internal);
+        if (node->get_child_count(p_include_internal) > 0) {
+            count += node->get_descendant_count(p_include_internal);
         }
     }
     return count;
 }
 TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
     TypedArray<Node> res = get_children(p_include_internal);
-
     TypedArray<Node> children = get_children(p_include_internal);
-    for(int i = 0; i < children.size(); i++) {
+    for (int i = 0; i < children.size(); i++) {
         Node *node = Object::cast_to<Node>(children[i]);
-        if(node->get_child_count(p_include_internal)>0){
-            res.append_array( node->get_descendants(p_include_internal) );
+        if (node->get_child_count(p_include_internal) > 0) {
+            res.append_array(node->get_descendants(p_include_internal));
         }
     }
-
-    return res;
 }
 
 Node *Node::get_node_or_null(const NodePath &p_path) const {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1289,6 +1289,19 @@ Node *Node::_get_child_by_name(const StringName &p_name) const {
 	}
 }
 
+int Node::get_descendant_count(bool p_include_internal) const {
+    int count = 0;
+    TypedArray<Node> children = get_children(p_include_internal);
+    count += children.size();
+    for(int i = 0; i < children.size(); i++) {
+        Node *node = Object::cast_to<Node>(children[i]);
+        if(node->get_child_count(p_include_internal)>0){
+            count+= node->get_descendant_count(p_include_internal);
+        }
+    }
+    return count;
+}
+
 Node *Node::get_node_or_null(const NodePath &p_path) const {
 	if (p_path.is_empty()) {
 		return nullptr;
@@ -2857,6 +2870,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_child_count", "include_internal"), &Node::get_child_count, DEFVAL(false)); // Note that the default value bound for include_internal is false, while the method is declared with true. This is because internal nodes are irrelevant for GDSCript.
 	ClassDB::bind_method(D_METHOD("get_children", "include_internal"), &Node::get_children, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
+    ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_node_or_null", "path"), &Node::get_node_or_null);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1301,6 +1301,17 @@ int Node::get_descendant_count(bool p_include_internal) const {
 	}
 	return count;
 }
+
+TypedArray<Node> Node::get_ancestors() const {
+	TypedArray<Node> res;
+	const Node* current_node = this;
+	while (current_node->get_parent() != nullptr){
+		res.append(current_node);
+		current_node = current_node->get_parent();
+	}
+	return res;
+}
+
 int Node::get_ancestor_count() const {
 	int count = 0;
 	const Node* current_node = this;
@@ -2893,6 +2904,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_descendants", "include_internal"), &Node::get_descendants, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_ancestors"), &Node::get_ancestors);
 	ClassDB::bind_method(D_METHOD("get_ancestor_count"), &Node::get_ancestor_count);
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1301,6 +1301,15 @@ int Node::get_descendant_count(bool p_include_internal) const {
 	}
 	return count;
 }
+int Node::get_ancestor_count() const {
+	int count = 0;
+	const Node* current_node = this;
+	while (current_node->get_parent() != nullptr){
+		count++;
+		current_node = current_node->get_parent();
+	}
+	return count;
+}
 
 TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
 	TypedArray<Node> res = get_children(p_include_internal);
@@ -2884,6 +2893,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_descendants", "include_internal"), &Node::get_descendants, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_ancestor_count"), &Node::get_ancestor_count);
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);
 	ClassDB::bind_method(D_METHOD("get_node_or_null", "path"), &Node::get_node_or_null);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1301,6 +1301,19 @@ int Node::get_descendant_count(bool p_include_internal) const {
     }
     return count;
 }
+TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
+    TypedArray<Node> res = get_children(p_include_internal);
+
+    TypedArray<Node> children = get_children(p_include_internal);
+    for(int i = 0; i < children.size(); i++) {
+        Node *node = Object::cast_to<Node>(children[i]);
+        if(node->get_child_count(p_include_internal)>0){
+            res.append_array( node->get_descendants(p_include_internal) );
+        }
+    }
+
+    return res;
+}
 
 Node *Node::get_node_or_null(const NodePath &p_path) const {
 	if (p_path.is_empty()) {
@@ -2870,6 +2883,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_child_count", "include_internal"), &Node::get_child_count, DEFVAL(false)); // Note that the default value bound for include_internal is false, while the method is declared with true. This is because internal nodes are irrelevant for GDSCript.
 	ClassDB::bind_method(D_METHOD("get_children", "include_internal"), &Node::get_children, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_child", "idx", "include_internal"), &Node::get_child, DEFVAL(false));
+    ClassDB::bind_method(D_METHOD("get_descendants", "include_internal"), &Node::get_descendants, DEFVAL(false));
     ClassDB::bind_method(D_METHOD("get_descendant_count", "include_internal"), &Node::get_descendant_count, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_node", "path"), &Node::has_node);
 	ClassDB::bind_method(D_METHOD("get_node", "path"), &Node::get_node);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1310,6 +1310,7 @@ TypedArray<Node> Node::get_descendants(bool p_include_internal) const {
 			res.append_array(node->get_descendants(p_include_internal));
 		}
 	}
+    return res;
 }
 
 Node *Node::get_node_or_null(const NodePath &p_path) const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -331,6 +331,7 @@ public:
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
+    TypedArray<Node> get_descendants(bool p_include_internal = true) const;
     int get_descendant_count(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -332,7 +332,7 @@ public:
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
 	TypedArray<Node> get_descendants(bool p_include_internal = true) const;
-    int get_descendant_count(bool p_include_internal = true) const;
+	int get_descendant_count(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -333,6 +333,7 @@ public:
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
 	TypedArray<Node> get_descendants(bool p_include_internal = true) const;
 	int get_descendant_count(bool p_include_internal = true) const;
+	int get_ancestor_count() const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -333,6 +333,7 @@ public:
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
 	TypedArray<Node> get_descendants(bool p_include_internal = true) const;
 	int get_descendant_count(bool p_include_internal = true) const;
+	TypedArray<Node> get_ancestors() const;
 	int get_ancestor_count() const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -331,7 +331,7 @@ public:
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
-    TypedArray<Node> get_descendants(bool p_include_internal = true) const;
+	TypedArray<Node> get_descendants(bool p_include_internal = true) const;
     int get_descendant_count(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -331,6 +331,7 @@ public:
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
+    int get_descendant_count(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;


### PR DESCRIPTION
`Node.get_descendants` returns the whole descendant tree as a single array using recursion. 
`Node.get_descendant_count` returns the amount of descendants.

Example:
```
scene (script assigned here)
|_node
    |_sprite
        |_shadow
    |_lights
        |_light
        |_light
|_other node
```
```gdscript
$node.get_descendants()
```
Result: `[sprite,shadow,lights,light,light]`
