### PR TITLE
Add `OS.get_physical_processor_count()` method

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -546,6 +546,10 @@ int OS::get_processor_count() const {
 	return ::OS::get_singleton()->get_processor_count();
 }
 
+int OS::get_physical_processor_count() const {
+	return ::OS::get_singleton()->get_physical_processor_count();
+}
+
 String OS::get_processor_name() const {
 	return ::OS::get_singleton()->get_processor_name();
 }
@@ -643,6 +647,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_delta_smoothing_enabled"), &OS::is_delta_smoothing_enabled);
 
 	ClassDB::bind_method(D_METHOD("get_processor_count"), &OS::get_processor_count);
+	ClassDB::bind_method(D_METHOD("get_physical_processor_count"), &OS::get_physical_processor_count);
 	ClassDB::bind_method(D_METHOD("get_processor_name"), &OS::get_processor_name);
 
 	ClassDB::bind_method(D_METHOD("get_system_fonts"), &OS::get_system_fonts);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -242,6 +242,7 @@ public:
 	bool is_stdout_verbose() const;
 
 	int get_processor_count() const;
+	int get_physical_processor_count() const;
 	String get_processor_name() const;
 
 	enum SystemDir {

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -373,6 +373,10 @@ int OS::get_processor_count() const {
 	return THREADING_NAMESPACE::thread::hardware_concurrency();
 }
 
+int OS::get_physical_processor_count() const {
+	return get_processor_count();
+}
+
 String OS::get_processor_name() const {
 	return "";
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -315,6 +315,7 @@ public:
 	virtual void set_exit_code(int p_code);
 
 	virtual int get_processor_count() const;
+	virtual int get_physical_processor_count() const;
 	virtual String get_processor_name() const;
 	virtual int get_default_thread_pool_size() const { return get_processor_count(); }
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -418,6 +418,14 @@
 				[b]Note:[/b] On Web platforms, it is still possible to determine the host platform's OS with feature tags. See [method has_feature].
 			</description>
 		</method>
+		<method name="get_physical_processor_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of [i]physical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be lower than the number of [i]logical[/i] CPU cores. In some situations, this can be used to set the level of parallelism for multithreaded algorithms that don't scale well to logical CPU cores. However, in most cases, [method get_processor_count] is more suited to determine parallelism.
+				[b]Note:[/b] On systems with big.LITTLE topologies (i.e. with "performance" and "efficiency" cores), all core types are taken into account.
+				[b]Note:[/b] This method is only implemented on Windows, macOS and Linux. On Android, iOS and Web, [method get_physical_processor_count] returns the same value as [method get_processor_count].
+			</description>
+		</method>
 		<method name="get_process_exit_code" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="pid" type="int" />
@@ -438,7 +446,8 @@
 		<method name="get_processor_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be greater than the number of [i]physical[/i] CPU cores.
+				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be greater than the number of [i]physical[/i] CPU cores. In most cases, [method get_processor_count] should be used instead of [method get_physical_processor_count] to determine parallelism to use for multithreaded algorithms. See also [method get_physical_processor_count].
+				[b]Note:[/b] On systems with big.LITTLE topologies (i.e. with "performance" and "efficiency" cores), all core types are taken into account.
 			</description>
 		</method>
 		<method name="get_processor_name" qualifiers="const">

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -121,6 +121,7 @@ public:
 	virtual Error shell_open(const String &p_uri) override;
 
 	virtual String get_unique_id() const override;
+	virtual int get_physical_processor_count() const override;
 	virtual String get_processor_name() const override;
 
 	virtual bool is_sandboxed() const override;

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -112,6 +112,7 @@ public:
 	virtual bool is_process_running(const ProcessID &p_pid) const override;
 
 	virtual String get_unique_id() const override;
+	virtual int get_physical_processor_count() const override;
 	virtual String get_processor_name() const override;
 
 	virtual String get_model_name() const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -76,6 +76,14 @@ String OS_MacOS::get_model_name() const {
 	return OS_Unix::get_model_name();
 }
 
+int OS_MacOS::get_physical_processor_count() const {
+	uint32_t num_cores = 0;
+	size_t num_cores_len = sizeof(num_cores);
+	sysctlbyname("hw.physicalcpu", &num_cores, &num_cores_len, 0, 0);
+
+	return num_cores;
+}
+
 String OS_MacOS::get_processor_name() const {
 	char buffer[256];
 	size_t buffer_len = 256;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1970,6 +1970,29 @@ String OS_Windows::get_model_name() const {
 	return OS::get_model_name();
 }
 
+int OS_Windows::get_physical_processor_count() const {
+	DWORD length = 0;
+	GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &length);
+	ERR_FAIL_COND_V_MSG(GetLastError() != ERROR_INSUFFICIENT_BUFFER, get_processor_count(), "Couldn't get the physical processor count. Returning the logical processor count.");
+
+	std::unique_ptr<uint8_t[]> buffer(new uint8_t[length]);
+	const PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info =
+			reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.get());
+
+	const BOOL result_second = GetLogicalProcessorInformationEx(RelationProcessorCore, info, &length);
+	ERR_FAIL_COND_V_MSG(result_second == FALSE, get_processor_count(), "Couldn't get the physical processor count. Returning the logical processor count.");
+
+	size_t nb_physical_cores = 0;
+	size_t offset = 0;
+	do {
+		const PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX current_info = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(buffer.get() + offset);
+		offset += current_info->Size;
+		nb_physical_cores += 1;
+	} while (offset < length);
+
+	return nb_physical_cores;
+}
+
 String OS_Windows::get_processor_name() const {
 	const String id = "Hardware\\Description\\System\\CentralProcessor\\0";
 
@@ -1989,7 +2012,6 @@ String OS_Windows::get_processor_name() const {
 		ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
 	}
 }
-
 void OS_Windows::run() {
 	if (!main_loop) {
 		return;

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -214,6 +214,7 @@ public:
 
 	virtual String get_locale() const override;
 
+	virtual int get_physical_processor_count() const override;
 	virtual String get_processor_name() const override;
 
 	virtual String get_model_name() const override;


### PR DESCRIPTION
This returns the number of physical CPU cores on the system, as opposed to `OS.get_processor_count()` which returns the number of logical CPU cores on the system.

Use cases:

- Configure parallelism for algorithms that don't scale well to logical CPU cores. In most cases, using the number of logical cores as a basis is recommended, but there are select cases where using a lower core count that matches the physical core count is more suited.
- Troubleshoot performance issues, as you can now detect whether a user has HyperThreading enabled or not (by checking whether `OS.get_physical_processor_count()` and `OS.get_processor_count()` are different).

**Testing project:** [test_physical_cpu_count.zip](https://github.com/godotengine/godot/files/11478809/test_physical_cpu_count.zip)

- This partially addresses https://github.com/godotengine/godot-proposals/issues/6821.

## TODO

- [x] Fix Windows implementation.
- [x] Test macOS implementation. I tested this on a M1 Mac mini and it returns `8` which sounds expected.
