### PR TITLE
Sort the list of addons before saving them

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3302,6 +3302,7 @@ void EditorNode::_update_addon_config() {
 	if (enabled_addons.size() == 0) {
 		ProjectSettings::get_singleton()->set("editor_plugins/enabled", Variant());
 	} else {
+		enabled_addons.sort();
 		ProjectSettings::get_singleton()->set("editor_plugins/enabled", enabled_addons);
 	}
 


### PR DESCRIPTION
Before this PR, addons would be in the order you checked them, which was not deterministic (you got a different order if you re-check an addon from the start or middle of the list). Now, they will be in alphabetical order, which is the same order that is shown visually in the UI already.