### PR TITLE
Properly clear material slots on mesh instance when material is freed

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -34,7 +34,6 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "rendering_server_default.h"
-#include "rendering_server_globals.h"
 
 #include <new>
 


### PR DESCRIPTION
The dependency code for mesh instance was simply calling `_instance_queue_update` when a material was freed. This function however does not unset the slots in which the material was used. 

This PR changes this logic and will first clear any usage of the material being freed, be it override, overlay, surface override or particles.

Fixes #67144
