### PR TITLE
Fix 2D audio in multiple viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1090,6 +1090,10 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 		RenderingServer::get_singleton()->viewport_remove_canvas(viewport, current_canvas);
 	}
 
+	if (world_2d.is_valid()) {
+		world_2d->remove_viewport(this);
+	}
+
 	if (p_world_2d.is_valid()) {
 		world_2d = p_world_2d;
 	} else {
@@ -1097,6 +1101,7 @@ void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 		world_2d = Ref<World2D>(memnew(World2D));
 	}
 
+	world_2d->register_viewport(this);
 	_update_audio_listener_2d();
 
 	if (is_inside_tree()) {
@@ -4149,6 +4154,7 @@ void Viewport::_validate_property(PropertyInfo &p_property) const {
 
 Viewport::Viewport() {
 	world_2d = Ref<World2D>(memnew(World2D));
+	world_2d->register_viewport(this);
 
 	viewport = RenderingServer::get_singleton()->viewport_create();
 	texture_rid = RenderingServer::get_singleton()->viewport_get_texture(viewport);

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -82,6 +82,14 @@ PhysicsDirectSpaceState2D *World2D::get_direct_space_state() {
 	return PhysicsServer2D::get_singleton()->space_get_direct_state(get_space());
 }
 
+void World2D::register_viewport(Viewport *p_viewport) {
+	viewports.insert(p_viewport);
+}
+
+void World2D::remove_viewport(Viewport *p_viewport) {
+	viewports.erase(p_viewport);
+}
+
 World2D::World2D() {
 	canvas = RenderingServer::get_singleton()->canvas_create();
 }

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -52,15 +52,15 @@ protected:
 	static void _bind_methods();
 	friend class Viewport;
 
-	void _register_viewport(Viewport *p_viewport);
-	void _remove_viewport(Viewport *p_viewport);
-
 public:
 	RID get_canvas() const;
 	RID get_space() const;
 	RID get_navigation_map() const;
 
 	PhysicsDirectSpaceState2D *get_direct_space_state();
+
+	void register_viewport(Viewport *p_viewport);
+	void remove_viewport(Viewport *p_viewport);
 
 	_FORCE_INLINE_ const HashSet<Viewport *> &get_viewports() { return viewports; }
 


### PR DESCRIPTION
While investigating the bug, I found this:
> `TODO: This is a mediocre workaround for #50958. Remove when that bug is fixed!`

The issue was closed, but the underlying issue was still there. For whatever reason World2D had a protected method `_register_viewport()` that was never used nor even implemented (or the implementation was removed). I made it public and now Viewport will register itself when setting World2D.

This wasn't enough to fix the bug tho, because while AudioStreamPlayer had access to all viewports, the latest viewport on the list was overwriting the sample volume. I wasn't sure how to resolve it, so the final volume is composed of max channel volumes across all viewports.

Properly fixes #50958
Fixes #76634