### PR TITLE
Embed natvis debug views in PDB

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -470,6 +470,7 @@ def configure_msvc(env, vcvars_msvc_config):
     env["BUILDERS"]["ProgramOriginal"] = env["BUILDERS"]["Program"]
     env["BUILDERS"]["Program"] = methods.precious_program
 
+    env.Append(LINKFLAGS=["/NATVIS:platform\windows\godot.natvis"])
     env.AppendUnique(LINKFLAGS=["/STACK:" + str(STACK_SIZE)])
 
 


### PR DESCRIPTION
This means the Visual Studio debugger can load them automatically; not sure how you are supposed to load them normally, the our docs only have information about VS Code and generally mentions of these files assume that you are debugging a project file.

Docs page for this: https://learn.microsoft.com/en-us/cpp/build/reference/natvis-add-natvis-to-pdb
