### PR TITLE
Don't change `RID` when changing `viewport_path` in `ViewportTexture`

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -60,6 +60,7 @@ class ViewportTexture : public Texture2D {
 	friend class Viewport;
 	Viewport *vp = nullptr;
 	bool vp_pending = false;
+	bool vp_changed = false;
 
 	void _setup_local_to_scene(const Node *p_loc_scene);
 


### PR DESCRIPTION
When changing `viewport_path`, the `proxy`'s target is changed to a new placeholder.

Add a flag `vp_changed` to prevent calling `setup_local_to_scene()` (mainly called while toggling `resource_local_to_scene`) when the target viewport has not changed.

Fix #77207.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
