### PR TITLE
Renamed "icon_alignment" to "horizontal_icon_alignment"

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -57,7 +57,7 @@
 			Button's icon, if text is present the icon will be placed before the text.
 			To edit margin and spacing of the icon, use [theme_item h_separation] theme property and [code]content_margin_*[/code] properties of the used [StyleBox]es.
 		</member>
-		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
+		<member name="horizontal_icon_alignment" type="int" setter="set_horizontal_icon_alignment" getter="get_horizontal_icon_alignment" enum="HorizontalAlignment" default="0">
 			Specifies if the icon should be aligned horizontally to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.
 		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -194,7 +194,7 @@ void EditorColorMap::create() {
 	add_conversion_exception("Breakpoint");
 }
 
-static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
+static Ref<StyleBoxTexture> make_texture_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
 	style->set_texture(p_texture);
 	style->set_texture_margin_individual(p_left * EDSCALE, p_top * EDSCALE, p_right * EDSCALE, p_bottom * EDSCALE);
@@ -1595,12 +1595,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	if (increase_scrollbar_touch_area) {
 		theme->set_stylebox("scroll", "HScrollBar", make_line_stylebox(separator_color, 50));
 	} else {
-		theme->set_stylebox("scroll", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+		theme->set_stylebox("scroll", "HScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
 	}
-	theme->set_stylebox("scroll_focus", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
-	theme->set_stylebox("grabber", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
-	theme->set_stylebox("grabber_highlight", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
-	theme->set_stylebox("grabber_pressed", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
+	theme->set_stylebox("scroll_focus", "HScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+	theme->set_stylebox("grabber", "HScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
+	theme->set_stylebox("grabber_highlight", "HScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+	theme->set_stylebox("grabber_pressed", "HScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
 
 	theme->set_icon("increment", "HScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
@@ -1613,12 +1613,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	if (increase_scrollbar_touch_area) {
 		theme->set_stylebox("scroll", "VScrollBar", make_line_stylebox(separator_color, 50, 1, 1, true));
 	} else {
-		theme->set_stylebox("scroll", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+		theme->set_stylebox("scroll", "VScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
 	}
-	theme->set_stylebox("scroll_focus", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
-	theme->set_stylebox("grabber", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
-	theme->set_stylebox("grabber_highlight", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
-	theme->set_stylebox("grabber_pressed", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
+	theme->set_stylebox("scroll_focus", "VScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+	theme->set_stylebox("grabber", "VScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
+	theme->set_stylebox("grabber_highlight", "VScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 1, 1, 1, 1));
+	theme->set_stylebox("grabber_pressed", "VScrollBar", make_texture_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 1, 1, 1, 1));
 
 	theme->set_icon("increment", "VScrollBar", empty_icon);
 	theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
@@ -1742,8 +1742,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("updown_disabled", "SpinBox", theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), SNAME("EditorIcons")));
 
 	// ProgressBar
-	theme->set_stylebox("background", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
-	theme->set_stylebox("fill", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
+	theme->set_stylebox("background", "ProgressBar", make_texture_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
+	theme->set_stylebox("fill", "ProgressBar", make_texture_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
 	theme->set_color("font_color", "ProgressBar", font_color);
 	theme->set_color("font_outline_color", "ProgressBar", font_outline_color);
 	theme->set_constant("outline_size", "ProgressBar", 0);

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -538,7 +538,7 @@ void ControlEditorPresetPicker::_add_row_button(HBoxContainer *p_row, const int 
 
 	Button *b = memnew(Button);
 	b->set_custom_minimum_size(Size2i(36, 36) * EDSCALE);
-	b->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	b->set_horizontal_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	b->set_tooltip_text(p_name);
 	b->set_flat(true);
 	p_row->add_child(b);

--- a/editor/renames_map_3_to_4.cpp
+++ b/editor/renames_map_3_to_4.cpp
@@ -322,7 +322,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "get_hand", "get_tracker_hand" }, // XRPositionalTracker
 	{ "get_handle_name", "_get_handle_name" }, // EditorNode3DGizmo
 	{ "get_handle_value", "_get_handle_value" }, // EditorNode3DGizmo
-	{ "get_icon_align", "get_icon_alignment" }, // Button
+	{ "get_icon_align", "get_horizontal_icon_alignment" }, // Button
 	{ "get_icon_types", "get_icon_type_list" }, // Theme
 	{ "get_idle_frames", "get_process_frames" }, // Engine
 	{ "get_import_options", "_get_import_options" }, // EditorImportPlugin
@@ -528,7 +528,7 @@ const char *RenamesMap3To4::gdscript_function_renames[][2] = {
 	{ "set_gravity_distance_scale", "set_gravity_point_unit_distance" }, // Area2D, Area3D
 	{ "set_gravity_vector", "set_gravity_direction" }, // Area2D, Area3D
 	{ "set_h_drag_enabled", "set_drag_horizontal_enabled" }, // Camera2D
-	{ "set_icon_align", "set_icon_alignment" }, // Button
+	{ "set_icon_align", "set_horizontal_icon_alignment" }, // Button
 	{ "set_interior_ambient", "set_ambient_color" }, // ReflectionProbe
 	{ "set_interior_ambient_energy", "set_ambient_color_energy" }, // ReflectionProbe
 	{ "set_invert_faces", "set_flip_faces" }, // CSGPrimitive3D
@@ -1115,7 +1115,7 @@ const char *RenamesMap3To4::gdscript_properties_renames[][2] = {
 	{ "gravity_vec", "gravity_direction" }, // Area(2D/3D)
 	{ "hint_tooltip", "tooltip_text" }, // Control
 	{ "hseparation", "h_separation" }, // Theme
-	{ "icon_align", "icon_alignment" }, // Button
+	{ "icon_align", "horizontal_icon_alignment" }, // Button
 	{ "iterations_per_second", "physics_ticks_per_second" }, // Engine
 	{ "invert_enable", "invert_enabled" }, // Polygon2D
 	{ "margin_bottom", "offset_bottom" }, // Control -- Breaks NinePatchRect, StyleBox.

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -587,7 +587,7 @@ HorizontalAlignment Button::get_text_alignment() const {
 	return alignment;
 }
 
-void Button::set_icon_alignment(HorizontalAlignment p_alignment) {
+void Button::set_horizontal_icon_alignment(HorizontalAlignment p_alignment) {
 	horizontal_icon_alignment = p_alignment;
 	update_minimum_size();
 	queue_redraw();
@@ -599,7 +599,7 @@ void Button::set_vertical_icon_alignment(VerticalAlignment p_alignment) {
 	queue_redraw();
 }
 
-HorizontalAlignment Button::get_icon_alignment() const {
+HorizontalAlignment Button::get_horizontal_icon_alignment() const {
 	return horizontal_icon_alignment;
 }
 
@@ -624,8 +624,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_clip_text"), &Button::get_clip_text);
 	ClassDB::bind_method(D_METHOD("set_text_alignment", "alignment"), &Button::set_text_alignment);
 	ClassDB::bind_method(D_METHOD("get_text_alignment"), &Button::get_text_alignment);
-	ClassDB::bind_method(D_METHOD("set_icon_alignment", "icon_alignment"), &Button::set_icon_alignment);
-	ClassDB::bind_method(D_METHOD("get_icon_alignment"), &Button::get_icon_alignment);
+	ClassDB::bind_method(D_METHOD("set_horizontal_icon_alignment", "horizontal_icon_alignment"), &Button::set_horizontal_icon_alignment);
+	ClassDB::bind_method(D_METHOD("get_horizontal_icon_alignment"), &Button::get_horizontal_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_vertical_icon_alignment", "vertical_icon_alignment"), &Button::set_vertical_icon_alignment);
 	ClassDB::bind_method(D_METHOD("get_vertical_icon_alignment"), &Button::get_vertical_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
@@ -641,7 +641,7 @@ void Button::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_text"), "set_clip_text", "get_clip_text");
 
 	ADD_GROUP("Icon Behavior", "");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_icon_alignment", "get_icon_alignment");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "horizontal_icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_horizontal_icon_alignment", "get_horizontal_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vertical_icon_alignment", PROPERTY_HINT_ENUM, "Top,Center,Bottom"), "set_vertical_icon_alignment", "get_vertical_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_icon"), "set_expand_icon", "is_expand_icon");
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -135,9 +135,9 @@ public:
 	void set_text_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_text_alignment() const;
 
-	void set_icon_alignment(HorizontalAlignment p_alignment);
+	void set_horizontal_icon_alignment(HorizontalAlignment p_alignment);
 	void set_vertical_icon_alignment(VerticalAlignment p_alignment);
-	HorizontalAlignment get_icon_alignment() const;
+	HorizontalAlignment get_horizontal_icon_alignment() const;
 	VerticalAlignment get_vertical_icon_alignment() const;
 
 	Button(const String &p_text = String());

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1878,7 +1878,7 @@ ColorPicker::ColorPicker() {
 	set_pick_color(Color(1, 1, 1));
 
 	btn_add_preset = memnew(Button);
-	btn_add_preset->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	btn_add_preset->set_horizontal_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	btn_add_preset->set_tooltip_text(RTR("Add current color as a preset."));
 	btn_add_preset->connect("pressed", callable_mp(this, &ColorPicker::_add_preset_pressed));
 	preset_container->add_child(btn_add_preset);


### PR DESCRIPTION
This commit addresses the inconsistency between the naming conventions of the icon alignment properties in the codebase. The "icon_alignment" property has been renamed to "horizontal_icon_alignment" to align with the existing "vertical_icon_alignment" property, ensuring consistency in naming.

By renaming "icon_alignment" to "horizontal_icon_alignment," the codebase now follows a clear and unified naming pattern for both vertical and horizontal icon alignment properties. This change improves code readability and maintainability,

No functional changes have been made to the behavior or functionality of the icon alignment properties themselves. The sole purpose of this commit is to ensure naming consistency within the codebase, promoting good coding practices and improving code clarity.

![project](https://github.com/godotengine/godot/assets/62446430/430da43d-71ba-4669-813f-90607941f6f9)