### PR TITLE
Stop dragging when `Slider` changes editability

### DIFF
--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -294,6 +294,7 @@ void Slider::set_editable(bool p_editable) {
 	if (editable == p_editable) {
 		return;
 	}
+	grab.active = false;
 
 	editable = p_editable;
 	queue_redraw();


### PR DESCRIPTION
Fix #59038. 