### PR TITLE
fix a test for wrapf with signed 32-bit float

### DIFF
--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -472,7 +472,7 @@ TEST_CASE_TEMPLATE("[Math] wrapf", T, float, double) {
 
 	CHECK(Math::wrapf(300'000'000'000.0, -20.0, 160.0) == doctest::Approx((T)120.0));
 	// float's precision is too low for 300'000'000'000.0, so we reduce it by a factor of 1000.
-	CHECK(Math::wrapf((float)300'000'000.0, (float)-20.0, (float)160.0) == doctest::Approx((T)128.0));
+	CHECK(Math::wrapf((float)15'000'000.0, (float)-20.0, (float)160.0) == doctest::Approx((T)60.0));
 }
 
 TEST_CASE_TEMPLATE("[Math] fract", T, float, double) {


### PR DESCRIPTION
This fix an issue on some architecture/OS (at least macos M1) where some checks would fail for `Math::wrapf` . The check in question tested the function with a 32-bit float greater than the range in which all integers are represented. this lead to a returned value which is different than the correct (in theory) value, which was the one checked. 
<img width="1001" alt="Capture d’écran 2023-05-03 à 04 01 08" src="https://user-images.githubusercontent.com/66184050/236799739-6f43c21d-7c98-4728-864d-fcbdd8314852.png">
I reduced the value to test inside the range where all integers are represented.
