### PR TITLE
[4.0] Fix agent avoidance position not updated when entering SceneTree

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -151,6 +151,10 @@ void NavigationAgent2D::_notification(int p_what) {
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
 
+			if (agent_parent && avoidance_enabled) {
+				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
+			}
+
 #ifdef DEBUG_ENABLED
 			if (NavigationServer2D::get_singleton()->get_debug_enabled()) {
 				debug_path_dirty = true;

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -63,6 +63,9 @@ void NavigationObstacle2D::_notification(int p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
+			if (parent_node2d && parent_node2d->is_inside_tree()) {
+				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_position());
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -154,6 +154,10 @@ void NavigationAgent3D::_notification(int p_what) {
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
 
+			if (agent_parent && avoidance_enabled) {
+				NavigationServer3D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
+			}
+
 #ifdef DEBUG_ENABLED
 			if (NavigationServer3D::get_singleton()->get_debug_enabled()) {
 				debug_path_dirty = true;

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -62,6 +62,9 @@ void NavigationObstacle3D::_notification(int p_what) {
 		case NOTIFICATION_POST_ENTER_TREE: {
 			set_agent_parent(get_parent());
 			set_physics_process_internal(true);
+			if (parent_node3d && parent_node3d->is_inside_tree()) {
+				NavigationServer3D::get_singleton()->agent_set_position(agent, parent_node3d->get_global_position());
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
Fixes agent avoidance position not updated when entering SceneTree.

This is for Godot 4.0 - 4.0.3 only cause master / Godot 4.1 already has this fixed in a different way with the recently merged avoidance rework.

Fixes https://github.com/godotengine/godot/issues/77106

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
