### PR TITLE
Add custom methods for adding editor translations

### DIFF
--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -81,7 +81,8 @@ class TranslationServer : public Object {
 	String fallback;
 
 	HashSet<Ref<Translation>> translations;
-	Ref<Translation> tool_translation;
+	Ref<Translation> default_tool_translation;
+	HashSet<Ref<Translation>> tool_translations;
 	Ref<Translation> property_translation;
 	Ref<Translation> doc_translation;
 	Ref<Translation> extractable_translation;
@@ -178,8 +179,10 @@ public:
 	int compare_locales(const String &p_locale_a, const String &p_locale_b) const;
 
 	String get_tool_locale();
-	void set_tool_translation(const Ref<Translation> &p_translation);
-	Ref<Translation> get_tool_translation() const;
+	void add_tool_translation(const Ref<Translation> &p_translation);
+	void remove_tool_translation(const Ref<Translation> &p_translation);
+	void set_default_tool_translation(const Ref<Translation> &p_translation);
+	HashSet<Ref<Translation>> get_tool_translations() const;
 	StringName tool_translate(const StringName &p_message, const StringName &p_context = "") const;
 	StringName tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
 	void set_property_translation(const Ref<Translation> &p_translation);

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -437,6 +437,22 @@
 				Optionally, you can specify a shortcut parameter. When pressed, this shortcut will toggle the dock's visibility once it's moved to the bottom panel (this shortcut does not affect the dock otherwise). See the default editor bottom panel shortcuts in the Editor Settings for inspiration. Per convention, they all use [kbd]Alt[/kbd] modifier.
 			</description>
 		</method>
+		<method name="add_custom_translation">
+			<return type="void" />
+			<param index="0" name="translation" type="Translation" />
+			<description>
+				Adds a translation for editor strings. Use when you want to localize your addon. You can support multiple languages by adding multiple translations with different [member Translation.locale].
+				[codeblock]
+				func _enter_tree():
+				    add_custom_translation(preload("res://addons/my_addon/language1.po"))
+				    add_custom_translation(preload("res://addons/my_addon/language2.po"))
+
+				func _exit_tree():
+				    remove_custom_translation(preload("res://addons/my_addon/language1.po"))
+				    remove_custom_translation(preload("res://addons/my_addon/language2.po"))
+				[/codeblock]
+			</description>
+		</method>
 		<method name="add_custom_type">
 			<return type="void" />
 			<param index="0" name="type" type="String" />
@@ -641,6 +657,13 @@
 			<param index="0" name="control" type="Control" />
 			<description>
 				Removes the control from the dock. You have to manually [method Node.queue_free] the control.
+			</description>
+		</method>
+		<method name="remove_custom_translation">
+			<return type="void" />
+			<param index="0" name="translation" type="Translation" />
+			<description>
+				Removes the [param translation] added by [method add_custom_translation]. Does nothing if that translation wasn't added.
 			</description>
 		</method>
 		<method name="remove_custom_type">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -544,6 +544,16 @@ void EditorPlugin::_editor_project_settings_changed() {
 }
 #endif
 
+void EditorPlugin::add_custom_translation(const Ref<Translation> &p_translation) {
+	ERR_FAIL_COND(p_translation.is_null());
+	TranslationServer::get_singleton()->add_tool_translation(p_translation);
+}
+
+void EditorPlugin::remove_custom_translation(const Ref<Translation> &p_translation) {
+	ERR_FAIL_COND(p_translation.is_null());
+	TranslationServer::get_singleton()->remove_tool_translation(p_translation);
+}
+
 void EditorPlugin::_notification(int p_what) {
 #ifndef DISABLE_DEPRECATED
 	switch (p_what) {
@@ -600,6 +610,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_inspector_plugin", "plugin"), &EditorPlugin::remove_inspector_plugin);
 	ClassDB::bind_method(D_METHOD("add_resource_conversion_plugin", "plugin"), &EditorPlugin::add_resource_conversion_plugin);
 	ClassDB::bind_method(D_METHOD("remove_resource_conversion_plugin", "plugin"), &EditorPlugin::remove_resource_conversion_plugin);
+	ClassDB::bind_method(D_METHOD("add_custom_translation", "translation"), &EditorPlugin::add_custom_translation);
+	ClassDB::bind_method(D_METHOD("remove_custom_translation", "translation"), &EditorPlugin::remove_custom_translation);
 	ClassDB::bind_method(D_METHOD("set_input_event_forwarding_always_enabled"), &EditorPlugin::set_input_event_forwarding_always_enabled);
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -52,6 +52,7 @@ class EditorToolAddons;
 class EditorTranslationParserPlugin;
 class EditorUndoRedoManager;
 class ScriptCreateDialog;
+class Translation;
 
 class EditorPlugin : public Node {
 	GDCLASS(EditorPlugin, Node);
@@ -242,6 +243,9 @@ public:
 
 	void add_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
 	void remove_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
+
+	void add_custom_translation(const Ref<Translation> &p_translation);
+	void remove_custom_translation(const Ref<Translation> &p_translation);
 
 	void enable_plugin();
 	void disable_plugin();

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -69,12 +69,20 @@ void load_editor_translations(const String &p_locale) {
 
 			if (tr.is_valid()) {
 				tr->set_locale(etl->lang);
-				TranslationServer::get_singleton()->set_tool_translation(tr);
+				TranslationServer::get_singleton()->add_tool_translation(tr);
 				break;
 			}
 		}
 
 		etl++;
+	}
+
+	if (TranslationServer::get_singleton()->get_tool_translations().is_empty()) {
+		// If no translation was added, default to a dummy English one.
+		Ref<Translation> en;
+		en.instantiate();
+		en->set_locale("en");
+		TranslationServer::get_singleton()->set_default_tool_translation(en);
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6885
Closes https://github.com/godotengine/godot-proposals/issues/1262

Test addon with translation:
[translationtest.zip](https://github.com/godotengine/godot/files/11480026/translationtest.zip)

The implementation is as described in the proposal, but it has one problem - it doesn't support translation context. Coupled with the fact that duplicate messages trigger a warning, there is a chance for a conflicting messages in translations of multiple plugins.

Alternative suggested approach is to modify TranslationServer methods to work in editor. It would still likely require a separate method, because AFAIK TranslationServer handles only project's translations (I think even in editor?). Editor translations have some dedicated methods that work differently.