### PR TITLE
Fix Input Map key assignments missing after project conversion

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -439,6 +439,7 @@ bool ProjectConverter3To4::convert() {
 				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, source_lines);
 				rename_input_map_scancode(source_lines, reg_container);
 				rename_common(RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, source_lines);
+				custom_rename(source_lines, "config_version=4", "config_version=5");
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else if (file_name.ends_with(".import")) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2272,14 +2272,6 @@ void ProjectManager::_perform_full_project_conversion() {
 	const String &path = selected_list[0].path;
 
 	print_line("Converting project: " + path);
-
-	Ref<ConfigFile> cf;
-	cf.instantiate();
-	cf->load(path.path_join("project.godot"));
-	cf->set_value("", "config_version", GODOT4_CONFIG_VERSION);
-	cf->save(path.path_join("project.godot"));
-	_project_list->set_project_version(path, GODOT4_CONFIG_VERSION);
-
 	List<String> args;
 	args.push_back("--path");
 	args.push_back(path);
@@ -2287,6 +2279,8 @@ void ProjectManager::_perform_full_project_conversion() {
 
 	Error err = OS::get_singleton()->create_instance(args);
 	ERR_FAIL_COND(err);
+
+	_project_list->set_project_version(path, GODOT4_CONFIG_VERSION);
 }
 
 void ProjectManager::_run_project_confirm() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76336

Input map key assignments are missing after converting a project from Godot 3 to Godot 4. This happens only when converting through the project manager and not when doing so through the CLI tool.

This issue is caused because, when converting with the project manager, there are some extra steps that try to bump the `config_version` from the `project.godot` file. While loading this file (`cf->load(path.path_join("project.godot"));`) in one of those steps, the loading process re-sets all of the values from the input map configs to zero. Probably because it's trying to load the old project file into the new version of the `ConfigFile` class.

Since there shouldn't be any difference between converting through both of the available methods, I moved the code to bump the version to the project converter class. This fixes the issue, input maps are now converted as expected.
Also, after converting through the CLI tool, the project manager will no longer show the conversion pop up when trying to open the project, since now the CLI tool will also have bumped the version on the config file, which was only done through the project manager before.

### Testing
Tested with a project that contains an input map with various keys assigned to it. Converted it both through the project manager and through the CLI tool. Both methods now work as expected.