### PR TITLE
Fix C# code examples in `String` and `StringName`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -325,7 +325,7 @@
 				[/gdscript]
 				[csharp]
 				var text = "hello world";
-				var encoded = text.ToUtf8Buffer().HexEncode(); # outputs "68656c6c6f20776f726c64"
+				var encoded = text.ToUtf8Buffer().HexEncode(); // outputs "68656c6c6f20776f726c64"
 				GD.Print(buf.HexDecode().GetStringFromUtf8());
 				[/csharp]
 				[/codeblocks]

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -308,7 +308,7 @@
 				[/gdscript]
 				[csharp]
 				var text = "hello world";
-				var encoded = text.ToUtf8Buffer().HexEncode(); # outputs "68656c6c6f20776f726c64"
+				var encoded = text.ToUtf8Buffer().HexEncode(); // outputs "68656c6c6f20776f726c64"
 				GD.Print(buf.HexDecode().GetStringFromUtf8());
 				[/csharp]
 				[/codeblocks]


### PR DESCRIPTION
`class_string.rst:823: WARNING: Could not lex literal_block as "csharp"`
`class_stringname.rst:777: WARNING: Could not lex literal_block as "csharp"`