### PR TITLE
Disable padding around highlighted rich text in the editor Output panel

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -90,6 +90,11 @@ void EditorLog::_update_theme() {
 		log->add_theme_font_override("mono_font", mono_font);
 	}
 
+	// Disable padding for highlighted background/foreground to prevent highlights from overlapping on close lines.
+	// This also better matches terminal output, which does not use any form of padding.
+	log->add_theme_constant_override("text_highlight_h_padding", 0);
+	log->add_theme_constant_override("text_highlight_v_padding", 0);
+
 	const int font_size = get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts"));
 	log->add_theme_font_size_override("normal_font_size", font_size);
 	log->add_theme_font_size_override("bold_font_size", font_size);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/77114 (can be merged independently).

This prevents `[bgcolor]` and `[fgcolor]` rendering from overlapping on nearby characters (especially on the line below).

This also makes it look closer to terminal output (which never uses padding).

**Testing project:** [test_print_rich_bgcolor.zip](https://github.com/godotengine/godot/files/11523263/test_print_rich_bgcolor.zip)

## Preview

Before | After
-|-
![Screenshot_20230521_000451](https://github.com/godotengine/godot/assets/180032/f3e5c0d3-a465-4b5b-91c6-5682d1bc53f5) | ![Screenshot_20230521_000426](https://github.com/godotengine/godot/assets/180032/ee847c41-fb8e-4f36-b665-6c3a8a566ed5)