### PR TITLE
Take 3D resolution scaling into account for mesh LOD

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -964,7 +964,12 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 		scene_data.z_far = p_camera_data->main_projection.get_z_far();
 
 		// this should be the same for all cameras..
-		scene_data.lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
+		const float lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
+
+		// Also, take into account resolution scaling for the multiplier, since we have more leeway with quality
+		// degradation visibility. Conversely, allow upwards scaling, too, for increased mesh detail at high res.
+		const float scaling_3d_scale = GLOBAL_GET("rendering/scaling_3d/scale");
+		scene_data.lod_distance_multiplier = lod_distance_multiplier * (1.0 / scaling_3d_scale);
 
 		if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_DISABLE_LOD) {
 			scene_data.screen_mesh_lod_threshold = 0.0;


### PR DESCRIPTION
Lower mesh quality is less visible on lower resolution. More obvious on higher resolution. Scale in both directions for either additional performance or consistent quality.

Closes #68484 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
