### PR TITLE
Verify that GLES3 cached shader load is successful

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -564,6 +564,13 @@ bool ShaderGLES3::_load_from_cache(Version *p_version) {
 			specialization.id = glCreateProgram();
 			glProgramBinary(specialization.id, variant_format, variant_bytes.ptr(), variant_bytes.size());
 
+			GLint link_status = 0;
+			glGetProgramiv(specialization.id, GL_LINK_STATUS, &link_status);
+			if (link_status != GL_TRUE) {
+				WARN_PRINT_ONCE("Failed to load cached shader, recompiling.");
+				return false;
+			}
+
 			_get_uniform_locations(specialization, p_version);
 
 			specialization.ok = true;


### PR DESCRIPTION
Fixes #77136

Verified by corrupting the shader data using 
variant_bytes.ptrw()[5] = 0;
right before loading.
Shader cache loading fails but the shader compilation kicks in and everything still works