### PR TITLE
Add function `ZIPReader::file_exists`

### DIFF
--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -25,6 +25,15 @@
 				Closes the underlying resources used by this instance.
 			</description>
 		</method>
+		<method name="file_exists">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="case_sensitive" type="bool" default="true" />
+			<description>
+				Returns [code]true[/code] if the file exists in the loaded zip archive.
+				Must be called after [method open].
+			</description>
+		</method>
 		<method name="get_files">
 			<return type="PackedStringArray" />
 			<description>

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -118,6 +118,21 @@ PackedByteArray ZIPReader::read_file(String p_path, bool p_case_sensitive) {
 	return data;
 }
 
+bool ZIPReader::file_exists(String p_path, bool p_case_sensitive) {
+	ERR_FAIL_COND_V_MSG(fa.is_null(), false, "ZIPReader must be opened before use.");
+
+	int cs = p_case_sensitive ? 1 : 2;
+	if (unzLocateFile(uzf, p_path.utf8().get_data(), cs) != UNZ_OK) {
+		return false;
+	}
+	if (unzOpenCurrentFile(uzf) != UNZ_OK) {
+		return false;
+	}
+
+	unzCloseCurrentFile(uzf);
+	return true;
+}
+
 ZIPReader::ZIPReader() {}
 
 ZIPReader::~ZIPReader() {
@@ -131,4 +146,5 @@ void ZIPReader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("close"), &ZIPReader::close);
 	ClassDB::bind_method(D_METHOD("get_files"), &ZIPReader::get_files);
 	ClassDB::bind_method(D_METHOD("read_file", "path", "case_sensitive"), &ZIPReader::read_file, DEFVAL(Variant(true)));
+	ClassDB::bind_method(D_METHOD("file_exists", "path", "case_sensitive"), &ZIPReader::file_exists, DEFVAL(Variant(true)));
 }

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -51,6 +51,7 @@ public:
 
 	PackedStringArray get_files();
 	PackedByteArray read_file(String p_path, bool p_case_sensitive);
+	bool file_exists(String p_path, bool p_case_sensitive);
 
 	ZIPReader();
 	~ZIPReader();


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/discussions/6834

I assumed it should consider a file it can find but not open as it not existing, essentially as a "will it make `read_file` not throw an error"
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
