### PR TITLE
Augment the `InputEvent` class with a `CANCELED` state

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -542,6 +542,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			Ref<InputEventScreenTouch> touch_event;
 			touch_event.instantiate();
 			touch_event->set_pressed(mb->is_pressed());
+			touch_event->set_canceled(mb->is_canceled());
 			touch_event->set_position(mb->get_position());
 			touch_event->set_double_tap(mb->is_double_click());
 			touch_event->set_device(InputEvent::DEVICE_ID_EMULATION);
@@ -613,6 +614,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				button_event->set_position(st->get_position());
 				button_event->set_global_position(st->get_position());
 				button_event->set_pressed(st->is_pressed());
+				button_event->set_canceled(st->is_canceled());
 				button_event->set_button_index(MouseButton::LEFT);
 				button_event->set_double_click(st->is_double_tap());
 

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -52,15 +52,15 @@ bool InputEvent::is_action(const StringName &p_action, bool p_exact_match) const
 }
 
 bool InputEvent::is_action_pressed(const StringName &p_action, bool p_allow_echo, bool p_exact_match) const {
-	bool pressed;
-	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>(const_cast<InputEvent *>(this)), p_action, p_exact_match, &pressed, nullptr, nullptr);
-	return valid && pressed && (p_allow_echo || !is_echo());
+	bool pressed_state;
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>(const_cast<InputEvent *>(this)), p_action, p_exact_match, &pressed_state, nullptr, nullptr);
+	return valid && pressed_state && (p_allow_echo || !is_echo());
 }
 
 bool InputEvent::is_action_released(const StringName &p_action, bool p_exact_match) const {
-	bool pressed;
-	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>(const_cast<InputEvent *>(this)), p_action, p_exact_match, &pressed, nullptr, nullptr);
-	return valid && !pressed;
+	bool pressed_state;
+	bool valid = InputMap::get_singleton()->event_get_action_status(Ref<InputEvent>(const_cast<InputEvent *>(this)), p_action, p_exact_match, &pressed_state, nullptr, nullptr);
+	return valid && !pressed_state;
 }
 
 float InputEvent::get_action_strength(const StringName &p_action, bool p_exact_match) const {
@@ -75,8 +75,16 @@ float InputEvent::get_action_raw_strength(const StringName &p_action, bool p_exa
 	return valid ? raw_strength : 0.0f;
 }
 
+bool InputEvent::is_canceled() const {
+	return canceled;
+}
+
 bool InputEvent::is_pressed() const {
-	return false;
+	return pressed && !canceled;
+}
+
+bool InputEvent::is_released() const {
+	return !pressed && !canceled;
 }
 
 bool InputEvent::is_echo() const {
@@ -108,7 +116,9 @@ void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_released", "action", "exact_match"), &InputEvent::is_action_released, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action", "exact_match"), &InputEvent::get_action_strength, DEFVAL(false));
 
+	ClassDB::bind_method(D_METHOD("is_canceled"), &InputEvent::is_canceled);
 	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEvent::is_pressed);
+	ClassDB::bind_method(D_METHOD("is_released"), &InputEvent::is_released);
 	ClassDB::bind_method(D_METHOD("is_echo"), &InputEvent::is_echo);
 
 	ClassDB::bind_method(D_METHOD("as_text"), &InputEvent::as_text);
@@ -316,10 +326,6 @@ void InputEventWithModifiers::_validate_property(PropertyInfo &p_property) const
 void InputEventKey::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
 	emit_changed();
-}
-
-bool InputEventKey::is_pressed() const {
-	return pressed;
 }
 
 void InputEventKey::set_keycode(Key p_keycode) {
@@ -668,8 +674,8 @@ void InputEventMouseButton::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
 }
 
