### PR TITLE
Improve `Skeleton3D::find_bone()` performance

### DIFF
--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -125,6 +125,7 @@ private:
 	bool process_order_dirty = false;
 
 	Vector<int> parentless_bones;
+	HashMap<String, int> name_to_bone_index;
 
 	void _make_dirty();
 	bool dirty = false;


### PR DESCRIPTION
Indexing Skeleon3D bones using HashMap

results of the script from #75915 before/after this fix
before
Time find_bone(): 1055
Time Dictionary: 59

After	
Time find_bone(): 65
Time Dictionary: 57


Fix #75915