### PR TITLE
[3.x] Timestamped input buffering - prevent stalling and improve timing

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -653,7 +653,7 @@ public:
 	virtual int get_power_seconds_left();
 	virtual int get_power_percent_left();
 
-	virtual void force_process_input(){};
+	virtual void force_process_input() {}
 	bool has_feature(const String &p_feature);
 
 	void set_has_server_feature_callback(HasServerFeatureCallback p_callback);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -654,11 +654,15 @@
 			Default [InputEventAction] to move up in the UI.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
-		<member name="input_devices/buffering/agile_event_flushing" type="bool" setter="" getter="" default="false">
+		<member name="input_devices/buffering/agile_event_flushing" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], key/touch/joystick events will be flushed just before every idle and physics frame.
 			If [code]false[/code], such events will be flushed only once per idle frame, between iterations of the engine.
 			Enabling this can greatly improve the responsiveness to input, specially in devices that need to run multiple physics frames per visible (idle) frame, because they can't run at the target frame rate.
 			[b]Note:[/b] Currently implemented only in Android.
+		</member>
+		<member name="input_devices/buffering/legacy_event_flushing" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], input events will be flushed on demand according to platform, instead of the new platform independent method.
+			[b]Note:[/b] Enabling this will break agile event flushing, which may reduce input timing resolution on some platforms.
 		</member>
 		<member name="input_devices/pointing/emulate_mouse_from_touch" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], sends mouse input events when tapping or swiping on the touchscreen.

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -40,6 +40,135 @@
 #include "core/os/thread.h"
 #endif
 