-bool InputEventMouseButton::is_pressed() const {
-	return pressed;
+void InputEventMouseButton::set_canceled(bool p_canceled) {
+	canceled = p_canceled;
 }
 
 void InputEventMouseButton::set_double_click(bool p_double_click) {
@@ -696,6 +702,7 @@ Ref<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, co
 
 	mb->set_button_mask(get_button_mask());
 	mb->set_pressed(pressed);
+	mb->set_canceled(canceled);
 	mb->set_double_click(double_click);
 	mb->set_factor(factor);
 	mb->set_button_index(button_index);
@@ -791,6 +798,7 @@ String InputEventMouseButton::as_text() const {
 
 String InputEventMouseButton::to_string() {
 	String p = is_pressed() ? "true" : "false";
+	String canceled_state = is_canceled() ? "true" : "false";
 	String d = double_click ? "true" : "false";
 
 	MouseButton idx = get_button_index();
@@ -817,7 +825,7 @@ String InputEventMouseButton::to_string() {
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String index_and_mods = vformat("button_index=%s, mods=%s", button_index, mods);
-	return vformat("InputEventMouseButton: %s, pressed=%s, position=(%s), button_mask=%d, double_click=%s", index_and_mods, p, String(get_position()), get_button_mask(), d);
+	return vformat("InputEventMouseButton: %s, pressed=%s, canceled=%s, position=(%s), button_mask=%d, double_click=%s", index_and_mods, p, canceled_state, String(get_position()), get_button_mask(), d);
 }
 
 void InputEventMouseButton::_bind_methods() {
@@ -828,13 +836,14 @@ void InputEventMouseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_button_index"), &InputEventMouseButton::get_button_index);
 
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventMouseButton::set_pressed);
-	//	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventMouseButton::is_pressed);
+	ClassDB::bind_method(D_METHOD("set_canceled", "canceled"), &InputEventMouseButton::set_canceled);
 
 	ClassDB::bind_method(D_METHOD("set_double_click", "double_click"), &InputEventMouseButton::set_double_click);
 	ClassDB::bind_method(D_METHOD("is_double_click"), &InputEventMouseButton::is_double_click);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "factor"), "set_factor", "get_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_index"), "set_button_index", "get_button_index");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "canceled"), "set_canceled", "is_canceled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "double_click"), "set_double_click", "is_double_click");
 }
@@ -942,6 +951,10 @@ bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
+	if (is_canceled() != motion->is_canceled()) {
+		return false;
+	}
+
 	if (is_pressed() != motion->is_pressed()) {
 		return false;
 	}
