### PR TITLE
Minor bugfixes to `ItemList`

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -597,6 +597,7 @@ void ItemList::set_fixed_icon_size(const Size2i &p_size) {
 
 	fixed_icon_size = p_size;
 	queue_redraw();
+	shape_changed = true;
 }
 
 Size2i ItemList::get_fixed_icon_size() const {
@@ -656,13 +657,6 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mb.is_valid() && mb->is_pressed()) {
 		search_string = ""; //any mousepress cancels
-		Vector2 pos = mb->get_position();
-		pos -= theme_cache.panel_style->get_offset();
-		pos.y += scroll_bar->get_value();
-
-		if (is_layout_rtl()) {
-			pos.x = get_size().width - pos.x;
-		}
 
 		int closest = get_item_at_position(mb->get_position(), true);
 


### PR DESCRIPTION
* Removed unused position code in `gui_input`
* Ensured `set_fixed_icon_size` updates cached size

The fixed icon size is used for the shape update here:
https://github.com/godotengine/godot/blob/bd1bc68ba07e330e814af19faf87d59da3f0ce6f/scene/gui/item_list.cpp#L1337

It doesn't look like the tooltip, metadata, tag icon, or icon transposed of an item affects the size at all but left the `shape_changed = true` unchanged there in case it somehow affects it.

Couldn't find any other properties that play a part in the shape update that didn't update the check but if anyone sees one do tell me and I'll add it.

It does seem like there's some leftover and unused code across `ItemList`, for example `min_rect_cache` is set but never used, will take a deeper dive into dead code in this class later.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
