### PR TITLE
Compress embedded GDExtension interface

### DIFF
--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -1,8 +1,18 @@
+import zlib
+
+
 def run(target, source, env):
     src = source[0]
     dst = target[0]
-    f = open(src, "r", encoding="utf-8")
+    f = open(src, "rb")
     g = open(dst, "w", encoding="utf-8")
+
+    buf = f.read()
+    decomp_size = len(buf)
+
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
 
     g.write(
         """/* THIS FILE IS GENERATED DO NOT EDIT */
@@ -11,25 +21,32 @@ def run(target, source, env):
 
 #ifdef TOOLS_ENABLED
 
+#include "core/io/compression.h"
 #include "core/io/file_access.h"
 #include "core/string/ustring.h"
 
-class GDExtensionInterfaceDump {
-	private:
-        static constexpr char const *gdextension_interface_dump ="""
+"""
     )
-    for line in f:
-        g.write('"' + line.rstrip().replace('"', '\\"') + '\\n"\n')
-    g.write(";\n")
+
+    g.write("static const int _gdextension_interface_data_compressed_size = " + str(len(buf)) + ";\n")
+    g.write("static const int _gdextension_interface_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    g.write("static const unsigned char _gdextension_interface_data_compressed[] = {\n")
+    for i in range(len(buf)):
+        g.write("\t" + str(buf[i]) + ",\n")
+    g.write("};\n")
 
     g.write(
         """
+class GDExtensionInterfaceDump {
     public:
         static void generate_gdextension_interface_file(const String &p_path) {
             Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
             ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
-            CharString cs(gdextension_interface_dump);
-            fa->store_buffer((const uint8_t *)cs.ptr(), cs.length());
+            Vector<uint8_t> data;
+            data.resize(_gdextension_interface_data_uncompressed_size);
+            int ret = Compression::decompress(data.ptrw(), _gdextension_interface_data_uncompressed_size, _gdextension_interface_data_compressed, _gdextension_interface_data_compressed_size, Compression::MODE_DEFLATE);
+            ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
+            fa->store_buffer(data.ptr(), data.size());
         };
 };
 


### PR DESCRIPTION
Stops older MSCV compiler versions from failing to build because of the huge string literal and saves about 60kb in the final executable.

Code largely follows that same patterns as `make_doc_header` and `make_certs_header`.