### PR TITLE
[3.x] Add 3D occlusion queries

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1719,6 +1719,13 @@
 		<member name="rendering/quality/lightmapping/use_bicubic_sampling.mobile" type="bool" setter="" getter="" default="false">
 			Lower-end override for [member rendering/quality/lightmapping/use_bicubic_sampling] on mobile devices, in order to reduce bandwidth usage.
 		</member>
+		<member name="rendering/quality/occlusion_queries/disable_for_vendors" type="String" setter="" getter="" default="&quot;PowerVR,Adreno&quot;">
+			The performance of occlusion queries can depend a lot on the implementation. Use this setting if your game runs worse with occlusion queries enabled on some devices.
+		</member>
+		<member name="rendering/quality/occlusion_queries/enable" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], use occlusion querries to cull away meshes that were not visible during the previous frame. This might result in meshes being invisible for the first frame they are on screen, but can significantly reduce render times if you have meshes with a lot of vertices in your scenes.
+			[b]Note:[/b] Only supported when using GLES3 rendering backend. This setting has no effect when using GLES2.
+		</member>
 		<member name="rendering/quality/reflections/atlas_size" type="int" setter="" getter="" default="2048">
 			Size of the atlas used by reflection probes. A larger size can result in higher visual quality, while a smaller size will be faster and take up less memory.
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -195,6 +195,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="allow_occlusion_queries" type="bool" setter="set_allow_occlusion_queries" getter="get_allow_occlusion_queries" default="true">
+			If [code]true[/code], the viewport will be using occlusion queries to cull not visible meshes. Note that occlusion queries also need to be enabled in the Project Settings by setting [member ProjectSettings.rendering/quality/occlusion_queries/enable] to [code]true[/code].
+		</member>
 		<member name="arvr" type="bool" setter="set_use_arvr" getter="use_arvr" default="false">
 			If [code]true[/code], the viewport will be used in AR/VR process.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3043,6 +3043,14 @@
 				If [code]true[/code], sets the viewport active, else sets it inactive.
 			</description>
 		</method>
+		<method name="viewport_set_allow_occlusion_queries">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="allow" type="bool" />
+			<description>
+				Enable or disable occlusion queries for a given Viewport. Note that occlusion queries also need to be enabled in the Project Settings by setting [member ProjectSettings.rendering/quality/occlusion_queries/enable] to [code]true[/code].
+			</description>
+		</method>
 		<method name="viewport_set_canvas_stacking">
 			<return type="void" />
 			<argument index="0" name="viewport" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1943,7 +1943,7 @@ void RasterizerSceneGLES3::_set_cull(bool p_front, bool p_disabled, bool p_rever
 	}
 }
 
-void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_element_count, const Transform &p_view_transform, const CameraMatrix &p_projection, RasterizerStorageGLES3::Sky *p_sky, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows) {
+void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_element_count, const Transform &p_view_transform, const CameraMatrix &p_projection, RasterizerStorageGLES3::Sky *p_sky, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows, bool p_occlusion_queries) {
 	glBindBufferBase(GL_UNIFORM_BUFFER, 0, state.scene_ubo); //bind globals ubo
 
 	bool use_radiance_map = false;
@@ -2007,12 +2007,102 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	bool prev_opaque_prepass = false;
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_OPAQUE_PREPASS, false);
 