+// Accumulating immediately rather than deferred at flush
+// is slightly more efficient (because of less allocations / transfer to the main buffer etc)
+// but is less accurate timing wise, so should only be used in frame buffering mode.
+void InputEventBuffer::accumulate_or_push_event(Ref<InputEvent> p_event, uint64_t p_timestamp) {
+	// Events can come in any time, including when we are preparing to read the incoming queue,
+	// so we must lock to prevent race condition.
+	MutexLock lock(data.incoming_mutex);
+
+	LocalVector<Event> &incoming = data.incoming[data.incoming_write];
+
+	// First, attempt to accumulate.
+	if (incoming.size()) {
+		Event &prev = incoming[incoming.size() - 1];
+		if (prev.event->accumulate(p_event)) {
+			return;
+		}
+	}
+
+	// Accumulate failed, fall back to push.
+	incoming.resize(incoming.size() + 1);
+	Event &e = incoming[incoming.size() - 1];
+	e.event = p_event;
+	e.timestamp = p_timestamp;
+}
+
+void InputEventBuffer::push_event(Ref<InputEvent> p_event, uint64_t p_timestamp) {
+	// Events can come in any time, including when we are preparing to read the incoming queue,
+	// so we must lock to prevent race condition.
+	MutexLock lock(data.incoming_mutex);
+
+	LocalVector<Event> &incoming = data.incoming[data.incoming_write];
+	incoming.resize(incoming.size() + 1);
+	Event &e = incoming[incoming.size() - 1];
+	e.event = p_event;
+	e.timestamp = p_timestamp;
+}
+
+void InputEventBuffer::_try_accumulate(uint64_t p_timestamp) {
+	// Try and accumulate events after the current front
+	// until we fail or pass the current timestamp.
+	List<Event>::Element *front = data.buffer.front();
+	Event &front_event = front->get();
+
+	while (List<Event>::Element *next = data.buffer.front()->next()) {
+		const Event &next_event = next->get();
+		if (next_event.timestamp > p_timestamp) {
+			// Don't want to accumulate events that are on the next tick..
+			// want to keep some resolution to the events.
+			break;
+		}
+		if (front_event.event->accumulate(next_event.event)) {
+			// Remove the accumulated event from the buffer.
+			data.buffer.swap(front, next);
+			data.buffer.pop_front();
+			// Check this does not invalidate front and front_event.
+			DEV_ASSERT(front == data.buffer.front());
+			DEV_ASSERT(&front_event == &front->get());
+		} else {
+			break;
+		}
+	}
+}
+
+void InputEventBuffer::flush_events(uint64_t p_current_timestamp, InputDefault &r_input_handler, bool p_accumulate) {
+	// Flushing function is not re-entrant.
+	// This is unlikely to be called multithread, but this check should be cheap.
+	MutexLock lock(data.buffer_mutex);
+
+	if (data.flushing) {
+		// only allow one flush at a time
+		return;
+	}
+	data.flushing = true;
+
+	data.incoming_mutex.lock();
+	SWAP(data.incoming_write, data.incoming_read);
+	data.incoming_mutex.unlock();
+
+	LocalVector<Event> &incoming = data.incoming[data.incoming_read];
+
+// #define GODOT_DEBUG_INPUT_EVENT_BUFFER
+#ifdef GODOT_DEBUG_INPUT_EVENT_BUFFER
+	String sz = "timestamp: " + itos(p_current_timestamp) + " incoming : " + itos(incoming.size());
+#endif
+
+	for (uint32_t n = 0; n < incoming.size(); n++) {
+		// Copy to main buffer.
+		data.buffer.push_back(incoming[n]);
+	}
+
+	// Prepare for more input next time, prevent leak.
+	incoming.clear();
+
+#ifdef GODOT_DEBUG_INPUT_EVENT_BUFFER
+	uint32_t processed = 0;
+#endif
+
+	// Now we can read through the input buffer, up to the current time, and process.
+	while (data.buffer.front()) {
+		const Event &e = data.buffer.front()->get();
+
+		// Timestamp within range?
+		if (e.timestamp > p_current_timestamp) {
+			// We are up to date, process no more input on this tick / frame.
+			break;
+		}
+
+		if (p_accumulate) {
+			_try_accumulate(p_current_timestamp);
+		}
+
+		r_input_handler._parse_input_event_impl(e.event, false, false);
+#ifdef GODOT_DEBUG_INPUT_EVENT_BUFFER
+		processed++;
+#endif
+
+		// Event processed, remove from buffer.
+		data.buffer.pop_front();
+	}
+
+#ifdef GODOT_DEBUG_INPUT_EVENT_BUFFER
+	if ((p_current_timestamp != UINT64_MAX) && processed) {
+		print_line(sz + ", processed : " + itos(processed));
+	}
+#endif
+
+	data.flushing = false;
+}
+
 void InputDefault::SpeedTrack::update(const Vector2 &p_delta_p) {
 	uint64_t tick = OS::get_singleton()->get_ticks_usec();
 	uint32_t tdiff = tick - last_tick;
@@ -314,7 +443,7 @@ Vector3 InputDefault::get_gyroscope() const {
 	return gyroscope;
 }
 
-void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated) {
+void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated, bool p_unlock) {
 	// This function does the final delivery of the input event to user land.
 	// Regardless where the event came from originally, this has to happen on the main thread.
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
@@ -362,9 +491,13 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			touch_event->set_pressed(mb->is_pressed());
 			touch_event->set_position(mb->get_position());
 			touch_event->set_double_tap(mb->is_doubleclick());
-			_THREAD_SAFE_UNLOCK_
-			main_loop->input_event(touch_event);
-			_THREAD_SAFE_LOCK_
+			if (p_unlock) {
+				_THREAD_SAFE_UNLOCK_
+				main_loop->input_event(touch_event);
+				_THREAD_SAFE_LOCK_
+			} else {
+				main_loop->input_event(touch_event);
+			}
 		}
 	}
 
@@ -386,9 +519,13 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			drag_event->set_relative(relative);
 			drag_event->set_speed(get_last_mouse_speed());
 
-			_THREAD_SAFE_UNLOCK_
-			main_loop->input_event(drag_event);
-			_THREAD_SAFE_LOCK_
+			if (p_unlock) {
+				_THREAD_SAFE_UNLOCK_
+				main_loop->input_event(drag_event);
+				_THREAD_SAFE_LOCK_
+			} else {
+				main_loop->input_event(drag_event);
+			}
 		}
 	}
 
@@ -434,7 +571,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 					button_event->set_button_mask(mouse_button_mask & ~(1 << (BUTTON_LEFT - 1)));
 				}
 
-				_parse_input_event_impl(button_event, true);
+				_parse_input_event_impl(button_event, true, p_unlock);
 			}
 		}
 	}
@@ -458,7 +595,7 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 			motion_event->set_button_mask(mouse_button_mask);
 			motion_event->set_pressure(1.f);
 
