### PR TITLE
 Apply new input validation method for Create Plugin dialog

### DIFF
--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -35,11 +35,20 @@
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/text_edit.h"
 #include "scene/gui/texture_rect.h"
 
+class EditorValidationPanel;
+
 class PluginConfigDialog : public ConfirmationDialog {
 	GDCLASS(PluginConfigDialog, ConfirmationDialog);
+
+	enum {
+		MSG_ID_PLUGIN,
+		MSG_ID_SUBFOLDER,
+		MSG_ID_SCRIPT,
+	};
 
 	LineEdit *name_edit = nullptr;
 	LineEdit *subfolder_edit = nullptr;
@@ -50,17 +59,14 @@ class PluginConfigDialog : public ConfirmationDialog {
 	LineEdit *script_edit = nullptr;
 	CheckBox *active_edit = nullptr;
 
-	TextureRect *name_validation = nullptr;
-	TextureRect *subfolder_validation = nullptr;
-	TextureRect *script_validation = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 
 	bool _edit_mode = false;
 
 	void _clear_fields();
 	void _on_confirmed();
 	void _on_canceled();
-	void _on_language_changed(const int p_language);
-	void _on_required_text_changed(const String &p_text);
+	void _on_required_text_changed();
 	String _get_subfolder();
 
 	static String _to_absolute_plugin_path(const String &p_plugin_name);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fix #76681 

- Add status panel to the create plugin dialog
- Remove unused info icons (for old validation)

|Old|New|
|-|-|
|<img src="https://user-images.githubusercontent.com/24380544/236707108-7083afc0-f944-4a31-b2e0-ed2e9bdcf73c.png" width="300">|<img src="https://user-images.githubusercontent.com/24380544/236598750-86413053-397d-4ced-922f-9beb1530b1a6.png" width="300">|


