### PR TITLE
Allow building on Windows using Clang without MinGW

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -139,6 +139,8 @@ elif platform_arg == "web":
     custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
 elif os.name == "nt" and methods.get_cmdline_bool("use_mingw", False):
     custom_tools = ["mingw"]
+elif os.name == "nt" and methods.get_cmdline_bool("use_llvm", False):
+    custom_tools = ["clang", "clangxx", "ar", "link"]
 
 # We let SCons build its default ENV as it includes OS-specific things which we don't
 # want to have to pull in manually.
@@ -745,9 +747,17 @@ if env.msvc:
         env.Append(CCFLAGS=["/Od"])
 else:
     if env["debug_symbols"]:
-        # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
-        # otherwise addr2line doesn't understand them
-        env.Append(CCFLAGS=["-gdwarf-4"])
+        if env["platform"] == "windows" and env["use_llvm"] and not env["use_dwarf"]:
+            # On Windows when using LLVM the -gcodeview creates debug symbols compatible
+            # with Microsoft debuggers.
+            # Additionally -g must be sent to the linker to make it actually produce
+            # a PDB file containing the debug symbols, otherwise they are discarded.
+            env.Append(CCFLAGS=["-gcodeview"])
+            env.Append(LINKFLAGS=["-g"])
+        else:
+            # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
+            # otherwise addr2line doesn't understand them
+            env.Append(CCFLAGS=["-gdwarf-4"])
         if methods.using_emcc(env):
             # Emscripten only produces dwarf symbols when using "-g3".
             env.Append(CCFLAGS=["-g3"])

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -16,7 +16,7 @@ SConscript("coreaudio/SCsub")
 SConscript("pulseaudio/SCsub")
 if env["platform"] == "windows":
     SConscript("wasapi/SCsub")
-    if not env.msvc:
+    if not env.msvc and (env["use_mingw"] or not env["use_llvm"]):
         SConscript("backtrace/SCsub")
 if env["xaudio2"]:
     if "xaudio2" not in supported:

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -70,6 +70,9 @@ if env["windows_subsystem"] == "gui":
     if env.msvc:
         env_wrap.Append(LINKFLAGS=["/SUBSYSTEM:CONSOLE"])
         env_wrap.Append(LINKFLAGS=["version.lib"])
+    elif not env["use_mingw"] and env["use_llvm"]:
+        env_wrap.Append(LINKFLAGS=["-Wl,-subsystem:console"])
+        env_wrap.Append(LIBS=["version"])
     else:
         env_wrap.Append(LINKFLAGS=["-Wl,--subsystem,console"])
         env_wrap.Append(LIBS=["version"])

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -36,7 +36,9 @@
 
 // Crash handler exception only enabled with MSVC
 #if defined(DEBUG_ENABLED)
+#if !defined(__clang__)
 #define CRASH_HANDLER_EXCEPTION 1
+#endif
 
 #ifdef _MSC_VER
 extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -194,6 +194,7 @@ def get_opts():
         ),
         BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed.", False),
         BoolVariable("use_llvm", "Use the LLVM compiler", False),
+        BoolVariable("use_dwarf", "Produce DWARF debug symbols instead of PDB when using the LLVM compiler", False),
         BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
         BoolVariable("use_ubsan", "Use LLVM compiler undefined behavior sanitizer (UBSAN)", False),
@@ -362,6 +363,34 @@ def setup_mingw(env: "SConsEnvironment"):
         sys.exit(255)
 
     print("Using MinGW, arch %s" % (env["arch"]))
