### PR TITLE
Fix another collision shape editor crash

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -436,7 +436,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 
 	switch (shape_type) {
 		case CAPSULE_SHAPE: {
-			Ref<CapsuleShape2D> shape = node->get_shape();
+			Ref<CapsuleShape2D> shape = current_shape;
 
 			handles.resize(2);
 			float radius = shape->get_radius();
@@ -451,7 +451,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		} break;
 
 		case CIRCLE_SHAPE: {
-			Ref<CircleShape2D> shape = node->get_shape();
+			Ref<CircleShape2D> shape = current_shape;
 
 			handles.resize(1);
 			handles.write[0] = Point2(shape->get_radius(), 0);
@@ -467,7 +467,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		} break;
 
 		case WORLD_BOUNDARY_SHAPE: {
-			Ref<WorldBoundaryShape2D> shape = node->get_shape();
+			Ref<WorldBoundaryShape2D> shape = current_shape;
 
 			handles.resize(2);
 			handles.write[0] = shape->get_normal() * shape->get_distance();
@@ -479,7 +479,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		} break;
 
 		case SEPARATION_RAY_SHAPE: {
-			Ref<SeparationRayShape2D> shape = node->get_shape();
+			Ref<SeparationRayShape2D> shape = current_shape;
 
 			handles.resize(1);
 			handles.write[0] = Point2(0, shape->get_length());
@@ -489,7 +489,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		} break;
 
 		case RECTANGLE_SHAPE: {
-			Ref<RectangleShape2D> shape = node->get_shape();
+			Ref<RectangleShape2D> shape = current_shape;
 
 			handles.resize(8);
 			Vector2 ext = shape->get_size() / 2;
@@ -501,7 +501,7 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 		} break;
 
 		case SEGMENT_SHAPE: {
-			Ref<SegmentShape2D> shape = node->get_shape();
+			Ref<SegmentShape2D> shape = current_shape;
 
 			handles.resize(2);
 			handles.write[0] = shape->get_a();


### PR DESCRIPTION
The collision shape editor checks in `NOTIFICATION_PROCESS` if the shape has not changed. In theory it should ensure that the shape is valid before trying to draw it. But turns out, for whatever reason, and contrary to the "Clear" context menu option, the revert arrow will remove the shape somewhere between `NOTIFICATION_PROCESS` and drawing function, which results in redraw with old data.

The PR makes the draw method use the currently cached shape, which means that in the aforementioned corner-case, the editor will draw old shape for a single frame.
*Of course* an alternative is adding a null check for node's shape, but the `current_shape` is updated reliably, so why not use it.

Fixes #76771