### PR TITLE
Cache feature list in `OS.has_feature()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -423,7 +423,14 @@ Error OS::set_thread_name(const String &p_name) {
 };
 
 bool OS::has_feature(const String &p_feature) const {
-	return ::OS::get_singleton()->has_feature(p_feature);
+	const bool *value_ptr = feature_cache.getptr(p_feature);
+	if (value_ptr) {
+		return *value_ptr;
+	} else {
+		const bool has = ::OS::get_singleton()->has_feature(p_feature);
+		feature_cache[p_feature] = has;
+		return has;
+	}
 }
 
 uint64_t OS::get_static_memory_usage() const {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -119,6 +119,8 @@ public:
 class OS : public Object {
 	GDCLASS(OS, Object);
 
+	mutable HashMap<String, bool> feature_cache;
+
 protected:
 	static void _bind_methods();
 	static OS *singleton;


### PR DESCRIPTION
`OS.has_feature()` works by going through a series of `if` statements and doing many string comparisons. There is no "feature list", so it has to be done this way, but since the features don't change at runtime, a feature can be cached after the first lookup. This is what this PR does and it improves the performance of this method by ~50%.