### PR TITLE
basis_universal: Update to 1.16.4

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -32,13 +32,16 @@ Files extracted from upstream source:
 ## basis_universal
 
 - Upstream: https://github.com/BinomialLLC/basis_universal
-- Version: git (a91e94c8495d7f470d3df326a364d49324cfd4a3, 2022)
+- Version: 1.16.4 (900e40fb5d2502927360fe2f31762bdbb624455f, 2023)
 - License: Apache 2.0
 
 Files extracted from upstream source:
 
 - `encoder/` and `transcoder/` folders
 - `LICENSE`
+
+Applied upstream PR https://github.com/BinomialLLC/basis_universal/pull/344 to
+fix build with our own copy of zstd (patch in `patches`).
 
 
 ## brotli

--- a/thirdparty/basis_universal/patches/basisu-pr344.patch
+++ b/thirdparty/basis_universal/patches/basisu-pr344.patch
@@ -1,0 +1,43 @@
+From b4a0fa23c13da413d94b99f307e401c3b83e0108 Mon Sep 17 00:00:00 2001
+From: Ondrej Stava <ondrej.stava@gmail.com>
+Date: Fri, 23 Apr 2021 18:59:45 -0700
+Subject: [PATCH] Made it easier to use the library with external zstdlib
+ implementations (mostly in non CMake builds).
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In our internal repository, we have our own version of zstdlib and introducing extra copy is both undesirable and potentially dangerous (due to ODR violations).
+
+Co-authored-by: Rémi Verschelde <rverschelde@gmail.com>
+---
+ encoder/basisu_comp.cpp          | 2 +-
+ transcoder/basisu_transcoder.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/encoder/basisu_comp.cpp b/encoder/basisu_comp.cpp
+index 41eae2b7..4e69e9e2 100644
+--- a/encoder/basisu_comp.cpp
++++ b/encoder/basisu_comp.cpp
+@@ -28,7 +28,7 @@
+ #endif
+ 
+ #if BASISD_SUPPORT_KTX2_ZSTD
+-#include "../zstd/zstd.h"
++#include <zstd.h>
+ #endif
+ 
+ // Set to 1 to disable the mipPadding alignment workaround (which only seems to be needed when no key-values are written at all)
+diff --git a/transcoder/basisu_transcoder.cpp b/transcoder/basisu_transcoder.cpp
+index 3aeba0ee..c698861f 100644
+--- a/transcoder/basisu_transcoder.cpp
++++ b/transcoder/basisu_transcoder.cpp
+@@ -155,7 +155,7 @@
+    // If BASISD_SUPPORT_KTX2_ZSTD is 0, UASTC files compressed with Zstd cannot be loaded.
+ 	#if BASISD_SUPPORT_KTX2_ZSTD
+ 		// We only use two Zstd API's: ZSTD_decompress() and ZSTD_isError()
+-		#include "../zstd/zstd.h"
++		#include <zstd.h>
+ 	#endif
+ #endif
+ 

--- a/thirdparty/basis_universal/transcoder/basisu_transcoder_internal.h
+++ b/thirdparty/basis_universal/transcoder/basisu_transcoder_internal.h
@@ -162,7 +162,7 @@ namespace basist
 				next_code[i + 1] = (total = ((total + syms_using_codesize[i]) << 1));
 			}
 
-			if (((1U << basisu::cHuffmanMaxSupportedInternalCodeSize) != total) && (used_syms > 1U))
+			if (((1U << basisu::cHuffmanMaxSupportedInternalCodeSize) != total) && (used_syms != 1U))
 				return false;
 
 			for (int tree_next = -1, sym_index = 0; sym_index < (int)total_syms; ++sym_index)


### PR DESCRIPTION
Almost no change in practice since the previous commit we tracked, but now this is a tagged release.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
