### PR TITLE
Conditionally free GI and FOG resources, they may not have been created

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -312,11 +312,21 @@ ALBEDO = vec3(1.0);
 void Fog::free_fog_shader() {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
 
-	volumetric_fog.process_shader.version_free(volumetric_fog.process_shader_version);
-	RD::get_singleton()->free(volumetric_fog.volume_ubo);
-	RD::get_singleton()->free(volumetric_fog.params_ubo);
-	material_storage->shader_free(volumetric_fog.default_shader);
-	material_storage->material_free(volumetric_fog.default_material);
+	if (volumetric_fog.process_shader_version.is_valid()) {
+		volumetric_fog.process_shader.version_free(volumetric_fog.process_shader_version);
+	}
+	if (volumetric_fog.volume_ubo.is_valid()) {
+		RD::get_singleton()->free(volumetric_fog.volume_ubo);
+	}
+	if (volumetric_fog.params_ubo.is_valid()) {
+		RD::get_singleton()->free(volumetric_fog.params_ubo);
+	}
+	if (volumetric_fog.default_shader.is_valid()) {
+		material_storage->shader_free(volumetric_fog.default_shader);
+	}
+	if (volumetric_fog.default_material.is_valid()) {
+		material_storage->material_free(volumetric_fog.default_material);
+	}
 }
 
 void Fog::FogShaderData::set_code(const String &p_code) {

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3581,18 +3581,40 @@ void GI::init(SkyRD *p_sky) {
 }
 
 void GI::free() {
-	RD::get_singleton()->free(default_voxel_gi_buffer);
-	RD::get_singleton()->free(voxel_gi_lights_uniform);
-	RD::get_singleton()->free(sdfgi_ubo);
+	if (default_voxel_gi_buffer.is_valid()) {
+		RD::get_singleton()->free(default_voxel_gi_buffer);
+	}
+	if (voxel_gi_lights_uniform.is_valid()) {
+		RD::get_singleton()->free(voxel_gi_lights_uniform);
+	}
+	if (sdfgi_ubo.is_valid()) {
+		RD::get_singleton()->free(sdfgi_ubo);
+	}
 
-	voxel_gi_debug_shader.version_free(voxel_gi_debug_shader_version);
-	voxel_gi_shader.version_free(voxel_gi_lighting_shader_version);
-	shader.version_free(shader_version);
-	sdfgi_shader.debug_probes.version_free(sdfgi_shader.debug_probes_shader);
-	sdfgi_shader.debug.version_free(sdfgi_shader.debug_shader);
-	sdfgi_shader.direct_light.version_free(sdfgi_shader.direct_light_shader);
-	sdfgi_shader.integrate.version_free(sdfgi_shader.integrate_shader);
-	sdfgi_shader.preprocess.version_free(sdfgi_shader.preprocess_shader);
+	if (voxel_gi_debug_shader_version.is_valid()) {
+		voxel_gi_debug_shader.version_free(voxel_gi_debug_shader_version);
+	}
+	if (voxel_gi_lighting_shader_version.is_valid()) {
+		voxel_gi_shader.version_free(voxel_gi_lighting_shader_version);
+	}
+	if (shader_version.is_valid()) {
+		shader.version_free(shader_version);
+	}
+	if (sdfgi_shader.debug_probes_shader.is_valid()) {
+		sdfgi_shader.debug_probes.version_free(sdfgi_shader.debug_probes_shader);
+	}
+	if (sdfgi_shader.debug_shader.is_valid()) {
+		sdfgi_shader.debug.version_free(sdfgi_shader.debug_shader);
+	}
+	if (sdfgi_shader.direct_light_shader.is_valid()) {
+		sdfgi_shader.direct_light.version_free(sdfgi_shader.direct_light_shader);
+	}
+	if (sdfgi_shader.integrate_shader.is_valid()) {
+		sdfgi_shader.integrate.version_free(sdfgi_shader.integrate_shader);
+	}
+	if (sdfgi_shader.preprocess_shader.is_valid()) {
+		sdfgi_shader.preprocess.version_free(sdfgi_shader.preprocess_shader);
+	}
 
 	if (voxel_gi_lights) {
 		memdelete_arr(voxel_gi_lights);


### PR DESCRIPTION
Depending on the renderer use, GI and FOG may not be (fully) initialised as parts are not supported (specifically with the mobile renderer but this may be applicable to other renderers in the future).

We thus need to only free those resources that we're initialised.

This prevents some error spam when Godot closes.