### PR TITLE
Avoid redundant locking in CallQueue

### DIFF
--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -61,7 +61,7 @@ private:
 	};
 
 	Mutex mutex;
-	typedef PagedAllocator<Page, true> Allocator;
+	typedef PagedAllocator<Page, false> Allocator;
 
 	Allocator *allocator = nullptr;
 	bool allocator_is_custom = false;


### PR DESCRIPTION
As far as I can tell, `CallQueue` functions are already thread-safe, so the allocator doesn't need to be thread safe in turn.