### PR TITLE
Fixing the variant type of an array not getting set properly when assigning from another array

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -208,8 +208,7 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 
 	if (original_array.get_type() == Variant::ARRAY) {
 		// Needed to preserve type of TypedArrays in meta pointer properties.
-		Array temp;
-		temp.assign(original_array.duplicate());
+		Array temp(original_array.duplicate());
 		array = temp;
 	} else {
 		array = original_array.duplicate();


### PR DESCRIPTION
If we assign an array from another array and the original array has variant type NIL, this wouldn't get updated with the new type from the array we are assigning from, creating some bugs. In particular this Fixes #76795 where the array not getting the right type and being stuck with NIL would get the GDScriptInstance::set to exit early and not properly call the setter function.
