### PR TITLE
Fix multiple issues in `WorkerThreadPool`

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -107,7 +107,7 @@ private:
 	};
 
 	TightLocalVector<ThreadData> threads;
-	SafeFlag exit_threads;
+	bool exit_threads = false;
 
 	HashMap<Thread::ID, int> thread_ids;
 	HashMap<TaskID, Task *> tasks;
@@ -115,7 +115,7 @@ private:
 
 	bool use_native_low_priority_threads = false;
 	uint32_t max_low_priority_threads = 0;
-	SafeNumeric<uint32_t> low_priority_threads_used;
+	uint32_t low_priority_threads_used = 0;
 
 	uint64_t last_task = 1;
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -302,15 +302,9 @@ void register_core_settings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "network/limits/packet_peer_stream/max_buffer_po2", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), (16));
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "network/tls/certificate_bundle_override", PROPERTY_HINT_FILE, "*.crt"), "");
 
-	int worker_threads = GLOBAL_DEF("threading/worker_pool/max_threads", -1);
-	bool low_priority_use_system_threads = GLOBAL_DEF("threading/worker_pool/use_system_threads_for_low_priority_tasks", true);
-	float low_property_ratio = GLOBAL_DEF("threading/worker_pool/low_priority_thread_ratio", 0.3);
-
-	if (Engine::get_singleton()->is_editor_hint() || Engine::get_singleton()->is_project_manager_hint()) {
-		worker_thread_pool->init();
-	} else {
-		worker_thread_pool->init(worker_threads, low_priority_use_system_threads, low_property_ratio);
-	}
+	GLOBAL_DEF("threading/worker_pool/max_threads", -1);
+	GLOBAL_DEF("threading/worker_pool/use_system_threads_for_low_priority_tasks", true);
+	GLOBAL_DEF("threading/worker_pool/low_priority_thread_ratio", 0.3);
 }
 
 void register_core_singletons() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1454,6 +1454,19 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif
 	}
 
+	// Initialize WorkerThreadPool.
+	{
+		int worker_threads = GLOBAL_GET("threading/worker_pool/max_threads");
+		bool low_priority_use_system_threads = GLOBAL_GET("threading/worker_pool/use_system_threads_for_low_priority_tasks");
+		float low_property_ratio = GLOBAL_GET("threading/worker_pool/low_priority_thread_ratio");
+
+		if (editor || project_manager) {
+			WorkerThreadPool::get_singleton()->init();
+		} else {
+			WorkerThreadPool::get_singleton()->init(worker_threads, low_priority_use_system_threads, low_property_ratio);
+		}
+	}
+
 	// Initialize user data dir.
 	OS::get_singleton()->ensure_user_data_dir();
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -135,6 +135,8 @@ int test_main(int argc, char *argv[]) {
 	OS::get_singleton()->set_cmdline("", args, List<String>());
 	DisplayServerMock::register_mock_driver();
 
+	WorkerThreadPool::get_singleton()->init();
+
 	// Run custom test tools.
 	if (test_commands) {
 		for (const KeyValue<String, TestFunc> &E : (*test_commands)) {


### PR DESCRIPTION
- Fix project settings being ignored.
- Made usages of `native_thread_allocator` thread-safe.
- Remove redundant thread-safety from `low_priority_threads_used`, `exit_threads`.
- Fix deadlock due to unintended extra lock of `task_mutex`.

**NOTE:** I have a concern that by cherry-picking this into 4.0 the users that tweaked `threading/worker_pool/*` settings will now get a behavior change. It's the correct thing to happen, but maybe too surprising for 4.0, or at least warrants a note in the release notes.

**UPDATE:** For the records, this may also fix some hard to reproduce crash related to a thread object in one of the projects used to test #74405, that worked fine otherwise.