### PR TITLE
Linux: Ensure WindowData minimized/maximized are mutually exclusive

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3497,8 +3497,8 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 
 	// Query display server about a possible new window state.
 	wd.fullscreen = _window_fullscreen_check(window_id);
-	wd.minimized = _window_minimize_check(window_id);
-	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE");
+	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE") && !wd.fullscreen;
+	wd.minimized = _window_minimize_check(window_id) && !wd.fullscreen && !wd.maximized;
 
 	// Readjusting the window position if the window is being reparented by the window manager for decoration
 	Window root, parent, *children;


### PR DESCRIPTION
This fixes #72728.

The window manager can break the assumption that fullscreen/maximized/minimized values are mutually exclusive. This appears to happen when the window is in progress transitioning from minimized to maximized.

The display server code relies on this assumption for proper state management, in particular for `DisplayServerX11::_validate_mode_on_map`'s "if" cases.

This PR ensures when querying the window manager in method `DisplayServerX11::_window_changed`, only one value can be true. The PR prioritizes fullscreen, maximum, and then minimized states, opting to assume the window is visible for conflicting values.
