### PR TITLE
Fix crash in FileAccessCompressed and improve error handling

### DIFF
--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -42,6 +42,7 @@ class FileAccessCompressed : public FileAccess {
 	uint32_t write_buffer_size = 0;
 	uint64_t write_max = 0;
 	uint32_t block_size = 0;
+	mutable Error last_error = OK;
 	mutable bool read_eof = false;
 	mutable bool at_end = false;
 
@@ -90,6 +91,7 @@ public:
 
 	virtual void flush() override;
 	virtual void store_8(uint8_t p_dest) override; ///< store a byte
+	virtual void store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
 	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2280,6 +2280,8 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 	f->store_buffer((const uint8_t *)"RSRC", 4); //magic at end
 
+	f->close();
+
 	if (f->get_error() != OK && f->get_error() != ERR_FILE_EOF) {
 		return ERR_CANT_CREATE;
 	}


### PR DESCRIPTION
Fixes partially https://github.com/godotengine/godot/issues/62585 (on MSVC #74582 is also required or it will just crash in `CowData::resize` before any of this matters)

Only the change in `WRITE_FIT` is strictly required to fix the crash.
The error handling improvements are required so that `ResourceSaver::save` doesn't OK when output file will be corrupted, with them it correctly returns `ERR_CANT_CREATE`.
Without the `FileAccessCompressed::store_buffer` implementation, the file writing will instead get stuck spamming errors for each byte in the buffer.
