### PR TITLE
Increment recursion count in Variant::recursive_hash()

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3080,7 +3080,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			return reinterpret_cast<const NodePath *>(_data._mem)->hash();
 		} break;
 		case DICTIONARY: {
-			return reinterpret_cast<const Dictionary *>(_data._mem)->recursive_hash(recursion_count);
+			return reinterpret_cast<const Dictionary *>(_data._mem)->recursive_hash(recursion_count + 1);
 
 		} break;
 		case CALLABLE: {
@@ -3094,7 +3094,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case ARRAY: {
 			const Array &arr = *reinterpret_cast<const Array *>(_data._mem);
-			return arr.recursive_hash(recursion_count);
+			return arr.recursive_hash(recursion_count + 1);
 
 		} break;
 		case PACKED_BYTE_ARRAY: {


### PR DESCRIPTION
I was looking through this code while working on another issue, and `Variant::recursive_hash()` doesn't appear to ever increment the recursion count!

For the similar `Variant::hash_compare()`, we're incrementing the recursion count when calling into the underlying `Array` and `Dictionary` methods, so that's what I've done here as well.

Of course, it's possible that I've just missed where the recursion count is incremented? But I just don't see it anywhere...