### PR TITLE
Add venv and .venv to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ tests/data/*.translation
 # Binutils tmp linker output of the form "stXXXXXX" where "X" is alphanumeric
 st[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]
 
+# Python development
+.venv
+venv
+
 # Python generated
 __pycache__/
 *.pyc


### PR DESCRIPTION
I want to install scons in a virtual environment to keep it isolated from other python projects on my system.

It's common in any python project to name your virtual environment `venv` and place it at the root of your repo, so I believe this belongs in the `.gitignore`
