### PR TITLE
GDScript: Add errors when calling unimplemented virtual functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -115,8 +115,8 @@ class GDScriptAnalyzer {
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);
 	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false, bool p_is_readonly = false) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
-	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg, StringName *r_native_class = nullptr);
-	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, bool &r_static, bool &r_vararg);
+	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags, StringName *r_native_class = nullptr);
+	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags);
 	void validate_call_arg(const List<GDScriptParser::DataType> &p_par_types, int p_default_args_count, bool p_is_vararg, const GDScriptParser::CallNode *p_call);
 	void validate_call_arg(const MethodInfo &p_method, const GDScriptParser::CallNode *p_call);
 	GDScriptParser::DataType get_operation_type(Variant::Operator p_operation, const GDScriptParser::DataType &p_a, const GDScriptParser::DataType &p_b, bool &r_valid, const GDScriptParser::Node *p_source);

--- a/modules/gdscript/tests/scripts/analyzer/errors/virtual_method_not_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/virtual_method_not_implemented.gd
@@ -1,0 +1,2 @@
+func test():
+	_get_property_list()

--- a/modules/gdscript/tests/scripts/analyzer/errors/virtual_method_not_implemented.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/virtual_method_not_implemented.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot call virtual function "_get_property_list()" because it hasn't been defined.

--- a/modules/gdscript/tests/scripts/analyzer/errors/virtual_super_not_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/virtual_super_not_implemented.gd
@@ -1,0 +1,5 @@
+func _init():
+	super()
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/virtual_super_not_implemented.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/virtual_super_not_implemented.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot call the parent class' virtual function "_init()" because it hasn't been defined.

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
@@ -1,0 +1,11 @@
+class TestOne:
+	func _get_property_list():
+		return {}
+
+class TestTwo extends TestOne:
+	func _init():
+		var _x = _get_property_list()
+
+func test():
+	var x = TestTwo.new()
+	var _x = x._get_property_list()

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
This PR does a small refactor of how method flags are handled in the GDScript analyzer. This way, it adds support for the analyzer to use any of MethodInfo's flags, where previously it could only use `METHOD_FLAG_STATIC` and `METHOD_FLAG_VARARG`.

As a side-effect, this also normalizes behavior between editor and release templates, which fixes #76938. The error is not exactly the same, as I didn't want to make changes to core, but it should be functionally similar:

**Editor:**

![image](https://github.com/godotengine/godot/assets/1133892/f1c49ef5-02d7-4f8e-9327-7f52165b3a24)

**Template release:**

![image](https://github.com/godotengine/godot/assets/1133892/977e7ca5-8c65-4895-b5dc-f37ac72a39ff)


Also works with an extra layer of indirection, with behavior similar between `editor` & `template_release`:
```GDScript
class TestZero:
	func _init():
		pass
	
class TestOne extends TestZero:
	pass

class TestTwo extends TestOne:
	func _init():
		super()
```


The tests added also brought a different issue to light, where using `super()` appears to generate a return variable discarded on calling super's _init(), which doesn't have a return value. This should be tackled in a different PR, which will have to change the output of this PR's tests.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