@@ -1012,15 +1025,12 @@ JoyAxis InputEventJoypadMotion::get_axis() const {
 
 void InputEventJoypadMotion::set_axis_value(float p_value) {
 	axis_value = p_value;
+	pressed = Math::abs(axis_value) >= 0.5f;
 	emit_changed();
 }
 
 float InputEventJoypadMotion::get_axis_value() const {
 	return axis_value;
-}
-
-bool InputEventJoypadMotion::is_pressed() const {
-	return Math::abs(axis_value) >= 0.5f;
 }
 
 bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const {
@@ -1037,12 +1047,12 @@ bool InputEventJoypadMotion::action_match(const Ref<InputEvent> &p_event, bool p
 	if (match) {
 		float jm_abs_axis_value = Math::abs(jm->get_axis_value());
 		bool same_direction = (((axis_value < 0) == (jm->axis_value < 0)) || jm->axis_value == 0);
-		bool pressed = same_direction && jm_abs_axis_value >= p_deadzone;
+		bool pressed_state = same_direction && jm_abs_axis_value >= p_deadzone;
 		if (r_pressed != nullptr) {
-			*r_pressed = pressed;
+			*r_pressed = pressed_state;
 		}
 		if (r_strength != nullptr) {
-			if (pressed) {
+			if (pressed_state) {
 				if (p_deadzone == 1.0f) {
 					*r_strength = 1.0f;
 				} else {
@@ -1120,10 +1130,6 @@ JoyButton InputEventJoypadButton::get_button_index() const {
 
 void InputEventJoypadButton::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
-}
-
-bool InputEventJoypadButton::is_pressed() const {
-	return pressed;
 }
 
 void InputEventJoypadButton::set_pressure(float p_pressure) {
@@ -1206,7 +1212,7 @@ String InputEventJoypadButton::as_text() const {
 }
 
 String InputEventJoypadButton::to_string() {
-	String p = pressed ? "true" : "false";
+	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventJoypadButton: button_index=%d, pressed=%s, pressure=%.2f", button_index, p, pressure);
 }
 
@@ -1226,7 +1232,6 @@ void InputEventJoypadButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pressure"), &InputEventJoypadButton::get_pressure);
 
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventJoypadButton::set_pressed);
-	//	ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventJoypadButton::is_pressed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_index"), "set_button_index", "get_button_index");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure"), "set_pressure", "get_pressure");
@@ -1255,8 +1260,8 @@ void InputEventScreenTouch::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
 }
 
-bool InputEventScreenTouch::is_pressed() const {
-	return pressed;
+void InputEventScreenTouch::set_canceled(bool p_canceled) {
+	canceled = p_canceled;
 }
 
 void InputEventScreenTouch::set_double_tap(bool p_double_tap) {
@@ -1274,21 +1279,23 @@ Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, co
 	st->set_index(index);
 	st->set_position(p_xform.xform(pos + p_local_ofs));
 	st->set_pressed(pressed);
+	st->set_canceled(canceled);
 	st->set_double_tap(double_tap);
 
 	return st;
 }
 
 String InputEventScreenTouch::as_text() const {
-	String status = pressed ? RTR("touched") : RTR("released");
+	String status = canceled ? RTR("canceled") : (pressed ? RTR("touched") : RTR("released"));
 
 	return vformat(RTR("Screen %s at (%s) with %s touch points"), status, String(get_position()), itos(index));
 }
 
 String InputEventScreenTouch::to_string() {
 	String p = pressed ? "true" : "false";
+	String canceled_state = canceled ? "true" : "false";
 	String double_tap_string = double_tap ? "true" : "false";
-	return vformat("InputEventScreenTouch: index=%d, pressed=%s, position=(%s), double_tap=%s", index, p, String(get_position()), double_tap_string);
+	return vformat("InputEventScreenTouch: index=%d, pressed=%s, canceled=%s, position=(%s), double_tap=%s", index, p, canceled_state, String(get_position()), double_tap_string);
 }
 
 void InputEventScreenTouch::_bind_methods() {
@@ -1299,13 +1306,14 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position"), &InputEventScreenTouch::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventScreenTouch::set_pressed);
-	//ClassDB::bind_method(D_METHOD("is_pressed"),&InputEventScreenTouch::is_pressed);
+	ClassDB::bind_method(D_METHOD("set_canceled", "canceled"), &InputEventScreenTouch::set_canceled);
 
 	ClassDB::bind_method(D_METHOD("set_double_tap", "double_tap"), &InputEventScreenTouch::set_double_tap);
 	ClassDB::bind_method(D_METHOD("is_double_tap"), &InputEventScreenTouch::is_double_tap);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "canceled"), "set_canceled", "is_canceled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "double_tap"), "set_double_tap", "is_double_tap");
 }
@@ -1457,10 +1465,6 @@ void InputEventAction::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
 }
 
-bool InputEventAction::is_pressed() const {
-	return pressed;
-}
-
 void InputEventAction::set_strength(float p_strength) {
 	strength = CLAMP(p_strength, 0.0f, 1.0f);
 }
@@ -1489,7 +1493,7 @@ bool InputEventAction::action_match(const Ref<InputEvent> &p_event, bool p_exact
 
 	bool match = action == act->action;
 	if (match) {
-		bool act_pressed = act->pressed;
+		bool act_pressed = act->is_pressed();
 		if (r_pressed != nullptr) {
 			*r_pressed = act_pressed;
 		}
@@ -1520,7 +1524,7 @@ String InputEventAction::as_text() const {
 }
 
 String InputEventAction::to_string() {
-	String p = pressed ? "true" : "false";
+	String p = is_pressed() ? "true" : "false";
 	return vformat("InputEventAction: action=\"%s\", pressed=%s", action, p);
 }
 
@@ -1529,12 +1533,9 @@ void InputEventAction::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_action"), &InputEventAction::get_action);
 
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventAction::set_pressed);
-	//ClassDB::bind_method(D_METHOD("is_pressed"), &InputEventAction::is_pressed);
 
 	ClassDB::bind_method(D_METHOD("set_strength", "strength"), &InputEventAction::set_strength);
 	ClassDB::bind_method(D_METHOD("get_strength"), &InputEventAction::get_strength);
-
-	//	ClassDB::bind_method(D_METHOD("is_action", "name"), &InputEventAction::is_action);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
@@ -1756,10 +1757,6 @@ void InputEventShortcut::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_shortcut"), &InputEventShortcut::get_shortcut);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "Shortcut"), "set_shortcut", "get_shortcut");
-}
-
-bool InputEventShortcut::is_pressed() const {
-	return true;
 }
 
 String InputEventShortcut::as_text() const {

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -56,6 +56,9 @@ class InputEvent : public Resource {
 	int device = 0;
 
 protected:
+	bool canceled = false;
+	bool pressed = false;
+
 	static void _bind_methods();
 
 public:
@@ -71,8 +74,9 @@ public:
 	float get_action_strength(const StringName &p_action, bool p_exact_match = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact_match = false) const;
 
-	// To be removed someday, since they do not make sense for all events
-	virtual bool is_pressed() const;
+	bool is_canceled() const;
+	bool is_pressed() const;
+	bool is_released() const;
 	virtual bool is_echo() const;
 
 	virtual String as_text() const = 0;
@@ -149,8 +153,6 @@ public:
 class InputEventKey : public InputEventWithModifiers {
 	GDCLASS(InputEventKey, InputEventWithModifiers);
 
-	bool pressed = false; /// otherwise release
-
 	Key keycode = Key::NONE; // Key enum, without modifier masks.
 	Key physical_keycode = Key::NONE;
 	Key key_label = Key::NONE;
@@ -163,7 +165,6 @@ protected:
 
 public:
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const override;
 
 	void set_keycode(Key p_keycode);
 	Key get_keycode() const;
@@ -229,7 +230,6 @@ class InputEventMouseButton : public InputEventMouse {
 
 	float factor = 1;
 	MouseButton button_index = MouseButton::NONE;
-	bool pressed = false; //otherwise released
 	bool double_click = false; //last even less than double click time
 
 protected:
@@ -243,7 +243,7 @@ public:
 	MouseButton get_button_index() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const override;
+	void set_canceled(bool p_canceled);
 
 	void set_double_click(bool p_double_click);
 	bool is_double_click() const;
@@ -312,8 +312,6 @@ public:
 	void set_axis_value(float p_value);
 	float get_axis_value() const;
 
-	virtual bool is_pressed() const override;
-
 	virtual bool action_match(const Ref<InputEvent> &p_event, bool p_exact_match, float p_deadzone, bool *r_pressed, float *r_strength, float *r_raw_strength) const override;
 	virtual bool is_match(const Ref<InputEvent> &p_event, bool p_exact_match = true) const override;
 
@@ -328,7 +326,6 @@ class InputEventJoypadButton : public InputEvent {
 	GDCLASS(InputEventJoypadButton, InputEvent);
 
 	JoyButton button_index = (JoyButton)0;
-	bool pressed = false;
 	float pressure = 0; //0 to 1
 protected:
 	static void _bind_methods();
@@ -338,7 +335,6 @@ public:
 	JoyButton get_button_index() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const override;
 
 	void set_pressure(float p_pressure);
 	float get_pressure() const;
@@ -360,7 +356,6 @@ class InputEventScreenTouch : public InputEventFromWindow {
 	GDCLASS(InputEventScreenTouch, InputEventFromWindow);
 	int index = 0;
 	Vector2 pos;
-	bool pressed = false;
 	bool double_tap = false;
 
 protected:
@@ -374,7 +369,7 @@ public:
 	Vector2 get_position() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const override;
+	void set_canceled(bool p_canceled);
 
 	void set_double_tap(bool p_double_tap);
 	bool is_double_tap() const;
@@ -434,7 +429,6 @@ class InputEventAction : public InputEvent {
 	GDCLASS(InputEventAction, InputEvent);
 
 	StringName action;
-	bool pressed = false;
 	float strength = 1.0f;
 
 protected:
@@ -445,7 +439,6 @@ public:
 	StringName get_action() const;
 
 	void set_pressed(bool p_pressed);
-	virtual bool is_pressed() const override;
 
 	void set_strength(float p_strength);
 	float get_strength() const;
@@ -569,7 +562,6 @@ protected:
 public:
 	void set_shortcut(Ref<Shortcut> p_shortcut);
 	Ref<Shortcut> get_shortcut();
-	virtual bool is_pressed() const override;
 
 	virtual String as_text() const override;
 	virtual String to_string() override;

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -71,6 +71,12 @@
 				Returns [code]true[/code] if this input event's type is one that can be assigned to an input action.
 			</description>
 		</method>
+		<method name="is_canceled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this input event has been canceled.
+			</description>
+		</method>
 		<method name="is_echo" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -91,6 +97,12 @@
 			<description>
 				Returns [code]true[/code] if this input event is pressed. Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
 				[b]Note:[/b] Due to keyboard ghosting, [method is_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
+			</description>
+		</method>
+		<method name="is_released" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this input event is released. Not relevant for events of type [InputEventMouseMotion] or [InputEventScreenDrag].
 			</description>
 		</method>
 		<method name="xformed_by" qualifiers="const">

--- a/doc/classes/InputEventMouseButton.xml
+++ b/doc/classes/InputEventMouseButton.xml
@@ -13,6 +13,9 @@
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" enum="MouseButton" default="0">
 			The mouse button identifier, one of the [enum MouseButton] button or button wheel constants.
 		</member>
+		<member name="canceled" type="bool" setter="set_canceled" getter="is_canceled" default="false">
+			If [code]true[/code], the mouse button event has been canceled.
+		</member>
 		<member name="double_click" type="bool" setter="set_double_click" getter="is_double_click" default="false">
 			If [code]true[/code], the mouse button's state is a double-click.
 		</member>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -11,6 +11,9 @@
 		<link title="InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>
 	</tutorials>
 	<members>
+		<member name="canceled" type="bool" setter="set_canceled" getter="is_canceled" default="false">
+			If [code]true[/code], the touch event has been canceled.
+		</member>
 		<member name="double_tap" type="bool" setter="set_double_tap" getter="is_double_tap" default="false">
 			If [code]true[/code], the touch's state is a double tap.
 		</member>

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -138,22 +138,19 @@ void AndroidInputHandler::process_key_event(int p_physical_keycode, int p_unicod
 }
 
 void AndroidInputHandler::_cancel_all_touch() {
-	_parse_all_touch(false, false, true);
+	_parse_all_touch(false, true);
 	touch.clear();
 }
 
-void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index) {
+void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled, bool p_double_tap) {
 	if (touch.size()) {
 		//end all if exist
 		for (int i = 0; i < touch.size(); i++) {
 			Ref<InputEventScreenTouch> ev;
 			ev.instantiate();
-			if (reset_index) {
-				ev->set_index(-1);
-			} else {
-				ev->set_index(touch[i].id);
-			}
+			ev->set_index(touch[i].id);
 			ev->set_pressed(p_pressed);
+			ev->set_canceled(p_canceled);
 			ev->set_position(touch[i].pos);
 			ev->set_double_tap(p_double_tap);
 			Input::get_singleton()->parse_input_event(ev);
@@ -180,7 +177,7 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 			}
 
 			//send touch
-			_parse_all_touch(true, p_double_tap);
+			_parse_all_touch(true, false, p_double_tap);
 
 		} break;
 		case AMOTION_EVENT_ACTION_MOVE: { //motion
@@ -257,11 +254,11 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 
 void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative) {
 	buttons_state = BitField<MouseButtonMask>();
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, p_source_mouse_relative);
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, true, false, p_source_mouse_relative);
 	mouse_event_info.valid = false;
 }
 
-void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_double_click, bool p_source_mouse_relative) {
+void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative) {
 	if (!mouse_event_info.valid) {
 		return;
 	}
@@ -278,6 +275,7 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 		hover_prev_pos = mouse_event_info.pos;
 	}
 	ev->set_pressed(p_pressed);
+	ev->set_canceled(p_canceled);
 	BitField<MouseButtonMask> changed_button_mask = BitField<MouseButtonMask>(buttons_state.operator int64_t() ^ event_buttons_mask.operator int64_t());
 
 	buttons_state = event_buttons_mask;
@@ -289,7 +287,7 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 }
 
 void AndroidInputHandler::_release_mouse_event_info(bool p_source_mouse_relative) {
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, p_source_mouse_relative);
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, false, p_source_mouse_relative);
 	mouse_event_info.valid = false;
 }
 
@@ -318,7 +316,7 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 
 			mouse_event_info.valid = true;
 			mouse_event_info.pos = p_event_pos;
-			_parse_mouse_event_info(event_buttons_mask, true, p_double_click, p_source_mouse_relative);
+			_parse_mouse_event_info(event_buttons_mask, true, false, p_double_click, p_source_mouse_relative);
 		} break;
 
 		case AMOTION_EVENT_ACTION_CANCEL: {

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -83,13 +83,13 @@ private:
 
 	void _wheel_button_click(BitField<MouseButtonMask> event_buttons_mask, const Ref<InputEventMouseButton> &ev, MouseButton wheel_button, float factor);
 
-	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_double_click, bool p_source_mouse_relative);
+	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative);
 
 	void _release_mouse_event_info(bool p_source_mouse_relative = false);
 
 	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
 
-	void _parse_all_touch(bool p_pressed, bool p_double_tap, bool reset_index = false);
+	void _parse_all_touch(bool p_pressed, bool p_canceled = false, bool p_double_tap = false);
 
 	void _release_all_touch();
 


### PR DESCRIPTION
The `InputEvent` class currently supports the `pressed` and `released` states, which given the binary nature, is represented by a `bool` field. 
This PR introduces the `CANCELED` state, which signals that an ongoing input event has been canceled. 
To represent all the states, the `InputEventState` enum is added and the `InputEvent` logic is refactored accordingly.

Fixes https://github.com/godotengine/godot/issues/75144
Address https://github.com/godotengine/godot/issues/74199

[3.x version](https://github.com/godotengine/godot/pull/76715)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
