### PR TITLE
Fix error in `BaseMaterial3D` when running doctool

### DIFF
--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -99,11 +99,20 @@ public:
 			p_elem->_root = nullptr;
 		}
 
+		void clear() {
+			while (_first) {
+				remove(_first);
+			}
+		}
+
 		_FORCE_INLINE_ SelfList<T> *first() { return _first; }
 		_FORCE_INLINE_ const SelfList<T> *first() const { return _first; }
 
 		_FORCE_INLINE_ List() {}
-		_FORCE_INLINE_ ~List() { ERR_FAIL_COND(_first != nullptr); }
+		_FORCE_INLINE_ ~List() {
+			// A self list must be empty on destruction.
+			DEV_ASSERT(_first == nullptr);
+		}
 	};
 
 private:

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -475,13 +475,11 @@ ShaderMaterial::~ShaderMaterial() {
 /////////////////////////////////
 
 Mutex BaseMaterial3D::material_mutex;
-SelfList<BaseMaterial3D>::List *BaseMaterial3D::dirty_materials = nullptr;
+SelfList<BaseMaterial3D>::List BaseMaterial3D::dirty_materials;
 HashMap<BaseMaterial3D::MaterialKey, BaseMaterial3D::ShaderData, BaseMaterial3D::MaterialKey> BaseMaterial3D::shader_map;
 BaseMaterial3D::ShaderNames *BaseMaterial3D::shader_names = nullptr;
 
 void BaseMaterial3D::init_shaders() {
-	dirty_materials = memnew(SelfList<BaseMaterial3D>::List);
-
 	shader_names = memnew(ShaderNames);
 
 	shader_names->albedo = "albedo";
@@ -568,14 +566,14 @@ HashMap<uint64_t, Ref<StandardMaterial3D>> BaseMaterial3D::materials_for_2d;
 void BaseMaterial3D::finish_shaders() {
 	materials_for_2d.clear();
 
-	memdelete(dirty_materials);
-	dirty_materials = nullptr;
+	dirty_materials.clear();
 
 	memdelete(shader_names);
+	shader_names = nullptr;
 }
 
 void BaseMaterial3D::_update_shader() {
-	dirty_materials->remove(&element);
+	dirty_materials.remove(&element);
 
 	MaterialKey mk = _compute_key();
 	if (mk == current_key) {
@@ -1494,8 +1492,8 @@ void BaseMaterial3D::_update_shader() {
 void BaseMaterial3D::flush_changes() {
 	MutexLock lock(material_mutex);
 
-	while (dirty_materials->first()) {
-		dirty_materials->first()->self()->_update_shader();
+	while (dirty_materials.first()) {
+		dirty_materials.first()->self()->_update_shader();
 	}
 }
 
@@ -1503,7 +1501,7 @@ void BaseMaterial3D::_queue_shader_change() {
 	MutexLock lock(material_mutex);
 
 	if (_is_initialized() && !element.in_list()) {
-		dirty_materials->add(&element);
+		dirty_materials.add(&element);
 	}
 }
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -452,7 +452,7 @@ private:
 	};
 
 	static Mutex material_mutex;
-	static SelfList<BaseMaterial3D>::List *dirty_materials;
+	static SelfList<BaseMaterial3D>::List dirty_materials;
 	static ShaderNames *shader_names;
 
 	SelfList<BaseMaterial3D> element;


### PR DESCRIPTION
Fixes #77339, ~~but I have no idea if doing it like this is a good idea.~~

~~The idea is, avoid errors caused by deleting a non-empty SelfList, by just emptying the list first.~~

Updated as per https://github.com/godotengine/godot/pull/77341#issuecomment-1557054915

Setting `shader_names` is unrelated and just cleanup to make it follow the same pattern as `dirty_materials`