+	//Set up occlusion queries
+	int oq_culled_element_count = 0;
+	Map<uint32_t, RasterizerStorageGLES3::OcclusionQueryData> *occlusion_queries = nullptr;
+
+	if (p_occlusion_queries) {
+		render_list_oq_culled.clear();
+
+		occlusion_queries = &storage->occlusion_queries_for_viewport[VSG::viewport->current_viewport_id.get_id()];
+	}
+
 	for (int i = 0; i < p_element_count; i++) {
 		RenderList::Element *e = p_elements[i];
 		RasterizerStorageGLES3::Material *material = e->material;
 		RasterizerStorageGLES3::Skeleton *skeleton = nullptr;
 		if (e->instance->skeleton.is_valid()) {
 			skeleton = storage->skeleton_owner.getornull(e->instance->skeleton);
+		}
+
+		bool started_query = false;
+
+		bool use_oq = false;
+		if (e->instance->base_type == VS::INSTANCE_MESH) {
+			//The overhead makes OQ counterproductive for too simple meshes
+			RasterizerStorageGLES3::Surface *s = static_cast<RasterizerStorageGLES3::Surface *>(e->geometry);
+			use_oq = p_occlusion_queries && s->array_len > 256;
+		}
+		if (use_oq) {
+			if (!occlusion_queries->has(e->instance->get_id())) {
+				// I am honestly unsure about this part. I would prefer to create enough queries in advance, store them in a list and then just get "new" queries from there instead.
+				// However, I found other parts of the codebase that create stuff only just when it is needed.
+				// For now I am gonna leave this here, I will probably need to address this after someone has reviewed this PR. I would also like feedback on whether I should move this to storage (or an inner class of storage)
+				GLuint query = 0;
+				glGenQueries(1, &query);
+
+				occlusion_queries->insert(e->instance->get_id(), RasterizerStorageGLES3::OcclusionQueryData{ RasterizerStorageGLES3::OcclusionQueryPrevAction::NoAction, 0, query, static_cast<RasterizerStorageGLES3::Surface *>(e->geometry)->get_id() });
+			}
+
+			RasterizerStorageGLES3::OcclusionQueryData &data = occlusion_queries->find(e->instance->get_id())->value();
+			uint64_t cur_frame = storage->frame.count;
+			GLuint query_result = 0;
+
+			bool query_already_started = false;
+
+			if (data.prev_action != RasterizerStorageGLES3::OcclusionQueryPrevAction::NoAction) {
+				if (data.prev_frame == cur_frame) {
+					// we already started a OQ for this object in this frame (e.g. in the early depth pass)
+					// just repeat what we did before and don't start a new query
+					if (data.prev_action == RasterizerStorageGLES3::OcclusionQueryPrevAction::Culled) {
+						//since we already have a query there is no reason to draw an AABB
+						continue;
+					}
+
+					//skip starting the query and just render the mesh
+					query_already_started = true;
+				} else {
+					GLuint query_result_available = 0;
+					glGetQueryObjectuiv(data.query, GL_QUERY_RESULT_AVAILABLE, &query_result_available);
+					if (query_result_available == GL_FALSE) {
+						query_result = 1; //let's just assume this is visible
+					} else {
+						glGetQueryObjectuiv(data.query, GL_QUERY_RESULT, &query_result);
+					}
+				}
+			}
+
+			/*Situations:
+				first time we see this object
+				visible last frame
+					draw it
+
+				visible this frame during early depth
+					skip query and just draw
+
+				not visible last frame
+					draw aabb
+			*/
+			if (data.prev_action == RasterizerStorageGLES3::OcclusionQueryPrevAction::NoAction || (data.prev_frame + 1 == cur_frame && query_result)) {
+				//draw it with query
+
+				data.prev_frame = cur_frame;
+				data.prev_action = RasterizerStorageGLES3::OcclusionQueryPrevAction::Rendered;
+
+				//start query
+				glBeginQuery(GL_ANY_SAMPLES_PASSED, data.query);
+
+				//necessary to stop the query later after we are done
+				started_query = true;
+			} else if (!query_already_started) {
+				RenderList::Element *e_oq_culled = render_list_oq_culled.add_element();
+				memcpy(e_oq_culled, e, sizeof(RenderList::Element));
+				oq_culled_element_count++;
+
+				data.prev_frame = cur_frame;
+				data.prev_action = RasterizerStorageGLES3::OcclusionQueryPrevAction::Culled;
+				continue;
+			}
 		}
 
 		bool rebind = first;
@@ -2187,6 +2277,9 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 			}
 		}
 		if (!ShaderGLES3::get_active()) {
+			if (started_query) {
+				glEndQuery(GL_ANY_SAMPLES_PASSED);
+			}
 			continue;
 		}
 
@@ -2205,6 +2298,10 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 		_render_geometry(e);
 
+		if (started_query) {
+			glEndQuery(GL_ANY_SAMPLES_PASSED);
+		}
+
 		prev_material = material;
 		prev_base_type = e->instance->base_type;
 		prev_geometry = e->geometry;
@@ -2216,8 +2313,12 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 		prev_opaque_prepass = use_opaque_prepass;
 		first = false;
 	}
-
+	print_line("post draw loop");
 	glBindVertexArray(0);
