### PR TITLE
Cleaner, faster StringBuilder implementation

### DIFF
--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -37,63 +37,45 @@ StringBuilder &StringBuilder::append(const String &p_string) {
 		return *this;
 	}
 
-	strings.push_back(p_string);
-	appended_strings.push_back(-1);
+	uint32_t len = p_string.length();
 
-	string_length += p_string.length();
+	uint32_t total_length = string_length + len;
+	if (capacity < total_length) {
+		while (capacity < total_length) {
+			capacity <<= 1;
+		}
+		buffer = (char32_t *)memrealloc(buffer, capacity * sizeof(char32_t));
+	}
+
+	memcpy(buffer + string_length, p_string.ptr(), len * sizeof(char32_t));
+
+	string_length = total_length;
+	strings++;
 
 	return *this;
 }
 
 StringBuilder &StringBuilder::append(const char *p_cstring) {
-	int32_t len = strlen(p_cstring);
+	uint32_t len = strlen(p_cstring);
 
-	c_strings.push_back(p_cstring);
-	appended_strings.push_back(len);
+	uint32_t total_length = string_length + len;
+	if (capacity < total_length) {
+		while (capacity < total_length) {
+			capacity <<= 1;
+		}
+		buffer = (char32_t *)memrealloc(buffer, capacity * sizeof(char32_t));
+	}
 
-	string_length += len;
+	for (uint32_t i = 0; i < len; i++) {
+		buffer[string_length + i] = p_cstring[i];
+	}
+
+	string_length = total_length;
+	strings++;
 
 	return *this;
 }
 
 String StringBuilder::as_string() const {
-	if (string_length == 0) {
-		return "";
-	}
-
-	char32_t *buffer = memnew_arr(char32_t, string_length);
-
-	int current_position = 0;
-
-	int godot_string_elem = 0;
-	int c_string_elem = 0;
-
-	for (int i = 0; i < appended_strings.size(); i++) {
-		if (appended_strings[i] == -1) {
-			// Godot string
-			const String &s = strings[godot_string_elem];
-
-			memcpy(buffer + current_position, s.ptr(), s.length() * sizeof(char32_t));
-
-			current_position += s.length();
-
-			godot_string_elem++;
-		} else {
-			const char *s = c_strings[c_string_elem];
-
-			for (int32_t j = 0; j < appended_strings[i]; j++) {
-				buffer[current_position + j] = s[j];
-			}
-
-			current_position += appended_strings[i];
-
-			c_string_elem++;
-		}
-	}
-
-	String final_string = String(buffer, string_length);
-
-	memdelete_arr(buffer);
-
-	return final_string;
+	return String(buffer, string_length);
 }

--- a/core/string/string_builder.h
+++ b/core/string/string_builder.h
@@ -36,13 +36,10 @@
 
 class StringBuilder {
 	uint32_t string_length = 0;
+	uint32_t capacity = 16;
+	uint32_t strings = 0;
 
-	Vector<String> strings;
-	Vector<const char *> c_strings;
-
-	// -1 means it's a Godot String
-	// a natural number means C string.
-	Vector<int32_t> appended_strings;
+	char32_t *buffer;
 
 public:
 	StringBuilder &append(const String &p_string);
@@ -65,7 +62,7 @@ public:
 	}
 
 	_FORCE_INLINE_ int num_strings_appended() const {
-		return appended_strings.size();
+		return strings;
 	}
 
 	_FORCE_INLINE_ uint32_t get_string_length() const {
@@ -78,7 +75,13 @@ public:
 		return as_string();
 	}
 
-	StringBuilder() {}
+	StringBuilder() {
+		buffer = (char32_t *)memalloc(16 * sizeof(char32_t));
+	}
+
+	~StringBuilder() {
+		memfree(buffer);
+	}
 };
 
 #endif // STRING_BUILDER_H


### PR DESCRIPTION
Reimplements `StringBuilder` using a single exponentially growing character buffer, instead of 3 separate arrays of strings. According to benchmarks, this achieves around a 5-7 times boost in performance. And it does it with fewer lines of code.