### PR TITLE
Add timestamps to stdout, file loggers and editor Output panel

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -194,6 +194,24 @@ RotatedFileLogger::RotatedFileLogger(const String &p_base_path, int p_max_files)
 #endif // MODULE_REGEX_ENABLED
 }
 
+bool RotatedFileLogger::_log_timestamps = true;
+
+void RotatedFileLogger::set_log_timestamps(bool value) {
+	_log_timestamps = value;
+}
+
+void RotatedFileLogger::store_to_log(const Ref<FileAccess> p_file, const uint8_t *p_buf, int p_len) {
+#ifdef MODULE_REGEX_ENABLED
+	// Strip ANSI escape codes (such as those inserted by `print_rich()`)
+	// before writing to file, as text editors cannot display those
+	// correctly.
+	// FIXME: How to convert uint8_t* to String?
+	p_file->store_string(strip_ansi_regex->sub(p_buf, "", true));
+#else
+	p_file->store_buffer(p_buf, p_len);
+#endif // MODULE_REGEX_ENABLED
+}
+
 void RotatedFileLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	if (!should_log(p_err)) {
 		return;
@@ -202,7 +220,9 @@ void RotatedFileLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	if (file.is_valid()) {
 		const int static_buf_size = 512;
 		char static_buf[static_buf_size];
+
 		char *buf = static_buf;
+
 		va_list list_copy;
 		va_copy(list_copy, p_list);
 		int len = vsnprintf(buf, static_buf_size, p_format, p_list);
@@ -212,14 +232,37 @@ void RotatedFileLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 		}
 		va_end(list_copy);
 
-#ifdef MODULE_REGEX_ENABLED
-		// Strip ANSI escape codes (such as those inserted by `print_rich()`)
-		// before writing to file, as text editors cannot display those
-		// correctly.
-		file->store_string(strip_ansi_regex->sub(String::utf8(buf), "", true));
-#else
-		file->store_buffer((uint8_t *)buf, len);
-#endif // MODULE_REGEX_ENABLED
+		const String string_buf = String(buf);
+		if (_log_timestamps) {
+			const String timestamp = Time::get_singleton()->get_datetime_string_from_system() + Time::get_singleton()->get_offset_string_from_offset_minutes(Time::get_singleton()->get_time_zone_from_system()["bias"]) + " | ";
+			if (string_buf.ends_with("\n")) {
+				// Handle multiline strings by displaying the timestamp on each line.
+				const PackedStringArray line_contents = string_buf.split("\n");
+				for (int i = 0; i < line_contents.size(); i++) {
+					if (i < line_contents.size() - 1) {
+						const PackedByteArray array = (timestamp + line_contents[i] + "\n").to_utf8_buffer();
+						const uint8_t *buf_ts = array.ptr();
+						const int buf_ts_size = array.size();
+						store_to_log(file, buf_ts, buf_ts_size);
+					} else if (!line_contents[i].is_empty()) {
+						// Last line, so don't add an extraneous newline.
+						const PackedByteArray array = (timestamp + line_contents[i]).to_utf8_buffer();
+						const uint8_t *buf_ts = array.ptr();
+						const int buf_ts_size = array.size();
+						store_to_log(file, buf_ts, buf_ts_size);
+					}
+				}
+			} else {
+				// Force `printraw()` to have a newline at end of print to prevent
+				// timestamps from looking broken.
+				const PackedByteArray array = (timestamp + string_buf + "\n").to_utf8_buffer();
+				const uint8_t *buf_ts = array.ptr();
+				const int buf_ts_size = array.size();
+				store_to_log(file, buf_ts, buf_ts_size);
+			}
+		} else {
+			store_to_log(file, buf, len);
+		}
 
 		if (len >= static_buf_size) {
 			Memory::free_static(buf);
@@ -233,14 +276,27 @@ void RotatedFileLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	}
 }
 
+bool StdLogger::_print_timestamps = false;
+
+void StdLogger::set_print_timestamps(bool value) {
+	_print_timestamps = value;
+}
+
 void StdLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 	if (!should_log(p_err)) {
 		return;
 	}
 
