### PR TITLE
mbedTLS: Disable weak crypto and TLS versions.

### DIFF
--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -20,12 +20,13 @@ if is_builtin or not has_module:
 # Only if the module is not enabled, we must compile here the required sources
 # to make a "light" build with only the necessary mbedtls files.
 if not has_module:
-    env_thirdparty = env_crypto.Clone()
-    env_thirdparty.disable_warnings()
-    # Custom config file
-    env_thirdparty.Append(
+    # Minimal mbedTLS config file
+    env_crypto.Append(
         CPPDEFINES=[("MBEDTLS_CONFIG_FILE", '\\"thirdparty/mbedtls/include/godot_core_mbedtls_config.h\\"')]
     )
+    # Build minimal mbedTLS library (MD5/SHA/Base64/AES).
+    env_thirdparty = env_crypto.Clone()
+    env_thirdparty.disable_warnings()
     thirdparty_mbedtls_dir = "#thirdparty/mbedtls/library/"
     thirdparty_mbedtls_sources = [
         "aes.c",
@@ -40,8 +41,16 @@ if not has_module:
     ]
     thirdparty_mbedtls_sources = [thirdparty_mbedtls_dir + file for file in thirdparty_mbedtls_sources]
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_mbedtls_sources)
+    # Needed to force rebuilding the library when the configuration file is updated.
+    env_thirdparty.Depends(thirdparty_obj, "#thirdparty/mbedtls/include/godot_core_mbedtls_config.h")
     env.core_sources += thirdparty_obj
-
+elif is_builtin:
+    # Module mbedTLS config file
+    env_crypto.Append(
+        CPPDEFINES=[("MBEDTLS_CONFIG_FILE", '\\"thirdparty/mbedtls/include/godot_module_mbedtls_config.h\\"')]
+    )
+    # Needed to force rebuilding the core files when the configuration file is updated.
+    thirdparty_obj = ["#thirdparty/mbedtls/include/godot_module_mbedtls_config.h"]
 
 # Godot source files
 

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -100,10 +100,14 @@ if env["builtin_mbedtls"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_mbed_tls.Prepend(CPPPATH=["#thirdparty/mbedtls/include/"])
+    env_mbed_tls.Append(
+        CPPDEFINES=[("MBEDTLS_CONFIG_FILE", '\\"thirdparty/mbedtls/include/godot_module_mbedtls_config.h\\"')]
+    )
 
     env_thirdparty = env_mbed_tls.Clone()
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+    env_thirdparty.Depends(thirdparty_obj, "#thirdparty/mbedtls/include/godot_module_mbedtls_config.h")
     env.modules_sources += thirdparty_obj
 
 

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -29,7 +29,6 @@
 /**************************************************************************/
 
 #include "packet_peer_mbed_dtls.h"
-#include "mbedtls/platform_util.h"
 
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_tls.h"

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -378,6 +378,7 @@ File extracted from upstream release tarball:
   Applied the patch in `patches/windows-arm64-hardclock.diff`
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
+- Added the file `godot_module_mbedtls_config.h` to customize the build configuration when bundling the full library.
 
 
 ## meshoptimizer

--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  godot_core_mbedtls_config.h                                           */
+/*  godot_module_mbedtls_config.h                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,26 +28,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CORE_MBEDTLS_CONFIG_H
-#define GODOT_CORE_MBEDTLS_CONFIG_H
+#ifndef GODOT_MODULE_MBEDTLS_CONFIG_H
+#define GODOT_MODULE_MBEDTLS_CONFIG_H
 
-#include <limits.h>
+#include "platform_config.h"
 
-// For AES
-#define MBEDTLS_CIPHER_MODE_CBC
-#define MBEDTLS_CIPHER_MODE_CFB
-#define MBEDTLS_CIPHER_MODE_CTR
-#define MBEDTLS_CIPHER_MODE_OFB
-#define MBEDTLS_CIPHER_MODE_XTS
+#ifdef GODOT_MBEDTLS_INCLUDE_H
 
-#define MBEDTLS_AES_C
-#define MBEDTLS_BASE64_C
-#define MBEDTLS_CTR_DRBG_C
-#define MBEDTLS_ENTROPY_C
-#define MBEDTLS_MD5_C
-#define MBEDTLS_SHA1_C
-#define MBEDTLS_SHA256_C
-#define MBEDTLS_PLATFORM_ZEROIZE_ALT
-#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+// Allow platforms to customize the mbedTLS configuration.
+#include GODOT_MBEDTLS_INCLUDE_H
 
-#endif // GODOT_CORE_MBEDTLS_CONFIG_H
+#else
+
+// Include default mbedTLS config.
+#include <mbedtls/config.h>
+
+// Disable weak cryptography.
+#undef MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
+#undef MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
+#undef MBEDTLS_SSL_CBC_RECORD_SPLITTING
+#undef MBEDTLS_SSL_PROTO_TLS1
+#undef MBEDTLS_SSL_PROTO_TLS1_1
+#undef MBEDTLS_ARC4_C
+#undef MBEDTLS_DES_C
+#undef MBEDTLS_DHM_C
+
+#endif // GODOT_MBEDTLS_INCLUDE_H
+
+#endif // GODOT_MODULE_MBEDTLS_CONFIG_H


### PR DESCRIPTION
This commit adds a new mbedTLS configuration header to customize the built-in library (and can be optionally replaced by a platform-specific one).

Currently, it disables most weak cryptographic functions (with the notable exceptions of MD5 and SHA-1), along with removing support for TLS versions 1.0 and 1.1 (making TLSv1.2 the only supported one).

Closes #76838 (superseded).