### PR TITLE
Navigation raycast to point

### DIFF
--- a/doc/classes/NavigationRaycastHit2D.xml
+++ b/doc/classes/NavigationRaycastHit2D.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationRaycastHit2D" inherits="RefCounted" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Metadata container for map get raycast to point.
+	</brief_description>
+	<description>
+		This class contains the metadata from [method NavigationServer2D.map_get_raycast_to_point].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="did_hit" type="bool" setter="set_did_hit" getter="get_did_hit" default="false">
+			Whether the raycast hit anything. This is the same value as returned by [method NavigationServer2D.map_get_raycast_to_point].
+		</member>
+		<member name="hit_normal" type="Vector2" setter="set_hit_normal" getter="get_hit_normal" default="Vector2(0, 0)">
+			The normal to the edge that the raycast hit.
+		</member>
+		<member name="hit_position" type="Vector2" setter="set_hit_position" getter="get_hit_position" default="Vector2(0, 0)">
+			The position at which the raycast hit.
+		</member>
+		<member name="raycast_path" type="PackedVector2Array" setter="set_raycast_path" getter="get_raycast_path" default="PackedVector2Array()">
+			The path followed by the raycast, with points at the start, at each edge crossed, and the end.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationRaycastHit3D.xml
+++ b/doc/classes/NavigationRaycastHit3D.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NavigationRaycastHit3D" inherits="RefCounted" is_experimental="true" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Metadata container for map get raycast to point.
+	</brief_description>
+	<description>
+		This class contains the metadata from [method NavigationServer3D.map_get_raycast_to_point].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="did_hit" type="bool" setter="set_did_hit" getter="get_did_hit" default="false">
+			Whether the raycast hit anything. This is the same value as returned by [method NavigationServer3D.map_get_raycast_to_point].
+		</member>
+		<member name="hit_normal" type="Vector3" setter="set_hit_normal" getter="get_hit_normal" default="Vector3(0, 0, 0)">
+			The normal to the edge that the raycast hit.
+		</member>
+		<member name="hit_position" type="Vector3" setter="set_hit_position" getter="get_hit_position" default="Vector3(0, 0, 0)">
+			The position at which the raycast hit.
+		</member>
+		<member name="raycast_path" type="PackedVector3Array" setter="set_raycast_path" getter="get_raycast_path" default="PackedVector3Array()">
+			The path followed by the raycast, with points at the start, at each edge crossed, and the end.
+		</member>
+	</members>
+</class>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -397,6 +397,17 @@
 				Returns the navigation path to reach the destination from the origin. [param navigation_layers] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
+		<method name="map_get_raycast_to_point" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="origin" type="Vector2" />
+			<param index="2" name="target" type="Vector2" />
+			<param index="3" name="hit_result" type="NavigationRaycastHit2D" />
+			<param index="4" name="navigation_layers" type="int" default="1" />
+			<description>
+				Returns true if a raycast from origin to target collides with an edge in the navigation [param map]. [param hit_result] is a NavigationRaycastHit2D to which will be assigned metadata of the raycast. [param navigation_layers] is a bitmask of all region navigation layers that the raycast may cross.
+			</description>
+		</method>
 		<method name="map_get_regions" qualifiers="const">
 			<return type="RID[]" />
 			<param index="0" name="map" type="RID" />

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -447,6 +447,17 @@
 				Returns the navigation path to reach the destination from the origin. [param navigation_layers] is a bitmask of all region navigation layers that are allowed to be in the path.
 			</description>
 		</method>
+		<method name="map_get_raycast_to_point" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="origin" type="Vector3" />
+			<param index="2" name="target" type="Vector3" />
+			<param index="3" name="hit_result" type="NavigationRaycastHit3D" />
+			<param index="4" name="navigation_layers" type="int" default="1" />
+			<description>
+				Returns true if a raycast from origin to target collides with an edge in the navigation [param map]. Metadata of the raycast will be assigned to [param hit_result]. [param navigation_layers] is a bitmask of all region navigation layers that the raycast may cross.
+			</description>
+		</method>
 		<method name="map_get_regions" qualifiers="const">
 			<return type="RID[]" />
 			<param index="0" name="map" type="RID" />

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -229,6 +229,19 @@ RID GodotNavigationServer::map_get_closest_point_owner(RID p_map, const Vector3 
 	return map->get_closest_point_owner(p_point);
 }
 
