### PR TITLE
Filter extraneous resources from sub-resource list

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3604,6 +3604,11 @@ void SceneTreeDock::_gather_resources(Node *p_node, List<Pair<Ref<Resource>, Nod
 			continue;
 		}
 
+		if (!res->is_built_in() || res->get_path().get_slice("::", 0) != edited_scene->get_scene_file_path()) {
+			// Ignore external and foreign resources.
+			continue;
+		}
+
 		const Pair<Ref<Resource>, Node *> pair(res, p_node);
 		r_resources.push_back(pair);
 	}


### PR DESCRIPTION
tbh I kind of forgot #75661 was already merged. I remembered just now and obviously found a bug after 0.001 seconds of using it. The dialog was supposed to list sub-resources used in the current scene, but it also included external resources and foreign resources (e.g. instance root scripts). The PR filters them out.