### PR TITLE
Accurately document StringName comparisons

### DIFF
--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -1020,14 +1020,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
+				Returns [code]true[/code] if the left [StringName]'s pointer comes before [param right]. Note that this will not match their [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url].
 			</description>
 		</operator>
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the left [String] comes before [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
+				Returns [code]true[/code] if the left [StringName]'s pointer comes before [param right] or if they are the same. Note that this will not match their [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url].
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -1048,14 +1048,14 @@
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the left [StringName] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order. Useful for sorting.
+				Returns [code]true[/code] if the left [StringName]'s pointer comes after [param right]. Note that this will not match their [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url].
 			</description>
 		</operator>
 		<operator name="operator &gt;=">
 			<return type="bool" />
 			<param index="0" name="right" type="StringName" />
 			<description>
-				Returns [code]true[/code] if the left [StringName] comes after [param right] in [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url], which roughly matches the alphabetical order, or if both are equal.
+				Returns [code]true[/code] if the left [StringName]'s pointer comes after [param right] or if they are the same. Note that this will not match their [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode order[/url].
 			</description>
 		</operator>
 	</operators>


### PR DESCRIPTION
A few months ago someone kindly wrote documentation for the operators of both `String` and `StringName` (https://github.com/godotengine/godot/pull/68217). Unfortunately, `StringName`'s comparison operators do not function the same as the ones for `String` do, comparing only the order of the pointers (at least, if my experimentation and understanding of the [engine code](https://github.com/godotengine/godot/blob/fb10f45efe52e330496e325b6b7efd0e52f769b0/core/string/string_name.h#L117) are to be believed).

This PR simply corrects the documentation of the comparison operators for `StringName`.
