### PR TITLE
Allow calling for Physics step from code

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -74,6 +74,15 @@ int Engine::get_max_fps() const {
 	return _max_fps;
 }
 
+void Engine::set_fixed_fps(int p_fps) {
+	ERR_FAIL_COND_MSG(p_fps <= -1, "Fixed FPS must be a positive value (or 0 to disable fixed FPS).");
+	fixed_fps = p_fps;
+}
+
+int Engine::get_fixed_fps() const {
+	return fixed_fps;
+}
+
 uint64_t Engine::get_frames_drawn() {
 	return frames_drawn;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -60,6 +60,7 @@ private:
 	int ips = 60;
 	double physics_jitter_fix = 0.5;
 	double _fps = 1;
+	int fixed_fps = 0;
 	int _max_fps = 0;
 	double _time_scale = 1.0;
 	uint64_t _physics_frames = 0;
@@ -97,6 +98,9 @@ public:
 
 	virtual void set_max_fps(int p_fps);
 	virtual int get_max_fps() const;
+
+	virtual void set_fixed_fps(int p_fps);
+	virtual int get_fixed_fps() const;
 
 	virtual double get_frames_per_second() const { return _fps; }
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1545,6 +1545,14 @@ int Engine::get_max_fps() const {
 	return ::Engine::get_singleton()->get_max_fps();
 }
 
+void Engine::set_fixed_fps(int p_fps) {
+	::Engine::get_singleton()->set_fixed_fps(p_fps);
+}
+
+int Engine::get_fixed_fps() const {
+	return ::Engine::get_singleton()->get_fixed_fps();
+}
+
 double Engine::get_frames_per_second() const {
 	return ::Engine::get_singleton()->get_frames_per_second();
 }
@@ -1687,6 +1695,8 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_physics_interpolation_fraction"), &Engine::get_physics_interpolation_fraction);
 	ClassDB::bind_method(D_METHOD("set_max_fps", "max_fps"), &Engine::set_max_fps);
 	ClassDB::bind_method(D_METHOD("get_max_fps"), &Engine::get_max_fps);
+	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fixed_fps"), &Engine::set_fixed_fps);
+	ClassDB::bind_method(D_METHOD("get_fixed_fps"), &Engine::get_fixed_fps);
 
 	ClassDB::bind_method(D_METHOD("set_time_scale", "time_scale"), &Engine::set_time_scale);
 	ClassDB::bind_method(D_METHOD("get_time_scale"), &Engine::get_time_scale);
@@ -1732,6 +1742,7 @@ void Engine::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_ticks_per_second"), "set_physics_ticks_per_second", "get_physics_ticks_per_second");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_physics_steps_per_frame"), "set_max_physics_steps_per_frame", "get_max_physics_steps_per_frame");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_fps"), "set_max_fps", "get_max_fps");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_scale"), "set_time_scale", "get_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "physics_jitter_fix"), "set_physics_jitter_fix", "get_physics_jitter_fix");
 }

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -478,6 +478,9 @@ public:
 	void set_max_fps(int p_fps);
 	int get_max_fps() const;
 
+	void set_fixed_fps(int p_fps);
+	int get_fixed_fps() const;
+
 	double get_frames_per_second() const;
 	uint64_t get_physics_frames() const;
 	uint64_t get_process_frames() const;

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -283,7 +283,7 @@
 	<members>
 		<member name="max_fps" type="int" setter="set_max_fps" getter="get_max_fps" default="0">
 			The maximum number of frames per second that can be rendered. A value of [code]0[/code] means "no limit". The actual number of frames per second may still be below this value if the CPU or GPU cannot keep up with the project logic and rendering.
-			Limiting the FPS can be useful to reduce system power consumption, which reduces heat and noise emissions (and improves battery life on mobile devices).
+			Limiting the FPS can be useful to reduce system power consumption, which reduces heat and noise emissions (and improves battery life on mobile devices). See also [member physics_ticks_per_second], [member fixed_fps] and [member ProjectSettings.application/run/max_fps].
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Enabled[/code], on monitors with variable refresh rate enabled (G-Sync/FreeSync), using a FPS limit a few frames lower than the monitor's refresh rate will [url=https://blurbusters.com/howto-low-lag-vsync-on/]reduce input lag while avoiding tearing[/url].
 			If [member ProjectSettings.display/window/vsync/vsync_mode] is [code]Disabled[/code], limiting the FPS to a high value that can be consistently reached on the system can reduce input lag compared to an uncapped framerate. Since this works by ensuring the GPU load is lower than 100%, this latency reduction is only effective in GPU-bottlenecked scenarios, not CPU-bottlenecked scenarios.
