### PR TITLE
Add tooltip plugin for AudioStream

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -4128,6 +4128,7 @@ FileSystemDock::FileSystemDock() {
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &FileSystemDock::_project_settings_changed));
 	add_resource_tooltip_plugin(memnew(EditorTextureTooltipPlugin));
+	add_resource_tooltip_plugin(memnew(EditorAudioStreamTooltipPlugin));
 }
 
 FileSystemDock::~FileSystemDock() {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -678,6 +678,8 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const Ref<Resource> &p_f
 		}
 	}
 
+	p_metadata["length"] = stream->get_length();
+
 	//post_process_preview(img);
 
 	Ref<Image> image = Image::create_from_data(w, h, false, Image::FORMAT_RGB8, img);

--- a/editor/plugins/editor_resource_tooltip_plugins.cpp
+++ b/editor/plugins/editor_resource_tooltip_plugins.cpp
@@ -103,6 +103,7 @@ bool EditorTextureTooltipPlugin::handles(const String &p_resource_type) const {
 Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	VBoxContainer *vb = Object::cast_to<VBoxContainer>(p_base);
+	DEV_ASSERT(vb);
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());
@@ -116,4 +117,30 @@ Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resou
 
 	hb->add_child(vb);
 	return hb;
+}
+
+// EditorAudioStreamTooltipPlugin
+
+bool EditorAudioStreamTooltipPlugin::handles(const String &p_resource_type) const {
+	return ClassDB::is_parent_class(p_resource_type, "AudioStream");
+}
+
+Control *EditorAudioStreamTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const {
+	VBoxContainer *vb = Object::cast_to<VBoxContainer>(p_base);
+	DEV_ASSERT(vb);
+
+	double length = p_metadata.get("length", 0.0);
+	if (length >= 60.0) {
+		vb->add_child(memnew(Label(vformat(TTR("Length: %0dm %0ds"), int(length / 60.0), int(fmod(length, 60))))));
+	} else if (length >= 1.0) {
+		vb->add_child(memnew(Label(vformat(TTR("Length: %0.1fs"), length))));
+	} else {
+		vb->add_child(memnew(Label(vformat(TTR("Length: %0.3fs"), length))));
+	}
+
+	TextureRect *tr = memnew(TextureRect);
+	vb->add_child(tr);
+	request_thumbnail(p_resource_path, tr);
+
+	return vb;
 }

--- a/editor/plugins/editor_resource_tooltip_plugins.h
+++ b/editor/plugins/editor_resource_tooltip_plugins.h
@@ -33,9 +33,8 @@
 
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
-#include <scene/gui/control.h>
+#include "scene/gui/control.h"
 
-class Control;
 class Texture2D;
 class TextureRect;
 class VBoxContainer;
@@ -61,6 +60,14 @@ public:
 
 class EditorTextureTooltipPlugin : public EditorResourceTooltipPlugin {
 	GDCLASS(EditorTextureTooltipPlugin, EditorResourceTooltipPlugin);
+
+public:
+	virtual bool handles(const String &p_resource_type) const override;
+	virtual Control *make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const override;
+};
+
+class EditorAudioStreamTooltipPlugin : public EditorResourceTooltipPlugin {
+	GDCLASS(EditorAudioStreamTooltipPlugin, EditorResourceTooltipPlugin);
 
 public:
 	virtual bool handles(const String &p_resource_type) const override;


### PR DESCRIPTION
Follow-up to #63263
EDIT: Updated version here: https://github.com/godotengine/godot/pull/77069#issuecomment-1570221966

This PR adds a tooltip plugin for AudioStream resource. Normally the tooltip would show simply the length and visual preview of the stream, but that would be too boring, so I added playback functionality 🤪

https://github.com/godotengine/godot/assets/2223172/7fe2a459-0eff-422f-8d51-251da397246d

It comes with play/pause, autoplay and 5s forward/backward seeking. I couldn't find a good way to add keyboard input to the tooltip, so I had to switch some flags and the tooltip causes some focus problems.

I initially came up with this idea as a fix for #63683, but #63263 wasn't merged in time and the issue was resolved in the meantime.