+
+
+def setup_llvm(env):
+    """Set up env for use with clang"""
+
+    Version = False
+
+    try:
+        out = subprocess.Popen(
+            "clang --version",
+            shell=True,
+            encoding="utf-8",
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        outs, errs = out.communicate()
+        if out.returncode == 0:
+            import re
+
+            Version = re.search("^clang version ([0-9\\.]+)\n", outs).group(1)
+    except Exception:
+        pass
+
+    if not Version:
+        print_error("CLang could not be found, make sure it is installed and in PATH.")
+        sys.exit(255)
+
+    print("Found clang version %s, arch %s" % (Version, env["arch"]))
 
 
 def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
@@ -947,6 +976,201 @@ def configure_mingw(env: "SConsEnvironment"):
     env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
 
 
+def configure_llvm(env: "SConsEnvironment"):
+    env.use_windows_spawn_fix()
+
+    if env["target"] != "template_release" and env.dev_build:
+        # Allow big objects. It's supposed not to have drawbacks but seems to break
+        # GCC LTO, so enabling for debug builds only (which are not built with LTO
+        # and are the only ones with too big objects).
+        env.Append(CCFLAGS=["-Wa,-mbig-obj"])
+
+    if env["windows_subsystem"] == "gui":
+        env.Append(LINKFLAGS=["-Wl,-subsystem:windows"])
+    else:
+        env.Append(LINKFLAGS=["-Wl,-subsystem:console"])
+        env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
+
+    ## Compiler configuration
+
+    if os.name != "nt":
+        env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
+
+    if env["arch"] == "x86_32":
+        if env["use_static_cpp"]:
+            env.Append(LINKFLAGS=["-static"])
+            env.Append(LINKFLAGS=["-static-libgcc"])
+            env.Append(LINKFLAGS=["-static-libstdc++"])
+    else:
+        if env["use_static_cpp"]:
+            env.Append(LINKFLAGS=["-static"])
+
+    # FIXME: Temporarily disabled, because llvm doesn't like the assembly
+    # if env["arch"] in ["x86_32", "x86_64"]:
+    #    env["x86_libtheora_opt_gcc"] = True
+
+    env.Append(CCFLAGS=["-ffp-contract=off"])
+
+    env["CC"] = "clang"
+    env["CXX"] = "clang++"
+    env["AS"] = "clang"  # CLang can act as an assembler, so it is not usually bundled with llvm-as
+    env["AR"] = "llvm-ar"
+    env["RANLIB"] = "llvm-ranlib"
+    env.extra_suffix = ".llvm" + env.extra_suffix
+
+    ## LTO
+
+    if env["lto"] == "auto":  # Full LTO for production with LLVM.
+        env["lto"] = "full"
+
+    if env["lto"] != "none":
+        if env["lto"] == "thin":
+            env.Append(LINKFLAGS=["-flto=thin"])
+        else:
+            env.Append(LINKFLAGS=["-flto"])
+
+    if env["use_asan"]:
+        env.Append(LINKFLAGS=["-Wl,-stack:" + str(STACK_SIZE_SANITIZERS)])
+    else:
+        env.Append(LINKFLAGS=["-Wl,-stack:" + str(STACK_SIZE)])
+
+    # Sanitizers
+
+    if int(env["target_win_version"], 16) < 0x0601:
+        print_error("`target_win_version` should be 0x0601 or higher (Windows 7).")
+        sys.exit(255)
+
+    if env["use_asan"] or env["use_ubsan"]:
+        if env["arch"] not in ["x86_32", "x86_64"]:
+            print("Sanitizers are only supported for x86_32 and x86_64.")
+            sys.exit(255)
+
+        env.extra_suffix += ".san"
+        env.AppendUnique(CPPDEFINES=["SANITIZERS_ENABLED"])
+        san_flags = []
+        if env["use_asan"]:
+            san_flags.append("-fsanitize=address")
+        if env["use_ubsan"]:
+            san_flags.append("-fsanitize=undefined")
+            # Disable the vptr check since it gets triggered on any COM interface calls.
+            san_flags.append("-fno-sanitize=vptr")
+        env.Append(CFLAGS=san_flags)
+        env.Append(CCFLAGS=san_flags)
+        env.Append(LINKFLAGS=san_flags)
+
+    if os.name == "nt" and methods._colorize:
+        env.Append(CCFLAGS=["$(-fansi-escape-codes$)", "$(-fcolor-diagnostics$)"])
+
+    # FIXME: Using thin AR causes link to fail. Possible incompatibility with MSVC linker. Force use of lld instead?
+    # if get_is_ar_thin_supported(env):
+    #     env.Append(ARFLAGS=["--thin"])
+
+    ## Compile flags
+
+    env.Append(CPPDEFINES=[])
+    env.Append(
+        CPPDEFINES=[
+            "WINDOWS_ENABLED",
+            "WASAPI_ENABLED",
+            "WINMIDI_ENABLED",
+            "TYPED_METHOD_BIND",
+            "WIN32",
+            # Prevent Windows SDK headers from defining min and max macros,
+            # which conflict with min and max templates
+            "NOMINMAX",
+            # The inline assembly trick used for older MSVC versions does not work for LLVM.
+            # Fall back to portable implementation.
+            # An alternative is to define __MINGW32__ but this would influence other libraries
+            "R128_STDC_ONLY",
+            ("WINVER", env["target_win_version"]),
+            ("_WIN32_WINNT", env["target_win_version"]),
+        ]
+    )
+    env.Append(
+        LIBS=[
+            "avrt",
+            "bcrypt",
+            "crypt32",
+            "dinput8",
+            "dsound",
+            "dwmapi",
+            "dwrite",
+            "dxguid",
+            "gdi32",
+            "imm32",
+            "iphlpapi",
+            "kernel32",
+            "ntdll",
+            "ole32",
+            "oleaut32",
+            "sapi",
+            "shell32",
+            "advapi32",
+            "shlwapi",
+            "user32",
+            "uuid",
+            "wbemuuid",
+            "winmm",
+            "ws2_32",
+            "wsock32",
+        ]
+    )
+
+    if env.debug_features:
+        env.Append(LIBS=["psapi", "dbghelp"])
+
+    if env["vulkan"]:
+        env.Append(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])
+        if not env["use_volk"]:
+            env.Append(LIBS=["vulkan"])
+
+    if env["d3d12"]:
+        # Check whether we have d3d12 dependencies installed.
+        if not os.path.exists(env["mesa_libs"]):
+            print_error(
+                "The Direct3D 12 rendering driver requires dependencies to be installed.\n"
+                "You can install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
+                "See the documentation for more information:\n\t"
+                "https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_windows.html"
+            )
+            sys.exit(255)
+
+        env.AppendUnique(CPPDEFINES=["D3D12_ENABLED", "RD_ENABLED"])
+        env.Append(LIBS=["dxgi", "dxguid"])
+
+        # PIX
+        if env["arch"] not in ["x86_64", "arm64"] or env["pix_path"] == "" or not os.path.exists(env["pix_path"]):
+            env["use_pix"] = False
+
+        if env["use_pix"]:
+            arch_subdir = "arm64" if env["arch"] == "arm64" else "x64"
+
+            env.Append(LIBPATH=[env["pix_path"] + "/bin/" + arch_subdir])
+            env.Append(LIBS=["WinPixEventRuntime"])
+
+        env.Append(LIBPATH=[env["mesa_libs"] + "/bin"])
+        env.Append(LIBS=["libNIR.windows." + env["arch"]])
+        env.Append(LIBS=["version"])  # Mesa dependency.
+
+    if env["opengl3"]:
+        env.Append(CPPDEFINES=["GLES3_ENABLED"])
+        if env["angle_libs"] != "":
+            env.AppendUnique(CPPDEFINES=["EGL_STATIC"])
+            env.Append(LIBPATH=[env["angle_libs"]])
+            env.Append(
+                LIBS=[
+                    "EGL.windows." + env["arch"],
+                    "GLES.windows." + env["arch"],
+                    "ANGLE.windows." + env["arch"],
+                ]
+            )
+            env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
+        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+
+    # resrc
+    env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
+
+
 def configure(env: "SConsEnvironment"):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
