### PR TITLE
Auto quadrant resizing for TileMap

### DIFF
--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/vector2i.h"
 #include "core/string/ustring.h"
+#include "thirdparty/oidn/mkl-dnn/src/common/math_utils.hpp"
 
 real_t Vector2::angle() const {
 	return Math::atan2(y, x);
@@ -129,6 +130,10 @@ Vector2 Vector2::project(const Vector2 &p_to) const {
 	return p_to * (dot(p_to) / p_to.length_squared());
 }
 
+Vector2 Vector2::aspect_ratio() const {
+	int divisor = mkldnn::impl::math::gcd(x, y);
+	return Vector2(x / divisor, y / divisor);
+}
 Vector2 Vector2::clamp(const Vector2 &p_min, const Vector2 &p_max) const {
 	return Vector2(
 			CLAMP(x, p_min.x, p_max.x),

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -170,6 +170,8 @@ struct _NO_DISCARD_ Vector2 {
 	Vector2 snapped(const Vector2 &p_by) const;
 	Vector2 clamp(const Vector2 &p_min, const Vector2 &p_max) const;
 	real_t aspect() const { return width / height; }
+	Vector2 aspect_ratio() const;
+	real_t area() const { return width * height; }
 
 	operator String() const;
 	operator Vector2i() const;

--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -32,6 +32,7 @@
 
 #include "core/math/vector2.h"
 #include "core/string/ustring.h"
+#include "thirdparty/oidn/mkl-dnn/src/common/math_utils.hpp"
 
 Vector2i Vector2i::clamp(const Vector2i &p_min, const Vector2i &p_max) const {
 	return Vector2i(
@@ -51,6 +52,11 @@ int64_t Vector2i::length_squared() const {
 
 double Vector2i::length() const {
 	return Math::sqrt((double)length_squared());
+}
+
+Vector2i Vector2i::aspect_ratio() const {
+	int divisor = mkldnn::impl::math::gcd(x, y);
+	return Vector2i(x / divisor, y / divisor);
 }
 
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -116,10 +116,12 @@ struct _NO_DISCARD_ Vector2i {
 	double length() const;
 
 	real_t aspect() const { return width / (real_t)height; }
+	Vector2i aspect_ratio() const;
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
 	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 	Vector2i snapped(const Vector2i &p_step) const;
+	real_t area() const { return width * height; }
 
 	operator String() const;
 	operator Vector2() const;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -474,26 +474,22 @@ int TileMap::get_effective_quadrant_size(int p_layer) const {
 	if (is_y_sort_enabled() && layers[p_layer].y_sort_enabled) {
 		return 1;
 	} else if (is_auto_quadrant_resize_enabled()) {
-		return get_auto_resized_quadrant();
+		return get_auto_resized_quadrant(p_layer);
 	}
 	return quadrant_size;
 }
 
-int TileMap::get_auto_resized_quadrant() const {
-	tile_changes_counter++;
-	if (tile_changes_counter < auto_quadrant_threshold) {
-		return quadrant_size;
+int TileMap::get_auto_resized_quadrant(int p_layer) const {
+	int to_calc = get_used_cells(p_layer).size();
+
+	if (to_calc < 128) {
+		to_calc > 1 ? to_calc += 0 : to_calc = 1;
+		return to_calc;
 	}
-	tile_changes_counter = 0;
-	int to_calc = 0;
-	int layer_count = get_layers_count();
-	for (int layer_id = 0; layer_id < layer_count; layer_id++) {
-		to_calc += get_used_cells(layer_id).size();
-	}
+
 
 	// get the minimum divisor unless it's a prime,
 	// if it is, return itself.
-
 	// Fermat test, for now (but with the sqrt as a limitation and/or assumption).
 	int sqr_to_calc = round(sqrt(to_calc));
 	for (int a = 2; a < sqr_to_calc; a++) {
@@ -592,18 +588,6 @@ void TileMap::set_auto_quadrant_resize_enabled(bool p_enabled) {
 		return;
 	}
 	auto_quadrant_resize = p_enabled;
-}
-
-void TileMap::set_auto_quadrant_threshold(int p_threshold) {
-	ERR_FAIL_COND_MSG(!is_auto_quadrant_resize_enabled(), "automatic quadrant resizing is disabled. It won't matter.");
-	if (auto_quadrant_threshold == p_threshold) {
-		return;
-	}
-	auto_quadrant_threshold = p_threshold;
-}
-
-int TileMap::get_auto_quadrant_threshold() const {
-	return auto_quadrant_threshold;
 }
 
 int TileMap::get_layers_count() const {
@@ -4183,8 +4167,6 @@ void TileMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_auto_quadrant_resize_enabled", "enabled"), &TileMap::set_auto_quadrant_resize_enabled);
 	ClassDB::bind_method(D_METHOD("is_auto_quadrant_resize_enabled"), &TileMap::is_auto_quadrant_resize_enabled);
-	ClassDB::bind_method(D_METHOD("set_auto_quadrant_threshold", "threshold"), &TileMap::set_auto_quadrant_threshold);
-	ClassDB::bind_method(D_METHOD("get_auto_quadrant_threshold"), &TileMap::get_auto_quadrant_threshold);
 
 	ClassDB::bind_method(D_METHOD("get_layers_count"), &TileMap::get_layers_count);
 	ClassDB::bind_method(D_METHOD("add_layer", "to_position"), &TileMap::add_layer);
@@ -4257,7 +4239,6 @@ void TileMap::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tile_set", PROPERTY_HINT_RESOURCE_TYPE, "TileSet"), "set_tileset", "get_tileset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_quadrant_resize"), "set_auto_quadrant_resize_enabled", "is_auto_quadrant_resize_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_quadrant_threshold", PROPERTY_HINT_RANGE, "0,128,1"), "set_auto_quadrant_threshold", "get_auto_quadrant_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cell_quadrant_size", PROPERTY_HINT_RANGE, "1,128,1"), "set_quadrant_size", "get_quadrant_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_animatable"), "set_collision_animatable", "is_collision_animatable");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_visibility_mode", PROPERTY_HINT_ENUM, "Default,Force Show,Force Hide"), "set_collision_visibility_mode", "get_collision_visibility_mode");

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -190,11 +190,6 @@ private:
 	VisibilityMode collision_visibility_mode = VISIBILITY_MODE_DEFAULT;
 	VisibilityMode navigation_visibility_mode = VISIBILITY_MODE_DEFAULT;
 
-	// auto quadrant resizing.
-	bool auto_quadrant_resize = true; // So the user should handle it only if needed.
-	/* int auto_quadrant_threshold = 16; */
-	/* mutable int tile_changes_counter = 0; */
-
 	// Updates.
 	bool pending_update = false;
 
@@ -318,12 +313,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	void set_auto_quadrant_resize_enabled(bool p_enabled);
-	bool is_auto_quadrant_resize_enabled() const;
-
-	void set_auto_quadrant_threshold(int p_threshold);
-	int get_auto_quadrant_threshold() const;
-																						 //
+	void auto_resize_quadrant();
 	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
 
 	// Layers management.
@@ -386,7 +376,6 @@ public:
 	TileMapCell get_cell(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	HashMap<Vector2i, TileMapQuadrant> *get_quadrant_map(int p_layer);
 	int get_effective_quadrant_size(int p_layer) const;
-	int get_auto_resized_quadrant(int p_layer) const;
 	//---
 
 	virtual void set_y_sort_enabled(bool p_enable) override;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -158,7 +158,6 @@ public:
 		int get_priority() const {
 			return priority;
 		}
-
 		TerrainConstraint(const TileMap *p_tile_map, const Vector2i &p_position, int p_terrain); // For the center terrain bit
 		TerrainConstraint(const TileMap *p_tile_map, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain); // For peering bits
 		TerrainConstraint(){};
@@ -310,10 +309,11 @@ public:
 	void set_tileset(const Ref<TileSet> &p_tileset);
 	Ref<TileSet> get_tileset() const;
 
+	void auto_resize_quadrants();
+
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	void auto_resize_quadrant();
 	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
 
 	// Layers management.

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -190,6 +190,11 @@ private:
 	VisibilityMode collision_visibility_mode = VISIBILITY_MODE_DEFAULT;
 	VisibilityMode navigation_visibility_mode = VISIBILITY_MODE_DEFAULT;
 
+	// auto quadrant resizing.
+	bool auto_quadrant_resize = true; // So the user should handle it only if needed.
+	int auto_quadrant_threshold = 16;
+	mutable int tile_changes_counter = 0;
+
 	// Updates.
 	bool pending_update = false;
 
@@ -313,6 +318,12 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
+	void set_auto_quadrant_resize_enabled(bool p_enabled);
+	bool is_auto_quadrant_resize_enabled() const;
+
+	void set_auto_quadrant_threshold(int p_threshold);
+	int get_auto_quadrant_threshold() const;
+																						 //
 	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, Color p_modulation = Color(1.0, 1.0, 1.0, 1.0), const TileData *p_tile_data_override = nullptr);
 
 	// Layers management.
@@ -375,6 +386,7 @@ public:
 	TileMapCell get_cell(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	HashMap<Vector2i, TileMapQuadrant> *get_quadrant_map(int p_layer);
 	int get_effective_quadrant_size(int p_layer) const;
+	int get_auto_resized_quadrant() const;
 	//---
 
 	virtual void set_y_sort_enabled(bool p_enable) override;

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -192,8 +192,8 @@ private:
 
 	// auto quadrant resizing.
 	bool auto_quadrant_resize = true; // So the user should handle it only if needed.
-	int auto_quadrant_threshold = 16;
-	mutable int tile_changes_counter = 0;
+	/* int auto_quadrant_threshold = 16; */
+	/* mutable int tile_changes_counter = 0; */
 
 	// Updates.
 	bool pending_update = false;
@@ -386,7 +386,7 @@ public:
 	TileMapCell get_cell(int p_layer, const Vector2i &p_coords, bool p_use_proxies = false) const;
 	HashMap<Vector2i, TileMapQuadrant> *get_quadrant_map(int p_layer);
 	int get_effective_quadrant_size(int p_layer) const;
-	int get_auto_resized_quadrant() const;
+	int get_auto_resized_quadrant(int p_layer) const;
 	//---
 
 	virtual void set_y_sort_enabled(bool p_enable) override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -39,6 +39,7 @@
 #include "scene/scene_string_names.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
+#include "scene/2d/camera_2d.h"
 
 // Dynamic properties.
 
@@ -366,6 +367,14 @@ Point2i Window::get_position_with_decorations() const {
 	}
 	return position;
 }
+
+Size2i Window::get_size_with_camera_2d() const {
+	if (get_camera_2d()) {
+		return (Size2(get_size()) / get_camera_2d()->get_zoom()).round();
+	}
+	return get_size();
+}
+
 
 Size2i Window::get_size_with_decorations() const {
 	ERR_READ_THREAD_GUARD_V(Size2i());
@@ -2515,6 +2524,8 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reset_size"), &Window::reset_size);
 
 	ClassDB::bind_method(D_METHOD("get_position_with_decorations"), &Window::get_position_with_decorations);
+
+	ClassDB::bind_method(D_METHOD("get_size_with_camera_2d"), &Window::get_size_with_camera_2d);
 	ClassDB::bind_method(D_METHOD("get_size_with_decorations"), &Window::get_size_with_decorations);
 
 	ClassDB::bind_method(D_METHOD("set_max_size", "max_size"), &Window::set_max_size);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -238,6 +238,7 @@ public:
 
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;
+	Size2i get_size_with_camera_2d() const;
 	void reset_size();
 
 	Point2i get_position_with_decorations() const;

--- a/thirdparty/oidn/mkl-dnn/src/common/c_types_map.hpp
+++ b/thirdparty/oidn/mkl-dnn/src/common/c_types_map.hpp
@@ -17,7 +17,7 @@
 #ifndef TYPE_MAPPING_HPP
 #define TYPE_MAPPING_HPP
 
-#include "mkldnn_types.h"
+#include "../../include/mkldnn_types.h"
 
 namespace mkldnn {
 namespace impl {

--- a/thirdparty/oidn/mkl-dnn/src/common/mkldnn_traits.hpp
+++ b/thirdparty/oidn/mkl-dnn/src/common/mkldnn_traits.hpp
@@ -20,7 +20,7 @@
 #include <assert.h>
 #include <stdint.h>
 
-#include "mkldnn.h"
+#include "../../include/mkldnn.h"
 #include "c_types_map.hpp"
 #include "nstl.hpp"
 #include "utils.hpp"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

I've just had this idea that it could be useful to make some math to decide how high the cell_quadrant_size should be and give this option for the user.

It's broken right now, but I thought it would be a good idea to PR and see your thoughts about it.
(broken as in it miss some tiles when drawing).