### PR TITLE
Change debug shape visibility when CollisionObject3D visibility changes

### DIFF
--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -103,6 +103,9 @@ void CollisionObject3D::_notification(int p_what) {
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			_update_pickable();
+			if (_are_collision_shapes_visible()) {
+				_update_debug_shapes_visiblity();
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_WORLD: {
@@ -405,10 +408,21 @@ void CollisionObject3D::_update_debug_shapes() {
 				Ref<Mesh> mesh = s.shape->get_debug_mesh();
 				RS::get_singleton()->instance_set_base(s.debug_shape, mesh->get_rid());
 				RS::get_singleton()->instance_set_transform(s.debug_shape, get_global_transform() * shapedata.xform);
+				RS::get_singleton()->instance_set_visible(s.debug_shape, is_visible_in_tree());
 			}
 		}
 	}
 	debug_shapes_to_update.clear();
+}
+
+void CollisionObject3D::_update_debug_shapes_visiblity() {
+	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
+		for (const ShapeData::ShapeBase &s : E.value.shapes) {
+			if (s.debug_shape.is_valid()) {
+				RS::get_singleton()->instance_set_visible(s.debug_shape, is_visible_in_tree());
+			}
+		}
+	}
 }
 
 void CollisionObject3D::_clear_debug_shapes() {

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -90,6 +90,7 @@ private:
 	void _update_shape_data(uint32_t p_owner);
 	void _shape_changed(const Ref<Shape3D> &p_shape);
 	void _update_debug_shapes();
+	void _update_debug_shapes_visiblity();
 	void _clear_debug_shapes();
 
 	void _apply_disabled();


### PR DESCRIPTION
Follow up of #48175

See https://github.com/godotengine/godot-proposals/issues/6857#issuecomment-1545411726 for details.
This is one way to solve, another way, for example, is to add a new method in CollisionObject3D to change the shape color, as described [here](https://github.com/godotengine/godot-proposals/issues/6857#issuecomment-1542934863).

Closes godotengine/godot-proposals#6857

Test scene: [co3d_visibility_toggle.zip](https://github.com/godotengine/godot/files/11461989/co3d_visibility_toggle.zip)

