### PR TITLE
Add Ctrl + A and Ctrl + Shift + A to (de)select all projects in project manager

### DIFF
--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1176,6 +1176,22 @@ void ProjectList::select_first_visible_project() {
 	}
 }
 
+void ProjectList::deselect_all_visible_projects() {
+	for (int i = 0; i < _projects.size(); i++) {
+		if (_projects[i].control->is_visible()) {
+			_deselect_project_nocheck(i);
+		}
+	}
+}
+
+void ProjectList::select_all_visible_projects() {
+	for (int i = 0; i < _projects.size(); i++) {
+		if (_projects[i].control->is_visible()) {
+			_select_project_nocheck(i);
+		}
+	}
+}
+
 Vector<ProjectList::Item> ProjectList::get_selected_projects() const {
 	Vector<Item> items;
 	if (_selected_project_paths.is_empty()) {

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -283,6 +283,8 @@ public:
 	void select_project(int p_index);
 	void deselect_project(int p_index);
 	void select_first_visible_project();
+	void select_all_visible_projects();
+	void deselect_all_visible_projects();
 	Vector<Item> get_selected_projects() const;
 	const HashSet<String> &get_selected_project_keys() const;
 	int get_single_selected_index() const;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1238,6 +1238,16 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 					keycode_handled = false;
 				}
 			} break;
+			case Key::A: {
+				if (k->is_command_or_control_pressed()) {
+					if (k->is_shift_pressed()) {
+						project_list->deselect_all_visible_projects();
+					} else {
+						project_list->select_all_visible_projects();
+					}
+					_update_project_buttons();
+				}
+			} break;
 			default: {
 				keycode_handled = false;
 			} break;


### PR DESCRIPTION
These keyboard shortcuts are commonly used in applications to (de)select all entries in a list.
