### PR TITLE
Returns null and does not cache when the source code of the script fails to load

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2592,20 +2592,12 @@ Ref<GDScript> GDScriptLanguage::get_script_by_fully_qualified_name(const String 
 /*************** RESOURCE ***************/
 
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-	if (r_error) {
-		*r_error = ERR_FILE_CANT_OPEN;
-	}
-
 	Error err;
 	Ref<GDScript> scr = GDScriptCache::get_full_script(p_path, err, "", p_cache_mode == CACHE_MODE_IGNORE);
 
-	if (scr.is_null()) {
-		// Don't fail loading because of parsing error.
-		scr.instantiate();
-	}
-
 	if (r_error) {
-		*r_error = OK;
+		// Don't fail loading because of parsing error.
+		*r_error = scr.is_valid() ? OK : err;
 	}
 
 	return scr;

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -253,7 +253,11 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 	Ref<GDScript> script;
 	script.instantiate();
 	script->set_path(p_path, true);
-	script->load_source_code(p_path);
+	r_error = script->load_source_code(p_path);
+
+	if (r_error) {
+		return Ref<GDScript>(); // Returns null and does not cache when the script fails to load.
+	}
 
 	Ref<GDScriptParserRef> parser_ref = get_parser(p_path, GDScriptParserRef::PARSED, r_error);
 	if (r_error == OK) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This usually means that an `ERR_FILE*` error occurred.

Fix #76941.

Previously, using `GDScriptCache::get_full_script()` would ignore errors during loading. Now, all errors are not ignored.
    
Judging in which period the error occurred, it can be judged based on the return value:
1. `null` + err: Error during script loading (`load_source_code()`).
2. `script` + err: Error during script parsing.


