### PR TITLE
Add `AnimationTrackFilter` and implement filter as an `AnimationNode`'s parameter.

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -142,10 +142,10 @@
 			<return type="Variant" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Gets the value of a parameter. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
+				Gets the value of a parameter. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
-		<method name="is_path_filtered" qualifiers="const">
+		<method name="is_path_filtered" qualifiers="const" is_deprecated="true">
 			<return type="bool" />
 			<param index="0" name="path" type="NodePath" />
 			<description>
@@ -159,7 +159,7 @@
 				Removes an input, call this only when inactive.
 			</description>
 		</method>
-		<method name="set_filter_path">
+		<method name="set_filter_path" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="path" type="NodePath" />
 			<param index="1" name="enable" type="bool" />
@@ -185,8 +185,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="filter_enabled" type="bool" setter="set_filter_enabled" getter="is_filter_enabled">
-			If [code]true[/code], filtering is enabled.
+		<member name="filter_enabled" type="bool" setter="set_filter_enabled" getter="is_filter_enabled" is_deprecated="true">
+			Deprecated, sets this property will do noting, gets will return [code]false[/code].
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/AnimationTrackFilter.xml
+++ b/doc/classes/AnimationTrackFilter.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationTrackFilter" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A filter to describe [AnimationNode]'s filters.
+	</brief_description>
+	<description>
+		A filter to describe [AnimationNode]'s filters.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="clear_tracks">
+			<return type="void" />
+			<description>
+				Clear all tracks.
+			</description>
+		</method>
+		<method name="get_track_amount" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_path" type="NodePath" />
+			<description>
+			</description>
+		</method>
+		<method name="has_trck" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="track_path" type="NodePath" />
+			<description>
+				Return [code]true[/code] if has [param track_path].
+			</description>
+		</method>
+		<method name="remove_track">
+			<return type="void" />
+			<param index="0" name="track_path" type="NodePath" />
+			<description>
+				Remove track, will do noting if this filter have not [param track_path].
+			</description>
+		</method>
+		<method name="set_track">
+			<return type="void" />
+			<param index="0" name="track_path" type="NodePath" />
+			<param index="1" name="amount" type="float" default="1.0" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="tracks" type="Dictionary" setter="set_tracks" getter="get_tracks" default="{}">
+			A array of animation tracks' Nodepath which should be filtered.
+		</member>
+	</members>
+</class>

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -49,7 +49,10 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
+#include "scene/resources/animation_track_filter.h"
 #include "scene/resources/style_box_flat.h"
+
+#define GET_ANIM_NODE_FILTER_BASE_PATH(m_node_name) AnimationTreeEditor::get_singleton()->get_base_path() + String(m_node_name) + "/filter"
 
 void AnimationNodeBlendTreeEditor::add_custom_type(const String &p_name, const Ref<Script> &p_script) {
 	for (int i = 0; i < add_options.size(); i++) {
@@ -219,9 +222,12 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 			} else {
 				inspect_filters->set_text(TTR("Edit Filters"));
 			}
+			inspect_filters->set_name("InspectFiltersButton");
+			Ref<AnimationTrackFilter> filter = tree->get(GET_ANIM_NODE_FILTER_BASE_PATH(E));
+			inspect_filters->set_tooltip_text(filter.is_valid() ? filter->get_path().get_file() : "");
 			inspect_filters->set_icon(get_editor_theme_icon(SNAME("AnimationFilter")));
 			node->add_child(inspect_filters);
-			inspect_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_inspect_filters).bind(E), CONNECT_DEFERRED);
+			inspect_filters->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_inspect_filters).bind(E, tree), CONNECT_DEFERRED);
 			inspect_filters->set_h_size_flags(SIZE_SHRINK_CENTER);
 		}
 
@@ -580,36 +586,6 @@ void AnimationNodeBlendTreeEditor::_open_in_editor(const String &p_which) {
 	AnimationTreeEditor::get_singleton()->enter_editor(p_which);
 }
 
