### PR TITLE
Make `EditorPropertyNameProcessor` check `EditorSettings` validity

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -36,6 +36,9 @@
 EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
 
 EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_inspector_style() {
+	if (!EditorSettings::get_singleton()) {
+		return STYLE_CAPITALIZED;
+	}
 	const Style style = (Style)EDITOR_GET("interface/inspector/default_property_name_style").operator int();
 	if (style == STYLE_LOCALIZED && !is_localization_available()) {
 		return STYLE_CAPITALIZED;
@@ -44,6 +47,9 @@ EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_insp
 }
 
 EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_settings_style() {
+	if (!EditorSettings::get_singleton()) {
+		return STYLE_LOCALIZED;
+	}
 	const bool translate = EDITOR_GET("interface/editor/localize_settings");
 	return translate ? STYLE_LOCALIZED : STYLE_CAPITALIZED;
 }
@@ -53,6 +59,9 @@ EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_tooltip_styl
 }
 
 bool EditorPropertyNameProcessor::is_localization_available() {
+	if (!EditorSettings::get_singleton()) {
+		return false;
+	}
 	const Vector<String> forbidden = String("en").split(",");
 	return forbidden.find(EDITOR_GET("interface/editor/editor_language")) == -1;
 }


### PR DESCRIPTION
`EditorSettings` is not guaranteed to be initialized at this point, the above access to editor settings uses a check, added a missing check here as well, was causing non-destructive errors on running the editor

Regression from #74264
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
