### PR TITLE
[TLS] Fix crashes trying to use TLS when not available.

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -60,6 +60,7 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, Ref<TLSOp
 	}
 
 	ERR_FAIL_COND_V(tls_options.is_valid() && tls_options->is_server(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(tls_options.is_valid() && !StreamPeerTLS::is_available(), ERR_UNAVAILABLE, "HTTPS is not available in this build.");
 	ERR_FAIL_COND_V(conn_host.length() < HOST_MIN_LEN, ERR_INVALID_PARAMETER);
 
 	if (conn_port < 0) {

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -332,7 +332,7 @@ void WSLPeer::_do_client_handshake() {
 		if (connection == tcp) {
 			// Start SSL handshake
 			tls = Ref<StreamPeerTLS>(StreamPeerTLS::create());
-			ERR_FAIL_COND_MSG(tls.is_null(), "SSL is not available in this build.");
+			ERR_FAIL_COND(tls.is_null());
 			if (tls->connect_to_stream(tcp, requested_host, tls_options) != OK) {
 				close(-1);
 				return; // Error.
@@ -500,6 +500,8 @@ Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
 	if (path.is_empty()) {
 		path = "/";
 	}
+
+	ERR_FAIL_COND_V_MSG(use_tls && !StreamPeerTLS::is_available(), ERR_UNAVAILABLE, "WSS is not available in this build.");
 
 	requested_url = p_url;
 	requested_host = host;

--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -436,6 +436,7 @@ ENetSocket enet_socket_create(ENetSocketType type) {
 }
 
 int enet_host_dtls_server_setup(ENetHost *host, void *p_options) {
+	ERR_FAIL_COND_V_MSG(!DTLSServer::is_available(), -1, "DTLS server is not available in this build.");
 	ENetGodotSocket *sock = (ENetGodotSocket *)host->socket;
 	if (!sock->can_upgrade()) {
 		return -1;
@@ -446,6 +447,7 @@ int enet_host_dtls_server_setup(ENetHost *host, void *p_options) {
 }
 
 int enet_host_dtls_client_setup(ENetHost *host, const char *p_for_hostname, void *p_options) {
+	ERR_FAIL_COND_V_MSG(!PacketPeerDTLS::is_available(), -1, "DTLS is not available in this build.");
 	ENetGodotSocket *sock = (ENetGodotSocket *)host->socket;
 	if (!sock->can_upgrade()) {
 		return -1;


### PR DESCRIPTION
If no StreamPeerTLS implementation is available, HTTPClient and WebSocketPeer will now correctly refuse to connect using TLS returning ERR_UNAVAILABLE.

Similarly, ENetConnection will refuse to setup DTLS when PacketPeerDTLS is not available.
