### PR TITLE
SCons: Enable variable shadowing warning by default with `warnings=all`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -698,7 +698,8 @@ if selected_platform in platform_list:
             if env["warnings"] == "extra":
                 env.Append(CCFLAGS=["/W4"])
             elif env["warnings"] == "all":
-                env.Append(CCFLAGS=["/W3"])
+                # C4458 is like -Wshadow. Part of /W4 but let's apply it for the default /W3 too.
+                env.Append(CCFLAGS=["/W3", "/w4458"])
             elif env["warnings"] == "moderate":
                 env.Append(CCFLAGS=["/W2"])
             # Disable warnings which we don't plan to fix.
@@ -724,10 +725,10 @@ if selected_platform in platform_list:
         if env["werror"]:
             env.Append(CCFLAGS=["/WX"])
     else:  # GCC, Clang
-        common_warnings = []
+        common_warnings = ["-Wshadow"]
 
         if methods.using_gcc(env):
-            common_warnings += ["-Wshadow-local", "-Wno-misleading-indentation"]
+            common_warnings += ["-Wno-misleading-indentation"]
             if cc_version_major == 7:  # Bogus warning fixed in 8+.
                 common_warnings += ["-Wno-strict-overflow"]
             if cc_version_major < 11:

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -10,7 +10,11 @@ if env["platform"] in ["haiku", "macos", "windows", "linuxbsd"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env.Prepend(CPPPATH=[thirdparty_dir])
+    # Treat glad headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
+    else:
+        env.Prepend(CPPPATH=[thirdparty_dir])
 
     env.Append(CPPDEFINES=["GLAD_ENABLED"])
     env.Append(CPPDEFINES=["GLES_OVER_GL"])

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -520,7 +520,11 @@ if env["builtin_icu4c"]:
 module_obj = []
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env_text_server_adv.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
+    else:
+        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_adv.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])


### PR DESCRIPTION
`-Wshadow` for GCC/Clang, C4458 for MSVC.

We already enforced C4458 on CI via `warnings=extra` (`/W4`) in the MSVC build, but for GCC we only warned about `-Wshadow=local`, not global.

This change should make the behavior across compilers more consistent, and avoid frustration with seeing the Windows CI build fail due to shadowing a class member, when it didn't report this while developing on Linux/macOS or on Windows with `warnings=all`.