### PR TITLE
Add support for OpenXR composition layers

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -94,6 +94,7 @@ if env["opengl3"]:
     env_openxr.add_source_files(module_obj, "extensions/openxr_opengl_extension.cpp")
 
 env_openxr.add_source_files(module_obj, "extensions/openxr_palm_pose_extension.cpp")
+env_openxr.add_source_files(module_obj, "extensions/openxr_composition_layer_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_composition_layer_depth_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_htc_controller_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_htc_vive_tracker_extension.cpp")

--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -19,6 +19,7 @@ def get_doc_classes():
         "OpenXRInteractionProfile",
         "OpenXRIPBinding",
         "OpenXRHand",
+        "OpenXRCompositionLayer",
     ]
 
 

--- a/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="OpenXRCompositionLayer" inherits="SubViewport" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A special viewport that is submitted to the OpenXR compositor for display in headset.
+	</brief_description>
+	<description>
+		Composition layers allow 2D viewports to be displayed inside of the headset by the XR compositor through special projections that retain their quality. This allows for rendering clear text while keeping the layer at a native resolution.
+		[b]Note:[/b] composition layers are only rendered inside of the headset.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="is_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the composition layer is supported by the platform. This requires OpenXR to be initialised.
+				[b]Note:[/b] when not supported, the viewport will still be rendered allowing you to create a fallback by displaying the viewport on a QuadMesh.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="composition_layer_type" type="int" setter="set_composition_layer_type" getter="get_composition_layer_type" enum="OpenXRCompositionLayer.CompositionLayerTypes" default="0">
+			The composition layer type determines how the viewport is displayed in headset.
+		</member>
+	</members>
+	<constants>
+		<constant name="COMPOSITION_LAYER_EQUIRECT2" value="0" enum="CompositionLayerTypes">
+			Composition layer is displayed on a curved rectangle.
+		</constant>
+		<constant name="COMPOSITION_LAYER_MAX" value="1" enum="CompositionLayerTypes">
+		</constant>
+	</constants>
+</class>

--- a/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
@@ -56,8 +56,8 @@ bool OpenXRCompositionLayerDepthExtension::is_available() {
 	return available;
 }
 
