### PR TITLE
Create OpenXR Texture Copy and Create Render Target

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3281,6 +3281,25 @@
 				[b]Note:[/b] The [param texture] must have the same width, height, depth and format as the current texture data. Otherwise, an error will be printed and the original texture won't be modified. If you need to use different width, height, depth or format, use [method texture_replace] instead.
 			</description>
 		</method>
+		<method name="texture_copy">
+			<return type="void" />
+			<param index="0" name="source_texture" type="RID" />
+			<param index="1" name="source_level" type="int" />
+			<param index="2" name="source_layer" type="int" />
+			<param index="3" name="dest_texture" type="RID" />
+			<param index="4" name="dest_level" type="int" />
+			<param index="5" name="dest_layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="texture_create_render_texture">
+			<return type="RID" />
+			<param index="0" name="width" type="int" />
+			<param index="1" name="height" type="int" />
+			<param index="2" name="layers" type="int" default="false" />
+			<description>
+			</description>
+		</method>
 		<method name="texture_get_native_handle" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="texture" type="RID" />

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -505,6 +505,7 @@ public:
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 
 	RID texture_create_external(Texture::Type p_type, Image::Format p_format, unsigned int p_image, int p_width, int p_height, int p_depth, int p_layers, RS::TextureLayeredType p_layered_type = RS::TEXTURE_LAYERED_2D_ARRAY);
+	RID texture_create_render_texture(int p_width, int p_height, int p_layers) override;
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override{};
@@ -521,6 +522,7 @@ public:
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override;
+	virtual void texture_copy(RID p_source_texture, int p_source_level, int p_source_layer, RID p_dest_texture, int p_dest_level, int p_dest_layer) override;
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) override;
 	virtual String texture_get_path(RID p_texture) const override;
@@ -550,6 +552,7 @@ public:
 	uint32_t texture_get_depth(RID p_texture) const;
 	void texture_bind(RID p_texture, uint32_t p_texture_no);
 	RID texture_create_radiance_cubemap(RID p_source, int p_resolution = -1) const;
+
 
 	/* TEXTURE ATLAS API */
 

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -98,6 +98,12 @@ public:
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override{};
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override{};
 
+	virtual RID texture_create_render_texture(int p_width, int p_height, int p_layers) override {
+		DummyTexture *texture = memnew(DummyTexture);
+		ERR_FAIL_COND_V(!texture, RID());
+		return texture_owner.make_rid(texture);
+	};
+
 	//these two APIs can be used together or in combination with the others.
 	virtual void texture_2d_placeholder_initialize(RID p_texture) override{};
 	virtual void texture_2d_layered_placeholder_initialize(RID p_texture, RenderingServer::TextureLayeredType p_layered_type) override{};
@@ -113,6 +119,7 @@ public:
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override { texture_free(p_by_texture); };
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override{};
+	virtual void texture_copy(RID p_source_texture, int p_source_level, int p_source_layer, RID p_dest_texture, int p_dest_level, int p_dest_layer) override {};
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) override{};
 	virtual String texture_get_path(RID p_texture) const override { return String(); };

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1106,6 +1106,11 @@ void TextureStorage::texture_proxy_initialize(RID p_texture, RID p_base) {
 	tex->proxies.push_back(p_texture);
 }
 
+
+RID TextureStorage::texture_create_render_texture(int p_width, int p_height, int p_layers) {
+	return RID();
+}
+
 void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_immediate) {
 	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -469,6 +469,8 @@ public:
 	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override;
 	virtual void texture_proxy_initialize(RID p_texture, RID p_base) override; //all slices, then all the mipmaps, must be coherent
 
+	virtual RID texture_create_render_texture(int p_width, int p_height, int p_layers);
+
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
@@ -484,6 +486,8 @@ public:
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) override;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override;
+	virtual void texture_copy(RID p_source_texture, int p_source_level, int p_source_layer, RID p_dest_texture, int p_dest_level, int p_dest_layer) override
+	{ /* stubbed */}
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) override;
 	virtual String texture_get_path(RID p_texture) const override;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -199,6 +199,7 @@ public:
 	FUNC2(texture_replace, RID, RID)
 
 	FUNC3(texture_set_size_override, RID, int, int)
