### PR TITLE
Add support for DPAD Center key of Android TV remote controller

### DIFF
--- a/platform/android/android_keys_utils.h
+++ b/platform/android/android_keys_utils.h
@@ -60,6 +60,7 @@ static AndroidGodotCodePair android_godot_code_pairs[] = {
 	{ AKEYCODE_DPAD_DOWN, Key::DOWN }, // (20) Directional Pad Down key.
 	{ AKEYCODE_DPAD_LEFT, Key::LEFT }, // (21) Directional Pad Left key.
 	{ AKEYCODE_DPAD_RIGHT, Key::RIGHT }, // (22) Directional Pad Right key.
+	{ AKEYCODE_DPAD_CENTER, Key::ENTER }, // (23) Directional Pad Center key.
 	{ AKEYCODE_VOLUME_UP, Key::VOLUMEUP }, // (24) Volume Up key.
 	{ AKEYCODE_VOLUME_DOWN, Key::VOLUMEDOWN }, // (25) Volume Down key.
 	{ AKEYCODE_POWER, Key::STANDBY }, // (26) Power key.


### PR DESCRIPTION
This PR fixes #77077