### PR TITLE
Allow up to INT32_MAX max size in Array/Dictionary editor

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -311,7 +311,7 @@ void EditorPropertyArray::update_property() {
 
 			size_slider = memnew(EditorSpinSlider);
 			size_slider->set_step(1);
-			size_slider->set_max(1000000);
+			size_slider->set_max(INT32_MAX);
 			size_slider->set_h_size_flags(SIZE_EXPAND_FILL);
 			size_slider->set_read_only(is_read_only());
 			size_slider->connect("value_changed", callable_mp(this, &EditorPropertyArray::_length_changed));


### PR DESCRIPTION
Quick update to editor_properties_array_dict max size. An array in the EditorInspector won't display a number higher than 1,000,000. The Range::Shared max value is stored in a double, as such the new max value has been updated to be DBL_MAX instead of an arbitrary magic number.

Resolves #77190