### PR TITLE
Fix errors that appear while reordering input map entries

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -451,7 +451,8 @@ void ProjectSettingsEditor::_action_reordered(const String &p_action_name, const
 
 	for (const PropertyInfo &prop : props) {
 		// Skip builtins and non-inputs
-		if (ProjectSettings::get_singleton()->is_builtin_setting(prop.name) || !prop.name.begins_with("input/")) {
+		// Order matters here, checking for "input/" filters out properties that aren't settings and produce errors in is_builtin_setting().
+		if (!prop.name.begins_with("input/") || ProjectSettings::get_singleton()->is_builtin_setting(prop.name)) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76177

(Copied from the issue comments):

I found out what causes both of these errors, I have some fix proposals but they'll probably need to be reviewed by someone with more knowledge of the engine than I have. Here's what I've found:

The problem happens inside the [`ProjectSettingsEditor::_action_reordered()`](https://github.com/godotengine/godot/blob/20ed51a9129f97bb8d001262155fb3ccfc1e3c89/editor/project_settings_editor.cpp#LL437C7-L437C7) function. This method starts by getting a list of all the project settings with `ProjectSettings::get_singleton()->get_property_list(&props);` and then iterating through them to find the user defined input ones. The issue arises because, to determine whether each setting of the list is a built-in and so not a user defined one, a call is made to `ProjectSettings::get_singleton()->is_builtin_setting(prop.name)` . In its first line this function asserts if the setting can be found in a list it has of the available project settings. Since it doesn't find either "ProjectSettings" or "script" it produces an error in both of those cases.

While both of these properties aren't really modifyable project settings, and aren't in fact returned by the function from `ProjectSettings` called by `ProjectSettings::get_singleton()->get_property_list(&props);`, they do get added to the list that's returned from it, each of them in some place in the `Object::get_property_list()` call that wraps the `ProjectSettings` one, and that's what produces the errors.

#### Where "script" gets added:

The `Object::get_property_list()` function adds the "script" property in this line [object.cpp#L507](https://github.com/godotengine/godot/blob/20ed51a9129f97bb8d001262155fb3ccfc1e3c89/core/object/object.cpp#L507). This property seems to be required by nodes that can have scripts attached to them. One thing that could be done is to add an exception for the "script" property when we're getting the Project Settings, like there seems to be for `Script` classes:
```gdscript
if (!is_class("Script") && !is_class("ProjectSettings")) {
	p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NEVER_DUPLICATE));
}
```
This change works, it removes the `Request for nonexistent project setting: script.` error message.

#### Where "ProjectSettings" gets added:

Before handling the virtual call to `get_property_list()`, the Object class always adds the name of the class as a property to the returned list of any `get_property_list()` call in this line:  [object.h#L480](https://github.com/godotengine/godot/blob/20ed51a9129f97bb8d001262155fb3ccfc1e3c89/core/object/object.h#L480) . This in our case is the `ProjectSettings` class name being added. Removing this line makes it so that the class name never gets added as the property of an object and solves the issue. The `Request for nonexistent project setting: ProjectSettings.` error doesn't show up anymore.

I'm not so sure about this one since I don't know if the class name as a property is used by any other classes, so changing it might have unintended consecuences in other parts of the engine.
A different way to fix the error might be to, inside the `ProjectSettings::get_property_list()` function, remove the "ProjectSettings" element from the list that it'll return by calling `p_list->erase(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));` right at the begginig of it. This also fixes the error.

Let me know what you think of these changes! I'll create a draft PR in the meantime with the changes I proposed.

### Edit:
Ended up changing `if (ProjectSettings::get_singleton()->is_builtin_setting(prop.name) || !prop.name.begins_with("input/")) {` for`if (!prop.name.begins_with("input/") || ps->is_builtin_setting(prop.name)) {` in the [ProjectSettingsEditor::_action_reordered()](https://github.com/godotengine/godot/blob/20ed51a9129f97bb8d001262155fb3ccfc1e3c89/editor/project_settings_editor.cpp#LL437C7-L437C7) function. so that it first checks for the "input/" settings, since both "script" and "ProjectSettings" don't start with it, they get filtered before calling the `ps->is_builtin_setting(prop.name)` function. As suggseted by @AThousandShips, this makes more sense than removing those properties from the Project Settings class . 