### PR TITLE
Fix unnecessary break when calculating the height of visible lines

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -290,9 +290,6 @@ void Label::_update_visible() {
 	int last_line = MIN(lines_rid.size(), lines_visible + lines_skipped);
 	for (int64_t i = lines_skipped; i < last_line; i++) {
 		minsize.height += TS->shaped_text_get_size(lines_rid[i]).y + line_spacing;
-		if (minsize.height > (get_size().height - style->get_minimum_size().height + line_spacing)) {
-			break;
-		}
 	}
 }
 


### PR DESCRIPTION
This break causes the minsize to be smaller than expected, and then the size keeps increasing by one line to cover all visible lines. This can cause performance issues when there are many visible lines.


Fix  #77268.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
