### PR TITLE
Make certain editor callbacks thread-safe

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5901,6 +5901,10 @@ void EditorNode::_add_dropped_files_recursive(const Vector<String> &p_files, Str
 }
 
 void EditorNode::_file_access_close_error_notify(const String &p_str) {
+	callable_mp_static(&EditorNode::_file_access_close_error_notify_impl).bind(p_str).call_deferred();
+}
+
+void EditorNode::_file_access_close_error_notify_impl(const String &p_str) {
 	add_io_error(vformat(TTR("Unable to write to file '%s', file in use, locked or lacking permissions."), p_str));
 }
 
@@ -6502,13 +6506,16 @@ static Node *_resource_get_edited_scene() {
 }
 
 void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_error, bool p_rich) {
-	EditorNode *en = static_cast<EditorNode *>(p_this);
+	callable_mp_static(&EditorNode::_print_handler_impl).bind(p_string, p_error, p_rich).call_deferred();
+}
+
+void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool p_rich) {
 	if (p_error) {
-		en->log->add_message(p_string, EditorLog::MSG_TYPE_ERROR);
+		singleton->log->add_message(p_string, EditorLog::MSG_TYPE_ERROR);
 	} else if (p_rich) {
-		en->log->add_message(p_string, EditorLog::MSG_TYPE_STD_RICH);
+		singleton->log->add_message(p_string, EditorLog::MSG_TYPE_STD_RICH);
 	} else {
-		en->log->add_message(p_string, EditorLog::MSG_TYPE_STD);
+		singleton->log->add_message(p_string, EditorLog::MSG_TYPE_STD);
 	}
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -518,8 +518,10 @@ private:
 	static void _editor_file_dialog_unregister(EditorFileDialog *p_dialog);
 
 	static void _file_access_close_error_notify(const String &p_str);
+	static void _file_access_close_error_notify_impl(const String &p_str);
 
 	static void _print_handler(void *p_this, const String &p_string, bool p_error, bool p_rich);
+	static void _print_handler_impl(const String &p_string, bool p_error, bool p_rich);
 	static void _resource_saved(Ref<Resource> p_resource, const String &p_path);
 	static void _resource_loaded(Ref<Resource> p_resource, const String &p_path);
 


### PR DESCRIPTION
The current design goal for the editor API is that it's not meant to be thread-safe. However, certain callbacks can be called from contexts that shouldn't contain explicit thread awareness. Therefore, the way to go is make those callbacks thread-safe, which is what this PR does.

A bit of story:
- In #71670 we could affect a specific component since it is its own class.
- In #71280 we could keep the editor API thread-unsafe because the affected functions were always called through a "bridge" that allowed to keep both ends unaware of threading.

Fixes #77235,