### PR TITLE
Add color_utils module

### DIFF
--- a/doc/classes/ColorUtils.xml
+++ b/doc/classes/ColorUtils.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ColorUtils" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A set of color conversion utilities.
+	</brief_description>
+	<description>
+		This class features static methods for converting to and from various color spaces.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="from_abgr32" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="abgr" type="int" />
+			<description>
+				Converts a 32-bit [int] containing ABGR to a [Color].
+			</description>
+		</method>
+		<method name="from_abgr64" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="abgr" type="int" />
+			<description>
+				Converts a 64-bit [int] containing ABGR to a [Color].
+			</description>
+		</method>
+		<method name="from_argb32" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="argb" type="int" />
+			<description>
+				Converts a 32-bit [int] containing ARGB to a [Color].
+			</description>
+		</method>
+		<method name="from_argb64" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="argb" type="int" />
+			<description>
+				Converts a 64-bit [int] containing ARGB to a [Color].
+			</description>
+		</method>
+		<method name="from_hsl" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="hsl" type="Vector3" />
+			<description>
+				Converts a [Vector3] containing [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSL[/url] to a [Color].
+			</description>
+		</method>
+		<method name="from_hsv" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="hsv" type="Vector3" />
+			<description>
+				Converts a [Vector3] containing [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSV[/url] to a [Color].
+			</description>
+		</method>
+		<method name="from_html" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="html" type="String" />
+			<description>
+				Returns a new color from [param html], an HTML hexadecimal color string. [param html] is not case-sensitive, and may be prefixed by a hash sign ([code]#[/code]).
+				[param html] must be a valid three-digit or six-digit hexadecimal color string, and may contain an alpha channel value. If [param html] does not contain an alpha channel value, an alpha channel value of 1.0 is applied. If [param html] is invalid, returns an empty color.
+			</description>
+		</method>
+		<method name="from_name" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Gets a [Color] by its [param name]. [param name] is not case-sensitive, and ignores all characters except letters.
+				The standardized color set is based on the [url=https://en.wikipedia.org/wiki/X11_color_names]X11 color names[/url], with the addition of TRANSPARENT.
+			</description>
+		</method>
+		<method name="from_ok_hsl" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="hsl" type="Vector3" />
+			<description>
+				Converts a [Vector3] containing [url=https://bottosson.github.io/posts/colorpicker]OK HSL[/url] to a [Color].
+			</description>
+		</method>
+		<method name="from_ok_hsv" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="hsv" type="Vector3" />
+			<description>
+				Converts a [Vector3] containing [url=https://bottosson.github.io/posts/colorpicker]OK HSV[/url] to a [Color].
+			</description>
+		</method>
+		<method name="from_rgba32" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="rgba" type="int" />
+			<description>
+				Converts a 32-bit [int] containing RGBA to a [Color].
+			</description>
+		</method>
+		<method name="from_rgba64" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="rgba" type="int" />
+			<description>
+				Converts a 64-bit [int] containing RGBA to a [Color].
+			</description>
+		</method>
+		<method name="from_rgbe9995" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="rgbe" type="int" />
+			<description>
+				Decodes a [Color] from an RGBE9995 format integer. See [constant Image.FORMAT_RGBE9995].
+			</description>
+		</method>
+		<method name="from_string" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="string" type="String" />
+			<param index="1" name="default" type="Color" default="Color(0, 0, 0, 1)" />
+			<description>
+				Creates a [Color] from the given string, which can be either an HTML color code or a named color (case-insensitive). Returns [param default] if the color cannot be inferred from the string.
+			</description>
+		</method>
+		<method name="html_is_valid" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="html" type="String" />
+			<description>
+				Returns [code]true[/code] if [param html] is a valid HTML hexadecimal color string. The string must be a hexadecimal value (case-insensitive) of either 3, 4, 6 or 8 digits, and may be prefixed by a hash sign ([code]#[/code]). This method is identical to [method String.is_valid_html_color].
+			</description>
+		</method>
+		<method name="linear_to_srgb" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Returns the [param color] converted to the [url=https://en.wikipedia.org/wiki/SRGB]sRGB[/url] color space. This method assumes the original color is in the linear color space.
+				See also [method srgb_to_linear] which performs the opposite operation.
+			</description>
+		</method>
+		<method name="name_is_valid" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns [code]true[/code] if [param name] is a valid color name (case-insensitive).
+			</description>
+		</method>
+		<method name="srgb_to_linear" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Returns the [param color] converted to the linear color space. This method assumes the original color is in the [url=https://en.wikipedia.org/wiki/SRGB]sRGB[/url] color space.
+				See also [method linear_to_srgb] which performs the opposite operation.
+			</description>
+		</method>
+		<method name="to_abgr32" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 32-bit [int] containing ABGR.
+			</description>
+		</method>
+		<method name="to_abgr64" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 64-bit [int] containing ABGR.
+			</description>
+		</method>
+		<method name="to_argb32" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 32-bit [int] containing ARGB.
+			</description>
+		</method>
+		<method name="to_argb64" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 64-bit [int] containing ARGB.
+			</description>
+		</method>
+		<method name="to_hsl" qualifiers="static">
+			<return type="Vector3" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a [Vector3] containing [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSL[/url].
+			</description>
+		</method>
+		<method name="to_hsv" qualifiers="static">
+			<return type="Vector3" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a [Vector3] containing [url=https://en.wikipedia.org/wiki/HSL_and_HSV]HSV[/url].
+			</description>
+		</method>
+		<method name="to_html" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="color" type="Color" />
+			<param index="1" name="with_alpha" type="bool" default="true" />
+			<description>
+				Returns the color converted to an HTML hexadecimal color [String] in RGBA format, without the hash ([code]#[/code]) prefix.
+				Setting [param with_alpha] to [code]false[/code], excludes alpha from the hexadecimal string, using RGB format instead of RGBA format.
+			</description>
+		</method>
+		<method name="to_ok_hsl" qualifiers="static">
+			<return type="Vector3" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a [Vector3] containing [url=https://bottosson.github.io/posts/colorpicker]OK HSL[/url].
+			</description>
+		</method>
+		<method name="to_ok_hsv" qualifiers="static">
+			<return type="Vector3" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a [Vector3] containing [url=https://bottosson.github.io/posts/colorpicker]OK HSV[/url].
+			</description>
+		</method>
+		<method name="to_rgba32" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 32-bit [int] containing RGBA.
+			</description>
+		</method>
+		<method name="to_rgba64" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Converts a [Color] to a 64-bit [int] containing RGBA.
+			</description>
+		</method>
+		<method name="to_rgbe9995" qualifiers="static">
+			<return type="int" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Encodes a [Color] to an RGBE9995 format integer. See [constant Image.FORMAT_RGBE9995].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/color_utils/SCsub
+++ b/modules/color_utils/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/color_utils/color_utils.cpp
+++ b/modules/color_utils/color_utils.cpp
@@ -1,0 +1,601 @@
+/**************************************************************************/
+/*  color_utils.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "color_utils.h"
+
+#include "named_colors.h"
+
+#include "core/math/math_defs.h"
+#include "core/math/math_funcs.h"
+#include "core/typedefs.h"
+
+#include "thirdparty/misc/ok_color.h"
+
+void ColorUtils::_bind_methods() {
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("html_is_valid", "html"), &ColorUtils::html_is_valid);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_html", "html"), &ColorUtils::from_html);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("name_is_valid", "name"), &ColorUtils::name_is_valid);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_name", "name"), &ColorUtils::from_name);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_string", "string", "default"), &ColorUtils::from_string, DEFVAL(Color()));
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_hsv", "hsv"), &ColorUtils::from_hsv);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_hsl", "hsl"), &ColorUtils::from_hsl);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_ok_hsv", "hsv"), &ColorUtils::from_ok_hsv);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_ok_hsl", "hsl"), &ColorUtils::from_ok_hsl);
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_rgba32", "rgba"), &ColorUtils::from_rgba32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_argb32", "argb"), &ColorUtils::from_argb32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_abgr32", "abgr"), &ColorUtils::from_abgr32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_rgba64", "rgba"), &ColorUtils::from_rgba64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_argb64", "argb"), &ColorUtils::from_argb64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_abgr64", "abgr"), &ColorUtils::from_abgr64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("from_rgbe9995", "rgbe"), &ColorUtils::from_rgbe9995);
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_html", "color", "with_alpha"), &ColorUtils::to_html, DEFVAL(true));
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_hsv", "color"), &ColorUtils::to_hsv);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_hsl", "color"), &ColorUtils::to_hsl);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_ok_hsv", "color"), &ColorUtils::to_ok_hsv);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_ok_hsl", "color"), &ColorUtils::to_ok_hsl);
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_rgba32", "color"), &ColorUtils::to_rgba32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_argb32", "color"), &ColorUtils::to_argb32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_abgr32", "color"), &ColorUtils::to_abgr32);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_rgba64", "color"), &ColorUtils::to_rgba64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_argb64", "color"), &ColorUtils::to_argb64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_abgr64", "color"), &ColorUtils::to_abgr64);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("to_rgbe9995", "color"), &ColorUtils::to_rgbe9995);
+
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("srgb_to_linear", "color"), &ColorUtils::srgb_to_linear);
+	ClassDB::bind_static_method("ColorUtils", D_METHOD("linear_to_srgb", "color"), &ColorUtils::linear_to_srgb);
+}
+
+static int _parse_col4(const String &p_str, int p_ofs) {
+	char character = p_str[p_ofs];
+
+	if (character >= '0' && character <= '9') {
+		return character - '0';
+	} else if (character >= 'a' && character <= 'f') {
+		return character + (10 - 'a');
+	} else if (character >= 'A' && character <= 'F') {
+		return character + (10 - 'A');
+	}
+
+	return -1;
+}
+
+static int _parse_col8(const String &p_str, int p_ofs) {
+	return _parse_col4(p_str, p_ofs) * 16 + _parse_col4(p_str, p_ofs + 1);
+}
+
+bool ColorUtils::html_is_valid(const String &p_html) {
+	String color = p_html;
+
+	if (color.length() == 0) {
+		return false;
+	}
+	if (color[0] == '#') {
+		color = color.substr(1);
+	}
+
+	// Check if the amount of hex digits is valid.
+	int len = color.length();
+	if (!(len == 3 || len == 4 || len == 6 || len == 8)) {
+		return false;
+	}
+
+	// Check if each hex digit is valid.
+	for (int i = 0; i < len; i++) {
+		if (_parse_col4(color, i) == -1) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+Color ColorUtils::from_html(const String &p_html) {
+	String color = p_html;
+
+	if (color.length() == 0) {
+		return Color();
+	}
+	if (color[0] == '#') {
+		color = color.substr(1);
+	}
+
+	// If enabled, use 1 hex digit per channel instead of 2.
+	// Other sizes aren't in the HTML/CSS spec but we could add them if desired.
+	bool is_shorthand = color.length() < 5;
+	bool with_alpha = false;
+
+	if (color.length() == 8) {
+		with_alpha = true;
+	} else if (color.length() == 6) {
+		with_alpha = false;
+	} else if (color.length() == 4) {
+		with_alpha = true;
+	} else if (color.length() == 3) {
+		with_alpha = false;
+	} else {
+		ERR_FAIL_V_MSG(Color(), "Invalid color code: " + p_html + ".");
+	}
+
+	float r, g, b, a = 1.0f;
+
+	if (is_shorthand) {
+		r = _parse_col4(color, 0) / 15.0f;
+		g = _parse_col4(color, 1) / 15.0f;
+		b = _parse_col4(color, 2) / 15.0f;
+		if (with_alpha) {
+			a = _parse_col4(color, 3) / 15.0f;
+		}
+	} else {
+		r = _parse_col8(color, 0) / 255.0f;
+		g = _parse_col8(color, 2) / 255.0f;
+		b = _parse_col8(color, 4) / 255.0f;
+		if (with_alpha) {
+			a = _parse_col8(color, 6) / 255.0f;
+		}
+	}
+
+	ERR_FAIL_COND_V_MSG(r < 0.0f, Color(), "Invalid color code: " + p_html + ".");
+	ERR_FAIL_COND_V_MSG(g < 0.0f, Color(), "Invalid color code: " + p_html + ".");
+	ERR_FAIL_COND_V_MSG(b < 0.0f, Color(), "Invalid color code: " + p_html + ".");
+	ERR_FAIL_COND_V_MSG(a < 0.0f, Color(), "Invalid color code: " + p_html + ".");
+
+	return Color(r, g, b, a);
+}
+
+static int _get_index(const String &p_name) {
+	String name;
+
+	for (const char32_t *s = p_name.ptr(); *s; s++) {
+		if (is_ascii_upper_case(*s)) {
+			name += *s;
+		} else if (is_ascii_lower_case(*s)) {
+			name += String::char_uppercase(*s);
+		}
+	}
+
+	int index = 0;
+
+	for (const NamedColor &named_color : named_colors) {
+		if (name == named_color.name.replace("_", "")) {
+			return index;
+		}
+
+		index++;
+	}
+
+	return -1;
+}
+
+bool ColorUtils::name_is_valid(const String &p_name) {
+	int index = _get_index(p_name);
+
+	if (index == -1) {
+		return false;
+	}
+
+	return true;
+}
+
+Color ColorUtils::from_name(const String &p_name) {
+	int index = _get_index(p_name);
+
+	if (index == -1) {
+		ERR_FAIL_V_MSG(Color(), "Invalid color name: " + p_name + ".");
+	}
+
+	return named_colors[index].color;
+}
+
+Color ColorUtils::from_string(const String &p_string, const Color &p_default) {
+	if (html_is_valid(p_string)) {
+		return from_html(p_string);
+	}
+
+	int index = _get_index(p_string);
+
+	if (index == -1) {
+		return p_default;
+	}
+
+	return named_colors[index].color;
+}
+
+Color _from_hcxm(float p_h, float p_c, float p_x, float p_m) {
+	p_h = Math::fmod(6.0f * p_h, 6.0f);
+
+	p_c += p_m;
+	p_x += p_m;
+
+	switch (static_cast<int>(p_h)) {
+		case 0:
+			return Color(p_c, p_x, p_m);
+		case 1:
+			return Color(p_x, p_c, p_m);
+		case 2:
+			return Color(p_m, p_c, p_x);
+		case 3:
+			return Color(p_m, p_x, p_c);
+		case 4:
+			return Color(p_x, p_m, p_c);
+		default:
+			return Color(p_c, p_m, p_x);
+	}
+}
+
+Color ColorUtils::from_hsv(const Vector3 &p_hsv) {
+	float h = static_cast<float>(p_hsv.x);
+	float s = static_cast<float>(p_hsv.y);
+	float v = static_cast<float>(p_hsv.z);
+
+	if (s == 0.0f) {
+		return Color(v, v, v);
+	}
+
+	float c = v * s;
+	float x = c * (1.0f - Math::abs(Math::fmod(6.0f * h, 2.0f) - 1.0f));
+	float m = v - c;
+
+	return _from_hcxm(h, c, x, m);
+}
+
+Color ColorUtils::from_hsl(const Vector3 &p_hsl) {
+	float h = static_cast<float>(p_hsl.x);
+	float s = static_cast<float>(p_hsl.y);
+	float l = static_cast<float>(p_hsl.z);
+
+	if (s == 0.0f) {
+		return Color(l, l, l);
+	}
+
+	float c = (1.0f - Math::abs(2.0f * l - 1.0f)) * s;
+	float x = c * (1.0f - Math::abs(Math::fmod(6.0f * h, 2.0f) - 1.0f));
+	float m = l - c / 2.0f;
+
+	return _from_hcxm(h, c, x, m);
+}
+
+Color ColorUtils::from_ok_hsv(const Vector3 &p_hsv) {
+	float h = static_cast<float>(p_hsv.x);
+	float s = static_cast<float>(p_hsv.y);
+	float v = static_cast<float>(p_hsv.z);
+
+	ok_color::HSV hsv = { h, s, v };
+	ok_color::RGB rgb = ok_color::okhsv_to_srgb(hsv);
+
+	return Color(rgb.r, rgb.g, rgb.b);
+}
+
+Color ColorUtils::from_ok_hsl(const Vector3 &p_hsl) {
+	float h = static_cast<float>(p_hsl.x);
+	float s = static_cast<float>(p_hsl.y);
+	float l = static_cast<float>(p_hsl.z);
+
+	ok_color::HSL hsl = { h, s, l };
+	ok_color::RGB rgb = ok_color::okhsl_to_srgb(hsl);
+
+	return Color(rgb.r, rgb.g, rgb.b);
+}
+
+Color ColorUtils::from_rgba32(uint32_t p_rgba) {
+	float a = (p_rgba & 0xFF) / 255.0f;
+	p_rgba >>= 8;
+	float b = (p_rgba & 0xFF) / 255.0f;
+	p_rgba >>= 8;
+	float g = (p_rgba & 0xFF) / 255.0f;
+	p_rgba >>= 8;
+	float r = (p_rgba & 0xFF) / 255.0f;
+
+	return Color(r, g, b, a);
+}
+
+Color ColorUtils::from_argb32(uint32_t p_argb) {
+	Color color = from_rgba32(p_argb);
+
+	return Color(color.a, color.r, color.g, color.b);
+}
+
+Color ColorUtils::from_abgr32(uint32_t p_abgr) {
+	Color color = from_rgba32(p_abgr);
+
+	return Color(color.a, color.b, color.g, color.r);
+}
+
+Color ColorUtils::from_rgba64(uint64_t p_rgba) {
+	float a = (p_rgba & 0xFFFF) / 65535.0f;
+	p_rgba >>= 16;
+	float b = (p_rgba & 0xFFFF) / 65535.0f;
+	p_rgba >>= 16;
+	float g = (p_rgba & 0xFFFF) / 65535.0f;
+	p_rgba >>= 16;
+	float r = (p_rgba & 0xFFFF) / 65535.0f;
+
+	return Color(r, g, b, a);
+}
+
+Color ColorUtils::from_argb64(uint64_t p_argb) {
+	Color color = from_rgba64(p_argb);
+
+	return Color(color.a, color.r, color.g, color.b);
+}
+
+Color ColorUtils::from_abgr64(uint64_t p_abgr) {
+	Color color = from_rgba64(p_abgr);
+
+	return Color(color.a, color.b, color.g, color.r);
+}
+
+Color ColorUtils::from_rgbe9995(uint32_t p_rgbe) {
+	float r = p_rgbe & 0x1ff;
+	float g = (p_rgbe >> 9) & 0x1ff;
+	float b = (p_rgbe >> 18) & 0x1ff;
+	float e = (p_rgbe >> 27);
+	float m = Math::pow(2.0f, e - 15.0f - 9.0f);
+
+	float rd = r * m;
+	float gd = g * m;
+	float bd = b * m;
+
+	return Color(rd, gd, bd, 1.0f);
+}
+
+static String _to_hex(float p_val) {
+	String hex;
+
+	int v = Math::round(p_val * 255.0f);
+	v = CLAMP(v, 0, 255);
+
+	for (int i = 0; i < 2; i++) {
+		char32_t c[2] = { 0, 0 };
+		int lv = v & 0xF;
+		if (lv < 10) {
+			c[0] = '0' + lv;
+		} else {
+			c[0] = 'a' + lv - 10;
+		}
+
+		v >>= 4;
+		String cs = const_cast<const char32_t *>(c);
+		hex = cs + hex;
+	}
+
+	return hex;
+}
+
+String ColorUtils::to_html(const Color &p_color, bool p_with_alpha) {
+	String html;
+
+	html += _to_hex(p_color.r);
+	html += _to_hex(p_color.g);
+	html += _to_hex(p_color.b);
+
+	if (p_with_alpha) {
+		html += _to_hex(p_color.a);
+	}
+
+	return html;
+}
+
+static float _calc_hue(const Color &p_color, float p_max, float p_delta) {
+	if (p_delta == 0.0f) {
+		return 0.0f;
+	}
+
+	float h;
+	if (p_color.r == p_max) {
+		h = 0.0f + (p_color.g - p_color.b) / p_delta;
+	} else if (p_color.g == p_max) {
+		h = 2.0f + (p_color.b - p_color.r) / p_delta;
+	} else {
+		h = 4.0f + (p_color.r - p_color.g) / p_delta;
+	}
+
+	return Math::fposmod(h / 6.0f, 1.0f);
+}
+
+Vector3 ColorUtils::to_hsv(const Color &p_color) {
+	float min = MIN(MIN(p_color.r, p_color.g), p_color.b);
+	float max = MAX(MAX(p_color.r, p_color.g), p_color.b);
+	float delta = max - min;
+
+	float v = max;
+	float s = (v != 0.0f) ? (delta / v) : 0.0f;
+	float h = _calc_hue(p_color, max, delta);
+
+	return Vector3(static_cast<real_t>(h), static_cast<real_t>(s), static_cast<real_t>(v));
+}
+
+Vector3 ColorUtils::to_hsl(const Color &p_color) {
+	float min = MIN(MIN(p_color.r, p_color.g), p_color.b);
+	float max = MAX(MAX(p_color.r, p_color.g), p_color.b);
+	float delta = max - min;
+
+	float l = (min + max) / 2.0f;
+	float s = (l != 0.0f && l != 1.0f) ? (delta / (1.0f - Math::abs(2.0f * l - 1.0f))) : 0.0f;
+	float h = _calc_hue(p_color, max, delta);
+
+	return Vector3(static_cast<real_t>(h), static_cast<real_t>(s), static_cast<real_t>(l));
+}
+
+static float _clamp_safe(float p_value) {
+	if (Math::is_nan(p_value)) {
+		return 0.0f;
+	}
+
+	return CLAMP(p_value, 0.0f, 1.0f);
+}
+
+Vector3 ColorUtils::to_ok_hsv(const Color &p_color) {
+	if (p_color.r == p_color.g && p_color.g == p_color.b) {
+		// Fallback to avoid edge cases with NaN value.
+		return to_ok_hsl(p_color);
+	}
+
+	ok_color::RGB rgb = { p_color.r, p_color.g, p_color.b };
+	ok_color::HSV hsv = ok_color::srgb_to_okhsv(rgb);
+
+	hsv.h = _clamp_safe(hsv.h);
+	hsv.s = _clamp_safe(hsv.s);
+	hsv.v = _clamp_safe(hsv.v);
+
+	return Vector3(static_cast<real_t>(hsv.h), static_cast<real_t>(hsv.s), static_cast<real_t>(hsv.v));
+}
+
+Vector3 ColorUtils::to_ok_hsl(const Color &p_color) {
+	ok_color::RGB rgb = { p_color.r, p_color.g, p_color.b };
+	ok_color::HSL hsl = ok_color::srgb_to_okhsl(rgb);
+
+	if (p_color.r == p_color.g && p_color.g == p_color.b) {
+		hsl.h = 0.0f;
+		hsl.s = 0.0f;
+	}
+
+	hsl.h = _clamp_safe(hsl.h);
+	hsl.s = _clamp_safe(hsl.s);
+	hsl.l = _clamp_safe(hsl.l);
+
+	return Vector3(static_cast<real_t>(hsl.h), static_cast<real_t>(hsl.s), static_cast<real_t>(hsl.l));
+}
+
+uint32_t ColorUtils::to_rgba32(const Color &p_color) {
+	uint32_t rgba = static_cast<uint8_t>(Math::round(p_color.r * 255.0f));
+	rgba <<= 8;
+	rgba |= static_cast<uint8_t>(Math::round(p_color.g * 255.0f));
+	rgba <<= 8;
+	rgba |= static_cast<uint8_t>(Math::round(p_color.b * 255.0f));
+	rgba <<= 8;
+	rgba |= static_cast<uint8_t>(Math::round(p_color.a * 255.0f));
+
+	return rgba;
+}
+
+uint32_t ColorUtils::to_argb32(const Color &p_color) {
+	Color color = Color(p_color.a, p_color.r, p_color.g, p_color.b);
+
+	return to_rgba32(color);
+}
+
+uint32_t ColorUtils::to_abgr32(const Color &p_color) {
+	Color color = Color(p_color.a, p_color.b, p_color.g, p_color.r);
+
+	return to_rgba32(color);
+}
+
+uint64_t ColorUtils::to_rgba64(const Color &p_color) {
+	uint64_t rgba = static_cast<uint16_t>(Math::round(p_color.r * 65535.0f));
+	rgba <<= 16;
+	rgba |= static_cast<uint16_t>(Math::round(p_color.g * 65535.0f));
+	rgba <<= 16;
+	rgba |= static_cast<uint16_t>(Math::round(p_color.b * 65535.0f));
+	rgba <<= 16;
+	rgba |= static_cast<uint16_t>(Math::round(p_color.a * 65535.0f));
+
+	return rgba;
+}
+
+uint64_t ColorUtils::to_argb64(const Color &p_color) {
+	Color color = Color(p_color.a, p_color.r, p_color.g, p_color.b);
+
+	return to_rgba64(color);
+}
+
+uint64_t ColorUtils::to_abgr64(const Color &p_color) {
+	Color color = Color(p_color.a, p_color.b, p_color.g, p_color.r);
+
+	return to_rgba64(color);
+}
+
+uint32_t ColorUtils::to_rgbe9995(const Color &p_color) {
+	const float pow2to9 = 512.0f;
+	const float B = 15.0f;
+	const float N = 9.0f;
+
+	// Result of: ((pow2to9 - 1.0f) / pow2to9) * powf(2.0f, 31.0f - 15.0f).
+	float sharedexp = 65408.000f;
+	float cRed = MAX(0.0f, MIN(sharedexp, p_color.r));
+	float cGreen = MAX(0.0f, MIN(sharedexp, p_color.g));
+	float cBlue = MAX(0.0f, MIN(sharedexp, p_color.b));
+
+	float cMax = MAX(cRed, MAX(cGreen, cBlue));
+	float expp = MAX(-B - 1.0f, Math::floor(Math::log(cMax) / static_cast<real_t>(Math_LN2))) + 1.0f + B;
+	float sMax = Math::floor((cMax / Math::pow(2.0f, expp - B - N)) + 0.5f);
+	float exps = expp + 1.0f;
+
+	if (0.0f <= sMax && sMax < pow2to9) {
+		exps = expp;
+	}
+
+	float sRed = Math::floor((cRed / Math::pow(2.0f, exps - B - N)) + 0.5f);
+	float sGreen = Math::floor((cGreen / Math::pow(2.0f, exps - B - N)) + 0.5f);
+	float sBlue = Math::floor((cBlue / Math::pow(2.0f, exps - B - N)) + 0.5f);
+
+	uint32_t r = (static_cast<uint32_t>(Math::fast_ftoi(sRed)) & 0x1FF);
+	uint32_t g = (static_cast<uint32_t>(Math::fast_ftoi(sGreen)) & 0x1FF) << 9;
+	uint32_t b = (static_cast<uint32_t>(Math::fast_ftoi(sBlue)) & 0x1FF) << 18;
+	uint32_t e = (static_cast<uint32_t>(Math::fast_ftoi(exps)) & 0x1F) << 27;
+
+	return r | g | b | e;
+}
+
+float _srgb_to_linear(float x) {
+	if (x <= 0.04045f) {
+		return x / 12.92f;
+	} else {
+		return Math::pow((x + 0.055f) / 1.055f, 2.4f);
+	}
+}
+
+Color ColorUtils::srgb_to_linear(const Color &p_color) {
+	float r = _srgb_to_linear(p_color.r);
+	float g = _srgb_to_linear(p_color.g);
+	float b = _srgb_to_linear(p_color.b);
+
+	return Color(r, g, b, p_color.a);
+}
+
+float _linear_to_srgb(float x) {
+	if (x <= 0.0031308f) {
+		return x * 12.92f;
+	} else {
+		return 1.055f * Math::pow(x, 0.4166666666666667f) - 0.055f;
+	}
+}
+
+Color ColorUtils::linear_to_srgb(const Color &p_color) {
+	float r = _linear_to_srgb(p_color.r);
+	float g = _linear_to_srgb(p_color.g);
+	float b = _linear_to_srgb(p_color.b);
+
+	return Color(r, g, b, p_color.a);
+}

--- a/modules/color_utils/color_utils.h
+++ b/modules/color_utils/color_utils.h
@@ -1,0 +1,85 @@
+/**************************************************************************/
+/*  color_utils.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef COLOR_UTILS_H
+#define COLOR_UTILS_H
+
+#include "core/math/color.h"
+#include "core/math/vector3.h"
+#include "core/object/class_db.h"
+#include "core/object/object.h"
+#include "core/string/ustring.h"
+
+class ColorUtils : public Object {
+	GDCLASS(ColorUtils, Object);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static bool html_is_valid(const String &p_html);
+	static Color from_html(const String &p_html);
+	static bool name_is_valid(const String &p_name);
+	static Color from_name(const String &p_name);
+	static Color from_string(const String &p_string, const Color &p_default = Color());
+
+	static Color from_hsv(const Vector3 &p_hsv);
+	static Color from_hsl(const Vector3 &p_hsl);
+	static Color from_ok_hsv(const Vector3 &p_hsv);
+	static Color from_ok_hsl(const Vector3 &p_hsl);
+
+	static Color from_rgba32(uint32_t p_rgba);
+	static Color from_argb32(uint32_t p_argb);
+	static Color from_abgr32(uint32_t p_abgr);
+	static Color from_rgba64(uint64_t p_rgba);
+	static Color from_argb64(uint64_t p_argb);
+	static Color from_abgr64(uint64_t p_abgr);
+	static Color from_rgbe9995(uint32_t p_rgbe);
+
+	static String to_html(const Color &p_color, bool p_with_alpha = true);
+
+	static Vector3 to_hsv(const Color &p_color);
+	static Vector3 to_hsl(const Color &p_color);
+	static Vector3 to_ok_hsv(const Color &p_color);
+	static Vector3 to_ok_hsl(const Color &p_color);
+
+	static uint32_t to_rgba32(const Color &p_color);
+	static uint32_t to_argb32(const Color &p_color);
+	static uint32_t to_abgr32(const Color &p_color);
+	static uint64_t to_rgba64(const Color &p_color);
+	static uint64_t to_argb64(const Color &p_color);
+	static uint64_t to_abgr64(const Color &p_color);
+	static uint32_t to_rgbe9995(const Color &p_color);
+
+	static Color srgb_to_linear(const Color &p_color);
+	static Color linear_to_srgb(const Color &p_color);
+};
+
+#endif // COLOR_UTILS_H

--- a/modules/color_utils/config.py
+++ b/modules/color_utils/config.py
@@ -1,0 +1,6 @@
+def can_build(env, platform):
+    return True
+
+
+def configure(env):
+    pass

--- a/modules/color_utils/named_colors.h
+++ b/modules/color_utils/named_colors.h
@@ -1,0 +1,198 @@
+/**************************************************************************/
+/*  named_colors.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NAMED_COLORS_H
+#define NAMED_COLORS_H
+
+#include "color_utils.h"
+
+#include "core/math/color.h"
+#include "core/string/ustring.h"
+
+// Names from https://en.wikipedia.org/wiki/X11_color_names
+
+struct NamedColor {
+	String name;
+	Color color;
+};
+
+// NOTE: This data is duplicated in the file:
+// modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+
+static NamedColor named_colors[] = {
+	{ String("ALICE_BLUE"), ColorUtils::from_rgba32(0xF0F8FFFF) },
+	{ String("ANTIQUE_WHITE"), ColorUtils::from_rgba32(0xFAEBD7FF) },
+	{ String("AQUA"), ColorUtils::from_rgba32(0x00FFFFFF) },
+	{ String("AQUAMARINE"), ColorUtils::from_rgba32(0x7FFFD4FF) },
+	{ String("AZURE"), ColorUtils::from_rgba32(0xF0FFFFFF) },
+	{ String("BEIGE"), ColorUtils::from_rgba32(0xF5F5DCFF) },
+	{ String("BISQUE"), ColorUtils::from_rgba32(0xFFE4C4FF) },
+	{ String("BLACK"), ColorUtils::from_rgba32(0x000000FF) },
+	{ String("BLANCHED_ALMOND"), ColorUtils::from_rgba32(0xFFEBCDFF) },
+	{ String("BLUE"), ColorUtils::from_rgba32(0x0000FFFF) },
+	{ String("BLUE_VIOLET"), ColorUtils::from_rgba32(0x8A2BE2FF) },
+	{ String("BROWN"), ColorUtils::from_rgba32(0xA52A2AFF) },
+	{ String("BURLYWOOD"), ColorUtils::from_rgba32(0xDEB887FF) },
+	{ String("CADET_BLUE"), ColorUtils::from_rgba32(0x5F9EA0FF) },
+	{ String("CHARTREUSE"), ColorUtils::from_rgba32(0x7FFF00FF) },
+	{ String("CHOCOLATE"), ColorUtils::from_rgba32(0xD2691EFF) },
+	{ String("CORAL"), ColorUtils::from_rgba32(0xFF7F50FF) },
+	{ String("CORNFLOWER_BLUE"), ColorUtils::from_rgba32(0x6495EDFF) },
+	{ String("CORNSILK"), ColorUtils::from_rgba32(0xFFF8DCFF) },
+	{ String("CRIMSON"), ColorUtils::from_rgba32(0xDC143CFF) },
+	{ String("CYAN"), ColorUtils::from_rgba32(0x00FFFFFF) },
+	{ String("DARK_BLUE"), ColorUtils::from_rgba32(0x00008BFF) },
+	{ String("DARK_CYAN"), ColorUtils::from_rgba32(0x008B8BFF) },
+	{ String("DARK_GOLDENROD"), ColorUtils::from_rgba32(0xB8860BFF) },
+	{ String("DARK_GRAY"), ColorUtils::from_rgba32(0xA9A9A9FF) },
+	{ String("DARK_GREEN"), ColorUtils::from_rgba32(0x006400FF) },
+	{ String("DARK_KHAKI"), ColorUtils::from_rgba32(0xBDB76BFF) },
+	{ String("DARK_MAGENTA"), ColorUtils::from_rgba32(0x8B008BFF) },
+	{ String("DARK_OLIVE_GREEN"), ColorUtils::from_rgba32(0x556B2FFF) },
+	{ String("DARK_ORANGE"), ColorUtils::from_rgba32(0xFF8C00FF) },
+	{ String("DARK_ORCHID"), ColorUtils::from_rgba32(0x9932CCFF) },
+	{ String("DARK_RED"), ColorUtils::from_rgba32(0x8B0000FF) },
+	{ String("DARK_SALMON"), ColorUtils::from_rgba32(0xE9967AFF) },
+	{ String("DARK_SEA_GREEN"), ColorUtils::from_rgba32(0x8FBC8FFF) },
+	{ String("DARK_SLATE_BLUE"), ColorUtils::from_rgba32(0x483D8BFF) },
+	{ String("DARK_SLATE_GRAY"), ColorUtils::from_rgba32(0x2F4F4FFF) },
+	{ String("DARK_TURQUOISE"), ColorUtils::from_rgba32(0x00CED1FF) },
+	{ String("DARK_VIOLET"), ColorUtils::from_rgba32(0x9400D3FF) },
+	{ String("DEEP_PINK"), ColorUtils::from_rgba32(0xFF1493FF) },
+	{ String("DEEP_SKY_BLUE"), ColorUtils::from_rgba32(0x00BFFFFF) },
+	{ String("DIM_GRAY"), ColorUtils::from_rgba32(0x696969FF) },
+	{ String("DODGER_BLUE"), ColorUtils::from_rgba32(0x1E90FFFF) },
+	{ String("FIREBRICK"), ColorUtils::from_rgba32(0xB22222FF) },
+	{ String("FLORAL_WHITE"), ColorUtils::from_rgba32(0xFFFAF0FF) },
+	{ String("FOREST_GREEN"), ColorUtils::from_rgba32(0x228B22FF) },
+	{ String("FUCHSIA"), ColorUtils::from_rgba32(0xFF00FFFF) },
+	{ String("GAINSBORO"), ColorUtils::from_rgba32(0xDCDCDCFF) },
+	{ String("GHOST_WHITE"), ColorUtils::from_rgba32(0xF8F8FFFF) },
+	{ String("GOLD"), ColorUtils::from_rgba32(0xFFD700FF) },
+	{ String("GOLDENROD"), ColorUtils::from_rgba32(0xDAA520FF) },
+	{ String("GRAY"), ColorUtils::from_rgba32(0xBEBEBEFF) },
+	{ String("GREEN"), ColorUtils::from_rgba32(0x00FF00FF) },
+	{ String("GREEN_YELLOW"), ColorUtils::from_rgba32(0xADFF2FFF) },
+	{ String("HONEYDEW"), ColorUtils::from_rgba32(0xF0FFF0FF) },
+	{ String("HOT_PINK"), ColorUtils::from_rgba32(0xFF69B4FF) },
+	{ String("INDIAN_RED"), ColorUtils::from_rgba32(0xCD5C5CFF) },
+	{ String("INDIGO"), ColorUtils::from_rgba32(0x4B0082FF) },
+	{ String("IVORY"), ColorUtils::from_rgba32(0xFFFFF0FF) },
+	{ String("KHAKI"), ColorUtils::from_rgba32(0xF0E68CFF) },
+	{ String("LAVENDER"), ColorUtils::from_rgba32(0xE6E6FAFF) },
+	{ String("LAVENDER_BLUSH"), ColorUtils::from_rgba32(0xFFF0F5FF) },
+	{ String("LAWN_GREEN"), ColorUtils::from_rgba32(0x7CFC00FF) },
+	{ String("LEMON_CHIFFON"), ColorUtils::from_rgba32(0xFFFACDFF) },
+	{ String("LIGHT_BLUE"), ColorUtils::from_rgba32(0xADD8E6FF) },
+	{ String("LIGHT_CORAL"), ColorUtils::from_rgba32(0xF08080FF) },
+	{ String("LIGHT_CYAN"), ColorUtils::from_rgba32(0xE0FFFFFF) },
+	{ String("LIGHT_GOLDENROD"), ColorUtils::from_rgba32(0xFAFAD2FF) },
+	{ String("LIGHT_GRAY"), ColorUtils::from_rgba32(0xD3D3D3FF) },
+	{ String("LIGHT_GREEN"), ColorUtils::from_rgba32(0x90EE90FF) },
+	{ String("LIGHT_PINK"), ColorUtils::from_rgba32(0xFFB6C1FF) },
+	{ String("LIGHT_SALMON"), ColorUtils::from_rgba32(0xFFA07AFF) },
+	{ String("LIGHT_SEA_GREEN"), ColorUtils::from_rgba32(0x20B2AAFF) },
+	{ String("LIGHT_SKY_BLUE"), ColorUtils::from_rgba32(0x87CEFAFF) },
+	{ String("LIGHT_SLATE_GRAY"), ColorUtils::from_rgba32(0x778899FF) },
+	{ String("LIGHT_STEEL_BLUE"), ColorUtils::from_rgba32(0xB0C4DEFF) },
+	{ String("LIGHT_YELLOW"), ColorUtils::from_rgba32(0xFFFFE0FF) },
+	{ String("LIME"), ColorUtils::from_rgba32(0x00FF00FF) },
+	{ String("LIME_GREEN"), ColorUtils::from_rgba32(0x32CD32FF) },
+	{ String("LINEN"), ColorUtils::from_rgba32(0xFAF0E6FF) },
+	{ String("MAGENTA"), ColorUtils::from_rgba32(0xFF00FFFF) },
+	{ String("MAROON"), ColorUtils::from_rgba32(0xB03060FF) },
+	{ String("MEDIUM_AQUAMARINE"), ColorUtils::from_rgba32(0x66CDAAFF) },
+	{ String("MEDIUM_BLUE"), ColorUtils::from_rgba32(0x0000CDFF) },
+	{ String("MEDIUM_ORCHID"), ColorUtils::from_rgba32(0xBA55D3FF) },
+	{ String("MEDIUM_PURPLE"), ColorUtils::from_rgba32(0x9370DBFF) },
+	{ String("MEDIUM_SEA_GREEN"), ColorUtils::from_rgba32(0x3CB371FF) },
+	{ String("MEDIUM_SLATE_BLUE"), ColorUtils::from_rgba32(0x7B68EEFF) },
+	{ String("MEDIUM_SPRING_GREEN"), ColorUtils::from_rgba32(0x00FA9AFF) },
+	{ String("MEDIUM_TURQUOISE"), ColorUtils::from_rgba32(0x48D1CCFF) },
+	{ String("MEDIUM_VIOLET_RED"), ColorUtils::from_rgba32(0xC71585FF) },
+	{ String("MIDNIGHT_BLUE"), ColorUtils::from_rgba32(0x191970FF) },
+	{ String("MINT_CREAM"), ColorUtils::from_rgba32(0xF5FFFAFF) },
+	{ String("MISTY_ROSE"), ColorUtils::from_rgba32(0xFFE4E1FF) },
+	{ String("MOCCASIN"), ColorUtils::from_rgba32(0xFFE4B5FF) },
+	{ String("NAVAJO_WHITE"), ColorUtils::from_rgba32(0xFFDEADFF) },
+	{ String("NAVY_BLUE"), ColorUtils::from_rgba32(0x000080FF) },
+	{ String("OLD_LACE"), ColorUtils::from_rgba32(0xFDF5E6FF) },
+	{ String("OLIVE"), ColorUtils::from_rgba32(0x808000FF) },
+	{ String("OLIVE_DRAB"), ColorUtils::from_rgba32(0x6B8E23FF) },
+	{ String("ORANGE"), ColorUtils::from_rgba32(0xFFA500FF) },
+	{ String("ORANGE_RED"), ColorUtils::from_rgba32(0xFF4500FF) },
+	{ String("ORCHID"), ColorUtils::from_rgba32(0xDA70D6FF) },
+	{ String("PALE_GOLDENROD"), ColorUtils::from_rgba32(0xEEE8AAFF) },
+	{ String("PALE_GREEN"), ColorUtils::from_rgba32(0x98FB98FF) },
+	{ String("PALE_TURQUOISE"), ColorUtils::from_rgba32(0xAFEEEEFF) },
+	{ String("PALE_VIOLET_RED"), ColorUtils::from_rgba32(0xDB7093FF) },
+	{ String("PAPAYA_WHIP"), ColorUtils::from_rgba32(0xFFEFD5FF) },
+	{ String("PEACH_PUFF"), ColorUtils::from_rgba32(0xFFDAB9FF) },
+	{ String("PERU"), ColorUtils::from_rgba32(0xCD853FFF) },
+	{ String("PINK"), ColorUtils::from_rgba32(0xFFC0CBFF) },
+	{ String("PLUM"), ColorUtils::from_rgba32(0xDDA0DDFF) },
+	{ String("POWDER_BLUE"), ColorUtils::from_rgba32(0xB0E0E6FF) },
+	{ String("PURPLE"), ColorUtils::from_rgba32(0xA020F0FF) },
+	{ String("REBECCA_PURPLE"), ColorUtils::from_rgba32(0x663399FF) },
+	{ String("RED"), ColorUtils::from_rgba32(0xFF0000FF) },
+	{ String("ROSY_BROWN"), ColorUtils::from_rgba32(0xBC8F8FFF) },
+	{ String("ROYAL_BLUE"), ColorUtils::from_rgba32(0x4169E1FF) },
+	{ String("SADDLE_BROWN"), ColorUtils::from_rgba32(0x8B4513FF) },
+	{ String("SALMON"), ColorUtils::from_rgba32(0xFA8072FF) },
+	{ String("SANDY_BROWN"), ColorUtils::from_rgba32(0xF4A460FF) },
+	{ String("SEA_GREEN"), ColorUtils::from_rgba32(0x2E8B57FF) },
+	{ String("SEASHELL"), ColorUtils::from_rgba32(0xFFF5EEFF) },
+	{ String("SIENNA"), ColorUtils::from_rgba32(0xA0522DFF) },
+	{ String("SILVER"), ColorUtils::from_rgba32(0xC0C0C0FF) },
+	{ String("SKY_BLUE"), ColorUtils::from_rgba32(0x87CEEBFF) },
+	{ String("SLATE_BLUE"), ColorUtils::from_rgba32(0x6A5ACDFF) },
+	{ String("SLATE_GRAY"), ColorUtils::from_rgba32(0x708090FF) },
+	{ String("SNOW"), ColorUtils::from_rgba32(0xFFFAFAFF) },
+	{ String("SPRING_GREEN"), ColorUtils::from_rgba32(0x00FF7FFF) },
+	{ String("STEEL_BLUE"), ColorUtils::from_rgba32(0x4682B4FF) },
+	{ String("TAN"), ColorUtils::from_rgba32(0xD2B48CFF) },
+	{ String("TEAL"), ColorUtils::from_rgba32(0x008080FF) },
+	{ String("THISTLE"), ColorUtils::from_rgba32(0xD8BFD8FF) },
+	{ String("TOMATO"), ColorUtils::from_rgba32(0xFF6347FF) },
+	{ String("TRANSPARENT"), ColorUtils::from_rgba32(0xFFFFFF00) },
+	{ String("TURQUOISE"), ColorUtils::from_rgba32(0x40E0D0FF) },
+	{ String("VIOLET"), ColorUtils::from_rgba32(0xEE82EEFF) },
+	{ String("WEB_GRAY"), ColorUtils::from_rgba32(0x808080FF) },
+	{ String("WEB_GREEN"), ColorUtils::from_rgba32(0x008000FF) },
+	{ String("WEB_MAROON"), ColorUtils::from_rgba32(0x800000FF) },
+	{ String("WEB_PURPLE"), ColorUtils::from_rgba32(0x800080FF) },
+	{ String("WHEAT"), ColorUtils::from_rgba32(0xF5DEB3FF) },
+	{ String("WHITE"), ColorUtils::from_rgba32(0xFFFFFFFF) },
+	{ String("WHITE_SMOKE"), ColorUtils::from_rgba32(0xF5F5F5FF) },
+	{ String("YELLOW"), ColorUtils::from_rgba32(0xFFFF00FF) },
+	{ String("YELLOW_GREEN"), ColorUtils::from_rgba32(0x9ACD32FF) },
+};
+
+#endif // NAMED_COLORS_H

--- a/modules/color_utils/register_types.cpp
+++ b/modules/color_utils/register_types.cpp
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "color_utils.h"
+
+void initialize_color_utils_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	GDREGISTER_CLASS(ColorUtils);
+}
+
+void uninitialize_color_utils_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}

--- a/modules/color_utils/register_types.h
+++ b/modules/color_utils/register_types.h
@@ -1,0 +1,34 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "modules/register_module_types.h"
+
+void initialize_color_utils_module(ModuleInitializationLevel p_level);
+void uninitialize_color_utils_module(ModuleInitializationLevel p_level);


### PR DESCRIPTION
Color space conversion outside of engine core.
Fixes: https://github.com/godotengine/godot-proposals/issues/6753

Demo project: [Color Demo.zip](https://github.com/godotengine/godot/files/11470087/Color.Demo.zip)
![Color Demo](https://github.com/godotengine/godot/assets/43251584/c80b235a-2ce8-42c3-945a-306a103dacc0)