### PR TITLE
[3.x] Linux: Don't use udev for joypad hotloading when running in a sandbox

### DIFF
--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -32,6 +32,8 @@
 
 #include "joypad_linux.h"
 
+#include "core/os/os.h"
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -77,13 +79,41 @@ void JoypadLinux::Joypad::reset() {
 	events.clear();
 }
 
+// This function is derived from SDL:
+// https://github.com/libsdl-org/SDL/blob/main/src/core/linux/SDL_sandbox.c#L28-L45
+static bool detect_sandbox() {
+	if (access("/.flatpak-info", F_OK) == 0) {
+		return true;
+	}
+
+	// For Snap, we check multiple variables because they might be set for
+	// unrelated reasons. This is the same thing WebKitGTK does.
+	if (OS::get_singleton()->has_environment("SNAP") && OS::get_singleton()->has_environment("SNAP_NAME") && OS::get_singleton()->has_environment("SNAP_REVISION")) {
+		return true;
+	}
+
+	if (access("/run/host/container-manager", F_OK) == 0) {
+		return true;
+	}
+
+	return false;
+}
+
 JoypadLinux::JoypadLinux(InputDefault *in) {
 #ifdef UDEV_ENABLED
-	use_udev = initialize_libudev() == 0;
-	if (use_udev) {
-		print_verbose("JoypadLinux: udev enabled and loaded successfully.");
+	if (detect_sandbox()) {
+		// Linux binaries in sandboxes / containers need special handling because
+		// libudev doesn't work there. So we need to fallback to manual parsing
+		// of /dev/input in such case.
+		use_udev = false;
+		print_verbose("JoypadLinux: udev enabled, but detected incompatible sandboxed mode. Falling back to /dev/input to detect joypads.");
 	} else {
-		print_verbose("JoypadLinux: udev enabled, but couldn't be loaded. Falling back to /dev/input to detect joypads.");
+		use_udev = initialize_libudev() == 0;
+		if (use_udev) {
+			print_verbose("JoypadLinux: udev enabled and loaded successfully.");
+		} else {
+			print_verbose("JoypadLinux: udev enabled, but couldn't be loaded. Falling back to /dev/input to detect joypads.");
+		}
 	}
 #else
 	print_verbose("JoypadLinux: udev disabled, parsing /dev/input to detect joypads.");


### PR DESCRIPTION
udev doesn't work in sandboxes, notably the new Steam container runtime as found notably on the Steam Deck, and in Flatpak/Snap packages.

Like SDL does, when we detect such a containerized environment, we fall back to parsing `/dev/input` directly.
See smcv's comments in #76879 for details.

Fixes #76879.

`3.x` backport of #76961.

CC @tcoxon 

I tested this one with Cassette Beasts on Steam Deck and it does seem to solve the issue.

Scenarios tested successfully:
- Connect Xbox controller (bluetooth) while the game is closed. Run the game, Xbox controller is working. Disconnect it, game notifies that it lost connection. Reconnect the Xbox controller, and the game finds it back.
- Same as above, but start with the controller disconnected when launching the game, and connecting the controller once the main menu is up. Also works fine.

It's not fully perfect as there's still the question of which of the two controllers (Xbox controller and Steam Deck builtin controller) the game decides to focus on when using both. Starting with the Xbox controller, disconnecting it, then using the Steam Deck controller will change which device the game expects to use, and then reconnecting the Xbox controller won't make it take precedence again, until changed manually in the Steam controller config. But this might be a game specific issue or a general Steam Deck quirk that may not be an engine bug.