### PR TITLE
[3.x] Augment the `InputEvent` class with a `CANCELED` state

### DIFF
--- a/core/os/input_event.h
+++ b/core/os/input_event.h
@@ -200,6 +200,9 @@ class InputEvent : public Resource {
 	int device;
 
 protected:
+	bool canceled = false;
+	bool pressed = false;
+
 	static void _bind_methods();
 
 public:
@@ -215,8 +218,9 @@ public:
 	float get_action_strength(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact_match = false) const;
 
-	// To be removed someday, since they do not make sense for all events
-	virtual bool is_pressed() const;
+	bool is_canceled() const;
+	bool is_pressed() const;
+	bool is_released() const;
 	virtual bool is_echo() const;
 	// ...-.
 
@@ -282,8 +286,6 @@ public:
 class InputEventKey : public InputEventWithModifiers {
 	GDCLASS(InputEventKey, InputEventWithModifiers);
 
-	bool pressed; /// otherwise release
-
 	uint32_t scancode; ///< check keyboard.h , KeyCode enum, without modifier masks
 	uint32_t physical_scancode;
 	uint32_t unicode; ///unicode
@@ -295,7 +297,6 @@ protected:
 
 public:
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	void set_scancode(uint32_t p_scancode);
 	uint32_t get_scancode() const;
@@ -351,7 +352,6 @@ class InputEventMouseButton : public InputEventMouse {
 
 	float factor;
 	int button_index;
-	bool pressed; //otherwise released
 	bool doubleclick; //last even less than doubleclick time
 
 protected:
@@ -365,7 +365,7 @@ public:
 	int get_button_index() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
+	void set_canceled(bool p_canceled);
 
 	void set_doubleclick(bool p_doubleclick);
 	bool is_doubleclick() const;
@@ -431,8 +431,6 @@ public:
 	void set_axis_value(float p_value);
 	float get_axis_value() const;
 
-	virtual bool is_pressed() const;
-
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, bool *p_pressed, float *p_strength, float *p_raw_strength, float p_deadzone) const;
 	virtual bool shortcut_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const;
 
@@ -446,7 +444,6 @@ class InputEventJoypadButton : public InputEvent {
 	GDCLASS(InputEventJoypadButton, InputEvent);
 
 	int button_index;
-	bool pressed;
 	float pressure; //0 to 1
 protected:
 	static void _bind_methods();
@@ -456,7 +453,6 @@ public:
 	int get_button_index() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	void set_pressure(float p_pressure);
 	float get_pressure() const;
@@ -474,7 +470,6 @@ class InputEventScreenTouch : public InputEvent {
 	GDCLASS(InputEventScreenTouch, InputEvent);
 	int index;
 	Vector2 pos;
-	bool pressed;
 	bool double_tap;
 
 protected:
@@ -488,7 +483,7 @@ public:
 	Vector2 get_position() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
+	void set_canceled(bool p_canceled);
 
 	void set_double_tap(bool p_double_tap);
 	bool is_double_tap() const;
@@ -534,7 +529,6 @@ class InputEventAction : public InputEvent {
 	GDCLASS(InputEventAction, InputEvent);
 
 	StringName action;
-	bool pressed;
 	float strength;
 
 protected:
@@ -545,7 +539,6 @@ public:
 	StringName get_action() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const;
 
 	void set_strength(float p_strength);
 	float get_strength() const;

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -71,6 +71,12 @@
 				Returns [code]true[/code] if this input event's type is one that can be assigned to an input action.
 			</description>
 		</method>
+		<method name="is_canceled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this input event has been canceled.
+			</description>
+		</method>
 		<method name="is_echo" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -82,6 +88,12 @@
 			<description>
 				Returns [code]true[/code] if this input event is pressed. Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
+			</description>
+		</method>
+		<method name="is_released" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this input event is released. Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
 			</description>
 		</method>
 		<method name="shortcut_match" qualifiers="const">

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -15,6 +15,9 @@
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" default="0">
 			The mouse button identifier, one of the [enum ButtonList] button or button wheel constants.
 		</member>
+		<member name="canceled" type="bool" setter="set_canceled" getter="is_canceled" default="false">
+			If [code]true[/code], the mouse button event has been canceled.
+		</member>
 		<member name="doubleclick" type="bool" setter="set_doubleclick" getter="is_doubleclick" default="false">
 			If [code]true[/code], the mouse button's state is a double-click.
 		</member>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -13,6 +13,9 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="canceled" type="bool" setter="set_canceled" getter="is_canceled" default="false">
+			If [code]true[/code], the touch event has been canceled.
+		</member>
 		<member name="double_tap" type="bool" setter="set_double_tap" getter="is_double_tap" default="false">
 			If [code]true[/code], the touch's state is a double tap.
 		</member>

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -360,6 +360,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			Ref<InputEventScreenTouch> touch_event;
 			touch_event.instance();
 			touch_event->set_pressed(mb->is_pressed());
+			touch_event->set_canceled(mb->is_canceled());
 			touch_event->set_position(mb->get_position());
 			touch_event->set_double_tap(mb->is_doubleclick());
 			_THREAD_SAFE_UNLOCK_
@@ -426,6 +427,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
 				button_event->set_pressed(st->is_pressed());
+				button_event->set_canceled(st->is_canceled());
 				button_event->set_button_index(BUTTON_LEFT);
 				button_event->set_doubleclick(st->is_double_tap());
 				if (st->is_pressed()) {

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -86,13 +86,13 @@ private:
 
 	void _wheel_button_click(int event_buttons_mask, const Ref<InputEventMouseButton> &ev, int wheel_button, float factor);
 
-	void _parse_mouse_event_info(int buttons_mask, bool p_pressed, bool p_double_click, bool p_source_mouse_relative);
+	void _parse_mouse_event_info(int buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative);
 
 	void _release_mouse_event_info(bool p_source_mouse_relative = false);
 
 	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
 
-	void _parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index = false);
+	void _parse_all_touch(bool p_pressed, bool p_canceled = false, bool p_double_tap = false);
 
 	void _release_all_touch();
 


### PR DESCRIPTION
The `InputEvent` class currently supports the `pressed` and `released` states, which given the binary nature, is represented by a `bool` field. 
This PR introduces the `CANCELED` state, which signals that an ongoing input event has been canceled. 
To represent all the states, the `InputEventState` enum is added and the `InputEvent` logic is refactored accordingly.

Fixes https://github.com/godotengine/godot/issues/75144
Address https://github.com/godotengine/godot/issues/74199

[main version](https://github.com/godotengine/godot/pull/76719)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
