### PR TITLE
CI: Fix running the unit tests on windows

### DIFF
--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -28,7 +28,7 @@ jobs:
             target: editor
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
-            sconsflags: debug_symbols=no vsproj=yes
+            sconsflags: debug_symbols=no vsproj=yes windows_subsystem=console
             bin: "./bin/godot.windows.editor.x86_64.exe"
 
           - name: Template (target=template_release)


### PR DESCRIPTION
When working on #76878 I noticed that the unit tests don't appear to run correctly on the windows editor leg.
The issue most likely is that the shell continued with (terminating) the script before the commands / tests were finished because the executable is normally not using the console subsystem.

~Draft because running the that build artifact locally fails the tests, but that is probably just the environment being wrong.~
The test run properly now and the output matches that of the macOS run (except that macOS has a few additional `+[NSString stringWithUTF8String:]: NULL cString` errors and colors)