### PR TITLE
Add `get_display_name()` to Script

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -921,3 +921,13 @@ PlaceHolderScriptInstance::~PlaceHolderScriptInstance() {
 		script->_placeholder_erased(this);
 	}
 }
+
+const String Script::get_display_name() const {
+	if (is_built_in() && !get_name().is_empty()) {
+		return vformat("%s (%s)", get_name(), get_path().get_slice("::", 0));
+	} else if (!get_global_name().is_empty()) {
+		return vformat("%s (%s)", get_global_name(), get_path());
+	} else {
+		return get_path();
+	}
+}

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -200,6 +200,8 @@ public:
 
 	virtual const Variant get_rpc_config() const = 0;
 
+	const String get_display_name() const;
+
 	Script() {
 		_define_ancestry(AncestralClass::SCRIPT);
 	}

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -613,7 +613,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 				additional_notes += "\n" + TTR("This script is a custom type.");
 				button_color.a = 0.5;
 			}
-			p_item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + scr->get_path() + additional_notes);
+			p_item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT, false, TTR("Open Script:") + " " + scr->get_display_name() + additional_notes);
 			p_item->set_button_color(0, p_item->get_button_count(0) - 1, button_color);
 		}
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -837,7 +837,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), e->get().start_line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
+			_err_print_error("GDScript::reload", (const char *)get_display_name().utf8().get_data(), e->get().start_line, ("Parse Error: " + e->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			e = e->next();
 		}
 		reloading = false;

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -162,7 +162,7 @@ void GDScriptByteCodeGenerator::write_start(GDScript *p_script, const StringName
 
 	function->name = p_function_name;
 	function->_script = p_script;
-	function->source = p_script->get_script_path();
+	function->source = p_script->get_display_name();
 
 #ifdef DEBUG_ENABLED
 	function->func_cname = (String(function->source) + " - " + String(p_function_name)).utf8();


### PR DESCRIPTION
The PR is inspired by this error:
![image](https://user-images.githubusercontent.com/2223172/236648882-26dffad0-a414-4378-840a-c8dec8517ec1.png)
Now imagine I have 10 built-in scripts in a scene. Finding the faulty one is *inconvenient*.

I located where this message comes from and applied the same formatting we use in script editor (i.e. `ScriptName (scene_path)`), but the I thought that repeating this format is counter-productive, so I added a new method to Script class: `get_display_name()`.

It works like this:
- if a script is built-in and has a name, display it as `ScriptName (scene_path)`
- if a script has a global name, display it as `GlobalName (script_path)`
- otherwise display its path

Now the error properly uses script's name if available:
![image](https://user-images.githubusercontent.com/2223172/236648971-f8688f74-ad08-413a-be63-93ed4f7d1e5a.png)

Also if a script has `class_name` attached, it's displayed too:
![image](https://user-images.githubusercontent.com/2223172/236648983-b3e0c135-33b8-4c74-8242-603f9c699944.png)

Ironically, I wasn't able to use this method in script editor, because disambiguation *destroys* everything. But I added it to scene tree:
![image](https://user-images.githubusercontent.com/2223172/236648991-ec57b349-1dee-4498-acd1-8ab20f569f86.png)
![image](https://user-images.githubusercontent.com/2223172/236649014-988829c0-5d0f-41a1-a70d-228b557e5510.png)
(notice how it displays `class_name`)

