### PR TITLE
LSP: Don't send empty completion command

### DIFF
--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1005,7 +1005,9 @@ struct CompletionItem {
 			if (commitCharacters.size()) {
 				dict["commitCharacters"] = commitCharacters;
 			}
-			dict["command"] = command.to_json();
+			if (!command.command.is_empty()) {
+				dict["command"] = command.to_json();
+			}
 		}
 		return dict;
 	}


### PR DESCRIPTION
Fixes #76789
makes it so that the server doesn't send an empty command, so you get a response like this:
```diff
{
  "sortText": "",
  "preselect": null,
  "label": "collision_polygon",
  "kind": 6,
  "insertText": "collision_polygon",
  "filterText": "",
  "documentation": {
    "value": "\tvar collision_polygon: PackedVector2Array\n\nDefined in [res://test_script.gd](file:///Users/achernik/projects/test_lsp/test_script.gd)",
    "kind": "markdown"
  },
  "detail": "",
  "deprecated": null,
  "data": {
    "textDocument": {
      "uri": "file:///Users/achernik/projects/test_lsp/test_script.gd"
    },
    "position": {
      "line": 48,
      "character": 7
    },
    "context": null
+  }
-  },
-  "command": {
-    "title": "",
-    "command": ""
  }
}
```