### PR TITLE
Remove erroneous signal connection

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4091,8 +4091,6 @@ ScriptEditor::ScriptEditor() {
 	Ref<EditorJSONSyntaxHighlighter> json_syntax_highlighter;
 	json_syntax_highlighter.instantiate();
 	register_syntax_highlighter(json_syntax_highlighter);
-
-	EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ScriptEditor::_close_builtin_scripts_from_scene));
 }
 
 ScriptEditor::~ScriptEditor() {


### PR DESCRIPTION
Fixes minor regression from #75864
The signal was mistakenly connected twice, resulting in startup errors.