### PR TITLE
Fix calling `TextureStorage::texture_3d_update()` could cause a crash

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1153,8 +1153,8 @@ void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &
 				image = image->duplicate();
 				image->convert(tex->validated_format);
 			}
-			all_data_size += images[i]->get_data().size();
-			images.push_back(image);
+			all_data_size += image->get_data().size();
+			images.write[i] = image;
 		}
 
 		all_data.resize(all_data_size); //consolidate all data here


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fix #77248.