### PR TITLE
GDScript: Do not RETURN_VALUE_DISCARDED for `super()` inside `_init()`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3122,7 +3122,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 
 #ifdef DEBUG_ENABLED
-		if (p_is_root && return_type.kind != GDScriptParser::DataType::UNRESOLVED && return_type.builtin_type != Variant::NIL) {
+		if (p_is_root && return_type.kind != GDScriptParser::DataType::UNRESOLVED && return_type.builtin_type != Variant::NIL &&
+				!(p_call->is_super && p_call->function_name == GDScriptLanguage::get_singleton()->strings._init)) {
 			parser->push_warning(p_call, GDScriptWarning::RETURN_VALUE_DISCARDED, p_call->function_name);
 		}
 
@@ -4710,7 +4711,7 @@ bool GDScriptAnalyzer::get_function_signature(GDScriptParser::Node *p_source, bo
 	}
 
 	if (p_is_constructor) {
-		function_name = "_init";
+		function_name = GDScriptLanguage::get_singleton()->strings._init;
 		r_static = true;
 	}
 

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_super_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_super_implemented.gd
@@ -1,0 +1,10 @@
+class TestOne:
+	func _init():
+		pass
+
+class TestTwo extends TestOne:
+	func _init():
+		super()
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_super_implemented.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_super_implemented.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
DO NOT BATCH MERGE WITH #77324, WILL RESULT IN BROKEN CI

![image](https://github.com/godotengine/godot/assets/1133892/951863e3-d6c3-4a9f-93e5-e7da8b513290)

Currently, calling `super()` inside `_init()` throws a RETURN_VALUE_DISCARDED warning. The analyzer identifies `super()` as being a constructor, which therefore returns an object of the relevant class. However, super() isn't really a constructor by itself: in this case, it is _part_ of the constructor, and so doesn't "return" a value.

A test case for this is already in #77324, which contains the warning. I am duplicating it here, without the warning, and it should conflict with the other PR so maybe it won't break CI?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
