### PR TITLE
Make ok_color a namespace instead of a class

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -247,8 +247,7 @@ void Color::set_ok_hsl(float p_h, float p_s, float p_l, float p_alpha) {
 	hsl.h = p_h;
 	hsl.s = p_s;
 	hsl.l = p_l;
-	ok_color new_ok_color;
-	ok_color::RGB rgb = new_ok_color.okhsl_to_srgb(hsl);
+	ok_color::RGB rgb = ok_color::okhsl_to_srgb(hsl);
 	Color c = Color(rgb.r, rgb.g, rgb.b, p_alpha).clamp();
 	r = c.r;
 	g = c.g;
@@ -595,8 +594,7 @@ float Color::get_ok_hsl_h() const {
 	rgb.r = r;
 	rgb.g = g;
 	rgb.b = b;
-	ok_color new_ok_color;
-	ok_color::HSL ok_hsl = new_ok_color.srgb_to_okhsl(rgb);
+	ok_color::HSL ok_hsl = ok_color::srgb_to_okhsl(rgb);
 	if (Math::is_nan(ok_hsl.h)) {
 		return 0.0f;
 	}
@@ -608,8 +606,7 @@ float Color::get_ok_hsl_s() const {
 	rgb.r = r;
 	rgb.g = g;
 	rgb.b = b;
-	ok_color new_ok_color;
-	ok_color::HSL ok_hsl = new_ok_color.srgb_to_okhsl(rgb);
+	ok_color::HSL ok_hsl = ok_color::srgb_to_okhsl(rgb);
 	if (Math::is_nan(ok_hsl.s)) {
 		return 0.0f;
 	}
@@ -621,8 +618,7 @@ float Color::get_ok_hsl_l() const {
 	rgb.r = r;
 	rgb.g = g;
 	rgb.b = b;
-	ok_color new_ok_color;
-	ok_color::HSL ok_hsl = new_ok_color.srgb_to_okhsl(rgb);
+	ok_color::HSL ok_hsl = ok_color::srgb_to_okhsl(rgb);
 	if (Math::is_nan(ok_hsl.l)) {
 		return 0.0f;
 	}

--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -32,7 +32,6 @@
 
 #include "core/math/color.h"
 #include "scene/gui/slider.h"
-#include "thirdparty/misc/ok_color.h"
 
 ColorMode::ColorMode(ColorPicker *p_color_picker) {
 	color_picker = p_color_picker;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -37,7 +37,6 @@
 #include "core/os/os.h"
 #include "scene/gui/color_mode.h"
 #include "servers/display_server.h"
-#include "thirdparty/misc/ok_color.h"
 #include "thirdparty/misc/ok_color_shader.h"
 
 List<Color> ColorPicker::preset_cache;

--- a/thirdparty/misc/ok_color.h
+++ b/thirdparty/misc/ok_color.h
@@ -22,9 +22,8 @@
 #include <cmath>
 #include <cfloat>
 
-class ok_color
+namespace ok_color
 {
-public:
 
 struct Lab { float L; float a; float b; };
 struct RGB { float r; float g; float b; };
@@ -33,11 +32,11 @@ struct HSL { float h; float s; float l; };
 struct LC { float L; float C; };
 
 // Alternative representation of (L_cusp, C_cusp)
-// Encoded so S = C_cusp/L_cusp and T = C_cusp/(1-L_cusp) 
+// Encoded so S = C_cusp/L_cusp and T = C_cusp/(1-L_cusp)
 // The maximum value for C in the triangle is then found as fmin(S*L, T*(1-L)), for a given L
 struct ST { float S; float T; };
 
-static constexpr float pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062f;
+constexpr float pi = 3.1415926535897932384626433832795028841971693993751058209749445923078164062f;
 
 float clamp(float x, float min, float max)
 {
@@ -132,7 +131,7 @@ float compute_max_saturation(float a, float b)
 
 	// Do one step Halley's method to get closer
 	// this gives an error less than 10e6, except for some blue hues where the dS/dh is close to infinite
-	// this should be sufficient for most applications, otherwise do two/three steps 
+	// this should be sufficient for most applications, otherwise do two/three steps
 
 	float k_l = +0.3963377774f * a + 0.2158037573f * b;
 	float k_m = -0.1055613458f * a - 0.0638541728f * b;
@@ -180,7 +179,7 @@ LC find_cusp(float a, float b)
 	return { L_cusp , C_cusp };
 }
 
-// Finds intersection of the line defined by 
+// Finds intersection of the line defined by
 // L = L0 * (1 - t) + t * L1;
 // C = t * C1;
 // a and b must be normalized so a^2 + b^2 == 1
@@ -454,7 +453,7 @@ Cs get_Cs(float L, float a_, float b_)
 
 	float C_max = find_gamut_intersection(a_, b_, L, 1, L, cusp);
 	ST ST_max = to_ST(cusp);
-	
+
 	// Scale factor to compensate for the curved part of gamut shape:
 	float k = C_max / fmin((L * ST_max.S), (1 - L) * ST_max.T);
 
@@ -596,7 +595,7 @@ RGB okhsv_to_srgb(HSV hsv)
 
 	float a_ = cosf(2.f * pi * h);
 	float b_ = sinf(2.f * pi * h);
-	
+
 	LC cusp = find_cusp(a_, b_);
 	ST ST_max = to_ST(cusp);
 	float S_max = ST_max.S;


### PR DESCRIPTION
It doesn't need to be a class, and it was a namespace in the original code.
I had to get rid of some includes of ok_color.h in files where it wasn't used anyway, because it caused errors during build.
Also my auto formatter got rid of some spaces that shouldn't be there in ok_color.h, and I'm deciding to commit these changes.