### PR TITLE
Fix message queue issues

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -309,6 +309,9 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	// --
 
 	Ref<Resource> res = _load(load_task.remapped_path, load_task.remapped_path != load_task.local_path ? load_task.local_path : String(), load_task.type_hint, load_task.cache_mode, &load_task.error, load_task.use_sub_threads, &load_task.progress);
+	if (mq_override) {
+		mq_override->flush();
+	}
 
 	thread_load_mutex.lock();
 
@@ -354,7 +357,6 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 
 	if (load_nesting == 0 && mq_override) {
 		memdelete(mq_override);
-		MessageQueue::set_thread_singleton_override(nullptr);
 	}
 }
 

--- a/core/object/message_queue.h
+++ b/core/object/message_queue.h
@@ -40,6 +40,8 @@
 class Object;
 
 class CallQueue {
+	friend class MessageQueue;
+
 public:
 	enum {
 		PAGE_SIZE_BYTES = 4096
@@ -74,6 +76,10 @@ private:
 	uint32_t max_pages = 0;
 	uint32_t pages_used = 0;
 	bool flushing = false;
+
+#ifdef DEV_ENABLED
+	bool is_current_thread_override = false;
+#endif
 
 	struct Message {
 		Callable callable;


### PR DESCRIPTION
Due to two mistakes on my part, a couple of mechanics of the `MessageQueue` were broken:
- Flushing from the default node processing group.
- Deferred calls made by resources during threaded resource loading.

Mistakes, respectively:
- I failed to rebase one aspect of #74405 over #77000, since the development of both overlapped, with incompatible changes that required adaptation.
- Don't ask me why, but MQ flushing ended up missing from #74405. (@lyuma, this explains why I didn't run into a crash due to the bad `memcpy()` you noticed.)

This PR mends the above issues and as such
- fixes #77218,
- fixes #77222,
- fixes #77192,
- and fixes #77193.