### PR TITLE
Make tile atlas merge dialog use filter nearest on both sides.

### DIFF
--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -306,6 +306,7 @@ AtlasMergingDialog::AtlasMergingDialog() {
 
 	VBoxContainer *atlas_merging_right_panel = memnew(VBoxContainer);
 	atlas_merging_right_panel->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	atlas_merging_right_panel->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	atlas_merging_h_split_container->add_child(atlas_merging_right_panel);
 
 	// Settings.

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -68,12 +68,15 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 				Vector2i tile_id = atlas_source->get_tile_id(tile_index);
 				atlas_size = atlas_size.max(tile_id + atlas_source->get_tile_size_in_atlas(tile_id));
 
-				Rect2i new_tile_rect_in_altas = Rect2i(atlas_offset + tile_id, atlas_source->get_tile_size_in_atlas(tile_id));
+				Rect2i new_tile_rect_in_atlas = Rect2i(atlas_offset + tile_id, atlas_source->get_tile_size_in_atlas(tile_id));
 
 				// Copy the texture.
+				int animation_columns = atlas_source->get_tile_animation_columns(tile_id);
+				Vector2i animation_separation = atlas_source->get_tile_animation_separation(tile_id);
 				for (int frame = 0; frame < atlas_source->get_tile_animation_frames_count(tile_id); frame++) {
 					Rect2i src_rect = atlas_source->get_tile_texture_region(tile_id, frame);
-					Rect2 dst_rect_wide = Rect2i(new_tile_rect_in_altas.position * new_texture_region_size, new_tile_rect_in_altas.size * new_texture_region_size);
+					Vector2i frame_coords = tile_id + (src_rect.size + animation_separation) * ((animation_columns > 0) ? Vector2i(frame % animation_columns, frame / animation_columns) : Vector2i(frame, 0));
+					Rect2 dst_rect_wide = Rect2i(new_tile_rect_in_atlas.position * new_texture_region_size + (frame > 0 ? frame_coords : Vector2i(0, 0)), new_tile_rect_in_atlas.size * new_texture_region_size);
 					if (dst_rect_wide.get_end().x > output_image->get_width() || dst_rect_wide.get_end().y > output_image->get_height()) {
 						output_image->crop(MAX(dst_rect_wide.get_end().x, output_image->get_width()), MAX(dst_rect_wide.get_end().y, output_image->get_height()));
 					}
@@ -81,7 +84,7 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 				}
 
 				// Add to the mapping.
-				merged_mapping[source_index][tile_id] = new_tile_rect_in_altas.position;
+				merged_mapping[source_index][tile_id] = new_tile_rect_in_atlas.position;
 			}
 
 			// Compute the atlas offset.


### PR DESCRIPTION
It is already using nearest on other side and everywhere else dealing with tiles I think?

Closes: https://github.com/godotengine/godot/issues/77367

Before:
![Screenshot (93)](https://github.com/godotengine/godot/assets/962340/d906d614-c4b4-41e5-863d-63de70a97d37)

After:
![Screenshot (92)](https://github.com/godotengine/godot/assets/962340/5f6b7617-53ea-47ed-8656-f089f2dbce62)
