### PR TITLE
Enable shadow warnings and fix raised errors

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -698,7 +698,8 @@ if selected_platform in platform_list:
             if env["warnings"] == "extra":
                 env.Append(CCFLAGS=["/W4"])
             elif env["warnings"] == "all":
-                env.Append(CCFLAGS=["/W3"])
+                # C4458 is like -Wshadow. Part of /W4 but let's apply it for the default /W3 too.
+                env.Append(CCFLAGS=["/W3", "/w4458"])
             elif env["warnings"] == "moderate":
                 env.Append(CCFLAGS=["/W2"])
             # Disable warnings which we don't plan to fix.
@@ -727,7 +728,7 @@ if selected_platform in platform_list:
         common_warnings = []
 
         if methods.using_gcc(env):
-            common_warnings += ["-Wshadow-local", "-Wno-misleading-indentation"]
+            common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]
             if cc_version_major == 7:  # Bogus warning fixed in 8+.
                 common_warnings += ["-Wno-strict-overflow"]
             if cc_version_major < 11:
@@ -737,6 +738,7 @@ if selected_platform in platform_list:
             if cc_version_major >= 12:  # False positives in our error macros, see GH-58747.
                 common_warnings += ["-Wno-return-type"]
         elif methods.using_clang(env) or methods.using_emcc(env):
+            common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
             # We often implement `operator<` for structs of pointers as a requirement
             # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
             common_warnings += ["-Wno-ordered-compare-function-pointers"]

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -596,9 +596,9 @@ private:
 		}
 	};
 
-	enum Orientation { NONE,
-		CLOCKWISE,
-		COUNTER_CLOCKWISE };
+	enum Orientation { ORIENTATION_NONE,
+		ORIENTATION_CLOCKWISE,
+		ORIENTATION_COUNTER_CLOCKWISE };
 
 	Vector3 scaling;
 	Vector3 center;
@@ -1140,13 +1140,13 @@ ConvexHullInternal::Orientation ConvexHullInternal::get_orientation(const Edge *
 			CHULL_ASSERT(!m.is_zero());
 			int64_t dot = n.dot(m);
 			CHULL_ASSERT(dot != 0);
-			return (dot > 0) ? COUNTER_CLOCKWISE : CLOCKWISE;
+			return (dot > 0) ? ORIENTATION_COUNTER_CLOCKWISE : ORIENTATION_CLOCKWISE;
 		}
-		return COUNTER_CLOCKWISE;
+		return ORIENTATION_COUNTER_CLOCKWISE;
 	} else if (p_prev->prev == p_next) {
-		return CLOCKWISE;
+		return ORIENTATION_CLOCKWISE;
 	} else {
-		return NONE;
+		return ORIENTATION_NONE;
 	}
 }
 
@@ -1176,7 +1176,7 @@ ConvexHullInternal::Edge *ConvexHullInternal::find_max_angle(bool p_ccw, const V
 					} else if ((cmp = cot.compare(p_min_cot)) < 0) {
 						p_min_cot = cot;
 						min_edge = e;
-					} else if ((cmp == 0) && (p_ccw == (get_orientation(min_edge, e, p_s, t) == COUNTER_CLOCKWISE))) {
+					} else if ((cmp == 0) && (p_ccw == (get_orientation(min_edge, e, p_s, t) == ORIENTATION_COUNTER_CLOCKWISE))) {
 						min_edge = e;
 					}
 				}
