### PR TITLE
Add support for extending GLTF with more texture formats and support WebP

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -103,6 +103,17 @@
 				The return value is used to determine if this [GLTFDocumentExtension] instance should be used for importing a given GLTF file. If [constant OK], the import will use this [GLTFDocumentExtension] instance. If not overridden, [constant OK] is returned.
 			</description>
 		</method>
+		<method name="_parse_image_data" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="image_data" type="PackedByteArray" />
+			<param index="2" name="mime_type" type="String" />
+			<param index="3" name="ret_image" type="Image" />
+			<description>
+				Part of the import process. This method is run after [method _parse_node_extensions] and before [method _parse_texture_json].
+				Runs when parsing image data from a GLTF file. The data could be sourced from a separate file, a URI, or a buffer, and then is passed as a byte array.
+			</description>
+		</method>
 		<method name="_parse_node_extensions" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="state" type="GLTFState" />
@@ -111,6 +122,16 @@
 			<description>
 				Part of the import process. This method is run after [method _get_supported_extensions] and before [method _generate_scene_node].
 				Runs when parsing the node extensions of a GLTFNode. This method can be used to process the extension JSON data into a format that can be used by [method _generate_scene_node]. The return value should be a member of the [enum Error] enum.
+			</description>
+		</method>
+		<method name="_parse_texture_json" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="texture_json" type="Dictionary" />
+			<param index="2" name="ret_gltf_texture" type="GLTFTexture" />
+			<description>
+				Part of the import process. This method is run after [method _parse_image_data] and before [method _generate_scene_node].
+				Runs when parsing the texture JSON from the GLTF textures array. This can be used to set the source image index to use as the texture.
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -70,6 +70,7 @@
 		<method name="get_images">
 			<return type="Texture2D[]" />
 			<description>
+				Gets the images of the GLTF file as an array of [Texture2D]s. These are the images that the [member GLTFTexture.src_image] index refers to.
 			</description>
 		</method>
 		<method name="get_lights">
@@ -182,6 +183,7 @@
 			<return type="void" />
 			<param index="0" name="images" type="Texture2D[]" />
 			<description>
+				Sets the images in the state stored as an array of [Texture2D]s. This can be used during export. These are the images that the [member GLTFTexture.src_image] index refers to.
 			</description>
 		</method>
 		<method name="set_lights">

--- a/modules/gltf/doc_classes/GLTFTexture.xml
+++ b/modules/gltf/doc_classes/GLTFTexture.xml
@@ -10,7 +10,8 @@
 		<member name="sampler" type="int" setter="set_sampler" getter="get_sampler" default="-1">
 			ID of the texture sampler to use when sampling the image. If -1, then the default texture sampler is used (linear filtering, and repeat wrapping in both axes).
 		</member>
-		<member name="src_image" type="int" setter="set_src_image" getter="get_src_image" default="0">
+		<member name="src_image" type="int" setter="set_src_image" getter="get_src_image" default="-1">
+			The index of the image associated with this texture, see [method GLTFState.get_images]. If -1, then this texture does not have an image assigned.
 		</member>
 	</members>
 </class>

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -35,6 +35,8 @@ void GLTFDocumentExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_import_preflight, "state", "extensions");
 	GDVIRTUAL_BIND(_get_supported_extensions);
 	GDVIRTUAL_BIND(_parse_node_extensions, "state", "gltf_node", "extensions");
+	GDVIRTUAL_BIND(_parse_image_data, "state", "image_data", "mime_type", "ret_image");
+	GDVIRTUAL_BIND(_parse_texture_json, "state", "texture_json", "ret_gltf_texture");
 	GDVIRTUAL_BIND(_generate_scene_node, "state", "gltf_node", "scene_parent");
 	GDVIRTUAL_BIND(_import_post_parse, "state");
 	GDVIRTUAL_BIND(_import_node, "state", "gltf_node", "json", "node");