+NavigationUtilities::NavigationRaycastHitResult GodotNavigationServer::_raycast_to_point_result(RID p_map, Vector3 p_origin, Vector3 p_target, uint32_t p_navigation_layers) const {
+	const NavMap *map = map_owner.get_or_null(p_map);
+	NavigationUtilities::NavigationRaycastHitResult hit = NavigationUtilities::NavigationRaycastHitResult();
+	ERR_FAIL_COND_V(map == nullptr, hit);
+
+	hit.did_hit = false;
+	hit.hit_position = Vector3();
+	hit.hit_normal = Vector3();
+	hit.raycast_path = Vector<Vector3>();
+	hit.did_hit = map->get_raycast_to_point(p_origin, p_target, p_navigation_layers, &hit.hit_position, &hit.hit_normal, &hit.raycast_path);
+	return hit;
+}
+
 TypedArray<RID> GodotNavigationServer::map_get_links(RID p_map) const {
 	TypedArray<RID> link_rids;
 	const NavMap *map = map_owner.get_or_null(p_map);

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -120,6 +120,8 @@ public:
 	virtual Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const override;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const override;
 
+	virtual NavigationUtilities::NavigationRaycastHitResult _raycast_to_point_result(RID p_map, Vector3 p_origin, Vector3 p_target, uint32_t p_navigation_layers = 1) const override;
+
 	virtual TypedArray<RID> map_get_links(RID p_map) const override;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const override;
 	virtual TypedArray<RID> map_get_agents(RID p_map) const override;

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -149,6 +149,8 @@ public:
 	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
 	RID get_closest_point_owner(const Vector3 &p_point) const;
 
+	bool get_raycast_to_point(Vector3 p_origin, Vector3 p_target, uint32_t p_navigation_layers = 1, Vector3 *r_hit_position = nullptr, Vector3 *r_hit_normal = nullptr, Vector<Vector3> *r_path = nullptr) const;
+
 	void add_region(NavRegion *p_region);
 	void remove_region(NavRegion *p_region);
 	const LocalVector<NavRegion *> &get_regions() const {

--- a/servers/navigation/navigation_raycast_hit_2d.cpp
+++ b/servers/navigation/navigation_raycast_hit_2d.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  navigation_raycast_hit_2d.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "navigation_raycast_hit_2d.h"
+
+void NavigationRaycastHit2D::set_did_hit(const bool &p_did_hit) {
+	did_hit = p_did_hit;
+}
+
+const bool &NavigationRaycastHit2D::get_did_hit() const {
+	return did_hit;
+}
+
+void NavigationRaycastHit2D::set_hit_position(const Vector2 &p_hit_position) {
+	hit_position = p_hit_position;
+}
+
+const Vector2 &NavigationRaycastHit2D::get_hit_position() {
+	return hit_position;
+}
+
+void NavigationRaycastHit2D::set_hit_normal(const Vector2 &p_hit_normal) {
+	hit_normal = p_hit_normal;
+}
+
+const Vector2 &NavigationRaycastHit2D::get_hit_normal() {
+	return hit_normal;
+}
+
+void NavigationRaycastHit2D::set_raycast_path(const Vector<Vector2> &p_raycast_path) {
+	raycast_path = p_raycast_path;
+}
+
+const Vector<Vector2> &NavigationRaycastHit2D::get_raycast_path() {
+	return raycast_path;
+}
+
+void NavigationRaycastHit2D::reset() {
+	did_hit = false;
+	hit_position = Vector2();
+	hit_normal = Vector2();
+	raycast_path.clear();
+}
+
+void NavigationRaycastHit2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_did_hit", "did_hit"), &NavigationRaycastHit2D::set_did_hit);
+	ClassDB::bind_method(D_METHOD("get_did_hit"), &NavigationRaycastHit2D::get_did_hit);
+
+	ClassDB::bind_method(D_METHOD("set_hit_position", "hit_position"), &NavigationRaycastHit2D::set_hit_position);
+	ClassDB::bind_method(D_METHOD("get_hit_position"), &NavigationRaycastHit2D::get_hit_position);
+
+	ClassDB::bind_method(D_METHOD("set_hit_normal", "hit_normal"), &NavigationRaycastHit2D::set_hit_normal);
+	ClassDB::bind_method(D_METHOD("get_hit_normal"), &NavigationRaycastHit2D::get_hit_normal);
+
+	ClassDB::bind_method(D_METHOD("set_raycast_path", "raycast_path"), &NavigationRaycastHit2D::set_raycast_path);
+	ClassDB::bind_method(D_METHOD("get_raycast_path"), &NavigationRaycastHit2D::get_raycast_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "did_hit"), "set_did_hit", "get_did_hit");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "hit_position"), "set_hit_position", "get_hit_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "hit_normal"), "set_hit_normal", "get_hit_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "raycast_path"), "set_raycast_path", "get_raycast_path");
+}

