### PR TITLE
Add customizable main loop iterator

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -222,6 +222,7 @@ SConscript("templates/SCsub")
 SConscript("string/SCsub")
 SConscript("config/SCsub")
 SConscript("error/SCsub")
+SConscript("iteration/SCsub")
 
 
 # Build it all as a library

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -107,8 +107,10 @@ public:
 
 	uint64_t get_frames_drawn();
 
+	void set_physics_frames(uint32_t p_physics_frames) { _physics_frames = p_physics_frames; }
 	uint64_t get_physics_frames() const { return _physics_frames; }
 	uint64_t get_process_frames() const { return _process_frames; }
+	void set_in_physics_frame(bool p_in_physics) { _in_physics = p_in_physics; }
 	bool is_in_physics_frame() const { return _in_physics; }
 	uint64_t get_frame_ticks() const { return _frame_ticks; }
 	double get_process_step() const { return _process_step; }

--- a/core/iteration/SCsub
+++ b/core/iteration/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.core_sources, "*.cpp")

--- a/core/iteration/custom_iterator.cpp
+++ b/core/iteration/custom_iterator.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  main.h                                                                */
+/* custom_iterator.cpp                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,68 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef MAIN_H
-#define MAIN_H
+#include "custom_iterator.h"
 
-#include "core/error/error_list.h"
-#include "core/iteration/custom_iterator.h"
-#include "core/os/thread.h"
-#include "core/typedefs.h"
-
-template <class T>
-class Vector;
-
-class Main {
-	static void print_help(const char *p_binary);
-	static uint64_t last_ticks;
-	static uint32_t hide_print_fps_attempts;
-	static uint32_t frames;
-	static uint32_t frame;
-	static bool force_redraw_requested;
-	static int iterating;
-	static bool agile_input_event_flushing;
-
-public:
-	static bool is_cmdline_tool();
-#ifdef TOOLS_ENABLED
-	enum CLIScope {
-		CLI_SCOPE_TOOL, // Editor and project manager.
-		CLI_SCOPE_PROJECT,
-	};
-	static const Vector<String> &get_forwardable_cli_arguments(CLIScope p_scope);
-#endif
-
-	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
-	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2(); // The thread calling setup2() will effectively become the main thread.
-	static String get_rendering_driver_name();
-#ifdef TESTS_ENABLED
-	static Error test_setup();
-	static void test_cleanup();
-#endif
-	static bool start();
-
-	static bool iteration();
-	static void force_redraw();
-
-	static bool is_iterating();
-
-	static void cleanup(bool p_force = false);
-};
-
-// Test main override is for the testing behavior.
-#define TEST_MAIN_OVERRIDE                                         \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#define TEST_MAIN_PARAM_OVERRIDE(argc, argv)                       \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#endif // MAIN_H
+void CustomIterator::_bind_methods() {
+}

--- a/core/iteration/custom_iterator.h
+++ b/core/iteration/custom_iterator.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  main.h                                                                */
+/* custom_iterator.h                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,68 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef MAIN_H
-#define MAIN_H
+#ifndef CUSTOM_ITERATOR_H
+#define CUSTOM_ITERATOR_H
 
-#include "core/error/error_list.h"
-#include "core/iteration/custom_iterator.h"
-#include "core/os/thread.h"
-#include "core/typedefs.h"
+#include "core/object/object.h"
+#include "iteration_server.h"
+#include "main/main_timer_sync.h"
 
-template <class T>
-class Vector;
-
-class Main {
-	static void print_help(const char *p_binary);
-	static uint64_t last_ticks;
-	static uint32_t hide_print_fps_attempts;
-	static uint32_t frames;
-	static uint32_t frame;
-	static bool force_redraw_requested;
-	static int iterating;
-	static bool agile_input_event_flushing;
+class CustomIterator : public Object {
+	GDCLASS(CustomIterator, Object)
+protected:
+	static void _bind_methods();
 
 public:
-	static bool is_cmdline_tool();
-#ifdef TOOLS_ENABLED
-	enum CLIScope {
-		CLI_SCOPE_TOOL, // Editor and project manager.
-		CLI_SCOPE_PROJECT,
-	};
-	static const Vector<String> &get_forwardable_cli_arguments(CLIScope p_scope);
-#endif
+	virtual String get_name() const = 0;
 
-	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
-	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2(); // The thread calling setup2() will effectively become the main thread.
-	static String get_rendering_driver_name();
-#ifdef TESTS_ENABLED
-	static Error test_setup();
-	static void test_cleanup();
-#endif
-	static bool start();
+	virtual IterationServer::IteratorType get_type() const = 0;
 
-	static bool iteration();
-	static void force_redraw();
+	virtual bool mixed_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) { return false; }
 
-	static bool is_iterating();
+	virtual bool process_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) { return false; }
 
-	static void cleanup(bool p_force = false);
+	virtual bool physics_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) { return false; }
+
+	virtual bool audio_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) { return false; }
 };
 
-// Test main override is for the testing behavior.
-#define TEST_MAIN_OVERRIDE                                         \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#define TEST_MAIN_PARAM_OVERRIDE(argc, argv)                       \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#endif // MAIN_H
+#endif //CUSTOM_ITERATOR_H

--- a/core/iteration/custom_iterator_extension.cpp
+++ b/core/iteration/custom_iterator_extension.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  main.h                                                                */
+/* custom_iterator_extension.cpp                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,68 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef MAIN_H
-#define MAIN_H
+#include "custom_iterator_extension.h"
 
-#include "core/error/error_list.h"
-#include "core/iteration/custom_iterator.h"
-#include "core/os/thread.h"
-#include "core/typedefs.h"
+void CustomIteratorExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_name);
+	GDVIRTUAL_BIND(_get_type);
 
-template <class T>
-class Vector;
-
-class Main {
-	static void print_help(const char *p_binary);
-	static uint64_t last_ticks;
-	static uint32_t hide_print_fps_attempts;
-	static uint32_t frames;
-	static uint32_t frame;
-	static bool force_redraw_requested;
-	static int iterating;
-	static bool agile_input_event_flushing;
-
-public:
-	static bool is_cmdline_tool();
-#ifdef TOOLS_ENABLED
-	enum CLIScope {
-		CLI_SCOPE_TOOL, // Editor and project manager.
-		CLI_SCOPE_PROJECT,
-	};
-	static const Vector<String> &get_forwardable_cli_arguments(CLIScope p_scope);
-#endif
-
-	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
-	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
-	static Error setup2(); // The thread calling setup2() will effectively become the main thread.
-	static String get_rendering_driver_name();
-#ifdef TESTS_ENABLED
-	static Error test_setup();
-	static void test_cleanup();
-#endif
-	static bool start();
-
-	static bool iteration();
-	static void force_redraw();
-
-	static bool is_iterating();
-
-	static void cleanup(bool p_force = false);
-};
-
-// Test main override is for the testing behavior.
-#define TEST_MAIN_OVERRIDE                                         \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#define TEST_MAIN_PARAM_OVERRIDE(argc, argv)                       \
-	bool run_test = false;                                         \
-	int return_code = Main::test_entrypoint(argc, argv, run_test); \
-	if (run_test) {                                                \
-		return return_code;                                        \
-	}
-
-#endif // MAIN_H
+	GDVIRTUAL_BIND(_mixed_iteration, "process_delta", "physics_delta", "frame_time", "time_scale");
+	GDVIRTUAL_BIND(_process_iteration, "process_delta", "physics_delta", "frame_time", "time_scale");
+	GDVIRTUAL_BIND(_physics_iteration, "process_delta", "physics_delta", "frame_time", "time_scale");
+	GDVIRTUAL_BIND(_audio_iteration, "process_delta", "physics_delta", "frame_time", "time_scale");
+}

--- a/core/iteration/custom_iterator_extension.h
+++ b/core/iteration/custom_iterator_extension.h
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/* custom_iterator_extension.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EXTENSION_ITERATOR_H
+#define EXTENSION_ITERATOR_H
+
+#include "custom_iterator.h"
+#include "iteration_server.h"
+
+class CustomIteratorExtension : public CustomIterator {
+	GDCLASS(CustomIteratorExtension, CustomIterator)
+
+protected:
+	static void _bind_methods();
+
+public:
+	GDVIRTUAL0RC(String, _get_name);
+	GDVIRTUAL0RC(IterationServer::IteratorType, _get_type);
+
+	GDVIRTUAL4R(bool, _mixed_iteration, float, float, GDExtensionPtr<MainFrameTime>, float);
+	GDVIRTUAL4R(bool, _process_iteration, float, float, GDExtensionPtr<MainFrameTime>, float);
+	GDVIRTUAL4R(bool, _physics_iteration, float, float, GDExtensionPtr<MainFrameTime>, float);
+	GDVIRTUAL4R(bool, _audio_iteration, float, float, GDExtensionPtr<MainFrameTime>, float);
+
+	bool mixed_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) override {
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_mixed_iteration, p_process_delta, p_physics_delta, p_frame_time, p_time_scale, ret);
+		return ret;
+	}
+
+	bool process_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) override {
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_process_iteration, p_process_delta, p_physics_delta, p_frame_time, p_time_scale, ret);
+		return ret;
+	}
+
+	bool physics_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) override {
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_physics_iteration, p_process_delta, p_physics_delta, p_frame_time, p_time_scale, ret);
+		return ret;
+	}
+
+	bool audio_iteration(float p_process_delta, float p_physics_delta, MainFrameTime *p_frame_time, float p_time_scale) override {
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_audio_iteration, p_process_delta, p_physics_delta, p_frame_time, p_time_scale, ret);
+		return ret;
+	}
+
+	String get_name() const override {
+		String ret;
+		GDVIRTUAL_REQUIRED_CALL(_get_name, ret);
+		return ret;
+	}
+
+	IterationServer::IteratorType get_type() const override {
+		IterationServer::IteratorType ret = IterationServer::ITERATOR_TYPE_UNSET;
+		GDVIRTUAL_REQUIRED_CALL(_get_type, ret);
+		return ret;
+	}
+};
+
+#endif //EXTENSION_ITERATOR_H

--- a/core/iteration/iteration_server.cpp
+++ b/core/iteration/iteration_server.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/* iteration_server.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "iteration_server.h"
+#include "core/config/project_settings.h"
+#include "custom_iterator.h"
+
+void IterationServer::_bind_methods() {
+	BIND_ENUM_CONSTANT(ITERATOR_TYPE_UNSET);
+	BIND_ENUM_CONSTANT(ITERATOR_TYPE_MIXED);
+	BIND_ENUM_CONSTANT(ITERATOR_TYPE_SEPARATE);
+
+	ClassDB::bind_static_method("IterationServer", D_METHOD("get_iterator_count"), IterationServer::get_iterator_count);
+	ClassDB::bind_static_method("IterationServer", D_METHOD("get_iterator", "index"), IterationServer::get_iterator);
+	ClassDB::bind_static_method("IterationServer", D_METHOD("register_iterator", "iterator"), IterationServer::register_iterator);
+	ClassDB::bind_static_method("IterationServer", D_METHOD("unregister_iterator", "iterator"), IterationServer::unregister_iterator);
+}
+
+/* Static members */
+CustomIterator *IterationServer::_iterators[MAX_ITERATORS];
+int IterationServer::_iterator_count = 0;
+CustomIterator *IterationServer::get_iterator(int p_idx) {
+	ERR_FAIL_INDEX_V(p_idx, _iterator_count, nullptr);
+
+	return _iterators[p_idx];
+}
+Error IterationServer::register_iterator(CustomIterator *p_iterator) {
+	ERR_FAIL_NULL_V(p_iterator, ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V_MSG(_iterator_count >= MAX_ITERATORS, ERR_UNAVAILABLE, "Iterator limit has been reach, cannot register more.");
+	for (int i = 0; i < _iterator_count; i++) {
+		const CustomIterator *other_iterator = _iterators[i];
+		ERR_FAIL_COND_V_MSG(other_iterator->get_name() == p_iterator->get_name(), ERR_ALREADY_EXISTS, "An iterator with name '" + p_iterator->get_name() + "' is already registered.");
+	}
+	_iterators[_iterator_count++] = p_iterator;
+	return OK;
+}
+Error IterationServer::unregister_iterator(const CustomIterator *p_iterator) {
+	for (int i = 0; i < _iterator_count; i++) {
+		if (_iterators[i] == p_iterator) {
+			_iterator_count--;
+			if (i < _iterator_count) {
+				SWAP(_iterators[i], _iterators[_iterator_count]);
+			}
+			return OK;
+		}
+	}
+	return ERR_DOES_NOT_EXIST;
+}
+bool IterationServer::is_iterator_enabled_for_process(const String &name) {
+	PackedStringArray enabled_process_iterators = ProjectSettings::get_singleton()->get_setting("application/config/process_iterators");
+
+	if (enabled_process_iterators.is_empty()) {
+		return true;
+	}
+
+	return enabled_process_iterators.has(name);
+}
+bool IterationServer::is_iterator_enabled_for_process(const CustomIterator *p_iterator) {
+	ERR_FAIL_COND_V_MSG(p_iterator == nullptr, false, "iterator is null");
+
+	if (!(p_iterator->get_type() & IteratorType::ITERATOR_TYPE_SEPARATE)) {
+		return false;
+	}
+	return is_iterator_enabled_for_process(p_iterator->get_name());
+}
+bool IterationServer::is_iterator_enabled_for_physics(const String &name) {
+	PackedStringArray enabled_physics_iterators = ProjectSettings::get_singleton()->get_setting("application/config/physics_iterators");
+
+	if (enabled_physics_iterators.is_empty()) {
+		return true;
+	}
+
+	return enabled_physics_iterators.has(name);
+}
+bool IterationServer::is_iterator_enabled_for_physics(const CustomIterator *p_iterator) {
+	ERR_FAIL_COND_V_MSG(p_iterator == nullptr, false, "iterator is null");
+
+	if (!(p_iterator->get_type() & IteratorType::ITERATOR_TYPE_SEPARATE)) {
+		return false;
+	}
+	return is_iterator_enabled_for_physics(p_iterator->get_name());
+}
+bool IterationServer::is_iterator_enabled_for_audio(const String &name) {
+	PackedStringArray enabled_audio_iterators = ProjectSettings::get_singleton()->get_setting("application/config/audio_iterators");
+
+	return enabled_audio_iterators.is_empty() || enabled_audio_iterators.has(name);
+}
+bool IterationServer::is_iterator_enabled_for_audio(const CustomIterator *p_iterator) {
+	ERR_FAIL_COND_V_MSG(p_iterator == nullptr, false, "iterator is null");
+
+	if (!(p_iterator->get_type() & IteratorType::ITERATOR_TYPE_SEPARATE)) {
+		return false;
+	}
+	return is_iterator_enabled_for_audio(p_iterator->get_name());
+}
+bool IterationServer::is_iterator_enabled_for_mixed(const String &name) {
+	PackedStringArray enabled_mixed_iterators = ProjectSettings::get_singleton()->get_setting("application/config/mixed_iterators");
+	return enabled_mixed_iterators.is_empty() || enabled_mixed_iterators.has(name);
+}
+bool IterationServer::is_iterator_enabled_for_mixed(const CustomIterator *p_iterator) {
+	ERR_FAIL_COND_V_MSG(p_iterator == nullptr, false, "iterator is null");
+
+	if (!(p_iterator->get_type() & IteratorType::ITERATOR_TYPE_MIXED)) {
+		return false;
+	}
+	return is_iterator_enabled_for_mixed(p_iterator->get_name());
+}

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -65,6 +65,9 @@
 #include "core/io/translation_loader_po.h"
 #include "core/io/udp_server.h"
 #include "core/io/xml_parser.h"
+#include "core/iteration/custom_iterator.h"
+#include "core/iteration/custom_iterator_extension.h"
+#include "core/iteration/iteration_server.h"
 #include "core/math/a_star.h"
 #include "core/math/a_star_grid_2d.h"
 #include "core/math/expression.h"
@@ -294,6 +297,11 @@ void register_core_types() {
 	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
 
 	worker_thread_pool = memnew(WorkerThreadPool);
+
+	// Iterators
+	GDREGISTER_VIRTUAL_CLASS(IterationServer);
+	GDREGISTER_ABSTRACT_CLASS(CustomIterator);
+	GDREGISTER_VIRTUAL_CLASS(CustomIteratorExtension);
 }
 
 void register_core_settings() {

--- a/doc/classes/CustomIterator.xml
+++ b/doc/classes/CustomIterator.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CustomIterator" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for custom iterators
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/CustomIteratorExtension.xml
+++ b/doc/classes/CustomIteratorExtension.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CustomIteratorExtension" inherits="CustomIterator" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_audio_iteration" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="process_delta" type="float" />
+			<param index="1" name="physics_delta" type="float" />
+			<param index="2" name="frame_time" type="MainFrameTime*" />
+			<param index="3" name="time_scale" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_type" qualifiers="virtual const">
+			<return type="int" enum="IterationServer.IteratorType" />
+			<description>
+			</description>
+		</method>
+		<method name="_mixed_iteration" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="process_delta" type="float" />
+			<param index="1" name="physics_delta" type="float" />
+			<param index="2" name="frame_time" type="MainFrameTime*" />
+			<param index="3" name="time_scale" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_physics_iteration" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="process_delta" type="float" />
+			<param index="1" name="physics_delta" type="float" />
+			<param index="2" name="frame_time" type="MainFrameTime*" />
+			<param index="3" name="time_scale" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_process_iteration" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="process_delta" type="float" />
+			<param index="1" name="physics_delta" type="float" />
+			<param index="2" name="frame_time" type="MainFrameTime*" />
+			<param index="3" name="time_scale" type="float" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/IterationServer.xml
+++ b/doc/classes/IterationServer.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="IterationServer" inherits="Object" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Iterator repository
+	</brief_description>
+	<description>
+		Enables registering of custom iterators and accessing of information about custom iterators.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_iterator" qualifiers="static">
+			<return type="CustomIterator" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns an instance of a [CustomIterator] with the given index.
+			</description>
+		</method>
+		<method name="get_iterator_count" qualifiers="static">
+			<return type="int" />
+			<description>
+				Returns the number of available iterators. Use with [method get_iterator].
+			</description>
+		</method>
+		<method name="register_iterator" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="iterator" type="CustomIterator" />
+			<description>
+				Registers a [CustomIterator] instance to be available with [code]IteratorDB[/code].
+				                Returns:
+				                - [constant OK] on success
+				                - [constant ERR_UNAVAILABLE] if [code]IteratorDB[/code] has reached it limit and cannot register any new iterator
+				                - [constant ERR_ALREADY_EXISTS] if [code]IteratorDB[/code] already contains an iterator with similar name
+			</description>
+		</method>
+		<method name="unregister_iterator" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="iterator" type="CustomIterator" />
+			<description>
+				Unregisters the [CustomIterator] instance from [code]IteratorDB[/code].
+				                Returns:
+				                - [constant OK] on success
+				                - [constant ERR_DOES_NOT_EXIST] if the iterator is already not registered in [code]IteratorDB[/code]
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="ITERATOR_TYPE_UNSET" value="0" enum="IteratorType">
+		</constant>
+		<constant name="ITERATOR_TYPE_MIXED" value="2" enum="IteratorType">
+		</constant>
+		<constant name="ITERATOR_TYPE_SEPARATE" value="1" enum="IteratorType">
+		</constant>
+	</constants>
+</class>

--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -32,6 +32,7 @@
 #define MAIN_TIMER_SYNC_H
 
 #include "core/config/engine.h"
+#include "core/variant/native_ptr.h"
 
 // Uncomment this define to get more debugging logs for the delta smoothing.
 // #define GODOT_DEBUG_DELTA_SMOOTHER
@@ -161,5 +162,7 @@ public:
 	// advance one frame, return timesteps to take
 	MainFrameTime advance(double p_physics_step, int p_physics_ticks_per_second);
 };
+
+GDVIRTUAL_NATIVE_PTR(MainFrameTime);
 
 #endif // MAIN_TIMER_SYNC_H


### PR DESCRIPTION
This is an implementation for the proposal godotengine/godot-proposals#1592 bases on the existing PR GH-42875 by @AndreaCatania 

I have rewritten the PR for:
1. Bring it up to date with master
2. Allow multiple custom iterators from different modules and extensions

The changes are:

Add class that allows specifying custom iterators
Add class that allows registering of custom iterators
Add possibility to set the enabled iterators in the project settings (default, if unset, is all are enabled)
Call the enabled iterators at the specific place in main where the default iterators are called

I added the classes CustomIterator (for modules) and CustomIteratorExtension (for gdextension)
Both work about the same, but the methods in CustomIteratorExtension have "_" prepended.
Mandatory methods to override are 

- get_name: Must return a unique name. This is used as an identifier.
- get_type: Must return a IterationServer::IteratorType flag value, which can have one or a (bitwise) combination of the follow values
- - ITERATOR_TYPE_SEPARATE: Iterator uses one or multiple of the separate methods for process, physics or audio iteration
- - ITERATOR_TYPE_MIXED: Iterator uses the mixed iteration method to for an iterator that combines several types.

There are also several methods that are optional or used conditionally:
- process_iteration, physics_iteration, audio_iteration: Called when get_type returns a flag with ITERATOR_TYPE_SEPARATE. These either add to, or replace the _process, _physics_process or AudioServer functionality.
- mixed_iteration: Called when get_type returns a flag with ITERATOR_TYPE_MIXED. This is when the iterator does not fit into a single type.

The "*_iteration" methods are called in the "Main::iteration()" methods at specific locations:

- mixed_iteration: The first iterator to be called. It is called before the default "_physics_process" is called.
- physics_iteration: Called right before the default "_physics_process" is called, but after mixed_iteration
- process_iteration: Called right before the default "_process" is called.
- audio_iteration: Called before the update of the AudioServer is be called

These methods should return a boolean value that indicates if the engine should be exited (by setting the "exit" variable in the Main::iteration() method to the returned value)

Registering works similar to ScriptServer, using the class "IterationServer":
Create instance of the custom iterator (using memnew) and call register_iterator passing it.

The enabled iterators can be configured in the project settings. There base path is "application/config" withthe following fields: process_iterators, physics_iterators, audio_iterators and mixed_iterators.
They are each a list of strings containing the names of the iterators that are enabled for the specific usage.
For the setting there is one special name: "main". By leaving that out one can disable the default functionality of either "_process", "_pysics_process" or updating of the AudioServer. When main is disabled for either process or physics_process a warning will be printed when opening the project in the editor.

There are some things that can/should be added (like tests and (more) documentation), but I wanted to open this PR at this point to see if this is an acceptable change in general and/or if there are things that should be changed - especially as I generally build on what @AndreaCatania  started - which was, as I understand, written with godex in mind - and am not absolutely sure of what is actually needed.