### PR TITLE
Fix double tap & drag on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -197,7 +197,10 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		if (event.actionMasked == MotionEvent.ACTION_UP) {
 			nextDownIsDoubleTap = false
 			GodotInputHandler.handleMotionEvent(event)
+		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && panningAndScalingEnabled == false) {
+			GodotInputHandler.handleMotionEvent(event)
 		}
+
 		return true
 	}
 


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/76587. This is very easy to reproduce, just compile on Android device a project which prints all input events:

```gdscript
extends Node2D
func _input(event):
	print(event)
```

In `master`, if you double tap & drag, **no events are emitted** for the drag. In this PR, you correctly see the drag events. This makes Android consistent with iOS and Windows (I haven't tested other platforms behavior).

The fix involves listening for motion events in the `onDoubleTapEvent` listener, because the native Android `GestureDetector` differentiates between motion events after a double tap and regular motion events.