-XrCompositionLayerBaseHeader *OpenXRCompositionLayerDepthExtension::get_composition_layer() {
+OpenXRCompositionLayerProvider::OrderedCompositionLayer OpenXRCompositionLayerDepthExtension::get_composition_layer() {
 	// Seems this is all done in our base layer... Just in case this changes...
 
-	return nullptr;
+	return { nullptr, 0 };
 }

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -1,0 +1,220 @@
+/**************************************************************************/
+/*  openxr_composition_layer_extension.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_composition_layer_extension.h"
+
+////////////////////////////////////////////////////////////////////////////
+// OpenXRCompositionLayerExtension
+
+OpenXRCompositionLayerExtension *OpenXRCompositionLayerExtension::singleton = nullptr;
+
+OpenXRCompositionLayerExtension *OpenXRCompositionLayerExtension::get_singleton() {
+	return singleton;
+}
+
+OpenXRCompositionLayerExtension::OpenXRCompositionLayerExtension() {
+	singleton = this;
+}
+
+OpenXRCompositionLayerExtension::~OpenXRCompositionLayerExtension() {
+	singleton = nullptr;
+}
+
+HashMap<String, bool *> OpenXRCompositionLayerExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME] = &available[COMPOSITION_LAYER_EQUIRECT_EXT];
+
+	return request_extensions;
+}
+
+bool OpenXRCompositionLayerExtension::is_available(CompositionLayerExtensions p_which) {
+	ERR_FAIL_INDEX_V(p_which, COMPOSITION_LAYER_EXT_MAX, false);
+
+	return available[p_which];
+}
+
+////////////////////////////////////////////////////////////////////////////
+// ViewportCompositionLayerProvider
+
+ViewportCompositionLayerProvider::ViewportCompositionLayerProvider() {
+	openxr_api = OpenXRAPI::get_singleton();
+	composition_layer_extension = OpenXRCompositionLayerExtension::get_singleton();
+
+	// Clear this.
+	setup_for_type(XR_TYPE_UNKNOWN);
+}
+
+ViewportCompositionLayerProvider::~ViewportCompositionLayerProvider() {
+	if (swapchain_info.swapchain != XR_NULL_HANDLE) {
+		openxr_api->free_swapchain(swapchain_info);
+	}
+}
+
+bool ViewportCompositionLayerProvider::is_supported() {
+	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
+		// OpenXR not initialised or we're in the editor?
+		return false;
+	}
+
+	switch (composition_layer.type) {
+		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
+			return composition_layer_extension->is_available(OpenXRCompositionLayerExtension::COMPOSITION_LAYER_EQUIRECT_EXT);
+		} break;
+		default: {
+			return false;
+		} break;
+	}
+}
+
+void ViewportCompositionLayerProvider::setup_for_type(XrStructureType p_type) {
+	// Note, we setup our type fully even if it's not supported on the current platform.
+	// This allows us to set it up in the editor.
+	switch (p_type) {
+		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
+			memset(&equirect_layer, 0, sizeof(XrCompositionLayerEquirect2KHR));
+			equirect_layer.type = XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR;
+			equirect_layer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT | XR_COMPOSITION_LAYER_CORRECT_CHROMATIC_ABERRATION_BIT;
+			equirect_layer.eyeVisibility = XR_EYE_VISIBILITY_BOTH;
+
+			// These needs to become configurable
+			equirect_layer.pose.orientation.x = 0.0;
+			equirect_layer.pose.orientation.y = 0.0;
+			equirect_layer.pose.orientation.z = 0.0;
+			equirect_layer.pose.orientation.w = 1.0;
+			equirect_layer.pose.position.x = 0.0; // this should probably be centered on the player?? or we leave it up to the user
+			equirect_layer.pose.position.y = 1.5;
+			equirect_layer.pose.position.z = 0.0;
+			equirect_layer.radius = 1.0;
+			equirect_layer.centralHorizontalAngle = 90.0 * Math_PI / 180.0;
+			equirect_layer.upperVerticalAngle = 25.0 * Math_PI / 180.0;
+			equirect_layer.lowerVerticalAngle = 25.0 * Math_PI / 180.0;
+		} break;
+		default: {
+			memset(&composition_layer, 0, sizeof(XrCompositionLayerBaseHeader));
+			composition_layer.type = XR_TYPE_UNKNOWN;
+		} break;
+	}
+}
+
+OpenXRCompositionLayerProvider::OrderedCompositionLayer ViewportCompositionLayerProvider::get_composition_layer() {
+	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
+		// OpenXR not initialised or we're in the editor?
+		return { nullptr, 0 };
+	}
+
+	if (!is_supported()) {
+		// Selected type is not supported, ignore our layer.
+		return { nullptr, 0 };
+	}
+
+	if (swapchain_info.swapchain == XR_NULL_HANDLE) {
+		// Don't have a swapchain to display? Ignore our layer.
+		return { nullptr, 0 };
+	}
+
+	if (swapchain_info.image_acquired) {
+		openxr_api->release_image(swapchain_info);
+	}
+
+	switch (composition_layer.type) {
+		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
+			// Setup additional info for swapchain
+			equirect_layer.subImage.swapchain = swapchain_info.swapchain;
+			equirect_layer.subImage.imageArrayIndex = swapchain_info.image_index;
+			equirect_layer.subImage.imageRect.offset.x = 0;
+			equirect_layer.subImage.imageRect.offset.y = 0;
+			equirect_layer.subImage.imageRect.extent.width = width;
+			equirect_layer.subImage.imageRect.extent.height = height;
+
+			equirect_layer.space = openxr_api->get_play_space();
+
+			return { &composition_layer, sort_order };
+		} break;
+		default: {
+			return { nullptr, 0 };
+		} break;
+	}
+}
+
+bool ViewportCompositionLayerProvider::update_swapchain(uint32_t p_width, uint32_t p_height) {
+	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
+		// OpenXR not initialised or we're in the editor?
+		return false;
+	}
+
+	if (!is_supported()) {
+		// Selected type is not supported?
+		return false;
+	}
+
+	// See if our current swapchain is outdated
+	if (swapchain_info.swapchain != XR_NULL_HANDLE) {
+		if (width == p_width && height == p_height) {
+			// We're all good! Just acquire it.
+			openxr_api->acquire_image(swapchain_info);
+			return true;
+		}
+
+		openxr_api->free_swapchain(swapchain_info);
+	}
+
+	// Create our new swap chain
+	int64_t swapchain_format = openxr_api->get_color_swapchain_format();
+	if (!openxr_api->create_swapchain(XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, swapchain_format, p_width, p_height, 3, 1, swapchain_info.swapchain, &swapchain_info.swapchain_graphics_data)) {
+		width = 0;
+		height = 0;
+		return false;
+	}
+
+	// Acquire our image so we can start rendering into it
+	openxr_api->acquire_image(swapchain_info);
+
+	width = p_width;
+	height = p_height;
+	return true;
+}
+
+void ViewportCompositionLayerProvider::free_swapchain() {
+	if (swapchain_info.swapchain != XR_NULL_HANDLE) {
+		openxr_api->free_swapchain(swapchain_info);
+	}
+
+	width = 0;
+	height = 0;
+}
+
+RID ViewportCompositionLayerProvider::get_image() {
+	if (openxr_api == nullptr) {
+		return RID();
+	}
+
+	return openxr_api->get_image(swapchain_info);
+}

--- a/modules/openxr/extensions/openxr_composition_layer_provider.h
+++ b/modules/openxr/extensions/openxr_composition_layer_provider.h
@@ -38,7 +38,16 @@
 // Interface for OpenXR extensions that provide a composition layer.
 class OpenXRCompositionLayerProvider {
 public:
-	virtual XrCompositionLayerBaseHeader *get_composition_layer() = 0;
+	struct OrderedCompositionLayer {
+		const XrCompositionLayerBaseHeader *composition_layer;
+		int sort_order;
+
+		_FORCE_INLINE_ bool operator()(const OrderedCompositionLayer &a, const OrderedCompositionLayer &b) const {
+			return a.sort_order < b.sort_order || (a.sort_order == b.sort_order && uint64_t(a.composition_layer) < uint64_t(b.composition_layer));
+		}
+	};
+
+	virtual OrderedCompositionLayer get_composition_layer() = 0;
 
 	virtual ~OpenXRCompositionLayerProvider() {}
 };

--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -163,12 +163,12 @@ void OpenXRFbPassthroughExtensionWrapper::on_session_created(const XrSession ses
 	}
 }
 
-XrCompositionLayerBaseHeader *OpenXRFbPassthroughExtensionWrapper::get_composition_layer() {
+OpenXRCompositionLayerProvider::OrderedCompositionLayer OpenXRFbPassthroughExtensionWrapper::get_composition_layer() {
 	if (is_passthrough_enabled()) {
 		composition_passthrough_layer.layerHandle = passthrough_layer;
-		return (XrCompositionLayerBaseHeader *)&composition_passthrough_layer;
+		return { (XrCompositionLayerBaseHeader *)&composition_passthrough_layer, -9999 }; // -9999 so this will always be our bottom layer
 	} else {
-		return nullptr;
+		return { nullptr, 0 };
 	}
 }
 

--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -56,7 +56,7 @@ public:
 
 	void on_instance_destroyed() override;
 
-	XrCompositionLayerBaseHeader *get_composition_layer() override;
+	OpenXRCompositionLayerProvider::OrderedCompositionLayer get_composition_layer() override;
 
 	bool is_passthrough_supported() {
 		return fb_passthrough_ext;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -60,6 +60,14 @@ class OpenXRVulkanExtension;
 class OpenXRInterface;
 
 class OpenXRAPI {
+public:
+	struct OpenXRSwapChainInfo {
+		XrSwapchain swapchain = XR_NULL_HANDLE;
+		void *swapchain_graphics_data = nullptr;
+		uint32_t image_index = 0;
+		bool image_acquired = false;
+	};
+
 private:
 	// our singleton
 	static OpenXRAPI *singleton;
@@ -137,13 +145,7 @@ private:
 		OPENXR_SWAPCHAIN_MAX
 	};
 
-	struct OpenXRSwapChainInfo {
-		XrSwapchain swapchain = XR_NULL_HANDLE;
-		void *swapchain_graphics_data = nullptr;
-		uint32_t image_index = 0;
-		bool image_acquired = false;
-	};
-
+	int64_t color_swapchain_format = 0;
 	OpenXRSwapChainInfo swapchains[OPENXR_SWAPCHAIN_MAX];
 
 	XrSpace play_space = XR_NULL_HANDLE;
@@ -233,11 +235,6 @@ private:
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
 	bool create_swapchains();
 	void destroy_session();
-
-	// swapchains
-	bool create_swapchain(XrSwapchainUsageFlags p_usage_flags, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, XrSwapchain &r_swapchain, void **r_swapchain_graphics_data);
-	bool acquire_image(OpenXRSwapChainInfo &p_swapchain);
-	bool release_image(OpenXRSwapChainInfo &p_swapchain);
 
 	// action map
 	struct Tracker { // Trackers represent tracked physical objects such as controllers, pucks, etc.
@@ -371,6 +368,14 @@ public:
 	// Render Target size multiplier
 	double get_render_target_size_multiplier() const;
 	void set_render_target_size_multiplier(double multiplier);
+
+	// swapchains
+	int64_t get_color_swapchain_format() const { return color_swapchain_format; }
+	bool create_swapchain(XrSwapchainUsageFlags p_usage_flags, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, XrSwapchain &r_swapchain, void **r_swapchain_graphics_data);
+	void free_swapchain(OpenXRSwapChainInfo &p_swapchain);
+	bool acquire_image(OpenXRSwapChainInfo &p_swapchain);
+	RID get_image(OpenXRSwapChainInfo &p_swapchain);
+	bool release_image(OpenXRSwapChainInfo &p_swapchain);
 
 	// action map
 	String get_default_action_map_resource_name();

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -36,9 +36,12 @@
 #include "action_map/openxr_interaction_profile.h"
 #include "action_map/openxr_interaction_profile_meta_data.h"
 #include "openxr_interface.h"
+
+#include "scene/openxr_composition_layer.h"
 #include "scene/openxr_hand.h"
 
 #include "extensions/openxr_composition_layer_depth_extension.h"
+#include "extensions/openxr_composition_layer_extension.h"
 #include "extensions/openxr_fb_display_refresh_rate_extension.h"
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 #include "extensions/openxr_hand_tracking_extension.h"
@@ -99,6 +102,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPalmPoseExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPicoControllerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRCompositionLayerDepthExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRCompositionLayerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRHTCControllerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRHTCViveTrackerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRHuaweiControllerExtension));
@@ -146,6 +150,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(OpenXRIPBinding);
 		GDREGISTER_CLASS(OpenXRInteractionProfile);
 
+		GDREGISTER_CLASS(OpenXRCompositionLayer);
 		GDREGISTER_CLASS(OpenXRHand);
 
 		XRServer *xr_server = XRServer::get_singleton();

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -1,0 +1,136 @@
+/**************************************************************************/
+/*  openxr_composition_layer.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "../extensions/openxr_composition_layer_extension.h"
+#include "../openxr_api.h"
+
+#include "openxr_composition_layer.h"
+
+#include "servers/rendering/rendering_server_default.h"
+#include "servers/rendering_server.h"
+
+// TODOs:
+// - make settings for pose, radius, scale and bias setable, possibly linking pose to player position (or leave that up to user)
+// - add gizmo to visualise positioning/output of composition layer
+// - add support for other composition layers
+
+OpenXRCompositionLayer::OpenXRCompositionLayer() {
+	openxr_api = OpenXRAPI::get_singleton();
+	openxr_layer_provider = memnew(ViewportCompositionLayerProvider);
+
+	if (openxr_api != nullptr) {
+		set_process_internal(true);
+	}
+}
+
+OpenXRCompositionLayer::~OpenXRCompositionLayer() {
+	if (openxr_layer_provider != nullptr) {
+		memdelete(openxr_layer_provider);
+		openxr_layer_provider = nullptr;
+	}
+}
+
+void OpenXRCompositionLayer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_composition_layer_type", "composition_layer_type"), &OpenXRCompositionLayer::set_composition_layer_type);
+	ClassDB::bind_method(D_METHOD("get_composition_layer_type"), &OpenXRCompositionLayer::get_composition_layer_type);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "composition_layer_type", PROPERTY_HINT_ENUM, "Equirect"), "set_composition_layer_type", "get_composition_layer_type");
+
+	ClassDB::bind_method(D_METHOD("is_supported"), &OpenXRCompositionLayer::is_supported);
+
+	BIND_ENUM_CONSTANT(COMPOSITION_LAYER_EQUIRECT2);
+	BIND_ENUM_CONSTANT(COMPOSITION_LAYER_MAX);
+}
+
+void OpenXRCompositionLayer::set_composition_layer_type(const CompositionLayerTypes p_type) {
+	composition_layer_type = p_type;
+
+	switch (composition_layer_type) {
+		case COMPOSITION_LAYER_EQUIRECT2: {
+			openxr_layer_provider->setup_for_type(XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR);
+		} break;
+		default: {
+			// this will clear it and make it inactive.
+			openxr_layer_provider->setup_for_type(XR_TYPE_UNKNOWN);
+		} break;
+	}
+}
+
+bool OpenXRCompositionLayer::is_supported() {
+	return openxr_layer_provider->is_supported();
+}
+
+void OpenXRCompositionLayer::_notification(int p_what) {
+	if (openxr_api == nullptr) {
+		return;
+	}
+
+	RenderingServer *rs = RenderingServer::get_singleton();
+	ERR_FAIL_NULL(rs);
+
+	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			// TODO, if our update mode will result in us not updating our viewport,
+			// we should skip this and reuse our last result.
+
+			if (openxr_layer_provider->is_supported()) {
+				// Update our XR swapchain
+				Size2i vp_size = get_size();
+				openxr_layer_provider->update_swapchain(vp_size.width, vp_size.height);
+
+				// Render to our XR swapchain image
+				RID vp = get_viewport_rid();
+				RID rt = rs->viewport_get_render_target(vp);
+				RSG::texture_storage->render_target_set_override(rt, openxr_layer_provider->get_image(), RID(), RID());
+			} else {
+				// We still render our viewport, this will allow the user to display the viewport with a Quadmesh.
+				RID vp = get_viewport_rid();
+				RID rt = rs->viewport_get_render_target(vp);
+				RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID());
+			}
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
+			// Add our composition layer provider to our OpenXR API,
+			// we do this even if not supported as the user may change type.
+			openxr_api->register_composition_layer_provider(openxr_layer_provider);
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			// Remove our composition layer provider from our OpenXR API
+			openxr_api->unregister_composition_layer_provider(openxr_layer_provider);
+
+			// reset our viewport
+			RID vp = get_viewport_rid();
+			RID rt = rs->viewport_get_render_target(vp);
+			RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID());
+
+			// free our swapchain
+			openxr_layer_provider->free_swapchain();
+		} break;
+	}
+}

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  openxr_composition_layer_depth_extension.h                            */
+/*  openxr_composition_layer.h                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,44 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef OPENXR_COMPOSITION_LAYER_DEPTH_EXTENSION_H
-#define OPENXR_COMPOSITION_LAYER_DEPTH_EXTENSION_H
+#ifndef OPENXR_COMPOSITION_LAYER_H
+#define OPENXR_COMPOSITION_LAYER_H
 
-#include "openxr_composition_layer_provider.h"
-#include "openxr_extension_wrapper.h"
+#include "scene/main/viewport.h"
 
-class OpenXRCompositionLayerDepthExtension : public OpenXRExtensionWrapper, public OpenXRCompositionLayerProvider {
+class OpenXRAPI;
+class ViewportCompositionLayerProvider;
+
+class OpenXRCompositionLayer : public SubViewport {
+	GDCLASS(OpenXRCompositionLayer, SubViewport);
+
 public:
-	static OpenXRCompositionLayerDepthExtension *get_singleton();
-
-	OpenXRCompositionLayerDepthExtension();
-	virtual ~OpenXRCompositionLayerDepthExtension() override;
-
-	virtual HashMap<String, bool *> get_requested_extensions() override;
-	bool is_available();
-	virtual OpenXRCompositionLayerProvider::OrderedCompositionLayer get_composition_layer() override;
+	enum CompositionLayerTypes {
+		COMPOSITION_LAYER_EQUIRECT2,
+		COMPOSITION_LAYER_MAX
+	};
 
 private:
-	static OpenXRCompositionLayerDepthExtension *singleton;
+	OpenXRAPI *openxr_api = nullptr;
+	ViewportCompositionLayerProvider *openxr_layer_provider = nullptr;
 
-	bool available = false;
+	CompositionLayerTypes composition_layer_type;
+
+protected:
+	static void _bind_methods();
+
+public:
+	OpenXRCompositionLayer();
+	~OpenXRCompositionLayer();
+
+	void set_composition_layer_type(const CompositionLayerTypes p_type);
+	CompositionLayerTypes get_composition_layer_type() const { return composition_layer_type; };
+
+	bool is_supported();
+
+	void _notification(int p_what);
 };
 
-#endif // OPENXR_COMPOSITION_LAYER_DEPTH_EXTENSION_H
+VARIANT_ENUM_CAST(OpenXRCompositionLayer::CompositionLayerTypes)
+
+#endif // OPENXR_COMPOSITION_LAYER_H


### PR DESCRIPTION
This PR adds support for OpenXRs composition layers specifically for layers where a 2D render result is projected within the HMD.
This is especially handy for rendering 2D UIs within the XR environment as some math magic with some of the projection shapes means we don't need to upscale the resolution of these buffers.

This new node subclasses `SubViewport` however we do need to configure it specifically for this purpose. The major difference is that we **MUST** render to an OpenXR swapchain in order for the XR compositor to use the images.
I may go back to my original idea to create a subclass of Node3D and create the viewport directly on the rendering server. This would also allow positioning this correctly.

The viewport is **not** displayed in Godot itself, it is purely displayed in the headset. 
**Note** that if the required extension is not supported by the platform the viewport is not displayed however the viewport is still rendered. This allows the user to create a fallback by displaying the viewport on a `QuadMesh` or other applicable mesh.

Todo:
- Find the bug that is preventing this from working
- Make it possible to further configure how the viewport is displayed
- Add a gizmo to display how the viewport will be displayed
- Implement further layer types
- Investigate interaction with UI elements. 

See:
- https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_KHR_composition_layer_cylinder
- https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_KHR_composition_layer_equirect2
- Potentially support others?
Only `equirect2` is currently implemented.

Test project:
[TestCompositionLayers.zip](https://github.com/godotengine/godot/files/11944275/TestCompositionLayers.zip)
