### PR TITLE
Fix various errors when running the unit tests

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -484,7 +484,10 @@ Ref<InputEventKey> InputEventKey::create_reference(Key p_keycode, bool p_physica
 		ie->set_keycode(p_keycode & KeyModifierMask::CODE_MASK);
 	}
 
-	ie->set_unicode(char32_t(p_keycode & KeyModifierMask::CODE_MASK));
+	char32_t ch = char32_t(p_keycode & KeyModifierMask::CODE_MASK);
+	if (ch < 0xd800 || (ch > 0xdfff && ch <= 0x10ffff)) {
+		ie->set_unicode(ch);
+	}
 
 	if ((p_keycode & KeyModifierMask::SHIFT) != Key::NONE) {
 		ie->set_shift_pressed(true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -581,8 +581,6 @@ void Main::test_cleanup() {
 		TextServerManager::get_singleton()->get_interface(i)->cleanup();
 	}
 
-	EngineDebugger::deinitialize();
-
 	ResourceLoader::remove_custom_loaders();
 	ResourceSaver::remove_custom_savers();
 
@@ -594,6 +592,7 @@ void Main::test_cleanup() {
 
 	GDExtensionManager::get_singleton()->deinitialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
+
 	unregister_platform_apis();
 	unregister_driver_types();
 	unregister_scene_types();
@@ -604,8 +603,12 @@ void Main::test_cleanup() {
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
 
+	EngineDebugger::deinitialize();
 	OS::get_singleton()->finalize();
 
+	if (packed_data) {
+		memdelete(packed_data);
+	}
 	if (translation_server) {
 		memdelete(translation_server);
 	}
@@ -621,16 +624,13 @@ void Main::test_cleanup() {
 	if (globals) {
 		memdelete(globals);
 	}
-	if (packed_data) {
-		memdelete(packed_data);
-	}
 	if (engine) {
 		memdelete(engine);
 	}
 
 	unregister_core_driver_types();
-	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	unregister_core_extensions();
+	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3865,8 +3865,8 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 				}
 				prev_font = gl.font_rid;
 
-				double scale = _font_get_scale(gl.font_rid, gl.font_size);
 				if (gl.font_rid.is_valid()) {
+					double scale = _font_get_scale(gl.font_rid, gl.font_size);
 					bool subpos = (scale != 1.0) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_ONE_HALF) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_ONE_QUARTER) || (_font_get_subpixel_positioning(gl.font_rid) == SUBPIXEL_POSITIONING_AUTO && gl.font_size <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE);
 					if (sd->text[j - sd->start] != 0 && !is_linebreak(sd->text[j - sd->start])) {
 						if (sd->orientation == ORIENTATION_HORIZONTAL) {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -40,11 +40,12 @@ Path3D::Path3D() {
 }
 
 Path3D::~Path3D() {
-	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(debug_instance);
 	}
 	if (debug_mesh.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
 		RS::get_singleton()->free(debug_mesh->get_rid());
 	}
 }

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -487,13 +487,13 @@ void add_exposed_classes(Context &r_context) {
 		}
 
 		if (!ClassDB::is_class_exposed(class_name)) {
-			MESSAGE(vformat("Ignoring class '%s' because it's not exposed.", class_name));
+			INFO(vformat("Ignoring class '%s' because it's not exposed.", class_name));
 			class_list.pop_front();
 			continue;
 		}
 
 		if (!ClassDB::is_class_enabled(class_name)) {
-			MESSAGE(vformat("Ignoring class '%s' because it's not enabled.", class_name));
+			INFO(vformat("Ignoring class '%s' because it's not enabled.", class_name));
 			class_list.pop_front();
 			continue;
 		}
@@ -717,15 +717,10 @@ void add_exposed_classes(Context &r_context) {
 
 			bool method_conflict = exposed_class.find_property_by_name(signal.name);
 
-			// TODO:
-			// ClassDB allows signal names that conflict with method or property names.
-			// However registering a signal with a conflicting name is still considered wrong.
-			// Unfortunately there are some existing cases that are yet to be fixed.
-			// Until those are fixed we will print a warning instead of failing the test.
 			String warn_msg = vformat(
 					"Signal name conflicts with %s: '%s.%s.",
 					method_conflict ? "method" : "property", class_name, signal.name);
-			TEST_FAIL_COND_WARN((method_conflict || exposed_class.find_method_by_name(signal.name)),
+			TEST_FAIL_COND((method_conflict || exposed_class.find_method_by_name(signal.name)),
 					warn_msg.utf8().get_data());
 
 			exposed_class.signals_.push_back(signal);

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3482,9 +3482,9 @@ TEST_CASE("[SceneTree][CodeEdit] symbol lookup") {
 		SIGNAL_CHECK("symbol_validate", signal_args);
 
 		SIGNAL_UNWATCH(code_edit, "symbol_validate");
-
-		memdelete(code_edit);
 	}
+
+	memdelete(code_edit);
 }
 
 TEST_CASE("[SceneTree][CodeEdit] line length guidelines") {

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -221,7 +221,9 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 	}
 
 	SUBCASE("[Viewport][GuiInputEvent] nullptr as argument doesn't lead to a crash.") {
+		ERR_PRINT_OFF;
 		CHECK_NOTHROW(root->push_input(nullptr));
+		ERR_PRINT_ON;
 	}
 
 	// Unit tests for Viewport::_gui_input_event (Mouse Buttons)

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -147,7 +147,7 @@ int register_test_command(String p_command, TestFunc p_function);
 	{                                                                                                 \
 		const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(m_action); \
 		const List<Ref<InputEvent>>::Element *first_event = events->front();                          \
-		Ref<InputEventKey> event = first_event->get();                                                \
+		Ref<InputEventKey> event = first_event->get()->duplicate();                                   \
 		event->set_pressed(true);                                                                     \
 		_SEND_DISPLAYSERVER_EVENT(event);                                                             \
 		MessageQueue::get_singleton()->flush();                                                       \

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -255,8 +255,8 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		}
 
 		if (suite_name.find("[Navigation]") != -1 && navigation_server_2d == nullptr && navigation_server_3d == nullptr) {
-			navigation_server_2d = memnew(NavigationServer2D);
 			navigation_server_3d = NavigationServer3DManager::new_default_server();
+			navigation_server_2d = memnew(NavigationServer2D);
 			return;
 		}
 	}


### PR DESCRIPTION
Currently running the unit tests prints a lot of errors and warnings: https://github.com/godotengine/godot/actions/runs/4924172553/jobs/8796973702#step:7:111
Most of them are unnecessary noise and in the way when actually writing tests, so this fixes (or silences) most of them.

- Reordered `Main::test_cleanup` to match `Main::cleanup` again to fix the `Profiler not registered` errors
- Moved the error in the `Path3D` destructor to avoid triggering it from the tests when the server is not actually needed.
- Downgraded the `Ignoring class` messages to avoid them showing up when running normally and they are not interesting.
- (Kinda unrelated) Removed a TODO as its issue no longer exists
- (Kinda unrelated) Moved a `memdelete` out of a condition to avoid potentially leaking its argument.
- Silenced an intentionally triggered error.
- Duplicate `InputEventKey` when sending actions to avoid warning about using an instance multiple times per frame
- Reorder the creation of the 2 and 3 D navigation server to avoid an error telling you to do exactly that.

---

~~This leaves one instance (caused by test_code_edit.h:3472) as that seems to be an actual issue with a nontrivial (at least to me) fix:~~
```
Unicode parsing error: Invalid unicode codepoint (400016)
Unicode parsing error, some characters were replaced with spaces: Invalid unicode codepoint (400016), cannot represent as UTF-16
ERROR: U_ILLEGAL_ARGUMENT_ERROR
   at: (modules\text_server_adv\script_iterator.cpp:71)
```
~~The error is caused by the code edit attempting to insert Key::CTRL/META as a character (which doesn't exist) into the text, not sure how to best fix this problem.~~

---

~~Also in the CI / when the fallback text server is enabled, some additional errors because attempts to shape text that doesn't have a suitable fallback font. Again I am not sure how to best fix this error (tho here just silencing it might be fine)~~
```
ERROR: Condition "!fd" is true. Returning: 0.0
   at: _font_get_scale (modules/text_server_fb/text_server_fb.cpp:1551)
```

---

https://github.com/godotengine/godot/actions/runs/4928298305/jobs/8806497746#step:7:111 All the errors are fixed now