### PR TITLE
rvo2: Include cstdint for uint32_t

### DIFF
--- a/thirdparty/rvo2/rvo2_2d/Definitions.h
+++ b/thirdparty/rvo2/rvo2_2d/Definitions.h
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <vector>
 

--- a/thirdparty/rvo2/rvo2_3d/Agent3d.h
+++ b/thirdparty/rvo2/rvo2_3d/Agent3d.h
@@ -38,6 +38,7 @@
 #define RVO3D_AGENT_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Fixes #76907.

Please test @timothyqiu @adamscott, I can't reproduce on Mageia 9 with GCC 12.3.0, I suspect the issue is specific to a change in libstdc++ from GCC 13 that you might both have on Arch Linux.

*Edit:* CI failure seems to be GH glitching again, will need a restart once they fixed their problem.