+
+	RasterizerStorageGLES3::Material *m = storage->material_owner.getptr(default_material);
+	_setup_material(m, false, false);
+	prev_material = m;
 
 	state.scene_shader.set_conditional(SceneShaderGLES3::ENABLE_OCTAHEDRAL_COMPRESSION, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_INSTANCING, false);
@@ -2239,6 +2340,40 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_CONTACT_SHADOWS, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_VERTEX_LIGHTING, false);
 	state.scene_shader.set_conditional(SceneShaderGLES3::USE_OPAQUE_PREPASS, false);
+
+	glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); //disable the color mask
+	glDepthMask(GL_FALSE);
+	glDisable(GL_CULL_FACE);
+	for (int i = 0; i < oq_culled_element_count; i++) {
+		RenderList::Element *e = render_list_oq_culled.elements[i];
+
+		state.scene_shader.set_conditional(SceneShaderGLES3::SHADELESS, true);
+
+		state.scene_shader.set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, e->instance->transform);
+
+		RasterizerStorageGLES3::OcclusionQueryData &data = storage->occlusion_queries_for_viewport[VSG::viewport->current_viewport_id.get_id()][e->instance->get_id()];
+		glBeginQuery(GL_ANY_SAMPLES_PASSED, data.query);
+
+		if (prev_geometry != e->geometry) {
+			RasterizerStorageGLES3::Surface *s = static_cast<RasterizerStorageGLES3::Surface *>(e->geometry);
+			if (s->aabb_array_id == 0) {
+				s->create_aabb_vbo(storage->aabb_index_id);
+			}
+
+			glBindVertexArray(s->aabb_array_id);
+		}
+		glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_SHORT, 0);
+
+		glEndQuery(GL_ANY_SAMPLES_PASSED);
+
+		prev_geometry = e->geometry;
+	}
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_TRUE);
+	glEnable(GL_CULL_FACE);
+	glBindVertexArray(0);
+
+	state.scene_shader.set_conditional(SceneShaderGLES3::SHADELESS, false);
 }
 
 void RasterizerSceneGLES3::_add_geometry(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, int p_material, bool p_depth_pass, bool p_shadow_pass) {
@@ -4182,6 +4317,13 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 	// Do depth prepass if it's explicitly enabled
 	bool use_depth_prepass = storage->config.use_depth_prepass;
 
+	// we don't want to do culling in AR
+	bool use_oq = storage->config.use_occlusion_queries;
+
+	use_oq = use_oq && VSG::viewport->viewport_get_update_mode(VSG::viewport->current_viewport_id) != VisualServer::ViewportUpdateMode::VIEWPORT_UPDATE_ONCE;
+	use_oq = use_oq && VSG::viewport->viewport_get_update_mode(VSG::viewport->current_viewport_id) != VisualServer::ViewportUpdateMode::VIEWPORT_UPDATE_DISABLED;
+	use_oq = use_oq && VSG::viewport->viewport_get_allow_occlusion_queries(VSG::viewport->current_viewport_id);
+
 	// If contact shadows are used then we need to do depth prepass even if it's otherwise disabled
 	use_depth_prepass = use_depth_prepass || state.used_contact_shadows;
 
@@ -4207,9 +4349,13 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 
 		render_list.clear();
 		_fill_render_list(p_cull_result, p_cull_count, true, false);
-		render_list.sort_by_key(false);
+		if (use_oq) {
+			render_list.sort_by_depth(false);
+		} else {
+			render_list.sort_by_key(false);
+		}
 		state.scene_shader.set_conditional(SceneShaderGLES3::RENDER_DEPTH, true);
-		_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, nullptr, false, false, true, false, false);
+		_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, nullptr, false, false, true, false, false, use_oq);
 		state.scene_shader.set_conditional(SceneShaderGLES3::RENDER_DEPTH, false);
 
 		glColorMask(1, 1, 1, 1);
@@ -4484,11 +4630,16 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 		glDisable(GL_BLEND);
 	}
 
