### PR TITLE
Bind forgotten default value for `GDExtension::open_library` argument

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -524,7 +524,7 @@ void GDExtension::deinitialize_library(InitializationLevel p_level) {
 }
 
 void GDExtension::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol", "use_legacy_interface"), &GDExtension::open_library);
+	ClassDB::bind_method(D_METHOD("open_library", "path", "entry_symbol", "use_legacy_interface"), &GDExtension::open_library, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("open_library", "path", "entry_symbol"), &GDExtension::open_library_compat_76406);
 	ClassDB::bind_method(D_METHOD("close_library"), &GDExtension::close_library);
 	ClassDB::bind_method(D_METHOD("is_library_open"), &GDExtension::is_library_open);

--- a/doc/classes/GDExtension.xml
+++ b/doc/classes/GDExtension.xml
@@ -32,7 +32,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="entry_symbol" type="String" />
-			<param index="2" name="use_legacy_interface" type="bool" />
+			<param index="2" name="use_legacy_interface" type="bool" default="false" />
 			<description>
 			</description>
 		</method>


### PR DESCRIPTION
Parameter was added in #76406 but that forgot to bind the default value for the newly added parameter.

https://github.com/godotengine/godot/blob/809a98216267f3066b9fec2f02b2042bdc9d3e0d/core/extension/gdextension.h#L75