### PR TITLE
Add more uses of appropriate cursors when resizing/moving some UI nodes

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -62,6 +62,15 @@ GraphEditMinimap::GraphEditMinimap(GraphEdit *p_edit) {
 	is_resizing = false;
 }
 
+Control::CursorShape GraphEditMinimap::get_cursor_shape(const Point2 &p_pos) const {
+	Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
+	if (is_resizing || (p_pos.x < resizer->get_width() && p_pos.y < resizer->get_height())) {
+		return CURSOR_FDIAGSIZE;
+	}
+
+	return Control::get_cursor_shape(p_pos);
+}
+
 void GraphEditMinimap::update_minimap() {
 	Vector2 graph_offset = _get_graph_offset();
 	Vector2 graph_size = _get_graph_size();
@@ -188,6 +197,14 @@ void GraphEditMinimap::gui_input(const Ref<InputEvent> &p_ev) {
 void GraphEditMinimap::_adjust_graph_scroll(const Vector2 &p_offset) {
 	Vector2 graph_offset = _get_graph_offset();
 	ge->set_scroll_ofs(p_offset + graph_offset - camera_size / 2);
+}
+
+Control::CursorShape GraphEdit::get_cursor_shape(const Point2 &p_pos) const {
+	if (moving_selection) {
+		return CURSOR_MOVE;
+	}
+
+	return Control::get_cursor_shape(p_pos);
 }
 
 PackedStringArray GraphEdit::get_configuration_warnings() const {

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -64,6 +64,8 @@ protected:
 public:
 	GraphEditMinimap(GraphEdit *p_edit);
 
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+
 	void update_minimap();
 	Rect2 get_camera_rect();
 
@@ -286,6 +288,8 @@ protected:
 	GDVIRTUAL4R(bool, _is_node_hover_valid, StringName, int, StringName, int);
 
 public:
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+
 	PackedStringArray get_configuration_warnings() const override;
 
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -990,7 +990,6 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_ev) {
 	Ref<InputEventMouseMotion> mm = p_ev;
 	if (resizing && mm.is_valid()) {
 		Vector2 mpos = mm->get_position();
-
 		Vector2 diff = mpos - resizing_from;
 
 		emit_signal(SNAME("resize_request"), resizing_from_size + diff);
@@ -1053,6 +1052,18 @@ void GraphNode::set_selectable(bool p_selectable) {
 
 bool GraphNode::is_selectable() {
 	return selectable;
+}
+
+Control::CursorShape GraphNode::get_cursor_shape(const Point2 &p_pos) const {
+	if (resizable) {
+		Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
+
+		if (resizing || (p_pos.x > get_size().x - resizer->get_width() && p_pos.y > get_size().y - resizer->get_height())) {
+			return CURSOR_FDIAGSIZE;
+		}
+	}
+
+	return Control::get_cursor_shape(p_pos);
 }
 
 Vector<int> GraphNode::get_allowed_size_flags_horizontal() const {

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -197,6 +197,8 @@ public:
 
 	virtual Size2 get_minimum_size() const override;
 
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
+
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2601,6 +2601,10 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 				}
 
 				gui.subwindow_focused->_rect_changed_callback(new_rect);
+
+				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+					DisplayServer::get_singleton()->cursor_set_shape(DisplayServer::CURSOR_MOVE);
+				}
 			}
 			if (gui.subwindow_drag == SUB_WINDOW_DRAG_CLOSE) {
 				gui.subwindow_drag_close_inside = gui.subwindow_drag_close_rect.has_point(mm->get_position());


### PR DESCRIPTION
- Use `FDIAGSIZE` when resizing a `GraphNode`.
- Use `MOVE` when when moving a `GraphNode` around.
- Use `FDIAGSIZE` when resizing the minimap of a `GraphEdit`.
- Use `MOVE` when when moving an embedded `Window` around.