### PR TITLE
GDScript: Fix calling static func from non-static is allowed

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1692,6 +1692,9 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 	GDScriptParser::FunctionNode *previous_function = parser->current_function;
 	parser->current_function = p_function;
 
+	bool previous_static_context = static_context;
+	static_context = p_function->is_static;
+
 	resolve_suite(p_function->body);
 
 	if (!p_function->get_datatype().is_hard_type() && p_function->body->get_datatype().is_set()) {
@@ -1707,6 +1710,7 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 	parser->ignored_warnings = previously_ignored_warnings;
 #endif
 	parser->current_function = previous_function;
+	static_context = previous_static_context;
 }
 
 void GDScriptAnalyzer::decide_suite_type(GDScriptParser::Node *p_suite, GDScriptParser::Node *p_statement) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/static_func_call_non_static.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/static_func_call_non_static.gd
@@ -1,0 +1,8 @@
+static func static_func():
+	non_static_func()
+
+func non_static_func():
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/static_func_call_non_static.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/static_func_call_non_static.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot call non-static function "non_static_func()" from static function "static_func()".


### PR DESCRIPTION
Fix the regression from #76264 reported in https://github.com/godotengine/godot-proposals/issues/6897#issuecomment-1550780818.
