### PR TITLE
Fix Skeleton3D editor crash regression after #76592

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1536,6 +1536,11 @@ void EditorInspectorSection::fold() {
 	queue_redraw();
 }
 
+void EditorInspectorSection::set_bg_color(const Color &p_bg_color) {
+	bg_color = p_bg_color;
+	queue_redraw();
+}
+
 bool EditorInspectorSection::has_revertable_properties() const {
 	return !revertable_properties.is_empty();
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -298,6 +298,7 @@ public:
 	VBoxContainer *get_vbox();
 	void unfold();
 	void fold();
+	void set_bg_color(const Color &p_bg_color);
 
 	bool has_revertable_properties() const;
 	void property_can_revert_changed(const String &p_path, bool p_can_revert);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -696,9 +696,6 @@ void Skeleton3DEditor::update_joint_tree() {
 	}
 }
 
-void Skeleton3DEditor::update_editors() {
-}
-
 void Skeleton3DEditor::create_editors() {
 	set_h_size_flags(SIZE_EXPAND_FILL);
 	set_focus_mode(FOCUS_ALL);
@@ -798,10 +795,8 @@ void Skeleton3DEditor::create_editors() {
 	animation_hb->add_child(key_insert_all_button);
 
 	// Bone tree.
-	const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
-
-	EditorInspectorSection *bones_section = memnew(EditorInspectorSection);
-	bones_section->setup("bones", "Bones", skeleton, section_color, true);
+	bones_section = memnew(EditorInspectorSection);
+	bones_section->setup("bones", "Bones", skeleton, Color(0.0f, 0.0, 0.0f), true);
 	add_child(bones_section);
 	bones_section->unfold();
 
@@ -832,7 +827,6 @@ void Skeleton3DEditor::create_editors() {
 void Skeleton3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			create_editors();
 			update_joint_tree();
 
 			joint_tree->connect("item_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_selection_changed));
@@ -858,6 +852,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			key_scale_button->set_icon(get_theme_icon(SNAME("KeyScale"), SNAME("EditorIcons")));
 			key_insert_button->set_icon(get_theme_icon(SNAME("Key"), SNAME("EditorIcons")));
 			key_insert_all_button->set_icon(get_theme_icon(SNAME("NewKey"), SNAME("EditorIcons")));
+			bones_section->set_bg_color(get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 			update_joint_tree();
 		} break;
@@ -946,6 +941,8 @@ void fragment() {
 	handles_mesh_instance->set_cast_shadows_setting(GeometryInstance3D::SHADOW_CASTING_SETTING_OFF);
 	handles_mesh.instantiate();
 	handles_mesh_instance->set_mesh(handles_mesh);
+
+	create_editors();
 }
 
 void Skeleton3DEditor::update_bone_original() {

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -132,6 +132,8 @@ class Skeleton3DEditor : public VBoxContainer {
 	Button *key_insert_button = nullptr;
 	Button *key_insert_all_button = nullptr;
 
+	EditorInspectorSection *bones_section = nullptr;
+
 	EditorFileDialog *file_dialog = nullptr;
 
 	bool keyable = false;
@@ -146,7 +148,6 @@ class Skeleton3DEditor : public VBoxContainer {
 	EditorFileDialog *file_export_lib = nullptr;
 
 	void update_joint_tree();
-	void update_editors();
 
 	void create_editors();
 


### PR DESCRIPTION
Control notifies a theme changed before the editor has entered the tree,

Fixes: https://github.com/godotengine/godot/issues/77046

However, I am not sure why Control notifies THEME_CHANGED before propagating ENTER_TREE to subclasses.
Note that moving the editor creating back to where it was before my change cause theme resources to be accessed before they are ready.
I could use someone with more expertise on theme changes and UI to double check if the fix makes sense or if there is a better way to handle this :)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
