### PR TITLE
Make `TextureButton` and `Button` update on texture change

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -30,6 +30,7 @@
 
 #include "button.h"
 
+#include "core/core_string_names.h"
 #include "core/string/translation.h"
 #include "servers/rendering_server.h"
 
@@ -533,8 +534,26 @@ String Button::get_language() const {
 }
 
 void Button::set_icon(const Ref<Texture2D> &p_icon) {
-	if (icon != p_icon) {
-		icon = p_icon;
+	if (icon == p_icon) {
+		return;
+	}
+
+	if (icon.is_valid()) {
+		icon->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Button::_texture_changed));
+	}
+
+	icon = p_icon;
+
+	if (icon.is_valid()) {
+		icon->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Button::_texture_changed));
+	}
+
+	queue_redraw();
+	update_minimum_size();
+}
+
+void Button::_texture_changed() {
+	if (icon.is_valid()) {
 		queue_redraw();
 		update_minimum_size();
 	}

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -96,6 +96,7 @@ private:
 	Size2 _fit_icon_size(const Size2 &p_size) const;
 
 	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "");
+	void _texture_changed();
 
 protected:
 	void _set_internal_margin(Side p_side, float p_value);

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -64,6 +64,9 @@ private:
 	bool hflip = false;
 	bool vflip = false;
 
+	void _set_texture(Ref<Texture2D> *p_destination, const Ref<Texture2D> &p_texture);
+	void _texture_changed();
+
 protected:
 	virtual Size2 get_minimum_size() const override;
 	virtual bool has_point(const Point2 &p_point) const override;


### PR DESCRIPTION
Fixes: #63801 (partially)

Using the approach from #75532

Does not work for `click_mask` as `BitMap` does not use the `changed` signal, out of scope for this PR to add that

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
