### PR TITLE
Prevent script templates from being registered as a class to inherit from in creation dialog.

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -159,6 +159,14 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 				return true; // Plugin is not enabled.
 			}
 		}
+
+		if (script_path.begins_with(EditorPaths::get_singleton()->get_script_templates_dir())) {
+			return true;
+		}
+
+		if (script_path.begins_with(EditorPaths::get_singleton()->get_project_script_templates_dir())) {
+			return true;
+		}
 	}
 
 	return false;
@@ -227,7 +235,9 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 			scr->get_language()->get_global_class_name(scr->get_path(), &extends);
 
 			inherits = extends;
-			inherited_type = TypeCategory::CPP_TYPE;
+			if (ClassDB::class_exists(inherits)) {
+				inherited_type = TypeCategory::CPP_TYPE;
+			}
 		} else {
 			inherits = scr->get_language()->get_global_class_name(base->get_path());
 			if (inherits.is_empty()) {
@@ -246,7 +256,9 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 				scr->get_language()->get_global_class_name(scr->get_path(), &extends);
 
 				inherits = extends;
-				inherited_type = TypeCategory::CPP_TYPE;
+				if (ClassDB::class_exists(inherits)) {
+					inherited_type = TypeCategory::CPP_TYPE;
+				}
 			} else {
 				inherits = scr->get_language()->get_global_class_name(base->get_path());
 				if (inherits.is_empty()) {


### PR DESCRIPTION
Technically fixes #76660. however I don't feel comfortable with the approach I took.

**Cause**:
The parent class which script template extends to is being handled as a CPP type by accident.

Global classes inside script templates folder are being added via `_add_type`.
Because script templates never gets past the parser stage, they don't have a base script to refer to, and recursive `_add_type` call assumes that base class resides in ClassDB instead.
This leads to `null` being registered in `search_options_types`, and searching for that item tries to read this value, causing a null pointer access.

By filtering a class that comes from script template path out, and checking if the certain class actually exists in ClassDB before going into CPP path, It prevents the crash described by an issue above to trigger.

**Discussion**:
I would like to receive some advice on whether this is actually a right approach to take, because I kind of feel like I'm just kicking the can down the road.

Godot docs phrases in the way that script templates being treated like an actual script is never supposed to happen, which makes me think that the script templates with custom `class_name` being registered as the global class is the true cause of the problem. I'm not sure how script templates should be handled by the editor.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
