### PR TITLE
mbedTLS: disable weak crypto and TLS versions.

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -375,7 +375,8 @@ File extracted from upstream release tarball:
 - The `LICENSE` file.
 - Applied the patch in `patches/1453.diff` to fix UWP build (upstream PR:
   https://github.com/ARMmbed/mbedtls/pull/1453).
-  Applied the patch in `patches/windows-arm64-hardclock.diff`
+  Applied the patch in `patches/windows-arm64-hardclock.diff`.
+  Applied the patch in `patches/config-customizations.diff`.
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
 

--- a/thirdparty/mbedtls/include/mbedtls/config.h
+++ b/thirdparty/mbedtls/include/mbedtls/config.h
@@ -986,7 +986,7 @@
  *             See dhm.h for more details.
  *
  */
-#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+//#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
 
 /**
  * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
@@ -1092,7 +1092,7 @@
  *             See dhm.h for more details.
  *
  */
-#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+//#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
 
 /**
  * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
@@ -1766,7 +1766,7 @@
  *
  * Comment this macro to disable 1/n-1 record splitting.
  */
-#define MBEDTLS_SSL_CBC_RECORD_SPLITTING
+//#define MBEDTLS_SSL_CBC_RECORD_SPLITTING
 
 /**
  * \def MBEDTLS_SSL_RENEGOTIATION
@@ -1847,7 +1847,7 @@
  *
  * Comment this macro to disable support for TLS 1.0
  */
-#define MBEDTLS_SSL_PROTO_TLS1
+//#define MBEDTLS_SSL_PROTO_TLS1
 
 /**
  * \def MBEDTLS_SSL_PROTO_TLS1_1
@@ -1859,7 +1859,7 @@
  *
  * Comment this macro to disable support for TLS 1.1 / DTLS 1.0
  */
-#define MBEDTLS_SSL_PROTO_TLS1_1
+//#define MBEDTLS_SSL_PROTO_TLS1_1
 
 /**
  * \def MBEDTLS_SSL_PROTO_TLS1_2
@@ -2474,7 +2474,7 @@
  *            it, and considering stronger ciphers instead.
  *
  */
-#define MBEDTLS_ARC4_C
+//#define MBEDTLS_ARC4_C
 
 /**
  * \def MBEDTLS_ASN1_PARSE_C
@@ -2786,7 +2786,7 @@
  * \warning   DES/3DES are considered weak ciphers and their use constitutes a
  *            security risk. We recommend considering stronger ciphers instead.
  */
-#define MBEDTLS_DES_C
+//#define MBEDTLS_DES_C
 
 /**
  * \def MBEDTLS_DHM_C
@@ -2807,7 +2807,7 @@
  *             See dhm.h for more details.
  *
  */
-#define MBEDTLS_DHM_C
+//#define MBEDTLS_DHM_C
 
 /**
  * \def MBEDTLS_ECDH_C

--- a/thirdparty/mbedtls/patches/config-customizations.diff
+++ b/thirdparty/mbedtls/patches/config-customizations.diff
@@ -1,0 +1,74 @@
+--- ../mbedtls/include/mbedtls/config.h	2023-05-10 05:36:27.559910096 +0200
++++ thirdparty/mbedtls/include/mbedtls/config.h	2023-05-10 05:39:30.949385023 +0200
+@@ -986,7 +986,7 @@
+  *             See dhm.h for more details.
+  *
+  */
+-#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
++//#define MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+ 
+ /**
+  * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
+@@ -1092,7 +1092,7 @@
+  *             See dhm.h for more details.
+  *
+  */
+-#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
++//#define MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+ 
+ /**
+  * \def MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+@@ -1766,7 +1766,7 @@
+  *
+  * Comment this macro to disable 1/n-1 record splitting.
+  */
+-#define MBEDTLS_SSL_CBC_RECORD_SPLITTING
++//#define MBEDTLS_SSL_CBC_RECORD_SPLITTING
+ 
+ /**
+  * \def MBEDTLS_SSL_RENEGOTIATION
+@@ -1847,7 +1847,7 @@
+  *
+  * Comment this macro to disable support for TLS 1.0
+  */
+-#define MBEDTLS_SSL_PROTO_TLS1
++//#define MBEDTLS_SSL_PROTO_TLS1
+ 
+ /**
+  * \def MBEDTLS_SSL_PROTO_TLS1_1
+@@ -1859,7 +1859,7 @@
+  *
+  * Comment this macro to disable support for TLS 1.1 / DTLS 1.0
+  */
+-#define MBEDTLS_SSL_PROTO_TLS1_1
++//#define MBEDTLS_SSL_PROTO_TLS1_1
+ 
+ /**
+  * \def MBEDTLS_SSL_PROTO_TLS1_2
+@@ -2474,7 +2474,7 @@
+  *            it, and considering stronger ciphers instead.
+  *
+  */
+-#define MBEDTLS_ARC4_C
++//#define MBEDTLS_ARC4_C
+ 
+ /**
+  * \def MBEDTLS_ASN1_PARSE_C
+@@ -2786,7 +2786,7 @@
+  * \warning   DES/3DES are considered weak ciphers and their use constitutes a
+  *            security risk. We recommend considering stronger ciphers instead.
+  */
+-#define MBEDTLS_DES_C
++//#define MBEDTLS_DES_C
+ 
+ /**
+  * \def MBEDTLS_DHM_C
+@@ -2807,7 +2807,7 @@
+  *             See dhm.h for more details.
+  *
+  */
+-#define MBEDTLS_DHM_C
++//#define MBEDTLS_DHM_C
+ 
+ /**
+  * \def MBEDTLS_ECDH_C


### PR DESCRIPTION
This commit disables most weak crypto options in mbedTLS (with the notable exceptions of MD5 and SHA-1).

This commit also disables support for TLS versions 1.0 and 1.1 (with TLSv1.2 currently being the only supported version).