### PR TITLE
Fixed width of CapsuleShape2D::get_rect + set center to center of shape

### DIFF
--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -97,7 +97,8 @@ void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 }
 
 Rect2 CapsuleShape2D::get_rect() const {
-	return Rect2(0, 0, radius, height);
+	const Vector2 half_size = Vector2(radius, height * 0.5);
+	return Rect2(-half_size, half_size * 2.0);
 }
 
 real_t CapsuleShape2D::get_enclosing_radius() const {


### PR DESCRIPTION
The width of the rect was only half of the width of the shape, and the 0;0 coord was at the top left of the rect.
Now the width properly matches the width of the shape, and the 0;0 coord is at the center of the shape. It should match the behavior of Godot 3.X (https://github.com/godotengine/godot/blob/3.x/scene/resources/capsule_shape_2d.cpp#L93-L99).

I haven't found a test file for CapsuleShape2D, I don't know if I have to create one or if it should be written in an existing file, or something else.