### PR TITLE
CSharpScript should not own method infos of the base class

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1652,18 +1652,7 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 }
 
 void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
-	if (!script->is_valid() || !script->valid) {
-		return;
-	}
-
-	const CSharpScript *top = script.ptr();
-	while (top != nullptr) {
-		for (const CSharpScript::CSharpMethodInfo &E : top->methods) {
-			p_list->push_back(E.method_info);
-		}
-
-		top = top->base_script.ptr();
-	}
+	script->get_script_method_list(p_list);
 }
 
 bool CSharpInstance::has_method(const StringName &p_method) const {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -615,7 +615,7 @@ namespace Godot.Bridge
                 Type? top = scriptType;
                 Type native = GodotObject.InternalGetClassNativeBase(top);
 
-                while (top != null && top != native)
+                if (top != null && top != native)
                 {
                     var methodList = GetMethodListForType(top);
 
@@ -647,8 +647,6 @@ namespace Godot.Bridge
                             methods.Add(methodInfo);
                         }
                     }
-
-                    top = top.BaseType;
                 }
 
                 *outMethodsDest = NativeFuncs.godotsharp_array_new_copy(


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

CSharpScript::methods should only hold methods defined by current class.

Previous implementation stores methods defined by current class and all base classes, thus 
result returned by CSharpInstance::get_method_list (which gather all method infos from current to base classes) contains duplicated method infos of base class.

The duplication can be visualized in method picking dialogue of signal connection dialogue panel.

For example, there are two C# scripts

```csharp
// Test.cs
using Godot;

public partial class Test : TestBase
{
    public void Bar()
    {
        GD.Print("C# Bar");
    }
}
```

```csharp
// TestBase.cs
using Godot;

public partial class TestBase : Node3D
{
    public void Foo()
    {
        GD.Print("C# Base");
    }
}
```

Attach the `Test` class to a node, and try to connect a signal to it. In method picking dialogue, the `Foo` method defined by `TestBase` is duplicated twice.

<img width="399" alt="Screenshot 2023-05-20 at 16 08 22" src="https://github.com/godotengine/godot/assets/22026948/268f58d4-5c6d-4707-8057-9b1e4bac3047">

This pr fix the duplication issue. The behaviour of methods like `CSharpScript::has_method`, `CSharpInstance::get_method_list` are consistent with the corresponding methods of GDScript.