-			_parse_input_event_impl(motion_event, true);
+			_parse_input_event_impl(motion_event, true, p_unlock);
 		}
 	}
 
@@ -484,9 +621,13 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 
 	if (ge.is_valid()) {
 		if (main_loop) {
-			_THREAD_SAFE_UNLOCK_
-			main_loop->input_event(ge);
-			_THREAD_SAFE_LOCK_
+			if (p_unlock) {
+				_THREAD_SAFE_UNLOCK_
+				main_loop->input_event(ge);
+				_THREAD_SAFE_LOCK_
+			} else {
+				main_loop->input_event(ge);
+			}
 		}
 	}
 
@@ -509,9 +650,13 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 	}
 
 	if (main_loop) {
-		_THREAD_SAFE_UNLOCK_
-		main_loop->input_event(p_event);
-		_THREAD_SAFE_LOCK_
+		if (p_unlock) {
+			_THREAD_SAFE_UNLOCK_
+			main_loop->input_event(p_event);
+			_THREAD_SAFE_LOCK_
+		} else {
+			main_loop->input_event(p_event);
+		}
 	}
 }
 
@@ -675,7 +820,7 @@ void InputDefault::ensure_touch_mouse_raised() {
 		button_event->set_button_index(BUTTON_LEFT);
 		button_event->set_button_mask(mouse_button_mask & ~(1 << (BUTTON_LEFT - 1)));
 
-		_parse_input_event_impl(button_event, true);
+		_parse_input_event_impl(button_event, true, true);
 	}
 }
 
@@ -750,46 +895,52 @@ void InputDefault::parse_input_event(const Ref<InputEvent> &p_event) {
 	}
 #endif
 
-	if (use_accumulated_input) {
-		if (buffered_events.empty() || !buffered_events.back()->get()->accumulate(p_event)) {
-			buffered_events.push_back(p_event);
-		}
-	} else if (use_input_buffering) {
-		buffered_events.push_back(p_event);
+	if (data.buffering_mode == Input::BUFFERING_MODE_NONE) {
+		_parse_input_event_impl(p_event, false, true);
 	} else {
-		_parse_input_event_impl(p_event, false);
-	}
-}
-void InputDefault::flush_buffered_events() {
-	_THREAD_SAFE_METHOD_
-
-	while (buffered_events.front()) {
-		// The final delivery of the input event involves releasing the lock.
-		// While the lock is released, another thread may lock it and add new events to the back.
-		// Therefore, we get each event and pop it while we still have the lock,
-		// to ensure the list is in a consistent state.
-		List<Ref<InputEvent>>::Element *E = buffered_events.front();
-		Ref<InputEvent> e = E->get();
-		buffered_events.pop_front();
-
-		_parse_input_event_impl(e, false);
+		// We can accumulate immediately on input if in frame mode,
+		// but if in agile / logical mode accumulation is deferred until flushing,
+		// so we can just push directly.
+		if ((data.buffering_mode == Input::BUFFERING_MODE_FRAME) && data.use_accumulated_input) {
+			_event_buffer.accumulate_or_push_event(p_event, OS::get_singleton()->get_ticks_usec());
+		} else {
+			_event_buffer.push_event(p_event, OS::get_singleton()->get_ticks_usec());
+		}
 	}
 }
 
