### PR TITLE
Implement record feature for AnimationTree.

### DIFF
--- a/core/templates/circular_deque.h
+++ b/core/templates/circular_deque.h
@@ -1,0 +1,580 @@
+/**************************************************************************/
+/*  circular_deque.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef CIRCULAR_DEQUE_H
+#define CIRCULAR_DEQUE_H
+
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/os/memory.h"
+#include "core/templates/vector.h"
+
+#include <initializer_list>
+#include <type_traits>
+
+// Capacity can't be increased automatically.
+// Instead, you should call "CircularDeque::reserve()" or "CircularDeque::adjust_capacity()" to grow the capacity explicitly.
+// If "allow_override_edges" is false, the CircularDeque can't push new element if is full.
+template <class T, class U = int32_t, bool force_trivial = false, bool allow_override_edges = true>
+class CircularDeque {
+private:
+#define DEFAULT_CAPACITY 16
+	U front_pos = -1;
+	U rear_pos = -1;
+
+	U count = 0;
+	U capacity = 0;
+
+	T *data = nullptr;
+
+public:
+	_FORCE_INLINE_ bool is_full() const {
+		return (rear_pos == capacity - 1 && front_pos == 0) || (rear_pos == front_pos - 1);
+	}
+
+	_FORCE_INLINE_ U size() const { return count; }
+	_FORCE_INLINE_ U get_capacity() const { return capacity; }
+
+	_FORCE_INLINE_ bool is_empty() const {
+		return front_pos == -1 || rear_pos == -1;
+	}
+
+	_FORCE_INLINE_ void push_back(const T &p_elem) {
+		if constexpr (!allow_override_edges) {
+			ERR_FAIL_COND(is_full());
+			count++;
+		} else {
+			if (is_full()) {
+				if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+					data[front_pos].~T();
+				}
+
+				if (front_pos == capacity - 1) {
+					front_pos = 0;
+				} else {
+					front_pos++;
+				}
+			} else {
+				count++;
+			}
+		}
+
+		if (front_pos == -1) {
+			rear_pos = front_pos = 0;
+		} else if (rear_pos == capacity - 1) {
+			rear_pos = 0;
+		} else {
+			rear_pos++;
+		}
+
+		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+			memnew_placement(&data[rear_pos], T(p_elem));
+		} else {
+			data[rear_pos] = p_elem;
+		}
+	}
+
+	_FORCE_INLINE_ void push_front(const T &p_elem) {
+		if constexpr (!allow_override_edges) {
+			ERR_FAIL_COND(is_full());
+			count++;
+		} else {
+			if (is_full()) {
+				if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+					data[rear_pos].~T();
+				}
+
+				if (rear_pos == 0) {
+					rear_pos = capacity - 1;
+				} else {
+					rear_pos--;
+				}
+			} else {
+				count++;
+			}
+		}
+
+		if (rear_pos == -1) {
+			front_pos = rear_pos = capacity - 1;
+		} else if (front_pos == 0) {
+			front_pos = capacity - 1;
+		} else {
+			front_pos--;
+		}
+
+		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+			memnew_placement(&data[front_pos], T(p_elem));
+		} else {
+			data[front_pos] = p_elem;
+		}
+	}
+
+	_FORCE_INLINE_ void pop_front() {
+		if (is_empty()) {
+			return;
+		}
+
+		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+			data[front_pos].~T();
+		}
+
+		if (front_pos == rear_pos) {
+			front_pos = -1;
+			rear_pos = -1;
+		} else if (front_pos == capacity - 1) {
+			front_pos = 0;
+		} else {
+			front_pos++;
+		}
+		count--;
+	}
+
+	_FORCE_INLINE_ void pop_back() {
+		if (is_empty()) {
+			return;
+		}
+
+		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+			data[rear_pos].~T();
+		}
+
+		if (front_pos == rear_pos) {
+			front_pos = -1;
+			rear_pos = -1;
+		} else if (rear_pos == 0) {
+			rear_pos = capacity - 1;
+		} else {
+			rear_pos--;
+		}
+		count--;
+	}
+
+	void remove_at(U p_index) {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, size());
+		p_index += front_pos;
+		if (p_index >= capacity) {
+			p_index -= capacity;
+		}
+
+		if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+			data[p_index].~T();
+		}
+
+		count--;
+
+		if (front_pos == rear_pos) {
+			front_pos = -1;
+			rear_pos = -1;
+		} else if (p_index > front_pos && (p_index - front_pos <= MAX(rear_pos - p_index, rear_pos + 1))) {
+			for (; p_index > front_pos; --p_index) {
+				data[p_index] = data[p_index - 1];
+			}
+
+			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+				data[front_pos].~T();
+			}
+
+			if (front_pos == capacity - 1) {
+				front_pos = 0;
+			} else {
+				front_pos++;
+			}
+		} else {
+			for (; p_index < rear_pos; ++p_index) {
+				data[p_index] = data[p_index + 1];
+			}
+
+			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+				data[rear_pos].~T();
+			}
+
+			if (rear_pos == 0) {
+				rear_pos = capacity - 1;
+			} else {
+				rear_pos--;
+			}
+		}
+	}
+
+	void insert(U p_index, const T &p_elem, bool p_pop_front_if_full = true) {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, size() + 1);
+		if (p_index == 0) {
+			push_front(p_elem);
+			return;
+		} else if (p_index == count - 1) {
+			push_back(p_elem);
+			return;
+		}
+
+		if constexpr (!allow_override_edges) {
+			ERR_FAIL_COND(is_full());
+			count++;
+		} else {
+			if (is_full()) {
+				if (p_pop_front_if_full) {
+					data[front_pos].~T();
+
+					if (front_pos == capacity - 1) {
+						front_pos = 0;
+					} else {
+						front_pos++;
+					}
+				} else {
+					data[rear_pos].~T();
+
+					if (rear_pos == 0) {
+						rear_pos = capacity - 1;
+					} else {
+						rear_pos--;
+					}
+				}
+			} else {
+				count++;
+			}
+		}
+
+		p_index += front_pos;
+		if (p_index >= capacity) {
+			p_index -= capacity;
+		}
+
+		if (p_index > front_pos && (p_index - front_pos <= MAX(rear_pos - p_index, rear_pos + 1))) {
+			p_index--;
+			if (front_pos == 0) {
+				data[capacity - 1] = data[0];
+				front_pos = capacity - 1;
+			} else {
+				front_pos--;
+			}
+
+			for (U i = (front_pos == capacity - 1) ? 0 : front_pos; i < p_index; ++i) {
+				data[i] = data[i + 1];
+			}
+		} else {
+			p_index++;
+			if (rear_pos == capacity - 1) {
+				data[0] = data[rear_pos];
+				rear_pos = 0;
+			} else {
+				rear_pos++;
+			}
+
+			for (U i = (rear_pos == 0) ? capacity - 1 : rear_pos; i > p_index; --i) {
+				data[i] = data[i - 1];
+			}
+		}
+
+		if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+			memnew_placement(&data[p_index], T(p_elem));
+		} else {
+			data[p_index] = p_elem;
+		}
+	}
+
+	int64_t find(const T &p_val, int p_from = 0) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_from, size());
+		if (rear_pos >= front_pos) {
+			for (U i = p_from + front_pos; i <= rear_pos; ++i) {
+				if (data[i] == p_val) {
+					return int64_t(i - front_pos);
+				}
+			}
+		} else {
+			p_from += front_pos;
+			if (p_from < capacity) {
+				for (U i = p_from; i < capacity; ++i) {
+					if (data[i] == p_val) {
+						return int64_t(i - front_pos);
+					}
+				}
+				p_from = 0;
+			} else {
+				p_from -= capacity;
+			}
+
+			for (U i = p_from; i <= rear_pos; ++i) {
+				if (data[i] == p_val) {
+					return int64_t(count - 1 - (rear_pos - i));
+				}
+			}
+		}
+		return -1;
+	}
+
+	int64_t rfind(const T &p_val, int p_from = -1) const {
+		p_from += capacity;
+		CRASH_BAD_UNSIGNED_INDEX(p_from, size());
+		if (rear_pos >= front_pos) {
+			for (U i = front_pos + front_pos; i >= front_pos; --i) {
+				if (data[i] == p_val) {
+					return int64_t(i - front_pos);
+				}
+			}
+		} else {
+			p_from = rear_pos - (count - 1 - p_from);
+			if (p_from >= 0) {
+				for (U i = p_from; i >= 0; --i) {
+					if (data[i] == p_val) {
+						return int64_t(count - 1 - (rear_pos - i));
+					}
+				}
+				p_from = capacity - 1;
+			} else {
+				p_from += capacity;
+			}
+
+			for (U i = p_from; i >= front_pos; --i) {
+				if (data[i] == p_val) {
+					return int64_t(i - front_pos);
+				}
+			}
+		}
+		return -1;
+	}
+
+	_FORCE_INLINE_ bool erase(const T &p_val) {
+		int idx = find(p_val);
+		if (idx >= 0) {
+			remove_at(idx);
+			return true;
+		}
+		return false;
+	}
+
+	_FORCE_INLINE_ void clear() { resize(0); }
+
+	_FORCE_INLINE_ void reset() {
+		clear();
+		if (data) {
+			memfree(data);
+			data = nullptr;
+			capacity = 0;
+			front_pos = -1;
+			rear_pos = -1;
+		}
+	}
+
+	void resize(U p_size) {
+		CRASH_COND(p_size > capacity);
+		if (p_size < size()) {
+			if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+				for (U i = size() - p_size; i > 0; i--) {
+					data[rear_pos].~T();
+					if (rear_pos == 0) {
+						rear_pos = capacity - 1;
+					}
+				}
+			} else {
+				rear_pos -= (size() - p_size);
+				if (rear_pos < 0) {
+					rear_pos += capacity;
+				}
+			}
+		} else if (p_size > size()) {
+			for (U i = p_size - size(); i > 0; --i) {
+				if (front_pos == -1) {
+					rear_pos = front_pos = 0;
+				} else if (rear_pos == capacity - 1) {
+					rear_pos = 0;
+				} else {
+					rear_pos++;
+				}
+
+				if constexpr (!std::is_trivially_constructible<T>::value && !force_trivial) {
+					memnew_placement(&data[rear_pos], T);
+				} else {
+					data[rear_pos] = {};
+				}
+			}
+		}
+
+		count = p_size;
+		if (count == 0) {
+			rear_pos = -1;
+			front_pos = -1;
+		}
+	}
+
+	_FORCE_INLINE_ void reserve(U p_capacity) {
+		if (p_capacity > get_capacity()) {
+			data = (T *)memrealloc(data, p_capacity * sizeof(T));
+			CRASH_COND_MSG(!data, "Out of memory");
+
+			if (front_pos > rear_pos) {
+				U move_count = capacity - 1 - front_pos;
+				for (U i = 0; i < move_count; ++i) {
+					data[p_capacity - i] = data[capacity - i];
+				}
+
+				if constexpr (!std::is_trivially_destructible<T>::value && !force_trivial) {
+					for (U i = p_capacity - get_capacity() - 1; i >= 0; --i) {
+						data[rear_pos + i].~T();
+					}
+				}
+
+				rear_pos += p_capacity - get_capacity();
+			}
+			capacity = p_capacity;
+		}
+	}
+
+	void adjust_capacity(U p_capacity) {
+		if (p_capacity > get_capacity()) {
+			reserve(p_capacity);
+		} else if (p_capacity < get_capacity()) {
+			// Resize.
+			if (p_capacity < size()) {
+				for (U i = size() - p_capacity; i > 0; ++i) {
+					pop_back();
+				}
+			}
+
+			// Move elements if need.
+			if (rear_pos > p_capacity) {
+				for (U i = 0; i < count; ++i) {
+					data[i] = data[front_pos + i];
+				}
+				front_pos = 0;
+				rear_pos = count - 1;
+			} else if (front_pos > rear_pos) {
+				U move_count = capacity - rear_pos;
+				for (U i = 0; i < move_count; ++i) {
+					data[front_pos + i] = data[rear_pos + i];
+				}
+				rear_pos = front_pos + 1;
+			}
+
+			// Realloc.
+			data = (T *)memrealloc(data, p_capacity * sizeof(T));
+			CRASH_COND_MSG(!data, "Out of memory");
+
+			capacity = p_capacity;
+		}
+	}
+
+	_FORCE_INLINE_ const T &operator[](U p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, size());
+		if (front_pos + p_index >= capacity) {
+			return data[front_pos + p_index - capacity];
+		} else {
+			return data[front_pos + p_index];
+		}
+	}
+
+	_FORCE_INLINE_ T &operator[](U p_index) {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, size());
+		if (front_pos + p_index >= capacity) {
+			return data[front_pos + p_index - capacity];
+		} else {
+			return data[front_pos + p_index];
+		}
+	}
+
+	operator Vector<T>() const {
+		Vector<T> ret;
+		ret.resize(size());
+		T *w = ret.ptrw();
+		if (rear_pos >= front_pos) {
+			memcpy(w, data + front_pos, sizeof(T) * size());
+		} else {
+			memcpy(w, data + front_pos, sizeof(T) * (capacity - front_pos));
+			memcpy(w, data, sizeof(T) * (rear_pos + 1));
+		}
+		return ret;
+	}
+
+	_FORCE_INLINE_ CircularDeque(U p_capacity = DEFAULT_CAPACITY) {
+		reserve(p_capacity);
+	}
+	_FORCE_INLINE_ CircularDeque(std::initializer_list<T> p_init) {
+		reserve(p_init.size());
+		for (const T &element : p_init) {
+			push_back(element);
+		}
+	}
+	_FORCE_INLINE_ CircularDeque(const CircularDeque &p_from) {
+		reserve(p_from.get_capacity());
+
+		if (p_from.is_empty()) {
+			return;
+		}
+
+		U from_size = p_from.size();
+
+		resize(from_size);
+		for (U i = 0; i < from_size; i++) {
+			data[i] = p_from[i];
+		}
+		front_pos = 0;
+		rear_pos = from_size - 1;
+	}
+
+	inline void operator=(const CircularDeque &p_from) {
+		adjust_capacity(p_from.get_capacity());
+
+		if (p_from.is_empty()) {
+			return;
+		}
+
+		U from_size = p_from.size();
+
+		resize(from_size);
+		for (U i = 0; i < from_size; i++) {
+			data[i] = p_from[i];
+		}
+		front_pos = 0;
+		rear_pos = from_size - 1;
+	}
+
+	inline void operator=(const Vector<T> &p_from) {
+		reserve(p_from.get_capacity());
+
+		if (p_from.is_empty()) {
+			return;
+		}
+
+		U from_size = p_from.size();
+
+		resize(from_size);
+		for (U i = 0; i < from_size; i++) {
+			data[i] = p_from[i];
+		}
+		front_pos = 0;
+		rear_pos = from_size - 1;
+	}
+
+	_FORCE_INLINE_ ~CircularDeque() {
+		if (data) {
+			reset();
+		}
+	}
+};
+
+#endif // CIRCULAR_DEQUE_H

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -27,7 +27,22 @@
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<description>
-				Manually advance the animations by the specified time (in seconds).
+			</description>
+		</method>
+		<method name="clear_records">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="discard_latest_records">
+			<return type="void" />
+			<param index="0" name="length" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_record_buffer_size" qualifiers="const">
+			<return type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="get_root_motion_position" qualifiers="const">
@@ -170,6 +185,23 @@
 				However, if the animation loops, an unintended discrete change may occur, so this is only useful for some simple use cases.
 			</description>
 		</method>
+		<method name="load_record">
+			<return type="bool" />
+			<param index="0" name="record_index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="resize_record_buffer">
+			<return type="void" />
+			<param index="0" name="resize" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="save_record">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="active" type="bool" setter="set_active" getter="is_active" default="false">
@@ -187,6 +219,12 @@
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="AnimationTree.AnimationProcessCallback" default="1">
 			The process mode of this [AnimationTree]. See [enum AnimationProcessCallback] for available modes.
+		</member>
+		<member name="record_buffer_max_size" type="int" setter="set_record_buffer_max_size" getter="get_record_buffer_max_size" default="1024">
+		</member>
+		<member name="recording_enabled" type="bool" setter="set_recording_enabled" getter="is_recording_enabled" default="false">
+		</member>
+		<member name="recording_rate" type="float" setter="set_recording_rate" getter="get_recording_rate" default="0.1">
 		</member>
 		<member name="root_motion_track" type="NodePath" setter="set_root_motion_track" getter="get_root_motion_track" default="NodePath(&quot;&quot;)">
 			The path to the Animation track used for root motion. Paths must be valid scene-tree paths to a node, and must be specified starting from the parent node of the node that will reproduce the animation. To specify a track that controls properties or bones, append its name after the path, separated by [code]":"[/code]. For example, [code]"character/skeleton:ankle"[/code] or [code]"character/mesh:transform/local"[/code].

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1041,6 +1041,7 @@ void AnimationTree::_process_graph(double p_delta) {
 			//if started, seek
 			root->_pre_process(SceneStringNames::get_singleton()->parameters_base_path, nullptr, &state, 0, true, false, Vector<StringName>());
 			started = false;
+			recording_accumulator = 0.0;
 		}
 
 		root->_pre_process(SceneStringNames::get_singleton()->parameters_base_path, nullptr, &state, p_delta, false, false, Vector<StringName>());
@@ -1898,13 +1899,17 @@ void AnimationTree::_notification(int p_what) {
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (active && process_callback == ANIMATION_PROCESS_IDLE) {
-				_process_graph(get_process_delta_time());
+				double delta = get_process_delta_time();
+				_process_graph(delta);
+				try_record_by_process_or_physics_process(delta);
 			}
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (active && process_callback == ANIMATION_PROCESS_PHYSICS) {
-				_process_graph(get_physics_process_delta_time());
+				double delta = get_process_delta_time();
+				_process_graph(delta);
+				try_record_by_process_or_physics_process(delta);
 			}
 		} break;
 	}
@@ -2203,6 +2208,83 @@ real_t AnimationTree::get_connection_activity(const StringName &p_path, int p_co
 	return (*activity)[p_connection].activity;
 }
 
+void AnimationTree::set_record_buffer_max_size(uint32_t p_max_size) {
+	record_buffer_max_size = p_max_size;
+
+	record_buffer.adjust_capacity(record_buffer_max_size);
+}
+
+void AnimationTree::resize_record_buffer(int p_size) {
+	record_buffer.resize(p_size);
+}
+
+void AnimationTree::discard_latest_records(uint32_t p_length) {
+	ERR_FAIL_COND(p_length > static_cast<uint32_t>(record_buffer.size()));
+
+	for (; p_length > 0; --p_length) {
+		record_buffer.pop_front();
+	}
+}
+
+void AnimationTree::set_recording_rate(real_t p_rate) {
+	recording_rate = p_rate;
+	real_t min_rate = 1.0 / Engine::get_singleton()->get_frames_per_second();
+	if (recording_rate > min_rate) {
+		recording_rate = min_rate;
+	}
+}
+
+void AnimationTree::save_record() {
+	Record new_record;
+
+	new_record.state_animation_states.reserve(state.animation_states.size());
+	for (const AnimationNode::AnimationState &E : state.animation_states) {
+		new_record.state_animation_states.push_back(E);
+	}
+
+#ifdef TOOLS_ENABLED
+	new_record.process_pass = process_pass;
+	new_record.state_valid = state.valid;
+	new_record.state_invalid_reasons = state.invalid_reasons;
+#endif // TOOLS_ENABLED
+
+	new_record.root_motion_position = root_motion_position;
+	new_record.root_motion_rotation = root_motion_rotation;
+	new_record.root_motion_scale = root_motion_scale;
+	new_record.root_motion_position_accumulator = root_motion_position_accumulator;
+	new_record.root_motion_rotation_accumulator = root_motion_rotation_accumulator;
+	new_record.root_motion_scale_accumulator = root_motion_scale_accumulator;
+	new_record.property_map = property_map;
+
+	record_buffer.push_front(new_record);
+}
+
+bool AnimationTree::load_record(uint32_t p_record_index) {
+	ERR_FAIL_COND_V(p_record_index >= static_cast<uint32_t>(record_buffer.size()), false);
+	const Record &record = record_buffer[p_record_index];
+
+	property_map = record.property_map;
+	root_motion_scale_accumulator = record.root_motion_scale_accumulator;
+	root_motion_rotation_accumulator = record.root_motion_rotation_accumulator;
+	root_motion_position_accumulator = record.root_motion_position_accumulator;
+	root_motion_scale = record.root_motion_scale;
+	root_motion_rotation = record.root_motion_rotation;
+	root_motion_position = record.root_motion_position;
+
+#ifdef TOOLS_ENABLED
+	state.invalid_reasons = record.state_invalid_reasons;
+	state.valid = record.state_valid;
+	process_pass = record.process_pass;
+#endif // TOOLS_ENABLED
+
+	state.animation_states.clear();
+	for (const AnimationNode::AnimationState &E : state.animation_states) {
+		state.animation_states.push_back(E);
+	}
+
+	return true;
+}
+
 void AnimationTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &AnimationTree::set_active);
 	ClassDB::bind_method(D_METHOD("is_active"), &AnimationTree::is_active);
@@ -2236,6 +2318,19 @@ void AnimationTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("advance", "delta"), &AnimationTree::advance);
 
+	ClassDB::bind_method(D_METHOD("set_record_buffer_max_size", "record_buffer_max_size"), &AnimationTree::set_record_buffer_max_size);
+	ClassDB::bind_method(D_METHOD("get_record_buffer_max_size"), &AnimationTree::get_record_buffer_max_size);
+	ClassDB::bind_method(D_METHOD("set_recording_enabled", "enabled"), &AnimationTree::set_recording_enabled);
+	ClassDB::bind_method(D_METHOD("is_recording_enabled"), &AnimationTree::is_recording_enabled);
+	ClassDB::bind_method(D_METHOD("set_recording_rate", "rate"), &AnimationTree::set_recording_rate);
+	ClassDB::bind_method(D_METHOD("get_recording_rate"), &AnimationTree::get_recording_rate);
+	ClassDB::bind_method(D_METHOD("get_record_buffer_size"), &AnimationTree::get_record_buffer_size);
+	ClassDB::bind_method(D_METHOD("resize_record_buffer", "resize"), &AnimationTree::resize_record_buffer);
+	ClassDB::bind_method(D_METHOD("clear_records"), &AnimationTree::clear_records);
+	ClassDB::bind_method(D_METHOD("discard_latest_records", "length"), &AnimationTree::discard_latest_records);
+	ClassDB::bind_method(D_METHOD("save_record"), &AnimationTree::save_record);
+	ClassDB::bind_method(D_METHOD("load_record", "record_index"), &AnimationTree::load_record);
+
 	GDVIRTUAL_BIND(_post_process_key_value, "animation", "track", "value", "object", "object_idx");
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "tree_root", PROPERTY_HINT_RESOURCE_TYPE, "AnimationRootNode"), "set_tree_root", "get_tree_root");
@@ -2248,19 +2343,22 @@ void AnimationTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "audio_max_polyphony", PROPERTY_HINT_RANGE, "1,127,1"), "set_audio_max_polyphony", "get_audio_max_polyphony");
 	ADD_GROUP("Root Motion", "root_motion_");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_motion_track"), "set_root_motion_track", "get_root_motion_track");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "record_buffer_max_size"), "set_record_buffer_max_size", "get_record_buffer_max_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "recording_enabled"), "set_recording_enabled", "is_recording_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "recording_rate"), "set_recording_rate", "get_recording_rate");
 
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_IDLE);
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_MANUAL);
 
 	ADD_SIGNAL(MethodInfo("animation_player_changed"));
-
 	// Signals from AnimationNodes.
 	ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 	ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING_NAME, "anim_name")));
 }
 
 AnimationTree::AnimationTree() {
+	record_buffer.adjust_capacity(record_buffer_max_size);
 }
 
 AnimationTree::~AnimationTree() {

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -32,6 +32,7 @@
 #define ANIMATION_TREE_H
 
 #include "animation_player.h"
+#include "core/templates/circular_deque.h"
 #include "scene/3d/node_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/animation.h"
@@ -368,6 +369,16 @@ private:
 
 	ObjectID last_animation_player;
 
+	real_t recording_accumulator = 0.0;
+
+	void try_record_by_process_or_physics_process(real_t p_delta) {
+		recording_accumulator += p_delta;
+		if (recording_accumulator > recording_rate) {
+			save_record();
+			recording_accumulator -= recording_rate;
+		}
+	}
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -379,6 +390,29 @@ protected:
 	GDVIRTUAL5RC(Variant, _post_process_key_value, Ref<Animation>, int, Variant, Object *, int);
 	Variant post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, const Object *p_object, int p_object_idx = -1);
 	virtual Variant _post_process_key_value(const Ref<Animation> &p_anim, int p_track, Variant p_value, const Object *p_object, int p_object_idx = -1);
+
+	struct Record {
+		TightLocalVector<AnimationNode::AnimationState> state_animation_states;
+#ifdef TOOLS_ENABLED
+		bool state_valid;
+		String state_invalid_reasons = ""; // Should be set optionally.
+		uint64_t process_pass;
+#endif // TOOLS_ENABLED
+
+		Vector3 root_motion_position;
+		Quaternion root_motion_rotation;
+		Vector3 root_motion_scale;
+		Vector3 root_motion_position_accumulator;
+		Quaternion root_motion_rotation_accumulator;
+		Vector3 root_motion_scale_accumulator;
+
+		HashMap<StringName, Pair<Variant, bool>> property_map;
+	};
+
+	uint32_t record_buffer_max_size = 1024;
+	CircularDeque<Record> record_buffer;
+	bool recording_enabled = false;
+	real_t recording_rate = 0.1;
 
 public:
 	void set_tree_root(const Ref<AnimationNode> &p_root);
@@ -419,6 +453,27 @@ public:
 	void advance(double p_time);
 
 	uint64_t get_last_process_pass() const;
+
+	void set_record_buffer_max_size(uint32_t P_record_buffer_max_size);
+	uint32_t get_record_buffer_max_size() const { return record_buffer_max_size; }
+
+	void set_recording_enabled(bool p_enabled) { recording_enabled = p_enabled; }
+	bool is_recording_enabled() const { return recording_enabled; }
+
+	void set_recording_rate(real_t p_rate);
+	real_t get_recording_rate() const { return recording_rate; }
+
+	int get_record_buffer_size() const { return record_buffer.size(); }
+	void resize_record_buffer(int p_size);
+
+	void clear_records() { record_buffer.clear(); }
+
+	void discard_latest_records(uint32_t p_length);
+
+	bool load_record(uint32_t p_record_index);
+
+	void save_record();
+
 	AnimationTree();
 	~AnimationTree();
 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Impelent record featrure to instead of [#77347](https://github.com/godotengine/godot/pull/77347).

https://github.com/godotengine/godot/assets/61624558/3501137e-6d88-404e-9625-f09cb2e7f23e

_Bugsquad edited:_ Closes https://github.com/godotengine/godot-proposals/issues/6807

Demo project:

[animation_rollback_test.zip](https://github.com/godotengine/godot/files/11574408/animation_rollback_test.zip)

Simple benchmark between `List<Record>`, `LocalVector<Record>` and `CircularDeque<Record>` for this use case:

![benchmark](https://github.com/godotengine/godot/assets/61624558/b67b3dc1-801e-43c8-92ae-5a8e271ef9df)

