### PR TITLE
Rename the Debugger's stack debug section

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1732,7 +1732,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 
 	{ //debugger
 		VBoxContainer *vbc = memnew(VBoxContainer);
-		vbc->set_name(TTR("Debugger"));
+		vbc->set_name(TTR("Stack Trace"));
 		Control *dbg = vbc;
 
 		HBoxContainer *hbc = memnew(HBoxContainer);


### PR DESCRIPTION
I was helping someone on Discord and they were confused by "Debugger" -> "Debugger", so this PR renames it to "Stack Debug" since this is the tab used for debugging the stack and it has stack frames and stack vars in it. Before:

![Screenshot from 2023-05-09 23-01-56](https://github.com/godotengine/godot/assets/1646875/65e88e7a-c50d-4210-b1c9-566cf6b53e75)

After:

![Screenshot from 2023-05-09 23-00-24](https://github.com/godotengine/godot/assets/1646875/8c12845e-fdcf-4944-9992-e62fc572d775)

(unrelated: I don't know why the green text takes up more space in the before image, it seems random)