### PR TITLE
Print a warning when a nested project is detected

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2350,12 +2350,13 @@ bool EditorFileSystem::_should_skip_directory(const String &p_path) {
 	}
 
 	if (FileAccess::exists(p_path.path_join("project.godot"))) {
-		// skip if another project inside this
+		// Skip if another project inside this.
+		WARN_PRINT_ONCE(vformat("Detected another project.godot at %s. The folder will be ignored.", p_path));
 		return true;
 	}
 
 	if (FileAccess::exists(p_path.path_join(".gdignore"))) {
-		// skip if a `.gdignore` file is inside this
+		// Skip if a `.gdignore` file is inside this.
 		return true;
 	}
 


### PR DESCRIPTION
Closes #77050
Requires #77080, otherwise the warning only appears in the external console.

This code runs on every filesystem scan, so printing a warning on every found project every time the files are scanned would be too spammy. Not many users reported similar issue, so it's fine using ONCE probably.