### PR TITLE
gltf: Permit sparse accessors without a bufferView.

### DIFF
--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="buffer_view" type="int" setter="set_buffer_view" getter="get_buffer_view" default="0">
+		<member name="buffer_view" type="int" setter="set_buffer_view" getter="get_buffer_view" default="-1">
 		</member>
 		<member name="byte_offset" type="int" setter="set_byte_offset" getter="get_byte_offset" default="0">
 		</member>

--- a/modules/gltf/structures/gltf_accessor.h
+++ b/modules/gltf/structures/gltf_accessor.h
@@ -39,7 +39,7 @@ struct GLTFAccessor : public Resource {
 	friend class GLTFDocument;
 
 private:
-	GLTFBufferViewIndex buffer_view = 0;
+	GLTFBufferViewIndex buffer_view = -1;
 	int byte_offset = 0;
 	int component_type = 0;
 	bool normalized = false;


### PR DESCRIPTION
Fix zeroed out sparse accessors.
See here for an explanation of this: https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/404

Godot already had code to support sparse accessors without a backing bufferView:
`GLTFDocument::_decode_accessor` , modules/gltf/gltf_document.cpp:1471
```cpp
	if (a->buffer_view >= 0) {
		ERR_FAIL_INDEX_V(a->buffer_view, p_state->buffer_views.size(), Vector<double>());

		const Error err = _decode_buffer_view(p_state, dst, a->buffer_view, skip_every, skip_bytes, element_size, a->count, a->type, component_count, a->component_type, component_size, a->normalized, a->byte_offset, p_for_vertex);
		if (err != OK) {
			return Vector<double>();
		}
	} else {
		//fill with zeros, as bufferview is not defined.
		for (int i = 0; i < (a->count * component_count); i++) {
			dst_buffer.write[i] = 0;
		}
	}
```
The else case hinges on the condition `a->buffer_view >= 0`. However, bufferView was being initialized to 0 in the class declaration, which overlaps with the index of the first valid bufferView.
That leads to the following errors when loading a glTF scene with sparse accessors and no bufferView.
Relevant model snippet:
```
{"accessors":[{"bufferView":0,"byteOffset":0,"componentType":5123,"count":37041,"type":"SCALAR"},{"bufferView":1,"byteOffset":0,"componentType":5126,"count":9100,"max":[0.00265623419545591,0.0148777030408382,0.00131141499150544],"min":[-0.00267000868917,0.00126878940500319,-0.00532415136695],"type":"VEC3"},{"bufferView":2,"byteOffset":0,"componentType":5126,"count":9100,"type":"VEC3"},{"bufferView":3,"byteOffset":0,"componentType":5126,"count":9100,"type":"VEC2"},{"bufferView":4,"byteOffset":0,"componentType":5123,"count":9100,"type":"VEC4"},{"bufferView":5,"byteOffset":0,"componentType":5126,"count":9100,"type":"VEC4"},{"componentType":5126,"count":9100,"max":[0.00024045034660957,0,0],"min":[-0.00023119844263,-0.00049460766604,-0.00043747483869],"name":"Ahoge_OFF","sparse":{"count":126,"indices":{"bufferView":6,"byteOffset":0,"componentType":5123},"values":{"bufferView":7,"byteOffset":0}},"type":"VEC3"}, ...
```
Mesh:
```
"meshes":[{"extras":{"targetNames":["Ahoge_OFF","tilt_L","tilt_R","up_L","up_R","down_L","down_R"]},"name":"Hair","primitives":[{"attributes":{"JOINTS_0":4,"NORMAL":2,"POSITION":1,"TEXCOORD_0":3,"WEIGHTS_0":5},"indices":0,"material":1,"mode":4,"targets":[{"POSITION":6},{"POSITION":7},{"POSITION":8},{"POSITION":9},{"POSITION":10},{"POSITION":11},{"POSITION":12}]}],"weights":[0,0,0,0,0,0,0]}, ...
```
See how the 6th element `Ahoge_OFF` has no `bufferView` property which causes the sparse accessor to default to 0's per the spec.

These errors are printed:
```
ERROR: Condition "buffer_end > bv->byte_length" is true. Returning: ERR_PARSE_ERROR
   at: GLTFDocument::_decode_buffer_view (modules\gltf\gltf_document.cpp:1328)
ERROR: Condition "buffer_end > bv->byte_length" is true. Returning: ERR_PARSE_ERROR
   at: GLTFDocument::_decode_buffer_view (modules\gltf\gltf_document.cpp:1328)
ERROR: Condition "buffer_end > bv->byte_length" is true. Returning: ERR_PARSE_ERROR
   at: GLTFDocument::_decode_buffer_view (modules\gltf\gltf_document.cpp:1328)
ERROR: Condition "!skin.is_valid()" is true. Continuing.
   at: PostImportPluginSkeletonRestFixer::internal_process (editor\import\post_import_plugin_skeleton_rest_fixer.cpp:117)
```

We can confirm that the `Ahoge_OFF` blend shape failed to import properly:
![Screenshot showing ahoge is not off](https://github.com/godotengine/godot/assets/39946030/3c79a4a4-15db-4bdd-b508-9c790ae40923)

With this PR, I can confirm that the `Ahoge_OFF` blend shape now acts as intended:
![Screenshot showing missing ahoge](https://github.com/godotengine/godot/assets/39946030/ac42a788-7884-48fa-afca-f291acf46ece)
(Sorry, I do not have permission to share the reproduction model publicly.)