### PR TITLE
Fix include text when excluding resources to export

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -242,6 +242,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 
 	export_filter->select(current->get_export_filter());
 	include_filters->set_text(current->get_include_filter());
+	include_label->set_text(current->get_export_filter() == EditorExportPreset::EXCLUDE_SELECTED_RESOURCES ? TTR("Resources to exclude:") : TTR("Resources to export:"));
 	exclude_filters->set_text(current->get_exclude_filter());
 	server_strip_message->set_visible(current->get_export_filter() == EditorExportPreset::EXPORT_CUSTOMIZED);
 
@@ -702,6 +703,7 @@ void ProjectExportDialog::_export_type_changed(int p_which) {
 	if (filter_type == EditorExportPreset::EXPORT_CUSTOMIZED && current->get_customized_files_count() == 0) {
 		current->set_file_export_mode("res://", EditorExportPreset::MODE_FILE_STRIP);
 	}
+	include_label->set_text(current->get_export_filter() == EditorExportPreset::EXCLUDE_SELECTED_RESOURCES ? TTR("Resources to exclude:") : TTR("Resources to export:"));
 
 	updating = true;
 	_fill_resource_tree();


### PR DESCRIPTION
Fix #76705 

The include_label text is updated accordingly to the selected export mode. The text is updated when both opening the export dialog or changing the selected export mode.

Here is the result when selecting the excluding export mode:
![image](https://github.com/godotengine/godot/assets/28391199/520f0334-a6c1-41a7-8ce9-0f63c8c20fc1)

When selecting the other export modes, the result is the same as before:
![image](https://github.com/godotengine/godot/assets/28391199/7148e3df-68f0-46cc-9385-a3d446ab69cb)

**What I have NOT tested:**
- Text translation (TTR): How is the new text "Resources to exclude:" translated? Do I need to register this text somewhere?
- Exporting with command line: exclude export mode works fine with the editor

This is my first contribution, so please tell me what I could have done better (code, PR workflow, issue description, ...) 😃 

Thanks! 