### PR TITLE
C#: Fix `SendToScriptDebugger` crash

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -103,7 +103,7 @@ namespace Godot.NativeInterop
         {
             try
             {
-                if (NativeFuncs.godotsharp_internal_script_debugger_is_active())
+                if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
                 {
                     SendToScriptDebugger(e);
                 }
@@ -122,7 +122,7 @@ namespace Godot.NativeInterop
         {
             try
             {
-                if (NativeFuncs.godotsharp_internal_script_debugger_is_active())
+                if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
                 {
                     SendToScriptDebugger(e);
                 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -56,7 +56,7 @@ namespace Godot.NativeInterop
             in godot_string p_file, int p_line, in godot_string p_err, in godot_string p_descr,
             godot_bool p_warning, in DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
 
-        internal static partial bool godotsharp_internal_script_debugger_is_active();
+        internal static partial godot_bool godotsharp_internal_script_debugger_is_active();
 
         internal static partial IntPtr godotsharp_internal_object_get_associated_gchandle(IntPtr ptr);
 


### PR DESCRIPTION
- Fixes #68662
- Fixes #77343
- Fixes #77370 (at least the crash of it, I cannot reproduce the underlying exception)
- Fixes #72123

Such a stupid error, it was so close to working correctly.

(On x64:)
The native code returned a bool as a single byte in the `al` register, leaving the rest of the `a` register whatever garbage it was before, but the native to managed transition interpreted the return value as a 4 byte bool in `eax`, which was mostly filled with garbage and thus not 0 (false) as intended.
Somehow on dev build none of this matters and the engine just doesn't crash hiding the issue.

With this patch the return value is correctly interpreted as a single byte value on the C# side.