### PR TITLE
Check DBus loading status before attempting to detect its version

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -138,6 +138,11 @@ FreeDesktopPortalDesktop::FreeDesktopPortalDesktop() {
 #else
 	unsupported = false;
 #endif
+
+	if (unsupported) {
+		return;
+	}
+
 	bool ver_ok = false;
 	int version_major = 0;
 	int version_minor = 0;

--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -141,6 +141,11 @@ FreeDesktopScreenSaver::FreeDesktopScreenSaver() {
 #else
 	unsupported = false;
 #endif
+
+	if (unsupported) {
+		return;
+	}
+
 	bool ver_ok = false;
 	int version_major = 0;
 	int version_minor = 0;


### PR DESCRIPTION
Fixes two related segfaults caused by running the DBus version check unconditionally and potentially calling null function pointers.

This was clearly an oversight as all the other wrappers have proper loading status checks.

## Extra notes

Note that I've tested this on my Wayland branch rebased onto master (with also some tasty PR "ports", pushing soon BTW), if for whatever reason the thing turns out to matter.

~~I'd also have implemented this with some early returns (which would've also made the diff smaller) but the code style around the part I touched seemed to indicate a preference for big if blocks. Just letting you know.~~ **Update**: Switched to early returns.