### PR TITLE
Small rework of tooltip plugins

### DIFF
--- a/doc/classes/EditorResourceTooltipPlugin.xml
+++ b/doc/classes/EditorResourceTooltipPlugin.xml
@@ -18,20 +18,23 @@
 			</description>
 		</method>
 		<method name="_make_tooltip_for_path" qualifiers="virtual const">
-			<return type="Object" />
+			<return type="Control" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="metadata" type="Dictionary" />
+			<param index="2" name="base" type="Control" />
 			<description>
-				Create and return a tooltip that will be displayed when the user hovers resource under given [param path] in filesystem dock. For best results, use [method make_default_tooltip] as a base. 
+				Create and return a tooltip that will be displayed when the user hovers a resource under the given [param path] in filesystem dock.
 				The [param metadata] dictionary is provided by preview generator (see method EditorResourcePreviewGenerator._generate]).
+				[param base] is the base default tooltip, which is a [VBoxContainer] with a file name, type and size labels. If another plugin handled the same file type, [param base] will be output from the previous plugin. For best result, make sure the base tooltip is part of the returned [Control].
 				[b]Note:[/b] It's unadvised to use [method ResourceLoader.load], especially with heavy resources like models or textures, because it will make the editor unresponsive when creating the tooltip. You can use [method request_thumbnail] if you want to display a preview in your tooltip.
-			</description>
-		</method>
-		<method name="make_default_tooltip" qualifiers="static">
-			<return type="VBoxContainer" />
-			<param index="0" name="path" type="String" />
-			<description>
-				Creates a default file tooltip. The tooltip includes file name, file size and [Resource] type if available.
+				[b]Note:[/b] If you decide to discard the [param base], make sure to call [method Node.queue_free], because it's not freed automatically.
+				[codeblock]
+				func _make_tooltip_for_path(path, metadata, base):
+				    var t_rect = TextureRect.new()
+				    request_thumbnail(path, t_rect)
+				    base.add_child(t_rect) # The TextureRect will appear at the bottom of the tooltip.
+				    return base
+				[/codeblock]
 			</description>
 		</method>
 		<method name="request_thumbnail" qualifiers="const">

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2291,20 +2291,12 @@ Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
 	}
 
 	const String type = ResourceLoader::get_resource_type(p_path);
-	Control *tooltip = nullptr;
+	Control *tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path);
 
 	for (const Ref<EditorResourceTooltipPlugin> &plugin : tooltip_plugins) {
 		if (plugin->handles(type)) {
-			tooltip = plugin->make_tooltip_for_path(p_path, EditorResourcePreview::get_singleton()->get_preview_metadata(p_path));
+			tooltip = plugin->make_tooltip_for_path(p_path, EditorResourcePreview::get_singleton()->get_preview_metadata(p_path), tooltip);
 		}
-
-		if (tooltip) {
-			break;
-		}
-	}
-
-	if (!tooltip) {
-		tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path);
 	}
 	return tooltip;
 }

--- a/editor/plugins/editor_resource_tooltip_plugins.cpp
+++ b/editor/plugins/editor_resource_tooltip_plugins.cpp
@@ -33,7 +33,6 @@
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
 
