### PR TITLE
Replace the use of StringBuilder with StringBuffer

### DIFF
--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -32,7 +32,7 @@
 
 #include "core/io/file_access_encrypted.h"
 #include "core/os/keyboard.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/variant/variant_parser.h"
 
 PackedStringArray ConfigFile::_get_sections() const {
@@ -132,7 +132,7 @@ void ConfigFile::erase_section_key(const String &p_section, const String &p_key)
 }
 
 String ConfigFile::encode_to_text() const {
-	StringBuilder sb;
+	StringBuffer<> sb;
 	bool first = true;
 	for (const KeyValue<String, HashMap<String, Variant>> &E : values) {
 		if (first) {

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -33,7 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/stream_peer_tcp.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 
 #define FILESYSTEM_CACHE_VERSION 1
 #define FILESYSTEM_PROTOCOL_VERSION 1
@@ -214,7 +214,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 	// Encode file cache to send it via network.
 	Vector<uint8_t> file_cache_buffer;
 	if (file_cache.size()) {
-		StringBuilder sbuild;
+		StringBuffer<> sbuild;
 		for (int i = 0; i < file_cache.size(); i++) {
 			sbuild.append(file_cache[i].path);
 			sbuild.append("::");

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -129,7 +129,7 @@ void ShaderGLES3::_setup(const char *p_vertex_code, const char *p_fragment_code,
 	feedbacks = p_feedback;
 	feedback_count = p_feedback_count;
 
-	StringBuilder tohash;
+	StringBuffer<> tohash;
 	/*
 	tohash.append("[SpirvCacheKey]");
 	tohash.append(RenderingDevice::get_singleton()->shader_get_spirv_cache_key());
@@ -160,7 +160,7 @@ RID ShaderGLES3::version_create() {
 	return version_owner.make_rid(version);
 }
 
-void ShaderGLES3::_build_variant_code(StringBuilder &builder, uint32_t p_variant, const Version *p_version, StageType p_stage_type, uint64_t p_specialization) {
+void ShaderGLES3::_build_variant_code(StringBuffer<> &builder, uint32_t p_variant, const Version *p_version, StageType p_stage_type, uint64_t p_specialization) {
 	if (RasterizerGLES3::is_gles_over_gl()) {
 		builder.append("#version 330\n");
 		builder.append("#define USE_GLES_OVER_GL\n");
@@ -315,11 +315,11 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 
 	//vertex stage
 	{
-		StringBuilder builder;
-		_build_variant_code(builder, p_variant, p_version, STAGE_TYPE_VERTEX, p_specialization);
+		StringBuffer<> buffer;
+		_build_variant_code(buffer, p_variant, p_version, STAGE_TYPE_VERTEX, p_specialization);
 
 		spec.vert_id = glCreateShader(GL_VERTEX_SHADER);
-		String builder_string = builder.as_string();
+		String builder_string = buffer.as_string();
 		CharString cs = builder_string.utf8();
 		const char *cstr = cs.ptr();
 		glShaderSource(spec.vert_id, 1, &cstr, nullptr);
@@ -363,11 +363,11 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 
 	//fragment stage
 	{
-		StringBuilder builder;
-		_build_variant_code(builder, p_variant, p_version, STAGE_TYPE_FRAGMENT, p_specialization);
+		StringBuffer<> buffer;
+		_build_variant_code(buffer, p_variant, p_version, STAGE_TYPE_FRAGMENT, p_specialization);
 
 		spec.frag_id = glCreateShader(GL_FRAGMENT_SHADER);
-		String builder_string = builder.as_string();
+		String builder_string = buffer.as_string();
 		CharString cs = builder_string.utf8();
 		const char *cstr = cs.ptr();
 		glShaderSource(spec.frag_id, 1, &cstr, nullptr);
@@ -484,24 +484,24 @@ RS::ShaderNativeSourceCode ShaderGLES3::version_get_native_source_code(RID p_ver
 		//vertex stage
 
 		{
-			StringBuilder builder;
-			_build_variant_code(builder, i, version, STAGE_TYPE_VERTEX, specialization_default_mask);
+			StringBuffer<> buffer;
+			_build_variant_code(buffer, i, version, STAGE_TYPE_VERTEX, specialization_default_mask);
 
 			RS::ShaderNativeSourceCode::Version::Stage stage;
 			stage.name = "vertex";
-			stage.code = builder.as_string();
+			stage.code = buffer.as_string();
 
 			source_code.versions.write[i].stages.push_back(stage);
 		}
 
 		//fragment stage
 		{
-			StringBuilder builder;
-			_build_variant_code(builder, i, version, STAGE_TYPE_FRAGMENT, specialization_default_mask);
+			StringBuffer<> buffer;
+			_build_variant_code(buffer, i, version, STAGE_TYPE_FRAGMENT, specialization_default_mask);
 
 			RS::ShaderNativeSourceCode::Version::Stage stage;
 			stage.name = "fragment";
-			stage.code = builder.as_string();
+			stage.code = buffer.as_string();
 
 			source_code.versions.write[i].stages.push_back(stage);
 		}
@@ -511,7 +511,7 @@ RS::ShaderNativeSourceCode ShaderGLES3::version_get_native_source_code(RID p_ver
 }
 
 String ShaderGLES3::_version_get_sha1(Version *p_version) const {
-	StringBuilder hash_build;
+	StringBuffer<> hash_build;
 
 	hash_build.append("[uniforms]");
 	hash_build.append(p_version->uniforms.get_data());
@@ -781,7 +781,7 @@ void ShaderGLES3::initialize(const String &p_general_defines, int p_base_texture
 	_init();
 
 	if (shader_cache_dir != String()) {
-		StringBuilder hash_build;
+		StringBuffer<> hash_build;
 
 		hash_build.append("[base_hash]");
 		hash_build.append(base_sha256);

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -33,7 +33,7 @@
 
 #include "core/math/projection.h"
 #include "core/os/mutex.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_map.h"
@@ -158,7 +158,7 @@ private:
 
 	StageTemplate stage_templates[STAGE_TYPE_MAX];
 
-	void _build_variant_code(StringBuilder &p_builder, uint32_t p_variant, const Version *p_version, StageType p_stage_type, uint64_t p_specialization);
+	void _build_variant_code(StringBuffer<> &p_builder, uint32_t p_variant, const Version *p_version, StageType p_stage_type, uint64_t p_specialization);
 
 	void _add_stage(const char *p_code, StageType p_stage_type);
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -32,7 +32,7 @@
 
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -949,7 +949,7 @@ void CodeTextEditor::_line_col_changed() {
 		}
 	}
 
-	StringBuilder sb;
+	StringBuffer<> sb;
 	sb.append(itos(text_editor->get_caret_line() + 1).lpad(4));
 	sb.append(" : ");
 	sb.append(itos(positional_column + 1).lpad(3));

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -33,7 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_saver.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "editor/create_dialog.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -147,7 +147,7 @@ void ShaderCreateDialog::_create_new() {
 			text_shader.instantiate();
 			shader = text_shader;
 
-			StringBuilder code;
+			StringBuffer<> code;
 			code += vformat("shader_type %s;\n", mode_menu->get_text().to_snake_case());
 
 			if (current_template == 0) { // Default template.

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -33,7 +33,7 @@
 #include "gdscript.h"
 #include "gdscript_function.h"
 
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 
 static String _get_variant_string(const Variant &p_variant) {
 	String txt;
@@ -101,7 +101,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 #define DADDR(m_ip) (_disassemble_address(_script, *this, _code_ptr[ip + m_ip]))
 
 	for (int ip = 0; ip < _code_size;) {
-		StringBuilder text;
+		StringBuffer<> text;
 		int incr = 0;
 
 		text += " ";
@@ -1282,7 +1282,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 		}
 
 		ip += incr;
-		if (text.get_string_length() > 0) {
+		if (text.length() > 0) {
 			print_line(text.as_string());
 		}
 	}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -41,7 +41,7 @@
 
 #ifdef DEBUG_ENABLED
 #include "core/os/os.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "servers/text_server.h"
 #endif
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -50,7 +50,7 @@
 #include "core/variant/variant.h"
 
 #ifdef DEBUG_ENABLED
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #endif
 
 class GDScriptParser {
@@ -1610,7 +1610,7 @@ public:
 	class TreePrinter {
 		int indent_level = 0;
 		String indent;
-		StringBuilder printed;
+		StringBuffer<> printed;
 		bool pending_indent = false;
 
 		void increase_indent();

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -41,7 +41,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access_pack.h"
 #include "core/os/os.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "scene/resources/packed_scene.h"
 
 #include "tests/test_macros.h"
@@ -450,7 +450,7 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 
 	result->status = GDTEST_RUNTIME_ERROR;
 
-	StringBuilder builder;
+	StringBuffer<> builder;
 	builder.append(">> ");
 	// Only include the function, file and line for script errors, otherwise the
 	// test outputs changes based on the platform/compiler.
@@ -600,7 +600,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	}
 
 #ifdef DEBUG_ENABLED
-	StringBuilder warning_string;
+	StringBuffer<> warning_string;
 	for (const GDScriptWarning &E : parser.get_warnings()) {
 		const GDScriptWarning warning = E;
 		warning_string.append(">> WARNING");

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -41,7 +41,7 @@
 #include "core/io/file_access_pack.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "scene/resources/packed_scene.h"
 
 #ifdef TOOLS_ENABLED
@@ -64,7 +64,7 @@ static void test_tokenizer(const String &p_code, const Vector<String> &p_lines) 
 
 	GDScriptTokenizer::Token current = tokenizer.scan();
 	while (current.type != GDScriptTokenizer::Token::TK_EOF) {
-		StringBuilder token;
+		StringBuffer<> token;
 		token += " --> "; // Padding for line number.
 
 		for (int l = current.start_line; l <= current.end_line && l <= p_lines.size(); l++) {
@@ -73,7 +73,7 @@ static void test_tokenizer(const String &p_code, const Vector<String> &p_lines) 
 
 		{
 			// Print carets to point at the token.
-			StringBuilder pointer;
+			StringBuffer<> pointer;
 			pointer += "     "; // Padding for line number.
 			int rightmost_column = current.rightmost_column;
 			if (current.end_line > current.start_line) {
@@ -95,7 +95,7 @@ static void test_tokenizer(const String &p_code, const Vector<String> &p_lines) 
 			token += "(";
 			token += Variant::get_type_name(current.literal.get_type());
 			token += ") ";
-			token += current.literal;
+			token += current.literal.operator String();
 		}
 
 		print_line(token.as_string());
@@ -129,7 +129,7 @@ static void test_tokenizer_buffer(const Vector<uint8_t> &p_buffer, const Vector<
 
 	GDScriptTokenizer::Token current = tokenizer.scan();
 	while (current.type != GDScriptTokenizer::Token::TK_EOF) {
-		StringBuilder token;
+		StringBuffer<> token;
 		token += " --> "; // Padding for line number.
 
 		for (int l = current.start_line; l <= current.end_line && l <= p_lines.size(); l++) {
@@ -142,7 +142,7 @@ static void test_tokenizer_buffer(const Vector<uint8_t> &p_buffer, const Vector<
 			token += "(";
 			token += Variant::get_type_name(current.literal.get_type());
 			token += ") ";
-			token += current.literal;
+			token += current.literal.operator String();
 		}
 
 		print_line(token.as_string());

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -45,12 +45,14 @@
 #include "core/os/os.h"
 #include "main/main.h"
 
-StringBuilder &operator<<(StringBuilder &r_sb, const String &p_string) {
+template <int SHORT_BUFFER_SIZE>
+StringBuffer<SHORT_BUFFER_SIZE> &operator<<(StringBuffer<SHORT_BUFFER_SIZE> &r_sb, const String &p_string) {
 	r_sb.append(p_string);
 	return r_sb;
 }
 
-StringBuilder &operator<<(StringBuilder &r_sb, const char *p_cstring) {
+template <int SHORT_BUFFER_SIZE>
+StringBuffer<SHORT_BUFFER_SIZE> &operator<<(StringBuffer<SHORT_BUFFER_SIZE> &r_sb, const char *p_cstring) {
 	r_sb.append(p_cstring);
 	return r_sb;
 }
@@ -183,7 +185,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 
 	String bbcode = p_bbcode;
 
-	StringBuilder output;
+	StringBuffer<> output;
 
 	List<String> tag_stack;
 	bool code_tag = false;
@@ -445,7 +447,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 
 	String bbcode = p_bbcode;
 
-	StringBuilder xml_output;
+	StringBuffer<> xml_output;
 
 	xml_output.append("<para>");
 
@@ -807,7 +809,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 	return xml_output.as_string();
 }
 
-void BindingsGenerator::_append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_text_method(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			OS::get_singleton()->print("Cannot resolve @GlobalScope method reference in documentation: %s\n", p_link_target.utf8().get_data());
@@ -876,7 +878,7 @@ void BindingsGenerator::_append_text_method(StringBuilder &p_output, const TypeI
 	}
 }
 
-void BindingsGenerator::_append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_text_member(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target.contains("/")) {
 		// Properties with '/' (slash) in the name are not declared in C#, so there is nothing to reference.
 		_append_text_undeclared(p_output, p_link_target);
@@ -918,7 +920,7 @@ void BindingsGenerator::_append_text_member(StringBuilder &p_output, const TypeI
 	}
 }
 
-void BindingsGenerator::_append_text_signal(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_text_signal(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (!p_target_itype || !p_target_itype->is_object_type) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			if (p_target_itype) {
@@ -949,7 +951,7 @@ void BindingsGenerator::_append_text_signal(StringBuilder &p_output, const TypeI
 	}
 }
 
-void BindingsGenerator::_append_text_enum(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_text_enum(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	const StringName search_cname = !p_target_itype ? p_target_cname : StringName(p_target_itype->name + "." + (String)p_target_cname);
 
 	HashMap<StringName, TypeInterface>::ConstIterator enum_match = enum_types.find(search_cname);
@@ -973,7 +975,7 @@ void BindingsGenerator::_append_text_enum(StringBuilder &p_output, const TypeInt
 	}
 }
 
-void BindingsGenerator::_append_text_constant(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_text_constant(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
 		_append_text_constant_in_global_scope(p_output, p_target_cname, p_link_target);
 	} else if (!p_target_itype || !p_target_itype->is_object_type) {
@@ -1043,7 +1045,7 @@ void BindingsGenerator::_append_text_constant(StringBuilder &p_output, const Typ
 	}
 }
 
-void BindingsGenerator::_append_text_constant_in_global_scope(StringBuilder &p_output, const String &p_target_cname, const String &p_link_target) {
+void BindingsGenerator::_append_text_constant_in_global_scope(StringBuffer<> &p_output, const String &p_target_cname, const String &p_link_target) {
 	// Try to find as a global constant
 	const ConstantInterface *target_iconst = find_constant_by_name(p_target_cname, global_constants);
 
@@ -1077,16 +1079,16 @@ void BindingsGenerator::_append_text_constant_in_global_scope(StringBuilder &p_o
 	}
 }
 
-void BindingsGenerator::_append_text_param(StringBuilder &p_output, const String &p_link_target) {
+void BindingsGenerator::_append_text_param(StringBuffer<> &p_output, const String &p_link_target) {
 	const String link_target = snake_to_camel_case(p_link_target);
 	p_output.append("'" + link_target + "'");
 }
 
-void BindingsGenerator::_append_text_undeclared(StringBuilder &p_output, const String &p_link_target) {
+void BindingsGenerator::_append_text_undeclared(StringBuffer<> &p_output, const String &p_link_target) {
 	p_output.append("'" + p_link_target + "'");
 }
 
-void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_xml_method(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			OS::get_singleton()->print("Cannot resolve @GlobalScope method reference in documentation: %s\n", p_link_target.utf8().get_data());
@@ -1157,7 +1159,7 @@ void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const Ty
 	}
 }
 
-void BindingsGenerator::_append_xml_member(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_xml_member(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target.contains("/")) {
 		// Properties with '/' (slash) in the name are not declared in C#, so there is nothing to reference.
 		_append_xml_undeclared(p_xml_output, p_link_target);
@@ -1199,7 +1201,7 @@ void BindingsGenerator::_append_xml_member(StringBuilder &p_xml_output, const Ty
 	}
 }
 
-void BindingsGenerator::_append_xml_signal(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_xml_signal(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (!p_target_itype || !p_target_itype->is_object_type) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			if (p_target_itype) {
@@ -1230,7 +1232,7 @@ void BindingsGenerator::_append_xml_signal(StringBuilder &p_xml_output, const Ty
 	}
 }
 
-void BindingsGenerator::_append_xml_enum(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_xml_enum(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	const StringName search_cname = !p_target_itype ? p_target_cname : StringName(p_target_itype->name + "." + (String)p_target_cname);
 
 	HashMap<StringName, TypeInterface>::ConstIterator enum_match = enum_types.find(search_cname);
@@ -1254,7 +1256,7 @@ void BindingsGenerator::_append_xml_enum(StringBuilder &p_xml_output, const Type
 	}
 }
 
-void BindingsGenerator::_append_xml_constant(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
+void BindingsGenerator::_append_xml_constant(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
 	if (p_link_target_parts[0] == name_cache.type_at_GlobalScope) {
 		_append_xml_constant_in_global_scope(p_xml_output, p_target_cname, p_link_target);
 	} else if (!p_target_itype || !p_target_itype->is_object_type) {
@@ -1324,7 +1326,7 @@ void BindingsGenerator::_append_xml_constant(StringBuilder &p_xml_output, const 
 	}
 }
 
-void BindingsGenerator::_append_xml_constant_in_global_scope(StringBuilder &p_xml_output, const String &p_target_cname, const String &p_link_target) {
+void BindingsGenerator::_append_xml_constant_in_global_scope(StringBuffer<> &p_xml_output, const String &p_target_cname, const String &p_link_target) {
 	// Try to find as a global constant
 	const ConstantInterface *target_iconst = find_constant_by_name(p_target_cname, global_constants);
 
@@ -1358,7 +1360,7 @@ void BindingsGenerator::_append_xml_constant_in_global_scope(StringBuilder &p_xm
 	}
 }
 
-void BindingsGenerator::_append_xml_param(StringBuilder &p_xml_output, const String &p_link_target, bool p_is_signal) {
+void BindingsGenerator::_append_xml_param(StringBuffer<> &p_xml_output, const String &p_link_target, bool p_is_signal) {
 	const String link_target = snake_to_camel_case(p_link_target);
 
 	if (!p_is_signal) {
@@ -1373,7 +1375,7 @@ void BindingsGenerator::_append_xml_param(StringBuilder &p_xml_output, const Str
 	}
 }
 
-void BindingsGenerator::_append_xml_undeclared(StringBuilder &p_xml_output, const String &p_link_target) {
+void BindingsGenerator::_append_xml_undeclared(StringBuffer<> &p_xml_output, const String &p_link_target) {
 	p_xml_output.append("<c>");
 	p_xml_output.append(p_link_target);
 	p_xml_output.append("</c>");
@@ -1505,7 +1507,7 @@ Error BindingsGenerator::_populate_method_icalls_table(const TypeInterface &p_it
 	return OK;
 }
 
-void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
+void BindingsGenerator::_generate_array_extensions(StringBuffer<> &p_output) {
 	p_output.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 	p_output.append("using System;\n\n");
 	// The class where we put the extensions doesn't matter, so just use "GD".
@@ -1572,7 +1574,7 @@ void BindingsGenerator::_generate_array_extensions(StringBuilder &p_output) {
 	p_output.append(CLOSE_BLOCK); // End of GD class.
 }
 
-void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
+void BindingsGenerator::_generate_global_constants(StringBuffer<> &p_output) {
 	// Constants (in partial GD class)
 
 	p_output.append("namespace " BINDINGS_NAMESPACE ";\n\n");
@@ -1696,7 +1698,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	// Generate source file for global scope constants and enums
 	{
-		StringBuilder constants_source;
+		StringBuffer<> constants_source;
 		_generate_global_constants(constants_source);
 		String output_file = path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_constants.cs");
 		Error save_err = _save_file(output_file, constants_source);
@@ -1709,7 +1711,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	// Generate source file for array extensions
 	{
-		StringBuilder extensions_source;
+		StringBuffer<> extensions_source;
 		_generate_array_extensions(extensions_source);
 		String output_file = path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_extensions.cs");
 		Error save_err = _save_file(output_file, extensions_source);
@@ -1744,7 +1746,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 	// Generate source file for built-in type constructor dictionary.
 
 	{
-		StringBuilder cs_built_in_ctors_content;
+		StringBuffer<> cs_built_in_ctors_content;
 
 		cs_built_in_ctors_content.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 		cs_built_in_ctors_content.append("using System;\n"
@@ -1806,7 +1808,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	// Generate native calls
 
-	StringBuilder cs_icalls_content;
+	StringBuffer<> cs_icalls_content;
 
 	cs_icalls_content.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 	cs_icalls_content.append("using System;\n"
@@ -1848,7 +1850,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	// Generate GeneratedIncludes.props
 
-	StringBuilder includes_props_content;
+	StringBuffer<> includes_props_content;
 	includes_props_content.append("<Project>\n"
 								  "  <ItemGroup>\n");
 
@@ -1914,7 +1916,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 	// Generate source file for editor type constructor dictionary.
 
 	{
-		StringBuilder cs_built_in_ctors_content;
+		StringBuffer<> cs_built_in_ctors_content;
 
 		cs_built_in_ctors_content.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 		cs_built_in_ctors_content.append("internal static class " BINDINGS_CLASS_CONSTRUCTOR_EDITOR "\n{");
@@ -1964,7 +1966,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 	// Generate native calls
 
-	StringBuilder cs_icalls_content;
+	StringBuffer<> cs_icalls_content;
 
 	cs_icalls_content.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 	cs_icalls_content.append("using System;\n"
@@ -2008,7 +2010,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 	// Generate GeneratedIncludes.props
 
-	StringBuilder includes_props_content;
+	StringBuffer<> includes_props_content;
 	includes_props_content.append("<Project>\n"
 								  "  <ItemGroup>\n");
 
@@ -2093,7 +2095,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 	_log("Generating %s.cs...\n", itype.proxy_name.utf8().get_data());
 
-	StringBuilder output;
+	StringBuffer<> output;
 
 	output.append("namespace " BINDINGS_NAMESPACE ";\n\n");
 
@@ -2636,7 +2638,7 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 	return _save_file(p_output_file, output);
 }
 
-Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuilder &p_output) {
+Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuffer<> &p_output) {
 	const MethodInterface *setter = p_itype.find_method_by_name(p_iprop.setter);
 
 	// Search it in base types too
@@ -2784,7 +2786,7 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 	return OK;
 }
 
-Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output, bool p_use_span) {
+Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::MethodInterface &p_imethod, int &p_method_bind_count, StringBuffer<> &p_output, bool p_use_span) {
 	const TypeInterface *return_type = _get_type_or_singleton_or_null(p_imethod.return_type);
 	ERR_FAIL_NULL_V_MSG(return_type, ERR_BUG, "Return type '" + p_imethod.return_type.cname + "' was not found.");
 
@@ -2829,7 +2831,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 	String method_bind_field = CS_STATIC_FIELD_METHOD_BIND_PREFIX + itos(p_method_bind_count);
 
 	String arguments_sig;
-	StringBuilder cs_in_statements;
+	StringBuffer<> cs_in_statements;
 	bool cs_in_expr_is_unsafe = false;
 
 	String icall_params = method_bind_field;
@@ -2848,7 +2850,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		icall_params += ", " + sformat(p_itype.cs_in_expr, self_reference);
 	}
 
-	StringBuilder default_args_doc;
+	StringBuffer<> default_args_doc;
 
 	// Retrieve information from the arguments
 	const ArgumentInterface &first = p_imethod.arguments.front()->get();
@@ -3013,7 +3015,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 			}
 		}
 
-		if (default_args_doc.get_string_length()) {
+		if (default_args_doc.length()) {
 			p_output.append(default_args_doc.as_string());
 		}
 
@@ -3084,7 +3086,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 		im_call += ".";
 		im_call += im_icall->name;
 
-		if (p_imethod.arguments.size() && cs_in_statements.get_string_length() > 0) {
+		if (p_imethod.arguments.size() && cs_in_statements.length() > 0) {
 			p_output.append(cs_in_statements.as_string());
 		}
 
@@ -3106,7 +3108,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 	return OK;
 }
 
-Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output) {
+Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuffer<> &p_output) {
 	String arguments_sig;
 
 	// Retrieve information from the arguments
@@ -3286,7 +3288,7 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 			} else {
 				p_output.append("(");
 
-				StringBuilder cs_emitsignal_params;
+				StringBuffer<> cs_emitsignal_params;
 
 				int idx = 0;
 				for (const ArgumentInterface &iarg : p_isignal.arguments) {
@@ -3319,15 +3321,15 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 	return OK;
 }
 
-Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, StringBuilder &r_output) {
+Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, StringBuffer<> &r_output) {
 	bool ret_void = p_icall.return_type.cname == name_cache.type_void;
 
 	const TypeInterface *return_type = _get_type_or_null(p_icall.return_type);
 	ERR_FAIL_NULL_V_MSG(return_type, ERR_BUG, "Return type '" + p_icall.return_type.cname + "' was not found.");
 
-	StringBuilder c_func_sig;
-	StringBuilder c_in_statements;
-	StringBuilder c_args_var_content;
+	StringBuffer<> c_func_sig;
+	StringBuffer<> c_in_statements;
+	StringBuffer<> c_args_var_content;
 
 	c_func_sig << "IntPtr " CS_PARAM_METHODBIND;
 
@@ -3533,7 +3535,7 @@ Error BindingsGenerator::_generate_cs_native_calls(const InternalCall &p_icall, 
 	return OK;
 }
 
-Error BindingsGenerator::_save_file(const String &p_path, const StringBuilder &p_content) {
+Error BindingsGenerator::_save_file(const String &p_path, const StringBuffer<> &p_content) {
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(file.is_null(), ERR_FILE_CANT_WRITE, "Cannot open file: '" + p_path + "'.");
 

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -37,7 +37,7 @@
 
 #include "core/doc_data.h"
 #include "core/object/class_db.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/string/ustring.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_help.h"
@@ -795,23 +795,23 @@ class BindingsGenerator {
 	String bbcode_to_text(const String &p_bbcode, const TypeInterface *p_itype);
 	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal = false);
 
-	void _append_text_method(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_text_signal(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_text_enum(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_text_constant(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_text_constant_in_global_scope(StringBuilder &p_output, const String &p_target_cname, const String &p_link_target);
-	void _append_text_param(StringBuilder &p_output, const String &p_link_target);
-	void _append_text_undeclared(StringBuilder &p_output, const String &p_link_target);
+	void _append_text_method(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_member(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_signal(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_enum(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_constant(StringBuffer<> &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_text_constant_in_global_scope(StringBuffer<> &p_output, const String &p_target_cname, const String &p_link_target);
+	void _append_text_param(StringBuffer<> &p_output, const String &p_link_target);
+	void _append_text_undeclared(StringBuffer<> &p_output, const String &p_link_target);
 
-	void _append_xml_method(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_xml_member(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_xml_signal(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_xml_enum(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_xml_constant(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
-	void _append_xml_constant_in_global_scope(StringBuilder &p_xml_output, const String &p_target_cname, const String &p_link_target);
-	void _append_xml_param(StringBuilder &p_xml_output, const String &p_link_target, bool p_is_signal);
-	void _append_xml_undeclared(StringBuilder &p_xml_output, const String &p_link_target);
+	void _append_xml_method(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_xml_member(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_xml_signal(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_xml_enum(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_xml_constant(StringBuffer<> &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
+	void _append_xml_constant_in_global_scope(StringBuffer<> &p_xml_output, const String &p_target_cname, const String &p_link_target);
+	void _append_xml_param(StringBuffer<> &p_xml_output, const String &p_link_target, bool p_is_signal);
+	void _append_xml_undeclared(StringBuffer<> &p_xml_output, const String &p_link_target);
 
 	int _determine_enum_prefix(const EnumInterface &p_ienum);
 	void _apply_prefix_to_enum_constants(EnumInterface &p_ienum, int p_prefix_length);
@@ -840,16 +840,16 @@ class BindingsGenerator {
 
 	Error _generate_cs_type(const TypeInterface &itype, const String &p_output_file);
 
-	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuilder &p_output);
-	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuilder &p_output, bool p_use_span);
-	Error _generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuilder &p_output);
+	Error _generate_cs_property(const TypeInterface &p_itype, const PropertyInterface &p_iprop, StringBuffer<> &p_output);
+	Error _generate_cs_method(const TypeInterface &p_itype, const MethodInterface &p_imethod, int &p_method_bind_count, StringBuffer<> &p_output, bool p_use_span);
+	Error _generate_cs_signal(const BindingsGenerator::TypeInterface &p_itype, const BindingsGenerator::SignalInterface &p_isignal, StringBuffer<> &p_output);
 
-	Error _generate_cs_native_calls(const InternalCall &p_icall, StringBuilder &r_output);
+	Error _generate_cs_native_calls(const InternalCall &p_icall, StringBuffer<> &r_output);
 
-	void _generate_array_extensions(StringBuilder &p_output);
-	void _generate_global_constants(StringBuilder &p_output);
+	void _generate_array_extensions(StringBuffer<> &p_output);
+	void _generate_global_constants(StringBuffer<> &p_output);
 
-	Error _save_file(const String &p_path, const StringBuilder &p_content);
+	Error _save_file(const String &p_path, const StringBuffer<> &p_content);
 
 	void _log(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -32,7 +32,7 @@
 #include "code_edit.compat.inc"
 
 #include "core/os/keyboard.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/string/ustring.h"
 #include "scene/theme/theme_db.h"
 
@@ -2083,7 +2083,7 @@ TypedArray<String> CodeEdit::get_code_completion_prefixes() const {
 }
 
 String CodeEdit::get_text_for_code_completion() const {
-	StringBuilder completion_text;
+	StringBuffer<> completion_text;
 	const int text_size = get_line_count();
 	for (int i = 0; i < text_size; i++) {
 		String line = get_line(i);
@@ -2384,7 +2384,7 @@ String CodeEdit::get_text_for_symbol_lookup() const {
 
 String CodeEdit::get_text_with_cursor_char(int p_line, int p_column) const {
 	const int text_size = get_line_count();
-	StringBuilder result;
+	StringBuffer<> result;
 	for (int i = 0; i < text_size; i++) {
 		String line_text = get_line(i);
 		if (i == p_line && p_column >= 0 && p_column <= line_text.size()) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -37,7 +37,7 @@
 #include "core/object/script_language.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/string/translation_server.h"
 #include "scene/gui/label.h"
 #include "scene/main/window.h"
@@ -3441,7 +3441,7 @@ void TextEdit::set_text(const String &p_text) {
 }
 
 String TextEdit::get_text() const {
-	StringBuilder ret_text;
+	StringBuffer<> ret_text;
 	const int text_size = text.size();
 	for (int i = 0; i < text_size; i++) {
 		ret_text += text[i];
@@ -5185,7 +5185,7 @@ int TextEdit::get_caret_wrap_index(int p_caret) const {
 String TextEdit::get_word_under_caret(int p_caret) const {
 	ERR_FAIL_COND_V(p_caret >= carets.size() || p_caret < -1, "");
 
-	StringBuilder selected_text;
+	StringBuffer<> selected_text;
 	for (int c = 0; c < carets.size(); c++) {
 		if (p_caret != -1 && p_caret != c) {
 			continue;
@@ -5451,7 +5451,7 @@ String TextEdit::get_selected_text(int p_caret) {
 		return _base_get_text(get_selection_from_line(p_caret), get_selection_from_column(p_caret), get_selection_to_line(p_caret), get_selection_to_column(p_caret));
 	}
 
-	StringBuilder selected_text;
+	StringBuffer<> selected_text;
 	Vector<int> sorted_carets = get_sorted_carets();
 	for (int i = 0; i < sorted_carets.size(); i++) {
 		int caret_index = sorted_carets[i];
@@ -5459,7 +5459,7 @@ String TextEdit::get_selected_text(int p_caret) {
 		if (!has_selection(caret_index)) {
 			continue;
 		}
-		if (selected_text.get_string_length() != 0) {
+		if (selected_text.length() != 0) {
 			selected_text += "\n";
 		}
 		selected_text += _base_get_text(get_selection_from_line(caret_index), get_selection_from_column(caret_index), get_selection_to_line(caret_index), get_selection_to_column(caret_index));
@@ -7267,7 +7267,7 @@ void TextEdit::_copy_internal(int p_caret) {
 	}
 
 	// Copy full lines.
-	StringBuilder clipboard;
+	StringBuffer<> clipboard;
 	Vector<Point2i> line_ranges;
 	if (p_caret == -1) {
 		// When there are multiple carets on a line, only copy it once.
@@ -8490,7 +8490,7 @@ String TextEdit::_base_get_text(int p_from_line, int p_from_column, int p_to_lin
 	ERR_FAIL_COND_V(p_to_line < p_from_line, String()); // 'from > to'.
 	ERR_FAIL_COND_V(p_to_line == p_from_line && p_to_column < p_from_column, String()); // 'from > to'.
 
-	StringBuilder ret;
+	StringBuffer<> ret;
 
 	for (int i = p_from_line; i <= p_to_line; i++) {
 		int begin = (i == p_from_line) ? p_from_column : 0;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1490,10 +1490,10 @@ String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port
 	ERR_FAIL_COND_V(p_port < 0 || p_port >= node->get_expanded_output_port_count(), String());
 	ERR_FAIL_COND_V(node->get_output_port_type(p_port) == VisualShaderNode::PORT_TYPE_TRANSFORM, String());
 
-	StringBuilder global_code;
-	StringBuilder global_code_per_node;
-	HashMap<Type, StringBuilder> global_code_per_func;
-	StringBuilder shader_code;
+	StringBuffer<> global_code;
+	StringBuffer<> global_code_per_node;
+	HashMap<Type, StringBuffer<>> global_code_per_func;
+	StringBuffer<> shader_code;
 	HashSet<StringName> classes;
 
 	global_code += String() + "shader_type canvas_item;\n";
@@ -1956,7 +1956,7 @@ void VisualShader::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringBuilder *p_global_code_per_node, HashMap<Type, StringBuilder> *p_global_code_per_func, StringBuilder &r_code, Vector<VisualShader::DefaultTextureParam> &r_def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &p_input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &p_output_connections, int p_node, HashSet<int> &r_processed, bool p_for_preview, HashSet<StringName> &r_classes) const {
+Error VisualShader::_write_node(Type type, StringBuffer<> *p_global_code, StringBuffer<> *p_global_code_per_node, HashMap<Type, StringBuffer<>> *p_global_code_per_func, StringBuffer<> &r_code, Vector<VisualShader::DefaultTextureParam> &r_def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &p_input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &p_output_connections, int p_node, HashSet<int> &r_processed, bool p_for_preview, HashSet<StringName> &r_classes) const {
 	const Ref<VisualShaderNode> vsnode = graph[type].nodes[p_node].node;
 
 	if (vsnode->is_disabled()) {
@@ -2537,10 +2537,10 @@ void VisualShader::_update_shader() const {
 
 	dirty.clear();
 
-	StringBuilder global_code;
-	StringBuilder global_code_per_node;
-	HashMap<Type, StringBuilder> global_code_per_func;
-	StringBuilder shader_code;
+	StringBuffer<> global_code;
+	StringBuffer<> global_code_per_node;
+	HashMap<Type, StringBuffer<>> global_code_per_func;
+	StringBuffer<> shader_code;
 	Vector<VisualShader::DefaultTextureParam> default_tex_params;
 	HashSet<StringName> classes;
 	HashMap<int, int> insertion_pos;
@@ -2706,7 +2706,7 @@ void VisualShader::_update_shader() const {
 		VMap<ConnectionKey, const List<Connection>::Element *> input_connections;
 		VMap<ConnectionKey, const List<Connection>::Element *> output_connections;
 
-		StringBuilder func_code;
+		StringBuffer<> func_code;
 		HashSet<int> processed;
 
 		bool is_empty_func = false;
@@ -2790,7 +2790,7 @@ void VisualShader::_update_shader() const {
 		if (shader_mode != Shader::MODE_PARTICLES) {
 			func_code += "\nvoid " + String(func_name[i]) + "() {\n";
 		}
-		insertion_pos.insert(i, shader_code.get_string_length() + func_code.get_string_length());
+		insertion_pos.insert(i, shader_code.length() + func_code.length());
 
 		Error err = _write_node(Type(i), &global_code, &global_code_per_node, &global_code_per_func, func_code, default_tex_params, input_connections, output_connections, NODE_ID_OUTPUT, processed, false, classes);
 		ERR_FAIL_COND(err != OK);

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -31,7 +31,7 @@
 #ifndef VISUAL_SHADER_H
 #define VISUAL_SHADER_H
 
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/templates/safe_refcount.h"
 #include "scene/gui/control.h"
 #include "scene/resources/shader.h"
@@ -159,7 +159,7 @@ private:
 		}
 	};
 
-	Error _write_node(Type p_type, StringBuilder *p_global_code, StringBuilder *p_global_code_per_node, HashMap<Type, StringBuilder> *p_global_code_per_func, StringBuilder &r_code, Vector<DefaultTextureParam> &r_def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &p_input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &p_output_connections, int p_node, HashSet<int> &r_processed, bool p_for_preview, HashSet<StringName> &r_classes) const;
+	Error _write_node(Type p_type, StringBuffer<> *p_global_code, StringBuffer<> *p_global_code_per_node, HashMap<Type, StringBuffer<>> *p_global_code_per_func, StringBuffer<> &r_code, Vector<DefaultTextureParam> &r_def_tex_params, const VMap<ConnectionKey, const List<Connection>::Element *> &p_input_connections, const VMap<ConnectionKey, const List<Connection>::Element *> &p_output_connections, int p_node, HashSet<int> &r_processed, bool p_for_preview, HashSet<StringName> &r_classes) const;
 
 	void _input_type_changed(Type p_type, int p_id);
 	bool has_func_name(RenderingServer::ShaderMode p_mode, const String &p_func_name) const;

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -32,7 +32,7 @@
 #define SHADER_RD_H
 
 #include "core/os/mutex.h"
-#include "core/string/string_builder.h"
+#include "core/string/string_buffer.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/rb_map.h"
@@ -142,7 +142,7 @@ private:
 
 	StageTemplate stage_templates[STAGE_TYPE_MAX];
 
-	void _build_variant_code(StringBuilder &p_builder, uint32_t p_variant, const Version *p_version, const StageTemplate &p_template);
+	void _build_variant_code(StringBuffer<> &p_builder, uint32_t p_variant, const Version *p_version, const StageTemplate &p_template);
 
 	void _add_stage(const char *p_code, StageType p_stage_type);
 


### PR DESCRIPTION
Replaces `StringBuilder` with `StringBuffer` across codebases, which seems to be present in a codebase for quite a while and had similar functionality as `StringBuilder`, but with improved performance as measured by the benchmark done by @SlugFiller.

It's mostly a full-on search-and-replace, but there are few modification to make it compile as well.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
