### PR TITLE
Fix `StringName` comparison

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -117,6 +117,15 @@ public:
 	_FORCE_INLINE_ bool operator<(const StringName &p_name) const {
 		return _data < p_name._data;
 	}
+	_FORCE_INLINE_ bool operator<=(const StringName &p_name) const {
+		return _data <= p_name._data;
+	}
+	_FORCE_INLINE_ bool operator>(const StringName &p_name) const {
+		return _data > p_name._data;
+	}
+	_FORCE_INLINE_ bool operator>=(const StringName &p_name) const {
+		return _data >= p_name._data;
+	}
 	_FORCE_INLINE_ bool operator==(const StringName &p_name) const {
 		// the real magic of all this mess happens here.
 		// this is why path comparisons are very fast


### PR DESCRIPTION
Comparisons were not correct, probably due to being cast to `String` and compared there (due to the casting not being explicit) but not clear how it was broken, but now it isn't

Now:
```
a == b false
a != b true
a <  b false
a <= b false
a >  b true
a >= b true
```

Fixes: #76218

Documentation handled by #77083

The alternative to this would be to change how the comparison is made by changing how it works in variant ops, but I think this is more elegant and doesn't break compat (for the non-broken comparisons), alternatively we could just remove the other comparisons

I feel keeping the pointer based comparisons is useful, doesn't add a lot of hacky fixes to avoid using the built-in operators on `StringName` (and the lack of any such method of comparison indicates to me that the pointer-based comparison was intended), and if you want unicode comparisons you can just cast it to `String`

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
