### PR TITLE
tile_animation_sync option

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -84,7 +84,7 @@
 			<return type="bool" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<description>
-				Returns if each animation start at first, or random frame.
+				Returns [code]true[/code] if animations are synchronized across all tiles for the tile at [param atlas_coords], [code]false[/code] otherwise. See also [method set_tile_animation_sync].
 			</description>
 		</method>
 		<method name="get_tile_animation_separation" qualifiers="const">
@@ -227,7 +227,7 @@
 			<param index="0" name="atlas_coords" type="Vector2i" />
 			<param index="1" name="sync" type="bool" />
 			<description>
-				Sets if each animation start at first, or random frame.
+				Sets whether the tile at [param atlas_coords] should have its animation synchronized with other tiles. If set to [code]true[/code], all tiles will start at the same frame, making their animations look identical. If set to [code]false[/code], the animation's start point will be randomized, which makes animations look different for each tile. Setting this to [code]false[/code] can help break up repetitive patterns with animated tiles. By default, this is set to [code]true[/code]. See also [method get_tile_animation_sync].
 			</description>
 		</method>
 		<method name="set_tile_animation_separation">

--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -80,6 +80,13 @@
 				Returns how many animation frames has the tile at coordinates [param atlas_coords].
 			</description>
 		</method>
+		<method name="get_tile_animation_sync" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="atlas_coords" type="Vector2i" />
+			<description>
+				Returns if each animation start at first, or random frame.
+			</description>
+		</method>
 		<method name="get_tile_animation_separation" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="atlas_coords" type="Vector2i" />
@@ -213,6 +220,14 @@
 			<param index="1" name="frames_count" type="int" />
 			<description>
 				Sets how many animation frames the tile at coordinates [param atlas_coords] has.
+			</description>
+		</method>
+		<method name="set_tile_animation_sync">
+			<return type="void" />
+			<param index="0" name="atlas_coords" type="Vector2i" />
+			<param index="1" name="sync" type="bool" />
+			<description>
+				Sets if each animation start at first, or random frame.
 			</description>
 		</method>
 		<method name="set_tile_animation_separation">

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -229,6 +229,12 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 			}
 			emit_signal(SNAME("changed"), "animation_columns");
 			return true;