-void AnimationNodeBlendTreeEditor::_filter_toggled() {
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Toggle Filter On/Off"));
-	undo_redo->add_do_method(_filter_edit.ptr(), "set_filter_enabled", filter_enabled->is_pressed());
-	undo_redo->add_undo_method(_filter_edit.ptr(), "set_filter_enabled", _filter_edit->is_filter_enabled());
-	undo_redo->add_do_method(this, "_update_filters", _filter_edit);
-	undo_redo->add_undo_method(this, "_update_filters", _filter_edit);
-	undo_redo->commit_action();
-	updating = false;
-}
-
-void AnimationNodeBlendTreeEditor::_filter_edited() {
-	TreeItem *edited = filters->get_edited();
-	ERR_FAIL_NULL(edited);
-
-	NodePath edited_path = edited->get_metadata(0);
-	bool filtered = edited->is_checked(0);
-
-	updating = true;
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Change Filter"));
-	undo_redo->add_do_method(_filter_edit.ptr(), "set_filter_path", edited_path, filtered);
-	undo_redo->add_undo_method(_filter_edit.ptr(), "set_filter_path", edited_path, _filter_edit->is_path_filtered(edited_path));
-	undo_redo->add_do_method(this, "_update_filters", _filter_edit);
-	undo_redo->add_undo_method(this, "_update_filters", _filter_edit);
-	undo_redo->commit_action();
-	updating = false;
-}
-
 bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &anode) {
 	if (updating || _filter_edit != anode) {
 		return false;
@@ -620,182 +596,32 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		return false;
 	}
 
-	Node *base = tree->get_node(tree->get_root_node());
-	if (!base) {
-		EditorNode::get_singleton()->show_warning(TTR("Animation player has no valid root node path, so unable to retrieve track names."));
-		return false;
-	}
-
 	updating = true;
 
-	HashSet<String> paths;
-	HashMap<String, RBSet<String>> types;
-	{
-		List<StringName> animation_list;
-		tree->get_animation_list(&animation_list);
+	String node_name = blend_tree->get_node_name(anode);
+	ERR_FAIL_COND_V(node_name.is_empty(), false);
 
-		for (const StringName &E : animation_list) {
-			Ref<Animation> anim = tree->get_animation(E);
-			for (int i = 0; i < anim->get_track_count(); i++) {
-				String track_path = anim->track_get_path(i);
-				paths.insert(track_path);
+	Ref<AnimationTrackFilter> filter = tree->get(GET_ANIM_NODE_FILTER_BASE_PATH(node_name));
+	filter_picker->set_edited_resource(filter);
 
-				String track_type_name;
-				Animation::TrackType track_type = anim->track_get_type(i);
-				switch (track_type) {
-					case Animation::TrackType::TYPE_ANIMATION: {
-						track_type_name = TTR("Anim Clips");
-					} break;
-					case Animation::TrackType::TYPE_AUDIO: {
-						track_type_name = TTR("Audio Clips");
-					} break;
-					case Animation::TrackType::TYPE_METHOD: {
-						track_type_name = TTR("Functions");
-					} break;
-					default: {
-					} break;
-				}
-				if (!track_type_name.is_empty()) {
-					types[track_path].insert(track_type_name);
-				}
-			}
-		}
-	}
+	GraphNode *gn = Object::cast_to<GraphNode>(graph->get_node(node_name));
+	ERR_FAIL_COND_V(!gn, false);
 
-	filter_enabled->set_pressed(anode->is_filter_enabled());
-	filters->clear();
-	TreeItem *root = filters->create_item();
+	Button *inspect_filters = Object::cast_to<Button>(gn->get_node_or_null(NodePath("InspectFiltersButton")));
+	ERR_FAIL_COND_V(!inspect_filters, false);
 
-	HashMap<String, TreeItem *> parenthood;
+	inspect_filters->set_tooltip_text(filter.is_valid() ? filter->get_path().get_file() : "");
 
-	for (const String &E : paths) {
-		NodePath path = E;
-		TreeItem *ti = nullptr;
-		String accum;
-		for (int i = 0; i < path.get_name_count(); i++) {
-			String name = path.get_name(i);
-			if (!accum.is_empty()) {
-				accum += "/";
-			}
-			accum += name;
-			if (!parenthood.has(accum)) {
-				if (ti) {
-					ti = filters->create_item(ti);
-				} else {
-					ti = filters->create_item(root);
-				}
-				parenthood[accum] = ti;
-				ti->set_text(0, name);
-				ti->set_selectable(0, false);
-				ti->set_editable(0, false);
-
-				if (base->has_node(accum)) {
-					Node *node = base->get_node(accum);
-					ti->set_icon(0, EditorNode::get_singleton()->get_object_icon(node, "Node"));
-				}
-
-			} else {
-				ti = parenthood[accum];
-			}
-		}
-
-		Node *node = nullptr;
-		if (base->has_node(accum)) {
-			node = base->get_node(accum);
-		}
-		if (!node) {
-			continue; //no node, can't edit
-		}
-
-		if (path.get_subname_count()) {
-			String concat = path.get_concatenated_subnames();
-
-			Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
-			if (skeleton && skeleton->find_bone(concat) != -1) {
-				//path in skeleton
-				const String &bone = concat;
-				int idx = skeleton->find_bone(bone);
-				List<String> bone_path;
-				while (idx != -1) {
-					bone_path.push_front(skeleton->get_bone_name(idx));
-					idx = skeleton->get_bone_parent(idx);
-				}
-
-				accum += ":";
-				for (List<String>::Element *F = bone_path.front(); F; F = F->next()) {
-					if (F != bone_path.front()) {
-						accum += "/";
-					}
-
-					accum += F->get();
-					if (!parenthood.has(accum)) {
-						ti = filters->create_item(ti);
-						parenthood[accum] = ti;
-						ti->set_text(0, F->get());
-						ti->set_selectable(0, false);
-						ti->set_editable(0, false);
-						ti->set_icon(0, get_editor_theme_icon(SNAME("BoneAttachment3D")));
-					} else {
-						ti = parenthood[accum];
-					}
-				}
-
-				ti->set_editable(0, !read_only);
-				ti->set_selectable(0, true);
-				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				ti->set_text(0, concat);
-				ti->set_checked(0, anode->is_path_filtered(path));
-				ti->set_icon(0, get_editor_theme_icon(SNAME("BoneAttachment3D")));
-				ti->set_metadata(0, path);
-
-			} else {
-				//just a property
-				ti = filters->create_item(ti);
-				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				ti->set_text(0, concat);
-				ti->set_editable(0, !read_only);
-				ti->set_selectable(0, true);
-				ti->set_checked(0, anode->is_path_filtered(path));
-				ti->set_metadata(0, path);
-			}
-		} else {
-			if (ti) {
-				//just a node, not a property track
-				String types_text = "[";
-				if (types.has(path)) {
-					RBSet<String>::Iterator F = types[path].begin();
-					types_text += *F;
-					while (F) {
-						types_text += " / " + *F;
-						;
-						++F;
-					}
-				}
-				types_text += "]";
-				ti = filters->create_item(ti);
-				ti->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-				ti->set_text(0, types_text);
-				ti->set_editable(0, !read_only);
-				ti->set_selectable(0, true);
-				ti->set_checked(0, anode->is_path_filtered(path));
-				ti->set_metadata(0, path);
-			}
-		}
-	}
+	filter_edit_dialog->set_read_only(read_only || filter.is_null());
+	bool update_result = filter_edit_dialog->update_filters(tree, filter);
 
 	updating = false;
 
-	return true;
+	return update_result;
 }
 
-void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
-	if (read_only) {
-		filter_dialog->set_title(TTR("Inspect Filtered Tracks:"));
-	} else {
-		filter_dialog->set_title(TTR("Edit Filtered Tracks:"));
-	}
-
-	filter_enabled->set_disabled(read_only);
+void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which, AnimationTree *p_tree) {
+	filter_picker->set_editable(!read_only);
 
 	Ref<AnimationNode> anode = blend_tree->get_node(p_which);
 	ERR_FAIL_COND(!anode.is_valid());
@@ -805,12 +631,30 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 		return;
 	}
 
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	filter_edit_dialog->popup_centered(Size2(500, 500) * EDSCALE);
 }
 
 void AnimationNodeBlendTreeEditor::_update_editor_settings() {
 	graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	graph->set_warped_panning(bool(EDITOR_GET("editors/panning/warped_mouse_panning")));
+}
+
+void AnimationNodeBlendTreeEditor::_filter_picker_resource_changed(Ref<AnimationTrackFilter> p_filter) {
+	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+	if (_filter_edit.is_valid() && tree) {
+		String node_name = blend_tree->get_node_name(_filter_edit);
+		ERR_FAIL_COND(node_name.is_empty());
+		String filter_base_path = GET_ANIM_NODE_FILTER_BASE_PATH(node_name);
+		Ref<AnimationTrackFilter> old_filter = tree->get(filter_base_path);
+
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Change Filter"));
+		undo_redo->add_do_property(tree, filter_base_path, p_filter);
+		undo_redo->add_undo_property(tree, filter_base_path, old_filter);
+		undo_redo->add_do_method(this, "_update_filters", _filter_edit);
+		undo_redo->add_undo_method(this, "_update_filters", _filter_edit);
+		undo_redo->commit_action();
+	}
 }
 
 void AnimationNodeBlendTreeEditor::_notification(int p_what) {
@@ -1101,23 +945,20 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	error_panel->add_child(error_label);
 	error_label->set_text("eh");
 
-	filter_dialog = memnew(AcceptDialog);
-	add_child(filter_dialog);
-	filter_dialog->set_title(TTR("Edit Filtered Tracks:"));
+	filter_edit_dialog = memnew(AnimationTrackFilterEditDialog);
+	add_child(filter_edit_dialog);
 
-	VBoxContainer *filter_vbox = memnew(VBoxContainer);
-	filter_dialog->add_child(filter_vbox);
+	HBoxContainer *filter_tool_bar = filter_edit_dialog->get_tool_bar();
 
-	filter_enabled = memnew(CheckBox);
-	filter_enabled->set_text(TTR("Enable Filtering"));
-	filter_enabled->connect("pressed", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_toggled));
-	filter_vbox->add_child(filter_enabled);
+	Label *filter_label = memnew(Label);
+	filter_label->set_text(TTR("filter:"));
+	filter_tool_bar->add_child(filter_label);
 
