### PR TITLE
GDScript: Fix `validate_call_arg()` for unresolved datatype

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4837,9 +4837,11 @@ void GDScriptAnalyzer::validate_call_arg(const List<GDScriptParser::DataType> &p
 		}
 		GDScriptParser::DataType arg_type = p_call->arguments[i]->get_datatype();
 
-		if ((arg_type.is_variant() || !arg_type.is_hard_type()) && !(par_type.is_hard_type() && par_type.is_variant())) {
-			// Argument can be anything, so this is unsafe.
-			mark_node_unsafe(p_call->arguments[i]);
+		if (arg_type.is_variant() || !arg_type.is_hard_type()) {
+			// Argument can be anything, so this is unsafe (unless the parameter is a hard variant).
+			if (!(par_type.is_hard_type() && par_type.is_variant())) {
+				mark_node_unsafe(p_call->arguments[i]);
+			}
 		} else if (par_type.is_hard_type() && !is_type_compatible(par_type, arg_type, true)) {
 			// Supertypes are acceptable for dynamic compliance, but it's unsafe.
 			mark_node_unsafe(p_call);


### PR DESCRIPTION
Fix wrong implication.

```
#0  GDScriptAnalyzer::is_type_compatible (this=0x7fffffffca30, p_target=..., 
    p_source=..., p_allow_implicit_conversion=true, p_source_node=0x0)
    at modules/gdscript/gdscript_analyzer.cpp:4969
#1  0x0000555558c7f359 in GDScriptAnalyzer::validate_call_arg (
    this=0x7fffffffca30, p_par_types=..., p_default_args_count=0, 
    p_is_vararg=false, p_call=0x55557dddd570)
    at modules/gdscript/gdscript_analyzer.cpp:4843
#2  0x0000555558c6fb97 in GDScriptAnalyzer::reduce_call (this=0x7fffffffca30, 
    p_call=0x55557dddd570, p_is_await=false, p_is_root=true)
    at modules/gdscript/gdscript_analyzer.cpp:3095
```

Closes #77066.