@@ -965,7 +1189,10 @@ def configure(env: "SConsEnvironment"):
         env["ENV"]["TMP"] = os.environ["TMP"]
 
     # First figure out which compiler, version, and target arch we're using
-    if os.getenv("VCINSTALLDIR") and detect_build_env_arch() and not env["use_mingw"]:
+    if env["use_llvm"] and not env["use_mingw"]:
+        setup_llvm(env)
+        env.msvc = False
+    elif os.getenv("VCINSTALLDIR") and detect_build_env_arch() and not env["use_mingw"]:
         setup_msvc_manual(env)
         env.msvc = True
         vcvars_msvc_config = True
@@ -980,6 +1207,9 @@ def configure(env: "SConsEnvironment"):
     # Now set compiler/linker flags
     if env.msvc:
         configure_msvc(env, vcvars_msvc_config)
+
+    elif env["use_llvm"]:
+        configure_llvm(env)
 
     else:  # MinGW
         configure_mingw(env)


### PR DESCRIPTION
Changes to the SCons script so that building with `use_llvm=yes` and `use_mingw=no` is possible on Windows. Additionally, both `use_llvm` and `use_mingw` can now be specified in `custom.py`, so it is no longer necessary to specify them in the command line on every build. Also, LLVM builds on Windows now produce a PDB by default. The option `use_dwarf` is added for creating DWARF debug symbols with LLVM instead.

LLVM is easier to install and update than MSVC and MinGW-LLVM. It produces faster executables than MinGW. And allows generating debug symbols in PDB format, which can be used by any standard debugging and profiling tools on Windows.

However, LLVM lacks compatibility certain assembly and intrinsics that are vendor-specific to either MinGW or MSVC. As a result, architecture-specific acceleration in libtheora in R128 is disabled.

###  Testers needed

This PR was tested on a system where MSVC is installed. LLVM automatically detects the presence of MSVC libraries and linker, and makes use of them. However, this should also work on a "clean" system with nothing but LLVM and Windows SDK installed. This requires testing, however, since `lld-link` is not guaranteed to be full compatible with the MSVC linker.

*Bugsquad edit (keywords for easier searching): clang-cl*
