### PR TITLE
Add `is_equal_approx`/`is_zero_approx` for floats to shading language

### DIFF
--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -90,6 +90,7 @@ public:
 		HashMap<StringName, String> renames;
 		HashMap<StringName, String> render_mode_defines;
 		HashMap<StringName, String> usage_defines;
+		HashMap<StringName, String> global_functions;
 		HashMap<StringName, String> custom_samplers;
 		ShaderLanguage::TextureFilter default_filter;
 		ShaderLanguage::TextureRepeat default_repeat;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -31,6 +31,10 @@
 #include "shader_types.h"
 #include "core/math/math_defs.h"
 
+const HashMap<StringName, ShaderLanguage::StageFunctionInfo> &ShaderTypes::get_functions() const {
+	return global_functions;
+}
+
 const HashMap<StringName, ShaderLanguage::FunctionInfo> &ShaderTypes::get_functions(RS::ShaderMode p_mode) const {
 	return shader_modes[p_mode].functions;
 }
@@ -55,6 +59,19 @@ static ShaderLanguage::BuiltInInfo constt(ShaderLanguage::DataType p_type) {
 
 ShaderTypes::ShaderTypes() {
 	singleton = this;
+
+	/*************** GLOBAL FUNCTIONS ***********************/
+
+	ShaderLanguage::StageFunctionInfo is_equal_approx_func;
+	is_equal_approx_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("a", ShaderLanguage::TYPE_FLOAT));
+	is_equal_approx_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("b", ShaderLanguage::TYPE_FLOAT));
+	is_equal_approx_func.return_type = ShaderLanguage::TYPE_BOOL;
+	global_functions["is_equal_approx"] = is_equal_approx_func;
+
+	ShaderLanguage::StageFunctionInfo is_zero_approx_func;
+	is_zero_approx_func.arguments.push_back(ShaderLanguage::StageFunctionInfo::Argument("x", ShaderLanguage::TYPE_FLOAT));
+	is_zero_approx_func.return_type = ShaderLanguage::TYPE_BOOL;
+	global_functions["is_zero_approx"] = is_zero_approx_func;
 
 	/*************** SPATIAL ***********************/
 

--- a/servers/rendering/shader_types.h
+++ b/servers/rendering/shader_types.h
@@ -42,6 +42,7 @@ class ShaderTypes {
 	};
 
 	HashMap<RS::ShaderMode, Type> shader_modes;
+	HashMap<StringName, ShaderLanguage::StageFunctionInfo> global_functions;
 
 	static ShaderTypes *singleton;
 
@@ -51,6 +52,7 @@ class ShaderTypes {
 public:
 	static ShaderTypes *get_singleton() { return singleton; }
 
+	const HashMap<StringName, ShaderLanguage::StageFunctionInfo> &get_functions() const;
 	const HashMap<StringName, ShaderLanguage::FunctionInfo> &get_functions(RS::ShaderMode p_mode) const;
 	const Vector<ShaderLanguage::ModeInfo> &get_modes(RS::ShaderMode p_mode) const;
 	const HashSet<String> &get_types() const;


### PR DESCRIPTION
Adds the support for these two functions to Godot Shading Language. If the user does not use them - they will not be added to the code and thus will not be compiled by the internal system compiler (main @reduz claim about adding custom functions).

![image](https://github.com/godotengine/godot/assets/3036176/d53f1223-3c1a-488b-a814-3a862af866b7)

This should fix (partly, only for floats): https://github.com/godotengine/godot-proposals/issues/6870