### PR TITLE
Fix building the Windows x86_32 target

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -706,16 +706,16 @@ Dictionary OS_Windows::get_memory_info() const {
 	}
 
 	if (pref_info.PhysicalTotal * pref_info.PageSize != 0) {
-		meminfo["physical"] = pref_info.PhysicalTotal * pref_info.PageSize;
+		meminfo["physical"] = static_cast<int64_t>(pref_info.PhysicalTotal * pref_info.PageSize);
 	}
 	if (pref_info.PhysicalAvailable * pref_info.PageSize != 0) {
-		meminfo["free"] = pref_info.PhysicalAvailable * pref_info.PageSize;
+		meminfo["free"] = static_cast<int64_t>(pref_info.PhysicalAvailable * pref_info.PageSize);
 	}
 	if (pref_info.CommitLimit * pref_info.PageSize != 0) {
-		meminfo["available"] = pref_info.CommitLimit * pref_info.PageSize;
+		meminfo["available"] = static_cast<int64_t>(pref_info.CommitLimit * pref_info.PageSize);
 	}
 	if (HighLimit - LowLimit != 0) {
-		meminfo["stack"] = HighLimit - LowLimit;
+		meminfo["stack"] = static_cast<int64_t>(HighLimit - LowLimit);
 	}
 
 	return meminfo;


### PR DESCRIPTION
In x86_32, `ULONG_PTR` and `SIZE_T` are defined as `unsigned long`, which is not a type supported by Variant without the `NEED_LONG_INT` define.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
