### PR TITLE
Fix incorrect Polygon2D description

### DIFF
--- a/doc/classes/Polygon2D.xml
+++ b/doc/classes/Polygon2D.xml
@@ -47,7 +47,7 @@
 			<return type="PackedFloat32Array" />
 			<param index="0" name="index" type="int" />
 			<description>
-				Returns the height values of the specified bone.
+				Returns the weight values of the specified bone.
 			</description>
 		</method>
 		<method name="set_bone_path">


### PR DESCRIPTION
Fixes the description. Should say "weight" instead of "height." Closes https://github.com/godotengine/godot-docs/issues/7383