-bool InputDefault::is_using_input_buffering() {
-	return use_input_buffering;
+void InputDefault::flush_buffered_events_ex(uint64_t p_up_to_timestamp) {
+	_event_buffer.flush_events(p_up_to_timestamp, *this, data.use_accumulated_input);
 }
 
-void InputDefault::set_use_input_buffering(bool p_enable) {
-	use_input_buffering = p_enable;
+void InputDefault::force_flush_buffered_events() {
+	flush_buffered_events_ex(UINT64_MAX);
 }
 
-bool InputDefault::is_using_accumulated_input() {
-	return use_accumulated_input;
+void InputDefault::flush_buffered_events_iteration() {
+	// legacy did not flush here.
+	if (data.use_legacy_flushing) {
+		return;
+	}
+
+	if (data.buffering_mode == BUFFERING_MODE_FRAME) {
+		flush_buffered_events_ex(UINT64_MAX);
+	}
 }
 
-void InputDefault::set_use_accumulated_input(bool p_enable) {
-	use_accumulated_input = p_enable;
+void InputDefault::flush_buffered_events_tick(uint64_t p_tick_timestamp) {
+	if (data.buffering_mode == BUFFERING_MODE_AGILE) {
+		flush_buffered_events_ex(p_tick_timestamp);
+	}
+}
+
+void InputDefault::flush_buffered_events_frame() {
+	// If we are in legacy mode, if not NONE or FRAME,
+	// then it will be AGILE, in which case legacy had a flush
+	// here, so the new logic works as before.
+	if (data.buffering_mode == BUFFERING_MODE_AGILE) {
+		flush_buffered_events_ex(UINT64_MAX);
+	}
 }
 
 void InputDefault::release_pressed_events() {
@@ -808,8 +959,6 @@ void InputDefault::release_pressed_events() {
 }
 
 InputDefault::InputDefault() {
-	use_input_buffering = false;
-	use_accumulated_input = true;
 	mouse_button_mask = 0;
 	emulate_touch_from_mouse = false;
 	emulate_mouse_from_touch = false;

--- a/main/main.h
+++ b/main/main.h
@@ -46,7 +46,6 @@ class Main {
 	static uint32_t frame;
 	static bool force_redraw_requested;
 	static int iterating;
-	static bool agile_input_event_flushing;
 
 public:
 	static bool is_project_manager();

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -518,5 +518,20 @@ void MainTimerSync::set_fixed_fps(int p_fixed_fps) {
 MainFrameTime MainTimerSync::advance(float p_frame_slice, int p_iterations_per_second) {
 	float cpu_idle_step = get_cpu_idle_step();
 
-	return advance_checked(p_frame_slice, p_iterations_per_second, cpu_idle_step);
+	MainFrameTime mft = advance_checked(p_frame_slice, p_iterations_per_second, cpu_idle_step);
+
+	// Now backcalculate the logical timing of the first physics tick.
+	// This is used for processing input.
+	// It is approximate, but should be fine for input.
+	mft.usec_per_tick = 1000000 / p_iterations_per_second;
+	uint64_t leftover_usec = mft.interpolation_fraction * mft.usec_per_tick;
+
+	// Note we are using the ACTUAL CPU time for this estimate,
+	// NOT the smoothed accumulated time.
+	// This is because the input timestamps are measured in realtime,
+	// and smoothed time / realtime can get out of sync.
+	mft.first_physics_tick_logical_time_usecs = current_cpu_ticks_usec;
+	mft.first_physics_tick_logical_time_usecs -= (mft.physics_steps * mft.usec_per_tick) + leftover_usec;
+
+	return mft;
 }

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -41,7 +41,13 @@ struct MainFrameTime {
 	int physics_steps; // number of times to iterate the physics engine
 	float interpolation_fraction; // fraction through the current physics tick
 
+	// Used for segmenting input processing to different physics ticks
+	// based on timestamps.
+	uint64_t first_physics_tick_logical_time_usecs = 0;
+	uint64_t usec_per_tick = 0;
+
 	void clamp_idle(float min_idle_step, float max_idle_step);
+	uint64_t get_logical_tick_time(uint32_t p_tick) const { return first_physics_tick_logical_time_usecs + (p_tick * usec_per_tick); }
 };
 
 class MainTimerSync {

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -227,6 +227,7 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 	input = memnew(InputDefault);
 	input->set_use_input_buffering(true); // Needed because events will come directly from the UI thread
+	input->set_has_input_thread(true);
 	input->set_fallback_mapping(godot_java->get_input_fallback_mapping());
 
 	return OK;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -3415,6 +3415,7 @@ void OS_OSX::push_input(const Ref<InputEvent> &p_event) {
 void OS_OSX::force_process_input() {
 	process_events(); // get rid of pending events
 	joypad_osx->process_joypads();
+	input->force_flush_buffered_events();
 }
 
 void OS_OSX::pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3565,6 +3565,7 @@ void OS_Windows::swap_buffers() {
 
 void OS_Windows::force_process_input() {
 	process_events(); // get rid of pending events
+	input->force_flush_buffered_events();
 }
 
 void OS_Windows::run() {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -4011,6 +4011,7 @@ void OS_X11::force_process_input() {
 #ifdef JOYDEV_ENABLED
 	joypad->process_joypads();
 #endif
+	input->force_flush_buffered_events();
 }
 
 void OS_X11::run() {


### PR DESCRIPTION
Input was resulting in stalling and ANRs on Android and possibly other platforms. This PR separates buffered input into two parts to prevent stalls. It also timestamps input events and applies them on the relevant logical physics tick, rather than attempting to apply them "realtime".

This PR is quite a significant refactor to input buffering in order to make it threadsafe, store timestamps, and offer accurate agile input on physics ticks on platforms with separate input thread. It also offers a legacy mode (with a project setting) in case of regressions, this can be removed once any bugs have been worked out, which should make the code simpler.

## N.B.
This PR was written immediately prior to #76399 being merged, which may have addressed some of the similar concerns for ANRs. This PR is thus more concerned with agile input than fixing ANRs.

## Explanation
The fix in #76399 was to deal with the problem that processing input events (which could take an extended amount of time, for say a load or reading a web address etc) was locking the input buffer. It took a simple approach of micro-unlock / relock for each input event.

This PR is a bit more involved, it changes the buffer into a more thread safe structure.

* Two mirror incoming buffers for incoming events (and events are timestamped as they come in)
* The active mirror is swapped quickly with a quick lock on flush, so there is no need for microlocking as in #76399
* The incoming read buffer is copied across to a master buffer, which is thus sorted by timestamp

When flushing the master buffer can thus be flushed up to a desired timestamp. This enables us to flush on physics ticks up to the _logical timestamp_ of the physics tick (rather than realtime of when the tick is processed).

This means input can be spread out correctly over logical time - if a frame has e.g. 8 physics ticks, an on off keypress can be assigned to say ticks 2 and 3, instead of being only applied if the key happens to be pressed at the frame time. This is essentially a (hopefully! :smile: ) more accurate version of @RandomShaper 's agile input.

## Accumulating
In AGILE mode, accumulating input (e.g. mouse motion) is deferred until flushing, which means that accumulation can be done accurately on a per tick basis. This can potentially give perfectly accurate input for say first person shooters, while still using accumulation to reduce the number of calls to user code and thus increase efficiency. In FRAME mode (and OS that do not support AGILE), accumulation still takes place correct to the nearest frame, as before.

## Input thread
There is one snag, for the input timestamps to be meaningful, we ideally want input to come in free flow from the OS. This so far only occurs on Android, where there is a separate thread for input. On most of the other platforms, the OS message pump is done once per frame, so the end result is the input gets bunched up like the current status quo.

However, if we have the input backend working correctly with timestamps / agile input, that does leave the option open to now improve the input accuracy on other platforms in later PRs.

We can either investigate using a separate input thread (ideally) or perhaps resampling the input queue from the OS multiples times per frame (in single threaded fashion). The latter is not ideal but could lead to some greater input resolution.

## Notes
* Adds a temporary `legacy_event_flushing` project setting for more backward compatibility (but even so, input is quite different so will need testing).
* I'll also do a PR for master, which may be able to support more platforms for AGILE.

## Demo Project
Can be run on desktop and Android.
Note that it will need to have export template compiled for android (or use the artifact), and set the custom template to be used by the export.
[AgileInputTest.zip](https://github.com/godotengine/godot/files/11469517/AgileInputTest.zip)
Note that the `frame_delay_ms` is used to limit the frames per second, and this also has the effect of limiting the frames per second in the editor (this is nothing to do with the PR).
It will run at 1tps, and the physics ticks will run 8 per frame.

When running:
* Pressing return or clicking mouse will show the press and release ticks on desktop. Note that these will be bunched on the frame tick, because there is no agile input available.
* On Android, touch the screen and move around. Note that the input ticks can be _between_ the frame ticks, and agile input is working.

## Status
* Now tested and working on Android.
* Tested and working on Linux with multiple message pumps on the main thread, although I have decided to leave this feature to a future PR:

Supporting multiple pumps offers some advantages but some disadvantages on platforms that don't have a separate input thread.

The reason is that the message pumps will tend to occur bunched up in time (probably before physics ticks), but this timing will be variable on different computers, depending on their GPU / CPU power. Variable input timing is generally something that might not be a good thing in games because it can make testing difficult with variable gameplay. But on the other hand it could be better than nothing in apps that seek to e.g. draw using the mouse.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