+	FUNC6(texture_copy, RID, int, int, RID, int, int)
 // FIXME: Disabled during Vulkan refactoring, should be ported.
 #if 0
 	FUNC2(texture_bind, RID, uint32_t)
@@ -215,6 +216,7 @@ public:
 	FUNC2(texture_set_force_redraw_if_visible, RID, bool)
 	FUNC2RC(RID, texture_get_rd_texture, RID, bool)
 	FUNC2RC(uint64_t, texture_get_native_handle, RID, bool)
+	FUNC3R(RID, texture_create_render_texture, int, int, int )
 
 	/* SHADER API */
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -75,6 +75,8 @@ public:
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
 
+	virtual RID texture_create_render_texture(int p_width, int p_height, int p_layers) = 0;
+
 	//these two APIs can be used together or in combination with the others.
 	virtual void texture_2d_placeholder_initialize(RID p_texture) = 0;
 	virtual void texture_2d_layered_placeholder_initialize(RID p_texture, RenderingServer::TextureLayeredType p_layered_type) = 0;
@@ -86,6 +88,7 @@ public:
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;
+	virtual void texture_copy(RID p_source_texture, int p_source_level, int p_source_layer, RID p_dest_texture, int p_dest_level, int p_dest_layer) = 0;
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) = 0;
 	virtual String texture_get_path(RID p_texture) const = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1693,6 +1693,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("texture_replace", "texture", "by_texture"), &RenderingServer::texture_replace);
 	ClassDB::bind_method(D_METHOD("texture_set_size_override", "texture", "width", "height"), &RenderingServer::texture_set_size_override);
+	ClassDB::bind_method(D_METHOD("texture_copy", "source_texture", "source_level", "source_layer", "dest_texture", "dest_level", "dest_layer"), &RenderingServer::texture_copy);
 
 	ClassDB::bind_method(D_METHOD("texture_set_path", "texture", "path"), &RenderingServer::texture_set_path);
 	ClassDB::bind_method(D_METHOD("texture_get_path", "texture"), &RenderingServer::texture_get_path);
@@ -1700,6 +1701,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_set_force_redraw_if_visible", "texture", "enable"), &RenderingServer::texture_set_force_redraw_if_visible);
 	ClassDB::bind_method(D_METHOD("texture_get_rd_texture", "texture", "srgb"), &RenderingServer::texture_get_rd_texture, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("texture_get_native_handle", "texture", "srgb"), &RenderingServer::texture_get_native_handle, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("texture_create_render_texture", "width", "height", "layers"), &RenderingServer::texture_create_render_texture, DEFVAL(false));
 
 	BIND_ENUM_CONSTANT(TEXTURE_LAYERED_2D_ARRAY);
 	BIND_ENUM_CONSTANT(TEXTURE_LAYERED_CUBEMAP);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -123,6 +123,7 @@ public:
 
 	virtual void texture_replace(RID p_texture, RID p_by_texture) = 0;
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) = 0;
+	virtual void texture_copy(RID p_source_texture, int p_source_level, int p_source_layer, RID p_dest_texture, int p_dest_level, int p_dest_layer) = 0;
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) = 0;
 	virtual String texture_get_path(RID p_texture) const = 0;
@@ -160,7 +161,7 @@ public:
 
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const = 0;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const = 0;
-
+	virtual RID texture_create_render_texture(int p_width, int p_height, int p_layers) = 0;
 	/* SHADER API */
 
 	enum ShaderMode {


### PR DESCRIPTION
These two functions created by Patrick Down are currently needed for the TiltFive plugin to work. 

`texture_copy` will hopefully soon be obsolete and will be removed from this PR once an upstream change in the TiltFive SDK becomes available.

`texture_create_render_texture` I need to evaluate further. This currently is possible in Vulkan through our RenderingDevice but not possible in OpenGL. The solution will likely need to change to only effect the OpenGL implementation. It is important for XR interfaces to be able to create alternative render textures. 