-	filters = memnew(Tree);
-	filter_vbox->add_child(filters);
-	filters->set_v_size_flags(SIZE_EXPAND_FILL);
-	filters->set_hide_root(true);
-	filters->connect("item_edited", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_edited));
+	filter_picker = memnew(EditorResourcePicker);
+	filter_picker->set_base_type(AnimationTrackFilter::get_class_static());
+	filter_picker->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	filter_picker->connect("resource_changed", callable_mp(this, &AnimationNodeBlendTreeEditor::_filter_picker_resource_changed));
+	filter_tool_bar->add_child(filter_picker);
 
 	open_file = memnew(EditorFileDialog);
 	add_child(open_file);

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -32,6 +32,8 @@
 #define ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H
 
 #include "core/object/script_language.h"
+#include "editor/editor_resource_picker.h"
+#include "editor/plugins/animation_track_filter_editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
@@ -47,6 +49,7 @@ class EditorFileDialog;
 class EditorProperty;
 class MenuButton;
 class PanelContainer;
+class AnimationTrackFilter;
 
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);
@@ -63,9 +66,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	PanelContainer *error_panel = nullptr;
 	Label *error_label = nullptr;
 
-	AcceptDialog *filter_dialog = nullptr;
-	Tree *filters = nullptr;
-	CheckBox *filter_enabled = nullptr;
+	AnimationTrackFilterEditDialog *filter_edit_dialog = nullptr;
+	EditorResourcePicker *filter_picker = nullptr;
 
 	HashMap<StringName, ProgressBar *> animations;
 	Vector<EditorProperty *> visible_properties;
@@ -113,9 +115,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _delete_nodes_request(const TypedArray<StringName> &p_nodes);
 
 	bool _update_filters(const Ref<AnimationNode> &anode);
-	void _inspect_filters(const String &p_which);
-	void _filter_edited();
-	void _filter_toggled();
+	void _inspect_filters(const String &p_which, AnimationTree *p_tree);
 	Ref<AnimationNode> _filter_edit;
 
 	void _popup(bool p_has_input_ports, const Vector2 &p_node_position);
@@ -127,6 +127,8 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _property_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 
 	void _update_editor_settings();
+
+	void _filter_picker_resource_changed(Ref<AnimationTrackFilter> p_filter);
 
 	EditorFileDialog *open_file = nullptr;
 	Ref<AnimationNode> file_loaded;

