### PR TITLE
Make SpriteFrames editor toolbar a `FlowContainer`

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/scene_tree_dock.h"
 #include "scene/gui/center_container.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -1711,11 +1712,11 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	sub_vb = memnew(VBoxContainer);
 	vbc->add_margin_child(TTR("Animation Frames:"), sub_vb, true);
 
-	HBoxContainer *hbc = memnew(HBoxContainer);
-	sub_vb->add_child(hbc);
+	HFlowContainer *hfc = memnew(HFlowContainer);
+	sub_vb->add_child(hfc);
 
 	playback_container = memnew(HBoxContainer);
-	hbc->add_child(playback_container);
+	hfc->add_child(playback_container);
 
 	play_bw_from = memnew(Button);
 	play_bw_from->set_flat(true);
@@ -1752,53 +1753,59 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	play_bw_from->connect("pressed", callable_mp(this, &SpriteFramesEditor::_play_bw_from_pressed));
 	stop->connect("pressed", callable_mp(this, &SpriteFramesEditor::_stop_pressed));
 
+	HBoxContainer *hbc_actions = memnew(HBoxContainer);
+	hfc->add_child(hbc_actions);
+
 	load = memnew(Button);
 	load->set_flat(true);
-	hbc->add_child(load);
+	hbc_actions->add_child(load);
 
 	load_sheet = memnew(Button);
 	load_sheet->set_flat(true);
-	hbc->add_child(load_sheet);
+	hbc_actions->add_child(load_sheet);
 
-	hbc->add_child(memnew(VSeparator));
+	hbc_actions->add_child(memnew(VSeparator));
 
 	copy = memnew(Button);
 	copy->set_flat(true);
-	hbc->add_child(copy);
+	hbc_actions->add_child(copy);
 
 	paste = memnew(Button);
 	paste->set_flat(true);
-	hbc->add_child(paste);
+	hbc_actions->add_child(paste);
 
-	hbc->add_child(memnew(VSeparator));
+	hbc_actions->add_child(memnew(VSeparator));
 
 	empty_before = memnew(Button);
 	empty_before->set_flat(true);
-	hbc->add_child(empty_before);
+	hbc_actions->add_child(empty_before);
 
 	empty_after = memnew(Button);
 	empty_after->set_flat(true);
-	hbc->add_child(empty_after);
+	hbc_actions->add_child(empty_after);
 
-	hbc->add_child(memnew(VSeparator));
+	hbc_actions->add_child(memnew(VSeparator));
 
 	move_up = memnew(Button);
 	move_up->set_flat(true);
-	hbc->add_child(move_up);
+	hbc_actions->add_child(move_up);
 
 	move_down = memnew(Button);
 	move_down->set_flat(true);
-	hbc->add_child(move_down);
+	hbc_actions->add_child(move_down);
 
 	delete_frame = memnew(Button);
 	delete_frame->set_flat(true);
-	hbc->add_child(delete_frame);
+	hbc_actions->add_child(delete_frame);
 
-	hbc->add_child(memnew(VSeparator));
+	hbc_actions->add_child(memnew(VSeparator));
+
+	HBoxContainer *hbc_frame_duration = memnew(HBoxContainer);
+	hfc->add_child(hbc_frame_duration);
 
 	Label *label = memnew(Label);
 	label->set_text(TTR("Frame Duration:"));
-	hbc->add_child(label);
+	hbc_frame_duration->add_child(label);
 
 	frame_duration = memnew(SpinBox);
 	frame_duration->set_prefix(String::utf8("×"));
@@ -1808,27 +1815,34 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	frame_duration->set_custom_arrow_step(0.1);
 	frame_duration->set_allow_lesser(false);
 	frame_duration->set_allow_greater(true);
-	hbc->add_child(frame_duration);
+	hbc_frame_duration->add_child(frame_duration);
 
-	hbc->add_spacer();
+	// Wide empty separation control. (like BoxContainer::add_spacer())
+	Control *c = memnew(Control);
+	c->set_mouse_filter(MOUSE_FILTER_PASS);
+	c->set_h_size_flags(SIZE_EXPAND_FILL);
+	hfc->add_child(c);
+
+	HBoxContainer *hbc_zoom = memnew(HBoxContainer);
+	hfc->add_child(hbc_zoom);
 
 	zoom_out = memnew(Button);
 	zoom_out->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_out));
 	zoom_out->set_flat(true);
 	zoom_out->set_tooltip_text(TTR("Zoom Out"));
-	hbc->add_child(zoom_out);
+	hbc_zoom->add_child(zoom_out);
 
 	zoom_reset = memnew(Button);
 	zoom_reset->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_reset));
 	zoom_reset->set_flat(true);
 	zoom_reset->set_tooltip_text(TTR("Zoom Reset"));
-	hbc->add_child(zoom_reset);
+	hbc_zoom->add_child(zoom_reset);
 
 	zoom_in = memnew(Button);
 	zoom_in->connect("pressed", callable_mp(this, &SpriteFramesEditor::_zoom_in));
 	zoom_in->set_flat(true);
 	zoom_in->set_tooltip_text(TTR("Zoom In"));
-	hbc->add_child(zoom_in);
+	hbc_zoom->add_child(zoom_in);
 
 	file = memnew(EditorFileDialog);
 	add_child(file);


### PR DESCRIPTION
Makes the SpriteFrames editor use HFlowContainer for its toolbar to reduce the minimum width. Makes the editor fit on smaller resolutions (it could get too wide after #71907). [Issue example from Reddit](https://www.reddit.com/r/godot/comments/13exw6i/very_noob_ui_question/).

Similar to #72050.

![zULQk2WrsM](https://github.com/godotengine/godot/assets/9283098/1d6739e9-4881-48d1-90e3-6d65882b1ad0)
