### PR TITLE
Linux/BSD platform: Change export name and fix `bsd` feature tag

### DIFF
--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -40,8 +40,8 @@ void register_linuxbsd_exporter_types() {
 void register_linuxbsd_exporter() {
 	Ref<EditorExportPlatformLinuxBSD> platform;
 	platform.instantiate();
-	platform->set_name("Linux/X11");
-	platform->set_os_name("Linux");
+	platform->set_name("Linux/BSD");
+	platform->set_os_name("LinuxBSD");
 	platform->set_chmod_flags(0755);
 
 	EditorExport::get_singleton()->add_export_platform(platform);

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -491,11 +491,19 @@ bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {
 		return font_config_initialized;
 	}
 #endif
+
+#ifndef __linux__
+	// `bsd` includes **all** BSD, not only "other BSD" (see `get_name()`).
+	if (p_feature == "bsd") {
+		return true;
+	}
+#endif
+
 	if (p_feature == "pc") {
 		return true;
 	}
 
-	// Match against the specific OS (linux, freebsd, etc).
+	// Match against the specific OS (`linux`, `freebsd`, `netbsd`, `openbsd`).
 	if (p_feature == get_name().to_lower()) {
 		return true;
 	}


### PR DESCRIPTION
1\. ~The `bsd` feature tag now includes all BSD systems, not just "other BSDs" (than FreeBSD, OpenBSD and NetBSD). See #76990.~ Extracted to #78272.

<details>
<summary>Outdated</summary>

![](https://github.com/godotengine/godot/assets/47700418/b3e801d3-f58c-4cf8-b252-ec21a91f82ef)

https://github.com/godotengine/godot/blob/a1a102299a044c310784e340ebb1f4e6cb7bc975/platform/linuxbsd/os_linuxbsd.cpp#L203-L215

https://github.com/godotengine/godot/blob/a1a102299a044c310784e340ebb1f4e6cb7bc975/platform/linuxbsd/os_linuxbsd.cpp#L488-L504

</details>

2\. The display name of the platform has been changed. X11 left as Wayland is not yet supported.

![](https://github.com/godotengine/godot/assets/47700418/501e49eb-ef80-4633-96df-967818c148f3)

The term "Linux/BSD" is already in use:

https://github.com/godotengine/godot/blob/a1a102299a044c310784e340ebb1f4e6cb7bc975/platform/linuxbsd/export/export_plugin.cpp#L341-L347

Docs:

```
doc/classes/EditorExportPlatformPC.xml: 1
  4: 61: 		Base class for the desktop platform exporter (Windows and Linux/BSD).
doc/classes/EditorPaths.xml: 1
  9: 23: 		[b]Note:[/b] On the Linux/BSD platform, Godot complies with the [url=https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html]XDG Base Directory Specification[/url]. Y
doc/classes/OS.xml: 7
137:106: [/i] cache data directory according to the operating system's standards. On the Linux/BSD platform, this path can be overridden by setting the [code]XDG_CACHE_HOME[/code] environment variab
197:114: r configuration directory according to the operating system's standards. On the Linux/BSD platform, this path can be overridden by setting the [code]XDG_CONFIG_HOME[/code] environment varia
212:105: l[/i] user data directory according to the operating system's standards. On the Linux/BSD platform, this path can be overridden by setting the [code]XDG_DATA_HOME[/code] environment variabl
486: 95:  element holds the driver version. For e.g. the [code]nvidia[/code] driver on a Linux/BSD platform, the version is in the format [code]510.85.02[/code]. For Windows, the driver's format is 
487: 65: 				[b]Note:[/b] This method is only supported on the platforms Linux/BSD and Windows when not running in headless mode. It returns an empty array on other platforms.
```

Perhaps we should replace the parentheses with brackets?

![](https://github.com/godotengine/godot/assets/47700418/6fd4c211-dd2e-4f92-a71d-13768fb80073)

3\. Added 2 feature tags to the dropdown list. `linux` ∪ `bsd` = `linuxbsd`, `linux` ⋂ `bsd` = ∅.

![](https://github.com/godotengine/godot/assets/47700418/258979ed-0444-4548-a846-b2ffa363ae27)

`freebsd`, `openbsd` and `netbsd` are supported but not added to the list due to their rarity.