### PR TITLE
C#: Check if .NET runtime has been finalized in the instance binding reference callback

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1303,6 +1303,15 @@ void CSharpLanguage::_instance_binding_free_callback(void *, void *, void *p_bin
 GDExtensionBool CSharpLanguage::_instance_binding_reference_callback(void *p_token, void *p_binding, GDExtensionBool p_reference) {
 	CRASH_COND(!p_binding);
 
+	if (GDMono::get_singleton() == nullptr) {
+#ifdef DEBUG_ENABLED
+		CSharpLanguage *csharp_lang = CSharpLanguage::get_singleton();
+		CRASH_COND(csharp_lang && !csharp_lang->script_bindings.is_empty());
+#endif
+		// Mono runtime finalized, all the gchandle bindings were already released
+		return true;
+	}
+
 	CSharpScriptBinding &script_binding = ((RBMap<Object *, CSharpScriptBinding>::Element *)p_binding)->get();
 
 	RefCounted *rc_owner = Object::cast_to<RefCounted>(script_binding.owner);


### PR DESCRIPTION
Fixes #77305

Turns out you can't detach an instance binding from an object, so duplicate a check from `_instance_binding_free_callback`.