### PR TITLE
Clarify that event handling does not affect `Input`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -217,6 +217,7 @@
 			<return type="void" />
 			<description>
 				Marks an input event as handled. Once you accept an input event, it stops propagating, even to nodes listening to [method Node._unhandled_input] or [method Node._unhandled_key_input].
+				[b]Note:[/b] This does not affect the methods in [Input], only the way events are propagated.
 			</description>
 		</method>
 		<method name="add_theme_color_override">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A singleton that deals with inputs. This includes key presses, mouse buttons and movement, joypads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in the [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
+		[b]Note:[/b] The methods here reflect the global input state and are not affected by [method Control.accept_event] or [method Viewport.set_input_as_handled], which only deal with the way input is propagated in the [SceneTree].
 	</description>
 	<tutorials>
 		<link title="Inputs documentation index">$DOCS_URL/tutorials/inputs/index.html</link>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -197,6 +197,7 @@
 			<return type="void" />
 			<description>
 				Stops the input from propagating further down the [SceneTree].
+				[b]Note:[/b] This does not affect the methods in [Input], only the way events are propagated.
 			</description>
 		</method>
 		<method name="set_positional_shadow_atlas_quadrant_subdiv">


### PR DESCRIPTION
Closes #76871

Seen this pop up in at least two issues now, and while the documentation makes it clear what it *does* affect it wasn't obvious what it didn't, so thought it'd be good to point out

Might be good to add some notes on this in the online documentation about input handling as well
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