@@ -50,12 +49,10 @@ void EditorResourceTooltipPlugin::_thumbnail_ready(const String &p_path, const R
 
 void EditorResourceTooltipPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_thumbnail_ready"), &EditorResourceTooltipPlugin::_thumbnail_ready);
-
-	ClassDB::bind_static_method("EditorResourceTooltipPlugin", D_METHOD("make_default_tooltip", "path"), &EditorResourceTooltipPlugin::make_default_tooltip);
 	ClassDB::bind_method(D_METHOD("request_thumbnail", "path", "control"), &EditorResourceTooltipPlugin::request_thumbnail);
 
 	GDVIRTUAL_BIND(_handles, "type");
-	GDVIRTUAL_BIND(_make_tooltip_for_path, "path", "metadata");
+	GDVIRTUAL_BIND(_make_tooltip_for_path, "path", "metadata", "base");
 }
 
 VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p_resource_path) {
@@ -91,10 +88,10 @@ bool EditorResourceTooltipPlugin::handles(const String &p_resource_type) const {
 	return ret;
 }
 
-Control *EditorResourceTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata) const {
-	Object *ret = nullptr;
-	GDVIRTUAL_CALL(_make_tooltip_for_path, p_resource_path, p_metadata, ret);
-	return Object::cast_to<Control>(ret);
+Control *EditorResourceTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const {
+	Control *ret = nullptr;
+	GDVIRTUAL_CALL(_make_tooltip_for_path, p_resource_path, p_metadata, p_base, ret);
+	return ret;
 }
 
 // EditorTextureTooltipPlugin
@@ -103,9 +100,9 @@ bool EditorTextureTooltipPlugin::handles(const String &p_resource_type) const {
 	return ClassDB::is_parent_class(p_resource_type, "Texture2D") || ClassDB::is_parent_class(p_resource_type, "Image");
 }
 
-Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata) const {
+Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const {
 	HBoxContainer *hb = memnew(HBoxContainer);
-	VBoxContainer *vb = EditorResourceTooltipPlugin::make_default_tooltip(p_resource_path);
+	VBoxContainer *vb = Object::cast_to<VBoxContainer>(p_base);
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());

--- a/editor/plugins/editor_resource_tooltip_plugins.h
+++ b/editor/plugins/editor_resource_tooltip_plugins.h
@@ -34,6 +34,7 @@
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
+#include <scene/gui/control.h>
 
 class Control;
 class Texture2D;
@@ -49,14 +50,14 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL1RC(bool, _handles, String)
-	GDVIRTUAL2RC(Object *, _make_tooltip_for_path, String, Dictionary)
+	GDVIRTUAL3RC(Control *, _make_tooltip_for_path, String, Dictionary, Control *)
 
 public:
 	static VBoxContainer *make_default_tooltip(const String &p_resource_path);
 	void request_thumbnail(const String &p_path, TextureRect *p_for_control) const;
 
 	virtual bool handles(const String &p_resource_type) const;
-	virtual Control *make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata) const;
+	virtual Control *make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const;
 };
 
 class EditorTextureTooltipPlugin : public EditorResourceTooltipPlugin {
@@ -64,7 +65,7 @@ class EditorTextureTooltipPlugin : public EditorResourceTooltipPlugin {
 
 public:
 	virtual bool handles(const String &p_resource_type) const override;
-	virtual Control *make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata) const override;
+	virtual Control *make_tooltip_for_path(const String &p_resource_path, const Dictionary &p_metadata, Control *p_base) const override;
 };
 
 #endif // EDITOR_RESOURCE_TOOLTIP_PLUGINS_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -132,8 +132,8 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorNode3DGizmo);
 	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);
-	GDREGISTER_ABSTRACT_CLASS(EditorResourceTooltipPlugin);
 	GDREGISTER_CLASS(EditorResourcePreviewGenerator);
+	GDREGISTER_CLASS(EditorResourceTooltipPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorFileSystem);
 	GDREGISTER_CLASS(EditorFileSystemDirectory);
 	GDREGISTER_CLASS(EditorVCSInterface);


### PR DESCRIPTION
This PR changes the API introduced in #63263
#77069 kind of exposed a limitation of not being able to customize already handled file tooltips. I brushed it off as something not really important, but then I had an idea how to change the API in a way that supports this use-case and also makes sense.

Previously, when a plugin handled a file and returned a tooltip, the filesystem dock would stop checking the plugin list. Now it will continue, which allows to customize the tooltip further by other plugins. `make_tooltip_for_path` has a new argument, which is the default tooltip or a tooltip from the previous plugin. `make_default_tooltip` became unexposed, because it's no longer necessary.

Here's a proof-of-concent plugin that hijacks texture tooltips and makes them inverted:
```GDScript
@tool
extends EditorPlugin

var plugin: EditorResourceTooltipPlugin

func _enter_tree() -> void:
	plugin = EvilTextureTooltipPlugin.new()
	get_editor_interface().get_file_system_dock().add_resource_tooltip_plugin(plugin)

func _exit_tree() -> void:
	get_editor_interface().get_file_system_dock().remove_resource_tooltip_plugin(plugin)

class EvilTextureTooltipPlugin extends  EditorResourceTooltipPlugin:
	var evil_material: ShaderMaterial
	
	func _init() -> void:
		var shader := Shader.new()
		shader.code = "shader_type canvas_item; void fragment() { COLOR = vec4(vec3(1.0) - COLOR.rgb, 1.0); }"
		evil_material = ShaderMaterial.new()
		evil_material.shader = shader
	
	func _handles(type: String) -> bool:
		return ClassDB.is_parent_class(type, "Texture2D") or ClassDB.is_parent_class(type, "Texture2D")
	
	func _make_tooltip_for_path(path: String, metadata: Dictionary, base: Object) -> Object:
		base.get_child(0).material = evil_material
		return base
```
![image](https://github.com/godotengine/godot/assets/2223172/291d8562-e584-462b-8cb0-2e3740309f1d)

Once this is merged, I'll change #77069 to only include the important part and the audio playback can be implemented as a custom addon (it doesn't really make sense in core xd)

I added `breaks compat` label, but this involves a feature that wasn't in any stable version yet.

EDIT:
Another important change I forgot to mention is that I made EditorResourceTooltipPlugin non-abstract. Otherwise it was impossible to instantiate even inheriting classes.