### PR TITLE
Add a project setting to mute audio on focus loss

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1290,6 +1290,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/energy_saving/keep_screen_on.editor", false);
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "audio/buses/default_bus_layout", PROPERTY_HINT_FILE, "*.tres"), "res://default_bus_layout.tres");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "audio/general/mute_on_focus_loss"), false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/3d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -366,6 +366,9 @@
 			The base strength of the panning effect for all [AudioStreamPlayer3D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer3D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones. When using speakers, you may find lower values to sound better as speakers have a lower stereo separation compared to headphones.
 		</member>
+		<member name="audio/general/mute_on_focus_loss" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], audio is muted when all windows spawned by the project loses focus (either by clicking outside, alt-tabbing or minimizing). This is recommended to be set to [code]true[/code] for games (while providing an option for players to disable this behavior) and [code]false[/code] for non-game applications.
+		</member>
 		<member name="audio/video/video_delay_compensation_ms" type="int" setter="" getter="" default="0">
 			Setting to hardcode audio delay when playing video. Best to leave this untouched unless you know what you are doing.
 		</member>

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -178,6 +178,8 @@ private:
 	void _theme_changed();
 	void _notify_theme_override_changed();
 	void _invalidate_theme_cache();
+	float mute_on_focus_loss_previous_db = 0.0;
+	bool mute_on_focus_loss_is_tweening = false;
 
 	Viewport *embedder = nullptr;
 
@@ -190,6 +192,8 @@ private:
 	void _window_drop_files(const Vector<String> &p_files);
 	void _rect_changed_callback(const Rect2i &p_callback);
 	void _event_callback(DisplayServer::WindowEvent p_event);
+	void _smooth_audio_mute_callback(float p_db);
+	void _smooth_audio_doone_callback(bool p_mute);
 	virtual bool _can_consume_input_events() const override;
 
 	Ref<Shortcut> debugger_stop_shortcut;


### PR DESCRIPTION
This is disabled by default to keep expectations from the current Godot version intact.

However, [most games should consider enabling this option by default](https://github.com/godotengine/godot-proposals/issues/3693) as it's common behavior on most PC games (while providing a way for users to disable it).

Tested on Linux, it works as expected including when using popups (which spawn separate windows). However, pressing <kbd>Alt + F9</kbd> to minimize the window (custom KDE shortcut) will not send a focus loss notification, so audio won't be muted in this case. This is an issue with DisplayServer, as minimizing by clicking the `-` button in the top-right corner sends a focus loss notification as expected.

Window may not be the best location for this code, but I'm not sure what would be a more suited location.

- This closes https://github.com/godotengine/godot-proposals/issues/3693.

**Testing project:** [test_mute_on_focus_loss.zip](https://github.com/godotengine/godot/files/11458778/test_mute_on_focus_loss.zip)

## TODO

- [ ] Add an editor setting to control this behavior on the editor itself (right now, it uses the project setting's value).