### PR TITLE
Make documentation sorting use natural order

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -137,7 +137,7 @@ public:
 					return arguments[0] < p_method.arguments[0];
 				}
 			}
-			return name < p_method.name;
+			return name.naturalcasecmp_to(p_method.name) < 0;
 		}
 		static MethodDoc from_dict(const Dictionary &p_dict) {
 			MethodDoc doc;
@@ -327,7 +327,7 @@ public:
 		bool is_deprecated = false;
 		bool is_experimental = false;
 		bool operator<(const PropertyDoc &p_prop) const {
-			return name < p_prop.name;
+			return name.naturalcasecmp_to(p_prop.name) < 0;
 		}
 		static PropertyDoc from_dict(const Dictionary &p_dict) {
 			PropertyDoc doc;
@@ -432,7 +432,7 @@ public:
 		bool operator<(const ThemeItemDoc &p_theme_item) const {
 			// First sort by the data type, then by name.
 			if (data_type == p_theme_item.data_type) {
-				return name < p_theme_item.name;
+				return name.naturalcasecmp_to(p_theme_item.name) < 0;
 			}
 			return data_type < p_theme_item.data_type;
 		}

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -94,6 +94,12 @@
 				[b]Note:[/b] Only call [method flush] when you actually need it. Otherwise, it will decrease performance due to constant disk writes.
 			</description>
 		</method>
+		<method name="get_8" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 8 bits from the file as an integer. See [method store_8] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
 		<method name="get_16" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -110,12 +116,6 @@
 			<return type="int" />
 			<description>
 				Returns the next 64 bits from the file as an integer. See [method store_64] for details on what values can be stored and retrieved this way.
-			</description>
-		</method>
-		<method name="get_8" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the next 8 bits from the file as an integer. See [method store_8] for details on what values can be stored and retrieved this way.
 			</description>
 		</method>
 		<method name="get_as_text" qualifiers="const">
@@ -322,6 +322,15 @@
 				[b]Note:[/b] This is an offset, so you should use negative numbers or the cursor will be at the end of the file.
 			</description>
 		</method>
+		<method name="store_8">
+			<return type="void" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an integer as 8 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
+				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
+			</description>
+		</method>
 		<method name="store_16">
 			<return type="void" />
 			<param index="0" name="value" type="int" />
@@ -378,15 +387,6 @@
 			<description>
 				Stores an integer as 64 bits in the file.
 				[b]Note:[/b] The [param value] must lie in the interval [code][-2^63, 2^63 - 1][/code] (i.e. be a valid [int] value).
-			</description>
-		</method>
-		<method name="store_8">
-			<return type="void" />
-			<param index="0" name="value" type="int" />
-			<description>
-				Stores an integer as 8 bits in the file.
-				[b]Note:[/b] The [param value] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
-				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
 			</description>
 		</method>
 		<method name="store_buffer">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -382,17 +382,17 @@
 				Converts a standard RGBE (Red Green Blue Exponent) image to an sRGB image.
 			</description>
 		</method>
-		<method name="rotate_180">
-			<return type="void" />
-			<description>
-				Rotates the image by [code]180[/code] degrees. The width and height of the image must be greater than [code]1[/code].
-			</description>
-		</method>
 		<method name="rotate_90">
 			<return type="void" />
 			<param index="0" name="direction" type="int" enum="ClockDirection" />
 			<description>
 				Rotates the image in the specified [param direction] by [code]90[/code] degrees. The width and height of the image must be greater than [code]1[/code]. If the width and height are not equal, the image will be resized.
+			</description>
+		</method>
+		<method name="rotate_180">
+			<return type="void" />
+			<description>
+				Rotates the image by [code]180[/code] degrees. The width and height of the image must be greater than [code]1[/code].
 			</description>
 		</method>
 		<method name="save_exr" qualifiers="const">

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -96,6 +96,13 @@
 				Decodes a 16-bit floating point number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0.0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
+		<method name="decode_s8" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="byte_offset" type="int" />
+			<description>
+				Decodes a 8-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+			</description>
+		</method>
 		<method name="decode_s16" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
@@ -117,11 +124,11 @@
 				Decodes a 64-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
-		<method name="decode_s8" qualifiers="const">
+		<method name="decode_u8" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="byte_offset" type="int" />
 			<description>
-				Decodes a 8-bit signed integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
+				Decodes a 8-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
 		<method name="decode_u16" qualifiers="const">
@@ -143,13 +150,6 @@
 			<param index="0" name="byte_offset" type="int" />
 			<description>
 				Decodes a 64-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
-			</description>
-		</method>
-		<method name="decode_u8" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="byte_offset" type="int" />
-			<description>
-				Decodes a 8-bit unsigned integer number from the bytes starting at [param byte_offset]. Fails if the byte count is insufficient. Returns [code]0[/code] if a valid number can't be decoded.
 			</description>
 		</method>
 		<method name="decode_var" qualifiers="const">
@@ -216,6 +216,14 @@
 				Encodes a 16-bit floating point number as bytes at the index of [param byte_offset] bytes. The array must have at least 2 bytes of space, starting at the offset.
 			</description>
 		</method>
+		<method name="encode_s8">
+			<return type="void" />
+			<param index="0" name="byte_offset" type="int" />
+			<param index="1" name="value" type="int" />
+			<description>
+				Encodes a 8-bit signed integer number (signed byte) at the index of [param byte_offset] bytes. The array must have at least 1 byte of space, starting at the offset.
+			</description>
+		</method>
 		<method name="encode_s16">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
@@ -240,12 +248,12 @@
 				Encodes a 64-bit signed integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 8 bytes of space, starting at the offset.
 			</description>
 		</method>
-		<method name="encode_s8">
+		<method name="encode_u8">
 			<return type="void" />
 			<param index="0" name="byte_offset" type="int" />
 			<param index="1" name="value" type="int" />
 			<description>
-				Encodes a 8-bit signed integer number (signed byte) at the index of [param byte_offset] bytes. The array must have at least 1 byte of space, starting at the offset.
+				Encodes a 8-bit unsigned integer number (byte) at the index of [param byte_offset] bytes. The array must have at least 1 byte of space, starting at the offset.
 			</description>
 		</method>
 		<method name="encode_u16">
@@ -270,14 +278,6 @@
 			<param index="1" name="value" type="int" />
 			<description>
 				Encodes a 64-bit unsigned integer number as bytes at the index of [param byte_offset] bytes. The array must have at least 8 bytes of space, starting at the offset.
-			</description>
-		</method>
-		<method name="encode_u8">
-			<return type="void" />
-			<param index="0" name="byte_offset" type="int" />
-			<param index="1" name="value" type="int" />
-			<description>
-				Encodes a 8-bit unsigned integer number (byte) at the index of [param byte_offset] bytes. The array must have at least 1 byte of space, starting at the offset.
 			</description>
 		</method>
 		<method name="encode_var">
@@ -310,6 +310,12 @@
 				Converts ASCII/Latin-1 encoded array to [String]. Fast alternative to [method get_string_from_utf8] if the content is ASCII/Latin-1 only. Unlike the UTF-8 function this function maps every byte to a character in the array. Multibyte sequences will not be interpreted correctly. For parsing user input always use [method get_string_from_utf8].
 			</description>
 		</method>
+		<method name="get_string_from_utf8" qualifiers="const">
+			<return type="String" />
+			<description>
+				Converts UTF-8 encoded array to [String]. Slower than [method get_string_from_ascii] but supports UTF-8 encoded data. Use this function if you are unsure about the source of the data. For user input this function should always be preferred. Returns empty string if source array is not valid UTF-8 string.
+			</description>
+		</method>
 		<method name="get_string_from_utf16" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -320,12 +326,6 @@
 			<return type="String" />
 			<description>
 				Converts UTF-32 encoded array to [String]. System endianness is assumed. Returns empty string if source array is not valid UTF-32 string.
-			</description>
-		</method>
-		<method name="get_string_from_utf8" qualifiers="const">
-			<return type="String" />
-			<description>
-				Converts UTF-8 encoded array to [String]. Slower than [method get_string_from_ascii] but supports UTF-8 encoded data. Use this function if you are unsure about the source of the data. For user input this function should always be preferred. Returns empty string if source array is not valid UTF-8 string.
 			</description>
 		</method>
 		<method name="get_string_from_wchar" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1242,6 +1242,30 @@
 		<member name="layer_names/2d_navigation/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 1. If left empty, the layer will display as "Layer 1".
 		</member>
+		<member name="layer_names/2d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/2d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/2d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/2d_navigation/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/2d_navigation/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/2d_navigation/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/2d_navigation/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/2d_navigation/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D navigation layer 9. If left empty, the layer will display as "Layer 9".
+		</member>
 		<member name="layer_names/2d_navigation/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 10. If left empty, the layer will display as "Layer 10".
 		</member>
@@ -1271,9 +1295,6 @@
 		</member>
 		<member name="layer_names/2d_navigation/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 19. If left empty, the layer will display as "Layer 19".
-		</member>
-		<member name="layer_names/2d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 2. If left empty, the layer will display as "Layer 2".
 		</member>
 		<member name="layer_names/2d_navigation/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 20. If left empty, the layer will display as "Layer 20".
@@ -1305,9 +1326,6 @@
 		<member name="layer_names/2d_navigation/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 29. If left empty, the layer will display as "Layer 29".
 		</member>
-		<member name="layer_names/2d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
 		<member name="layer_names/2d_navigation/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 30. If left empty, the layer will display as "Layer 30".
 		</member>
@@ -1317,26 +1335,32 @@
 		<member name="layer_names/2d_navigation/layer_32" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D navigation layer 32. If left empty, the layer will display as "Layer 32".
 		</member>
-		<member name="layer_names/2d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/2d_navigation/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/2d_navigation/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/2d_navigation/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/2d_navigation/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/2d_navigation/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D navigation layer 9. If left empty, the layer will display as "Layer 9".
-		</member>
 		<member name="layer_names/2d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 1. If left empty, the layer will display as "Layer 1".
+		</member>
+		<member name="layer_names/2d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/2d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/2d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/2d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/2d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/2d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/2d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/2d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D physics layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="layer_names/2d_physics/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 10. If left empty, the layer will display as "Layer 10".
@@ -1368,9 +1392,6 @@
 		<member name="layer_names/2d_physics/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
-		<member name="layer_names/2d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 2. If left empty, the layer will display as "Layer 2".
-		</member>
 		<member name="layer_names/2d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 20. If left empty, the layer will display as "Layer 20".
 		</member>
@@ -1401,9 +1422,6 @@
 		<member name="layer_names/2d_physics/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 29. If left empty, the layer will display as "Layer 29".
 		</member>
-		<member name="layer_names/2d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
 		<member name="layer_names/2d_physics/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 30. If left empty, the layer will display as "Layer 30".
 		</member>
@@ -1413,26 +1431,32 @@
 		<member name="layer_names/2d_physics/layer_32" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D physics layer 32. If left empty, the layer will display as "Layer 32".
 		</member>
-		<member name="layer_names/2d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/2d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/2d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/2d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/2d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/2d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D physics layer 9. If left empty, the layer will display as "Layer 9".
-		</member>
 		<member name="layer_names/2d_render/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D render layer 1. If left empty, the layer will display as "Layer 1".
+		</member>
+		<member name="layer_names/2d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/2d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/2d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/2d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/2d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/2d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/2d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/2d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 2D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="layer_names/2d_render/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D render layer 10. If left empty, the layer will display as "Layer 10".
@@ -1464,35 +1488,35 @@
 		<member name="layer_names/2d_render/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D render layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
-		<member name="layer_names/2d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 2. If left empty, the layer will display as "Layer 2".
-		</member>
 		<member name="layer_names/2d_render/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 2D render layer 20. If left empty, the layer will display as "Layer 20".
 		</member>
-		<member name="layer_names/2d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
-		<member name="layer_names/2d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/2d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/2d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/2d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/2d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/2d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 2D render layer 9. If left empty, the layer will display as "Layer 9".
-		</member>
 		<member name="layer_names/3d_navigation/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 1. If left empty, the layer will display as "Layer 1".
+		</member>
+		<member name="layer_names/3d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/3d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/3d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/3d_navigation/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/3d_navigation/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/3d_navigation/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/3d_navigation/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/3d_navigation/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D navigation layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="layer_names/3d_navigation/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 10. If left empty, the layer will display as "Layer 10".
@@ -1524,9 +1548,6 @@
 		<member name="layer_names/3d_navigation/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
-		<member name="layer_names/3d_navigation/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 2. If left empty, the layer will display as "Layer 2".
-		</member>
 		<member name="layer_names/3d_navigation/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 20. If left empty, the layer will display as "Layer 20".
 		</member>
@@ -1557,9 +1578,6 @@
 		<member name="layer_names/3d_navigation/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 29. If left empty, the layer will display as "Layer 29".
 		</member>
-		<member name="layer_names/3d_navigation/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
 		<member name="layer_names/3d_navigation/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 30. If left empty, the layer will display as "Layer 30".
 		</member>
@@ -1569,26 +1587,32 @@
 		<member name="layer_names/3d_navigation/layer_32" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D navigation layer 32. If left empty, the layer will display as "Layer 32".
 		</member>
-		<member name="layer_names/3d_navigation/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/3d_navigation/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/3d_navigation/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/3d_navigation/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/3d_navigation/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/3d_navigation/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D navigation layer 9. If left empty, the layer will display as "Layer 9".
-		</member>
 		<member name="layer_names/3d_physics/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 1. If left empty, the layer will display as "Layer 1".
+		</member>
+		<member name="layer_names/3d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/3d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/3d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/3d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/3d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/3d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/3d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/3d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D physics layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="layer_names/3d_physics/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 10. If left empty, the layer will display as "Layer 10".
@@ -1620,9 +1644,6 @@
 		<member name="layer_names/3d_physics/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
-		<member name="layer_names/3d_physics/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 2. If left empty, the layer will display as "Layer 2".
-		</member>
 		<member name="layer_names/3d_physics/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 20. If left empty, the layer will display as "Layer 20".
 		</member>
@@ -1653,9 +1674,6 @@
 		<member name="layer_names/3d_physics/layer_29" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 29. If left empty, the layer will display as "Layer 29".
 		</member>
-		<member name="layer_names/3d_physics/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
 		<member name="layer_names/3d_physics/layer_30" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 30. If left empty, the layer will display as "Layer 30".
 		</member>
@@ -1665,26 +1683,32 @@
 		<member name="layer_names/3d_physics/layer_32" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D physics layer 32. If left empty, the layer will display as "Layer 32".
 		</member>
-		<member name="layer_names/3d_physics/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/3d_physics/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/3d_physics/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/3d_physics/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/3d_physics/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/3d_physics/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D physics layer 9. If left empty, the layer will display as "Layer 9".
-		</member>
 		<member name="layer_names/3d_render/layer_1" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 1. If left empty, the layer will display as "Layer 1".
+		</member>
+		<member name="layer_names/3d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 2. If left empty, the layer will display as "Layer 2".
+		</member>
+		<member name="layer_names/3d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 3. If left empty, the layer will display as "Layer 3".
+		</member>
+		<member name="layer_names/3d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 4. If left empty, the layer will display as "Layer 4".
+		</member>
+		<member name="layer_names/3d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 5. If left empty, the layer will display as "Layer 5".
+		</member>
+		<member name="layer_names/3d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 6. If left empty, the layer will display as "Layer 6".
+		</member>
+		<member name="layer_names/3d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 7. If left empty, the layer will display as "Layer 7".
+		</member>
+		<member name="layer_names/3d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 8. If left empty, the layer will display as "Layer 8".
+		</member>
+		<member name="layer_names/3d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
+			Optional name for the 3D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="layer_names/3d_render/layer_10" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 10. If left empty, the layer will display as "Layer 10".
@@ -1716,32 +1740,8 @@
 		<member name="layer_names/3d_render/layer_19" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 19. If left empty, the layer will display as "Layer 19".
 		</member>
-		<member name="layer_names/3d_render/layer_2" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 2. If left empty, the layer will display as "Layer 2".
-		</member>
 		<member name="layer_names/3d_render/layer_20" type="String" setter="" getter="" default="&quot;&quot;">
 			Optional name for the 3D render layer 20. If left empty, the layer will display as "Layer 20".
-		</member>
-		<member name="layer_names/3d_render/layer_3" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 3. If left empty, the layer will display as "Layer 3".
-		</member>
-		<member name="layer_names/3d_render/layer_4" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 4. If left empty, the layer will display as "Layer 4".
-		</member>
-		<member name="layer_names/3d_render/layer_5" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 5. If left empty, the layer will display as "Layer 5".
-		</member>
-		<member name="layer_names/3d_render/layer_6" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 6. If left empty, the layer will display as "Layer 6".
-		</member>
-		<member name="layer_names/3d_render/layer_7" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 7. If left empty, the layer will display as "Layer 7".
-		</member>
-		<member name="layer_names/3d_render/layer_8" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 8. If left empty, the layer will display as "Layer 8".
-		</member>
-		<member name="layer_names/3d_render/layer_9" type="String" setter="" getter="" default="&quot;&quot;">
-			Optional name for the 3D render layer 9. If left empty, the layer will display as "Layer 9".
 		</member>
 		<member name="memory/limits/message_queue/max_size_mb" type="int" setter="" getter="" default="32">
 			Godot uses a message queue to defer some function calls. If you run out of space on it (you will see an error), you can increase the size here.

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_8">
+			<return type="int" />
+			<description>
+				Gets a signed byte from the stream.
+			</description>
+		</method>
 		<method name="get_16">
 			<return type="int" />
 			<description>
@@ -26,12 +32,6 @@
 			<return type="int" />
 			<description>
 				Gets a signed 64-bit value from the stream.
-			</description>
-		</method>
-		<method name="get_8">
-			<return type="int" />
-			<description>
-				Gets a signed byte from the stream.
 			</description>
 		</method>
 		<method name="get_available_bytes" qualifiers="const">
@@ -73,6 +73,12 @@
 				Gets an ASCII string with byte-length [param bytes] from the stream. If [param bytes] is negative (default) the length will be read from the stream using the reverse process of [method put_string].
 			</description>
 		</method>
+		<method name="get_u8">
+			<return type="int" />
+			<description>
+				Gets an unsigned byte from the stream.
+			</description>
+		</method>
 		<method name="get_u16">
 			<return type="int" />
 			<description>
@@ -91,12 +97,6 @@
 				Gets an unsigned 64-bit value from the stream.
 			</description>
 		</method>
-		<method name="get_u8">
-			<return type="int" />
-			<description>
-				Gets an unsigned byte from the stream.
-			</description>
-		</method>
 		<method name="get_utf8_string">
 			<return type="String" />
 			<param index="0" name="bytes" type="int" default="-1" />
@@ -111,6 +111,13 @@
 				Gets a Variant from the stream. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				Internally, this uses the same decoding mechanism as the [method @GlobalScope.bytes_to_var] method.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
+			</description>
+		</method>
+		<method name="put_8">
+			<return type="void" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Puts a signed byte into the stream.
 			</description>
 		</method>
 		<method name="put_16">
@@ -132,13 +139,6 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Puts a signed 64-bit value into the stream.
-			</description>
-		</method>
-		<method name="put_8">
-			<return type="void" />
-			<param index="0" name="value" type="int" />
-			<description>
-				Puts a signed byte into the stream.
 			</description>
 		</method>
 		<method name="put_data">
@@ -185,6 +185,13 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="put_u8">
+			<return type="void" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Puts an unsigned byte into the stream.
+			</description>
+		</method>
 		<method name="put_u16">
 			<return type="void" />
 			<param index="0" name="value" type="int" />
@@ -204,13 +211,6 @@
 			<param index="0" name="value" type="int" />
 			<description>
 				Puts an unsigned 64-bit value into the stream.
-			</description>
-		</method>
-		<method name="put_u8">
-			<return type="void" />
-			<param index="0" name="value" type="int" />
-			<description>
-				Puts an unsigned byte into the stream.
 			</description>
 		</method>
 		<method name="put_utf8_string">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -964,6 +964,12 @@
 				Returns the string converted to uppercase.
 			</description>
 		</method>
+		<method name="to_utf8_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-8]UTF-8[/url] encoded [PackedByteArray]. This method is slightly slower than [method to_ascii_buffer], but supports all UTF-8 characters. For most cases, prefer using this method.
+			</description>
+		</method>
 		<method name="to_utf16_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
@@ -974,12 +980,6 @@
 			<return type="PackedByteArray" />
 			<description>
 				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-32]UTF-32[/url] encoded [PackedByteArray].
-			</description>
-		</method>
-		<method name="to_utf8_buffer" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-8]UTF-8[/url] encoded [PackedByteArray]. This method is slightly slower than [method to_ascii_buffer], but supports all UTF-8 characters. For most cases, prefer using this method.
 			</description>
 		</method>
 		<method name="to_wchar_buffer" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -871,6 +871,12 @@
 				Returns the string converted to uppercase.
 			</description>
 		</method>
