### PR TITLE
Fix crash when changing node type from PopupMenu to ItemList

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2051,8 +2051,13 @@ bool PopupMenu::_get(const StringName &p_name, Variant &r_ret) const {
 			r_ret = get_item_icon(item_index);
 			return true;
 		} else if (property == "checkable") {
-			r_ret = this->items[item_index].checkable_type;
-			return true;
+			if (item_index >= 0 && item_index < items.size()) {
+				r_ret = items[item_index].checkable_type;
+				return true;
+			} else {
+				r_ret = Item::CHECKABLE_TYPE_NONE;
+				ERR_FAIL_V(true);
+			}
 		} else if (property == "checked") {
 			r_ret = is_item_checked(item_index);
 			return true;


### PR DESCRIPTION
This is fixing the crash from [#76673](https://github.com/godotengine/godot/issues/76673)

Changing the type of a node from PopupMenu to ItemList will crash if the PopupMenu has an item with a 'checktable_type' other than "No". This PR adds a check for when the array of items is empty, just like for the other properties. 

Note that this instead prints an "out of bounds" error message in the output, just like for the other properties, so this doesn't fix the core of the issue, just the crash.

_Bugsquad edit: Fixes https://github.com/godotengine/godot/issues/76673_