### PR TITLE
[3.x] Fix rendering tiles using nested AtlasTextures

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -564,18 +564,19 @@ void TileMap::update_dirty_quadrants() {
 			}
 
 			Ref<Texture> normal_map = tile_set->tile_get_normal_map(c.id);
-			Color modulate = tile_set->tile_get_modulate(c.id);
-			Color self_modulate = get_self_modulate();
-			modulate = Color(modulate.r * self_modulate.r, modulate.g * self_modulate.g,
-					modulate.b * self_modulate.b, modulate.a * self_modulate.a);
+			Color modulate = tile_set->tile_get_modulate(c.id) * get_self_modulate();
 			if (r == Rect2()) {
 				tex->draw_rect(canvas_item, rect, false, modulate, c.transpose, normal_map);
 			} else {
-				if (!multirect_started) {
-					multirect_started = true;
-					VisualServerCanvasHelper::tilemap_begin();
+				Rect2 dst_rect;
+				Rect2 src_rect;
+				if (tex->get_combined_rect_region(rect, r, dst_rect, src_rect)) {
+					if (!multirect_started) {
+						multirect_started = true;
+						VisualServerCanvasHelper::tilemap_begin();
+					}
+					VisualServerCanvasHelper::tilemap_add_rect(canvas_item, dst_rect, tex->get_rid(), src_rect, modulate, c.transpose, normal_map.is_valid() ? normal_map->get_rid() : RID(), clip_uv);
 				}
-				VisualServerCanvasHelper::tilemap_add_rect(canvas_item, rect, tex->get_rid(), r, modulate, c.transpose, normal_map.is_valid() ? normal_map->get_rid() : RID(), clip_uv);
 			}
 
 			Vector<TileSet::ShapeData> shapes = tile_set->tile_get_shapes(c.id);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -77,6 +77,7 @@ public:
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>(), bool p_clip_uv = true) const;
 	virtual bool get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const;
+	virtual bool get_combined_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_combined_rect, Rect2 &r_combined_src_rect) const;
 
 	virtual Ref<Image> get_data() const { return Ref<Image>(); }
 
@@ -276,6 +277,7 @@ public:
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>(), bool p_clip_uv = true) const;
 	virtual bool get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const;
+	virtual bool get_combined_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_combined_rect, Rect2 &r_combined_src_rect) const;
 
 	bool is_pixel_opaque(int p_x, int p_y) const;
 
@@ -317,7 +319,6 @@ public:
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>()) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, const Ref<Texture> &p_normal_map = Ref<Texture>(), bool p_clip_uv = true) const;
-	virtual bool get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const;
 
 	bool is_pixel_opaque(int p_x, int p_y) const;
 


### PR DESCRIPTION
In #68960 rendering TileMap tiles was changed from:
https://github.com/godotengine/godot/blob/1426cd3b3a90155b992c5b5d2ba5a2a59d883069/scene/2d/tile_map.cpp#L571
to:
https://github.com/godotengine/godot/blob/910ddd13c43bfdb024e52bd2ea29e0105f9714f1/scene/2d/tile_map.cpp#L578

AtlasTexture's override of the `Texture::draw_rect_region` was properly handling nested AtlasTextures, but `VisualServerCanvasHelper::tilemap_add_rect` is not, it uses the passed rects directly within the VisualServer.

This PR adds `Texture::get_combined_rect_region` virtual method which returns the proper final dst/src rects in case of nested AtlasTextures. Such rects can be passed to `VisualServerCanvasHelper::tilemap_add_rect` and alike.
I've changed only the TileMap to use this new method, not sure if anything else would need to be changed too (like fonts or anything else changed in #68960? :thinking:).
Not sure if that's the best solution but it works. :upside_down_face:

Fixes #76686.

Also removed `MeshTexture::get_rect_region` override as it was doing the same thing as `Texture::get_rect_region` anyway.