### PR TITLE
Avoid making unnecessary copies of `LocalVector`

### DIFF
--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -658,7 +658,7 @@ private:
 
 	Vector3 get_gd_normal(Face *p_face);
 
-	bool shift_face(Face *p_face, real_t p_amount, LocalVector<Vertex *> p_stack);
+	bool shift_face(Face *p_face, real_t p_amount, LocalVector<Vertex *> &p_stack);
 
 public:
 	~ConvexHullInternal() {
@@ -1775,7 +1775,7 @@ real_t ConvexHullInternal::shrink(real_t p_amount, real_t p_clamp_amount) {
 	return p_amount;
 }
 
-bool ConvexHullInternal::shift_face(Face *p_face, real_t p_amount, LocalVector<Vertex *> p_stack) {
+bool ConvexHullInternal::shift_face(Face *p_face, real_t p_amount, LocalVector<Vertex *> &p_stack) {
 	Vector3 orig_shift = get_gd_normal(p_face) * -p_amount;
 	if (scaling[0] != 0) {
 		orig_shift[0] /= scaling[0];

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -361,8 +361,7 @@ bool VisualShaderGraphPlugin::is_node_has_parameter_instances_relatively(VisualS
 		}
 	}
 
-	LocalVector<int> prev_connected_nodes;
-	visual_shader->get_prev_connected_nodes(p_type, p_node, prev_connected_nodes);
+	const LocalVector<int> &prev_connected_nodes = visual_shader->get_prev_connected_nodes(p_type, p_node);
 
 	for (const int &E : prev_connected_nodes) {
 		result = is_node_has_parameter_instances_relatively(p_type, E);
@@ -5012,8 +5011,7 @@ void VisualShaderEditor::_update_next_previews(int p_node_id) {
 }
 
 void VisualShaderEditor::_get_next_nodes_recursively(VisualShader::Type p_type, int p_node_id, LocalVector<int> &r_nodes) const {
-	LocalVector<int> next_connections;
-	visual_shader->get_next_connected_nodes(p_type, p_node_id, next_connections);
+	const LocalVector<int> &next_connections = visual_shader->get_next_connected_nodes(p_type, p_node_id);
 
 	for (int node_id : next_connections) {
 		r_nodes.push_back(node_id);

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -234,7 +234,7 @@ TypedArray<RID> GodotNavigationServer::map_get_links(RID p_map) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, link_rids);
 
-	const LocalVector<NavLink *> links = map->get_links();
+	const LocalVector<NavLink *> &links = map->get_links();
 	link_rids.resize(links.size());
 
 	for (uint32_t i = 0; i < links.size(); i++) {
@@ -248,7 +248,7 @@ TypedArray<RID> GodotNavigationServer::map_get_regions(RID p_map) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, regions_rids);
 
-	const LocalVector<NavRegion *> regions = map->get_regions();
+	const LocalVector<NavRegion *> &regions = map->get_regions();
 	regions_rids.resize(regions.size());
 
 	for (uint32_t i = 0; i < regions.size(); i++) {
@@ -262,7 +262,7 @@ TypedArray<RID> GodotNavigationServer::map_get_agents(RID p_map) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_COND_V(map == nullptr, agents_rids);
 
-	const LocalVector<NavAgent *> agents = map->get_agents();
+	const LocalVector<NavAgent *> &agents = map->get_agents();
 	agents_rids.resize(agents.size());
 
 	for (uint32_t i = 0; i < agents.size(); i++) {

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -620,9 +620,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 						}
 
 						if (!found) {
-							LocalVector<int> new_group;
-							new_group.push_back(corner_idx);
-							normal_group_indices.push_back(new_group);
+							normal_group_indices.push_back({ corner_idx });
 							normal_group_averages.push_back(ray_normal);
 						}
 					}

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -203,11 +203,11 @@ public: // internal methods
 	_FORCE_INLINE_ Ref<VisualShaderNode> get_node_unchecked(Type p_type, int p_id) const {
 		return graph[p_type].nodes[p_id].node;
 	}
-	_FORCE_INLINE_ void get_next_connected_nodes(Type p_type, int p_id, LocalVector<int> &r_list) const {
-		r_list = graph[p_type].nodes[p_id].next_connected_nodes;
+	_FORCE_INLINE_ const LocalVector<int> &get_next_connected_nodes(Type p_type, int p_id) const {
+		return graph[p_type].nodes[p_id].next_connected_nodes;
 	}
-	_FORCE_INLINE_ void get_prev_connected_nodes(Type p_type, int p_id, LocalVector<int> &r_list) const {
-		r_list = graph[p_type].nodes[p_id].prev_connected_nodes;
+	_FORCE_INLINE_ const LocalVector<int> &get_prev_connected_nodes(Type p_type, int p_id) const {
+		return graph[p_type].nodes[p_id].prev_connected_nodes;
 	}
 
 	Vector<int> get_node_list(Type p_type) const;


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/75819#issuecomment-1534794194 and me checking when happens when you just make the copy constructor explicit (it causes a bunch of friction with the various containers that make copies of their contents pretty liberally, https://github.com/RedworkDE/godot/tree/explicit-copy-localvector)

This PR fixes the unnecessary and easily avoidable copies found in the process. There are a bunch more optimization opportunities by making `LocalVector` movable and using that in some places, instead of just making a copy and then just discarding the original, but I left that out of this PR.
