### PR TITLE
Expose get_window_id() from Window class

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -194,6 +194,12 @@
 				See [method Control.get_theme_color] for details.
 			</description>
 		</method>
+		<method name="get_window_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the ID of the window.
+			</description>
+		</method>
 		<method name="grab_focus">
 			<return type="void" />
 			<description>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2478,6 +2478,8 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);
 
+	ClassDB::bind_method(D_METHOD("get_window_id"), &Window::get_window_id);
+
 	ClassDB::bind_method(D_METHOD("set_initial_position", "initial_position"), &Window::set_initial_position);
 	ClassDB::bind_method(D_METHOD("get_initial_position"), &Window::get_initial_position);
 


### PR DESCRIPTION
Window classes often need a Window ID for operations. This will help with performing operations on cached Windows.

Closes #76934 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
