### PR TITLE
CI: Use GODOT_BASE_BRANCH for the godot-cpp checkout

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
 

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes
 

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key, and godot-cpp checkout. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
@@ -182,6 +182,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: godotengine/godot-cpp
+          ref: ${{ env.GODOT_BASE_BRANCH }}
           submodules: 'recursive'
           path: 'godot-cpp'
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
 

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
   EM_VERSION: 3.1.18

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,7 +5,7 @@ on:
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:
-  # Only used for the cache key. Increment version to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   SCONS_CACHE_MSVC_CONFIG: true


### PR DESCRIPTION
`master` counterpart of #77204. Doesn't change anything right now but makes the branch ready for branching off to `4.1` eventually.

We could also use `GODOT_BASE_BRANCH` for the https://github.com/godotengine/regression-test-project checkout, but currently it doesn't have a `master` branch, only `4.0`.