### PR TITLE
Expose getters/setters for debug collision and path colors

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -91,6 +91,30 @@
 				Creates and returns a new [Tween]. The Tween will start automatically on the next process frame or physics frame (depending on [enum Tween.TweenProcessMode]).
 			</description>
 		</method>
+		<method name="get_debug_collision_contact_color" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Gets the color used to draw collision contacts when using "Visible Collision Shapes".
+			</description>
+		</method>
+		<method name="get_debug_collisions_color" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Gets the color used to draw collision shapes when using "Visible Collision Shapes".
+			</description>
+		</method>
+		<method name="get_debug_paths_color" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Gets the color used to draw paths when using "Visible Paths".
+			</description>
+		</method>
+		<method name="get_debug_paths_width" qualifiers="const">
+			<return type="float" />
+			<description>
+				Gets the line width used to draw paths when using "Visible Paths".
+			</description>
+		</method>
 		<method name="get_first_node_in_group">
 			<return type="Node" />
 			<param index="0" name="group" type="StringName" />
@@ -178,6 +202,34 @@
 			<description>
 				Reloads the currently active scene.
 				Returns [constant OK] on success, [constant ERR_UNCONFIGURED] if no [member current_scene] was defined yet, [constant ERR_CANT_OPEN] if [member current_scene] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if the scene cannot be instantiated.
+			</description>
+		</method>
+		<method name="set_debug_collision_contact_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the color used to draw collision contacts when using "Visible Collision Shapes".
+			</description>
+		</method>
+		<method name="set_debug_collisions_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the color used to draw collision shapes when using "Visible Collision Shapes".
+			</description>
+		</method>
+		<method name="set_debug_paths_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the color used to draw paths when using "Visible Paths".
+			</description>
+		</method>
+		<method name="set_debug_paths_width">
+			<return type="void" />
+			<param index="0" name="width" type="float" />
+			<description>
+				Sets the line width used to draw paths when using "Visible Paths".
 			</description>
 		</method>
 		<method name="set_group">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1255,6 +1255,15 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_debug_navigation_hint", "enable"), &SceneTree::set_debug_navigation_hint);
 	ClassDB::bind_method(D_METHOD("is_debugging_navigation_hint"), &SceneTree::is_debugging_navigation_hint);
 
+	ClassDB::bind_method(D_METHOD("set_debug_collisions_color", "color"), &SceneTree::set_debug_collisions_color);
+	ClassDB::bind_method(D_METHOD("get_debug_collisions_color"), &SceneTree::get_debug_collisions_color);
+	ClassDB::bind_method(D_METHOD("set_debug_collision_contact_color", "color"), &SceneTree::set_debug_collision_contact_color);
+	ClassDB::bind_method(D_METHOD("get_debug_collision_contact_color"), &SceneTree::get_debug_collision_contact_color);
+	ClassDB::bind_method(D_METHOD("set_debug_paths_color", "color"), &SceneTree::set_debug_paths_color);
+	ClassDB::bind_method(D_METHOD("get_debug_paths_color"), &SceneTree::get_debug_paths_color);
+	ClassDB::bind_method(D_METHOD("set_debug_paths_width", "width"), &SceneTree::set_debug_paths_width);
+	ClassDB::bind_method(D_METHOD("get_debug_paths_width"), &SceneTree::get_debug_paths_width);
+
 	ClassDB::bind_method(D_METHOD("set_edited_scene_root", "scene"), &SceneTree::set_edited_scene_root);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &SceneTree::get_edited_scene_root);
 


### PR DESCRIPTION
For SG Physics 2D (an Open Source deterministic 2D physics engine), I need to be able to access `SceneTree::get_debug_collisions_color()` from GDExtension. Basically, it needs to be able to draw its debug collision shapes in the same way as Godot is drawing the built-in debug collision shapes.

However, while I was in there, I also exposed a bunch of related getters and setters, because it felt weird to expose just the one but not the others:

- `SceneTree::set_debug_collisions_color()`
- `SceneTree::set_debug_collision_contact_color()`
- `SceneTree::get_debug_collision_contact_color()`
- `SceneTree::set_debug_paths_color()`
- `SceneTree::get_debug_paths_color()`
- `SceneTree::set_debug_paths_width()`
- `SceneTree::get_debug_paths_width()`

I don't need any of those, but I could imagine similar scenarios where they'd be useful!