@@ -291,6 +291,10 @@
 		</member>
 		<member name="max_physics_steps_per_frame" type="int" setter="set_max_physics_steps_per_frame" getter="get_max_physics_steps_per_frame" default="8">
 			Controls the maximum number of physics steps that can be simulated each rendered frame. The default value is tuned to avoid "spiral of death" situations where expensive physics simulations trigger more expensive simulations indefinitely. However, the game will appear to slow down if the rendering FPS is less than [code]1 / max_physics_steps_per_frame[/code] of [member physics_ticks_per_second]. This occurs even if [code]delta[/code] is consistently used in physics calculations. To avoid this, increase [member max_physics_steps_per_frame] if you have increased [member physics_ticks_per_second] significantly above its default value.
+		</member>
+		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="0">
+			If set to a value greater than [code]0[/code], this forces the engine to simulate as fast as possible while respecting the given FPS as a [code]delta[/code] value passed to [method Node._process] functions. This can be used for non-realtime simulation such as offline video recording, benchmarking or AI training. See also [member max_fps] and [member ProjectSettings.application/run/fixed_fps].
+			Non-realtime simulation can also be enabled using the [code]--fixed-fps &lt;fps&gt;[/code] command line argument.
 		</member>
 		<member name="physics_jitter_fix" type="float" setter="set_physics_jitter_fix" getter="get_physics_jitter_fix" default="0.5">
 			Controls how much physics ticks are synchronized with real time. For 0 or less, the ticks are synchronized. Such values are recommended for network games, where clock synchronization matters. Higher values cause higher deviation of the in-game clock and real clock but smooth out framerate jitters. The default value of 0.5 should be fine for most; values above 2 could cause the game to react to dropped frames with a noticeable delay and are not recommended.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -305,6 +305,12 @@
 			If [code]true[/code], disables printing to standard output. This is equivalent to starting the editor or project with the [code]--quiet[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url]. See also [member application/run/disable_stderr].
 			Changes to this setting will only be applied upon restarting the application.
 		</member>
+		<member name="application/run/fixed_fps" type="int" setter="" getter="" default="0">
+			If set to a value greater than [code]0[/code], this forces the engine to simulate as fast as possible while respecting the given FPS as a [code]delta[/code] value passed to [method Node._process] functions. This can be used for non-realtime simulation such as benchmarking or AI training. See also [member ProjectSettings.debug/settings/fps/force_fps] and [member physics/common/physics_ticks_per_second].
+			Non-realtime simulation can also be enabled using the [code]--fixed-fps &lt;fps&gt;[/code] command line argument, which takes priority over [member application/run/fixed_fps].
+			[b]Note:[/b] This property is only read when the project starts. To toggle non-realtime simulation at runtime, set [member Engine.fixed_fps] instead.
+			[b]Note:[/b] When running the project from the editor with Movie Maker mode enabled, [member editor/movie_writer/fps] takes priority over [member application/run/fixed_fps].
+		</member>
 		<member name="application/run/flush_stdout_on_print" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], flushes the standard output stream every time a line is printed. This affects both terminal logging and file logging.
 			When running a project, this setting must be enabled if you want logs to be collected by service managers such as systemd/journalctl. This setting is disabled by default on release builds, since flushing on every printed line will negatively affect performance if lots of lines are printed in a rapid succession. Also, if this setting is enabled, logged files will still be written successfully if the application crashes or is otherwise killed by the user (without being closed "normally").
@@ -331,7 +337,7 @@
 			Path to the main scene file that will be loaded when the project runs.
 		</member>
 		<member name="application/run/max_fps" type="int" setter="" getter="" default="0">
-			Maximum number of frames per second allowed. A value of [code]0[/code] means "no limit". The actual number of frames per second may still be below this value if the CPU or GPU cannot keep up with the project logic and rendering.
+			Maximum number of frames per second allowed. A value of [code]0[/code] means "no limit". The actual number of frames per second may still be below this value if the CPU or GPU cannot keep up with the project logic and rendering. See also [member physics/common/physics_ticks_per_second] and [member application/run/fixed_fps].
 			Limiting the FPS can be useful to reduce system power consumption, which reduces heat and noise emissions (and improves battery life on mobile devices).
 			If [member display/window/vsync/vsync_mode] is set to [code]Enabled[/code] or [code]Adaptive[/code], it takes precedence and the forced FPS number cannot exceed the monitor's refresh rate.
 			If [member display/window/vsync/vsync_mode] is [code]Enabled[/code], on monitors with variable refresh rate enabled (G-Sync/FreeSync), using a FPS limit a few frames lower than the monitor's refresh rate will [url=https://blurbusters.com/howto-low-lag-vsync-on/]reduce input lag while avoiding tearing[/url].
@@ -825,7 +831,7 @@
 		</member>
 		<member name="editor/movie_writer/fps" type="int" setter="" getter="" default="60">
 			The number of frames per second to record in the video when writing a movie. Simulation speed will adjust to always match the specified framerate, which means the engine will appear to run slower at higher [member editor/movie_writer/fps] values. Certain FPS values will require you to adjust [member editor/movie_writer/mix_rate] to prevent audio from desynchronizing over time.
