### PR TITLE
Fix `draw_multiline_colors` usage

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -171,7 +171,7 @@
 			<param index="1" name="color" type="Color" />
 			<param index="2" name="width" type="float" default="-1.0" />
 			<description>
-				Draws multiple disconnected lines with a uniform [param color]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline] instead.
+				Draws multiple disconnected lines with a uniform [param width] and [param color]. Each line is defined by two consecutive points from [param points] array, i.e. i-th segment consists of [code]points[2 * i][/code], [code]points[2 * i + 1][/code] endpoints. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline] instead.
 				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 			</description>
 		</method>
@@ -181,7 +181,7 @@
 			<param index="1" name="colors" type="PackedColorArray" />
 			<param index="2" name="width" type="float" default="-1.0" />
 			<description>
-				Draws multiple disconnected lines with a uniform [param width] and segment-by-segment coloring. Colors assigned to line segments match by index between [param points] and [param colors]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline_colors] instead.
+				Draws multiple disconnected lines with a uniform [param width] and segment-by-segment coloring. Each segment is defined by two consecutive points from [param points] array and a corresponding color from [param colors] array, i.e. i-th segment consists of [code]points[2 * i][/code], [code]points[2 * i + 1][/code] endpoints and has [code]colors[i][/code] color. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw interconnected lines, use [method draw_polyline_colors] instead.
 				If [param width] is negative, then two-point primitives will be drawn instead of a four-point ones. This means that when the CanvasItem is scaled, the lines will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 			</description>
 		</method>
@@ -258,7 +258,7 @@
 			<param index="2" name="width" type="float" default="-1.0" />
 			<param index="3" name="antialiased" type="bool" default="false" />
 			<description>
-				Draws interconnected line segments with a uniform [param width] and segment-by-segment coloring, and optional antialiasing (supported only for positive [param width]). Colors assigned to line segments match by index between [param points] and [param colors]. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline_colors] instead. See also [method draw_polygon].
+				Draws interconnected line segments with a uniform [param width], point-by-point coloring, and optional antialiasing (supported only for positive [param width]). Colors assigned to line points match by index between [param points] and [param colors], i.e. each line segment is filled with a gradient between the colors of the endpoints. When drawing large amounts of lines, this is faster than using individual [method draw_line] calls. To draw disconnected lines, use [method draw_multiline_colors] instead. See also [method draw_polygon].
 				If [param width] is negative, then the polyline is drawn using [constant RenderingServer.PRIMITIVE_LINE_STRIP]. This means that when the CanvasItem is scaled, the polyline will remain thin. If this behavior is not desired, then pass a positive [param width] like [code]1.0[/code].
 			</description>
 		</method>

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -309,8 +309,8 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		Rect2 rect = Rect2(from_x, (get_size().height - fh) / 2, to_x - from_x, fh);
 		draw_rect(rect, Color(0.25, 0.25, 0.25));
 
-		Vector<Vector2> lines;
-		lines.resize((to_x - from_x + 1) * 2);
+		Vector<Vector2> points;
+		points.resize((to_x - from_x) * 2);
 		preview_len = preview->get_length();
 
 		for (int i = from_x; i < to_x; i++) {
@@ -320,14 +320,13 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 			float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 			int idx = i - from_x;
-			lines.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
-			lines.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+			points.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
+			points.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
 		}
 
-		Vector<Color> color;
-		color.push_back(Color(0.75, 0.75, 0.75));
+		Vector<Color> colors = { Color(0.75, 0.75, 0.75) };
 
-		RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, color);
+		RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 
 		if (p_selected) {
 			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
@@ -667,8 +666,8 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		bg.b = 1 - color.b;
 		draw_rect(rect, bg);
 
-		Vector<Vector2> lines;
-		Vector<Color> colorv;
+		Vector<Vector2> points;
+		Vector<Color> colors = { color };
 		{
 			Ref<Animation> ap_anim = ap->get_animation(anim);
 
@@ -685,16 +684,14 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 						continue;
 					}
 
-					lines.push_back(Point2(x, y));
-					lines.push_back(Point2(x + 1, y));
+					points.push_back(Point2(x, y));
+					points.push_back(Point2(x + 1, y));
 				}
 			}
-
-			colorv.push_back(color);
 		}
 
-		if (lines.size() > 2) {
-			RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, colorv);
+		if (points.size() > 2) {
+			RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 		}
 
 		int limit = to_x - from_x - 4;
@@ -919,8 +916,8 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 	Rect2 rect = Rect2(from_x, (h - fh) / 2, to_x - from_x, fh);
 	draw_rect(rect, Color(0.25, 0.25, 0.25));
 
-	Vector<Vector2> lines;
-	lines.resize((to_x - from_x + 1) * 2);
+	Vector<Vector2> points;
+	points.resize((to_x - from_x) * 2);
 	preview_len = preview->get_length();
 
 	for (int i = from_x; i < to_x; i++) {
@@ -933,14 +930,13 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i - from_x;
-		lines.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
-		lines.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+		points.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
+		points.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
 	}
 
