### PR TITLE
Fix CSGPolygon3D in path mode disappearing at runtime

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1827,7 +1827,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			}
 		}
 
-		if (!path || !path->is_inside_tree()) {
+		if (!path) {
 			return new_brush;
 		}
 


### PR DESCRIPTION
This partially reverts #72427 in order to fix #72771.