--- a/editor/plugins/animation_track_filter_editor_plugin.cpp
+++ b/editor/plugins/animation_track_filter_editor_plugin.cpp
@@ -1,0 +1,488 @@
+/**************************************************************************/
+/*  animation_track_filter_editor_plugin.cpp                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "animation_track_filter_editor_plugin.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_resource_picker.h"
+#include "editor/editor_scale.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/animation_tree_editor_plugin.h"
+#include "scene/gui/spin_box.h"
+#include "scene/gui/texture_rect.h"
+#include "scene/gui/tree.h"
+#include "scene/resources/animation_track_filter.h"
+
+// AnimationTrackFilterEditDialog::TrackItem
+void AnimationTrackFilterEditDialog::TrackItem::_amount_changed(double p_value) {
+	ERR_FAIL_COND(track_path.is_empty());
+	emit_signal(SNAME("amount_changed"), get_track_path(), p_value);
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("amount_changed", PropertyInfo(Variant::NODE_PATH, "track_path"), PropertyInfo(Variant::FLOAT, "amount")));
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_editable(bool p_editable) {
+	amount->set_editable(p_editable);
+	amount->set_focus_mode(p_editable ? FOCUS_ALL : FOCUS_NONE);
+	if (p_editable) {
+		set_as_uneditable_track(false);
+	}
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_as_uneditable_track(bool p_editable) {
+	amount->set_visible(!p_editable);
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_icon(const Ref<Texture2D> &p_icon) {
+	icon->set_texture(p_icon);
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_text(const String &p_text) {
+	text->set_text(p_text);
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_amount(float p_amount) {
+	amount->set_value_no_signal(p_amount);
+}
+
+float AnimationTrackFilterEditDialog::TrackItem::get_amount() const {
+	return amount->get_value();
+}
+
+void AnimationTrackFilterEditDialog::TrackItem::set_track_path(const NodePath &p_track_path) {
+	track_path = p_track_path;
+}
+
+NodePath AnimationTrackFilterEditDialog::TrackItem::get_track_path() const {
+	return track_path;
+}
+
+AnimationTrackFilterEditDialog::TrackItem::TrackItem() {
+	amount = memnew(SpinBox);
+	add_child(amount);
+	amount->set_step(0.01);
+	amount->set_min(0.0);
+	amount->set_max(1.0);
+	amount->set_v_size_flags(SIZE_SHRINK_CENTER);
+	amount->set_allow_lesser(false);
+	amount->set_allow_greater(false);
+	amount->set_focus_mode(FocusMode::FOCUS_NONE);
+	amount->connect(SNAME("value_changed"), callable_mp(this, &TrackItem::_amount_changed));
+
+	icon = memnew(TextureRect);
+	add_child(icon);
+	icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+
+	text = memnew(Label);
+	add_child(text);
+}
+
+// AnimationTrackFilterEditDialog
+void AnimationTrackFilterEditDialog::_tree_draw() {
+	hide_invisiable_track_items();
+
+	RID ci = tree_focus_rect->get_canvas_item();
+
+	if (filter_tree->has_focus()) {
+		RS::get_singleton()->canvas_item_add_clip_ignore(ci, true);
+		focus_style->draw(ci, filter_tree->get_rect());
+		RS::get_singleton()->canvas_item_add_clip_ignore(ci, false);
+	} else {
+		RS::get_singleton()->canvas_item_clear(ci);
+	}
+}
+
+void AnimationTrackFilterEditDialog::_tree_item_draw(TreeItem *p_item, const Rect2 &p_rect) const {
+	ERR_FAIL_COND(!track_items.has(p_item));
+	TrackItem *track_item = track_items[p_item];
+	track_item->set_rect(p_rect);
+	track_item->show();
+}
+
+void AnimationTrackFilterEditDialog::_track_item_amount_changed(const NodePath &p_track_path, double p_amount) {
+	ERR_FAIL_NULL(filter);
+
+	updating = true;
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Edit Filter"));
+
+	undo_redo->add_do_method(filter.ptr(), "set_track", p_track_path, p_amount);
+	undo_redo->add_undo_method(filter.ptr(), "set_track", p_track_path, filter->get_track_amount(p_track_path));
+
+	undo_redo->commit_action();
+
+	updating = false;
+}
+
+bool is_item_collapsed_recursively(TreeItem *p_item) {
+	if (p_item->is_collapsed()) {
+		return true;
+	}
+
+	if (p_item->get_parent()) {
+		return is_item_collapsed_recursively(p_item->get_parent());
+	}
+	return false;
+}
+
+void AnimationTrackFilterEditDialog::hide_invisiable_track_items() {
+	Rect2 tree_rect = Rect2(filter_tree->get_scroll(), filter_tree->get_size());
+	for (const KeyValue<TreeItem *, TrackItem *> &E : track_items) {
+		Rect2 item_rect = filter_tree->get_item_rect(E.key);
+		if (!tree_rect.intersects(item_rect) || is_item_collapsed_recursively(E.key->get_parent())) {
+			E.value->hide();
+		}
+	}
+}
+
+AnimationTrackFilterEditDialog::TrackItem *AnimationTrackFilterEditDialog::get_or_create_track_items_and_setup_tree_item(TreeItem *p_item) {
+	if (track_items.has(p_item)) {
+		return track_items[p_item];
+	}
+	p_item->set_cell_mode(0, TreeItem::CELL_MODE_CUSTOM);
+	p_item->set_custom_draw(0, this, SNAME("_tree_item_draw"));
+
+	TrackItem *ret = memnew(TrackItem);
+	track_items.insert(p_item, ret);
+	filter_tree->add_child(ret);
+	ret->connect(SNAME("amount_changed"), callable_mp(this, &AnimationTrackFilterEditDialog::_track_item_amount_changed));
+	return ret;
+}
+
+void AnimationTrackFilterEditDialog::_notification(int p_what) {
+	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
+		if (!is_visible()) {
+			anim_player = nullptr;
+			filter.unref();
+		}
+	} else if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_READY) {
+		focus_style = filter_tree->get_theme_stylebox("focus");
+	}
+}
+
+void AnimationTrackFilterEditDialog::set_read_only(bool p_read_only) {
+	read_only = p_read_only;
+
+	if (is_read_only()) {
+		set_title(TTR("Inspect Filtered Tracks:"));
+	} else {
+		set_title(TTR("Edit Filtered Tracks:"));
+	}
+}
+
+bool AnimationTrackFilterEditDialog::is_read_only() const {
+	return read_only;
+}
+
+bool AnimationTrackFilterEditDialog::update_filters(class AnimationMixer *p_player, const Ref<AnimationTrackFilter> &p_filter) {
+	anim_player = p_player;
+	filter = p_filter;
+
+	for (KeyValue<TreeItem *, TrackItem *> E : track_items) {
+		filter_tree->remove_child(E.value);
+		E.value->queue_free();
+	}
+	track_items.clear();
+	filter_tree->clear();
+
+	if (!p_player) {
+		EditorNode::get_singleton()->show_warning(TTR("Player path set is invalid, so unable to retrieve track names."));
+		return false;
+	}
+
+	Node *base = p_player->get_node(p_player->get_root_node());
+
+	if (!base) {
+		EditorNode::get_singleton()->show_warning(TTR("Animation player has no valid root node path, so unable to retrieve track names."));
+		return false;
+	}
+
+	updating = true;
+
+	HashSet<String> paths;
+	HashMap<String, RBSet<String>> types;
+	{
+		List<StringName> animation_list;
+		p_player->get_animation_list(&animation_list);
+
+		for (const StringName &E : animation_list) {
+			Ref<Animation> anim = p_player->get_animation(E);
+			for (int i = 0; i < anim->get_track_count(); i++) {
+				String track_path = anim->track_get_path(i);
+				paths.insert(track_path);
+
+				String track_type_name;
+				Animation::TrackType track_type = anim->track_get_type(i);
+				switch (track_type) {
+					case Animation::TrackType::TYPE_ANIMATION: {
+						track_type_name = TTR("Anim Clips");
+					} break;
+					case Animation::TrackType::TYPE_AUDIO: {
+						track_type_name = TTR("Audio Clips");
+					} break;
+					case Animation::TrackType::TYPE_METHOD: {
+						track_type_name = TTR("Functions");
+					} break;
+					default: {
+					} break;
+				}
+				if (!track_type_name.is_empty()) {
+					types[track_path].insert(track_type_name);
+				}
+			}
+		}
+	}
+
+	TreeItem *root = filter_tree->create_item();
+
+	HashMap<String, TreeItem *> parenthood;
+
+	for (const String &E : paths) {
+		NodePath path = E;
+		TreeItem *ti = nullptr;
+		String accum;
+		for (int i = 0; i < path.get_name_count(); i++) {
+			String name = path.get_name(i);
+			if (!accum.is_empty()) {
+				accum += "/";
+			}
+			accum += name;
+			if (!parenthood.has(accum)) {
+				if (ti) {
+					ti = filter_tree->create_item(ti);
+				} else {
+					ti = filter_tree->create_item(root);
+				}
+				parenthood[accum] = ti;
+
+				TrackItem *track_item = get_or_create_track_items_and_setup_tree_item(ti);
+				track_item->set_text(name);
+				track_item->set_editable(false);
+				track_item->set_as_uneditable_track(true);
+
+				if (base->has_node(accum)) {
+					Node *node = base->get_node(accum);
+					track_item->set_icon(EditorNode::get_singleton()->get_object_icon(node, "Node"));
+				}
+
+			} else {
+				ti = parenthood[accum];
+			}
+		}
+
+		Node *node = nullptr;
+		if (base->has_node(accum)) {
+			node = base->get_node(accum);
+		}
+		if (!node) {
+			continue; //no node, can't edit
+		}
+
+		if (path.get_subname_count()) {
+			String concat = path.get_concatenated_subnames();
+
+			Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(node);
+			if (skeleton && skeleton->find_bone(concat) != -1) {
+				//path in skeleton
+				const String &bone = concat;
+				int idx = skeleton->find_bone(bone);
+				List<String> bone_path;
+				while (idx != -1) {
+					bone_path.push_front(skeleton->get_bone_name(idx));
+					idx = skeleton->get_bone_parent(idx);
+				}
+
+				accum += ":";
+				for (List<String>::Element *F = bone_path.front(); F; F = F->next()) {
+					if (F != bone_path.front()) {
+						accum += "/";
+					}
+
+					accum += F->get();
+					if (!parenthood.has(accum)) {
+						ti = filter_tree->create_item(ti);
+						parenthood[accum] = ti;
+
+						TrackItem *track_item = get_or_create_track_items_and_setup_tree_item(ti);
+						track_item->set_icon(get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
+						track_item->set_editable(false);
+						track_item->set_as_uneditable_track(true);
+						track_item->set_text(F->get());
+					} else {
+						ti = parenthood[accum];
+					}
+				}
+
+				ti->set_metadata(0, path);
+
+				TrackItem *track_item = get_or_create_track_items_and_setup_tree_item(ti);
+				track_item->set_track_path(path);
+				track_item->set_icon(get_theme_icon(SNAME("BoneAttachment3D"), SNAME("EditorIcons")));
+				track_item->set_editable(!is_read_only());
+				track_item->set_amount(p_filter.is_valid() && p_filter->has_track(path) ? p_filter->get_track_amount(path) : 0.0f);
+				track_item->set_text(concat);
+
+			} else {
+				//just a property
+				ti = filter_tree->create_item(ti);
+				ti->set_metadata(0, path);
+
+				TrackItem *track_item = get_or_create_track_items_and_setup_tree_item(ti);
+				track_item->set_track_path(path);
+				track_item->set_editable(!is_read_only());
+				track_item->set_amount(p_filter.is_valid() && p_filter->has_track(path) ? p_filter->get_track_amount(path) : 0.0f);
+				track_item->set_text(concat);
+			}
+		} else {
+			if (ti) {
+				//just a node, not a property track
+				String types_text = "[";
+				if (types.has(path)) {
+					RBSet<String>::Iterator F = types[path].begin();
+					types_text += *F;
+					while (F) {
+						types_text += " / " + *F;
+						;
+						++F;
+					}
+				}
+				types_text += "]";
+				ti = filter_tree->create_item(ti);
+				ti->set_metadata(0, path);
+
+				TrackItem *track_item = get_or_create_track_items_and_setup_tree_item(ti);
+				track_item->set_track_path(path);
+				track_item->set_editable(!is_read_only());
+				track_item->set_amount(p_filter.is_valid() && p_filter->has_track(path) ? p_filter->get_track_amount(path) : 0.0f);
+				track_item->set_text(types_text);
+			}
+		}
+	}
+
+	updating = false;
+	return true;
+}
+
+HBoxContainer *AnimationTrackFilterEditDialog::get_tool_bar() const {
+	return tool_bar;
+}
+
+void AnimationTrackFilterEditDialog::_bind_methods() {
+	ClassDB::bind_method("_tree_item_draw", &AnimationTrackFilterEditDialog::_tree_item_draw);
+	ClassDB::bind_method("update_filters", &AnimationTrackFilterEditDialog::update_filters);
+}
+
+AnimationTrackFilterEditDialog::AnimationTrackFilterEditDialog() {
+	VBoxContainer *vbox = memnew(VBoxContainer);
+	add_child(vbox);
+
+	tool_bar = memnew(HBoxContainer);
+	vbox->add_child(tool_bar);
+
+	filter_tree = memnew(Tree);
+	vbox->add_child(filter_tree);
+	filter_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	filter_tree->set_hide_root(true);
+	filter_tree->connect("draw", callable_mp(this, &AnimationTrackFilterEditDialog::_tree_draw));
+
+	tree_focus_rect = memnew(Control);
+	tree_focus_rect->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	add_child(tree_focus_rect);
+	tree_focus_rect->set_anchors_preset(Control::PRESET_FULL_RECT);
+
+	set_read_only(false);
+}
+
+// AnimationNodeFilterTracksEditor
+void AnimationNodeFilterTracksEditor::_edit_requested() {
+	AnimationTrackFilter *filter = cast_to<AnimationTrackFilter>(get_edited_object());
+	ERR_FAIL_NULL(filter);
+
+	Callable call_back = callable_mp(this, &AnimationNodeFilterTracksEditor::update_property);
+	if (!filter->is_connected("changed", call_back)) {
+		filter->connect("changed", call_back);
+	}
+
+	edit_dialog->set_read_only(is_read_only());
+
+	if (!update_filters()) {
+		return;
+	}
+
+	edit_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+}
+
+bool AnimationNodeFilterTracksEditor::update_filters() {
+	AnimationTree *tree = AnimationTreeEditor::get_singleton()->get_animation_tree();
+	if (!tree) {
+		EditorNode::get_singleton()->show_warning(TTR("No animation tree selected, so unable to retrieve track names."));
+		return false;
+	}
+
+	Ref<AnimationTrackFilter> filter = cast_to<AnimationTrackFilter>(get_edited_object());
+
+	return edit_dialog->update_filters(tree, filter);
+}
+
+void AnimationNodeFilterTracksEditor::update_property() {
+	edit_btn->set_text(TTR("Count: ") + itos(cast_to<AnimationTrackFilter>(get_edited_object())->get_tracks().size()));
+}
+
+AnimationNodeFilterTracksEditor::AnimationNodeFilterTracksEditor() {
+	edit_btn = memnew(Button);
+	edit_btn->set_h_size_flags(SizeFlags::SIZE_EXPAND_FILL);
+	edit_btn->connect("pressed", callable_mp(this, &AnimationNodeFilterTracksEditor::_edit_requested));
+	add_child(edit_btn);
+
+	edit_dialog = memnew(AnimationTrackFilterEditDialog);
+	add_child(edit_dialog);
+}
+
+// AnimationTrackFilterEditorInspectorPlugin
+bool AnimationTrackFilterEditorInspectorPlugin::can_handle(Object *p_object) {
+	return p_object && cast_to<AnimationTrackFilter>(p_object) && AnimationTreeEditor::get_singleton()->get_animation_tree();
+}
+
+bool AnimationTrackFilterEditorInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	if (cast_to<AnimationTrackFilter>(p_object) && p_path == "tracks") {
+		add_property_editor(p_path, memnew(AnimationNodeFilterTracksEditor));
+		return true;
+	}
+	return false;
+}
+
+AnimationTrackFilterEditorPlugin::AnimationTrackFilterEditorPlugin() {
+	Ref<AnimationTrackFilterEditorInspectorPlugin> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/animation_track_filter_editor_plugin.h
+++ b/editor/plugins/animation_track_filter_editor_plugin.h
@@ -1,0 +1,144 @@
+/**************************************************************************/
+/*  animation_track_filter_editor_plugin.h                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef ANIMATION_TRACK_FILTER_EDITOR_PLUGIN_H
+#define ANIMATION_TRACK_FILTER_EDITOR_PLUGIN_H
+
+#include "editor/editor_inspector.h"
+#include "editor/editor_plugin.h"
+#include "scene/gui/dialogs.h"
+
+class AnimationTrackFilter;
+class AnimationNode;
+class EditorResourcePicker;
+class Tree;
+class AnimationMixer;
+class TreeItem;
+
+class AnimationTrackFilterEditDialog : public AcceptDialog {
+	GDCLASS(AnimationTrackFilterEditDialog, AcceptDialog)
+
+	class TrackItem : public HBoxContainer {
+		GDCLASS(TrackItem, HBoxContainer)
+
+		NodePath track_path;
+
+		SpinBox *amount = nullptr;
+		TextureRect *icon = nullptr;
+		Label *text = nullptr;
+
+		void _amount_changed(double p_value);
+
+	protected:
+		static void _bind_methods();
+
+	public:
+		void set_editable(bool p_editable);
+		void set_icon(const Ref<Texture2D> &p_icon);
+		void set_text(const String &p_text);
+		void set_amount(float p_amount);
+		void set_track_path(const NodePath &p_track_path);
+		void set_as_uneditable_track(bool p_editable);
+		float get_amount() const;
+
+		NodePath get_track_path() const;
+		void set_amount_changed_callback();
+
+		TrackItem();
+	};
+
+	Ref<StyleBox> focus_style;
+	Control *tree_focus_rect;
+
+	Tree *filter_tree;
+	bool read_only = false;
+	bool updating = false;
+
+	HBoxContainer *tool_bar = nullptr;
+	AnimationMixer *anim_player = nullptr;
+	Ref<AnimationTrackFilter> filter;
+
+	void _tree_draw();
+	void _tree_item_draw(TreeItem *p_item, const Rect2 &p_rect) const;
+	void _track_item_amount_changed(const NodePath &p_track_path, double p_amount);
+
+	void hide_invisiable_track_items();
+	TrackItem *get_or_create_track_items_and_setup_tree_item(TreeItem *p_item);
+
+	HashMap<TreeItem *, TrackItem *> track_items;
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	void set_read_only(bool p_read_only);
+	bool is_read_only() const;
+	bool update_filters(class AnimationMixer *p_player, const Ref<AnimationTrackFilter> &p_filter);
+
+	HBoxContainer *get_tool_bar() const;
+
+	AnimationTrackFilterEditDialog();
+};
+
+class AnimationNodeFilterTracksEditor : public EditorProperty {
+	GDCLASS(AnimationNodeFilterTracksEditor, EditorProperty);
+
+	EditorResourcePicker *picker = nullptr;
+
+	Button *edit_btn = nullptr;
+	AnimationTrackFilterEditDialog *edit_dialog = nullptr;
+
+	void _edit_requested();
+
+	bool update_filters();
+
+public:
+	virtual void update_property() override;
+
+	AnimationNodeFilterTracksEditor();
+};
+
+class AnimationTrackFilterEditorInspectorPlugin : public EditorInspectorPlugin {
+	GDCLASS(AnimationTrackFilterEditorInspectorPlugin, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
+};
+
+class AnimationTrackFilterEditorPlugin : public EditorPlugin {
+	GDCLASS(AnimationTrackFilterEditorPlugin, EditorPlugin);
+
+public:
+	AnimationTrackFilterEditorPlugin();
+};
+
+#endif // ANIMATION_TRACK_FILTER_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -64,6 +64,7 @@
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
+#include "editor/plugins/animation_track_filter_editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/audio_stream_editor_plugin.h"
 #include "editor/plugins/audio_stream_randomizer_editor_plugin.h"
@@ -199,6 +200,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(ResourceImporterWAV);
 
 	// This list is alphabetized, and plugins that depend on Node2D are in their own section below.
+	EditorPlugins::add_by_type<AnimationTrackFilterEditorPlugin>();
 	EditorPlugins::add_by_type<AnimationTreeEditorPlugin>();
 	EditorPlugins::add_by_type<AudioStreamEditorPlugin>();
 	EditorPlugins::add_by_type<AudioStreamRandomizerEditorPlugin>();

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -410,7 +410,6 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "has_color_override", "has_theme_color_override" }, // Control -- Breaks Theme
 	{ "has_constant", "has_theme_constant" }, // Control
 	{ "has_constant_override", "has_theme_constant_override" }, // Control
-	{ "has_filter", "_has_filter" }, // AnimationNode
 	{ "has_font", "has_theme_font" }, // Control -- Breaks Theme
 	{ "has_font_override", "has_theme_font_override" }, // Control
 	{ "has_icon", "has_theme_icon" }, // Control -- Breaks Theme

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -256,6 +256,8 @@ Variant AnimationNodeOneShot::get_parameter_default_value(const StringName &p_pa
 		return false;
 	} else if (p_parameter == time_to_restart) {
 		return -1;
+	} else if (p_parameter == filter) {
+		return Variant();
 	} else {
 		return 0.0;
 	}
@@ -554,6 +556,9 @@ void AnimationNodeAdd2::get_parameter_list(List<PropertyInfo> *r_list) const {
 }
 
 Variant AnimationNodeAdd2::get_parameter_default_value(const StringName &p_parameter) const {
+	if (p_parameter == filter) {
+		return Variant();
+	}
 	return 0;
 }
 
@@ -592,6 +597,9 @@ void AnimationNodeAdd3::get_parameter_list(List<PropertyInfo> *r_list) const {
 }
 
 Variant AnimationNodeAdd3::get_parameter_default_value(const StringName &p_parameter) const {
+	if (p_parameter == filter) {
+		return Variant();
+	}
 	return 0;
 }
 
@@ -633,6 +641,9 @@ void AnimationNodeBlend2::get_parameter_list(List<PropertyInfo> *r_list) const {
 }
 
 Variant AnimationNodeBlend2::get_parameter_default_value(const StringName &p_parameter) const {
+	if (p_parameter == filter) {
+		return Variant();
+	}
 	return 0; // For blend amount.
 }
 
@@ -678,16 +689,20 @@ String AnimationNodeBlend3::get_caption() const {
 	return "Blend3";
 }
 
+bool AnimationNodeBlend3::has_filter() const {
+	return true;
+}
+
 double AnimationNodeBlend3::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
 	double amount = get_parameter(blend_amount);
 
 	AnimationMixer::PlaybackInfo pi = p_playback_info;
 	pi.weight = MAX(0, -amount);
-	double rem0 = blend_input(0, pi, FILTER_IGNORE, sync, p_test_only);
+	double rem0 = blend_input(0, pi, FILTER_PASS, sync, p_test_only);
 	pi.weight = 1.0 - ABS(amount);
-	double rem1 = blend_input(1, pi, FILTER_IGNORE, sync, p_test_only);
+	double rem1 = blend_input(1, pi, FILTER_BLEND, sync, p_test_only);
 	pi.weight = MAX(0, amount);
-	double rem2 = blend_input(2, pi, FILTER_IGNORE, sync, p_test_only);
+	double rem2 = blend_input(2, pi, FILTER_PASS, sync, p_test_only);
 
 	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); // Hacky but good enough.
 }

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -242,6 +242,7 @@ public:
 
 	virtual String get_caption() const override;
 
+	virtual bool has_filter() const override;
 	virtual double _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
 	AnimationNodeBlend3();
 };

--- a/scene/animation/animation_tree.compat.inc
+++ b/scene/animation/animation_tree.compat.inc
@@ -30,6 +30,81 @@
 
 #ifndef DISABLE_DEPRECATED
 
+// AnimationNode
+void AnimationNode::set_filter_path(const NodePath &p_path, bool p_enable) {
+	WARN_DEPRECATED;
+	Ref<AnimationTrackFilter> track_filter = get_parameter(filter);
+	ERR_FAIL_NULL(track_filter);
+	track_filter->set_track(p_path, p_enable ? 1.0f : 0.0f);
+}
+
+void AnimationNode::set_filter_enabled(bool p_enable) {
+	WARN_DEPRECATED;
+}
+
+bool AnimationNode::is_filter_enabled() const {
+	WARN_DEPRECATED;
+	return false;
+}
+
+bool AnimationNode::is_path_filtered(const NodePath &p_path) const {
+	WARN_DEPRECATED;
+	Ref<AnimationTrackFilter> track_filter = get_parameter(filter);
+	if (track_filter.is_valid()) {
+		return track_filter->has_track(p_path);
+	}
+	return false;
+}
+
+Array AnimationNode::_get_filters() const {
+	WARN_DEPRECATED;
+	Ref<AnimationTrackFilter> track_filter = get_parameter(filter);
+	ERR_FAIL_NULL_V(track_filter, {});
+
+	Array paths;
+	for (const AnimationTrackFilter::TrackFilterInfo &E : track_filter->get_tracks()) {
+		paths.push_back(String(E.track)); // Use strings, so sorting is possible.
+	}
+	paths.sort(); // Done so every time the scene is saved, it does not change.
+
+	return paths;
+}
+
+void AnimationNode::_set_filters(const Array &p_filters) {
+	WARN_DEPRECATED;
+	ERR_FAIL_NULL(process_state);
+	ERR_FAIL_COND(!process_state->tree->property_parent_map.has(node_state.base_path));
+	ERR_FAIL_COND(!process_state->tree->property_parent_map[node_state.base_path].has(filter));
+	StringName path = process_state->tree->property_parent_map[node_state.base_path][filter];
+
+	Ref<AnimationTrackFilter> track_filter = process_state->tree->property_map[path].first;
+	if (track_filter.is_null()) {
+		track_filter.instantiate();
+		process_state->tree->property_map[path].first = track_filter;
+	}
+
+	track_filter->clear_tracks();
+
+	for (int i = 0; i < p_filters.size(); i++) {
+		track_filter->set_track(p_filters[i], 1.0);
+	}
+}
+
+void AnimationNode::_bind_compatibility_methods() {
+	ClassDB::bind_method(D_METHOD("set_filter_path", "path", "enable"), &AnimationNode::set_filter_path);
+	ClassDB::bind_method(D_METHOD("is_path_filtered", "path"), &AnimationNode::is_path_filtered);
+
+	ClassDB::bind_method(D_METHOD("set_filter_enabled", "enable"), &AnimationNode::set_filter_enabled);
+	ClassDB::bind_method(D_METHOD("is_filter_enabled"), &AnimationNode::is_filter_enabled);
+
+	ClassDB::bind_method(D_METHOD("_set_filters", "filters"), &AnimationNode::_set_filters);
+	ClassDB::bind_method(D_METHOD("_get_filters"), &AnimationNode::_get_filters);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_filter_enabled", "is_filter_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "filters", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_filters", "_get_filters");
+}
+
+// AnimationTree
 void AnimationTree::_set_process_callback_bind_compat_80813(AnimationTree::AnimationProcessCallback p_mode) {
 	set_callback_mode_process(static_cast<AnimationMixer::AnimationCallbackModeProcess>(static_cast<int>(p_mode)));
 }

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -60,8 +60,6 @@ public:
 
 	bool closable = false;
 	Vector<Input> inputs;
-	HashMap<NodePath, bool> filter;
-	bool filter_enabled = false;
 
 	// Temporary state for blending process which needs to be stored in each AnimationNodes.
 	struct NodeState {
@@ -81,8 +79,6 @@ public:
 		uint64_t last_pass = 0;
 	} *process_state = nullptr;
 
-	Array _get_filters() const;
-	void _set_filters(const Array &p_filters);
 	friend class AnimationNodeBlendTree;
 	double _blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationNode *p_new_parent, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false, real_t *r_activity = nullptr);
 	double _pre_process(ProcessState *p_process_state, AnimationMixer::PlaybackInfo p_playback_info);
@@ -116,7 +112,13 @@ protected:
 	GDVIRTUAL0RC(String, _get_caption)
 	GDVIRTUAL0RC(bool, _has_filter)
 
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+#endif // DISABLE_DEPRECATED
+
 public:
+	StringName filter = PNAME("filter");
+
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const;
@@ -140,16 +142,21 @@ public:
 	int get_input_count() const;
 	int find_input(const String &p_name) const;
 
+	void set_closable(bool p_closable);
+	bool is_closable() const;
+
+	virtual bool has_filter() const;
+
+#ifndef DISABLE_DEPRECATED
 	void set_filter_path(const NodePath &p_path, bool p_enable);
 	bool is_path_filtered(const NodePath &p_path) const;
 
 	void set_filter_enabled(bool p_enable);
 	bool is_filter_enabled() const;
 
-	void set_closable(bool p_closable);
-	bool is_closable() const;
-
-	virtual bool has_filter() const;
+	Array _get_filters() const;
+	void _set_filters(const Array &p_filters);
+#endif // DISABLE_DEPRECATED
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const;
 	Ref<AnimationNode> find_node_by_path(const String &p_name) const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -142,6 +142,7 @@
 #include "scene/main/window.h"
 #include "scene/resources/animated_texture.h"
 #include "scene/resources/animation_library.h"
+#include "scene/resources/animation_track_filter.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/audio_stream_polyphonic.h"
 #include "scene/resources/audio_stream_wav.h"
@@ -901,6 +902,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(TextureCubemapArrayRD);
 	GDREGISTER_CLASS(Texture3DRD);
 
+	GDREGISTER_CLASS(AnimationTrackFilter);
 	GDREGISTER_CLASS(Animation);
 	GDREGISTER_CLASS(AnimationLibrary);
 

--- a/scene/resources/animation_track_filter.cpp
+++ b/scene/resources/animation_track_filter.cpp
@@ -1,0 +1,118 @@
+/**************************************************************************/
+/*  animation_track_filter.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "animation_track_filter.h"
+
+Dictionary AnimationTrackFilter::get_tracks_bind() const {
+	tracks.sort();
+	Dictionary ret;
+	for (const TrackFilterInfo &E : tracks) {
+		ret[E.track] = E.amount;
+	}
+	return ret;
+}
+
+void AnimationTrackFilter::set_tracks_bind(const Dictionary &p_tracks) {
+	tracks.clear();
+	Array track_paths = p_tracks.keys();
+	Array track_amounts = p_tracks.values();
+	for (int i = 0; i < track_paths.size(); ++i) {
+		//	Validation.
+		ERR_CONTINUE(!Variant::can_convert(track_paths[i].get_type(), Variant::NODE_PATH));
+		ERR_CONTINUE(!Variant::can_convert(track_amounts[i].get_type(), Variant::FLOAT));
+
+		tracks.push_back({ track_paths[i], CLAMP(track_amounts[i].operator float(), 0.0f, 1.0f) });
+	}
+	emit_changed();
+}
+
+void AnimationTrackFilter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_tracks", "tracks"), &AnimationTrackFilter::set_tracks_bind);
+	ClassDB::bind_method(D_METHOD("get_tracks"), &AnimationTrackFilter::get_tracks_bind);
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "tracks"), "set_tracks", "get_tracks");
+
+	ClassDB::bind_method(D_METHOD("has_trck", "track_path"), &AnimationTrackFilter::has_track);
+	ClassDB::bind_method(D_METHOD("remove_track", "track_path"), &AnimationTrackFilter::remove_track);
+	ClassDB::bind_method(D_METHOD("get_track_amount", "track_path"), &AnimationTrackFilter::get_track_amount);
+	ClassDB::bind_method(D_METHOD("set_track", "track_path", "amount"), &AnimationTrackFilter::set_track, DEFVAL(1.0f));
+	ClassDB::bind_method(D_METHOD("clear_tracks"), &AnimationTrackFilter::clear_tracks);
+}
+
+bool AnimationTrackFilter::has_track(const NodePath &p_track_path) const {
+	for (const TrackFilterInfo &E : tracks) {
+		if (E.track == p_track_path) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void AnimationTrackFilter::remove_track(const NodePath &p_track_path) {
+	for (size_t i = 0; i < tracks.size(); ++i) {
+		if (tracks[i].track == p_track_path) {
+			SWAP(tracks[i], tracks[tracks.size() - 1]);
+			tracks.resize(tracks.size() - 1);
+			emit_changed();
+			return;
+		}
+	}
+}
+
+float AnimationTrackFilter::get_track_amount(const NodePath &p_track_path) const {
+	for (const TrackFilterInfo &E : tracks) {
+		if (E.track == p_track_path) {
+			return E.amount;
+		}
+	}
+	return 0.0f;
+}
+
+void AnimationTrackFilter::set_track(const NodePath &p_track_path, float p_amount) {
+	p_amount = CLAMP(p_amount, 0.0f, 1.0f);
+
+	if (Math::is_zero_approx(p_amount)) {
+		remove_track(p_track_path);
+		return;
+	}
+
+	for (TrackFilterInfo &E : tracks) {
+		if (E.track == p_track_path) {
+			E.amount = p_amount;
+			emit_changed();
+			return;
+		}
+	}
+	tracks.push_back({ p_track_path, p_amount });
+	emit_changed();
+}
+
+void AnimationTrackFilter::clear_tracks() {
+	tracks.clear();
+}

--- a/scene/resources/animation_track_filter.h
+++ b/scene/resources/animation_track_filter.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  animation_track_filter.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef ANIMATION_TRACK_FILTER_H
+#define ANIMATION_TRACK_FILTER_H
+
+#include "core/io/resource.h"
+#include "core/variant/typed_array.h"
+
+class AnimationTrackFilter : public Resource {
+	GDCLASS(AnimationTrackFilter, Resource);
+
+public:
+	struct TrackFilterInfo {
+		NodePath track;
+		float amount;
+		_FORCE_INLINE_ bool operator<(const TrackFilterInfo &p_other) const { return String(track) < String(p_other.track); }
+	};
+
+private:
+	mutable LocalVector<TrackFilterInfo> tracks;
+
+#ifdef TOOLS_ENABLED
+	friend class AnimationNodeBlendTreeEditor;
+#endif
+
+protected:
+	static void _bind_methods();
+
+public:
+	const LocalVector<TrackFilterInfo> &get_tracks() const { return tracks; }
+	void set_tracks(const LocalVector<TrackFilterInfo> &p_tracks) {
+		tracks = p_tracks;
+		emit_changed();
+	}
+
+	// Todo: Use Typed Dictionary or TypedArray<Struct> instead of Dictionary.
+	Dictionary get_tracks_bind() const;
+	void set_tracks_bind(const Dictionary &p_tracks);
+
+	float get_track_amount(const NodePath &p_track_path) const;
+	bool has_track(const NodePath &p_track_path) const;
+	void remove_track(const NodePath &p_track_path);
+	void set_track(const NodePath &p_track_path, float p_amount);
+
+	void clear_tracks();
+};
+
+#endif // ANIMATION_TRACK_FILTER_H


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Implement [#6808](https://github.com/godotengine/godot-proposals/issues/6808).

+ Add resource type `AnimationTrackFilter`, remove `AnimationNode` menbers:
   + `filter`, `filter_enabled`
   + `_get_filters()`, `_set_filters()`, `has_filter()`, `set_filter_path()`, `set_filter_path()`, 
+ Implement `filter` like  other `AnimationNode`'s parameters.
+ Modify `AnimationNodeBlendTreeEditor` to adapt to first change.
+ Implement `AnimationTrackFilterEditorPlugin` to edit filter tracks in inspector.


https://github.com/godotengine/godot/assets/61624558/d60a00fc-9506-400b-af81-c008b572d16a

--------------------------------------------------------------------------------------------------------------

This pr implement filter for `AnimationNodeBlend3`, will close [#76506](https://github.com/godotengine/godot/pull/76506).

The filter is implemented as gradual style, will close [#7578](https://github.com/godotengine/godot-proposals/issues/7578).

_Bugsquad Edited:_
Closes https://github.com/godotengine/godot-proposals/discussions/7896