### PR TITLE
Exclude incorrect completion options for `render_mode` in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8027,6 +8027,9 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 	while (tk.type != TK_EOF) {
 		switch (tk.type) {
 			case TK_RENDER_MODE: {
+#ifdef DEBUG_ENABLED
+				keyword_completion_context = CF_UNSPECIFIED;
+#endif // DEBUG_ENABLED
 				while (true) {
 					StringName mode;
 					_get_completable_identifier(nullptr, COMPLETION_RENDER_MODE, mode);
@@ -8114,6 +8117,9 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						return ERR_PARSE_ERROR;
 					}
 				}
+#ifdef DEBUG_ENABLED
+				keyword_completion_context = CF_GLOBAL_SPACE;
+#endif // DEBUG_ENABLED
 			} break;
 			case TK_STRUCT: {
 				ShaderNode::Struct st;


### PR DESCRIPTION
<details>
<summary>Before</summary>

![image](https://github.com/godotengine/godot/assets/3036176/cea8edf2-c8bc-4fe8-8203-68571629f17d)

</details>

<details>
<summary>After</summary>

![image](https://github.com/godotengine/godot/assets/3036176/4982414c-9b8f-4329-b840-d796fa465514)

</details>
