### PR TITLE
[3.x] GDNative: Add Core API 1.4, move `Transform2D::determinant` there

### DIFF
--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -23,7 +23,23 @@
             "major": 1,
             "minor": 3
           },
-          "next": null,
+          "next": {
+            "type": "CORE",
+            "version": {
+              "major": 1,
+              "minor": 4
+            },
+            "next": null,
+            "api": [
+              {
+                "name": "godot_transform2d_determinant",
+                "return_type": "godot_real",
+                "arguments": [
+                  ["const godot_transform2d *", "p_self"]
+                ]
+              }
+            ]
+          },
           "api": [
             {
               "name": "godot_dictionary_merge",
@@ -4427,13 +4443,6 @@
       {
         "name": "godot_transform2d_get_scale",
         "return_type": "godot_vector2",
-        "arguments": [
-          ["const godot_transform2d *", "p_self"]
-        ]
-      },
-      {
-        "name": "godot_transform2d_determinant",
-        "return_type": "godot_real",
         "arguments": [
           ["const godot_transform2d *", "p_self"]
         ]


### PR DESCRIPTION
It was added in #76323 but broke compatibility by being introduced in an already released core API (1.0).

Fixes #77283.

@necrashter I haven't tested the change, could you confirm that it fixes the issue?