### PR TITLE
Allow setting negative `WorldBoundaryShape2D.distance` through the editor

### DIFF
--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -98,13 +98,11 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 	Vector3 segment = p_dir;
 	real_t den = normal.dot(segment);
 
-	//printf("den is %i\n",den);
 	if (Math::is_zero_approx(den)) {
 		return false;
 	}
 
 	real_t dist = (normal.dot(p_from) - d) / den;
-	//printf("dist is %i\n",dist);
 
 	if (dist > (real_t)CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
 
@@ -121,13 +119,11 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	Vector3 segment = p_begin - p_end;
 	real_t den = normal.dot(segment);
 
-	//printf("den is %i\n",den);
 	if (Math::is_zero_approx(den)) {
 		return false;
 	}
 
 	real_t dist = (normal.dot(p_begin) - d) / den;
-	//printf("dist is %i\n",dist);
 
 	if (dist < (real_t)-CMP_EPSILON || dist > (1.0f + (real_t)CMP_EPSILON)) {
 		return false;

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -138,7 +138,7 @@
 		<method name="normalized" qualifiers="const">
 			<return type="Plane" />
 			<description>
-				Returns a copy of the plane, normalized.
+				Returns a copy of the plane, with normalized [member normal] (so it's a unit vector). Returns [code]Plane(0, 0, 0, 0)[/code] if [member normal] can't be normalized (it has zero length).
 			</description>
 		</method>
 		<method name="project" qualifiers="const">
@@ -151,11 +151,11 @@
 	</methods>
 	<members>
 		<member name="d" type="float" setter="" getter="" default="0.0">
-			The distance from the origin to the plane, in the direction of [member normal]. This value is typically non-negative.
+			The distance from the origin to the plane, expressed in terms of [member normal] (according to its direction and magnitude). Actual absolute distance from the origin to the plane can be calculated as [code]abs(d) / normal.length()[/code] (if [member normal] has zero length then this [Plane] does not represent a valid plane).
 			In the scalar equation of the plane [code]ax + by + cz = d[/code], this is [code]d[/code], while the [code](a, b, c)[/code] coordinates are represented by the [member normal] property.
 		</member>
 		<member name="normal" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
-			The normal of the plane, which must be a unit vector.
+			The normal of the plane, typically a unit vector. Shouldn't be a zero vector as [Plane] with such [member normal] does not represent a valid plane.
 			In the scalar equation of the plane [code]ax + by + cz = d[/code], this is the vector [code](a, b, c)[/code], where [code]d[/code] is the [member d] property.
 		</member>
 		<member name="x" type="float" setter="" getter="" default="0.0">

--- a/doc/classes/WorldBoundaryShape2D.xml
+++ b/doc/classes/WorldBoundaryShape2D.xml
@@ -10,10 +10,11 @@
 	</tutorials>
 	<members>
 		<member name="distance" type="float" setter="set_distance" getter="get_distance" default="0.0">
-			The line's distance from the origin.
+			The distance from the origin to the line, expressed in terms of [member normal] (according to its direction and magnitude). Actual absolute distance from the origin to the line can be calculated as [code]abs(distance) / normal.length()[/code].
+			In the scalar equation of the line [code]ax + by = d[/code], this is [code]d[/code], while the [code](a, b)[/code] coordinates are represented by the [member normal] property.
 		</member>
 		<member name="normal" type="Vector2" setter="set_normal" getter="get_normal" default="Vector2(0, -1)">
-			The line's normal. Defaults to [code]Vector2.UP[/code].
+			The line's normal, typically a unit vector. Its direction indicates the non-colliding half-plane. Can be of any length but zero. Defaults to [code]Vector2.UP[/code].
 		</member>
 	</members>
 </class>

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -155,7 +155,8 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 				Ref<WorldBoundaryShape2D> world_boundary = node->get_shape();
 
 				if (idx == 0) {
-					world_boundary->set_distance(p_point.length());
+					Vector2 normal = world_boundary->get_normal();
+					world_boundary->set_distance(p_point.dot(normal) / normal.length_squared());
 				} else {
 					world_boundary->set_normal(p_point.normalized());
 				}

--- a/scene/resources/world_boundary_shape_2d.cpp
+++ b/scene/resources/world_boundary_shape_2d.cpp
@@ -35,8 +35,8 @@
 #include "servers/rendering_server.h"
 
 bool WorldBoundaryShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-	Vector2 point = get_distance() * get_normal();
-	Vector2 l[2][2] = { { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 }, { point, point + get_normal() * 30 } };
+	Vector2 point = distance * normal;
+	Vector2 l[2][2] = { { point - normal.orthogonal() * 100, point + normal.orthogonal() * 100 }, { point, point + normal * 30 } };
 
 	for (int i = 0; i < 2; i++) {
 		Vector2 closest = Geometry2D::get_closest_point_to_segment(p_point, l[i]);
@@ -57,11 +57,19 @@ void WorldBoundaryShape2D::_update_shape() {
 }
 
 void WorldBoundaryShape2D::set_normal(const Vector2 &p_normal) {
+	// Can be non-unit but prevent zero.
+	ERR_FAIL_COND(p_normal.is_zero_approx());
+	if (normal == p_normal) {
+		return;
+	}
 	normal = p_normal;
 	_update_shape();
 }
 
 void WorldBoundaryShape2D::set_distance(real_t p_distance) {
+	if (distance == p_distance) {
+		return;
+	}
 	distance = p_distance;
 	_update_shape();
 }
@@ -75,20 +83,20 @@ real_t WorldBoundaryShape2D::get_distance() const {
 }
 
 void WorldBoundaryShape2D::draw(const RID &p_to_rid, const Color &p_color) {
-	Vector2 point = get_distance() * get_normal();
+	Vector2 point = distance * normal;
 	real_t line_width = 3.0;
 
-	Vector2 l1[2] = { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 };
+	Vector2 l1[2] = { point - normal.orthogonal() * 100, point + normal.orthogonal() * 100 };
 	RS::get_singleton()->canvas_item_add_line(p_to_rid, l1[0], l1[1], p_color, line_width);
-	Vector2 l2[2] = { point + get_normal().normalized() * (0.5 * line_width), point + get_normal() * 30 };
+	Vector2 l2[2] = { point + normal.normalized() * (0.5 * line_width), point + normal * 30 };
 	RS::get_singleton()->canvas_item_add_line(p_to_rid, l2[0], l2[1], p_color, line_width);
 }
 
 Rect2 WorldBoundaryShape2D::get_rect() const {
-	Vector2 point = get_distance() * get_normal();
+	Vector2 point = distance * normal;
 
-	Vector2 l1[2] = { point - get_normal().orthogonal() * 100, point + get_normal().orthogonal() * 100 };
-	Vector2 l2[2] = { point, point + get_normal() * 30 };
+	Vector2 l1[2] = { point - normal.orthogonal() * 100, point + normal.orthogonal() * 100 };
+	Vector2 l2[2] = { point, point + normal * 30 };
 	Rect2 rect;
 	rect.position = l1[0];
 	rect.expand_to(l1[1]);
@@ -109,7 +117,7 @@ void WorldBoundaryShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_distance"), &WorldBoundaryShape2D::get_distance);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "normal"), "set_normal", "get_normal");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance", PROPERTY_HINT_RANGE, "0.01,1024,0.01,or_greater,suffix:px"), "set_distance", "get_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance", PROPERTY_HINT_RANGE, "-1024,1024,0.01,or_greater,or_less,suffix:px"), "set_distance", "get_distance");
 }
 
 WorldBoundaryShape2D::WorldBoundaryShape2D() :


### PR DESCRIPTION
Fixes #77144.

- Allows setting negative `WorldBoundaryShape2D.distance` in the inspector (smaller values can be typed in manually):

|Before|After|
|-|-|
|![U33RaXk86m](https://github.com/godotengine/godot/assets/9283098/5c705e25-fdfd-4266-8f30-dad14905e136)|![HQN2vbIAug](https://github.com/godotengine/godot/assets/9283098/451a3673-6a5b-46a7-a26f-e4e59658a717)|

- Allows setting negative `WorldBoundaryShape2D.distance` with the handle, also fixes incorrect line distance calculation from the handle:

|Before|After|
|-|-|
|![TFbJg4Ge8o](https://github.com/godotengine/godot/assets/9283098/b7f9e0b6-9ab4-4071-bc8f-f9774d6f115d)|![Igre4t5yjL](https://github.com/godotengine/godot/assets/9283098/83b0cc4d-8052-446f-9067-5ce7b6e32926)|
|![MRCXMWGbwT](https://github.com/godotengine/godot/assets/9283098/6c15c875-2891-4664-989e-4347170e3d7b)|![0rwlqbCLRS](https://github.com/godotengine/godot/assets/9283098/c6767ceb-661e-4772-8932-f53016465c25)|

- Fixes/clarifies some docs.