### PR TITLE
Add Array and Dictionary Destructuring to GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1386,6 +1386,10 @@ void GDScriptAnalyzer::resolve_node(GDScriptParser::Node *p_node, bool p_is_root
 		case GDScriptParser::Node::VARIABLE:
 			resolve_variable(static_cast<GDScriptParser::VariableNode *>(p_node), true);
 			break;
+		case GDScriptParser::Node::ARRAY_DESTRUCTURING:
+		case GDScriptParser::Node::DICT_DESTRUCTURING:
+			resolve_destructuring(static_cast<GDScriptParser::DestructuringNode *>(p_node));
+			break;
 		case GDScriptParser::Node::WHILE:
 			resolve_while(static_cast<GDScriptParser::WhileNode *>(p_node));
 			break;
@@ -1875,6 +1879,159 @@ void GDScriptAnalyzer::resolve_variable(GDScriptParser::VariableNode *p_variable
 #endif
 }
 
+void GDScriptAnalyzer::resolve_destructuring(GDScriptParser::DestructuringNode *p_destructuring) {
+	bool is_array = p_destructuring->type == GDScriptParser::Node::ARRAY_DESTRUCTURING;
+	if (p_destructuring->is_top_level) {
+		if (!p_destructuring->initializer) {
+			return;
+		}
+
+		reduce_expression(p_destructuring->initializer);
+		GDScriptParser::DataType type = p_destructuring->initializer->get_datatype();
+		if (is_array && !type.is_variant() && (type.kind != GDScriptParser::DataType::BUILTIN || type.builtin_type != Variant::ARRAY)) {
+			push_error(vformat(R"(Cannot apply destructuring to %s expression of type "%s")", is_array ? "non-array" : "non-dictionary", type.to_string()), p_destructuring->initializer);
+		}
+	}
+
+	switch (p_destructuring->inner_type) {
+		case GDScriptParser::DestructuringNode::IDENTIFIER: {
+			reduce_identifier(p_destructuring->source->identifier);
+			p_destructuring->source->set_datatype(p_destructuring->source->identifier->get_datatype());
+			if (p_destructuring->is_spread) {
+				GDScriptParser::DataType type = p_destructuring->source->get_datatype();
+				if (!type.is_variant() && (type.kind != GDScriptParser::DataType::BUILTIN || type.builtin_type != (is_array ? Variant::ARRAY : Variant::DICTIONARY))) {
+					push_error(vformat(R"(Cannot destructure %s identifier "%s" of type "%s", because it has the spread qualifier.)", is_array ? "non-array" : "non-dictionary", p_destructuring->source->identifier->name, type.to_string()), p_destructuring->source);
+				}
+			}
+		} break;
+		case GDScriptParser::DestructuringNode::VARIABLE: {
+			static constexpr const char *kind = "destructuring variable";
+			resolve_assignable(p_destructuring->source, kind);
+			if (p_destructuring->is_spread) {
+				GDScriptParser::DataType type = p_destructuring->source->get_datatype();
+				if (!type.is_variant() && (type.kind != GDScriptParser::DataType::BUILTIN || type.builtin_type != (is_array ? Variant::ARRAY : Variant::DICTIONARY))) {
+					push_error(vformat(R"(Cannot destructure %s identifier "%s" of type "%s", because it has the spread qualifier.)", is_array ? "non-array" : "non-dictionary", p_destructuring->source->identifier->name, type.to_string()), p_destructuring->source);
+				}
+			}
+		} break;
+		case GDScriptParser::DestructuringNode::DESTRUCTURE: {
+			if (p_destructuring->type == GDScriptParser::Node::ARRAY_DESTRUCTURING) {
+				int idx = 0;
+				for (GDScriptParser::DestructuringNode *inner_destructuring : static_cast<GDScriptParser::ArrayDestructuringNode *>(p_destructuring)->destructured) {
+					resolve_destructuring(inner_destructuring);
+					if (!p_destructuring->is_top_level) {
+						// TODO: Allow analyzing type mismatches in nested destructuring
+						continue;
+					}
+					if (inner_destructuring->is_spread) {
+						continue;
+					}
+					// Allow us to type check certain Array declarations against certain destructuring expressions
+					if (p_destructuring->initializer->type != GDScriptParser::Node::ARRAY) {
+						continue;
+					}
+					GDScriptParser::ArrayNode *initializer = static_cast<GDScriptParser::ArrayNode *>(p_destructuring->initializer);
+					if (initializer->elements.size() - 1 < idx) {
+						continue;
+					}
+					GDScriptParser::ExpressionNode *expression = initializer->elements[idx];
+					if (!expression->reduced || expression->get_datatype().kind != GDScriptParser::DataType::BUILTIN) {
+						continue;
+					}
+
+					switch (inner_destructuring->inner_type) {
+						case GDScriptParser::DestructuringNode::IDENTIFIER:
+						case GDScriptParser::DestructuringNode::VARIABLE: {
+							GDScriptParser::VariableNode *source = inner_destructuring->source;
+							if (source->get_datatype().is_hard_type() && source->get_datatype().kind == GDScriptParser::DataType::BUILTIN && expression->get_datatype().builtin_type != source->get_datatype().builtin_type) {
+								push_error(vformat(R"(Mismatched type "%s" at index %d in the destructuring expression, expected "%s".)", source->get_datatype().to_string(), idx, expression->get_datatype().to_string()), inner_destructuring);
+							}
+						} break;
+						case GDScriptParser::DestructuringNode::DESTRUCTURE: {
+							if (inner_destructuring->type == GDScriptParser::Node::ARRAY_DESTRUCTURING && expression->get_datatype().builtin_type != Variant::ARRAY) {
+								push_error(vformat(R"(Mismatched type "Array" at index %d in the destructuring expression, expected "%s".)", idx, expression->get_datatype().to_string()), inner_destructuring);
+							}
+						} break;
+						case GDScriptParser::DestructuringNode::NONE: {
+						} break;
+					}
+					idx += 1;
+				}
+			} else {
+				for (const KeyValue<GDScriptParser::IdentifierNode *, GDScriptParser::DestructuringNode *> &E : static_cast<GDScriptParser::DictDestructuringNode *>(p_destructuring)->destructured) {
+					if (E.value->has_computed_key) {
+						reduce_identifier(E.key);
+					}
+					resolve_destructuring(E.value);
+					if (!p_destructuring->is_top_level) {
+						// TODO: Allow analyzing type mismatches in nested destructuring
+						continue;
+					}
+					if (E.value->has_computed_key) {
+						// TODO: Allow computed key when analyzing type mismatches
+						continue;
+					}
+					// Allow us to type check certain Dictionary declarations against certain destructuring expressions
+					if (p_destructuring->initializer->type != GDScriptParser::Node::DICTIONARY) {
+						continue;
+					}
+					String key;
+					GDScriptParser::ExpressionNode *expression = nullptr;
+					GDScriptParser::DictionaryNode *initializer = static_cast<GDScriptParser::DictionaryNode *>(p_destructuring->initializer);
+					for (const GDScriptParser::DictionaryNode::Pair &pair : initializer->elements) {
+						if (!pair.value->reduced || pair.value->get_datatype().kind != GDScriptParser::DataType::BUILTIN || !E.key) {
+							continue;
+						}
+
+						switch (pair.key->type) {
+							case GDScriptParser::Node::IDENTIFIER: {
+								if (initializer->style == GDScriptParser::DictionaryNode::PYTHON_DICT) {
+									continue;
+								}
+								GDScriptParser::IdentifierNode *dict_key = static_cast<GDScriptParser::IdentifierNode *>(pair.key);
+								if (dict_key->name != E.key->name) {
+									continue;
+								}
+								key = dict_key->name;
+								expression = pair.value;
+							} break;
+							case GDScriptParser::Node::LITERAL: {
+								GDScriptParser::LiteralNode *dict_key = static_cast<GDScriptParser::LiteralNode *>(pair.key);
+								key = dict_key->value.stringify();
+								if (key != E.key->name) {
+									continue;
+								}
+								expression = pair.value;
+							} break;
+							default: {
+								continue;
+							}
+						}
+					}
+					switch (E.value->inner_type) {
+						case GDScriptParser::DestructuringNode::IDENTIFIER:
+						case GDScriptParser::DestructuringNode::VARIABLE: {
+							GDScriptParser::VariableNode *source = E.value->source;
+							if (expression && source->get_datatype().is_hard_type() && source->get_datatype().kind == GDScriptParser::DataType::BUILTIN && expression->get_datatype().builtin_type != source->get_datatype().builtin_type) {
+								push_error(vformat(R"(Mismatched type "%s" with key "%s" in the destructuring expression, expected "%s".)", source->get_datatype().to_string(), key, expression->get_datatype().to_string()), E.value);
+							}
+						} break;
+						case GDScriptParser::DestructuringNode::DESTRUCTURE: {
+							if (expression && E.value->type == GDScriptParser::Node::DICT_DESTRUCTURING && expression->get_datatype().builtin_type != Variant::DICTIONARY) {
+								push_error(vformat(R"(Mismatched type "Dictionary" with key "%s" in the destructuring expression, expected "%s".)", key, expression->get_datatype().to_string()), E.value);
+							}
+						} break;
+						case GDScriptParser::DestructuringNode::NONE: {
+						} break;
+					}
+				}
+			};
+		} break;
+		case GDScriptParser::DestructuringNode::NONE: {
+		} break;
+	}
+}
+
 void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local) {
 	static constexpr const char *kind = "constant";
 	resolve_assignable(p_constant, kind);
@@ -2345,6 +2502,8 @@ void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expre
 		case GDScriptParser::Node::TYPE:
 		case GDScriptParser::Node::VARIABLE:
 		case GDScriptParser::Node::WHILE:
+		case GDScriptParser::Node::ARRAY_DESTRUCTURING:
+		case GDScriptParser::Node::DICT_DESTRUCTURING:
 			ERR_FAIL_MSG("Reaching unreachable case");
 	}
 }

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -72,6 +72,7 @@ class GDScriptAnalyzer {
 	void resolve_suite(GDScriptParser::SuiteNode *p_suite);
 	void resolve_assignable(GDScriptParser::AssignableNode *p_assignable, const char *p_kind);
 	void resolve_variable(GDScriptParser::VariableNode *p_variable, bool p_is_local);
+	void resolve_destructuring(GDScriptParser::DestructuringNode *p_destructuring);
 	void resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local);
 	void resolve_parameter(GDScriptParser::ParameterNode *p_parameter);
 	void resolve_if(GDScriptParser::IfNode *p_if);

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -165,6 +165,163 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 	return result;
 }
 