+		<method name="to_utf8_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-8]UTF-8[/url] encoded [PackedByteArray]. This method is slightly slower than [method to_ascii_buffer], but supports all UTF-8 characters. For most cases, prefer using this method.
+			</description>
+		</method>
 		<method name="to_utf16_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
@@ -881,12 +887,6 @@
 			<return type="PackedByteArray" />
 			<description>
 				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-32]UTF-32[/url] encoded [PackedByteArray].
-			</description>
-		</method>
-		<method name="to_utf8_buffer" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Converts the string to a [url=https://en.wikipedia.org/wiki/UTF-8]UTF-8[/url] encoded [PackedByteArray]. This method is slightly slower than [method to_ascii_buffer], but supports all UTF-8 characters. For most cases, prefer using this method.
 			</description>
 		</method>
 		<method name="to_wchar_buffer" qualifiers="const">

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -417,6 +417,7 @@ void DocTools::generate(bool p_basic_types) {
 				ClassDB::get_property_list(name, &own_properties, true);
 			}
 
+			// Sort is still needed here to handle inherited properties, even though it is done below, do not remove.
 			properties.sort();
 			own_properties.sort();
 
@@ -535,9 +536,10 @@ void DocTools::generate(bool p_basic_types) {
 				c.properties.push_back(prop);
 			}
 
+			c.properties.sort();
+
 			List<MethodInfo> method_list;
 			ClassDB::get_method_list(name, &method_list, true);
-			method_list.sort();
 
 			for (const MethodInfo &E : method_list) {
 				if (E.name.is_empty() || (E.name[0] == '_' && !(E.flags & METHOD_FLAG_VIRTUAL))) {
@@ -570,6 +572,8 @@ void DocTools::generate(bool p_basic_types) {
 
 				c.methods.push_back(method);
 			}
+
+			c.methods.sort();
 
 			List<MethodInfo> signal_list;
 			ClassDB::get_signal_list(name, &signal_list, true);
@@ -709,7 +713,6 @@ void DocTools::generate(bool p_basic_types) {
 
 		List<MethodInfo> method_list;
 		v.get_method_list(&method_list);
-		method_list.sort();
 		Variant::get_constructor_list(Variant::Type(i), &method_list);
 
 		for (int j = 0; j < Variant::OP_AND; j++) { // Showing above 'and' is pretty confusing and there are a lot of variations.
@@ -831,6 +834,8 @@ void DocTools::generate(bool p_basic_types) {
 				c.methods.push_back(method);
 			}
 		}
+
+		c.methods.sort();
 
 		List<PropertyInfo> properties;
 		v.get_property_list(&properties);

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -69,14 +69,14 @@
 		<member name="icons/app_store_1024x1024" type="String" setter="" getter="">
 			App Store application icon file. If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
+		<member name="icons/ipad_76x76" type="String" setter="" getter="">
+			Home screen application icon file on iPad (1x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+		</member>
 		<member name="icons/ipad_152x152" type="String" setter="" getter="">
 			Home screen application icon file on iPad (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/ipad_167x167" type="String" setter="" getter="">
 			Home screen application icon file on iPad (3x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
-		</member>
-		<member name="icons/ipad_76x76" type="String" setter="" getter="">
-			Home screen application icon file on iPad (1x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/iphone_120x120" type="String" setter="" getter="">
 			Home screen application icon file on iPhone (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
@@ -114,25 +114,25 @@
 		<member name="landscape_launch_screens/iphone_2436x1125" type="String" setter="" getter="">
 			Application launch screen image file, if left empty project splash screen is used instead.
 		</member>
+		<member name="portrait_launch_screens/ipad_768x1024" type="String" setter="" getter="">
+			Application launch screen image file, if left empty project splash screen is used instead.
+		</member>
 		<member name="portrait_launch_screens/ipad_1536x2048" type="String" setter="" getter="">
 			Application launch screen image file, if left empty project splash screen is used instead.
 		</member>
-		<member name="portrait_launch_screens/ipad_768x1024" type="String" setter="" getter="">
+		<member name="portrait_launch_screens/iphone_640x960" type="String" setter="" getter="">
+			Application launch screen image file, if left empty project splash screen is used instead.
+		</member>
+		<member name="portrait_launch_screens/iphone_640x1136" type="String" setter="" getter="">
+			Application launch screen image file, if left empty project splash screen is used instead.
+		</member>
+		<member name="portrait_launch_screens/iphone_750x1334" type="String" setter="" getter="">
 			Application launch screen image file, if left empty project splash screen is used instead.
 		</member>
 		<member name="portrait_launch_screens/iphone_1125x2436" type="String" setter="" getter="">
 			Application launch screen image file, if left empty project splash screen is used instead.
 		</member>
 		<member name="portrait_launch_screens/iphone_1242x2208" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
-		</member>
-		<member name="portrait_launch_screens/iphone_640x1136" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
-		</member>
-		<member name="portrait_launch_screens/iphone_640x960" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
-		</member>
-		<member name="portrait_launch_screens/iphone_750x1334" type="String" setter="" getter="">
 			Application launch screen image file, if left empty project splash screen is used instead.
 		</member>
 		<member name="privacy/camera_usage_description" type="String" setter="" getter="">


### PR DESCRIPTION
The reason for using a new comparison is that it otherwise changes the order of methods in a way that I feel is incorrect and breaks with how it seems to usually be done, ordering for example `is_themed` before `is_theme_valid`

Only updates the sorting of elements that were already sorted, and left the comparison of constants, arguments, and classes unchanged

Fixes #76718

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
