### PR TITLE
Fix a typo in the debug shadow split renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -692,7 +692,7 @@ void fragment() {
 
 shader_type spatial;
 
-render_mode debug_shadow_splits.
+render_mode debug_shadow_splits;
 
 void fragment() {
 	ALBEDO = vec3(1.0, 1.0, 1.0);


### PR DESCRIPTION
Small little typo that somehow got introduced copying the shader from forward+ to mobile. 