### PR TITLE
OptionButton PopupMenu icon_max_width now defaults to the Button theme value

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -88,6 +88,7 @@
 			<description>
 				Returns the [PopupMenu] contained in this button.
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member Window.visible] property.
+				[b]Note:[/b] By default, theme constant [theme_item PopupMenu.icon_max_width] for the returned [PopupMenu] is set to the [OptionButton] [theme_item Button.icon_max_width].
 			</description>
 		</method>
 		<method name="get_selectable_item" qualifiers="const">

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -137,6 +137,9 @@ void OptionButton::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
+			if (has_theme_constant(SNAME("icon_max_width"))) {
+				popup->add_theme_constant_override("icon_max_width", get_theme_constant("icon_max_width"));
+			}
 			if (has_theme_icon(SNAME("arrow"))) {
 				if (is_layout_rtl()) {
 					_set_internal_margin(SIDE_LEFT, theme_cache.arrow_icon->get_width());


### PR DESCRIPTION
This change causes the `OptionButton` `icon_max_width` theme value to propagate by default to it's `PopupMenu` (returned by `get_popup()`, which avoids some unexpected behavior, and spares the need to get the popup and override the icon width separately.

This allows the icon width to be set for the `OptionButton` and have the icon width match for the popup. The popup icon width can still be separately set via a theme override after obtaining the popup via `get_popup()'.
