### PR TITLE
Fix `AnimatedSprite3D` autoplay warning

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1095,13 +1095,13 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 		frames->get_animation_list(&al);
 		if (al.size() == 0) {
 			set_animation(StringName());
-			set_autoplay(String());
+			autoplay = String();
 		} else {
 			if (!frames->has_animation(animation)) {
 				set_animation(al[0]);
 			}
 			if (!frames->has_animation(autoplay)) {
-				set_autoplay(String());
+				autoplay = String();
 			}
 		}
 	}


### PR DESCRIPTION
Same as #75258 but for AnimatedSprite3D.

Fixes #77023.