### PR TITLE
Fix PCK file path inconsistencies

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -48,7 +48,8 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t 
 }
 
 void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted) {
-	PathMD5 pmd5(p_path.md5_buffer());
+	String simplified_path = p_path.simplify_path();
+	PathMD5 pmd5(simplified_path.md5_buffer());
 
 	bool exists = files.has(pmd5);
 
@@ -68,7 +69,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 
 	if (!exists) {
 		//search for dir
-		String p = p_path.replace_first("res://", "");
+		String p = simplified_path.replace_first("res://", "");
 		PackedDir *cd = root;
 
 		if (p.contains("/")) { //in a subdir
@@ -87,7 +88,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 				}
 			}
 		}
-		String filename = p_path.get_file();
+		String filename = simplified_path.get_file();
 		// Don't add as a file if the path points to a directory
 		if (!filename.is_empty()) {
 			cd->files.insert(filename);

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -184,7 +184,8 @@ public:
 };
 
 Ref<FileAccess> PackedData::try_open_path(const String &p_path) {
-	PathMD5 pmd5(p_path.md5_buffer());
+	String simplified_path = p_path.simplify_path();
+	PathMD5 pmd5(simplified_path.md5_buffer());
 	HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.find(pmd5);
 	if (!E) {
 		return nullptr; //not found
@@ -197,7 +198,7 @@ Ref<FileAccess> PackedData::try_open_path(const String &p_path) {
 }
 
 bool PackedData::has_path(const String &p_path) {
-	return files.has(PathMD5(p_path.md5_buffer()));
+	return files.has(PathMD5(p_path.simplify_path().md5_buffer()));
 }
 
 bool PackedData::has_directory(const String &p_path) {

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -115,7 +115,9 @@ Error PCKPacker::add_file(const String &p_file, const String &p_src, bool p_encr
 	}
 
 	File pf;
-	pf.path = p_file;
+	// Simplify path here and on every 'files' access so that paths that have extra '/'
+	// symbols in them still match to the MD5 hash for the saved path.
+	pf.path = p_file.simplify_path();
 	pf.src_path = p_src;
 	pf.ofs = ofs;
 	pf.size = f->get_length();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77317

### Changes
Before these changes, adding a file to a PCK would store a MD5 hash for the path's string value. Since a path with an extra '/' symbol in it would produce a different hash, some `FileAccess` methods weren't able to find or open these PCK files when using paths with extra '/' symbols in them, as their hashes didn't match the stored ones. 
Simplifying the paths (Which removes extra '/' symbols) when storing the MD5 value and when looking for it makes it so that paths with extra '/' symbols in them still match to the stored path.

### Testing
Tested all three cases that weren't working in the issue example. They are all working now: 
``` gdscript
# This is valid
FileAccess.open("res://my//path/icon.svg", FileAccess.READ)
# This is not valid --> Now valid
FileAccess.open("res://my/path/icon.svg", FileAccess.READ)
# This is also not valid --> Now valid
FileAccess.open("res://my//path/////icon.svg", FileAccess.READ)
```

The non-PCK FileAccess calls given as examples in the issue continue working.

Also tested some other functions that use the modifyed methods to make sure they are still working correctly. These included `FileAccess::exists`, `FileAccess::get_modified_time` and `ProjectSettings:: _load_resource_pack`,