### PR TITLE
Fix 'linux' and specific BSD feature tags

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -494,6 +494,11 @@ bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {
 		return true;
 	}
 
+	// Match against the specific OS (linux, freebsd, etc).
+	if (p_feature == get_name().to_lower()) {
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
After #76540, GDExtension's that have libraries like this are broken:

```
linux.debug.x86_64 = "res://bin/libexample.so"
```

... you now have to change that to:

```
linuxbsd.debug.x86_64 = "res://bin/libexample.so"
```

This also affects project settings that used the ".linux" suffix - those would also need to update to ".linuxbsd".

This PR makes the 'linux' feature tag work on Linux again, and it should also allow specific BSD tags (ex. freebsd, netbsd, etc) which were previously supported as well, but I don't personally have a way to test those.

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/76990.*