### PR TITLE
GitHub Actions: Link build artifacts in pull request descriptions

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -2,6 +2,9 @@ name: 🤖 Android Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -2,6 +2,9 @@ name: 🍏 iOS Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -2,6 +2,9 @@ name: 🐧 Linux Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -2,6 +2,9 @@ name: 🍎 macOS Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/pr_artifacts.yml
+++ b/.github/workflows/pr_artifacts.yml
@@ -1,0 +1,67 @@
+name: Link build artifacts in pull request description
+on:
+  workflow_run:
+    workflows:
+      - 🔗 GHA
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-artifacts:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - id: pr-number
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const {owner, repo} = context.repo;
+            const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
+            const pullUserId = ${{github.event.sender.id}};
+            const prNumber = await (async () => {
+              const pulls = await github.rest.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+
+            if (!prNumber) {
+              return core.error(`No matching pull request found`);
+            }
+
+            return prNumber;
+
+      - id: artifacts-text
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+
+            return allArtifacts.data.artifacts.reduce((acc, item) => {
+              if (item.name === "assets") return acc;
+              acc += `
+              - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
+              return acc;
+            }, '### Build artifacts');
+
+      - id: add-to-pr
+        uses: garrettjoecox/pr-section@3.1.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          pr-number: ${{ steps.pr-number.outputs.result }}
+          section-name: artifacts
+          section-value: '${{ steps.artifacts-text.outputs.result }}'

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,6 +1,9 @@
 name: 🔗 GHA
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-runner
   cancel-in-progress: true

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,6 +2,9 @@ name: 📊 Static Checks
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
   cancel-in-progress: true

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -2,6 +2,9 @@ name: 🌐 Web Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 env:
   # Only used for the cache key. Increment version to force clean build.

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -2,6 +2,9 @@ name: 🏁 Windows Builds
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:


### PR DESCRIPTION
- *Related to https://github.com/godotengine/godot/pull/49115.*

Based on <https://github.com/HarbourMasters/Shipwright/blob/develop/.github/workflows/pr-artifacts.yml>. The effects of this pull request won't be seen on this pull request itself, but it should be able to apply to old pull requests once they receive a new commit or force-push. [nightly.link](https://nightly.link/) is used so that links work for non logged-in users too.

The section added at the bottom of OP in a pull request is correctly updated when commits are pushed, including force-pushes and squashes.

**Note:** Before this is merged, permissions must be changed in the **Settings > Actions** tab of the GitHub repository:

![image](https://user-images.githubusercontent.com/180032/236562936-a13e1fd4-0cc2-4f77-8ab7-080a2ba9af27.png)

The actions are configured to use a restricted set of permissions using YAML, so other workflows will remain read-only.

## Preview

The following block is added at the bottom of each pull request:


![image](https://user-images.githubusercontent.com/180032/236563286-8d334e2e-b1c5-4eac-9cf5-be1196517e3d.png) |
-|


___

Thanks to @garrettjoecox for helping me troubleshoot the action :slightly_smiling_face:
