### PR TITLE
Hide Animation Frames section when there are no animations

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1198,7 +1198,13 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 		List<StringName> anim_names;
 		frames->get_animation_list(&anim_names);
 		anim_names.sort_custom<StringName::AlphCompare>();
-
+		if (!anim_names.size()) {
+			missing_anim_label->show();
+			anim_frames_vb->hide();
+			return;
+		}
+		missing_anim_label->hide();
+		anim_frames_vb->show();
 		bool searching = anim_search_box->get_text().size();
 		String searched_string = searching ? anim_search_box->get_text().to_lower() : String();
 
@@ -1705,12 +1711,22 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	delete_anim->set_shortcut_context(animations);
 	delete_anim->set_shortcut(ED_SHORTCUT("sprite_frames/delete_animation", TTR("Delete Animation"), Key::KEY_DELETE));
 
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	add_child(vbc);
-	vbc->set_h_size_flags(SIZE_EXPAND_FILL);
+	missing_anim_label = memnew(Label);
+	missing_anim_label->set_text(TTR("This resource does not have any animations."));
+	missing_anim_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	missing_anim_label->set_v_size_flags(SIZE_EXPAND_FILL);
+	missing_anim_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	missing_anim_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	missing_anim_label->hide();
+	add_child(missing_anim_label);
+
+	anim_frames_vb = memnew(VBoxContainer);
+	add_child(anim_frames_vb);
+	anim_frames_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+	anim_frames_vb->hide();
 
 	sub_vb = memnew(VBoxContainer);
-	vbc->add_margin_child(TTR("Animation Frames:"), sub_vb, true);
+	anim_frames_vb->add_margin_child(TTR("Animation Frames:"), sub_vb, true);
 
 	HFlowContainer *hfc = memnew(HFlowContainer);
 	sub_vb->add_child(hfc);

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -127,6 +127,9 @@ class SpriteFramesEditor : public HSplitContainer {
 	LineEdit *anim_search_box = nullptr;
 	Tree *animations = nullptr;
 
+	Label *missing_anim_label = nullptr;
+	VBoxContainer *anim_frames_vb = nullptr;
+
 	EditorFileDialog *file = nullptr;
 
 	AcceptDialog *dialog = nullptr;


### PR DESCRIPTION
Fixes #74372

When there are no animations, a message is shown, similar to other parts of the engine, like the Animation Player, and TileMap editor : 

![2023-05-19_01-15](https://github.com/godotengine/godot/assets/3624853/56efb85a-9d5f-424f-b935-9506f71fbb06)

The message goes away when at least one animation is added : 

![2023-05-19_01-15_1](https://github.com/godotengine/godot/assets/3624853/c5d274ca-c5f0-4c60-ad3f-a7131409981a)
