### PR TITLE
[3.x] RichTextLabel: Cache text property when toggling BBCode

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2741,8 +2741,17 @@ void RichTextLabel::set_use_bbcode(bool p_enable) {
 	if (use_bbcode == p_enable) {
 		return;
 	}
+
+	if (p_enable) {
+		cached_text = get_text();
+	}
+
 	use_bbcode = p_enable;
 	set_bbcode(bbcode);
+
+	if (!p_enable) {
+		set_text(cached_text);
+	}
 	property_list_changed_notify();
 }
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -408,6 +408,7 @@ private:
 
 	bool use_bbcode;
 	String bbcode;
+	String cached_text;
 
 	int fixed_width;
 


### PR DESCRIPTION
Closes #75899

This little hack prevents the `text` from disappearing when you accidentally toggle bbcode or you have `text` saved in scene, but bbcode is enabled (idk if it's possible, the issue suggests that it might happen when you are upgrading). The text will be stored until you reload the scene, so you can disable bbcode and copy it. It does not affect `bbcode_text` property.