### PR TITLE
Make the lightmap size hint property appear as read-only in the editor

### DIFF
--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -76,7 +76,7 @@
 		<method name="get_lightmap_size_hint" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
-				Returns the size hint of this mesh for lightmap-unwrapping in UV-space.
+				Returns the texture size to use in the lightmap's UV space to represent the mesh's baked lighting. Higher values will make the lighting more detailed, while also allowing smaller albedo/emission texture details to be taken into account for global illumination. When baking, this is multiplied by [member GeometryInstance3D.gi_lightmap_scale]. If [method get_lightmap_size_hint] returns [code]Vector2i(0, 0)[/code], the engine falls back to a size of 64×64 when baking.
 			</description>
 		</method>
 		<method name="get_mesh">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -197,7 +197,8 @@
 	</methods>
 	<members>
 		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint" default="Vector2i(0, 0)">
-			Sets a hint to be used for lightmap resolution.
+			The texture size to use in the lightmap's UV space to represent the mesh's baked lighting. Higher values will make the lighting more detailed, while also allowing smaller albedo/emission texture details to be taken into account for global illumination. This is multiplied by [member GeometryInstance3D.gi_lightmap_scale]. If [member lightmap_size_hint] is set to [code]Vector2i(0, 0)[/code], the engine falls back to a size of 64×64.
+			[b]Note:[/b] Do not set [member lightmap_size_hint] manually on imported meshes or [PrimitiveMesh]es with the [member PrimitiveMesh.add_uv2] property set to [code]true[/code], as changes will be lost when the mesh is reimported or regenerated.
 		</member>
 	</members>
 	<constants>

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -799,7 +799,9 @@ void Mesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_aabb"), &Mesh::get_aabb);
 	ClassDB::bind_method(D_METHOD("get_faces"), &Mesh::_get_faces);
 
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "lightmap_size_hint"), "set_lightmap_size_hint", "get_lightmap_size_hint");
+	// Lightmap Size Hint is set on import or when modifying a PrimitiveMesh's size, so manual changes to it are often lost.
+	// However, being able to see it for debugging purposes is useful, so it's visible as a read-only property.
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "lightmap_size_hint", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY), "set_lightmap_size_hint", "get_lightmap_size_hint");
 
 	ClassDB::bind_method(D_METHOD("get_surface_count"), &Mesh::get_surface_count);
 	ClassDB::bind_method(D_METHOD("surface_get_arrays", "surf_idx"), &Mesh::surface_get_arrays);


### PR DESCRIPTION
Lightmap Size Hint is set on import or when modifying a PrimitiveMesh's size, so manual changes to it are often lost.

However, being able to see it for debugging purposes is useful, so it's visible as a read-only property. This does not impact your ability to set `lightmap_size_hint` from a script (for procedural generation).

- This closes https://github.com/godotengine/godot/issues/106698.
- See discussion starting from https://github.com/godotengine/godot/pull/75164#issuecomment-1478876239.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/481f4bcf-d2ac-4834-a906-4df3d152489c)