### PR TITLE
Add `dump()` and `dump_string()` global scope methods

### DIFF
--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -76,6 +76,12 @@ inline void print_line_rich(const Variant &v) {
 	__print_line_rich(stringify_variants(v));
 }
 
+#ifdef DEBUG_ENABLED
+inline void dump(Variant v) {
+	__print_line_rich(v.dump(0));
+}
+#endif
+
 template <typename... Args>
 void print_line(const Variant &p_var, Args... p_args) {
 	__print_line(stringify_variants(p_var, p_args...));

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -829,6 +829,7 @@ public:
 	bool identity_compare(const Variant &p_variant) const;
 	bool booleanize() const;
 	String stringify(int recursion_count = 0) const;
+	String dump(int recursion_count = 0) const;
 	String to_json_string() const;
 
 	static void get_constants_for_type(Variant::Type p_type, List<StringName> *p_constants);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1119,6 +1119,23 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 	r_error.error = Callable::CallError::CALL_OK;
 }
 
+Variant VariantUtilityFunctions::dump(const Variant &p_variant) {
+#ifdef DEBUG_ENABLED
+	::dump(p_variant);
+#else
+	print_line(p_variant);
+#endif
+	return p_variant;
+}
+
+String VariantUtilityFunctions::dump_string(const Variant &p_variant) {
+#ifdef DEBUG_ENABLED
+	return p_variant.dump();
+#else
+	return p_variant.operator String();
+#endif
+}
+
 String VariantUtilityFunctions::var_to_str(const Variant &p_var) {
 	String vars;
 	VariantWriter::write_to_string(p_var, vars);
@@ -1835,6 +1852,9 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDVARARGV_CNAME(print_verbose, _print_verbose, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_error, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDVARARGV(push_warning, sarray(), Variant::UTILITY_FUNC_TYPE_GENERAL);
+
+	FUNCBINDR(dump, sarray("variant"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(dump_string, sarray("variant"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
 	FUNCBINDR(var_to_str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(str_to_var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -139,6 +139,8 @@ struct VariantUtilityFunctions {
 	static void printraw(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void push_error(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void push_warning(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
+	static Variant dump(const Variant &p_variant);
+	static String dump_string(const Variant &p_variant);
 	static String var_to_str(const Variant &p_var);
 	static Variant str_to_var(const String &p_var);
 	static PackedByteArray var_to_bytes(const Variant &p_var);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -362,6 +362,28 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="dump">
+			<return type="Variant" />
+			<param index="0" name="variant" type="Variant" />
+			<description>
+				Prints a value with type information and rich formatting to improve the debugging experience. Unlike [method print], this returns the evaluated value, so you can insert it in the middle of existing code as follows:
+				[codeblock]
+				dump("Hello world!")  # Prints `"Hello world!"` with visible quotes to denote that this is a String.
+				var example = dump(123)  # Prints `123`. `example` now contains 123 as an integer (not a string).
+				[/codeblock]
+				See also [method dump_string].
+				[b]Note:[/b] In release export templates, [method dump] doesn't apply any formatting and acts like [method print] (while still returning the value it evaluates, unlike [method print]).
+			</description>
+		</method>
+		<method name="dump_string">
+			<return type="String" />
+			<param index="0" name="variant" type="Variant" />
+			<description>
+				Returns a [String] containing the passed [param variant] type information and BBCode formatting to improve the debugging experience. The returned value can be displayed in a [RichTextLabel] node with [member RichTextLabel.bbcode_enabled] set to [code]true[/code], or displayed in a [method print_rich] statement.
+				See also [method dump].
+				[b]Note:[/b] In release export templates, [method dump_string] doesn't apply any formatting and acts like [method str].
+			</description>
+		</method>
 		<method name="ease" keywords="smooth">
 			<return type="float" />
 			<param index="0" name="x" type="float" />
@@ -857,6 +879,7 @@
 				GD.Print("a", "b", a); // Prints "ab[1, 2, 3]"
 				[/csharp]
 				[/codeblocks]
+				For debugging, [method dump] is preferable as it provides additional information and also returns the value it's evaluating.
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed. See also [member Engine.print_to_stdout] and [member ProjectSettings.application/run/disable_stdout].
 			</description>
 		</method>
@@ -875,6 +898,7 @@
 				GD.PrintRich("[color=green][b]Hello world![/b][/color]"); // Prints "Hello world!", in green with a bold font.
 				[/csharp]
 				[/codeblocks]
+				For debugging, [method dump] is preferable as it provides additional information.
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed.
 				[b]Note:[/b] On Windows, only Windows 10 and later correctly displays ANSI escape codes in standard output.
 				[b]Note:[/b] Output displayed in the editor supports clickable [code skip-lint][url=address]text[/url][/code] tags. The [code skip-lint][url][/code] tag's [code]address[/code] value is handled by [method OS.shell_open] when clicked.

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -185,6 +185,7 @@
 				# Create instance of a scene.
 				var diamond = preload("res://diamond.tscn").instantiate()
 				[/codeblock]
+				For debugging, [method @GlobalScope.dump] is preferable as it provides additional information.
 				[b]Note:[/b] [method preload] is a keyword, not a function. So you cannot access it as a [Callable].
 			</description>
 		</method>
@@ -197,6 +198,7 @@
 				Test print
 				At: res://test.gd:15:_process()
 				[/codeblock]
+				For debugging, [method @GlobalScope.dump] is preferable as it provides additional information.
 				[b]Note:[/b] Calling this function from a [Thread] is not supported. Doing so will instead print the thread ID.
 			</description>
 		</method>


### PR DESCRIPTION
`dump()` prints a value with formatting and additional information while returning the value. This makes for more convenient debugging.

`dump_string()` returns the formatted string as BBCode, which can be displayed in a RichTextLabel node or with a `print_rich()` statement.

In release builds, `dump()` acts like `print()` and `dump_string()` acts like `str()`.

A non-rich `dump_string()` variant could be added for display in Label and Label3D, but this is best done with https://github.com/godotengine/godot/pull/78310 as to avoid code duplication.

- See https://github.com/godotengine/godot-proposals/issues/538.

**Testing project:** [test_dump.zip](https://github.com/godotengine/godot/files/11523265/test_dump.zip)

## Preview

### RichTextLabel

![Screenshot_20230715_210932](https://github.com/godotengine/godot/assets/180032/de6875d9-a356-42db-9ca1-ab55ae57036a)

### Terminal output (VS Code)

- ~~*Note: Truecolor ANSI code conversion is not implemented in terminal output yet. This issue is independent of this PR.*~~
  - **Edit:** This is now fixed now that https://github.com/godotengine/godot/pull/98118 has been merged. Colors can be previewed in terminal output just like in the editor Output panel (not shown on the screenshot).

![Screenshot_20230715_211003](https://github.com/godotengine/godot/assets/180032/8d3011fa-227c-40b0-83a5-57cead5af7da)

### Editor Output panel

- *Note: Colors will be improved by https://github.com/godotengine/godot/pull/77114.*

![Screenshot_20230715_210948](https://github.com/godotengine/godot/assets/180032/c1b25b35-4a58-4915-9149-6904442e44e9)