@@ -65,6 +67,22 @@ Error GLTFDocumentExtension::parse_node_extensions(Ref<GLTFState> p_state, Ref<G
 	ERR_FAIL_NULL_V(p_gltf_node, ERR_INVALID_PARAMETER);
 	Error err = OK;
 	GDVIRTUAL_CALL(_parse_node_extensions, p_state, p_gltf_node, p_extensions, err);
+	return err;
+}
+
+Error GLTFDocumentExtension::parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) {
+	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_NULL_V(r_image, ERR_INVALID_PARAMETER);
+	Error err = OK;
+	GDVIRTUAL_CALL(_parse_image_data, p_state, p_image_data, p_mime_type, r_image, err);
+	return err;
+}
+
+Error GLTFDocumentExtension::parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) {
+	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	ERR_FAIL_NULL_V(r_gltf_texture, ERR_INVALID_PARAMETER);
+	Error err = OK;
+	GDVIRTUAL_CALL(_parse_texture_json, p_state, p_texture_json, r_gltf_texture, err);
 	return err;
 }
 

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -44,6 +44,8 @@ public:
 	virtual Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions);
 	virtual Vector<String> get_supported_extensions();
 	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions);
+	virtual Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image);
+	virtual Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture);
 	virtual Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent);
 	virtual Error import_post_parse(Ref<GLTFState> p_state);
 	virtual Error import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
@@ -58,6 +60,8 @@ public:
 	GDVIRTUAL2R(Error, _import_preflight, Ref<GLTFState>, Vector<String>);
 	GDVIRTUAL0R(Vector<String>, _get_supported_extensions);
 	GDVIRTUAL3R(Error, _parse_node_extensions, Ref<GLTFState>, Ref<GLTFNode>, Dictionary);
