### PR TITLE
Use WorkerThreadPool for Server threads

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -82,6 +82,16 @@ int Engine::get_audio_output_latency() const {
 	return _audio_output_latency;
 }
 
+void Engine::increment_frames_drawn() {
+	if (frame_server_synced) {
+		server_syncs++;
+	} else {
+		server_syncs = 0;
+	}
+	frame_server_synced = 0;
+
+	frames_drawn++;
+}
 uint64_t Engine::get_frames_drawn() {
 	return frames_drawn;
 }
@@ -349,6 +359,11 @@ Engine *Engine::singleton = nullptr;
 
 Engine *Engine::get_singleton() {
 	return singleton;
+}
+
+bool Engine::notify_frame_server_synced() {
+	frame_server_synced = true;
+	return server_syncs > server_sync_frame_count_warning;
 }
 
 Engine::Engine() {

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -89,6 +89,10 @@ private:
 	String write_movie_path;
 	String shader_cache_path;
 
+	static constexpr int server_sync_frame_count_warning = 5;
+	int server_syncs = 0;
+	bool frame_server_synced = false;
+
 public:
 	static Engine *get_singleton();
 
@@ -174,6 +178,9 @@ public:
 	bool is_validation_layers_enabled() const;
 	bool is_generate_spirv_debug_info_enabled() const;
 	int32_t get_gpu_index() const;
+
+	void increment_frames_drawn();
+	bool notify_frame_server_synced();
 
 	Engine();
 	virtual ~Engine() {}

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -115,6 +115,10 @@ void RasterizerGLES3::end_viewport(bool p_swap_buffers) {
 	}
 }
 
