### PR TITLE
Fix regression with right click on main selection

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1819,7 +1819,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 					}
 				}
 			}
-			if (!caret_clicked) {
+			if (caret_clicked < 0) {
 				tx->deselect();
 				tx->remove_secondary_carets();
 				caret_clicked = 0;


### PR DESCRIPTION
Fix #76864

Really sorry about that but #76472  introduce a regression when right clicking on the main selection or first selection of multiselection : it will deselect it and show the "no selection" version of context menu.

Cause : Stupid mistake when checking if a selection has been clicked. In script editor, ``caret_clicked`` is not a bool but an int. Need to check if this variable is lesser than 0 instead of false...
