### PR TITLE
CI: Skip codespell check if `CHANGED_FILES` is empty

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -102,9 +102,9 @@ jobs:
           fi
 
       - name: Spell checks via codespell
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.CHANGED_FILES != ''
         uses: codespell-project/actions-codespell@v1
         with:
-          skip: "*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
+          skip: "./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
           ignore_words_list: "curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te,vai"
           path: ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
This can happen when only thirdparty files are changed, since we grep them out. Re-add `bin` and `thirdparty` to the skip list for good measure.

Follow-up to #76828 and #76842.

Tested successfully with https://github.com/akien-mga/godot/pull/14, a change to only `thirdparty/README.md` properly skips the codespell step.