### PR TITLE
Link the right build property to REAL_T_IS_DOUBLE

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -270,7 +270,7 @@ namespace GodotTools.Build
                 buildInfo.CustomProperties.Add($"GodotTargetPlatform={platform}");
 
             if (Internal.GodotIsRealTDouble())
-                buildInfo.CustomProperties.Add("GodotRealTIsDouble=true");
+                buildInfo.CustomProperties.Add("GodotFloat64=true");
 
             return buildInfo;
         }
@@ -288,7 +288,7 @@ namespace GodotTools.Build
             buildInfo.CustomProperties.Add($"GodotTargetPlatform={platform}");
 
             if (Internal.GodotIsRealTDouble())
-                buildInfo.CustomProperties.Add("GodotRealTIsDouble=true");
+                buildInfo.CustomProperties.Add("GodotFloat64=true");
 
             return buildInfo;
         }


### PR DESCRIPTION
`GodotRealTIsDouble` is not a thing, the MSBuild targets/props files all use `GodotFloat64`.