### PR TITLE
Add a default keyboard shortcut to take a screenshot in a running project

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -351,6 +351,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_filedialog_refresh",                         TTRC("Refresh") },
     { "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
     { "ui_swap_input_direction ",                      TTRC("Swap Input Direction") },
+    { "ui_take_screenshot",                            TTRC("Take Screenshot") },
     { "",                                              ""}
 	/* clang-format on */
 };
@@ -723,6 +724,11 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::QUOTELEFT | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_swap_input_direction", inputs);
+
+	// ///// Miscellaneous Shortcuts /////
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::F12));
+	default_builtin_cache.insert("ui_take_screenshot", inputs);
 
 	return default_builtin_cache;
 }

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1087,6 +1087,10 @@
 		<member name="input/ui_swap_input_direction" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to swap input direction, i.e. change between left-to-right to right-to-left modes. Affects text-editting controls ([LineEdit], [TextEdit]).
 		</member>
+		<member name="input/ui_take_screenshot" type="Dictionary" setter="" getter="">
+			Saves a screenshot in PNG format to [code]user://screenshot_YYYY-MM-DDTHHMMSS.png[/code]. The path to the screenshot is printed to standard output after taking the screenshot.
+			[b]Note:[/b] If the project uses the [code]viewport[/code] [member display/window/stretch/mode], the screenshot's dimensions will match the base window size defined by [member display/window/size/viewport_width] and [member display/window/size/viewport_height] instead of the current window size.
+		</member>
 		<member name="input/ui_text_add_selection_for_next_occurrence" type="Dictionary" setter="" getter="">
 			If a selection is currently active with the last caret in text fields, searches for the next occurrence of the selection, adds a caret and selects the next occurrence.
 			If no selection is currently active with the last caret in text fields, selects the word currently under the caret.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -33,6 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"
+#include "core/io/dir_access.h"
+#include "core/os/time.h"
 #include "core/string/translation.h"
 #include "core/variant/variant_parser.h"
 #include "scene/gui/control.h"
@@ -1541,6 +1543,32 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 	if (p_ev->get_device() != InputEvent::DEVICE_ID_INTERNAL) {
 		emit_signal(SceneStringNames::get_singleton()->window_input, p_ev);
+	}
+
+	if (!Engine::get_singleton()->is_editor_hint() && p_ev->is_action_pressed("ui_take_screenshot")) {
+		// The editor already has its own screenshot taking functionality.
+		const Ref<ViewportTexture> texture = get_texture();
+		ERR_FAIL_COND_MSG(texture.is_null(), "Cannot get a viewport texture from the window for taking a screenshot.");
+		const Ref<Image> img = texture->get_image();
+		ERR_FAIL_COND_MSG(img.is_null(), "Cannot get an image from a viewport texture of the window for taking a screenshot.");
+
+		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		String project_name = GLOBAL_GET("application/config/name");
+		if (project_name.is_empty()) {
+			project_name = "[unnamed project]";
+		}
+		// Use a subfolder with the project name in the user's Pictures folder for easier discovery of the screenshots taken.
+		const String path = OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_PICTURES).path_join(project_name).path_join("screenshot_" + Time::get_singleton()->get_datetime_string_from_system().replace(":", "") + ".png");
+		da->make_dir_recursive(path.get_base_dir());
+		const Error error = img->save_png(path);
+
+		ERR_FAIL_COND_MSG(error != OK, vformat("Cannot save screenshot to: %s", path));
+		// Using formatting around the printed path allows using Ctrl + Click in VS Code's integrated terminal to open the screenshot:
+		// <https://github.com/microsoft/vscode/issues/97941>
+		print_line_rich(vformat("Screenshot saved to: [u]%s[/u]", path));
+
+		// Prevent embedded subwindows from also taking a screenshot.
+		return;
 	}
 
 	if (is_inside_tree()) {


### PR DESCRIPTION
The default key binding for `ui_take_screenshot` is <kbd>F12</kbd>, but it can be changed in the project settings' input map (make sure to enable **Show Built-in Actions**). See https://github.com/godotengine/godot-proposals/issues/6789 for detailed rationale.

- This closes https://github.com/godotengine/godot-proposals/issues/6789.

**Testing project:** [test_take_screenshot.zip](https://github.com/godotengine/godot/files/11458251/test_take_screenshot.zip)

## Preview

*Screenshot of a project with a transparent background while paused, without any tearing despite having V-Sync disabled:*

![screenshot_2023-05-12T041210](https://github.com/godotengine/godot/assets/180032/4ce5e4a8-1c07-4e93-8336-1acc0d823224)