@@ -1375,7 +1375,7 @@ void ConvexHullInternal::merge(IntermediateHull &p_h0, IntermediateHull &p_h1) {
 				int64_t dot = (*e->target - *c0).dot(normal);
 				CHULL_ASSERT(dot <= 0);
 				if ((dot == 0) && ((*e->target - *c0).dot(t) > 0)) {
-					if (!start0 || (get_orientation(start0, e, s, Point32(0, 0, -1)) == CLOCKWISE)) {
+					if (!start0 || (get_orientation(start0, e, s, Point32(0, 0, -1)) == ORIENTATION_CLOCKWISE)) {
 						start0 = e;
 					}
 				}
@@ -1390,7 +1390,7 @@ void ConvexHullInternal::merge(IntermediateHull &p_h0, IntermediateHull &p_h1) {
 				int64_t dot = (*e->target - *c1).dot(normal);
 				CHULL_ASSERT(dot <= 0);
 				if ((dot == 0) && ((*e->target - *c1).dot(t) > 0)) {
-					if (!start1 || (get_orientation(start1, e, s, Point32(0, 0, -1)) == COUNTER_CLOCKWISE)) {
+					if (!start1 || (get_orientation(start1, e, s, Point32(0, 0, -1)) == ORIENTATION_COUNTER_CLOCKWISE)) {
 						start1 = e;
 					}
 				}

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -59,15 +59,15 @@ public:
 
 		/*! Constructs a ray from origin, direction, and ray segment. Near
 		 *  has to be smaller than far. */
-		_FORCE_INLINE_ Ray(const Vector3 &org,
-				const Vector3 &dir,
-				float tnear = 0.0f,
-				float tfar = INFINITY) :
-				org(org),
-				tnear(tnear),
-				dir(dir),
+		_FORCE_INLINE_ Ray(const Vector3 &p_org,
+				const Vector3 &p_dir,
+				float p_tnear = 0.0f,
+				float p_tfar = INFINITY) :
+				org(p_org),
+				tnear(p_tnear),
+				dir(p_dir),
 				time(0.0f),
-				tfar(tfar),
+				tfar(p_tfar),
 				mask(-1),
 				u(0.0),
 				v(0.0),

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -382,10 +382,10 @@ String Time::get_time_string_from_system(bool p_utc) const {
 
 Dictionary Time::get_time_zone_from_system() const {
 	OS::TimeZoneInfo info = OS::get_singleton()->get_time_zone_info();
-	Dictionary timezone;
-	timezone["bias"] = info.bias;
-	timezone["name"] = info.name;
-	return timezone;
+	Dictionary ret_timezone;
+	ret_timezone["bias"] = info.bias;
+	ret_timezone["name"] = info.name;
+	return ret_timezone;
 }
 
 double Time::get_unix_time_from_system() const {

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -10,7 +10,11 @@ if env["platform"] in ["haiku", "macos", "windows", "linuxbsd"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env.Prepend(CPPPATH=[thirdparty_dir])
+    # Treat glad headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
+    else:
+        env.Prepend(CPPPATH=[thirdparty_dir])
 
     env.Append(CPPDEFINES=["GLAD_ENABLED"])
     env.Append(CPPDEFINES=["GLES_OVER_GL"])

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -222,8 +222,8 @@ Error AudioDriverPulseAudio::init_output_device() {
 			break;
 	}
 
-	int latency = GLOBAL_GET("audio/driver/output_latency");
-	buffer_frames = closest_power_of_2(latency * mix_rate / 1000);
+	int tmp_latency = GLOBAL_GET("audio/driver/output_latency");
+	buffer_frames = closest_power_of_2(tmp_latency * mix_rate / 1000);
 	pa_buffer_size = buffer_frames * pa_map.channels;
 
 	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " output channels");

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -301,11 +301,11 @@ bool FileAccessUnix::file_exists(const String &p_path) {
 
 uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	String file = fix_path(p_file);
-	struct stat flags = {};
-	int err = stat(file.utf8().get_data(), &flags);
+	struct stat status = {};
+	int err = stat(file.utf8().get_data(), &status);
 
 	if (!err) {
-		return flags.st_mtime;
+		return status.st_mtime;
 	} else {
 		print_verbose("Failed to get modified time for: " + p_file + "");
 		return 0;
@@ -314,11 +314,11 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 
 uint32_t FileAccessUnix::_get_unix_permissions(const String &p_file) {
 	String file = fix_path(p_file);
-	struct stat flags = {};
-	int err = stat(file.utf8().get_data(), &flags);
+	struct stat status = {};
+	int err = stat(file.utf8().get_data(), &status);
 
 	if (!err) {
-		return flags.st_mode & 0x7FF; //only permissions
+		return status.st_mode & 0x7FF; //only permissions
 	} else {
 		ERR_FAIL_V_MSG(0, "Failed to get unix permissions for: " + p_file + ".");
 	}

--- a/editor/import/collada.h
+++ b/editor/import/collada.h
@@ -69,7 +69,7 @@ public:
 		bool double_sided = true;
 		bool unshaded = false;
 
-		String get_texture_path(const String &p_source, Collada &state) const;
+		String get_texture_path(const String &p_source, Collada &p_state) const;
 
 		Effect() {
 			diffuse.color = Color(1, 1, 1, 1);
@@ -266,7 +266,7 @@ public:
 			}
 		}
 
-		void fix_unit_scale(const Collada &state);
+		void fix_unit_scale(const Collada &p_state);
 
 		bool operator<(const Vertex &p_vert) const {
 			if (uid == p_vert.uid) {
@@ -348,7 +348,7 @@ public:
 
 		Node *parent = nullptr;
 
-		Transform3D compute_transform(const Collada &state) const;
+		Transform3D compute_transform(const Collada &p_state) const;
 		Transform3D get_global_transform() const;
 		Transform3D get_transform() const;
 
@@ -526,39 +526,39 @@ public:
 private: // private stuff
 	HashMap<String, int> channel_map;
 
-	void _parse_asset(XMLParser &parser);
-	void _parse_image(XMLParser &parser);
-	void _parse_material(XMLParser &parser);
-	void _parse_effect_material(XMLParser &parser, Effect &effect, String &id);
-	void _parse_effect(XMLParser &parser);
-	void _parse_camera(XMLParser &parser);
-	void _parse_light(XMLParser &parser);
-	void _parse_animation_clip(XMLParser &parser);
+	void _parse_asset(XMLParser &p_parser);
+	void _parse_image(XMLParser &p_parser);
+	void _parse_material(XMLParser &p_parser);
+	void _parse_effect_material(XMLParser &p_parser, Effect &p_effect, String &p_id);
+	void _parse_effect(XMLParser &p_parser);
+	void _parse_camera(XMLParser &p_parser);
+	void _parse_light(XMLParser &p_parser);
+	void _parse_animation_clip(XMLParser &p_parser);
 
-	void _parse_mesh_geometry(XMLParser &parser, String p_id, String p_name);
-	void _parse_curve_geometry(XMLParser &parser, String p_id, String p_name);
+	void _parse_mesh_geometry(XMLParser &p_parser, String p_id, String p_name);
+	void _parse_curve_geometry(XMLParser &p_parser, String p_id, String p_name);
 
-	void _parse_skin_controller(XMLParser &parser, String p_id);
-	void _parse_morph_controller(XMLParser &parser, String p_id);
-	void _parse_controller(XMLParser &parser);
+	void _parse_skin_controller(XMLParser &p_parser, String p_id);
+	void _parse_morph_controller(XMLParser &p_parser, String p_id);
+	void _parse_controller(XMLParser &p_parser);
 
-	Node *_parse_visual_instance_geometry(XMLParser &parser);
-	Node *_parse_visual_instance_camera(XMLParser &parser);
-	Node *_parse_visual_instance_light(XMLParser &parser);
+	Node *_parse_visual_instance_geometry(XMLParser &p_parser);
+	Node *_parse_visual_instance_camera(XMLParser &p_parser);
+	Node *_parse_visual_instance_light(XMLParser &p_parser);
 
-	Node *_parse_visual_node_instance_data(XMLParser &parser);
-	Node *_parse_visual_scene_node(XMLParser &parser);
-	void _parse_visual_scene(XMLParser &parser);
+	Node *_parse_visual_node_instance_data(XMLParser &p_parser);
+	Node *_parse_visual_scene_node(XMLParser &p_parser);
+	void _parse_visual_scene(XMLParser &p_parser);
 
-	void _parse_animation(XMLParser &parser);
-	void _parse_scene(XMLParser &parser);
-	void _parse_library(XMLParser &parser);
+	void _parse_animation(XMLParser &p_parser);
+	void _parse_scene(XMLParser &p_parser);
+	void _parse_library(XMLParser &p_parser);
 
-	Variant _parse_param(XMLParser &parser);
-	Vector<float> _read_float_array(XMLParser &parser);
-	Vector<String> _read_string_array(XMLParser &parser);
-	Transform3D _read_transform(XMLParser &parser);
-	String _read_empty_draw_type(XMLParser &parser);
+	Variant _parse_param(XMLParser &p_parser);
+	Vector<float> _read_float_array(XMLParser &p_parser);
+	Vector<String> _read_string_array(XMLParser &p_parser);
+	Transform3D _read_transform(XMLParser &p_parser);
+	String _read_empty_draw_type(XMLParser &p_parser);
 
 	void _joint_set_owner(Collada::Node *p_node, NodeSkeleton *p_owner);
 	void _create_skeletons(Collada::Node **p_node, NodeSkeleton *p_skeleton = nullptr);

--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -155,8 +155,8 @@ struct CSGBrushOperation {
 		float vertex_snap = 0.0;
 
 		inline void _add_distance(List<IntersectionDistance> &r_intersectionsA, List<IntersectionDistance> &r_intersectionsB, bool p_from_B, real_t p_distance, bool p_is_conormal) const;
-		inline bool _bvh_inside(FaceBVH *facebvhptr, int p_max_depth, int p_bvh_first, int p_face_idx) const;
-		inline int _create_bvh(FaceBVH *facebvhptr, FaceBVH **facebvhptrptr, int p_from, int p_size, int p_depth, int &r_max_depth, int &r_max_alloc);
+		inline bool _bvh_inside(FaceBVH *r_facebvhptr, int p_max_depth, int p_bvh_first, int p_face_idx) const;
+		inline int _create_bvh(FaceBVH *r_facebvhptr, FaceBVH **r_facebvhptrptr, int p_from, int p_size, int p_depth, int &r_max_depth, int &r_max_alloc);
 
 		void add_face(const Vector3 p_points[3], const Vector2 p_uvs[3], bool p_smooth, bool p_invert, const Ref<Material> &p_material, bool p_from_b);
 		void mark_inside_faces();

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -466,8 +466,8 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 			}
 
 			bool found = false;
-			for (const String &path : mdfind_paths) {
-				found = _autodetect_path(path.path_join("Contents/MacOS"));
+			for (const String &found_path : mdfind_paths) {
+				found = _autodetect_path(found_path.path_join("Contents/MacOS"));
 				if (found) {
 					break;
 				}

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -520,7 +520,11 @@ if env["builtin_icu4c"]:
 module_obj = []
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env_text_server_adv.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
+    else:
+        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_adv.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -12,7 +12,11 @@ if "svg" in env.module_list:
     env_text_server_fb.Prepend(CPPPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/lib"])
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
+    if not env.msvc:
+        env_text_server_fb.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
+    else:
+        env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_fb.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])

--- a/platform/ios/ios.mm
+++ b/platform/ios/ios.mm
@@ -72,8 +72,8 @@ CHHapticEngine *iOS::get_haptic_engine_instance() API_AVAILABLE(ios(13)) {
 void iOS::vibrate_haptic_engine(float p_duration_seconds) API_AVAILABLE(ios(13)) {
 	if (@available(iOS 13, *)) { // We need the @available check every time to make the compiler happy...
 		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
+			CHHapticEngine *cur_haptic_engine = get_haptic_engine_instance();
+			if (cur_haptic_engine) {
 				NSDictionary *hapticDict = @{
 					CHHapticPatternKeyPattern : @[
 						@{CHHapticPatternKeyEvent : @{
@@ -88,7 +88,7 @@ void iOS::vibrate_haptic_engine(float p_duration_seconds) API_AVAILABLE(ios(13))
 				NSError *error;
 				CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
 
-				[[haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
+				[[cur_haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
 
 				NSLog(@"Could not vibrate using haptic engine: %@", error);
 			}
@@ -103,9 +103,9 @@ void iOS::vibrate_haptic_engine(float p_duration_seconds) API_AVAILABLE(ios(13))
 void iOS::start_haptic_engine() {
 	if (@available(iOS 13, *)) {
 		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
-				[haptic_engine startWithCompletionHandler:^(NSError *returnedError) {
+			CHHapticEngine *cur_haptic_engine = get_haptic_engine_instance();
+			if (cur_haptic_engine) {
+				[cur_haptic_engine startWithCompletionHandler:^(NSError *returnedError) {
 					if (returnedError) {
 						NSLog(@"Could not start haptic engine: %@", returnedError);
 					}
@@ -122,9 +122,9 @@ void iOS::start_haptic_engine() {
 void iOS::stop_haptic_engine() {
 	if (@available(iOS 13, *)) {
 		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
-				[haptic_engine stopWithCompletionHandler:^(NSError *returnedError) {
+			CHHapticEngine *cur_haptic_engine = get_haptic_engine_instance();
+			if (cur_haptic_engine) {
+				[cur_haptic_engine stopWithCompletionHandler:^(NSError *returnedError) {
 					if (returnedError) {
 						NSLog(@"Could not stop haptic engine: %@", returnedError);
 					}

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -60,6 +60,9 @@
 
 typedef GLXContext (*GLXCREATECONTEXTATTRIBSARBPROC)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
 
+// To prevent shadowing warnings
+#undef glGetString
+
 struct vendor {
 	const char *glxvendor = nullptr;
 	int priority = 0;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2725,8 +2725,8 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Cu
 		XcursorImageDestroy(cursor_image);
 	} else {
 		// Reset to default system cursor
-		if (img[p_shape]) {
-			cursors[p_shape] = XcursorImageLoadCursor(x11_display, img[p_shape]);
+		if (cursor_img[p_shape]) {
+			cursors[p_shape] = XcursorImageLoadCursor(x11_display, cursor_img[p_shape]);
 		}
 
 		CursorShape c = current_cursor;
@@ -5360,7 +5360,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	for (int i = 0; i < CURSOR_MAX; i++) {
 		cursors[i] = None;
-		img[i] = nullptr;
+		cursor_img[i] = nullptr;
 	}
 
 	XInitThreads(); //always use threads
@@ -5717,8 +5717,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			"question_arrow"
 		};
 
-		img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
-		if (!img[i]) {
+		cursor_img[i] = XcursorLibraryLoadImage(cursor_file[i], cursor_theme, cursor_size);
+		if (!cursor_img[i]) {
 			const char *fallback = nullptr;
 
 			switch (i) {
@@ -5756,7 +5756,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 					fallback = "bd_double_arrow";
 					break;
 				case CURSOR_MOVE:
-					img[i] = img[CURSOR_DRAG];
+					cursor_img[i] = cursor_img[CURSOR_DRAG];
 					break;
 				case CURSOR_VSPLIT:
 					fallback = "sb_v_double_arrow";
@@ -5769,11 +5769,11 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 					break;
 			}
 			if (fallback != nullptr) {
-				img[i] = XcursorLibraryLoadImage(fallback, cursor_theme, cursor_size);
+				cursor_img[i] = XcursorLibraryLoadImage(fallback, cursor_theme, cursor_size);
 			}
 		}
-		if (img[i]) {
-			cursors[i] = XcursorImageLoadCursor(x11_display, img[i]);
+		if (cursor_img[i]) {
+			cursors[i] = XcursorImageLoadCursor(x11_display, cursor_img[i]);
 		} else {
 			print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
 		}
@@ -5912,8 +5912,8 @@ DisplayServerX11::~DisplayServerX11() {
 		if (cursors[i] != None) {
 			XFreeCursor(x11_display, cursors[i]);
 		}
-		if (img[i] != nullptr) {
-			XcursorImageDestroy(img[i]);
+		if (cursor_img[i] != nullptr) {
+			XcursorImageDestroy(cursor_img[i]);
 		}
 	}
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -306,7 +306,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	const char *cursor_theme = nullptr;
 	int cursor_size = 0;
-	XcursorImage *img[CURSOR_MAX];
+	XcursorImage *cursor_img[CURSOR_MAX];
 	Cursor cursors[CURSOR_MAX];
 	Cursor null_cursor;
 	CursorShape current_cursor = CURSOR_ARROW;

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -44,6 +44,9 @@
 
 typedef GLXContext (*GLXCREATECONTEXTATTRIBSARBPROC)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
 
+// To prevent shadowing warnings
+#undef glXCreateContextAttribsARB
+
 struct GLManager_X11_Private {
 	::GLXContext glx_context;
 };

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -1840,9 +1840,9 @@ Error DisplayServerMacOS::dialog_show(String p_title, String p_description, Vect
 	if (!p_callback.is_null()) {
 		Variant button = button_pressed;
 		Variant *buttonp = &button;
-		Variant ret;
+		Variant fun_ret;
 		Callable::CallError ce;
-		p_callback.callp((const Variant **)&buttonp, 1, ret, ce);
+		p_callback.callp((const Variant **)&buttonp, 1, fun_ret, ce);
 	}
 
 	return OK;
@@ -1872,9 +1872,9 @@ Error DisplayServerMacOS::dialog_input_text(String p_title, String p_description
 	if (!p_callback.is_null()) {
 		Variant text = ret;
 		Variant *textp = &text;
-		Variant ret;
+		Variant fun_ret;
 		Callable::CallError ce;
-		p_callback.callp((const Variant **)&textp, 1, ret, ce);
+		p_callback.callp((const Variant **)&textp, 1, fun_ret, ce);
 	}
 
 	return OK;
@@ -1897,7 +1897,7 @@ void DisplayServerMacOS::mouse_set_mode(MouseMode p_mode) {
 	bool previously_shown = (mouse_mode == MOUSE_MODE_VISIBLE || mouse_mode == MOUSE_MODE_CONFINED);
 
 	if (show_cursor && !previously_shown) {
-		WindowID window_id = get_window_at_screen_position(mouse_get_position());
+		window_id = get_window_at_screen_position(mouse_get_position());
 		if (window_id != INVALID_WINDOW_ID) {
 			send_window_event(windows[window_id], WINDOW_EVENT_MOUSE_ENTER);
 		}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -435,8 +435,6 @@ String OS_Windows::get_distribution_name() const {
 }
 
 String OS_Windows::get_version() const {
-	typedef LONG NTSTATUS;
-	typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 	RtlGetVersionPtr version_ptr = (RtlGetVersionPtr)GetProcAddress(GetModuleHandle("ntdll.dll"), "RtlGetVersion");
 	if (version_ptr != nullptr) {
 		RTL_OSVERSIONINFOW fow;
@@ -554,9 +552,9 @@ OS::DateTime OS_Windows::get_datetime(bool p_utc) const {
 
 	//Get DST information from Windows, but only if p_utc is false.
 	TIME_ZONE_INFORMATION info;
-	bool daylight = false;
+	bool is_daylight = false;
 	if (!p_utc && GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
-		daylight = true;
+		is_daylight = true;
 	}
 
 	DateTime dt;
@@ -567,20 +565,20 @@ OS::DateTime OS_Windows::get_datetime(bool p_utc) const {
 	dt.hour = systemtime.wHour;
 	dt.minute = systemtime.wMinute;
 	dt.second = systemtime.wSecond;
-	dt.dst = daylight;
+	dt.dst = is_daylight;
 	return dt;
 }
 
 OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
 	TIME_ZONE_INFORMATION info;
-	bool daylight = false;
+	bool is_daylight = false;
 	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
-		daylight = true;
+		is_daylight = true;
 	}
 
 	// Daylight Bias needs to be added to the bias if DST is in effect, or else it will not properly update.
 	TimeZoneInfo ret;
-	if (daylight) {
+	if (is_daylight) {
 		ret.name = info.DaylightName;
 		ret.bias = info.Bias + info.DaylightBias;
 	} else {

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -71,15 +71,15 @@ public:
 
 		/*! Constructs a ray from origin, direction, and ray segment. Near
 		 *  has to be smaller than far. */
-		_FORCE_INLINE_ Ray(const Vector3 &org,
-				const Vector3 &dir,
-				float tnear = 0.0f,
-				float tfar = INFINITY) :
-				org(org),
-				tnear(tnear),
-				dir(dir),
+		_FORCE_INLINE_ Ray(const Vector3 &p_org,
+				const Vector3 &p_dir,
+				float p_tnear = 0.0f,
+				float p_tfar = INFINITY) :
+				org(p_org),
+				tnear(p_tnear),
+				dir(p_dir),
 				time(0.0f),
-				tfar(tfar),
+				tfar(p_tfar),
 				mask(-1),
 				u(0.0),
 				v(0.0),

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -61,7 +61,7 @@ class AudioStreamPlaybackWAV : public AudioStreamPlayback {
 	Ref<AudioStreamWAV> base;
 
 	template <class Depth, bool is_stereo, bool is_ima_adpcm>
-	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &offset, int32_t &increment, uint32_t amount, IMA_ADPCM_State *ima_adpcm);
+	void do_resample(const Depth *p_src, AudioFrame *p_dst, int64_t &p_offset, int32_t &p_increment, uint32_t p_amount, IMA_ADPCM_State *p_ima_adpcm);
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -436,7 +436,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 	String code;
 
 	switch (p_node->type) {
-		case SL::Node::TYPE_SHADER: {
+		case SL::Node::NODE_TYPE_SHADER: {
 			SL::ShaderNode *pnode = (SL::ShaderNode *)p_node;
 
 			for (int i = 0; i < pnode->render_modes.size(); i++) {
@@ -781,11 +781,11 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 			//code+=dump_node_code(pnode->body,p_level);
 		} break;
-		case SL::Node::TYPE_STRUCT: {
+		case SL::Node::NODE_TYPE_STRUCT: {
 		} break;
-		case SL::Node::TYPE_FUNCTION: {
+		case SL::Node::NODE_TYPE_FUNCTION: {
 		} break;
-		case SL::Node::TYPE_BLOCK: {
+		case SL::Node::NODE_TYPE_BLOCK: {
 			SL::BlockNode *bnode = (SL::BlockNode *)p_node;
 
 			//variables
@@ -796,7 +796,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			for (int i = 0; i < bnode->statements.size(); i++) {
 				String scode = _dump_node_code(bnode->statements[i], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
 
-				if (bnode->statements[i]->type == SL::Node::TYPE_CONTROL_FLOW || bnode->single_statement) {
+				if (bnode->statements[i]->type == SL::Node::NODE_TYPE_CONTROL_FLOW || bnode->single_statement) {
 					code += scode; //use directly
 					if (bnode->use_comma_between_statements && i + 1 < bnode->statements.size()) {
 						code += ",";
@@ -810,7 +810,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_VARIABLE_DECLARATION: {
+		case SL::Node::NODE_TYPE_VARIABLE_DECLARATION: {
 			SL::VariableDeclarationNode *vdnode = (SL::VariableDeclarationNode *)p_node;
 
 			String declaration;
@@ -868,7 +868,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 			code += declaration;
 		} break;
-		case SL::Node::TYPE_VARIABLE: {
+		case SL::Node::NODE_TYPE_VARIABLE: {
 			SL::VariableNode *vnode = (SL::VariableNode *)p_node;
 			bool use_fragment_varying = false;
 
@@ -961,7 +961,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_ARRAY_CONSTRUCT: {
+		case SL::Node::NODE_TYPE_ARRAY_CONSTRUCT: {
 			SL::ArrayConstructNode *acnode = (SL::ArrayConstructNode *)p_node;
 			int sz = acnode->initializer.size();
 			if (acnode->datatype == SL::TYPE_STRUCT) {
@@ -981,7 +981,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 			code += ")";
 		} break;
-		case SL::Node::TYPE_ARRAY: {
+		case SL::Node::NODE_TYPE_ARRAY: {
 			SL::ArrayNode *anode = (SL::ArrayNode *)p_node;
 			bool use_fragment_varying = false;
 
@@ -1072,7 +1072,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_CONSTANT: {
+		case SL::Node::NODE_TYPE_CONSTANT: {
 			SL::ConstantNode *cnode = (SL::ConstantNode *)p_node;
 
 			if (cnode->array_size == 0) {
@@ -1099,7 +1099,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_OPERATOR: {
+		case SL::Node::NODE_TYPE_OPERATOR: {
 			SL::OperatorNode *onode = (SL::OperatorNode *)p_node;
 
 			switch (onode->op) {
@@ -1130,7 +1130,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				case SL::OP_CALL:
 				case SL::OP_STRUCT:
 				case SL::OP_CONSTRUCT: {
-					ERR_FAIL_COND_V(onode->arguments[0]->type != SL::Node::TYPE_VARIABLE, String());
+					ERR_FAIL_COND_V(onode->arguments[0]->type != SL::Node::NODE_TYPE_VARIABLE, String());
 					const SL::VariableNode *vnode = static_cast<const SL::VariableNode *>(onode->arguments[0]);
 					const SL::FunctionNode *func = nullptr;
 					const bool is_internal_func = internal_functions.has(vnode->name);
@@ -1200,12 +1200,12 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 								bool done = false;
 								do {
 									switch (node->type) {
-										case SL::Node::TYPE_VARIABLE: {
+										case SL::Node::NODE_TYPE_VARIABLE: {
 											name = static_cast<const SL::VariableNode *>(node)->name;
 											done = true;
 											found = true;
 										} break;
-										case SL::Node::TYPE_MEMBER: {
+										case SL::Node::NODE_TYPE_MEMBER: {
 											node = static_cast<const SL::MemberNode *>(node)->owner;
 										} break;
 										default: {
@@ -1227,12 +1227,12 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 							bool correct_texture_uniform = false;
 
 							switch (onode->arguments[i]->type) {
-								case SL::Node::TYPE_VARIABLE: {
+								case SL::Node::NODE_TYPE_VARIABLE: {
 									const SL::VariableNode *varnode = static_cast<const SL::VariableNode *>(onode->arguments[i]);
 									texture_uniform = varnode->name;
 									correct_texture_uniform = true;
 								} break;
-								case SL::Node::TYPE_ARRAY: {
+								case SL::Node::NODE_TYPE_ARRAY: {
 									const SL::ArrayNode *anode = static_cast<const SL::ArrayNode *>(onode->arguments[i]);
 									texture_uniform = anode->name;
 									correct_texture_uniform = true;
@@ -1361,7 +1361,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_CONTROL_FLOW: {
+		case SL::Node::NODE_TYPE_CONTROL_FLOW: {
 			SL::ControlFlowNode *cfnode = (SL::ControlFlowNode *)p_node;
 			if (cfnode->flow_op == SL::FLOW_OP_IF) {
 				code += _mktab(p_level) + "if (" + _dump_node_code(cfnode->expressions[0], p_level, r_gen_code, p_actions, p_default_actions, p_assigning) + ")\n";
@@ -1413,7 +1413,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 			}
 
 		} break;
-		case SL::Node::TYPE_MEMBER: {
+		case SL::Node::NODE_TYPE_MEMBER: {
 			SL::MemberNode *mnode = (SL::MemberNode *)p_node;
 			code = _dump_node_code(mnode->owner, p_level, r_gen_code, p_actions, p_default_actions, p_assigning) + "." + mnode->name;
 			if (mnode->index_expression != nullptr) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3063,7 +3063,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 	Vector<StringName> args2;
 	Vector<int> args3;
 
-	ERR_FAIL_COND_V(p_func->arguments[0]->type != Node::TYPE_VARIABLE, false);
+	ERR_FAIL_COND_V(p_func->arguments[0]->type != Node::NODE_TYPE_VARIABLE, false);
 
 	StringName name = static_cast<VariableNode *>(p_func->arguments[0])->name.operator String();
 
@@ -3117,14 +3117,14 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 				failed_builtin = true;
 				bool fail = false;
 				for (int i = 0; i < argcount; i++) {
-					if (p_func->arguments[i + 1]->type == Node::TYPE_ARRAY) {
+					if (p_func->arguments[i + 1]->type == Node::NODE_TYPE_ARRAY) {
 						const ArrayNode *anode = static_cast<const ArrayNode *>(p_func->arguments[i + 1]);
 						if (anode->call_expression == nullptr && !anode->is_indexed()) {
 							fail = true;
 							break;
 						}
 					}
-					if (get_scalar_type(args[i]) == args[i] && p_func->arguments[i + 1]->type == Node::TYPE_CONSTANT && convert_constant(static_cast<ConstantNode *>(p_func->arguments[i + 1]), builtin_func_defs[idx].args[i])) {
+					if (get_scalar_type(args[i]) == args[i] && p_func->arguments[i + 1]->type == Node::NODE_TYPE_CONSTANT && convert_constant(static_cast<ConstantNode *>(p_func->arguments[i + 1]), builtin_func_defs[idx].args[i])) {
 						//all good, but needs implicit conversion later
 					} else if (args[i] != builtin_func_defs[idx].args[i]) {
 						fail = true;
@@ -3160,7 +3160,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 								int max = builtin_func_const_args[constarg_idx].max;
 
 								bool error = false;
-								if (p_func->arguments[arg]->type == Node::TYPE_VARIABLE) {
+								if (p_func->arguments[arg]->type == Node::NODE_TYPE_VARIABLE) {
 									const VariableNode *vn = static_cast<VariableNode *>(p_func->arguments[arg]);
 
 									bool is_const = false;
@@ -3172,7 +3172,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 										error = true;
 									}
 								} else {
-									if (p_func->arguments[arg]->type == Node::TYPE_CONSTANT) {
+									if (p_func->arguments[arg]->type == Node::NODE_TYPE_CONSTANT) {
 										const ConstantNode *cn = static_cast<ConstantNode *>(p_func->arguments[arg]);
 
 										if (cn->get_datatype() == TYPE_INT && cn->values.size() == 1) {
@@ -3207,17 +3207,17 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 									break;
 								}
 								if (arg_idx < argcount) {
-									if (p_func->arguments[arg_idx + 1]->type != Node::TYPE_VARIABLE && p_func->arguments[arg_idx + 1]->type != Node::TYPE_MEMBER && p_func->arguments[arg_idx + 1]->type != Node::TYPE_ARRAY) {
+									if (p_func->arguments[arg_idx + 1]->type != Node::NODE_TYPE_VARIABLE && p_func->arguments[arg_idx + 1]->type != Node::NODE_TYPE_MEMBER && p_func->arguments[arg_idx + 1]->type != Node::NODE_TYPE_ARRAY) {
 										_set_error(vformat(RTR("Argument %d of function '%s' is not a variable, array, or member."), arg_idx + 1, String(name)));
 										return false;
 									}
 
-									if (p_func->arguments[arg_idx + 1]->type == Node::TYPE_ARRAY) {
+									if (p_func->arguments[arg_idx + 1]->type == Node::NODE_TYPE_ARRAY) {
 										ArrayNode *mn = static_cast<ArrayNode *>(p_func->arguments[arg_idx + 1]);
 										if (mn->is_const) {
 											fail = true;
 										}
-									} else if (p_func->arguments[arg_idx + 1]->type == Node::TYPE_MEMBER) {
+									} else if (p_func->arguments[arg_idx + 1]->type == Node::NODE_TYPE_MEMBER) {
 										MemberNode *mn = static_cast<MemberNode *>(p_func->arguments[arg_idx + 1]);
 										if (mn->basetype_const) {
 											fail = true;
@@ -3250,18 +3250,18 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 									}
 
 									StringName var_name;
-									if (p_func->arguments[arg_idx + 1]->type == Node::TYPE_ARRAY) {
+									if (p_func->arguments[arg_idx + 1]->type == Node::NODE_TYPE_ARRAY) {
 										var_name = static_cast<const ArrayNode *>(p_func->arguments[arg_idx + 1])->name;
-									} else if (p_func->arguments[arg_idx + 1]->type == Node::TYPE_MEMBER) {
+									} else if (p_func->arguments[arg_idx + 1]->type == Node::NODE_TYPE_MEMBER) {
 										Node *n = static_cast<const MemberNode *>(p_func->arguments[arg_idx + 1])->owner;
-										while (n->type == Node::TYPE_MEMBER) {
+										while (n->type == Node::NODE_TYPE_MEMBER) {
 											n = static_cast<const MemberNode *>(n)->owner;
 										}
-										if (n->type != Node::TYPE_VARIABLE && n->type != Node::TYPE_ARRAY) {
+										if (n->type != Node::NODE_TYPE_VARIABLE && n->type != Node::NODE_TYPE_ARRAY) {
 											_set_error(vformat(RTR("Argument %d of function '%s' is not a variable, array, or member."), arg_idx + 1, String(name)));
 											return false;
 										}
-										if (n->type == Node::TYPE_VARIABLE) {
+										if (n->type == Node::NODE_TYPE_VARIABLE) {
 											var_name = static_cast<const VariableNode *>(n)->name;
 										} else { // TYPE_ARRAY
 											var_name = static_cast<const ArrayNode *>(n)->name;
@@ -3298,7 +3298,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 					}
 					//implicitly convert values if possible
 					for (int i = 0; i < argcount; i++) {
-						if (get_scalar_type(args[i]) != args[i] || args[i] == builtin_func_defs[idx].args[i] || p_func->arguments[i + 1]->type != Node::TYPE_CONSTANT) {
+						if (get_scalar_type(args[i]) != args[i] || args[i] == builtin_func_defs[idx].args[i] || p_func->arguments[i + 1]->type != Node::NODE_TYPE_CONSTANT) {
 							//can't do implicit conversion here
 							continue;
 						}
@@ -3422,7 +3422,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 		bool fail = false;
 
 		for (int j = 0; j < args.size(); j++) {
-			if (get_scalar_type(args[j]) == args[j] && p_func->arguments[j + 1]->type == Node::TYPE_CONSTANT && args3[j] == 0 && convert_constant(static_cast<ConstantNode *>(p_func->arguments[j + 1]), pfunc->arguments[j].type)) {
+			if (get_scalar_type(args[j]) == args[j] && p_func->arguments[j + 1]->type == Node::NODE_TYPE_CONSTANT && args3[j] == 0 && convert_constant(static_cast<ConstantNode *>(p_func->arguments[j + 1]), pfunc->arguments[j].type)) {
 				//all good, but it needs implicit conversion later
 			} else if (args[j] != pfunc->arguments[j].type || (args[j] == TYPE_STRUCT && args2[j] != pfunc->arguments[j].type_str) || args3[j] != pfunc->arguments[j].array_size) {
 				String func_arg_name;
@@ -3457,7 +3457,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 		if (!fail) {
 			//implicitly convert values if possible
 			for (int k = 0; k < args.size(); k++) {
-				if (get_scalar_type(args[k]) != args[k] || args[k] == pfunc->arguments[k].type || p_func->arguments[k + 1]->type != Node::TYPE_CONSTANT) {
+				if (get_scalar_type(args[k]) != args[k] || args[k] == pfunc->arguments[k].type || p_func->arguments[k + 1]->type != Node::NODE_TYPE_CONSTANT) {
 					//can't do implicit conversion here
 					continue;
 				}
@@ -3565,7 +3565,7 @@ bool ShaderLanguage::_parse_function_arguments(BlockNode *p_block, const Functio
 			return false;
 		}
 
-		if (is_const_decl && arg->type == Node::TYPE_VARIABLE) {
+		if (is_const_decl && arg->type == Node::NODE_TYPE_VARIABLE) {
 			const VariableNode *var = static_cast<const VariableNode *>(arg);
 			if (!var->is_const) {
 				_set_error(RTR("Expected constant expression."));
@@ -4531,7 +4531,7 @@ bool ShaderLanguage::_validate_varying_assign(ShaderNode::Varying &p_varying, St
 
 bool ShaderLanguage::_check_node_constness(const Node *p_node) const {
 	switch (p_node->type) {
-		case Node::TYPE_OPERATOR: {
+		case Node::NODE_TYPE_OPERATOR: {
 			const OperatorNode *op_node = static_cast<const OperatorNode *>(p_node);
 			for (int i = int(op_node->op == OP_CALL); i < op_node->arguments.size(); i++) {
 				if (!_check_node_constness(op_node->arguments[i])) {
@@ -4539,15 +4539,15 @@ bool ShaderLanguage::_check_node_constness(const Node *p_node) const {
 				}
 			}
 		} break;
-		case Node::TYPE_CONSTANT:
+		case Node::NODE_TYPE_CONSTANT:
 			break;
-		case Node::TYPE_VARIABLE: {
+		case Node::NODE_TYPE_VARIABLE: {
 			const VariableNode *var_node = static_cast<const VariableNode *>(p_node);
 			if (!var_node->is_const) {
 				return false;
 			}
 		} break;
-		case Node::TYPE_ARRAY: {
+		case Node::NODE_TYPE_ARRAY: {
 			const ArrayNode *arr_node = static_cast<const ArrayNode *>(p_node);
 			if (!arr_node->is_const) {
 				return false;
@@ -4560,7 +4560,7 @@ bool ShaderLanguage::_check_node_constness(const Node *p_node) const {
 }
 
 bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_function_info, String *r_message) {
-	if (p_node->type == Node::TYPE_OPERATOR) {
+	if (p_node->type == Node::NODE_TYPE_OPERATOR) {
 		OperatorNode *op = static_cast<OperatorNode *>(p_node);
 
 		if (op->op == OP_INDEX) {
@@ -4577,7 +4577,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_functi
 			return false;
 		}
 
-	} else if (p_node->type == Node::TYPE_MEMBER) {
+	} else if (p_node->type == Node::NODE_TYPE_MEMBER) {
 		MemberNode *member = static_cast<MemberNode *>(p_node);
 
 		if (member->has_swizzling_duplicates) {
@@ -4589,7 +4589,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_functi
 
 		return _validate_assign(member->owner, p_function_info, r_message);
 
-	} else if (p_node->type == Node::TYPE_VARIABLE) {
+	} else if (p_node->type == Node::NODE_TYPE_VARIABLE) {
 		VariableNode *var = static_cast<VariableNode *>(p_node);
 
 		if (shader->uniforms.has(var->name)) {
@@ -4609,7 +4609,7 @@ bool ShaderLanguage::_validate_assign(Node *p_node, const FunctionInfo &p_functi
 		if (!(p_function_info.built_ins.has(var->name) && p_function_info.built_ins[var->name].constant)) {
 			return true;
 		}
-	} else if (p_node->type == Node::TYPE_ARRAY) {
+	} else if (p_node->type == Node::NODE_TYPE_ARRAY) {
 		ArrayNode *arr = static_cast<ArrayNode *>(p_node);
 
 		if (shader->constants.has(arr->name) || arr->is_const) {
@@ -4727,7 +4727,7 @@ Error ShaderLanguage::_parse_array_size(BlockNode *p_block, const FunctionInfo &
 			_set_tkpos(pos);
 			Node *n = _parse_and_reduce_expression(p_block, p_function_info);
 			if (n) {
-				if (n->type == Node::TYPE_VARIABLE) {
+				if (n->type == Node::NODE_TYPE_VARIABLE) {
 					VariableNode *vn = static_cast<VariableNode *>(n);
 					if (vn) {
 						ConstantNode::Value v;
@@ -4750,7 +4750,7 @@ Error ShaderLanguage::_parse_array_size(BlockNode *p_block, const FunctionInfo &
 							}
 						}
 					}
-				} else if (n->type == Node::TYPE_OPERATOR) {
+				} else if (n->type == Node::NODE_TYPE_OPERATOR) {
 					_set_error(vformat(RTR("Array size expressions are not supported.")));
 					return ERR_PARSE_ERROR;
 				}
@@ -5296,10 +5296,10 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 									ArgumentQualifier arg_qual = call_function->arguments[i].qualifier;
 									bool is_out_arg = arg_qual != ArgumentQualifier::ARGUMENT_QUALIFIER_IN;
 
-									if (n->type == Node::TYPE_VARIABLE || n->type == Node::TYPE_ARRAY) {
+									if (n->type == Node::NODE_TYPE_VARIABLE || n->type == Node::NODE_TYPE_ARRAY) {
 										StringName varname;
 
-										if (n->type == Node::TYPE_VARIABLE) {
+										if (n->type == Node::NODE_TYPE_VARIABLE) {
 											VariableNode *vn = static_cast<VariableNode *>(n);
 											varname = vn->name;
 										} else { // TYPE_ARRAY
@@ -5347,23 +5347,23 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 									if (is_const_arg || is_out_arg) {
 										StringName varname;
 
-										if (n->type == Node::TYPE_CONSTANT || n->type == Node::TYPE_OPERATOR || n->type == Node::TYPE_ARRAY_CONSTRUCT) {
+										if (n->type == Node::NODE_TYPE_CONSTANT || n->type == Node::NODE_TYPE_OPERATOR || n->type == Node::NODE_TYPE_ARRAY_CONSTRUCT) {
 											if (!is_const_arg) {
 												error = true;
 											}
-										} else if (n->type == Node::TYPE_ARRAY) {
+										} else if (n->type == Node::NODE_TYPE_ARRAY) {
 											ArrayNode *an = static_cast<ArrayNode *>(n);
 											if (!is_const_arg && (an->call_expression != nullptr || an->is_const)) {
 												error = true;
 											}
 											varname = an->name;
-										} else if (n->type == Node::TYPE_VARIABLE) {
+										} else if (n->type == Node::NODE_TYPE_VARIABLE) {
 											VariableNode *vn = static_cast<VariableNode *>(n);
 											if (vn->is_const && !is_const_arg) {
 												error = true;
 											}
 											varname = vn->name;
-										} else if (n->type == Node::TYPE_MEMBER) {
+										} else if (n->type == Node::NODE_TYPE_MEMBER) {
 											MemberNode *mn = static_cast<MemberNode *>(n);
 											if (mn->basetype_const && is_out_arg) {
 												error = true;
@@ -5389,7 +5389,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 									}
 									if (is_sampler_type(call_function->arguments[i].type)) {
 										//let's see where our argument comes from
-										ERR_CONTINUE(n->type != Node::TYPE_VARIABLE); //bug? this should always be a variable
+										ERR_CONTINUE(n->type != Node::NODE_TYPE_VARIABLE); //bug? this should always be a variable
 										VariableNode *vn = static_cast<VariableNode *>(n);
 										StringName varname = vn->name;
 										if (shader->uniforms.has(varname)) {
@@ -5599,7 +5599,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 							return nullptr;
 						}
 
-						if (index_expression->type == Node::TYPE_CONSTANT) {
+						if (index_expression->type == Node::NODE_TYPE_CONSTANT) {
 							ConstantNode *cnode = static_cast<ConstantNode *>(index_expression);
 							if (cnode) {
 								if (!cnode->values.is_empty()) {
@@ -6064,7 +6064,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 							return nullptr;
 						}
 
-						if (index_expression->type == Node::TYPE_CONSTANT) {
+						if (index_expression->type == Node::NODE_TYPE_CONSTANT) {
 							ConstantNode *cnode = static_cast<ConstantNode *>(index_expression);
 							if (cnode) {
 								if (!cnode->values.is_empty()) {
@@ -6118,7 +6118,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 				String member_struct_name;
 
 				if (expr->get_array_size() > 0) {
-					if (index->type == Node::TYPE_CONSTANT) {
+					if (index->type == Node::NODE_TYPE_CONSTANT) {
 						uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
 						if (index_constant >= (uint32_t)expr->get_array_size()) {
 							_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, expr->get_array_size() - 1));
@@ -6136,7 +6136,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						case TYPE_IVEC2:
 						case TYPE_UVEC2:
 						case TYPE_MAT2:
-							if (index->type == Node::TYPE_CONSTANT) {
+							if (index->type == Node::NODE_TYPE_CONSTANT) {
 								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
 								if (index_constant >= 2) {
 									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 1));
@@ -6170,7 +6170,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						case TYPE_IVEC3:
 						case TYPE_UVEC3:
 						case TYPE_MAT3:
-							if (index->type == Node::TYPE_CONSTANT) {
+							if (index->type == Node::NODE_TYPE_CONSTANT) {
 								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
 								if (index_constant >= 3) {
 									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 2));
@@ -6203,7 +6203,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						case TYPE_IVEC4:
 						case TYPE_UVEC4:
 						case TYPE_MAT4:
-							if (index->type == Node::TYPE_CONSTANT) {
+							if (index->type == Node::NODE_TYPE_CONSTANT) {
 								uint32_t index_constant = static_cast<ConstantNode *>(index)->values[0].uint;
 								if (index_constant >= 4) {
 									_set_error(vformat(RTR("Index [%d] out of range [%d..%d]."), index_constant, 0, 3));
@@ -6702,7 +6702,7 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 }
 
 ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, ShaderLanguage::Node *p_node) {
-	if (p_node->type != Node::TYPE_OPERATOR) {
+	if (p_node->type != Node::NODE_TYPE_OPERATOR) {
 		return p_node;
 	}
 
@@ -6710,7 +6710,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 	OperatorNode *op = static_cast<OperatorNode *>(p_node);
 
 	if (op->op == OP_CONSTRUCT) {
-		ERR_FAIL_COND_V(op->arguments[0]->type != Node::TYPE_VARIABLE, p_node);
+		ERR_FAIL_COND_V(op->arguments[0]->type != Node::NODE_TYPE_VARIABLE, p_node);
 
 		DataType type = op->get_datatype();
 		DataType base = get_scalar_type(type);
@@ -6720,7 +6720,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 
 		for (int i = 1; i < op->arguments.size(); i++) {
 			op->arguments.write[i] = _reduce_expression(p_block, op->arguments[i]);
-			if (op->arguments[i]->type == Node::TYPE_CONSTANT) {
+			if (op->arguments[i]->type == Node::NODE_TYPE_CONSTANT) {
 				ConstantNode *cn = static_cast<ConstantNode *>(op->arguments[i]);
 
 				if (get_scalar_type(cn->datatype) == base) {
@@ -6772,7 +6772,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
 		return cn;
 	} else if (op->op == OP_NEGATE) {
 		op->arguments.write[0] = _reduce_expression(p_block, op->arguments[0]);
-		if (op->arguments[0]->type == Node::TYPE_CONSTANT) {
+		if (op->arguments[0]->type == Node::NODE_TYPE_CONSTANT) {
 			ConstantNode *cn = static_cast<ConstantNode *>(op->arguments[0]);
 
 			DataType base = get_scalar_type(cn->datatype);
@@ -7179,7 +7179,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 										return ERR_PARSE_ERROR;
 									}
 
-									if (is_const && n->type == Node::TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
+									if (is_const && n->type == Node::NODE_TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
 										_set_error(RTR("Expected a constant expression."));
 										return ERR_PARSE_ERROR;
 									}
@@ -7235,7 +7235,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 					if (!n) {
 						return ERR_PARSE_ERROR;
 					}
-					if (is_const && n->type == Node::TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
+					if (is_const && n->type == Node::NODE_TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
 						OperatorNode *op = static_cast<OperatorNode *>(n);
 						for (int i = 1; i < op->arguments.size(); i++) {
 							if (!_check_node_constness(op->arguments[i])) {
@@ -7245,7 +7245,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 						}
 					}
 
-					if (n->type == Node::TYPE_CONSTANT) {
+					if (n->type == Node::NODE_TYPE_CONSTANT) {
 						ConstantNode *const_node = static_cast<ConstantNode *>(n);
 						if (const_node && const_node->values.size() == 1) {
 							var.value = const_node->values[0];
@@ -7412,7 +7412,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 						ControlFlowNode *flow = static_cast<ControlFlowNode *>(switch_block->statements[i]);
 						if (flow) {
 							if (flow->flow_op == FLOW_OP_CASE) {
-								if (flow->expressions[0]->type == Node::TYPE_CONSTANT) {
+								if (flow->expressions[0]->type == Node::NODE_TYPE_CONSTANT) {
 									ConstantNode *cn = static_cast<ConstantNode *>(flow->expressions[0]);
 									if (!cn || cn->values.is_empty()) {
 										return ERR_PARSE_ERROR;
@@ -7422,7 +7422,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 										return ERR_PARSE_ERROR;
 									}
 									constants.insert(cn->values[0].sint);
-								} else if (flow->expressions[0]->type == Node::TYPE_VARIABLE) {
+								} else if (flow->expressions[0]->type == Node::NODE_TYPE_VARIABLE) {
 									VariableNode *vn = static_cast<VariableNode *>(flow->expressions[0]);
 									if (!vn) {
 										return ERR_PARSE_ERROR;
@@ -7852,9 +7852,9 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			if (!expr) {
 				return ERR_PARSE_ERROR;
 			}
-			is_condition = expr->type == Node::TYPE_OPERATOR && expr->get_datatype() == TYPE_BOOL;
+			is_condition = expr->type == Node::NODE_TYPE_OPERATOR && expr->get_datatype() == TYPE_BOOL;
 
-			if (expr->type == Node::TYPE_OPERATOR) {
+			if (expr->type == Node::NODE_TYPE_OPERATOR) {
 				OperatorNode *op = static_cast<OperatorNode *>(expr);
 				if (op->op == OP_EMPTY) {
 					is_var_init = true;
@@ -8916,7 +8916,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						if (!expr) {
 							return ERR_PARSE_ERROR;
 						}
-						if (expr->type != Node::TYPE_CONSTANT) {
+						if (expr->type != Node::NODE_TYPE_CONSTANT) {
 							_set_error(RTR("Expected constant expression after '='."));
 							return ERR_PARSE_ERROR;
 						}
@@ -9276,7 +9276,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 											return ERR_PARSE_ERROR;
 										}
 
-										if (n->type == Node::TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
+										if (n->type == Node::NODE_TYPE_OPERATOR && static_cast<OperatorNode *>(n)->op == OP_CALL) {
 											_set_error(RTR("Expected constant expression."));
 											return ERR_PARSE_ERROR;
 										}
@@ -9343,7 +9343,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									keyword_completion_context = CF_GLOBAL_SPACE;
 								}
 #endif // DEBUG_ENABLED
-								if (expr->type == Node::TYPE_OPERATOR && static_cast<OperatorNode *>(expr)->op == OP_CALL) {
+								if (expr->type == Node::NODE_TYPE_OPERATOR && static_cast<OperatorNode *>(expr)->op == OP_CALL) {
 									OperatorNode *op = static_cast<OperatorNode *>(expr);
 									for (int i = 1; i < op->arguments.size(); i++) {
 										if (!_check_node_constness(op->arguments[i])) {
@@ -9756,7 +9756,7 @@ Error ShaderLanguage::_find_last_flow_op_in_op(ControlFlowNode *p_flow, FlowOper
 	bool found = false;
 
 	for (int i = p_flow->blocks.size() - 1; i >= 0; i--) {
-		if (p_flow->blocks[i]->type == Node::TYPE_BLOCK) {
+		if (p_flow->blocks[i]->type == Node::NODE_TYPE_BLOCK) {
 			BlockNode *last_block = static_cast<BlockNode *>(p_flow->blocks[i]);
 			if (_find_last_flow_op_in_block(last_block, p_op) == OK) {
 				found = true;
@@ -9774,7 +9774,7 @@ Error ShaderLanguage::_find_last_flow_op_in_block(BlockNode *p_block, FlowOperat
 	bool found = false;
 
 	for (int i = p_block->statements.size() - 1; i >= 0; i--) {
-		if (p_block->statements[i]->type == Node::TYPE_CONTROL_FLOW) {
+		if (p_block->statements[i]->type == Node::NODE_TYPE_CONTROL_FLOW) {
 			ControlFlowNode *flow = static_cast<ControlFlowNode *>(p_block->statements[i]);
 			if (flow->flow_op == p_op) {
 				found = true;
@@ -9785,7 +9785,7 @@ Error ShaderLanguage::_find_last_flow_op_in_block(BlockNode *p_block, FlowOperat
 					break;
 				}
 			}
-		} else if (p_block->statements[i]->type == Node::TYPE_BLOCK) {
+		} else if (p_block->statements[i]->type == Node::NODE_TYPE_BLOCK) {
 			BlockNode *block = static_cast<BlockNode *>(p_block->statements[i]);
 			if (_find_last_flow_op_in_block(block, p_op) == OK) {
 				found = true;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -357,18 +357,18 @@ public:
 		Node *next = nullptr;
 
 		enum Type {
-			TYPE_SHADER,
-			TYPE_FUNCTION,
-			TYPE_BLOCK,
-			TYPE_VARIABLE,
-			TYPE_VARIABLE_DECLARATION,
-			TYPE_CONSTANT,
-			TYPE_OPERATOR,
-			TYPE_CONTROL_FLOW,
-			TYPE_MEMBER,
-			TYPE_ARRAY,
-			TYPE_ARRAY_CONSTRUCT,
-			TYPE_STRUCT,
+			NODE_TYPE_SHADER,
+			NODE_TYPE_FUNCTION,
+			NODE_TYPE_BLOCK,
+			NODE_TYPE_VARIABLE,
+			NODE_TYPE_VARIABLE_DECLARATION,
+			NODE_TYPE_CONSTANT,
+			NODE_TYPE_OPERATOR,
+			NODE_TYPE_CONTROL_FLOW,
+			NODE_TYPE_MEMBER,
+			NODE_TYPE_ARRAY,
+			NODE_TYPE_ARRAY_CONSTRUCT,
+			NODE_TYPE_STRUCT,
 		};
 
 		Type type;
@@ -407,7 +407,7 @@ public:
 		virtual bool is_indexed() const override { return op == OP_INDEX; }
 
 		OperatorNode() :
-				Node(TYPE_OPERATOR) {}
+				Node(NODE_TYPE_OPERATOR) {}
 	};
 
 	struct VariableNode : public Node {
@@ -421,7 +421,7 @@ public:
 		virtual String get_datatype_name() const override { return String(struct_name); }
 
 		VariableNode() :
-				Node(TYPE_VARIABLE) {}
+				Node(NODE_TYPE_VARIABLE) {}
 	};
 
 	struct VariableDeclarationNode : public Node {
@@ -442,7 +442,7 @@ public:
 		virtual DataType get_datatype() const override { return datatype; }
 
 		VariableDeclarationNode() :
-				Node(TYPE_VARIABLE_DECLARATION) {}
+				Node(NODE_TYPE_VARIABLE_DECLARATION) {}
 	};
 
 	struct ArrayNode : public Node {
@@ -462,7 +462,7 @@ public:
 		virtual bool is_indexed() const override { return index_expression != nullptr; }
 
 		ArrayNode() :
-				Node(TYPE_ARRAY) {}
+				Node(NODE_TYPE_ARRAY) {}
 	};
 
 	struct ArrayConstructNode : public Node {
@@ -475,7 +475,7 @@ public:
 		virtual int get_array_size() const override { return initializer.size(); }
 
 		ArrayConstructNode() :
-				Node(TYPE_ARRAY_CONSTRUCT) {}
+				Node(NODE_TYPE_ARRAY_CONSTRUCT) {}
 	};
 
 	struct ConstantNode : public Node {
@@ -498,7 +498,7 @@ public:
 		virtual int get_array_size() const override { return array_size; }
 
 		ConstantNode() :
-				Node(TYPE_CONSTANT) {}
+				Node(NODE_TYPE_CONSTANT) {}
 	};
 
 	struct FunctionNode;
@@ -536,7 +536,7 @@ public:
 		bool use_comma_between_statements = false;
 
 		BlockNode() :
-				Node(TYPE_BLOCK) {}
+				Node(NODE_TYPE_BLOCK) {}
 	};
 
 	struct ControlFlowNode : public Node {
@@ -545,7 +545,7 @@ public:
 		Vector<BlockNode *> blocks;
 
 		ControlFlowNode() :
-				Node(TYPE_CONTROL_FLOW) {}
+				Node(NODE_TYPE_CONTROL_FLOW) {}
 	};
 
 	struct MemberNode : public Node {
@@ -569,13 +569,13 @@ public:
 		virtual bool is_indexed() const override { return index_expression != nullptr || call_expression != nullptr; }
 
 		MemberNode() :
-				Node(TYPE_MEMBER) {}
+				Node(NODE_TYPE_MEMBER) {}
 	};
 
 	struct StructNode : public Node {
 		List<MemberNode *> members;
 		StructNode() :
-				Node(TYPE_STRUCT) {}
+				Node(NODE_TYPE_STRUCT) {}
 	};
 
 	struct FunctionNode : public Node {
@@ -611,7 +611,7 @@ public:
 		virtual int get_array_size() const override { return return_array_size; }
 
 		FunctionNode() :
-				Node(TYPE_FUNCTION) {}
+				Node(NODE_TYPE_FUNCTION) {}
 	};
 
 	struct ShaderNode : public Node {
@@ -718,7 +718,7 @@ public:
 		Vector<Struct> vstructs;
 
 		ShaderNode() :
-				Node(TYPE_SHADER) {}
+				Node(NODE_TYPE_SHADER) {}
 	};
 
 	struct UniformOrderComparator {


### PR DESCRIPTION
Enables `-Wshadow` on all targets and fixes the errors caused by that

Any suggestions on the specific way this is done are welcome, used the method that made sense to me but if some better way is available please suggest it

The trick of `-isystem` solves the issues raised inside the msdfgen headers but can't prevent shadowing of things in our source files from headers marked as such

Tried to, at least in trivial places where I already made changes, to enforce `p_` names for parameters but didn't focus on this where it didn't cause shadowing, as it is quite a big task

My suggestion would be that if/when this gets approved to halt other PRs being merged until this can be verified against the latest codebase, and then rebase everything else before merging to avoid any (though unlikely) new shadowings being introduced

Builds on #76914, which I have copied into this with some modifications to be able to rebase without losing changes, if that gets superseded by this I'll add the changes it made as a separate commit with co-author 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