--- a/servers/navigation/navigation_raycast_hit_2d.h
+++ b/servers/navigation/navigation_raycast_hit_2d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  navigation_utilities.h                                                */
+/*  navigation_raycast_hit_2d.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,61 +28,36 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAVIGATION_UTILITIES_H
-#define NAVIGATION_UTILITIES_H
+#ifndef NAVIGATION_RAYCAST_HIT_2D_H
+#define NAVIGATION_RAYCAST_HIT_2D_H
 
-#include "core/math/vector3.h"
-#include "core/variant/typed_array.h"
+#include "core/object/ref_counted.h"
 
-namespace NavigationUtilities {
+class NavigationRaycastHit2D : public RefCounted {
+	GDCLASS(NavigationRaycastHit2D, RefCounted);
 
-enum PathfindingAlgorithm {
-	PATHFINDING_ALGORITHM_ASTAR = 0,
-};
-
-enum PathPostProcessing {
-	PATH_POSTPROCESSING_CORRIDORFUNNEL = 0,
-	PATH_POSTPROCESSING_EDGECENTERED,
-};
-
-enum PathSegmentType {
-	PATH_SEGMENT_TYPE_REGION = 0,
-	PATH_SEGMENT_TYPE_LINK
-};
-
-enum PathMetadataFlags {
-	PATH_INCLUDE_NONE = 0,
-	PATH_INCLUDE_TYPES = 1,
-	PATH_INCLUDE_RIDS = 2,
-	PATH_INCLUDE_OWNERS = 4,
-	PATH_INCLUDE_ALL = PATH_INCLUDE_TYPES | PATH_INCLUDE_RIDS | PATH_INCLUDE_OWNERS
-};
-
-struct PathQueryParameters {
-	PathfindingAlgorithm pathfinding_algorithm = PATHFINDING_ALGORITHM_ASTAR;
-	PathPostProcessing path_postprocessing = PATH_POSTPROCESSING_CORRIDORFUNNEL;
-	RID map;
-	Vector3 start_position;
-	Vector3 target_position;
-	uint32_t navigation_layers = 1;
-	BitField<PathMetadataFlags> metadata_flags = PATH_INCLUDE_ALL;
-};
-
-struct PathQueryResult {
-	PackedVector3Array path;
-	PackedInt32Array path_types;
-	TypedArray<RID> path_rids;
-	PackedInt64Array path_owner_ids;
-};
-
-struct NavigationRaycastHitResult {
 	bool did_hit;
-	Vector3 hit_position;
-	Vector3 hit_normal;
-	PackedVector3Array raycast_path;
-	real_t raycast_path_cost;
+	Vector2 hit_position;
+	Vector2 hit_normal;
+	Vector<Vector2> raycast_path;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_did_hit(const bool &p_did_hit);
+	const bool &get_did_hit() const;
+
+	void set_hit_position(const Vector2 &p_hit_position);
+	const Vector2 &get_hit_position();
+
+	void set_hit_normal(const Vector2 &p_hit_normal);
+	const Vector2 &get_hit_normal();
+
+	void set_raycast_path(const Vector<Vector2> &p_raycast_path);
+	const Vector<Vector2> &get_raycast_path();
+
+	void reset();
 };
 
-} //namespace NavigationUtilities
-
-#endif // NAVIGATION_UTILITIES_H
+#endif // NAVIGATION_RAYCAST_HIT_2D_H

--- a/servers/navigation/navigation_raycast_hit_3d.cpp
+++ b/servers/navigation/navigation_raycast_hit_3d.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  navigation_raycast_hit_3d.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "navigation_raycast_hit_3d.h"
+
+void NavigationRaycastHit3D::set_did_hit(const bool &p_did_hit) {
+	did_hit = p_did_hit;
+}
+
+const bool &NavigationRaycastHit3D::get_did_hit() const {
+	return did_hit;
+}
+
+void NavigationRaycastHit3D::set_hit_position(const Vector3 &p_hit_position) {
+	hit_position = p_hit_position;
+}
+
+const Vector3 &NavigationRaycastHit3D::get_hit_position() {
+	return hit_position;
+}
+
+void NavigationRaycastHit3D::set_hit_normal(const Vector3 &p_hit_normal) {
+	hit_normal = p_hit_normal;
+}
+
+const Vector3 &NavigationRaycastHit3D::get_hit_normal() {
+	return hit_normal;
+}
+
+void NavigationRaycastHit3D::set_raycast_path(const Vector<Vector3> &p_raycast_path) {
+	raycast_path = p_raycast_path;
+}
+
+const Vector<Vector3> &NavigationRaycastHit3D::get_raycast_path() {
+	return raycast_path;
+}
+
+void NavigationRaycastHit3D::reset() {
+	did_hit = false;
+	hit_position = Vector3();
+	hit_normal = Vector3();
+	raycast_path.clear();
+}
+
+void NavigationRaycastHit3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_did_hit", "did_hit"), &NavigationRaycastHit3D::set_did_hit);
+	ClassDB::bind_method(D_METHOD("get_did_hit"), &NavigationRaycastHit3D::get_did_hit);
+
+	ClassDB::bind_method(D_METHOD("set_hit_position", "hit_position"), &NavigationRaycastHit3D::set_hit_position);
+	ClassDB::bind_method(D_METHOD("get_hit_position"), &NavigationRaycastHit3D::get_hit_position);
+
+	ClassDB::bind_method(D_METHOD("set_hit_normal", "hit_normal"), &NavigationRaycastHit3D::set_hit_normal);
+	ClassDB::bind_method(D_METHOD("get_hit_normal"), &NavigationRaycastHit3D::get_hit_normal);
+
+	ClassDB::bind_method(D_METHOD("set_raycast_path", "raycast_path"), &NavigationRaycastHit3D::set_raycast_path);
+	ClassDB::bind_method(D_METHOD("get_raycast_path"), &NavigationRaycastHit3D::get_raycast_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "did_hit"), "set_did_hit", "get_did_hit");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "hit_position"), "set_hit_position", "get_hit_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "hit_normal"), "set_hit_normal", "get_hit_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "raycast_path"), "set_raycast_path", "get_raycast_path");
+}

--- a/servers/navigation/navigation_raycast_hit_3d.h
+++ b/servers/navigation/navigation_raycast_hit_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  navigation_utilities.h                                                */
+/*  navigation_raycast_hit_3d.h                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,61 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAVIGATION_UTILITIES_H
-#define NAVIGATION_UTILITIES_H
+#ifndef NAVIGATION_RAYCAST_HIT_3D_H
+#define NAVIGATION_RAYCAST_HIT_3D_H
 
-#include "core/math/vector3.h"
-#include "core/variant/typed_array.h"
+#include "core/object/ref_counted.h"
 
-namespace NavigationUtilities {
+class NavigationRaycastHit3D : public RefCounted {
+	GDCLASS(NavigationRaycastHit3D, RefCounted);
 
-enum PathfindingAlgorithm {
-	PATHFINDING_ALGORITHM_ASTAR = 0,
-};
-
-enum PathPostProcessing {
-	PATH_POSTPROCESSING_CORRIDORFUNNEL = 0,
-	PATH_POSTPROCESSING_EDGECENTERED,
-};
-
-enum PathSegmentType {
-	PATH_SEGMENT_TYPE_REGION = 0,
-	PATH_SEGMENT_TYPE_LINK
-};
-
-enum PathMetadataFlags {
-	PATH_INCLUDE_NONE = 0,
-	PATH_INCLUDE_TYPES = 1,
-	PATH_INCLUDE_RIDS = 2,
-	PATH_INCLUDE_OWNERS = 4,
-	PATH_INCLUDE_ALL = PATH_INCLUDE_TYPES | PATH_INCLUDE_RIDS | PATH_INCLUDE_OWNERS
-};
-
-struct PathQueryParameters {
-	PathfindingAlgorithm pathfinding_algorithm = PATHFINDING_ALGORITHM_ASTAR;
-	PathPostProcessing path_postprocessing = PATH_POSTPROCESSING_CORRIDORFUNNEL;
-	RID map;
-	Vector3 start_position;
-	Vector3 target_position;
-	uint32_t navigation_layers = 1;
-	BitField<PathMetadataFlags> metadata_flags = PATH_INCLUDE_ALL;
-};
-
-struct PathQueryResult {
-	PackedVector3Array path;
-	PackedInt32Array path_types;
-	TypedArray<RID> path_rids;
-	PackedInt64Array path_owner_ids;
-};
-
-struct NavigationRaycastHitResult {
 	bool did_hit;
 	Vector3 hit_position;
 	Vector3 hit_normal;
-	PackedVector3Array raycast_path;
+	Vector<Vector3> raycast_path;
 	real_t raycast_path_cost;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_did_hit(const bool &p_did_hit);
+	const bool &get_did_hit() const;
+
+	void set_hit_position(const Vector3 &p_hit_position);
+	const Vector3 &get_hit_position();
+
+	void set_hit_normal(const Vector3 &p_hit_normal);
+	const Vector3 &get_hit_normal();
+
+	void set_raycast_path(const Vector<Vector3> &p_raycast_path);
+	const Vector<Vector3> &get_raycast_path();
+
+	void reset();
 };
 
-} //namespace NavigationUtilities
-
-#endif // NAVIGATION_UTILITIES_H
+#endif // NAVIGATION_RAYCAST_HIT_3D_H

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -379,6 +379,8 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_closest_point", "map", "to_point"), &NavigationServer2D::map_get_closest_point);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_owner", "map", "to_point"), &NavigationServer2D::map_get_closest_point_owner);
 
+	ClassDB::bind_method(D_METHOD("map_get_raycast_to_point", "map", "origin", "target", "hit_result", "navigation_layers"), &NavigationServer2D::map_get_raycast_to_point, DEFVAL(1));
+
 	ClassDB::bind_method(D_METHOD("map_get_links", "map"), &NavigationServer2D::map_get_links);
 	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer2D::map_get_regions);
 	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer2D::map_get_agents);
@@ -611,4 +613,16 @@ void NavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &
 	p_query_result->set_path_types(_query_result.path_types);
 	p_query_result->set_path_rids(_query_result.path_rids);
 	p_query_result->set_path_owner_ids(_query_result.path_owner_ids);
+}
+
+bool NavigationServer2D::map_get_raycast_to_point(RID p_map, Vector2 p_origin, Vector2 p_target, Ref<NavigationRaycastHit2D> p_hit, uint32_t p_navigation_layers) const {
+	ERR_FAIL_COND_V(!p_hit.is_valid(), false);
+	NavigationUtilities::NavigationRaycastHitResult hit = NavigationServer3D::get_singleton()->_raycast_to_point_result(p_map, v2_to_v3(p_origin), v2_to_v3(p_target), p_navigation_layers);
+
+	p_hit->set_did_hit(hit.did_hit);
+	p_hit->set_hit_position(v3_to_v2(hit.hit_position));
+	p_hit->set_hit_normal(v3_to_v2(hit.hit_normal));
+	p_hit->set_raycast_path(vector_v3_to_v2(hit.raycast_path));
+
+	return hit.did_hit;
 }

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -37,6 +37,7 @@
 #include "scene/resources/navigation_polygon.h"
 #include "servers/navigation/navigation_path_query_parameters_2d.h"
 #include "servers/navigation/navigation_path_query_result_2d.h"
+#include "servers/navigation/navigation_raycast_hit_2d.h"
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class NavigationServer2D : public Object {
@@ -242,6 +243,8 @@ public:
 
 	/// Returns a customized navigation path using a query parameters object
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result) const;
+
+	virtual bool map_get_raycast_to_point(RID p_map, Vector2 p_origin, Vector2 p_target, Ref<NavigationRaycastHit2D> p_hit, uint32_t p_navigation_layers = 1) const;
 
 	/// Destroy the `RID`
 	virtual void free(RID p_object);

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -53,6 +53,8 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_normal", "map", "to_point"), &NavigationServer3D::map_get_closest_point_normal);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_owner", "map", "to_point"), &NavigationServer3D::map_get_closest_point_owner);
 
+	ClassDB::bind_method(D_METHOD("map_get_raycast_to_point", "map", "origin", "target", "hit_result", "navigation_layers"), &NavigationServer3D::map_get_raycast_to_point, DEFVAL(1));
+
 	ClassDB::bind_method(D_METHOD("map_get_links", "map"), &NavigationServer3D::map_get_links);
 	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer3D::map_get_regions);
 	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer3D::map_get_agents);
@@ -851,6 +853,18 @@ void NavigationServer3D::query_path(const Ref<NavigationPathQueryParameters3D> &
 	p_query_result->set_path_types(_query_result.path_types);
 	p_query_result->set_path_rids(_query_result.path_rids);
 	p_query_result->set_path_owner_ids(_query_result.path_owner_ids);
+}
+
+bool NavigationServer3D::map_get_raycast_to_point(RID p_map, Vector3 p_origin, Vector3 p_target, Ref<NavigationRaycastHit3D> p_hit, uint32_t p_navigation_layers) const {
+	ERR_FAIL_COND_V(!p_hit.is_valid(), false);
+	NavigationUtilities::NavigationRaycastHitResult hit = _raycast_to_point_result(p_map, p_origin, p_target, p_navigation_layers);
+
+	p_hit->set_did_hit(hit.did_hit);
+	p_hit->set_hit_position(hit.hit_position);
+	p_hit->set_hit_normal(hit.hit_normal);
+	p_hit->set_raycast_path(hit.raycast_path);
+
+	return hit.did_hit;
 }
 
 ///////////////////////////////////////////////////////

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -37,6 +37,7 @@
 #include "scene/3d/navigation_region_3d.h"
 #include "servers/navigation/navigation_path_query_parameters_3d.h"
 #include "servers/navigation/navigation_path_query_result_3d.h"
+#include "servers/navigation/navigation_raycast_hit_3d.h"
 
 /// This server uses the concept of internal mutability.
 /// All the constant functions can be called in multithread because internally
@@ -99,6 +100,10 @@ public:
 	virtual Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const = 0;
 	virtual Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const = 0;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const = 0;
+
+	// Returns whether a raycast hits, outputs data to hit result object
+	virtual bool map_get_raycast_to_point(RID p_map, Vector3 p_origin, Vector3 p_target, Ref<NavigationRaycastHit3D> p_hit, uint32_t p_navigation_layers = 1) const;
+	virtual NavigationUtilities::NavigationRaycastHitResult _raycast_to_point_result(RID p_map, Vector3 p_origin, Vector3 p_target, uint32_t p_navigation_layers) const = 0;
 
 	virtual TypedArray<RID> map_get_links(RID p_map) const = 0;
 	virtual TypedArray<RID> map_get_regions(RID p_map) const = 0;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -54,6 +54,8 @@ public:
 	Vector3 map_get_closest_point(RID p_map, const Vector3 &p_point) const override { return Vector3(); }
 	Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const override { return Vector3(); }
 	RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const override { return RID(); }
+	bool map_get_raycast_to_point(RID p_map, Vector3 p_origin, Vector3 p_target, Ref<NavigationRaycastHit3D> p_hit_result, uint32_t p_navigation_layers) const override { return false; }
+	NavigationUtilities::NavigationRaycastHitResult _raycast_to_point_result(RID p_map, Vector3 p_origin, Vector3 p_target, uint32_t p_navigation_layers) const override { return NavigationUtilities::NavigationRaycastHitResult(); }
 	TypedArray<RID> map_get_links(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_regions(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -167,6 +167,8 @@ void register_server_types() {
 	GDREGISTER_CLASS(NavigationPathQueryParameters3D);
 	GDREGISTER_CLASS(NavigationPathQueryResult2D);
 	GDREGISTER_CLASS(NavigationPathQueryResult3D);
+	GDREGISTER_CLASS(NavigationRaycastHit2D);
+	GDREGISTER_CLASS(NavigationRaycastHit3D);
 
 	GDREGISTER_CLASS(XRServer);
 	GDREGISTER_CLASS(CameraServer);


### PR DESCRIPTION
### Adds raycast on map functionality to navigation server

A raycast on the navmap is helpful for checking Line-of-Sight, finding distances to boundaries - and is supported in both Unity and Unreal, in a similar implementation.

The initial problem I faced which required this was placing rigid formations on the navmap. Useful also for line-of-sight, and potentially some edge-case agent behaviours.
Responds to request for a ray test here:
https://github.com/godotengine/godot-proposals/issues/5066

Usage:
![image](https://github.com/godotengine/godot/assets/65900711/f31beabd-8d14-477a-807c-785ff1fd025d)

