### PR TITLE
Support long path in file access on Windows

### DIFF
--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -68,7 +68,7 @@ protected:
 	virtual String _get_root_string() const;
 
 	AccessType get_access_type() const;
-	String fix_path(String p_path) const;
+	virtual String fix_path(String p_path) const;
 
 	template <class T>
 	static Ref<DirAccess> _create_builtin() {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -81,7 +81,7 @@ protected:
 	static void _bind_methods();
 
 	AccessType get_access_type() const;
-	String fix_path(const String &p_path) const;
+	virtual String fix_path(const String &p_path) const;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) = 0; ///< open a file
 	virtual uint64_t _get_modified_time(const String &p_file) = 0;
 	virtual void _set_access_type(AccessType p_access);

--- a/drivers/windows/dir_access_windows.h
+++ b/drivers/windows/dir_access_windows.h
@@ -53,6 +53,9 @@ class DirAccessWindows : public DirAccess {
 	bool _cisdir = false;
 	bool _cishidden = false;
 
+protected:
+	virtual String fix_path(String p_path) const override;
+
 public:
 	virtual Error list_dir_begin() override; ///< This starts dir listing
 	virtual String get_next() override;

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -68,6 +68,14 @@ bool FileAccessWindows::is_path_invalid(const String &p_path) {
 	return invalid_files.has(fname);
 }
 
+String FileAccessWindows::fix_path(const String &p_path) const {
+	String r_path = FileAccess::fix_path(p_path);
+	if (r_path.is_absolute_path() && !r_path.is_network_share_path() && r_path.length() > MAX_PATH) {
+		r_path = "\\\\?\\" + r_path.replace("/", "\\");
+	}
+	return r_path;
+}
+
 Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	if (is_path_invalid(p_path)) {
 #ifdef DEBUG_ENABLED

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -54,6 +54,7 @@ class FileAccessWindows : public FileAccess {
 	static HashSet<String> invalid_files;
 
 public:
+	virtual String fix_path(const String &p_path) const override;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 


### PR DESCRIPTION
Tentative fix for some of the issues with long paths on windows (in particular with shader cache).
Fixes: https://github.com/godotengine/godot/issues/73583
Should fix most of the cases for this: https://github.com/godotengine/godot/issues/52799
Note that dir_access already uses the \\?\ format for long paths.
My understanding from the microsoft docs is that unicode version of the file functions all support this format.
However, I haven't tested it on older windows versions and there might be some good reasons to not do this

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