+	const char *timestamp = "";
+	if (_print_timestamps) {
+		timestamp = (Time::get_singleton()->get_datetime_string_from_system() + Time::get_singleton()->get_offset_string_from_offset_minutes(Time::get_singleton()->get_time_zone_from_system()["bias"]) + " | ").utf8().ptr();
+	}
+
 	if (p_err) {
+		fprintf(stderr, "%s", timestamp);
 		vfprintf(stderr, p_format, p_list);
 	} else {
+		printf("%s", timestamp);
 		vprintf(p_format, p_list);
 		if (_flush_stdout_on_print) {
 			// Don't always flush when printing stdout to avoid performance

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -68,7 +68,11 @@ public:
  * Writes messages to stdout/stderr.
  */
 class StdLogger : public Logger {
+	static bool _print_timestamps;
+
 public:
+	static void set_print_timestamps(bool p_value);
+
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
 	virtual ~StdLogger() {}
 };
@@ -83,15 +87,20 @@ class RotatedFileLogger : public Logger {
 	String base_path;
 	int max_files;
 
+	static bool _log_timestamps;
+
 	Ref<FileAccess> file;
 
 	void clear_old_backups();
 	void rotate_file();
+	void store_to_log(const Ref<FileAccess> p_file, const uint8_t *p_buf, int p_len);
 
 	Ref<RegEx> strip_ansi_regex;
 
 public:
 	explicit RotatedFileLogger(const String &p_base_path, int p_max_files = 10);
+
+	static void set_log_timestamps(bool p_value);
 
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
 };

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1189,6 +1189,10 @@
 		<member name="run/output/max_lines" type="int" setter="" getter="">
 			Maximum number of lines to show at any one time in the Output panel.
 		</member>
+		<member name="run/output/show_timestamps" type="bool" setter="" getter="">
+			If [code]true[/code], prefix all lines in the Output panel with timestamps in local time in the following format: [code]YYYY-MM-DD HH:MM:SS |[/code].
+			[b]Note:[/b] [member run/output/show_timestamps] does not affect standard output/error and file logging, which are controlled by [member ProjectSettings.application/run/print_timestamps_in_stdout] and [member ProjectSettings.debug/file_logging/log_timestamps] instead.
+		</member>
 		<member name="run/platforms/linuxbsd/prefer_wayland" type="bool" setter="" getter="">
 			If [code]true[/code], on Linux/BSD, the editor will check for Wayland first instead of X11 (if available).
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -385,6 +385,11 @@
 		<member name="application/run/print_header" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], the engine header is printed in the console on startup. This header describes the current version of the engine, as well as the renderer being used. This behavior can also be disabled on the command line with the [code]--no-header[/code] option.
 		</member>
+		<member name="application/run/print_timestamps_in_stdout" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], prefix all lines in standard output and error streams with ISO 8601 timestamps in local time in the following format: [code]YYYY-MM-DDTHH:MM:SS+HH:MM |[/code]. The timezone offset is denoted by [code]+HH:MM[/code] at the end. See also [member debug/file_logging/log_timestamps].
+			[b]Note:[/b] This setting does not affect the editor's Output panel. This is controlled by [member EditorSettings.run/output/show_timestamps] instead.
+			[b]Note:[/b] This setting only affects the project itself, not the editor's own output.
+		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.
 		</member>
@@ -485,6 +490,9 @@
 		<member name="debug/file_logging/log_path" type="String" setter="" getter="" default="&quot;user://logs/godot.log&quot;">
 			Path at which to store log files for the project. Using a path under [code]user://[/code] is recommended.
 			This can be specified manually on the command line using the [code]--log-file &lt;file&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url]. If this command line argument is specified, log rotation is automatically disabled (see [member debug/file_logging/max_log_files]).