-	render_list.sort_by_key(false);
+	if (use_oq && !use_depth_prepass) {
+		render_list.sort_by_depth(false);
+	} else {
+		// If we already did the OQ in the prepass we don't need to sort anymore, since we won't start any new queries.
+		render_list.sort_by_key(false);
+	}
 
 	if (state.directional_light_count == 0) {
 		directional_light = nullptr;
-		_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, sky, false, false, false, false, use_shadows);
+		_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, sky, false, false, false, false, use_shadows, use_oq);
 	} else {
 		for (int i = 0; i < state.directional_light_count; i++) {
 			directional_light = directional_lights[i];
@@ -4496,7 +4647,7 @@ void RasterizerSceneGLES3::render_scene(const Transform &p_cam_transform, const 
 				glEnable(GL_BLEND);
 			}
 			_setup_directional_light(i, p_cam_transform.affine_inverse(), use_shadows);
-			_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, sky, false, false, false, i > 0, use_shadows);
+			_render_list(render_list.elements, render_list.element_count, p_cam_transform, p_cam_projection, sky, false, false, false, i > 0, use_shadows, use_oq);
 		}
 	}
 
@@ -5094,6 +5245,7 @@ void RasterizerSceneGLES3::initialize() {
 		glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
 	}
 	render_list.init();
+	render_list_oq_culled.init();
 	state.cube_to_dp_shader.init();
 
 	shadow_atlas_realloc_tolerance_msec = 500;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -817,6 +817,8 @@ public:
 		}
 	};
 
+	RenderList render_list_oq_culled;
+
 	LightInstance *directional_light;
 	LightInstance *directional_lights[RenderList::MAX_DIRECTIONAL_LIGHTS];
 	RID first_directional_light;
@@ -830,7 +832,7 @@ public:
 	_FORCE_INLINE_ void _render_geometry(RenderList::Element *e);
 	void _setup_light(RenderList::Element *e, const Transform &p_view_transform);
 
-	void _render_list(RenderList::Element **p_elements, int p_element_count, const Transform &p_view_transform, const CameraMatrix &p_projection, RasterizerStorageGLES3::Sky *p_sky, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows);
+	void _render_list(RenderList::Element **p_elements, int p_element_count, const Transform &p_view_transform, const CameraMatrix &p_projection, RasterizerStorageGLES3::Sky *p_sky, bool p_reverse_cull, bool p_alpha_pass, bool p_shadow, bool p_directional_add, bool p_directional_shadows, bool p_occlusion_queries = false);
 
 	_FORCE_INLINE_ void _add_geometry(RasterizerStorageGLES3::Geometry *p_geometry, InstanceBase *p_instance, RasterizerStorageGLES3::GeometryOwner *p_owner, int p_material, bool p_depth_pass, bool p_shadow_pass);
 

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3343,6 +3343,46 @@ void RasterizerStorageGLES3::update_dirty_materials() {
 	}
 }
 
