### PR TITLE
Fix compile issue in not very conformant compilers

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -52,13 +52,17 @@ protected:
 	// During group processing, these are thread-safe.
 	// Outside group processing, these avoid the cost of sync by working as plain primitive types.
 	union MTFlag {
-		SafeFlag mt{};
+		SafeFlag mt;
 		bool st;
+		MTFlag() :
+				mt{} {}
 	};
 	template <class T>
 	union MTNumeric {
-		SafeNumeric<T> mt{};
+		SafeNumeric<T> mt;
 		T st;
+		MTNumeric() :
+				mt{} {}
 	};
 
 public:


### PR DESCRIPTION
C++11 (or was it C++14) conformant compilers let you have an initializer for a single member of a union. It turns out that at least certain MSVC 2019 toolchain releases fail to meet that rule.

Fixes #77338.
