### PR TITLE
Add NavigationRegion function to change navigation map

### DIFF
--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -30,6 +30,12 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the current navigation map [RID] used by this region.
+			</description>
+		</method>
 		<method name="get_region_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -50,6 +56,13 @@
 			<param index="1" name="value" type="bool" />
 			<description>
 				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<param index="0" name="navigation_map" type="RID" />
+			<description>
+				Sets the [RID] of the navigation map this region should use. By default the region will automatically join the [World2D] default navigation map so this function is only required to override the default map.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -30,6 +30,12 @@
 				Returns whether or not the specified layer of the [member navigation_layers] bitmask is enabled, given a [param layer_number] between 1 and 32.
 			</description>
 		</method>
+		<method name="get_navigation_map" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the current navigation map [RID] used by this region.
+			</description>
+		</method>
 		<method name="get_region_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -42,6 +48,13 @@
 			<param index="1" name="value" type="bool" />
 			<description>
 				Based on [param value], enables or disables the specified layer in the [member navigation_layers] bitmask, given a [param layer_number] between 1 and 32.
+			</description>
+		</method>
+		<method name="set_navigation_map">
+			<return type="void" />
+			<param index="0" name="navigation_map" type="RID" />
+			<description>
+				Sets the [RID] of the navigation map this region should use. By default the region will automatically join the [World3D] default navigation map so this function is only required to override the default map.
 			</description>
 		</method>
 	</methods>

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -40,6 +40,7 @@ class NavigationRegion2D : public Node2D {
 	bool use_edge_connections = true;
 
 	RID region;
+	RID map_override;
 	uint32_t navigation_layers = 1;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
@@ -79,6 +80,9 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
+	void set_navigation_map(RID p_navigation_map);
+	RID get_navigation_map() const;
+
 	void set_use_edge_connections(bool p_enabled);
 	bool get_use_edge_connections() const;
 
@@ -115,6 +119,9 @@ public:
 
 private:
 	void _update_avoidance_constrain();
+	void _region_enter_navigation_map();
+	void _region_exit_navigation_map();
+	void _region_update_transform();
 };
 
 #endif // NAVIGATION_REGION_2D_H

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -41,6 +41,7 @@ class NavigationRegion3D : public Node3D {
 	bool use_edge_connections = true;
 
 	RID region;
+	RID map_override;
 	uint32_t navigation_layers = 1;
 	real_t enter_cost = 0.0;
 	real_t travel_cost = 1.0;
@@ -77,6 +78,9 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
+	void set_navigation_map(RID p_navigation_map);
+	RID get_navigation_map() const;
+
 	void set_use_edge_connections(bool p_enabled);
 	bool get_use_edge_connections() const;
 
@@ -106,6 +110,11 @@ public:
 
 	NavigationRegion3D();
 	~NavigationRegion3D();
+
+private:
+	void _region_enter_navigation_map();
+	void _region_exit_navigation_map();
+	void _region_update_transform();
 };
 
 #endif // NAVIGATION_REGION_3D_H


### PR DESCRIPTION
Adds NavigationRegion function to change navigation map.

Currently it is only possible to switch the navigation map of a region by using the NavigationServer API directly.
Having it on the node makes it work with enter / exit of Scenetree as well as making the possibility to switch maps more discoverable.

Build on top of https://github.com/godotengine/godot/pull/77175 that needs to be merged first.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
