### PR TITLE
CI: Use gh-cli for changed files, and workaround codespell skip list bug

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -28,15 +28,17 @@ jobs:
 
       - name: Get changed files
         id: changed-files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} 2> /dev/null || true)
+            files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
           elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.forced }}" == "false" -a "${{ github.event.created }}" == "false" ]; then
             files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
           fi
           echo "$files" >> changed.txt
           cat changed.txt
-          files=$(echo "$files" | tr '\n' ' ')
+          files=$(echo "$files" | grep -v 'thirdparty' | xargs -I {} sh -c 'echo "./{}"' | tr '\n' ' ')
           echo "CHANGED_FILES=$files" >> $GITHUB_ENV
 
       - name: File formatting checks (file_format.sh)
@@ -103,7 +105,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: codespell-project/actions-codespell@v1
         with:
-          skip: ./.*,./**/.*,./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json
-          check_hidden: false
-          ignore_words_list: curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te,vai
+          skip: "*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
+          ignore_words_list: "curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te,vai"
           path: ${{ env.CHANGED_FILES }}

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -44,7 +44,7 @@ static void _add_file(String f, const uint64_t &p_modified_time, HashMap<String,
 	const uint64_t *cached_mt = cached_files.getptr(f);
 	if (cached_mt && *cached_mt == p_modified_time) {
 		// File is good, skip it.
-		cached_files.erase(f); // Erase to mark this file as existing. Remaning files not added to files_to_send will be considered erased here, so they need to be erased in the client too.
+		cached_files.erase(f); // Erase to mark this file as existing. Remaining files not added to files_to_send will be considered erased here, so they need to be erased in the client too.
 		return;
 	}
 	files_to_send.insert(f, p_modified_time);


### PR DESCRIPTION
For PRs, this should give a more accurate list, as the previous method would
diff to the tip of the `master` branch, which could include new commits (and
thus changed files) not present in the PR branch.

Also works around this upstream codespell bug: https://github.com/codespell-project/codespell/issues/1915

Instead of relying on the skip list for folders, we exclude them manually. `.git` and `bin` should never be part of the list of files changed in Git so we don't bother with them.

And works around another misfeature of https://github.com/codespell-project/actions-codespell - the `check_hidden` optional parameter is considered true if defined, even if set to `false`... the only way not to enable it is not to mention it.