+		</member>
+		<member name="debug/file_logging/log_timestamps" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], prefix all lines with ISO 8601 timestamps in local time in the following format: [code]YYYY-MM-DDTHH:MM:SS+HH:MM |[/code]. The timezone offset is denoted by [code]+HH:MM[/code] at the end. See also [member application/run/print_timestamps_in_stdout].
 		</member>
 		<member name="debug/file_logging/max_log_files" type="int" setter="" getter="" default="5">
 			Specifies the maximum number of log files allowed (used for rotation). Set to [code]1[/code] to disable log file rotation.

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -74,6 +74,7 @@ private:
 		Ref<Texture2D> warning_icon;
 
 		Color message_color;
+		Color timestamp_color;
 	} theme_cache;
 
 	// Encapsulates all data and functionality regarding filters.
@@ -127,6 +128,9 @@ private:
 	Vector<LogMessage> messages;
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	HashMap<MessageType, LogFilter *> type_filter_map;
+
+	// Caches the value of the Show Timestamps editor setting.
+	bool show_timestamps = false;
 
 	RichTextLabel *log = nullptr;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1014,6 +1014,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("run/output/always_clear_output_on_play", true, true);
 
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "run/output/max_lines", 10000, "100,100000,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "run/output/font_size", 13, "8,48,1")
+	_initial_set("run/output/show_timestamps", false);
 
 	// Platform
 	_initial_set("run/platforms/linuxbsd/prefer_wayland", false, true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -992,6 +992,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_RST("application/run/flush_stdout_on_print", false);
 	GLOBAL_DEF_RST("application/run/flush_stdout_on_print.debug", true);
 
+	GLOBAL_DEF_RST("application/run/print_timestamps_in_stdout", false);
+
 	MAIN_PRINT("Main: Parse CMDLine");
 
 	/* argument parsing and main creation */
@@ -2118,6 +2120,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("debug/file_logging/enable_file_logging.pc", true);
 	GLOBAL_DEF("debug/file_logging/log_path", "user://logs/godot.log");
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/file_logging/max_log_files", PROPERTY_HINT_RANGE, "0,20,1,or_greater"), 5);
+	GLOBAL_DEF("debug/file_logging/log_timestamps", true);
 
 	// If `--log-file` is used to override the log path, allow creating logs for the project manager or editor
 	// and even if file logging is disabled in the Project Settings.
@@ -2177,6 +2180,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	Logger::set_flush_stdout_on_print(GLOBAL_GET("application/run/flush_stdout_on_print"));
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		StdLogger::set_print_timestamps(GLOBAL_GET("application/run/print_timestamps_in_stdout"));
+	}
+	RotatedFileLogger::set_log_timestamps(GLOBAL_GET("debug/file_logging/log_timestamps"));
 
 	// Rendering drivers configuration.
 


### PR DESCRIPTION
Timestamps use ISO 8601 format, prefixing every printed line with `YYYY-MM-DDTHH:MM:SS+HH:MM |`. `+HH:MM` at the end denotes the timezone offset. In the editor, they use `YYYY-MM-DD HH:MM:SS` for better readability. Both are printed in local time.

Timestamp display can be toggled separately for stdout/stderr and file loggers in the Project Settings. By default, timestamps are logged to files, are not printed in stdout/stderr and are not shown in the editor Output panel. The "compact identical lines" option in the editor Output panel works correctly when timestamps are shown, with the timestamp becoming the time of the latest print.

- This closes https://github.com/godotengine/godot-proposals/issues/1786.

## TODO

- [ ] Handle multiline strings in stdout (each line should have a timestamp). This is already done in the editor Output panel and file logging.
- [ ] Optimize code to query date/time only once (or perhaps twice) per second at most, as this can take a non-negligible amount of time if printing lots of lines at the same time.
  - Currently, in a debug build, `master` takes 1.8s to log and print 200,000 lines (with stdout not being displayed in terminal), and this PR takes 3.1s.[^1]
    - In an optimized build, this same operation takes 1.6s in `master` and this PR takes 2.2s.[^1]

[^1]: These metrics include engine startup and shutdown, as this was measured using `hyperfine` and the `--quit` CLI argument.

