### PR TITLE
Fix paste value not updated in dictionaries/arrays (reverted)

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -218,6 +218,9 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 	array.set(index, p_value);
 	object->set_array(array);
 	emit_changed(get_edited_property(), array, "", true);
+	if (!p_changing) {
+		update_property();
+	}
 }
 
 void EditorPropertyArray::_change_type(Object *p_button, int p_index) {
@@ -747,6 +750,9 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 		object->set_dict(dict);
 		emit_changed(get_edited_property(), dict, "", true);
+	}
+	if (!p_changing) {
+		update_property();
 	}
 }
 


### PR DESCRIPTION
Fixes #75124


when a value of a Dictionarry/array was modified it would never call `update_property` as `emit_changed` was called with  `p_changing == true` whatever the case. 

Edit : forced the call directly to `update_property` when `p_changing == false`. This will update less and will make it work for `new_item` key and value which I didn't think of previously.
With this new approach #76795 is not fixed anymore