+void RasterizerGLES3::context_move_to_current_thread() {
+	DisplayServer::get_singleton()->make_rendering_thread();
+}
+
 void RasterizerGLES3::clear_depth(float p_depth) {
 #ifdef GL_API_ENABLED
 	if (is_gles_over_gl()) {

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -115,6 +115,8 @@ public:
 	_ALWAYS_INLINE_ double get_frame_delta_time() const { return delta; }
 	_ALWAYS_INLINE_ double get_total_time() const { return time_total; }
 
+	virtual void context_move_to_current_thread();
+
 	static RasterizerGLES3 *get_singleton() { return singleton; }
 	RasterizerGLES3();
 	~RasterizerGLES3();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3799,11 +3799,11 @@ bool Main::iteration() {
 		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (RenderingServer::get_singleton()->has_changed()) {
 				RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands
-				Engine::get_singleton()->frames_drawn++;
+				Engine::get_singleton()->increment_frames_drawn();
 			}
 		} else {
 			RenderingServer::get_singleton()->draw(true, scaled_step); // flush visual commands
-			Engine::get_singleton()->frames_drawn++;
+			Engine::get_singleton()->increment_frames_drawn();
 			force_redraw_requested = false;
 		}
 	}

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -32,43 +32,28 @@
 
 #include "core/os/os.h"
 
-void PhysicsServer3DWrapMT::thread_exit() {
-	exit = true;
-}
-
 void PhysicsServer3DWrapMT::thread_step(real_t p_delta) {
-	physics_server_3d->step(p_delta);
-	step_sem.post();
-}
-
-void PhysicsServer3DWrapMT::_thread_callback(void *_instance) {
-	PhysicsServer3DWrapMT *vsmt = reinterpret_cast<PhysicsServer3DWrapMT *>(_instance);
-
-	vsmt->thread_loop();
-}
-
-void PhysicsServer3DWrapMT::thread_loop() {
 	server_thread = Thread::get_caller_id();
+	command_queue.flush_all();
+	physics_server_3d->step(p_delta);
+	command_queue.flush_all(); // Flush pending commands before and after
+	server_thread = Thread::UNASSIGNED_ID;
+}
 
-	physics_server_3d->init();
-
-	exit = false;
-	step_thread_up = true;
-	while (!exit) {
-		// flush commands one by one, until exit is requested
-		command_queue.wait_and_flush();
+void PhysicsServer3DWrapMT::_main_thread_sync() {
+	if (task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(task_id);
+		task_id = WorkerThreadPool::INVALID_TASK_ID;
 	}
 
-	command_queue.flush_all(); // flush all
-
-	physics_server_3d->finish();
+	server_thread = Thread::MAIN_ID;
 }
 
 /* EVENT QUEUING */
 
 void PhysicsServer3DWrapMT::step(real_t p_step) {
 	if (create_thread) {
-		command_queue.push(this, &PhysicsServer3DWrapMT::thread_step, p_step);
+		task_id = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &PhysicsServer3DWrapMT::thread_step).bind(p_step), true);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
 		physics_server_3d->step(p_step);
@@ -77,10 +62,9 @@ void PhysicsServer3DWrapMT::step(real_t p_step) {
 
 void PhysicsServer3DWrapMT::sync() {
 	if (create_thread) {
-		if (first_frame) {
-			first_frame = false;
-		} else {
-			step_sem.wait(); //must not wait if a step was not issued
+		if (task_id != WorkerThreadPool::INVALID_TASK_ID) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(task_id);
+			task_id = WorkerThreadPool::INVALID_TASK_ID;
 		}
 	}
 	physics_server_3d->sync();
@@ -95,24 +79,15 @@ void PhysicsServer3DWrapMT::end_sync() {
 }
 
 void PhysicsServer3DWrapMT::init() {
-	if (create_thread) {
-		//OS::get_singleton()->release_rendering_thread();
-		thread.start(_thread_callback, this);
-		while (!step_thread_up) {
-			OS::get_singleton()->delay_usec(1000);
-		}
-	} else {
-		physics_server_3d->init();
-	}
+	physics_server_3d->init();
 }
 
 void PhysicsServer3DWrapMT::finish() {
-	if (thread.is_started()) {
-		command_queue.push(this, &PhysicsServer3DWrapMT::thread_exit);
-		thread.wait_to_finish();
-	} else {
-		physics_server_3d->finish();
+	if (task_id != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(task_id);
+		task_id = WorkerThreadPool::INVALID_TASK_ID;
 	}
+	physics_server_3d->finish();
 }
 
 PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread) :
@@ -121,12 +96,12 @@ PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool 
 	create_thread = p_create_thread;
 
 	if (!p_create_thread) {
-		server_thread = Thread::get_caller_id();
+		server_thread = Thread::MAIN_ID;
 	} else {
-		server_thread = 0;
+		server_thread = Thread::UNASSIGNED_ID;
 	}
 
-	main_thread = Thread::get_caller_id();
+	main_thread = Thread::MAIN_ID;
 }
 
 PhysicsServer3DWrapMT::~PhysicsServer3DWrapMT() {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -32,6 +32,7 @@
 #define PHYSICS_SERVER_3D_WRAP_MT_H
 
 #include "core/config/project_settings.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_server_3d.h"
@@ -42,29 +43,39 @@
 #define SYNC_DEBUG
 #endif
 
+#ifdef DEBUG_ENABLED
+#define MAIN_THREAD_SYNC                                                                                                                                     \
+	if (Engine::get_singleton()->notify_frame_server_synced()) {                                                                                             \
+		WARN_PRINT("Call to " + String(__FUNCTION__) + " causing PhysicsServer3D synchronizations on every frame. This significantly affects performance."); \
+	}                                                                                                                                                        \
+	const_cast<PhysicsServer3DWrapMT *>(this)->_main_thread_sync();
+#else
+#define MAIN_THREAD_SYNC const_cast<PhysicsServer3DWrapMT *>(this)->_main_thread_sync();
+#endif
+
 class PhysicsServer3DWrapMT : public PhysicsServer3D {
 	mutable PhysicsServer3D *physics_server_3d;
 
 	mutable CommandQueueMT command_queue;
 
 	static void _thread_callback(void *_instance);
-	void thread_loop();
 
 	Thread::ID server_thread;
 	Thread::ID main_thread;
-	volatile bool exit = false;
-	Thread thread;
-	volatile bool step_thread_up = false;
 	bool create_thread = false;
+	WorkerThreadPool::TaskID task_id = WorkerThreadPool::INVALID_TASK_ID;
 
-	Semaphore step_sem;
 	void thread_step(real_t p_delta);
 
 	void thread_exit();
 
+	void _main_thread_sync();
+
 	bool first_frame = true;
 
 	Mutex alloc_mutex;
+
+	int pool_max_size = 0;
 
 public:
 #define ServerName PhysicsServer3D
@@ -410,5 +421,7 @@ public:
 #undef DEBUG_SYNC
 #endif
 #undef SYNC_DEBUG
+
+#undef MAIN_THREAD_SYNC
 
 #endif // PHYSICS_SERVER_3D_WRAP_MT_H

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -109,6 +109,8 @@ public:
 	static bool is_low_end() { return low_end; };
 	virtual bool is_xr_enabled() const;
 
+	virtual void context_move_to_current_thread() {}
+
 	static RendererCompositor *get_singleton() { return singleton; }
 	RendererCompositor();
 	virtual ~RendererCompositor() {}


### PR DESCRIPTION
* Servers now use WorkerThreadPool for background computation.
* This helps keep the number of threads used fixed at all times.
* It also ensures everything works on HTML5 with threads.
* And makes it easier to support disabling threads for also HTML5.

The only downside of this is that GLES3 threads likely no longer work because every time the render thread is called, the thread context is different. This needs to be researched how to fix. Maybe if GLES3 is used, threaded rendering server should be disabled for the time being?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
