### PR TITLE
[3.x] Fix input ANR in the Godot Android editor

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -661,6 +661,7 @@ bool InputDefault::is_emulating_touch_from_mouse() const {
 // Calling this whenever the game window is focused helps unstucking the "touch mouse"
 // if the OS or its abstraction class hasn't properly reported that touch pointers raised
 void InputDefault::ensure_touch_mouse_raised() {
+	_THREAD_SAFE_METHOD_
 	if (mouse_from_touch_index != -1) {
 		mouse_from_touch_index = -1;
 


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/76400 to fix input ANR in the Godot Android editor

[main version](https://github.com/godotengine/godot/pull/76980)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
