### PR TITLE
Fix `notify_property_list_changed` not updating inspector when `p_changing` is true.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3386,7 +3386,7 @@ void EditorInspector::edit(Object *p_object) {
 	}
 	if (object) {
 		_clear();
-		object->disconnect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
+		object->disconnect("property_list_changed", callable_mp(this, &EditorInspector::_property_list_changed_callback));
 	}
 	per_array_page.clear();
 
@@ -3397,7 +3397,7 @@ void EditorInspector::edit(Object *p_object) {
 		if (scroll_cache.has(object->get_instance_id())) { //if exists, set something else
 			update_scroll_request = scroll_cache[object->get_instance_id()]; //done this way because wait until full size is accommodated
 		}
-		object->connect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
+		object->connect("property_list_changed", callable_mp(this, &EditorInspector::_property_list_changed_callback));
 		update_tree();
 	}
 	emit_signal(SNAME("edited_object_changed"));
@@ -3612,12 +3612,12 @@ void EditorInspector::_page_change_request(int p_new_page, const StringName &p_a
 	}
 }
 
-void EditorInspector::_edit_request_change(Object *p_object, const String &p_property) {
+void EditorInspector::_edit_request_change(Object *p_object, const String &p_property, const bool p_forced) {
 	if (object != p_object) { //may be undoing/redoing for a non edited object, so ignore
 		return;
 	}
 
-	if (changing) {
+	if (changing && !p_forced) {
 		return;
 	}
 
@@ -4003,10 +4003,10 @@ void EditorInspector::_notification(int p_what) {
 	}
 }
 
-void EditorInspector::_changed_callback() {
+void EditorInspector::_property_list_changed_callback() {
 	//this is called when property change is notified via notify_property_list_changed()
 	if (object != nullptr) {
-		_edit_request_change(object, String());
+		_edit_request_change(object, String(), true);
 	}
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -520,8 +520,8 @@ class EditorInspector : public ScrollContainer {
 	HashMap<StringName, int> per_array_page;
 	void _page_change_request(int p_new_page, const StringName &p_array_prefix);
 
-	void _changed_callback();
-	void _edit_request_change(Object *p_object, const String &p_prop);
+	void _property_list_changed_callback();
+	void _edit_request_change(Object *p_object, const String &p_prop, const bool p_forced = false);
 
 	void _keying_changed();
 


### PR DESCRIPTION
Fixes #76795

This enables the possibility to force the editing when calling `_edit_request_change` and use it in the `_property_list_changed_callback` (which was renamed for clarity of when this callback was called)