### PR TITLE
Fix for Clang dev_mode Windows build

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -667,7 +667,7 @@ Ref<Image> DisplayServerWindows::screen_get_image(int p_screen) const {
 				SelectObject(hdc, hbm);
 				BitBlt(hdc, 0, 0, width, height, dc, p1.x, p1.y, SRCCOPY);
 
-				BITMAPINFO bmp_info = { 0 };
+				BITMAPINFO bmp_info = {};
 				bmp_info.bmiHeader.biSize = sizeof(bmp_info.bmiHeader);
 				bmp_info.bmiHeader.biWidth = width;
 				bmp_info.bmiHeader.biHeight = -height;


### PR DESCRIPTION
Adds a fix / workaround for `dev_mode` (all warnings and warnings as errors) build when building for Windows using Clang. Seems like a Clang issue, GCC apparently doesn't enable these warnings for `-Wall`.

Alterantively, we could maybe add `-Wno-missing-field-initializers` and `-Wno-missing-braces` when building with Clang to avoid these in the future, but this is probably a pretty rare issue.

Clang error:

```
platform\windows\display_server_windows.cpp:670:31: error: missing field 'biWidth' initializer [-Werror,-Wmissing-field-initializers]
                                BITMAPINFO bmp_info = { 0 };
                                                          ^
platform\windows\display_server_windows.cpp:670:29: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
                                BITMAPINFO bmp_info = { 0 };
                                                        ^
                                                        {}
platform\windows\display_server_windows.cpp:670:31: error: missing field 'bmiColors' initializer [-Werror,-Wmissing-field-initializers]
                                BITMAPINFO bmp_info = { 0 };
                                                          ^
3 errors generated.
```