### PR TITLE
Add a method to get points of intersection between camera frustum and a plane

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -484,14 +484,14 @@ Vector2 Projection::get_far_plane_half_extents() const {
 bool Projection::get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const {
 	Vector<Plane> planes = get_projection_planes(Transform3D());
 	const Planes intersections[8][3] = {
-		{ PLANE_FAR, PLANE_LEFT, PLANE_TOP },
-		{ PLANE_FAR, PLANE_LEFT, PLANE_BOTTOM },
-		{ PLANE_FAR, PLANE_RIGHT, PLANE_TOP },
-		{ PLANE_FAR, PLANE_RIGHT, PLANE_BOTTOM },
 		{ PLANE_NEAR, PLANE_LEFT, PLANE_TOP },
-		{ PLANE_NEAR, PLANE_LEFT, PLANE_BOTTOM },
-		{ PLANE_NEAR, PLANE_RIGHT, PLANE_TOP },
+		{ PLANE_NEAR, PLANE_TOP, PLANE_RIGHT },
 		{ PLANE_NEAR, PLANE_RIGHT, PLANE_BOTTOM },
+		{ PLANE_NEAR, PLANE_BOTTOM, PLANE_LEFT },
+		{ PLANE_FAR, PLANE_LEFT, PLANE_TOP },
+		{ PLANE_FAR, PLANE_TOP, PLANE_RIGHT },
+		{ PLANE_FAR, PLANE_RIGHT, PLANE_BOTTOM },
+		{ PLANE_FAR, PLANE_BOTTOM, PLANE_LEFT },
 	};
 
 	for (int i = 0; i < 8; i++) {

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -42,6 +42,13 @@
 				Returns the camera's frustum planes in world space units as an array of [Plane]s in the following order: near, far, left, top, right, bottom. Not to be confused with [member frustum_offset].
 			</description>
 		</method>
+		<method name="get_frustum_plane_intersection" qualifiers="const">
+			<return type="PackedVector3Array" />
+			<param index="0" name="plane" type="Plane" />
+			<description>
+				Returns the points of intersection between camera's frustum planes and [param plane] in world space.
+			</description>
+		</method>
 		<method name="get_pyramid_shape_rid">
 			<return type="RID" />
 			<description>

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -348,10 +348,10 @@ Vector<Vector3> Camera3D::get_near_plane_points() const {
 
 	Vector<Vector3> points = {
 		Vector3(),
-		endpoints[4],
-		endpoints[5],
-		endpoints[6],
-		endpoints[7]
+		endpoints[0],
+		endpoints[1],
+		endpoints[2],
+		endpoints[3]
 	};
 	return points;
 }
@@ -535,6 +535,7 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_doppler_tracking", "mode"), &Camera3D::set_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_doppler_tracking"), &Camera3D::get_doppler_tracking);
 	ClassDB::bind_method(D_METHOD("get_frustum"), &Camera3D::_get_frustum);
+	ClassDB::bind_method(D_METHOD("get_frustum_plane_intersection", "plane"), &Camera3D::get_frustum_plane_intersection);
 	ClassDB::bind_method(D_METHOD("is_position_in_frustum", "world_point"), &Camera3D::is_position_in_frustum);
 	ClassDB::bind_method(D_METHOD("get_camera_rid"), &Camera3D::get_camera);
 	ClassDB::bind_method(D_METHOD("get_pyramid_shape_rid"), &Camera3D::get_pyramid_shape_rid);
@@ -667,6 +668,43 @@ Vector<Plane> Camera3D::get_frustum() const {
 TypedArray<Plane> Camera3D::_get_frustum() const {
 	Variant ret = get_frustum();
 	return ret;
+}
+
+Vector<Vector3> Camera3D::get_frustum_plane_intersection(const Plane &p_plane) const {
+	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector<Vector3>(), "Camera is not inside scene.");
+
+	Size2 viewport_size = get_viewport()->get_visible_rect().size;
+
+	Projection cm;
+
+	if (mode == PROJECTION_ORTHOGONAL) {
+		cm.set_orthogonal(size, viewport_size.aspect(), near, far, keep_aspect == KEEP_WIDTH);
+	} else {
+		cm.set_perspective(fov, viewport_size.aspect(), near, far, keep_aspect == KEEP_WIDTH);
+	}
+
+	Vector3 endpoints[8];
+	cm.get_endpoints(get_camera_transform(), endpoints);
+
+	Vector<Vector3> intersections;
+
+	for (int i = 0; i < 4; i++) {
+		Vector3 intersection;
+		// Near to far intersection
+		if (p_plane.intersects_segment(endpoints[i], endpoints[i + 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+		// Near to near intersection
+		if (p_plane.intersects_segment(endpoints[i], endpoints[(i + 1) % 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+		// Far to far intersection
+		if (p_plane.intersects_segment(endpoints[i + 4], endpoints[((i + 1) % 4) + 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+	}
+
+	return intersections;
 }
 
 bool Camera3D::is_position_in_frustum(const Vector3 &p_position) const {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -155,6 +155,7 @@ public:
 	bool get_cull_mask_value(int p_layer_number) const;
 
 	virtual Vector<Plane> get_frustum() const;
+	virtual Vector<Vector3> get_frustum_plane_intersection(const Plane &p_plane) const;
 	bool is_position_in_frustum(const Vector3 &p_position) const;
 
 	void set_environment(const Ref<Environment> &p_environment);

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -194,6 +194,47 @@ Vector<Plane> XRCamera3D::get_frustum() const {
 	return cm.get_projection_planes(get_camera_transform());
 };
 
+Vector<Vector3> XRCamera3D::get_frustum_plane_intersection(const Plane &p_plane) const {
+	// get our XRServer
+	XRServer *xr_server = XRServer::get_singleton();
+	ERR_FAIL_NULL_V(xr_server, Vector<Vector3>());
+
+	Ref<XRInterface> xr_interface = xr_server->get_primary_interface();
+	if (xr_interface.is_null()) {
+		// we might be in the editor or have VR turned off, just call superclass
+		return Camera3D::get_frustum_plane_intersection(p_plane);
+	}
+
+	ERR_FAIL_COND_V(!is_inside_world(), Vector<Vector3>());
+
+	Size2 viewport_size = get_viewport()->get_visible_rect().size;
+	// TODO Just use the first view for now, this is mostly for debugging so we may look into using our combined projection here.
+	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
+
+	Vector3 endpoints[8];
+	cm.get_endpoints(get_camera_transform(), endpoints);
+
+	Vector<Vector3> intersections;
+
+	for (int i = 0; i < 4; i++) {
+		Vector3 intersection;
+		// Near to far intersection
+		if (p_plane.intersects_segment(endpoints[i], endpoints[i + 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+		// Near to near intersection
+		if (p_plane.intersects_segment(endpoints[i], endpoints[(i + 1) % 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+		// Far to far intersection
+		if (p_plane.intersects_segment(endpoints[i + 4], endpoints[((i + 1) % 4) + 4], &intersection)) {
+			intersections.push_back(intersection);
+		}
+	}
+
+	return intersections;
+};
+
 XRCamera3D::XRCamera3D() {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -61,6 +61,7 @@ public:
 	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
 	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const override;
 	virtual Vector<Plane> get_frustum() const override;
+	virtual Vector<Vector3> get_frustum_plane_intersection(const Plane &p_plane) const override;
 
 	XRCamera3D();
 	~XRCamera3D();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Closes godotengine/godot-proposals#6015

Implements `Camera3D::get_frustum_plane_intersection()` that returns the points of intersection between camera frustum and a plane. The function can be used to find an approximation of an area the camera sees (RTS games for example). The points are returned in a clockwise order*[^1] from cameras perspective in global coordinates.

This could arguably also belong to either `Geometry3D` or `Projection` but `Camera3D` was chosen due discoverability and maintainability (feel free to disagree).

I also reordered the order of endpoints in `Projection.get_endpoints()` to make it easier to iterate them and match the `Projection.get_frustum()` (near before far, sides in clockwise order). The function isn't exposed and the order was only relevant for `Camera3D.get_pyramid_shape_rid()`, so this won't affect end-user.

Also seemingly the projection differs for XR so I tried to take that into account but cannot ensure it works as intended.

@Chaosus Anything to add/change?
[^1]: If the plane intersects both near- and far-plane this might not be the case; This could be taken into account but since intersecting both is rare (within the use-cases described in the proposal) and there's a likelihood the result is reordered anyway, it is better to keep the function simple.
