### PR TITLE
Fixed issues with blend modes in OpenGL 3 renderer

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -3452,6 +3452,10 @@ void SceneShaderData::set_code(const String &p_code) {
 		blend_mode = BLEND_MODE_ALPHA_TO_COVERAGE;
 	}
 
+	if (blend_mode == BLEND_MODE_ADD || blend_mode == BLEND_MODE_SUB || blend_mode == BLEND_MODE_MUL) {
+		uses_blend_alpha = true; // Force alpha used because of blend.
+	}
+
 	valid = true;
 }
 


### PR DESCRIPTION
Added uses_blend_alpha = true for ADD, SUBTRACT, and MULTIPLY blend modes to match the other renderers.

Fixes #76334