### PR TITLE
Additional cleanup of bone editors

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -51,10 +51,8 @@
 #include "scene/scene_string_names.h"
 
 void BoneTransformEditor::create_editors() {
-	const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
-
 	section = memnew(EditorInspectorSection);
-	section->setup("trf_properties", label, this, section_color, true);
+	section->setup("trf_properties", label, this, Color(0.0f, 0.0f, 0.0f), true);
 	section->unfold();
 	add_child(section);
 
@@ -93,7 +91,7 @@ void BoneTransformEditor::create_editors() {
 
 	// Transform/Matrix section.
 	rest_section = memnew(EditorInspectorSection);
-	rest_section->setup("trf_properties_transform", "Rest", this, section_color, true);
+	rest_section->setup("trf_properties_transform", "Rest", this, Color(0.0f, 0.0f, 0.0f), true);
 	section->get_vbox()->add_child(rest_section);
 
 	// Transform/Matrix property.
@@ -106,8 +104,10 @@ void BoneTransformEditor::create_editors() {
 
 void BoneTransformEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			create_editors();
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
+			section->set_bg_color(section_color);
+			rest_section->set_bg_color(section_color);
 		} break;
 	}
 }
@@ -127,6 +127,7 @@ void BoneTransformEditor::_value_changed(const String &p_property, Variant p_val
 
 BoneTransformEditor::BoneTransformEditor(Skeleton3D *p_skeleton) :
 		skeleton(p_skeleton) {
+	create_editors();
 }
 
 void BoneTransformEditor::set_keyable(const bool p_keyable) {


### PR DESCRIPTION
As discussed in rocket chat, this is the follow up of: https://github.com/godotengine/godot/pull/77074
BoneTransformEditor::create_editor is called from the constructor rather than NOTIFICATION_ENTER_TREE and the background color for EditorInspectSections are updated on theme change.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
