### PR TITLE
Cherry-picks for the 4.0 branch (future 4.0.3) - 5th batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,12 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 - Rename internal root canvas group to start with underscore ([GH-76149](https://github.com/godotengine/godot/pull/76149)).
 - Make acos and asin safe ([GH-76906](https://github.com/godotengine/godot/pull/76906)).
 
+#### Documentation
+
+- Exclude overridden properties from Property Descriptions section ([GH-77027](https://github.com/godotengine/godot/pull/77027)).
+
 #### Editor
 
-- Make EditorToaster's handler thread-safe ([GH-71670](https://github.com/godotengine/godot/pull/71670)).
 - Prevent off-screen controls in editor ([GH-73646](https://github.com/godotengine/godot/pull/73646)).
 - Re-enable script editor File menu shortcuts when the menu is hidden ([GH-74319](https://github.com/godotengine/godot/pull/74319)).
 - Prevent color conversion of the big Godot logo ([GH-75653](https://github.com/godotengine/godot/pull/75653)).
@@ -73,7 +76,6 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 - Adjust size of some dialogs ([GH-75895](https://github.com/godotengine/godot/pull/75895)).
 - Change cursor consistently when panning in the 2D Editor ([GH-75997](https://github.com/godotengine/godot/pull/75997)).
 - Validate renderer selection in project manager and expose default renderer setting as an enum ([GH-76331](https://github.com/godotengine/godot/pull/76331)).
-- Improve the UX of ViewportTexture in the editor ([GH-64388](https://github.com/godotengine/godot/pull/64388)).
 - Close built-in shaders when closing scene ([GH-75864](https://github.com/godotengine/godot/pull/75864)).
 - Command Palette search now also uses original English command names ([GH-76523](https://github.com/godotengine/godot/pull/76523)).
 - Preserve scene unique names when saving branch as scene ([GH-76609](https://github.com/godotengine/godot/pull/76609)).
@@ -96,7 +98,7 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 - Use DXT1 when compressing PNGs with RGB format ([GH-76516](https://github.com/godotengine/godot/pull/76516)).
 - gltf: Permit sparse accessors without a bufferView ([GH-76875](https://github.com/godotengine/godot/pull/76875)).
 
-#### Network
+#### Networking
 
 - Poll LSP/DAP clients for connection status updates ([GH-75850](https://github.com/godotengine/godot/pull/75850)).
 
@@ -189,6 +191,7 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 - Fix Node arrays appear as Object arrays in the inspector ([GH-76530](https://github.com/godotengine/godot/pull/76530)).
 - Fix CollisionShape2D editor crashes ([GH-76546](https://github.com/godotengine/godot/pull/76546), [GH-76798](https://github.com/godotengine/godot/pull/76798)).
 - Fix 2D shader preview draws over uniform ([GH-76555](https://github.com/godotengine/godot/pull/76555)).
+- Fix crash when trying to create bones from Control ([GH-77160](https://github.com/godotengine/godot/pull/77160)).
 
 #### Export
 
@@ -240,6 +243,10 @@ See the [release announcement](https://godotengine.org/article/maintenance-relea
 
 - Fix NavigationObstacles not being added to avoidance simulation ([GH-75756](https://github.com/godotengine/godot/pull/75756)).
 - Fix NavigationMesh baking for HeightMapShape ([GH-76212](https://github.com/godotengine/godot/pull/76212)).
+
+#### Networking
+
+- Fix crashes trying to use TLS when not available ([GH-77011](https://github.com/godotengine/godot/pull/77011)).
 
 #### Particles
 

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -60,6 +60,7 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, Ref<TLSOp
 	}
 
 	ERR_FAIL_COND_V(tls_options.is_valid() && tls_options->is_server(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(tls_options.is_valid() && !StreamPeerTLS::is_available(), ERR_UNAVAILABLE, "HTTPS is not available in this build.");
 	ERR_FAIL_COND_V(conn_host.length() < HOST_MIN_LEN, ERR_INVALID_PARAMETER);
 
 	if (conn_port < 0) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2436,10 +2436,10 @@
 			Enum value which doesn't correspond to any MIDI message. This is used to initialize [enum MIDIMessage] properties with a generic state.
 		</constant>
 		<constant name="MIDI_MESSAGE_NOTE_OFF" value="8" enum="MIDIMessage">
-			MIDI note OFF message. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+			MIDI note OFF message. Not all MIDI devices send this event; some send [constant MIDI_MESSAGE_NOTE_ON] with zero velocity instead. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
 		</constant>
 		<constant name="MIDI_MESSAGE_NOTE_ON" value="9" enum="MIDIMessage">
-			MIDI note ON message. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
+			MIDI note ON message. Some MIDI devices send this event with velocity zero instead of [constant MIDI_MESSAGE_NOTE_OFF], but implementations vary. See the documentation of [InputEventMIDI] for information of how to use MIDI inputs.
 		</constant>
 		<constant name="MIDI_MESSAGE_AFTERTOUCH" value="10" enum="MIDIMessage">
 			MIDI aftertouch message. This message is most often sent by pressing down on the key after it "bottoms out".

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2843,10 +2843,10 @@
 			The property is read-only in the [EditorInspector].
 		</constant>
 		<constant name="PROPERTY_USAGE_DEFAULT" value="6" enum="PropertyUsageFlags" is_bitfield="true">
-			Default usage (storage, editor and network).
+			Default usage (storage and editor).
 		</constant>
 		<constant name="PROPERTY_USAGE_NO_EDITOR" value="2" enum="PropertyUsageFlags" is_bitfield="true">
-			Default usage but without showing the property in the editor (storage, network).
+			Default usage but without showing the property in the editor (storage).
 		</constant>
 		<constant name="METHOD_FLAG_NORMAL" value="1" enum="MethodFlags" is_bitfield="true">
 			Flag for a normal method.

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -81,7 +81,8 @@
 			Returns a value indicating the type of message for this MIDI signal. This is a member of the [enum MIDIMessage] enum.
 			For MIDI messages between 0x80 and 0xEF, only the left half of the bits are returned as this value, as the other part is the channel (ex: 0x94 becomes 0x9). For MIDI messages from 0xF0 to 0xFF, the value is returned as-is.
 			Notes will return [constant MIDI_MESSAGE_NOTE_ON] when activated, but they might not always return [constant MIDI_MESSAGE_NOTE_OFF] when deactivated, therefore your code should treat the input as stopped if some period of time has passed.
-			For more information, see the MIDI message status byte list chart linked above.
+			Some MIDI devices may send [constant MIDI_MESSAGE_NOTE_ON] with zero velocity instead of [constant MIDI_MESSAGE_NOTE_OFF].
+			For more information, see the note in [member velocity] and the MIDI message status byte list chart linked above.
 		</member>
 		<member name="pitch" type="int" setter="set_pitch" getter="get_pitch" default="0">
 			The pitch index number of this MIDI signal. This value ranges from 0 to 127. On a piano, middle C is 60, and A440 is 69, see the "MIDI note" column of the piano key frequency chart on Wikipedia for more information.
@@ -90,7 +91,8 @@
 			The pressure of the MIDI signal. This value ranges from 0 to 127. For many devices, this value is always zero.
 		</member>
 		<member name="velocity" type="int" setter="set_velocity" getter="get_velocity" default="0">
-			The velocity of the MIDI signal. This value ranges from 0 to 127. For a piano, this corresponds to how quickly the key was pressed, and is rarely above about 110 in practice. Note that some MIDI devices may send a [constant MIDI_MESSAGE_NOTE_ON] message with zero velocity and expect this to be treated the same as a [constant MIDI_MESSAGE_NOTE_OFF] message, but device implementations vary so Godot reports event data exactly as received.
+			The velocity of the MIDI signal. This value ranges from 0 to 127. For a piano, this corresponds to how quickly the key was pressed, and is rarely above about 110 in practice.
+			[b]Note:[/b] Some MIDI devices may send a [constant MIDI_MESSAGE_NOTE_ON] message with zero velocity and expect this to be treated the same as a [constant MIDI_MESSAGE_NOTE_OFF] message, but device implementations vary so Godot reports event data exactly as received. Depending on the hardware and the needs of the game/app, this MIDI quirk can be handled robustly with a couple lines of script (check for [constant MIDI_MESSAGE_NOTE_ON] with velocity zero).
 		</member>
 	</members>
 </class>

--- a/doc/classes/PlaceholderCubemap.xml
+++ b/doc/classes/PlaceholderCubemap.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [Cubemap] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaceholderCubemapArray.xml
+++ b/doc/classes/PlaceholderCubemapArray.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [CubemapArray] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaceholderTexture2D.xml
+++ b/doc/classes/PlaceholderTexture2D.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [Texture2D] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaceholderTexture2DArray.xml
+++ b/doc/classes/PlaceholderTexture2DArray.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [Texture2D] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaceholderTexture3D.xml
+++ b/doc/classes/PlaceholderTexture3D.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [Texture3D] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PlaceholderTextureLayered.xml
+++ b/doc/classes/PlaceholderTextureLayered.xml
@@ -7,6 +7,7 @@
 		This class is used when loading a project that uses a [TextureLayered] subclass in 2 conditions:
 		- When running the project exported in dedicated server mode, only the texture's dimensions are kept (as they may be relied upon for gameplay purposes or positioning of other elements). This allows reducing the exported PCK's size significantly.
 		- When this subclass is missing due to using a different engine version or build (e.g. modules disabled).
+		[b]Note:[/b] This is not intended to be used as an actual texture for rendering. It is not guaranteed to work like one in shaders or materials (for example when calculating UV).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -17,7 +17,6 @@
 	<members>
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
-			[b]Note:[/b] In the editor, it is automatically updated when the target viewport's node path changes due to renaming or moving the viewport or its ancestors. At runtime, it may not be able to automatically update due to the inability to determine the scene root.
 		</member>
 	</members>
 </class>

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -1,10 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="WorkerThreadPool" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		A singleton that allocates some [Thread]s on startup, used to offload tasks to these threads.
 	</brief_description>
 	<description>
+		The [WorkerThreadPool] singleton allocates a set of [Thread]s (called worker threads) on project startup and provides methods for offloading tasks to them. This can be used for simple multithreading without having to create [Thread]s.
+		Tasks hold the [Callable] to be run by the threads. [WorkerThreadPool] can be used to create regular tasks, which will be taken by one worker thread, or group tasks, which can be distributed between multiple worker threads. Group tasks execute the [Callable] multiple times, which makes them useful for iterating over a lot of elements, such as the enemies in an arena.
+		Here's a sample on how to offload an expensive function to worker threads:
+		[codeblocks]
+		[gdscript]
+		var enemies = [] # An array to be filled with enemies.
+
+		func process_enemy_ai(enemy_index):
+		    var processed_enemy = enemies[enemy_index]
+		    # Expensive logic...
+
+		func _process(delta):
+		    var task_id = WorkerThreadPool.add_group_task(process_enemy_ai, enemies.size())
+		    # Other code...
+		    WorkerThreadPool.wait_for_group_task_completion(task_id)
+		    # Other code that depends on the enemy AI already being processed.
+		[/gdscript]
+		[csharp]
+		private List&lt;Node&gt; _enemies = new List&lt;Node&gt;(); // A list to be filled with enemies.
+
+		private void ProcessEnemyAI(int enemyIndex)
+		{
+		    Node processedEnemy = _enemies[enemyIndex];
+		    // Expensive logic here.
+		}
+
+		public override void _Process(double delta)
+		{
+		    long taskId = WorkerThreadPool.AddGroupTask(Callable.From&lt;int&gt;(ProcessEnemyAI), _enemies.Count);
+		    // Other code...
+		    WorkerThreadPool.WaitForGroupTaskCompletion(taskId);
+		    // Other code that depends on the enemy AI already being processed.
+		}
+		[/csharp]
+		[/codeblocks]
+		The above code relies on the number of elements in the [code]enemies[/code] array remaining constant during the multithreaded part.
+		[b]Note:[/b] Using this singleton could affect performance negatively if the task being distributed between threads is not computationally expensive.
 	</description>
 	<tutorials>
+		<link title="Using multiple threads">$DOCS_URL/tutorials/performance/using_multiple_threads.html</link>
+		<link title="Thread-safe APIs">$DOCS_URL/tutorials/performance/thread_safe_apis.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_group_task">
@@ -15,6 +55,9 @@
 			<param index="3" name="high_priority" type="bool" default="false" />
 			<param index="4" name="description" type="String" default="&quot;&quot;" />
 			<description>
+				Adds [param action] as a group task to be executed by the worker threads. The [Callable] will be called a number of times based on [param elements], with the first thread calling it with the value [code]0[/code] as a parameter, and each consecutive execution incrementing this value by 1 until it reaches [code]element - 1[/code].
+				The number of threads the task is distributed to is defined by [param tasks_needed], where the default value [code]-1[/code] means it is distributed to all worker threads. [param high_priority] determines if the task has a high priority or a low priority (default). You can optionally provide a [param description] to help with debugging.
+				Returns a group task ID that can be used by other methods.
 			</description>
 		</method>
 		<method name="add_task">
@@ -23,36 +66,44 @@
 			<param index="1" name="high_priority" type="bool" default="false" />
 			<param index="2" name="description" type="String" default="&quot;&quot;" />
 			<description>
+				Adds [param action] as a task to be executed by a worker thread. [param high_priority] determines if the task has a high priority or a low priority (default). You can optionally provide a [param description] to help with debugging.
+				Returns a task ID that can be used by other methods.
 			</description>
 		</method>
 		<method name="get_group_processed_element_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="group_id" type="int" />
 			<description>
+				Returns how many times the [Callable] of the group task with the given ID has already been executed by the worker threads.
+				[b]Note:[/b] If a thread has started executing the [Callable] but is yet to finish, it won't be counted.
 			</description>
 		</method>
 		<method name="is_group_task_completed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="group_id" type="int" />
 			<description>
+				Returns [code]true[/code] if the group task with the given ID is completed.
 			</description>
 		</method>
 		<method name="is_task_completed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="task_id" type="int" />
 			<description>
+				Returns [code]true[/code] if the task with the given ID is completed.
 			</description>
 		</method>
 		<method name="wait_for_group_task_completion">
 			<return type="void" />
 			<param index="0" name="group_id" type="int" />
 			<description>
+				Pauses the thread that calls this method until the group task with the given ID is completed.
 			</description>
 		</method>
 		<method name="wait_for_task_completion">
 			<return type="void" />
 			<param index="0" name="task_id" type="int" />
 			<description>
+				Pauses the thread that calls this method until the task with the given ID is completed.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -841,14 +841,15 @@ void EditorHelp::_update_doc() {
 	// Properties overview
 	HashSet<String> skip_methods;
 
-	bool has_properties = cd.properties.size() != 0;
-	if (cd.is_script_doc) {
-		has_properties = false;
-		for (int i = 0; i < cd.properties.size(); i++) {
-			if (cd.properties[i].name.begins_with("_") && cd.properties[i].description.strip_edges().is_empty()) {
-				continue;
-			}
-			has_properties = true;
+	bool has_properties = false;
+	bool has_property_descriptions = false;
+	for (const DocData::PropertyDoc &prop : cd.properties) {
+		if (cd.is_script_doc && prop.name.begins_with("_") && prop.description.strip_edges().is_empty()) {
+			continue;
+		}
+		has_properties = true;
+		if (!prop.overridden) {
+			has_property_descriptions = true;
 			break;
 		}
 	}
@@ -1527,7 +1528,7 @@ void EditorHelp::_update_doc() {
 	}
 
 	// Property descriptions
-	if (has_properties) {
+	if (has_property_descriptions) {
 		section_line.push_back(Pair<String, int>(TTR("Property Descriptions"), class_desc->get_paragraph_count() - 2));
 		_push_title_font();
 		class_desc->add_text(TTR("Property Descriptions"));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1516,6 +1516,11 @@ void EditorInspectorSection::fold() {
 	queue_redraw();
 }
 
+void EditorInspectorSection::set_bg_color(const Color &p_bg_color) {
+	bg_color = p_bg_color;
+	queue_redraw();
+}
+
 bool EditorInspectorSection::has_revertable_properties() const {
 	return !revertable_properties.is_empty();
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -297,6 +297,7 @@ public:
 	VBoxContainer *get_vbox();
 	void unfold();
 	void fold();
+	void set_bg_color(const Color &p_bg_color);
 
 	bool has_revertable_properties() const;
 	void property_can_revert_changed(const String &p_path, bool p_can_revert);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3998,6 +3998,7 @@ void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 	Ref<ViewportTexture> vt;
 	vt.instantiate();
 	vt->set_viewport_path_in_scene(get_tree()->get_edited_scene_root()->get_path_to(to_node));
+	vt->setup_local_to_scene();
 
 	emit_changed(get_edited_property(), vt);
 	update_property();

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -145,12 +145,6 @@ void EditorToaster::_notification(int p_what) {
 }
 
 void EditorToaster::_error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {
-	// This may be called from a thread. Since we will deal with non-thread-safe elements,
-	// we have to put it in the queue for safety.
-	callable_mp_static(&EditorToaster::_error_handler_impl).bind(p_file, p_line, p_error, p_errorexp, p_editor_notify, p_type).call_deferred();
-}
-
-void EditorToaster::_error_handler_impl(const String &p_file, int p_line, const String &p_error, const String &p_errorexp, bool p_editor_notify, int p_type) {
 	if (!EditorToaster::get_singleton() || !EditorToaster::get_singleton()->is_inside_tree()) {
 		return;
 	}
@@ -164,8 +158,13 @@ void EditorToaster::_error_handler_impl(const String &p_file, int p_line, const 
 	int show_all_setting = EDITOR_GET("interface/editor/show_internal_errors_in_toast_notifications");
 
 	if (p_editor_notify || (show_all_setting == 0 && in_dev) || show_all_setting == 1) {
-		String err_str = !p_errorexp.is_empty() ? p_errorexp : p_error;
-		String tooltip_str = p_file + ":" + itos(p_line);
+		String err_str;
+		if (p_errorexp && p_errorexp[0]) {
+			err_str = String::utf8(p_errorexp);
+		} else {
+			err_str = String::utf8(p_error);
+		}
+		String tooltip_str = String::utf8(p_file) + ":" + itos(p_line);
 
 		if (!p_editor_notify) {
 			if (p_type == ERR_HANDLER_WARNING) {
@@ -175,7 +174,7 @@ void EditorToaster::_error_handler_impl(const String &p_file, int p_line, const 
 			}
 		}
 
-		Severity severity = ((ErrorHandlerType)p_type == ERR_HANDLER_WARNING) ? SEVERITY_WARNING : SEVERITY_ERROR;
+		Severity severity = (p_type == ERR_HANDLER_WARNING) ? SEVERITY_WARNING : SEVERITY_ERROR;
 		EditorToaster::get_singleton()->popup_str(err_str, severity, tooltip_str);
 	}
 }

--- a/editor/editor_toaster.h
+++ b/editor/editor_toaster.h
@@ -89,7 +89,6 @@ private:
 	const double default_message_duration = 5.0;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type);
-	static void _error_handler_impl(const String &p_file, int p_line, const String &p_error, const String &p_errorexp, bool p_editor_notify, int p_type);
 	void _update_vbox_position();
 	void _update_disable_notifications_button();
 	void _auto_hide_or_free_toasts();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4594,6 +4594,9 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			undo_redo->create_action(TTR("Create Custom Bone2D(s) from Node(s)"));
 			for (const KeyValue<Node *, Object *> &E : selection) {
 				Node2D *n2d = Object::cast_to<Node2D>(E.key);
+				if (!n2d) {
+					continue;
+				}
 
 				Bone2D *new_bone = memnew(Bone2D);
 				String new_bone_name = n2d->get_name();

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -695,9 +695,6 @@ void Skeleton3DEditor::update_joint_tree() {
 	}
 }
 
-void Skeleton3DEditor::update_editors() {
-}
-
 void Skeleton3DEditor::create_editors() {
 	set_h_size_flags(SIZE_EXPAND_FILL);
 	set_focus_mode(FOCUS_ALL);
@@ -797,10 +794,8 @@ void Skeleton3DEditor::create_editors() {
 	animation_hb->add_child(key_insert_all_button);
 
 	// Bone tree.
-	const Color section_color = get_theme_color(SNAME("prop_subsection"), SNAME("Editor"));
-
-	EditorInspectorSection *bones_section = memnew(EditorInspectorSection);
-	bones_section->setup("bones", "Bones", skeleton, section_color, true);
+	bones_section = memnew(EditorInspectorSection);
+	bones_section->setup("bones", "Bones", skeleton, Color(0.0f, 0.0, 0.0f), true);
 	add_child(bones_section);
 	bones_section->unfold();
 
@@ -831,7 +826,6 @@ void Skeleton3DEditor::create_editors() {
 void Skeleton3DEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			create_editors();
 			update_joint_tree();
 
 			joint_tree->connect("item_selected", callable_mp(this, &Skeleton3DEditor::_joint_tree_selection_changed));
@@ -857,6 +851,7 @@ void Skeleton3DEditor::_notification(int p_what) {
 			key_scale_button->set_icon(get_theme_icon(SNAME("KeyScale"), SNAME("EditorIcons")));
 			key_insert_button->set_icon(get_theme_icon(SNAME("Key"), SNAME("EditorIcons")));
 			key_insert_all_button->set_icon(get_theme_icon(SNAME("NewKey"), SNAME("EditorIcons")));
+			bones_section->set_bg_color(get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
 			update_joint_tree();
 		} break;
@@ -945,6 +940,8 @@ void fragment() {
 	handles_mesh_instance->set_cast_shadows_setting(GeometryInstance3D::SHADOW_CASTING_SETTING_OFF);
 	handles_mesh.instantiate();
 	handles_mesh_instance->set_mesh(handles_mesh);
+
+	create_editors();
 }
 
 void Skeleton3DEditor::update_bone_original() {

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -132,6 +132,8 @@ class Skeleton3DEditor : public VBoxContainer {
 	Button *key_insert_button = nullptr;
 	Button *key_insert_all_button = nullptr;
 
+	EditorInspectorSection *bones_section = nullptr;
+
 	EditorFileDialog *file_dialog = nullptr;
 
 	bool keyable = false;
@@ -146,7 +148,6 @@ class Skeleton3DEditor : public VBoxContainer {
 	EditorFileDialog *file_export_lib = nullptr;
 
 	void update_joint_tree();
-	void update_editors();
 
 	void create_editors();
 

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -5,7 +5,8 @@
 	</brief_description>
 	<description>
 		A script implemented in the GDScript programming language. The script extends the functionality of all objects that instantiate it.
-		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+		Calling [method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+		If you are looking for GDScript's built-in functions, see [@GDScript] instead.
 	</description>
 	<tutorials>
 		<link title="GDScript documentation index">$DOCS_URL/tutorials/scripting/gdscript/index.html</link>

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -332,7 +332,7 @@ void WSLPeer::_do_client_handshake() {
 		if (connection == tcp) {
 			// Start SSL handshake
 			tls = Ref<StreamPeerTLS>(StreamPeerTLS::create());
-			ERR_FAIL_COND_MSG(tls.is_null(), "SSL is not available in this build.");
+			ERR_FAIL_COND(tls.is_null());
 			if (tls->connect_to_stream(tcp, requested_host, tls_options) != OK) {
 				close(-1);
 				return; // Error.
@@ -503,6 +503,8 @@ Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
 	if (path.is_empty()) {
 		path = "/";
 	}
+
+	ERR_FAIL_COND_V_MSG(use_tls && !StreamPeerTLS::is_available(), ERR_UNAVAILABLE, "WSS is not available in this build.");
 
 	requested_url = p_url;
 	requested_host = host;

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -42,7 +42,7 @@ void TouchScreenButton::set_texture_normal(const Ref<Texture2D> &p_texture) {
 	}
 	texture_normal = p_texture;
 	if (texture_normal.is_valid()) {
-		texture_normal->connect(SceneStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		texture_normal->connect(SceneStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw), CONNECT_REFERENCE_COUNTED);
 	}
 	queue_redraw();
 }
@@ -60,7 +60,7 @@ void TouchScreenButton::set_texture_pressed(const Ref<Texture2D> &p_texture_pres
 	}
 	texture_pressed = p_texture_pressed;
 	if (texture_pressed.is_valid()) {
-		texture_pressed->connect(SceneStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		texture_pressed->connect(SceneStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw), CONNECT_REFERENCE_COUNTED);
 	}
 	queue_redraw();
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -317,8 +317,6 @@ private:
 	Ref<ViewportTexture> default_texture;
 	HashSet<ViewportTexture *> viewport_textures;
 
-	void _update_viewport_path();
-
 	SDFOversize sdf_oversize = SDF_OVERSIZE_120_PERCENT;
 	SDFScale sdf_scale = SDF_SCALE_50_PERCENT;
 

--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -436,6 +436,7 @@ ENetSocket enet_socket_create(ENetSocketType type) {
 }
 
 int enet_host_dtls_server_setup(ENetHost *host, void *p_options) {
+	ERR_FAIL_COND_V_MSG(!DTLSServer::is_available(), -1, "DTLS server is not available in this build.");
 	ENetGodotSocket *sock = (ENetGodotSocket *)host->socket;
 	if (!sock->can_upgrade()) {
 		return -1;
@@ -446,6 +447,7 @@ int enet_host_dtls_server_setup(ENetHost *host, void *p_options) {
 }
 
 int enet_host_dtls_client_setup(ENetHost *host, const char *p_for_hostname, void *p_options) {
+	ERR_FAIL_COND_V_MSG(!PacketPeerDTLS::is_available(), -1, "DTLS is not available in this build.");
 	ENetGodotSocket *sock = (ENetGodotSocket *)host->socket;
 	if (!sock->can_upgrade()) {
 		return -1;


### PR DESCRIPTION
Final batch before building 4.0.3-stable. 

- Two previous cherry-pick have been reverted.
  - https://github.com/godotengine/godot/pull/71670 required further changes, which aren't safe for a patch release.
  - https://github.com/godotengine/godot/pull/64388 causes a regression which needs to be fixed, so it's better to err on the side of caution and give it a bit more time to be tested in `master`.
- Several documentation changes and very safe fixes (including crashes) added.
- Changelog should be up to date.
- Still needs a version bump ahead of starting the build 🙃 