+		} else if (p_name == "animation_sync") {
+			for (TileSelection tile : tiles) {
+				tile_set_atlas_source->set_tile_animation_sync(tile.tile, p_value);
+			}
+			emit_signal(SNAME("changed"), "animation_sync");
+			return true;
 		} else if (p_name == "animation_separation") {
 			for (TileSelection tile : tiles) {
 				bool has_room_for_tile = tile_set_atlas_source->has_room_for_tile(tile.tile, tile_set_atlas_source->get_tile_size_in_atlas(tile.tile), tile_set_atlas_source->get_tile_animation_columns(tile.tile), p_value, tile_set_atlas_source->get_tile_animation_frames_count(tile.tile), tile.tile);
@@ -343,6 +349,9 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_get(const StringName &p_na
 		if (p_name == "animation_columns") {
 			r_ret = tile_set_atlas_source->get_tile_animation_columns(coords);
 			return true;
+		} else if (p_name == "animation_sync") {
+			r_ret = tile_set_atlas_source->get_tile_animation_sync(coords);
+			return true;
 		} else if (p_name == "animation_separation") {
 			r_ret = tile_set_atlas_source->get_tile_animation_separation(coords);
 			return true;
@@ -415,6 +424,7 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 	if (all_alternatve_id_zero) {
 		p_list->push_back(PropertyInfo(Variant::NIL, GNAME("Animation", "animation_"), PROPERTY_HINT_NONE, "animation_", PROPERTY_USAGE_GROUP));
 		p_list->push_back(PropertyInfo(Variant::INT, PNAME("animation_columns")));
+		p_list->push_back(PropertyInfo(Variant::BOOL, PNAME("animation_sync")));
 		p_list->push_back(PropertyInfo(Variant::VECTOR2I, PNAME("animation_separation")));
 		p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("animation_speed")));
 		p_list->push_back(PropertyInfo(Variant::INT, PNAME("animation_frames_count"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, "Frames,animation_frame_"));

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1501,12 +1501,16 @@ void TileMap::draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<
 		} else {
 			real_t speed = atlas_source->get_tile_animation_speed(p_atlas_coords);
 			real_t animation_duration = atlas_source->get_tile_animation_total_duration(p_atlas_coords) / speed;
+			bool sync = atlas_source->get_tile_animation_sync(p_atlas_coords);
+			int frames_count = atlas_source->get_tile_animation_frames_count(p_atlas_coords);
+			int start_frame = sync ? 0 : rand() % frames_count;
 			real_t time = 0.0;
-			for (int frame = 0; frame < atlas_source->get_tile_animation_frames_count(p_atlas_coords); frame++) {
-				real_t frame_duration = atlas_source->get_tile_animation_frame_duration(p_atlas_coords, frame) / speed;
+			for (int frame = 0; frame < frames_count; frame++) {
+				int current_frame = (frame + start_frame) % frames_count;
+				real_t frame_duration = atlas_source->get_tile_animation_frame_duration(p_atlas_coords, current_frame) / speed;
 				RenderingServer::get_singleton()->canvas_item_add_animation_slice(p_canvas_item, animation_duration, time, time + frame_duration, 0.0);
 
-				Rect2i source_rect = atlas_source->get_runtime_tile_texture_region(p_atlas_coords, frame);
+				Rect2i source_rect = atlas_source->get_runtime_tile_texture_region(p_atlas_coords, current_frame);
 				tex->draw_rect_region(p_canvas_item, dest_rect, source_rect, modulate, transpose, p_tile_set->is_uv_clipping());
 
 				time += frame_duration;

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -3917,6 +3917,9 @@ bool TileSetAtlasSource::_set(const StringName &p_name, const Variant &p_value) 
 			} else if (components[1] == "animation_columns") {
 				set_tile_animation_columns(coords, p_value);
 				return true;
+			} else if (components[1] == "animation_sync") {
+				set_tile_animation_sync(coords, p_value);
+				return true;
 			} else if (components[1] == "animation_separation") {
 				set_tile_animation_separation(coords, p_value);
 				return true;
@@ -3984,6 +3987,9 @@ bool TileSetAtlasSource::_get(const StringName &p_name, Variant &r_ret) const {
 				} else if (components[1] == "animation_columns") {
 					r_ret = get_tile_animation_columns(coords);
 					return true;
+				} else if (components[1] == "animation_sync") {
+					r_ret = get_tile_animation_sync(coords);
+					return true;
 				} else if (components[1] == "animation_separation") {
 					r_ret = get_tile_animation_separation(coords);
 					return true;
@@ -4047,6 +4053,13 @@ void TileSetAtlasSource::_get_property_list(List<PropertyInfo> *p_list) const {
 		// animation_columns.
 		property_info = PropertyInfo(Variant::INT, "animation_columns", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR);
 		if (E_tile.value.animation_columns == 0) {
+			property_info.usage ^= PROPERTY_USAGE_STORAGE;
+		}
+		tile_property_list.push_back(property_info);
+
+		// animation_sync.
+		property_info = PropertyInfo(Variant::BOOL, "animation_sync", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR);
+		if (E_tile.value.animation_sync) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		tile_property_list.push_back(property_info);
@@ -4188,6 +4201,20 @@ void TileSetAtlasSource::set_tile_animation_columns(const Vector2i p_atlas_coord
 int TileSetAtlasSource::get_tile_animation_columns(const Vector2i p_atlas_coords) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
 	return tiles[p_atlas_coords].animation_columns;
+}
+
+void TileSetAtlasSource::set_tile_animation_sync(const Vector2i p_atlas_coords, bool p_sync) {
+	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
+
+	tiles[p_atlas_coords].animation_sync = p_sync;
+
+	emit_signal(SNAME("changed"));
+}
+
+bool TileSetAtlasSource::get_tile_animation_sync(const Vector2i p_atlas_coords) const {
+	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), bool(), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
+
+	return tiles[p_atlas_coords].animation_sync;
 }
 
 void TileSetAtlasSource::set_tile_animation_separation(const Vector2i p_atlas_coords, const Vector2i p_separation) {
@@ -4548,6 +4575,8 @@ void TileSetAtlasSource::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_tile_animation_columns", "atlas_coords", "frame_columns"), &TileSetAtlasSource::set_tile_animation_columns);
 	ClassDB::bind_method(D_METHOD("get_tile_animation_columns", "atlas_coords"), &TileSetAtlasSource::get_tile_animation_columns);
+	ClassDB::bind_method(D_METHOD("set_tile_animation_sync", "atlas_coords", "sync"), &TileSetAtlasSource::set_tile_animation_sync);
+	ClassDB::bind_method(D_METHOD("get_tile_animation_sync", "atlas_coords"), &TileSetAtlasSource::get_tile_animation_sync);
 	ClassDB::bind_method(D_METHOD("set_tile_animation_separation", "atlas_coords", "separation"), &TileSetAtlasSource::set_tile_animation_separation);
 	ClassDB::bind_method(D_METHOD("get_tile_animation_separation", "atlas_coords"), &TileSetAtlasSource::get_tile_animation_separation);
 	ClassDB::bind_method(D_METHOD("set_tile_animation_speed", "atlas_coords", "speed"), &TileSetAtlasSource::set_tile_animation_speed);

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -597,6 +597,7 @@ private:
 
 		// Animation
 		int animation_columns = 0;
+		bool animation_sync = true;
 		Vector2i animation_separation;
 		real_t animation_speed = 1.0;
 		LocalVector<real_t> animation_frames_durations;
@@ -695,6 +696,8 @@ public:
 	// Animation.
 	void set_tile_animation_columns(const Vector2i p_atlas_coords, int p_frame_columns);
 	int get_tile_animation_columns(const Vector2i p_atlas_coords) const;
+	void set_tile_animation_sync(const Vector2i p_atlas_coords, const bool p_sync);
+	bool get_tile_animation_sync(const Vector2i p_atlas_coords) const;
 	void set_tile_animation_separation(const Vector2i p_atlas_coords, const Vector2i p_separation);
 	Vector2i get_tile_animation_separation(const Vector2i p_atlas_coords) const;
 	void set_tile_animation_speed(const Vector2i p_atlas_coords, real_t p_speed);


### PR DESCRIPTION
this adds a sync option that is on by default just above separation
if turned off all animations of that type will start at random frame instead of 0
to address my recent issue and proposal

https://github.com/godotengine/godot-proposals/issues/6856
https://github.com/godotengine/godot/issues/57677

thanks.

- *Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/6856.*