### PR TITLE
Docs: Point to @GDScript in GDscript (script impl)

### DIFF
--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		A script implemented in the GDScript programming language. The script extends the functionality of all objects that instantiate it.
-		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+		Calling [method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+		If you are looking for GDScript's built-in functions, see [@GDScript] instead.
 	</description>
 	<tutorials>
 		<link title="GDScript documentation index">$DOCS_URL/tutorials/scripting/gdscript/index.html</link>


### PR DESCRIPTION
While looking up where `load()` was actually documented today (in `@GDScript`), I was disoriented for a second when I landed in `GDScript` (which to make matters worse also references `load()` in a code example and shows up in search).

This adds a simple reference to `@GDScript`, which is probably overwhelmingly more used than `GDScript` which is a bit more niche. `GlobalScope` also references `@GDScript` in this way.