-	Vector<Color> color;
-	color.push_back(Color(0.75, 0.75, 0.75));
+	Vector<Color> colors = { Color(0.75, 0.75, 0.75) };
 
-	RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, color);
+	RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 
 	Color cut_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 	cut_color.a = 0.7;
@@ -1279,8 +1275,8 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		bg.b = 1 - color.b;
 		draw_rect(rect, bg);
 
-		Vector<Vector2> lines;
-		Vector<Color> colorv;
+		Vector<Vector2> points;
+		Vector<Color> colors = { color };
 		{
 			Ref<Animation> ap_anim = ap->get_animation(anim);
 
@@ -1297,16 +1293,14 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 						continue;
 					}
 
-					lines.push_back(Point2(x, y));
-					lines.push_back(Point2(x + 1, y));
+					points.push_back(Point2(x, y));
+					points.push_back(Point2(x + 1, y));
 				}
 			}
-
-			colorv.push_back(color);
 		}
 
-		if (lines.size() > 2) {
-			RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), lines, colorv);
+		if (points.size() > 2) {
+			RS::get_singleton()->canvas_item_add_multiline(get_canvas_item(), points, colors);
 		}
 
 		int limit = to_x - from_x - 4;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -1145,7 +1145,7 @@ void EditorAudioStreamPicker::_preview_draw() {
 
 	Rect2 rect(Point2(), size);
 
-	if (audio_stream->get_length() > 0) {
+	if (audio_stream->get_length() > 0 && size.width > 0) {
 		rect.size.height *= 0.5;
 
 		stream_preview_rect->draw_rect(rect, Color(0, 0, 0, 1));
@@ -1153,8 +1153,8 @@ void EditorAudioStreamPicker::_preview_draw() {
 		Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(audio_stream);
 		float preview_len = preview->get_length();
 
-		Vector<Vector2> lines;
-		lines.resize(size.width * 2);
+		Vector<Vector2> points;
+		points.resize(size.width * 2);
 
 		for (int i = 0; i < size.width; i++) {
 			float ofs = i * preview_len / size.width;
@@ -1163,14 +1163,13 @@ void EditorAudioStreamPicker::_preview_draw() {
 			float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 			int idx = i;
-			lines.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
-			lines.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
+			points.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
+			points.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
 		}
 
-		Vector<Color> color;
-		color.push_back(get_theme_color(SNAME("contrast_color_2"), SNAME("Editor")));
+		Vector<Color> colors = { get_theme_color(SNAME("contrast_color_2"), SNAME("Editor")) };
 
-		RS::get_singleton()->canvas_item_add_multiline(stream_preview_rect->get_canvas_item(), lines, color);
+		RS::get_singleton()->canvas_item_add_multiline(stream_preview_rect->get_canvas_item(), points, colors);
 
 		if (tagged_frame_offset_count) {
 			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -85,13 +85,13 @@ void AudioStreamImportSettings::_draw_preview() {
 
 	Ref<Font> beat_font = get_theme_font(SNAME("main"), SNAME("EditorFonts"));
 	int main_size = get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts"));
-	Vector<Vector2> lines;
-	lines.resize(rect_size.width * 2);
+	Vector<Vector2> points;
+	points.resize((int)rect_size.width * 2);
 	Color color_active = get_theme_color(SNAME("contrast_color_2"), SNAME("Editor"));
 	Color color_inactive = color_active;
 	color_inactive.a *= 0.5;
-	Vector<Color> color;
-	color.resize(lines.size());
+	Vector<Color> colors;
+	colors.resize((int)rect_size.width);
 
 	float inactive_from = 1e20;
 	float beat_size = 0;
@@ -115,16 +115,15 @@ void AudioStreamImportSettings::_draw_preview() {
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i;
-		lines.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
-		lines.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
+		points.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
+		points.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
 
-		Color c = ofs > inactive_from ? color_inactive : color_active;
-
-		color.write[idx * 2 + 0] = c;
-		color.write[idx * 2 + 1] = c;
+		colors.write[idx] = ofs > inactive_from ? color_inactive : color_active;
 	}
 
-	RS::get_singleton()->canvas_item_add_multiline(_preview->get_canvas_item(), lines, color);
+	if (!points.is_empty()) {
+		RS::get_singleton()->canvas_item_add_multiline(_preview->get_canvas_item(), points, colors);
+	}
 
 	if (beat_size) {
 		Color beat_color = Color(1, 1, 1, 1);

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -74,14 +74,18 @@ void AudioStreamEditor::_notification(int p_what) {
 }
 
 void AudioStreamEditor::_draw_preview() {
-	Rect2 rect = _preview->get_rect();
 	Size2 size = get_size();
+	if ((int)size.width <= 0) {
+		return; // No points to draw.
+	}
+
+	Rect2 rect = _preview->get_rect();
 
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
 	float preview_len = preview->get_length();
 
-	Vector<Vector2> lines;
-	lines.resize(size.width * 2);
+	Vector<Vector2> points;
+	points.resize((int)size.width * 2);
 
 	for (int i = 0; i < size.width; i++) {
 		float ofs = i * preview_len / size.width;
@@ -90,11 +94,13 @@ void AudioStreamEditor::_draw_preview() {
 		float min = preview->get_min(ofs, ofs_n) * 0.5 + 0.5;
 
 		int idx = i;
-		lines.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
-		lines.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
+		points.write[idx * 2 + 0] = Vector2(i + 1, rect.position.y + min * rect.size.y);
+		points.write[idx * 2 + 1] = Vector2(i + 1, rect.position.y + max * rect.size.y);
 	}
 
-	RS::get_singleton()->canvas_item_add_multiline(_preview->get_canvas_item(), lines, { get_theme_color(SNAME("contrast_color_2"), SNAME("Editor")) });
+	Vector<Color> colors = { get_theme_color(SNAME("contrast_color_2"), SNAME("Editor")) };
+
+	RS::get_singleton()->canvas_item_add_multiline(_preview->get_canvas_item(), points, colors);
 }
 
 void AudioStreamEditor::_preview_changed(ObjectID p_which) {

--- a/scene/2d/marker_2d.cpp
+++ b/scene/2d/marker_2d.cpp
@@ -33,19 +33,15 @@
 void Marker2D::_draw_cross() {
 	const real_t extents = get_gizmo_extents();
 
-	// Add more points to create a "hard stop" in the color gradient.
-	PackedVector2Array points_x = {
+	PackedVector2Array points = {
 		Point2(+extents, 0),
 		Point2(),
 		Point2(),
-		Point2(-extents, 0)
-	};
-
-	PackedVector2Array points_y = {
+		Point2(-extents, 0),
 		Point2(0, +extents),
 		Point2(),
 		Point2(),
-		Point2(0, -extents)
+		Point2(0, -extents),
 	};
 
 	// Use the axis color which is brighter for the positive axis.
@@ -54,22 +50,15 @@ void Marker2D::_draw_cross() {
 	// (which can be important depending on how it's used).
 	// Axis colors are taken from `axis_x_color` and `axis_y_color` (defined in `editor/editor_themes.cpp`).
 	const Color color_x = Color(0.96, 0.20, 0.32);
-	PackedColorArray colors_x = {
-		color_x,
-		color_x,
-		color_x.lerp(Color(0, 0, 0), 0.5),
-		color_x.lerp(Color(0, 0, 0), 0.5)
-	};
-	draw_multiline_colors(points_x, colors_x);
-
 	const Color color_y = Color(0.53, 0.84, 0.01);
-	PackedColorArray colors_y = {
+	PackedColorArray colors = {
+		color_x,
+		color_x.darkened(0.5),
 		color_y,
-		color_y,
-		color_y.lerp(Color(0, 0, 0), 0.5),
-		color_y.lerp(Color(0, 0, 0), 0.5)
+		color_y.darkened(0.5),
 	};
-	draw_multiline_colors(points_y, colors_y);
+
+	draw_multiline_colors(points, colors);
 }
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
In #74883, I fixed an inconsistency in `draw_multiline_colors()` for `width < 0`: if you passed the number of colors equal to **the number of lines**, then this did not work, unlike `width > 0`. But I did not pay attention to the fact that this worked when passing the number of colors equal to **the number of points**. The documentation says the following:

> Draws multiple disconnected lines with a uniform width and segment-by-segment coloring. Colors assigned to line segments match by index between points and colors. When drawing large amounts of lines, this is faster than using individual draw_line() calls. To draw interconnected lines, use draw_polyline_colors() instead.

Since this works for `width > 0` and `draw_multiline*` is analogous to `draw_line`, I suggest that the old behavior for `width < 0` is wrong, the number of colors should be equal to the number of lines (or 1), not the number of points.

Note that this is inconsistent with `draw_polyline*`, in these methods the colors correspond to points, not segments (and you can use gradients).

![](https://github.com/godotengine/godot/assets/47700418/5511b104-8ef4-4c84-9531-294c0f8fc35c)

```
An idea

multiline:
  colors.size() == 1 -- One color
  colors.size() == points.size() -- Points
  colors.size() * 2 == points.size() -- Lines

polyline:
  colors.size() == 1 -- One color
  colors.size() == points.size() -- Points
  colors.size() == points.size() - 1 -- Segments
```

I had an idea to allow the number of colors to be equal to the number of points to avoid breaking compatibility, but it's hard to do for `width > 0` as there is a call to `canvas_item_add_line` in the loop in that case.

https://github.com/godotengine/godot/blob/fd4a06c51555904104b18494d0224f450d74fe2a/servers/rendering/renderer_canvas_cull.cpp#L1205-L1222

Closes #76973.
