### PR TITLE
Add a project setting to limit FPS on focus loss

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1261,6 +1261,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("application/run/main_loop_type", "SceneTree");
 	GLOBAL_DEF("application/config/auto_accept_quit", true);
 	GLOBAL_DEF("application/config/quit_on_go_back", true);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "application/run/max_fps_when_unfocused", PROPERTY_HINT_RANGE, "0,1000,1"), 10);
+	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "application/run/low_processor_mode_when_unfocused"), true);
 
 	// The default window size is tuned to:
 	// - Have a 16:9 aspect ratio,

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -311,6 +311,9 @@
 		<member name="application/run/low_processor_mode_sleep_usec" type="int" setter="" getter="" default="6900">
 			Amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
 		</member>
+		<member name="application/run/low_processor_mode_when_unfocused" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables low-processor usage mode when the window is unfocused. This can be used to reduce power consumption. See also [member application/run/low_processor_mode].
+		</member>
 		<member name="application/run/main_loop_type" type="String" setter="" getter="" default="&quot;SceneTree&quot;">
 			The name of the type implementing the engine's main loop.
 		</member>
@@ -325,6 +328,9 @@
 			If [member display/window/vsync/vsync_mode] is [code]Disabled[/code], limiting the FPS to a high value that can be consistently reached on the system can reduce input lag compared to an uncapped framerate. Since this works by ensuring the GPU load is lower than 100%, this latency reduction is only effective in GPU-bottlenecked scenarios, not CPU-bottlenecked scenarios.
 			See also [member physics/common/physics_ticks_per_second].
 			[b]Note:[/b] This property is only read when the project starts. To change the rendering FPS cap at runtime, set [member Engine.max_fps] instead.
+		</member>
+		<member name="application/run/max_fps_when_unfocused" type="int" setter="" getter="" default="10">
+			Maximum number of frames per second allowed when the window is unfocused. This can be used to reduce power consumption. This override is only applied if set to a value greater than [code]0[/code]. See also [member application/run/max_fps].
 		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -178,6 +178,8 @@ private:
 	void _theme_changed();
 	void _notify_theme_override_changed();
 	void _invalidate_theme_cache();
+	int max_fps_on_focus_loss_previous = 0;
+	bool low_processor_mode_on_focus_loss_previous = false;
 
 	Viewport *embedder = nullptr;
 


### PR DESCRIPTION
Alternative implementation of https://github.com/godotengine/godot/pull/47812 (it turns out I forgot about that PR). See also https://github.com/godotengine/godot/pull/76987.

This is enabled by default to save power automatically and improve editor performance if the project is running in the background.

- This closes https://github.com/godotengine/godot-proposals/issues/2001.

**Testing project:** [test_max_fps_on_focus_loss.zip](https://github.com/godotengine/godot/files/11459160/test_max_fps_on_focus_loss.zip)