### PR TITLE
Add safe acos and safe asin

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -807,8 +807,7 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 	z = (rows[1][0] - rows[0][1]) / s;
 
 	r_axis = Vector3(x, y, z);
-	// CLAMP to avoid NaN if the value passed to acos is not in [0,1].
-	r_angle = Math::acos(CLAMP((rows[0][0] + rows[1][1] + rows[2][2] - 1) / 2, (real_t)0.0, (real_t)1.0));
+	r_angle = Math::safe_acos((rows[0][0] + rows[1][1] + rows[2][2] - 1) / 2);
 }
 
 void Basis::set_quaternion(const Quaternion &p_quaternion) {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -74,11 +74,27 @@ public:
 	static _ALWAYS_INLINE_ double tanh(double p_x) { return ::tanh(p_x); }
 	static _ALWAYS_INLINE_ float tanh(float p_x) { return ::tanhf(p_x); }
 
-	static _ALWAYS_INLINE_ double asin(double p_x) { return ::asin(p_x); }
-	static _ALWAYS_INLINE_ float asin(float p_x) { return ::asinf(p_x); }
+	// GUIDELINES on use of asin / acos.
+	// Use safe version if you are SURE a clamp is needed.
+	// Use unsafe version if you are SURE a clamp is not needed, OR Nan is dealt with (and likely to be a bottleneck).
+	// Use generic version if you are not sure.
+	static _ALWAYS_INLINE_ double safe_asin(double p_x) { return p_x < -1 ? (-Math_PI / 2) : (p_x > 1 ? (Math_PI / 2) : ::asin(p_x)); }
+	static _ALWAYS_INLINE_ float safe_asin(float p_x) { return p_x < -1 ? (-Math_PI / 2) : (p_x > 1 ? (Math_PI / 2) : ::asinf(p_x)); }
 
-	static _ALWAYS_INLINE_ double acos(double p_x) { return ::acos(p_x); }
-	static _ALWAYS_INLINE_ float acos(float p_x) { return ::acosf(p_x); }
+	static _ALWAYS_INLINE_ double unsafe_asin(double p_x) { return ::asin(p_x); }
+	static _ALWAYS_INLINE_ float unsafe_asin(float p_x) { return ::asinf(p_x); }
+
+	static _ALWAYS_INLINE_ double asin(double p_x) { return safe_asin(p_x); }
+	static _ALWAYS_INLINE_ float asin(float p_x) { return safe_asin(p_x); }
+
+	static _ALWAYS_INLINE_ double safe_acos(double p_x) { return p_x < -1 ? Math_PI : (p_x > 1 ? 0 : ::acos(p_x)); }
+	static _ALWAYS_INLINE_ float safe_acos(float p_x) { return p_x < -1 ? Math_PI : (p_x > 1 ? 0 : ::acosf(p_x)); }
+
+	static _ALWAYS_INLINE_ double unsafe_acos(double p_x) { return ::acos(p_x); }
+	static _ALWAYS_INLINE_ float unsafe_acos(float p_x) { return ::acosf(p_x); }
+
+	static _ALWAYS_INLINE_ double acos(double p_x) { return safe_acos(p_x); }
+	static _ALWAYS_INLINE_ float acos(float p_x) { return safe_acos(p_x); }
 
 	static _ALWAYS_INLINE_ double atan(double p_x) { return ::atan(p_x); }
 	static _ALWAYS_INLINE_ float atan(float p_x) { return ::atanf(p_x); }

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -35,7 +35,7 @@
 
 real_t Quaternion::angle_to(const Quaternion &p_to) const {
 	real_t d = dot(p_to);
-	return Math::acos(CLAMP(d * d * 2 - 1, -1, 1));
+	return Math::safe_acos(d * d * 2 - 1);
 }
 
 Vector3 Quaternion::get_euler(EulerOrder p_order) const {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -65,7 +65,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the arc cosine of [param x] in radians. Use to get the angle of cosine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method acos] will return [constant @GDScript.NAN].
+				Returns the arc cosine of [param x] in radians. Use to get the angle of cosine [param x]. [param x] will be clamped between [code]-1.0[/code] and [code]1.0[/code] (inclusive), in order to prevent [method acos] from returning [constant @GDScript.NAN].
 				[codeblock]
 				# c is 0.523599 or 30 degrees if converted with rad_to_deg(c)
 				var c = acos(0.866025)
@@ -76,7 +76,7 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns the arc sine of [param x] in radians. Use to get the angle of sine [param x]. [param x] must be between [code]-1.0[/code] and [code]1.0[/code] (inclusive), otherwise, [method asin] will return [constant @GDScript.NAN].
+				Returns the arc sine of [param x] in radians. Use to get the angle of sine [param x]. [param x] will be clamped between [code]-1.0[/code] and [code]1.0[/code] (inclusive), in order to prevent [method asin] from returning [constant @GDScript.NAN].
 				[codeblock]
 				# s is 0.523599 or 30 degrees if converted with rad_to_deg(s)
 				var s = asin(0.5)

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -157,15 +157,17 @@ TEST_CASE_TEMPLATE("[Math] asin/acos/atan", T, float, double) {
 	CHECK(Math::asin((T)0.1) == doctest::Approx((T)0.1001674212));
 	CHECK(Math::asin((T)0.5) == doctest::Approx((T)0.5235987756));
 	CHECK(Math::asin((T)1.0) == doctest::Approx((T)1.5707963268));
-	CHECK(Math::is_nan(Math::asin((T)1.5)));
-	CHECK(Math::is_nan(Math::asin((T)450.0)));
+	CHECK(Math::asin((T)2.0) == doctest::Approx((T)1.5707963268));
+	CHECK(Math::is_nan(Math::unsafe_asin((T)1.5)));
+	CHECK(Math::is_nan(Math::unsafe_asin((T)450.0)));
 
 	CHECK(Math::acos((T)-0.1) == doctest::Approx((T)1.670963748));
 	CHECK(Math::acos((T)0.1) == doctest::Approx((T)1.4706289056));
 	CHECK(Math::acos((T)0.5) == doctest::Approx((T)1.0471975512));
 	CHECK(Math::acos((T)1.0) == doctest::Approx((T)0.0));
-	CHECK(Math::is_nan(Math::acos((T)1.5)));
-	CHECK(Math::is_nan(Math::acos((T)450.0)));
+	CHECK(Math::acos((T)2.0) == doctest::Approx((T)0.0));
+	CHECK(Math::is_nan(Math::unsafe_acos((T)1.5)));
+	CHECK(Math::is_nan(Math::unsafe_acos((T)450.0)));
 
 	CHECK(Math::atan((T)-0.1) == doctest::Approx((T)-0.0996686525));
 	CHECK(Math::atan((T)0.1) == doctest::Approx((T)0.0996686525));


### PR DESCRIPTION
A common bug with using acos and asin is that input outside -1 to 1 range will result in Nan output. This can occur due to floating point error in the input.

The standard solution is to provide safe_acos function with clamped input. For Godot it may make more sense to make the standard functions safe, and add extra unsafe functions for rare occasions when needed.

Fixes #76857

## Notes
* I'm equally happy to explicitly use `safe_acos` and have the default unsafe (I've used this in the past), but given how often this mistake is made by contributors and users (basically nearly everywhere), I'd be inclined to think making the default safe might be wise
* I've gone for both explicit versions (`safe` and `unsafe`) to make it clear in calling code whether clamping has taken place, as well as wrapping the default to the safe version. Would be happy to change if anyone has better suggestions for how to approach.
* We could also consider replacing all `acos` and `asin` use in the core engine with explicit versions, to make it obvious to the reader / writer the problem, and the choice of the appropriate version.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