-			This can be specified manually on the command line using the [code]--fixed-fps &lt;fps&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
+			This can be specified manually on the command line using the [code]--fixed-fps &lt;fps&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url]. See also [member application/run/fixed_fps], which also applies when not using Movie Maker mode. [member editor/movie_writer/fps] takes priority over [member application/run/fixed_fps] when running the project from the editor with Movie Maker mode enabled.
 		</member>
 		<member name="editor/movie_writer/mix_rate" type="int" setter="" getter="" default="48000">
 			The audio mix rate to use in the recorded audio when writing a movie (in Hz). This can be different from [member audio/driver/mix_rate], but this value must be divisible by [member editor/movie_writer/fps] to prevent audio from desynchronizing over time.
@@ -2131,7 +2137,7 @@
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
 		<member name="physics/common/physics_ticks_per_second" type="int" setter="" getter="" default="60">
-			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. See also [member application/run/max_fps].
+			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. See also [member application/run/max_fps] and [member application/run/fixed_fps].
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_ticks_per_second] instead.
 			[b]Note:[/b] Only [member physics/common/max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member physics/common/max_physics_steps_per_frame] if increasing [member physics/common/physics_ticks_per_second] significantly above its default value.
 		</member>

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -412,7 +412,7 @@ MainFrameTime MainTimerSync::advance_core(double p_physics_step, int p_physics_t
 
 // calls advance_core, keeps track of deficit it adds to animaption_step, make sure the deficit sum stays close to zero
 MainFrameTime MainTimerSync::advance_checked(double p_physics_step, int p_physics_ticks_per_second, double p_process_step) {
-	if (fixed_fps != -1) {
+	if (fixed_fps >= 1) {
 		p_process_step = 1.0 / fixed_fps;
 	}
 

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
+import os
 import build_scripts.mono_configure as mono_configure
+import build_scripts.build_assemblies as build_assemblies
+from methods import glob_recursive
 
 Import("env")
 Import("env_modules")
 
+env_local = env.Clone()
 env_mono = env_modules.Clone()
 
 # Configure Mono
@@ -29,3 +33,41 @@ elif env["platform"] == "android":
 if env.editor_build:
     env_mono.add_source_files(env.modules_sources, "editor/*.cpp")
     SConscript("editor/script_templates/SCsub")
+
+    if env_local["build_csharp"]:
+       env_local["build_assemblies"] = True
+       env_local["generate_mono_glue"] = True
+
+    if env_local["build_assemblies"] or env_local["generate_mono_glue"]:
+        gd = os.path.join(env_local.Dir("#bin").abspath, "godot" + env_local["PROGSUFFIX"])
+
+        if env_local["generate_mono_glue"]:
+            env_local["BUILDERS"]["CSharpGlue"] = Builder(action=gd + " --headless --generate-mono-glue modules/mono/glue")
+
+            # the only generated files with fixed names are these
+            glue_targets = [
+                "glue/GodotSharp/GodotSharp/Generated/GD_constants.cs",
+                "glue/GodotSharp/GodotSharp/Generated/GD_extensions.cs",
+                "glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props",
+                "glue/GodotSharp/GodotSharp/Generated/NativeCalls.cs",
+                "glue/GodotSharp/GodotSharpEditor/Generated/EditorNativeCalls.cs",
+                "glue/GodotSharp/GodotSharpEditor/Generated/GeneratedIncludes.props",
+            ]
+
+            glue_sources = [gd]
+            env_local.Alias("generate_mono_glue", [env_local.CSharpGlue(glue_targets, glue_sources)])
+
+        if env_local["build_assemblies"]:
+            env_local["BUILDERS"]["CSharpBuildAssemblies"] = Builder(
+                action=env_local.Run(build_assemblies.make_assemblies, "Building C# assemblies.")
+            )
+
+            assemblies_targets = []
+            for build_config in ["Debug", "Release"]:
+                editor_api_dir = os.path.join("#bin", "GodotSharp", "Api", build_config)
+                assemblies_targets += [
+                    os.path.join(editor_api_dir, filename) for filename in build_assemblies.target_filenames
+                ]
+
+            assemblies_sources = glob_recursive("**/*.cs", "glue")
+            env_local.Alias("build_assemblies", [env_local.CSharpBuildAssemblies(assemblies_targets, assemblies_sources)])

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -36,3 +36,13 @@ def get_doc_path():
 def is_enabled():
     # The module is disabled by default. Use module_mono_enabled=yes to enable it.
     return False
+
+
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable("generate_mono_glue", "Generate C# glue", False),
+        BoolVariable("build_assemblies", "Build C# assemblies", False),
+        BoolVariable("build_csharp", "Generate and build C# bindings", False),
+    ]


### PR DESCRIPTION
fixes #24769

exposes a function that calls a physics tick with the given delta type in parameter
also allows to set ```Engine.physics_ticks_per_second``` to 0

My particular use case is training AI in a sped-up, not-real-time environment.

related to #76462 but with a different approach