### Example log file

```log
2023-07-16T00:01:15+02:00 | Godot Engine v4.2.dev.custom_build.6b39157b9 - https://godotengine.org
2023-07-16T00:01:15+02:00 | Vulkan API 1.3.242 - Forward+ - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce RTX 4090
2023-07-16T00:01:16+02:00 |  
2023-07-16T00:01:16+02:00 | Test message.
2023-07-16T00:01:16+02:00 | 
2023-07-16T00:01:16+02:00 | Test message.
2023-07-16T00:01:16+02:00 | Test message 2.
2023-07-16T00:01:16+02:00 | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam est sapien, hendrerit a leo a, accumsan condimentum magna. Aliquam et nisl et nisi aliquet elementum ac id sapien. Cras nec rutrum risus. Suspendisse vel urna vel ante posuere varius ac sit amet nibh. Pellentesque ante est, venenatis a laoreet ut, aliquam quis nulla. Donec interdum malesuada lorem, in egestas augue ultricies quis. Integer sagittis dolor nunc, in ullamcorper felis scelerisque cursus. Nulla suscipit ut velit at vehicula. Nulla tempor dui nec fermentum porttitor. Sed ullamcorper hendrerit dictum. Curabitur non accumsan velit. Praesent eleifend dolor magna, tristique vehicula lacus dignissim at. Cras vel ultrices ipsum, quis condimentum sapien. Proin ut tortor varius, egestas nulla ut, aliquam nisi. Maecenas eu mi nec tellus pulvinar posuere ac a risus. Suspendisse nisl metus, fermentum vel tortor sit amet, mollis dapibus tortor. Etiam luctus ante elit, nec ultrices est dignissim a. Aenean vel facilisis nibh. Praesent eros leo, luctus non convallis quis, finibus et arcu. In ac elementum augue. Maecenas efficitur tortor eros, nec cursus est sagittis posuere. Curabitur bibendum posuere risus, vel rutrum lacus fermentum non. Sed quis quam eget justo posuere dictum. Donec nec feugiat libero. Donec suscipit dui at leo vestibulum, eget efficitur sapien porta. Maecenas et nunc vel nibh egestas sagittis eget nec nibh. Mauris fermentum est at aliquet auctor. Morbi a erat eget lectus porttitor maximus id vel diam. Proin et sodales leo. Fusce suscipit tincidunt porta. Donec sed turpis vel nulla lobortis rhoncus. Sed sollicitudin eget nulla quis blandit. Aliquam cursus porttitor neque et eleifend. Pellentesque efficitur finibus erat. Aliquam hendrerit arcu at elit feugiat molestie. Donec consectetur, nisi id tempus luctus, velit tellus auctor lorem, vitae facilisis urna ex eget felis. Morbi nec purus enim. Integer et quam tincidunt, interdum neque vel, ultricies sapien. Donec lobortis metus ipsum, id semper diam maximus ut. Mauris a felis et mauris ullamcorper viverra vitae in massa. Proin egestas felis euismod sapien sagittis ultricies. Quisque suscipit tristique ligula, a blandit lorem aliquet id. Quisque feugiat id est tristique cursus. Sed tincidunt eros ac ipsum consectetur tempus. Sed lacinia, sapien in dictum consectetur, tortor sapien malesuada orci, sit amet elementum lacus lorem a ante. Etiam ultricies, urna finibus maximus iaculis, nibh velit egestas nibh, et efficitur nibh nibh vitae sapien. Morbi quis suscipit est, nec rutrum elit. Pellentesque at mattis elit. Aliquam nulla urna, vehicula suscipit justo a, cursus dignissim ipsum. Curabitur finibus vestibulum aliquet. Nam scelerisque justo sed bibendum tempus. Aliquam erat volutpat. Aliquam eget malesuada ex. In hac habitasse platea dictumst. Suspendisse tempus dolor vitae dignissim aliquet. Sed magna dolor, euismod eget fringilla non, imperdiet et libero. 
```