+void RasterizerStorageGLES3::Surface::create_aabb_vbo(GLuint aabb_index_id) {
+	glGenVertexArrays(1, &aabb_array_id);
+	glBindVertexArray(aabb_array_id);
+
+	Vector3 aabb_size = aabb.get_size();
+	Vector3 aabb_center = aabb.get_center();
+
+	float min_x = (-aabb_size.x / 2.0) + aabb_center.x;
+	float max_x = (aabb_size.x / 2.0) + aabb_center.x;
+	float min_y = (-aabb_size.y / 2.0) + aabb_center.y;
+	float max_y = (aabb_size.y / 2.0) + aabb_center.y;
+	float min_z = (-aabb_size.z / 2.0) + aabb_center.z;
+	float max_z = (aabb_size.z / 2.0) + aabb_center.z;
+
+	GLfloat _aabb_vertices[] = {
+		min_x, min_y, max_z, //0
+		max_x, min_y, max_z, //1
+		min_x, max_y, max_z, //2
+		max_x, max_y, max_z, //3
+		min_x, min_y, min_z, //4
+		max_x, min_y, min_z, //5
+		min_x, max_y, min_z, //6
+		max_x, max_y, min_z //7
+	};
+
+	//generate VBO and VAO for AABB
+	glGenBuffers(1, &aabb_vertex_id);
+	glBindBuffer(GL_ARRAY_BUFFER, aabb_vertex_id);
+	glBufferData(GL_ARRAY_BUFFER, 8 * 3 * sizeof(GLfloat), &_aabb_vertices, GL_STATIC_DRAW);
+
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(GLfloat) * 3, 0);
+	glEnableVertexAttribArray(0);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, aabb_index_id);
+
+	glBindVertexArray(0); //essential!
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
 /* MESH API */
 
 RID RasterizerStorageGLES3::mesh_create() {
@@ -4087,6 +4127,28 @@ void RasterizerStorageGLES3::mesh_remove_surface(RID p_mesh, int p_surface) {
 
 	glDeleteVertexArrays(1, &surface->array_id);
 	glDeleteVertexArrays(1, &surface->instancing_array_id);
+
+	//delete aabb stuff
+	print_line("mesh_remove_surface");
+	if (surface->aabb_array_id) {
+		glDeleteBuffers(1, &surface->aabb_vertex_id);
+		glDeleteVertexArrays(1, &surface->aabb_array_id);
+
+		//delete all the queries for this surface across all viewports
+		for (Map<uint32_t, Map<uint32_t, OcclusionQueryData>>::Element *maps = occlusion_queries_for_viewport.front(); maps; maps = maps->next()) {
+			Map<uint32_t, OcclusionQueryData> oqs = maps->value();
+
+			Map<uint32_t, OcclusionQueryData>::Element *E = oqs.front();
+			while (E != nullptr) {
+				Map<uint32_t, OcclusionQueryData>::Element *next = E->next();
+				if (E->value().surface == surface->get_id()) {
+					glDeleteQueries(1, &E->value().query);
+					oqs.erase(E);
+				}
+				E = next;
+			}
+		}
+	}
 
 	for (int i = 0; i < surface->blend_shapes.size(); i++) {
 		glDeleteBuffers(1, &surface->blend_shapes[i].vertex_id);
@@ -8395,6 +8457,22 @@ void RasterizerStorageGLES3::initialize() {
 
 	config.use_physical_light_attenuation = GLOBAL_GET("rendering/quality/shading/use_physical_light_attenuation");
 
+	config.use_occlusion_queries = bool(GLOBAL_GET("rendering/quality/occlusion_queries/enable"));
+	if (config.use_occlusion_queries) {
+		String vendors = GLOBAL_GET("rendering/quality/occlusion_queries/disable_for_vendors");
+		Vector<String> vendor_match = vendors.split(",");
+		for (int i = 0; i < vendor_match.size(); i++) {
+			String v = vendor_match[i].strip_edges();
+			if (v == String()) {
+				continue;
+			}
+
+			if (renderer.findn(v) != -1) {
+				config.use_occlusion_queries = false;
+			}
+		}
+	}
+
 	config.use_depth_prepass = bool(GLOBAL_GET("rendering/quality/depth_prepass/enable"));
 	if (config.use_depth_prepass) {
 		String vendors = GLOBAL_GET("rendering/quality/depth_prepass/disable_for_vendors");
@@ -8444,9 +8522,41 @@ void RasterizerStorageGLES3::update_dirty_resources() {
 
 RasterizerStorageGLES3::RasterizerStorageGLES3() {
 	config.should_orphan = true;
+
+	// create the shared ibo used by all AABBs
+	GLushort _indices[] = {
+		//Top
+		2, 6, 7,
+		2, 7, 3,
+		//Bottom
+		0, 5, 4,
+		0, 1, 5,
+		//Left
+		0, 6, 2,
+		0, 4, 6,
+		//Right
+		1, 3, 7,
+		1, 7, 5,
+		//Front
+		0, 2, 3,
+		0, 3, 1,
+		//Back
+		4, 7, 6,
+		4, 5, 7
+	};
+	glGenBuffers(1, &aabb_index_id);
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, aabb_index_id);
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, 36 * sizeof(GLushort), &_indices, GL_STATIC_DRAW);
 }
 
 RasterizerStorageGLES3::~RasterizerStorageGLES3() {
+	glDeleteBuffers(1, &aabb_index_id);
+	for (Map<uint32_t, Map<uint32_t, OcclusionQueryData>>::Element *pair = occlusion_queries_for_viewport.front(); pair; pair = pair->next()) {
+		for (Map<uint32_t, OcclusionQueryData>::Element *E = pair->value().front(); E; E = E->next()) {
+			glDeleteQueries(1, &E->value().query);
+		}
+	}
+
 	if (shaders.cache) {
 		memdelete(shaders.cache);
 	}

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -58,6 +58,8 @@ void glTexStorage2DCustom(GLenum target, GLsizei levels, GLenum internalformat, 
 
 class RasterizerStorageGLES3 : public RasterizerStorage {
 public:
+	GLuint aabb_index_id;
+
 	RasterizerCanvasGLES3 *canvas;
 	RasterizerSceneGLES3 *scene;
 	static GLuint system_fbo; //on some devices, such as apple, screen is rendered to yet another fbo.
@@ -106,6 +108,9 @@ public:
 		bool keep_original_textures;
 
 		bool use_depth_prepass;
+
+		bool use_occlusion_queries;
+
 		bool force_vertex_shading;
 
 		// in some cases the legacy render didn't orphan. We will mark these
@@ -117,6 +122,20 @@ public:
 		bool async_compilation_enabled;
 		bool shader_cache_enabled;
 	} config;
+
+	enum class OcclusionQueryPrevAction {
+		NoAction,
+		Rendered,
+		Culled
+	};
+
+	struct OcclusionQueryData {
+		OcclusionQueryPrevAction prev_action = OcclusionQueryPrevAction::NoAction;
+		uint64_t prev_frame = 0;
+		GLuint query;
+		uint32_t surface;
+	};
+	Map<uint32_t, Map<uint32_t, OcclusionQueryData>> occlusion_queries_for_viewport;
 
 	mutable struct Shaders {
 		CopyShaderGLES3 copy;
@@ -663,6 +682,9 @@ public:
 		GLuint vertex_id;
 		GLuint index_id;
 
+		GLuint aabb_array_id;
+		GLuint aabb_vertex_id;
+
 		GLuint index_wireframe_id;
 		GLuint array_wireframe_id;
 		GLuint instancing_array_wireframe_id;
@@ -697,6 +719,8 @@ public:
 			mesh->instance_change_notify(false, true);
 			mesh->update_multimeshes();
 		}
+
+		void create_aabb_vbo(GLuint aabb_index_id);
 
 		int total_data_size;
 

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -135,6 +135,7 @@ MaterialEditor::MaterialEditor() {
 	add_child(vc);
 	vc->set_anchors_and_margins_preset(PRESET_WIDE);
 	viewport = memnew(Viewport);
+	viewport->set_allow_occlusion_queries(false);
 	Ref<World> world;
 	world.instance();
 	viewport->set_world(world); //use own world

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -111,6 +111,7 @@ MeshEditor::MeshEditor() {
 	Ref<World> world;
 	world.instance();
 	viewport->set_world(world); //use own world
+	viewport->set_allow_occlusion_queries(false);
 	add_child(viewport);
 	viewport->set_disable_input(true);
 	viewport->set_msaa(Viewport::MSAA_2X);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1330,6 +1330,15 @@ Ref<ViewportTexture> Viewport::get_texture() const {
 	return default_texture;
 }
 
+void Viewport::set_allow_occlusion_queries(bool p_allow) {
+	allow_oq = p_allow;
+	VS::get_singleton()->viewport_set_allow_occlusion_queries(viewport, p_allow);
+}
+
+bool Viewport::get_allow_occlusion_queries() const {
+	return allow_oq;
+}
+
 void Viewport::set_vflip(bool p_enable) {
 	vflip = p_enable;
 	VisualServer::get_singleton()->viewport_set_vflip(viewport, p_enable);
@@ -3269,6 +3278,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_update_mode", "mode"), &Viewport::set_update_mode);
 	ClassDB::bind_method(D_METHOD("get_update_mode"), &Viewport::get_update_mode);
 
+	ClassDB::bind_method(D_METHOD("set_allow_occlusion_queries", "allow"), &Viewport::set_allow_occlusion_queries);
+	ClassDB::bind_method(D_METHOD("get_allow_occlusion_queries"), &Viewport::get_allow_occlusion_queries);
+
 	ClassDB::bind_method(D_METHOD("set_msaa", "msaa"), &Viewport::set_msaa);
 	ClassDB::bind_method(D_METHOD("get_msaa"), &Viewport::get_msaa);
 
@@ -3385,6 +3397,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "usage", PROPERTY_HINT_ENUM, "2D,2D Without Sampling,3D,3D Without Effects"), "set_usage", "get_usage");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "render_direct_to_screen"), "set_use_render_direct_to_screen", "is_using_render_direct_to_screen");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Overdraw,Wireframe"), "set_debug_draw", "get_debug_draw");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_occlusion_queries"), "set_allow_occlusion_queries", "get_allow_occlusion_queries");
 	ADD_GROUP("Render Target", "render_target_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "render_target_v_flip"), "set_vflip", "get_vflip");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_target_clear_mode", PROPERTY_HINT_ENUM, "Always,Never,Next Frame"), "set_clear_mode", "get_clear_mode");
@@ -3543,6 +3556,7 @@ Viewport::Viewport() {
 	use_32_bpc_depth = false;
 
 	usage = USAGE_3D;
+	allow_oq = true;
 	debug_draw = DEBUG_DRAW_DISABLED;
 	clear_mode = CLEAR_MODE_ALWAYS;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -278,6 +278,8 @@ private:
 
 	Usage usage;
 
+	bool allow_oq;
+
 	int shadow_atlas_size;
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
@@ -501,6 +503,9 @@ public:
 	void set_update_mode(UpdateMode p_mode);
 	UpdateMode get_update_mode() const;
 	Ref<ViewportTexture> get_texture() const;
+
+	void set_allow_occlusion_queries(bool p_allow);
+	bool get_allow_occlusion_queries() const;
 
 	void set_shadow_atlas_size(int p_size);
 	int get_shadow_atlas_size() const;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -491,6 +491,7 @@ public:
 	BIND1(viewport_detach, RID)
 
 	BIND2(viewport_set_update_mode, RID, ViewportUpdateMode)
+	BIND2(viewport_set_allow_occlusion_queries, RID, bool)
 	BIND2(viewport_set_vflip, RID, bool)
 
 	BIND1RC(RID, viewport_get_texture, RID)

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -70,6 +70,7 @@ void VisualServerViewport::_draw_3d(Viewport *p_viewport, ARVRInterface::Eyes p_
 		arvr_interface = ARVRServer::get_singleton()->get_primary_interface();
 	}
 
+	current_viewport_id = p_viewport->self;
 	if (p_viewport->use_arvr && arvr_interface.is_valid()) {
 		VSG::scene->render_camera(arvr_interface, p_eye, p_viewport->camera, p_viewport->scenario, p_viewport->size, p_viewport->shadow_atlas);
 	} else {
@@ -487,12 +488,34 @@ void VisualServerViewport::viewport_detach(RID p_viewport) {
 	viewport->viewport_to_screen = 0;
 }
 
+VS::ViewportUpdateMode VisualServerViewport::viewport_get_update_mode(RID p_viewport) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND_V(!viewport, VS::ViewportUpdateMode::VIEWPORT_UPDATE_ONCE);
+
+	return viewport->update_mode;
+}
+
 void VisualServerViewport::viewport_set_update_mode(RID p_viewport, VS::ViewportUpdateMode p_mode) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
 	viewport->update_mode = p_mode;
 }
+
+bool VisualServerViewport::viewport_get_allow_occlusion_queries(RID p_viewport) const {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND_V(!viewport, true);
+
+	return viewport->allow_oq;
+}
+
+void VisualServerViewport::viewport_set_allow_occlusion_queries(RID p_viewport, bool p_allow) {
+	Viewport *viewport = viewport_owner.getornull(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	viewport->allow_oq = p_allow;
+}
+
 void VisualServerViewport::viewport_set_vflip(RID p_viewport, bool p_enable) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -55,6 +55,8 @@ public:
 		RID render_target;
 		RID render_target_texture;
 
+		bool allow_oq;
+
 		int viewport_to_screen;
 		Rect2 viewport_to_screen_rect;
 		bool viewport_render_direct_to_screen;
@@ -108,6 +110,7 @@ public:
 		Map<RID, CanvasData> canvas_map;
 
 		Viewport() {
+			allow_oq = true;
 			update_mode = VS::VIEWPORT_UPDATE_WHEN_VISIBLE;
 			clear_mode = VS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;
@@ -141,6 +144,8 @@ public:
 
 	Vector<Viewport *> active_viewports;
 
+	RID current_viewport_id = RID();
+
 private:
 	Color clear_color;
 	void _draw_3d(Viewport *p_viewport, ARVRInterface::Eyes p_eye);
@@ -159,8 +164,12 @@ public:
 
 	void viewport_set_active(RID p_viewport, bool p_active);
 	void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport);
+	VS::ViewportUpdateMode viewport_get_update_mode(RID p_viewport);
 	void viewport_set_update_mode(RID p_viewport, VS::ViewportUpdateMode p_mode);
 	void viewport_set_vflip(RID p_viewport, bool p_enable);
+
+	void viewport_set_allow_occlusion_queries(RID p_viewport, bool p_allow);
+	bool viewport_get_allow_occlusion_queries(RID p_viewport) const;
 
 	void viewport_set_clear_mode(RID p_viewport, VS::ViewportClearMode p_clear_mode);
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -399,6 +399,7 @@ public:
 	FUNC1(viewport_detach, RID)
 
 	FUNC2(viewport_set_update_mode, RID, ViewportUpdateMode)
+	FUNC2(viewport_set_allow_occlusion_queries, RID, bool)
 	FUNC2(viewport_set_vflip, RID, bool)
 
 	FUNC1RC(RID, viewport_get_texture, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2079,6 +2079,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_render_direct_to_screen", "viewport", "enabled"), &VisualServer::viewport_set_render_direct_to_screen);
 	ClassDB::bind_method(D_METHOD("viewport_detach", "viewport"), &VisualServer::viewport_detach);
 	ClassDB::bind_method(D_METHOD("viewport_set_update_mode", "viewport", "update_mode"), &VisualServer::viewport_set_update_mode);
+	ClassDB::bind_method(D_METHOD("viewport_set_allow_occlusion_queries", "viewport", "allow"), &VisualServer::viewport_set_allow_occlusion_queries);
 	ClassDB::bind_method(D_METHOD("viewport_set_vflip", "viewport", "enabled"), &VisualServer::viewport_set_vflip);
 	ClassDB::bind_method(D_METHOD("viewport_set_clear_mode", "viewport", "clear_mode"), &VisualServer::viewport_set_clear_mode);
 	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport"), &VisualServer::viewport_get_texture);
@@ -2673,6 +2674,9 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF_RST("rendering/misc/mesh_storage/split_stream", false);
 
 	GLOBAL_DEF_RST("rendering/quality/shading/use_physical_light_attenuation", false);
+
+	GLOBAL_DEF("rendering/quality/occlusion_queries/enable", false);
+	GLOBAL_DEF("rendering/quality/occlusion_queries/disable_for_vendors", "PowerVR,Adreno");
 
 	GLOBAL_DEF("rendering/quality/depth_prepass/enable", true);
 	GLOBAL_DEF("rendering/quality/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -664,6 +664,7 @@ public:
 	};
 
 	virtual void viewport_set_update_mode(RID p_viewport, ViewportUpdateMode p_mode) = 0;
+	virtual void viewport_set_allow_occlusion_queries(RID p_viewport, bool p_allow) = 0;
 	virtual void viewport_set_vflip(RID p_viewport, bool p_enable) = 0;
 
 	enum ViewportClearMode {


### PR DESCRIPTION
This PR makes it possible to use occlusion queries to cull away parts of the scene that are not visible. While not being quite as high quality as the manual occluders we already have this has the advantage that it can be enabled by clicking a simple check box in the settings.

The visibility of culled objects is checked with their bounding box every frame, if the bounding box would be visible the renderer checks the visibility of the original asset in the next frame. Especially in scenes with badly optimized 3d assets that have too many vertices, this can result in nice performance gains (see screenshot below).

Note that the performance of occlusion query can vary a LOT on different hardware & drivers, so I included a settings option to disable this feature depending on the GPU vendor. I also hard-limited this feature to meshes that have more than 256 vertices, due to the overhead of OQ.

The current implementation is as general-purpose as I could make it, with OQ enabled for pretty much all meshes. I have two branches that are more complicated and try to be smarter about this (e.g. exclude animated meshes, etc.) but after a LOT of ~professional testing~ trial and error, I think that this version is better for most use cases.

Something that I will probably need to change is the way I generate the query objects, I left a comment at the relevant line of code. Would greatly appreciate feedback on that in particular.


<details>
<summary>Screenshot</summary>

Sorry for the lackluster image, This is the best I could do on short notice. If I remember I will replace this with a better screenshot tomorrow when I take some time to work through my old PRs.

Anyways, this shows the GPU load in a scene that has a bunch of unoptimized meshes. The valleys are when I had a wall between me and the hero assets, the peaks are when I could see them.

Note that this image was taken with the depth pre-pass disabled. If I were to enable it the difference would be even bigger, since the pre-pass needs to evaluate all the vertices a second time.

![image](https://user-images.githubusercontent.com/6329420/236973533-5270acb1-c4c6-4c76-a6ac-845907bd6ca2.png)
</details>



---

This PR was sponsored by Ramatak with 💚