+	GDVIRTUAL4R(Error, _parse_image_data, Ref<GLTFState>, PackedByteArray, String, Ref<Image>);
+	GDVIRTUAL3R(Error, _parse_texture_json, Ref<GLTFState>, Dictionary, Ref<GLTFTexture>);
 	GDVIRTUAL3R(Node3D *, _generate_scene_node, Ref<GLTFState>, Ref<GLTFNode>, Node *);
 	GDVIRTUAL1R(Error, _import_post_parse, Ref<GLTFState>);
 	GDVIRTUAL4R(Error, _import_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_texture.h                                                        */
+/*  gltf_document_extension_texture_webp.h                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GLTF_TEXTURE_H
-#define GLTF_TEXTURE_H
+#ifndef GLTF_DOCUMENT_EXTENSION_TEXTURE_WEBP_H
+#define GLTF_DOCUMENT_EXTENSION_TEXTURE_WEBP_H
 
-#include "../gltf_defines.h"
-#include "core/io/resource.h"
+#include "gltf_document_extension.h"
 
-class GLTFTexture : public Resource {
-	GDCLASS(GLTFTexture, Resource);
-
-private:
-	GLTFImageIndex src_image = -1;
-	GLTFTextureSamplerIndex sampler = -1;
-
-protected:
-	static void _bind_methods();
+class GLTFDocumentExtensionTextureWebP : public GLTFDocumentExtension {
+	GDCLASS(GLTFDocumentExtensionTextureWebP, GLTFDocumentExtension);
 
 public:
-	GLTFImageIndex get_src_image() const;
-	void set_src_image(GLTFImageIndex val);
-	GLTFTextureSamplerIndex get_sampler() const;
-	void set_sampler(GLTFTextureSamplerIndex val);
+	// Import process.
+	Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) override;
+	Vector<String> get_supported_extensions() override;
+	Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) override;
+	Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) override;
 };
 
-#endif // GLTF_TEXTURE_H
+#endif // GLTF_DOCUMENT_EXTENSION_TEXTURE_WEBP_H

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -151,6 +151,8 @@ private:
 	Error _serialize_texture_samplers(Ref<GLTFState> p_state);
 	Error _serialize_images(Ref<GLTFState> p_state, const String &p_path);
 	Error _serialize_lights(Ref<GLTFState> p_state);
+	Ref<Image> _parse_image_bytes_into_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_mime_type, int p_index);
+	void _parse_image_save_image(Ref<GLTFState> p_state, const String &p_mime_type, int p_index, Ref<Image> p_image);
 	Error _parse_images(Ref<GLTFState> p_state, const String &p_base_path);
 	Error _parse_textures(Ref<GLTFState> p_state);
 	Error _parse_texture_samplers(Ref<GLTFState> p_state);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -31,6 +31,7 @@
 #include "register_types.h"
 
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
+#include "extensions/gltf_document_extension_texture_webp.h"
 #include "extensions/gltf_spec_gloss.h"
 #include "extensions/physics/gltf_document_extension_physics.h"
 #include "gltf_document.h"
@@ -131,6 +132,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(GLTFTextureSampler);
 		// Register GLTFDocumentExtension classes with GLTFDocument.
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionPhysics);
+		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureWebP);
 		bool is_editor = ::Engine::get_singleton()->is_editor_hint();
 		if (!is_editor) {
 			GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionConvertImporterMesh);

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -40,10 +40,10 @@
 #include <webp/decode.h>
 #include <webp/encode.h>
 
-static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
+static Ref<Image> _webp_mem_loader_func(const uint8_t *p_webp_data, int p_size) {
 	Ref<Image> img;
 	img.instantiate();
-	Error err = WebPCommon::webp_load_image_from_buffer(img.ptr(), p_png, p_size);
+	Error err = WebPCommon::webp_load_image_from_buffer(img.ptr(), p_webp_data, p_size);
 	ERR_FAIL_COND_V(err, Ref<Image>());
 	return img;
 }


### PR DESCRIPTION
This PR improves the GLTF importer by allowing extensions to add support for image and texture formats. This PR also adds support for WebP importing via [`EXT_texture_webp`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_texture_webp) as an example to prove that it works, and since WebP support is already a part of Godot it's pretty simple to say this should be core.

These same extension hooks can be used to implement other formats, so #76572 can be updated after this PR is merged to use this API. This also gives us the option to have KTX be an extension in the asset library instead of core. I don't have an opinion of whether it should be core or not, but regardless this extension system is cleaner.

Two new methods have been added to GLTFDocumentExtension:

* `_parse_image_data`: Passes in the image bytes and MIME type as parameters, which can be used to import an image by setting data of the Image passed into the `r_image` return parameter.
* `_parse_texture_json`: Passes in the texture JSON, which can be used to set the parameters of the GLTF texture.

Some notes and changes to GLTFDocument:

* The default value of the source image index in GLTFTexture was changed from 0 to -1. It was a mistake in the old code to have 0 be the default since 0 is a valid image index, the default should be invalid.
* In the current master, if a MIME type or file extension is not recognized the import will prematurely stop. Now it will continue, trying all available paths before giving up. I have done some testing with several types of files with invalid data to confirm that this does not crash the engine.
* ~~I removed `Vector<Ref<Image>> source_images;` since it was unnecessary. It was not used consistently, and only read in one place, which I have replaced with just reading `Vector<Ref<Texture2D>> images;`~~
* The code in the `_parse_image_bytes_into_image` and `_parse_image_save_image` methods used to be inside of `_parse_images`, but that method was very long and hard to read, so I split it up. This isn't strictly necessary for adding support for more texture formats but it significantly helps with readability.
* These changes only add support for importing multiple formats, not exporting them. In the future if we want to support that we will first need an export dialog (I plan to make a proposal for this... eventually).
* Both on the current master and in this PR, the extract textures option always saves as `.png`, regardless of what was actually contained in the GLTF file (so a GLTF file with a JPEG will save a `.png` when extracting). I asked @fire about this and he does not think it's a problem. Even if we want to change this, it could wait for another PR, I just wanted to make a note here in case people are wondering why a GLTF using WebP is placing `.png` on the file system.

Test project (includes both PNG and WebP, stored as embedded, separate, and base64): [gltf-webp-import-test.zip](https://github.com/godotengine/godot/files/11437552/gltf-webp-import-test.zip)

This work was sponsored by The Mirror.