+Error GDScriptCompiler::_parse_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::DestructuringNode *p_target, GDScriptCodeGenerator::Address p_source) {
+	switch (p_target->type) {
+		case GDScriptParser::Node::ARRAY_DESTRUCTURING: {
+			return _parse_array_destructuring(codegen, r_error, static_cast<const GDScriptParser::ArrayDestructuringNode *>(p_target), p_source);
+		} break;
+		case GDScriptParser::Node::DICT_DESTRUCTURING: {
+			return _parse_dictionary_destructuring(codegen, r_error, static_cast<const GDScriptParser::DictDestructuringNode *>(p_target), p_source);
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(Error::FAILED, "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); // Unreachable code.
+		} break;
+	}
+}
+
+Error GDScriptCompiler::_parse_array_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::ArrayDestructuringNode *p_target, GDScriptCodeGenerator::Address p_source) {
+	int idx = 0;
+	for (GDScriptParser::DestructuringNode *E : p_target->destructured) {
+		if (E->inner_type == GDScriptParser::DestructuringNode::NONE) {
+			// A "none" ("_") destructuring element doesn't need to be computed,
+			// but it does still count towards the next index access.
+			idx += 1;
+			continue;
+		}
+
+		if (E->is_spread) {
+			if (E->inner_type == GDScriptParser::DestructuringNode::DESTRUCTURE) {
+				// Create temp for sliced Array
+				GDScriptCodeGenerator::Address temp = codegen.add_temporary(p_source.type);
+
+				// Slice the Array
+				codegen.generator->write_call(temp, p_source, R"(slice)", { codegen.add_constant(idx) });
+				// Because this is an inner destructuring, Recursion time!
+				_parse_destructuring(codegen, r_error, E, temp);
+				codegen.generator->pop_temporary();
+				if (r_error) {
+					return r_error;
+				}
+			} else {
+				GDScriptCodeGenerator::Address var = codegen.locals[E->source->identifier->name];
+
+				// Slice the Array and store the result in the target variable
+				codegen.generator->write_call(var, p_source, R"(slice)", { codegen.add_constant(idx) });
+			}
+
+			continue;
+		} else {
+			// Index the source Array and store the result in temporary variable
+			GDScriptCodeGenerator::Address temp = codegen.add_temporary();
+			codegen.generator->write_get(temp, codegen.add_constant(idx), p_source);
+
+			if (E->inner_type == GDScriptParser::DestructuringNode::DESTRUCTURE) {
+				// Inner destructuring, recursion time!
+				_parse_destructuring(codegen, r_error, E, temp);
+				codegen.generator->pop_temporary();
+				if (r_error) {
+					return r_error;
+				}
+				idx += 1;
+				continue;
+			}
+
+			// Finally, store the temporary variable into the target var
+			GDScriptCodeGenerator::Address var = codegen.locals[E->source->identifier->name];
+			if (E->source->datatype_specifier || E->source->get_datatype().is_hard_type()) {
+				codegen.generator->write_assign_with_conversion(var, temp);
+			} else {
+				codegen.generator->write_assign(var, temp);
+			}
+			codegen.generator->pop_temporary();
+			idx += 1;
+		}
+	}
+
+	return r_error;
+}
+
+Error GDScriptCompiler::_parse_dictionary_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::DictDestructuringNode *p_target, GDScriptCodeGenerator::Address p_source) {
+	// Inner element for ease of computing a spread.
+	struct Element {
+		GDScriptParser::IdentifierNode *key;
+		bool has_computed;
+	};
+	Vector<Element> keys;
+	for (const KeyValue<GDScriptParser::IdentifierNode *, GDScriptParser::DestructuringNode *> &E : p_target->destructured) {
+		if (E.value->inner_type == GDScriptParser::DestructuringNode::NONE) {
+			// A "none" ("_") destructuring element doesn't need to be computed,
+			// but we still store it in the keys Vector, so a spread can take it into account.
+			keys.append(Element{ E.key, E.value->has_computed_key });
+			continue;
+		}
+
+		if (E.value->is_spread) {
+			GDScriptCodeGenerator::Address var = codegen.locals[E.value->source->identifier->name];
+
+			// Duplicate and save the source Dictionary
+			GDScriptCodeGenerator::Address temp = codegen.add_temporary(p_source.type);
+			codegen.generator->write_call(temp, p_source, R"(duplicate)", {});
+
+			// Remove from the duplicate all the keys referenced in this destructuring
+			for (const Element &I : keys) {
+				GDScriptCodeGenerator::Address ret;
+				GDScriptCodeGenerator::Address expr = I.has_computed ? _parse_expression(codegen, r_error, I.key) : codegen.add_constant(I.key->name);
+				codegen.generator->write_call(ret, temp, R"(erase)", { expr });
+				if (expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+				if (r_error) {
+					return r_error;
+				}
+			}
+
+			// Store the temporary variable into the target var
+			if (E.value->source->datatype_specifier) {
+				codegen.generator->write_assign_with_conversion(var, temp);
+			} else {
+				codegen.generator->write_assign(var, temp);
+			}
+			codegen.generator->pop_temporary();
+			continue;
+		} else {
+			// Index the source dictionary and store the result in temporary variable
+			GDScriptCodeGenerator::Address temp = codegen.add_temporary();
+			GDScriptCodeGenerator::Address expr = E.value->has_computed_key ? _parse_expression(codegen, r_error, E.key) : codegen.add_constant(E.key->name);
+			codegen.generator->write_get(temp, expr, p_source);
+			if (expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+				codegen.generator->pop_temporary();
+			}
+			if (r_error) {
+				return r_error;
+			}
+			// Store this destructuring element, so we can reference it later in a spread, if needed
+			keys.append(Element{ E.key, E.value->has_computed_key });
+
+			if (E.value->inner_type == GDScriptParser::DestructuringNode::DESTRUCTURE) {
+				// Inner destructuring, recursion time!
+				_parse_destructuring(codegen, r_error, E.value, temp);
+				codegen.generator->pop_temporary();
+				if (r_error) {
+					return r_error;
+				}
+				continue;
+			}
+
+			// Finally, store the temporary variable into the target var
+			GDScriptCodeGenerator::Address var = codegen.locals[E.value->source->identifier->name];
+			if (E.value->source->datatype_specifier || E.value->source->get_datatype().is_hard_type()) {
+				codegen.generator->write_assign_with_conversion(var, temp);
+			} else {
+				codegen.generator->write_assign(var, temp);
+			}
+			codegen.generator->pop_temporary();
+		}
+	}
+
+	return r_error;
+}
+
 static bool _is_exact_type(const PropertyInfo &p_par_type, const GDScriptDataType &p_arg_type) {
 	if (!p_arg_type.has_type) {
 		return false;
@@ -1966,6 +2123,19 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 			case GDScriptParser::Node::PASS:
 				// Nothing to do.
 				break;
+			case GDScriptParser::Node::ARRAY_DESTRUCTURING:
+			case GDScriptParser::Node::DICT_DESTRUCTURING: {
+				const GDScriptParser::DestructuringNode *lv = static_cast<const GDScriptParser::DestructuringNode *>(s);
+
+				GDScriptCodeGenerator::Address expr = _parse_expression(codegen, err, lv->initializer);
+				_parse_destructuring(codegen, err, lv, expr);
+				if (expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+					codegen.generator->pop_temporary();
+				}
+				if (err) {
+					return err;
+				}
+			} break;
 			default: {
 				// Expression.
 				if (s->is_expression()) {

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -124,6 +124,9 @@ class GDScriptCompiler {
 	Error _create_binary_operator(CodeGen &codegen, const GDScriptParser::ExpressionNode *p_left_operand, const GDScriptParser::ExpressionNode *p_right_operand, Variant::Operator op, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 
 	GDScriptDataType _gdtype_from_datatype(const GDScriptParser::DataType &p_datatype, GDScript *p_owner);
+	Error _parse_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::DestructuringNode *p_target, GDScriptCodeGenerator::Address p_source);
+	Error _parse_array_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::ArrayDestructuringNode *p_target, GDScriptCodeGenerator::Address p_source);
+	Error _parse_dictionary_destructuring(CodeGen &codegen, Error &r_error, const GDScriptParser::DictDestructuringNode *p_target, GDScriptCodeGenerator::Address p_source);
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1632,7 +1632,17 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 			break;
 		case GDScriptTokenizer::Token::VAR:
 			advance();
-			result = parse_variable(false, false);
+			if (check(GDScriptTokenizer::Token::BRACKET_OPEN)) {
+				push_multiline(true);
+				advance();
+				result = parse_destructuring(alloc_node<ArrayDestructuringNode>());
+			} else if (check(GDScriptTokenizer::Token::BRACE_OPEN)) {
+				push_multiline(true);
+				advance();
+				result = parse_destructuring(alloc_node<DictDestructuringNode>());
+			} else {
+				result = parse_variable(false, false);
+			}
 			break;
 		case GDScriptTokenizer::Token::CONST:
 			advance();
@@ -2307,6 +2317,183 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode 
 	}
 
 	return identifier;
+}
+
+GDScriptParser::DestructuringNode *GDScriptParser::parse_destructuring(GDScriptParser::DestructuringNode *p_destructuring, bool p_is_top_level) {
+	bool is_array = p_destructuring->type == Node::ARRAY_DESTRUCTURING;
+	GDScriptTokenizer::Token::Type closing = is_array ? GDScriptTokenizer::Token::BRACKET_CLOSE : GDScriptTokenizer::Token::BRACE_CLOSE;
+
+	bool has_spread = false;
+	p_destructuring->inner_type = DestructuringNode::DESTRUCTURE;
+	p_destructuring->is_top_level = p_is_top_level;
+	if (!check(closing)) {
+		do {
+			if (check(closing)) {
+				// Allow for trailing comma.
+				break;
+			}
+
+			// Try to match a key identifier (ie, foo = ...) only for Dictionaries
+			bool is_missing_identifier_key = true;
+			bool has_computed_key = false;
+			IdentifierNode *identifier_key = nullptr;
+			if (!is_array && check(GDScriptTokenizer::Token::IDENTIFIER)) {
+				advance();
+				identifier_key = parse_identifier();
+				is_missing_identifier_key = false;
+				if (match(GDScriptTokenizer::Token::EQUAL)) {
+					has_computed_key = false;
+				} else if (match(GDScriptTokenizer::Token::COLON)) {
+					has_computed_key = true;
+				} else {
+					push_error(R"(Expected "=" or ":" after destructuring identifier key.)");
+					continue;
+				}
+			}
+
+			// Try to match a spread (specifically, ..[])
+			if (is_array) {
+				has_spread = match(GDScriptTokenizer::Token::PERIOD_PERIOD);
+			}
+
+			// Try to match an inner destructuring (ie, var [foo, [bar]] or var { foo = { ... } })
+			if (match(GDScriptTokenizer::Token::BRACE_OPEN) || match(GDScriptTokenizer::Token::BRACKET_OPEN)) {
+				GDScriptParser::DestructuringNode *destructured;
+				if (previous.type == GDScriptTokenizer::Token::BRACE_OPEN) {
+					destructured = alloc_node<DictDestructuringNode>();
+				} else {
+					destructured = alloc_node<ArrayDestructuringNode>();
+				}
+
+				destructured->has_computed_key = has_computed_key;
+				if (is_array) {
+					destructured->is_spread = has_spread;
+					static_cast<GDScriptParser::ArrayDestructuringNode *>(p_destructuring)->destructured.append(parse_destructuring(destructured, false));
+				} else {
+					if (is_missing_identifier_key) {
+						push_error(R"(Expected identifier for destructuring key.)", destructured);
+						complete_extents(destructured);
+						continue;
+					}
+					static_cast<GDScriptParser::DictDestructuringNode *>(p_destructuring)->destructured.insert(identifier_key, parse_destructuring(destructured, false));
+				}
+				continue;
+			}
+
+			// Check whether we have a destructured spread, but without the destructuring itself
+			if (has_spread) {
+				push_error(R"(Only the last element in a destructuring expression can have the spread qualifier ("..").)");
+				continue;
+			}
+
+			// Try to match a "none"
+			if (match(GDScriptTokenizer::Token::UNDERSCORE)) {
+				GDScriptParser::DestructuringNode *destructured = alloc_node<DestructuringNode>();
+				destructured->inner_type = DestructuringNode::NONE;
+				destructured->has_computed_key = has_computed_key;
+				if (is_array) {
+					static_cast<GDScriptParser::ArrayDestructuringNode *>(p_destructuring)->destructured.append(destructured);
+				} else {
+					static_cast<GDScriptParser::DictDestructuringNode *>(p_destructuring)->destructured.insert(identifier_key, destructured);
+				}
+				complete_extents(destructured);
+				continue;
+			}
+
+			// Generic destructuring
+			GDScriptParser::DestructuringNode *destructured = alloc_node<DestructuringNode>();
+			destructured->has_computed_key = has_computed_key;
+
+			// Try to match a variable (as opposed to just referencing an existing identifier)
+			bool is_variable = match(GDScriptTokenizer::Token::VAR);
+
+			// Try to match a spread (ie, var ..identifier)
+			has_spread = match(GDScriptTokenizer::Token::PERIOD_PERIOD);
+
+			// Try to match an identifier
+			advance();
+			IdentifierNode *identifier = previous.is_identifier() ? parse_identifier() : nullptr;
+			if (identifier == nullptr) {
+				push_error(R"(Expected identifier as a destructuring element.)", p_destructuring);
+				complete_extents(destructured);
+				continue;
+			}
+
+			// For dictionary destructuring, if the element has spread, it can't have a destructuring key, otherwise it must.
+			if (!is_array) {
+				if (!has_spread && is_missing_identifier_key) {
+					// Allows missing identifier keys to default to the identifier itself
+					identifier_key = identifier;
+				}
+				if (has_spread && !is_missing_identifier_key) {
+					push_error(vformat(
+									   R"(Unexpected identifier for destructuring element with spread qualifier (".."). Remove either the destructuring identifier "%s" or the spread qualifier.)",
+									   identifier_key->name),
+							destructured);
+					complete_extents(destructured);
+					continue;
+				}
+			}
+
+			destructured->source = alloc_node<VariableNode>();
+			destructured->source->identifier = identifier;
+			destructured->inner_type = is_variable ? DestructuringNode::VARIABLE : DestructuringNode::IDENTIFIER;
+
+			// Try to match a type for the previous identifier (ie, foo: String)
+			if (match(GDScriptTokenizer::Token::COLON)) {
+				if (!is_variable) {
+					push_error(R"(Invalid ":" for destructured identifier. Maybe you intended in creating a variable instead (var foo:<your type>)?)", identifier);
+					complete_extents(destructured->source);
+					complete_extents(destructured);
+					continue;
+				}
+				TypeNode *type = parse_type();
+				if (type) {
+					destructured->source->datatype_specifier = type;
+				} else {
+					destructured->source->infer_datatype = true;
+				}
+			}
+
+			if (is_variable) {
+				// Add this to the local variables, so it can be properly validated and compiled
+				const SuiteNode::Local &local = current_suite->get_local(identifier->name);
+				if (local.type != SuiteNode::Local::UNDEFINED) {
+					push_error(vformat(R"(There is already a variable named "%s" declared in this scope.)", identifier->name), identifier);
+				}
+				current_suite->add_local(destructured->source, current_function);
+			}
+
+			destructured->is_spread = has_spread;
+			if (is_array) {
+				static_cast<GDScriptParser::ArrayDestructuringNode *>(p_destructuring)->destructured.push_back(destructured);
+			} else {
+				static_cast<GDScriptParser::DictDestructuringNode *>(p_destructuring)->destructured.insert(identifier_key, destructured);
+			}
+
+			complete_extents(destructured->source);
+			complete_extents(destructured);
+		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end() && !has_spread);
+	}
+	if (p_is_top_level) {
+		pop_multiline();
+	}
+	consume(closing, vformat(has_spread ? R"(Expected closing "%s" after spread (..).)" : R"(Expected closing "%s" after destructuring.)", tokenizer.get_token_name(closing)));
+
+	if (p_is_top_level) {
+		consume(GDScriptTokenizer::Token::EQUAL, R"(Expected assignment ("=") after destructuring.)");
+
+		// For destructuring, an initializer is a must
+		p_destructuring->initializer = parse_expression(false);
+		if (p_destructuring->initializer == nullptr) {
+			push_error(R"(Expected expression for destructuring after "=".)");
+		}
+
+		end_statement("destructuring");
+	}
+
+	complete_extents(p_destructuring);
+	return p_destructuring;
 }
 
 GDScriptParser::LiteralNode *GDScriptParser::parse_literal() {
@@ -4050,7 +4237,7 @@ bool GDScriptParser::warning_annotations(const AnnotationNode *p_annotation, Nod
 	return !has_error;
 
 #else // ! DEBUG_ENABLED
-	// Only available in debug builds.
+	  // Only available in debug builds.
 	return true;
 #endif // DEBUG_ENABLED
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -294,6 +294,8 @@ public:
 			TYPE_TEST,
 			UNARY_OPERATOR,
 			VARIABLE,
+			ARRAY_DESTRUCTURING,
+			DICT_DESTRUCTURING,
 			WHILE,
 		};
 
@@ -1215,6 +1217,40 @@ public:
 		}
 	};
 
+	struct DestructuringNode : public Node {
+		enum Type {
+			NONE,
+			VARIABLE,
+			IDENTIFIER,
+			DESTRUCTURE,
+		};
+
+		bool is_top_level = false;
+		bool is_spread = false;
+		bool has_computed_key = false;
+		Type inner_type = DESTRUCTURE;
+		union {
+			ExpressionNode *initializer = nullptr;
+			VariableNode *source;
+		};
+	};
+
+	struct ArrayDestructuringNode : DestructuringNode {
+		Vector<DestructuringNode *> destructured;
+
+		ArrayDestructuringNode() {
+			type = ARRAY_DESTRUCTURING;
+		}
+	};
+
+	struct DictDestructuringNode : DestructuringNode {
+		HashMap<IdentifierNode *, DestructuringNode *> destructured;
+
+		DictDestructuringNode() {
+			type = DICT_DESTRUCTURING;
+		}
+	};
+
 	struct WhileNode : public Node {
 		ExpressionNode *condition = nullptr;
 		SuiteNode *loop = nullptr;
@@ -1461,6 +1497,7 @@ private:
 	ExpressionNode *parse_self(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_identifier(ExpressionNode *p_previous_operand, bool p_can_assign);
 	IdentifierNode *parse_identifier();
+	DestructuringNode *parse_destructuring(GDScriptParser::DestructuringNode *p_destructuring, bool p_is_top_level = true);
 	ExpressionNode *parse_builtin_constant(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_unary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_binary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);

--- a/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_an_invalid_initializer_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_an_invalid_initializer_type.gd
@@ -1,0 +1,4 @@
+func test():
+    var a: int
+    var b: int
+    var [a, b] = 42

--- a/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_an_invalid_initializer_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_an_invalid_initializer_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot apply destructuring to non-array expression of type "int"

--- a/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_type_mismatch.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_type_mismatch.gd
@@ -1,0 +1,4 @@
+func test():
+    var a: int
+    var b: int
+    var [a, b] = ["hello", 42]

--- a/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_type_mismatch.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/array_destructuring_with_type_mismatch.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Mismatched type "int" at index 0 in the destructuring expression, expected "String".

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_destructuring_with_type_mismatch.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_destructuring_with_type_mismatch.gd
@@ -1,0 +1,4 @@
+func test():
+    var a: int
+    var b: int
+    var { foo = a, bar = b } = { foo = "hello", bar = 42 }

--- a/modules/gdscript/tests/scripts/analyzer/errors/dictionary_destructuring_with_type_mismatch.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/dictionary_destructuring_with_type_mismatch.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Mismatched type "int" with key "foo" in the destructuring expression, expected "String".

--- a/modules/gdscript/tests/scripts/parser/errors/Invalid_dictionary_destructuring_with_missing_closing_braces.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/Invalid_dictionary_destructuring_with_missing_closing_braces.gd
@@ -1,0 +1,2 @@
+func test():
+    var {foo = a, bar = b = {foo = 1, bar = 2} # Should error

--- a/modules/gdscript/tests/scripts/parser/errors/Invalid_dictionary_destructuring_with_missing_closing_braces.out
+++ b/modules/gdscript/tests/scripts/parser/errors/Invalid_dictionary_destructuring_with_missing_closing_braces.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected closing "}" after destructuring.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_closing_bracket.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_closing_bracket.gd
@@ -1,0 +1,2 @@
+func test():
+    var [a, b, c = [1, 2, 3] # Should error

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_closing_bracket.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_closing_bracket.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected closing "]" after destructuring.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_elements.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_elements.gd
@@ -1,0 +1,2 @@
+func test():
+    var [a, , c] = [1, 2, 3]

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_elements.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_array_destructuring_with_missing_elements.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected identifier as a destructuring element.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_elements.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_elements.gd
@@ -1,0 +1,2 @@
+func test():
+    var {foo = a, bar = } = {foo = 1, bar = 2}

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_elements.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_elements.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected identifier as a destructuring element.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_initializer.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_initializer.gd
@@ -1,0 +1,2 @@
+func test():
+    var {foo = a, bar = b}

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_initializer.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_dictionary_destructuring_with_missing_initializer.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected assignment ("=") after destructuring.

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_mixed_destructuring_with_spread_in_the_middle.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_mixed_destructuring_with_spread_in_the_middle.gd
@@ -1,0 +1,2 @@
+func test():
+    var [a, ..rest, b] = [1, 2, 3, 4]

--- a/modules/gdscript/tests/scripts/parser/errors/invalid_mixed_destructuring_with_spread_in_the_middle.out
+++ b/modules/gdscript/tests/scripts/parser/errors/invalid_mixed_destructuring_with_spread_in_the_middle.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Only the last element in a destructuring expression can have the spread qualifier ("..").

--- a/modules/gdscript/tests/scripts/parser/features/array_destructuring.gd
+++ b/modules/gdscript/tests/scripts/parser/features/array_destructuring.gd
@@ -1,0 +1,32 @@
+func test():
+    print("Simple usage:")
+    if true:
+        var [var foo, var ..bar] = [123, "1234"]
+        print(foo) # Should print "123"
+        print(bar) # Should print "["1234"]"
+
+    print("Complex usage:")
+    if true:
+        var [var a, var b, ..[var c, var d, ..[var e, var f]]] = [1, 2, 3, 4, 5, 6]
+        prints(a, b, c, d, e, f) # Should print "1 2 3 4 5 6"
+
+    print("Typed usage:")
+    if true:
+        var [var foo: int, var bar: String] = [123, "1234"]
+        print(foo) # Should print "123"
+        print(bar) # Should print "1234"
+
+    print("Empty slot usage:")
+    if true:
+        var [_, var bar: String] = [123, "1234"]
+        print(bar) # Should print "1234"
+
+    print("Multiple lines usage:")
+    if true:
+        var [
+            var foo: int,
+            var bar: String
+        ] = [123, "1234"]
+        print(foo) # Should print "123"
+        print(bar) # Should print "1234"
+

--- a/modules/gdscript/tests/scripts/parser/features/array_destructuring.out
+++ b/modules/gdscript/tests/scripts/parser/features/array_destructuring.out
@@ -1,0 +1,14 @@
+GDTEST_OK
+Simple usage:
+123
+["1234"]
+Complex usage:
+1 2 3 4 5 6
+Typed usage:
+123
+1234
+Empty slot usage:
+1234
+Multiple lines usage:
+123
+1234

--- a/modules/gdscript/tests/scripts/parser/features/dict_destructuring.gd
+++ b/modules/gdscript/tests/scripts/parser/features/dict_destructuring.gd
@@ -1,0 +1,36 @@
+func test():
+    print("Simple usage:")
+    if true:
+        var { foo = var foo, var ..bar } = { foo = 123, bar = 1234 }
+        print(foo) # Should print "123"
+        print(bar) # Should print "{ "bar": 1234 }"
+
+    print("Complex usage:")
+    if true:
+        var { foo = [_, { bar = var bar }] } = { foo = [{ bar = 123 }, { bar = "hello!" }] }
+        print(bar) # Should print "hello!"
+
+    print("Typed usage:")
+    if true:
+        var { foo = var foo: int, bar = var bar: Vector2 } = { foo = 123, bar = Vector2.ZERO }
+        print(foo) # Should print "123"
+        print(bar) # Should print "(0, 0)"
+
+    print("Empty slot usage:")
+    if true:
+        var { foo = _, var ..bar } = { foo = 123, bar = 1234 }
+        print(bar) # Should print "{ "bar": 1234 }"
+
+    print("Multiple lines usage:")
+    if true:
+        var {
+            userId = var user_id,
+            id = var id,
+            title = var title,
+            completed = var completed,
+        } = { userId = 1, id = 1, title = "Hi!", completed = "yep" }
+        print(user_id) # Should print "1"
+        print(id) # Should print "1"
+        print(title) # Should print "Hi!"
+        print(completed) # Should print "yep"
+

--- a/modules/gdscript/tests/scripts/parser/features/dict_destructuring.out
+++ b/modules/gdscript/tests/scripts/parser/features/dict_destructuring.out
@@ -1,0 +1,16 @@
+GDTEST_OK
+Simple usage:
+123
+{ "bar": 1234 }
+Complex usage:
+hello!
+Typed usage:
+123
+(0, 0)
+Empty slot usage:
+{ "bar": 1234 }
+Multiple lines usage:
+1
+1
+Hi!
+yep

--- a/modules/gdscript/tests/scripts/runtime/features/destructuring.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/destructuring.gd
@@ -1,0 +1,12 @@
+func test():
+    var user_id_key := "userId"
+    var {
+        user_id_key: var user_id,
+        name = var name,
+        arr = [_, { foo = var foo }, var ..everything_else]
+    } = {
+        userId = 123,
+        name = "josaid",
+        arr = ["ignore me", { foo = "this is foo" }, "everything", "else"]
+    }
+    prints(user_id, name, foo, everything_else)

--- a/modules/gdscript/tests/scripts/runtime/features/destructuring.out
+++ b/modules/gdscript/tests/scripts/runtime/features/destructuring.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+123 josaid this is foo ["everything", "else"]


### PR DESCRIPTION
# Destructuring Expression in GDScript

This PR adds a new expression to GDScript to allow the easy and somewhat safe destructuring of Arrays and Dictionaries. It was initially based off https://github.com/godotengine/godot-proposals/issues/2135 and further discussed over RocketChat.
It's also part of the current GDScript 4.1 Roadmap.

## TODOs

- [x] Create a TODO

## Getting intimate

Although distructuring Arrays is different than distructuring Dictionaries, they can be mixed together and do share some similarities, namely:
- Both can happen over a variable:
  ```gdscript
  var [var a: int] = [123]
  var { foo = var b: int } = { foo = 321 }
  ``` 
- Both can happen over an identifier (referencing an existing variable):
  ```gdscript
  var a: int
  var [a] = [123]
  var b: int
  var { foo = b } = { foo = 321 }
  ``` 
- Both can be mixed together (also called inner destructuring):
  ```gdscript
  var [{ foo = var foo }] = [{ foo = 123 }]
  print(foo) # Will print 123
  var { foo = [var bar] } = { foo = [123] }
  print(bar # Will print 123
  ```

### Type-checking

Type-checking has also been added wherever possible:
- Array destructuring can only happen over Arrays:
  ```gdscript
  var [var foo] = 123 # This will error
  ```
- If conditions are met, type-checking is done between the destructured element and the source array/dictionary:
  ```gdscript
  var [var foo: int] = ["123"] # Will error: Mismatched type "int" at index 0 in the destructuring expression, expected "String".
  var { foo = var foo: int } = { foo = "123" } # Will error: Mismatched type "int" with key "foo" in the destructuring expression, expected "String".
  ```

### Arrays

Getting into the specifics, destructuring for Arrays has the following features:
- Skip over certain indices:
  ```gdscript
  var [_, var foo] = [123, 321]
  print(foo) # Will print 321
  ```
- Collect all non-destructured elements into a single element (also known as a spread):
  ```gdscript
  var [var foo, var ..remaining] = [123, 321, 123321]
  print(foo) # Will print 123
  print(remaining) # Will print [321, 123321]
  ```

### Dictionaries

And destructuring for Dictionaries has the following features:
- Plain identifying keys:
  ```gdscript
  var { foo = var a } = { foo = 123 }
  print(a) # Will print 123
  ```
- Computed identifying keys (currently only supports identifiers, which references existing variables):
  ```gdscript
  var foo_key := "foo"
  var { foo_key: var a } = { foo = 123 }
  print(a) # Will print 123
  ```
- Collect all non-destructured elements into a single element (also known as a spread):
  ```gdscript
  var { foo = var a, var ..b } = { foo = 123, bar = 321, foobar = 123321 }
  print(a) # Will print 123
  print(b) # Will print { "bar": 321, "foobar": 123321 }
  ```

### Real world example

And because a feature is only as good as it's useful, this is an (working) example of an EditorScript that loads some JSON and destructures it using the syntax this PR introduces:
```gdscript
@tool
extends EditorScript


func _run():
	var client := HTTPRequest.new()
	get_editor_interface().get_base_control().add_child(client)
	client.request_completed.connect(
		func(_result: int, _response_code: int, _headers: PackedStringArray, data: PackedByteArray):
			var [_, {
				userId = var user_id: int,
				id = var id: int,
				title = var title: String,
				body = var body: String,
			}] = JSON.parse_string(data.get_string_from_utf8())
			print("Second Post:\nuserId: %s\nid: %s\ntitle: %s\nbody: %s" % [user_id, id, title, body])
	)
	client.request("https://jsonplaceholder.typicode.com/posts")
```
Which prints:
```
Second Post:
userId: 1
id: 2
title: qui est esse
body: est rerum tempore vitae
sequi sint nihil reprehenderit dolor beatae ea dolores neque
fugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis
qui aperiam non debitis possimus qui neque nisi nulla
```

Closes https://github.com/godotengine/godot-proposals/issues/2135
