### PR TITLE
Fix lossless formats in PortableCompressedTexture2D

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -33,7 +33,6 @@
 #include "core/error/error_list.h"
 #include "core/error/error_macros.h"
 #include "core/io/image_loader.h"
-#include "core/io/marshalls.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_funcs.h"
 #include "core/string/print_string.h"
@@ -3935,33 +3934,16 @@ Image::Image(const uint8_t *p_mem_png_jpg, int p_len) {
 	mipmaps = false;
 	format = FORMAT_L8;
 
-	if (p_len < 4) {
-		if (p_len > 0) {
-			ERR_FAIL_MSG("The image can not be loaded: data length is too small (less than 4 bytes).");
-		}
-		return;
-	}
-
-	const uint8_t png_marker[] = { 0x89, 0x50, 0x4E, 0x47 };
-	const uint8_t webp_marker[] = { 0x52, 0x49, 0x46, 0x46 };
-	const uint8_t jpg_marker[] = { 0xFF, 0xD8, 0xFF };
-
-	if (_png_mem_loader_func && memcmp(p_mem_png_jpg, png_marker, sizeof(png_marker)) == 0) {
+	if (_png_mem_loader_func) {
 		copy_internals_from(_png_mem_loader_func(p_mem_png_jpg, p_len));
-
-	} else if (_webp_mem_loader_func && memcmp(p_mem_png_jpg, webp_marker, sizeof(webp_marker)) == 0) {
-		copy_internals_from(_webp_mem_loader_func(p_mem_png_jpg, p_len));
-
-	} else if (_jpg_mem_loader_func && memcmp(p_mem_png_jpg, jpg_marker, sizeof(jpg_marker)) == 0) {
-		copy_internals_from(_jpg_mem_loader_func(p_mem_png_jpg, p_len));
-
-	} else {
-		ERR_FAIL_MSG(vformat("Unexpected image format marker: %4X. Use 0x474E5089 for PNG, 0x46464952 for WEBP or 0x__FFD8FF for JPG.",
-				decode_uint32(p_mem_png_jpg)));
 	}
 
-	if (is_empty()) {
-		ERR_FAIL_MSG("The image can not be loaded");
+	if (is_empty() && _jpg_mem_loader_func) {
+		copy_internals_from(_jpg_mem_loader_func(p_mem_png_jpg, p_len));
+	}
+
+	if (is_empty() && _webp_mem_loader_func) {
+		copy_internals_from(_webp_mem_loader_func(p_mem_png_jpg, p_len));
 	}
 }
 


### PR DESCRIPTION
Sorry for my bad English(((

PortableCompressedTexture2D have a problem with creating from PNG images and some other little problems.
I want to use this resource type as the way to import animations from Aseprite in my [Aseprite importers plugin bundle](https://github.com/nklbdev/godot-4-aseprite-importers)

For now I am creating one PNG image near every `*.aseprite`-file that imported. Then call some methods to update filesystem and import the image. Then plugin is continuing it's work and embedding new image in an imported resource.

PortableCompressedTexture2D is a beautiful way to embed PNG data silently in SpriteFrames or other resources. But it is not usable now. Method `create_from_image` cannot load PNG image and shows errors in console:

```
WARNING: Not a PNG file
     at: PNGDriverCommon::check_error (drivers\png\png_driver_common.cpp:56)
ERROR: Condition "!success" is true. Returning: ERR_FILE_CORRUPT
   at: PNGDriverCommon::png_to_image (drivers\png\png_driver_common.cpp:69)
ERROR: Condition "err" is true. Returning: Ref<Image>()
   at: ImageLoaderPNG::load_mem_png (drivers\png\image_loader_png.cpp:64)
ERROR: It's not a reference to a valid Image object.
   at: (.\core/io/image.h:426)
ERROR: Condition "err" is true. Returning: Ref<Image>()
   at: _jpegd_mem_loader_func (modules\jpg\image_loader_jpegd.cpp:131)
ERROR: It's not a reference to a valid Image object.
   at: (.\core/io/image.h:426)
ERROR: Condition "p_width <= 0 || p_width > 16384" is true.
   at: GLES3::TextureStorage::texture_set_size_override (drivers\gles3\storage\texture_storage.cpp:1053)
```

This is because PNG image have not only PNG prefix "‰PNG", but also [Godot's own "PNG " prefix](https://github.com/godotengine/godot/blob/ffd32a244b43ff58c13819c2debf8cf3b58ecbdc/drivers/png/image_loader_png.cpp#L80)

This pull-request is for fixing it. Have a nice day!