### PR TITLE
Standardize Object ptrcall encoding on `Object **`

### DIFF
--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -242,8 +242,11 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+		if (p_ptr == nullptr) {
+			return Ref<T>();
+		}
 		// p_ptr points to a RefCounted object
-		return Ref<T>(const_cast<T *>(reinterpret_cast<const T *>(p_ptr)));
+		return Ref<T>(const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr)));
 	}
 
 	typedef Ref<T> EncodeT;
@@ -259,8 +262,11 @@ struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
+		if (p_ptr == nullptr) {
+			return Ref<T>();
+		}
 		// p_ptr points to a RefCounted object
-		return Ref<T>((T *)p_ptr);
+		return Ref<T>(*((T *const *)p_ptr));
 	}
 };
 

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -159,7 +159,10 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <class T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return const_cast<T *>(reinterpret_cast<const T *>(p_ptr));
+		if (p_ptr == nullptr) {
+			return nullptr;
+		}
+		return const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr));
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -170,7 +173,10 @@ struct PtrToArg<T *> {
 template <class T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(p_ptr);
+		if (p_ptr == nullptr) {
+			return nullptr;
+		}
+		return *reinterpret_cast<T *const *>(p_ptr);
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -502,7 +502,7 @@ public:
 			case Variant::PACKED_COLOR_ARRAY:
 				return get_color_array(v);
 			case Variant::OBJECT:
-				return v->_get_obj().obj;
+				return get_object(v);
 			case Variant::VARIANT_MAX:
 				ERR_FAIL_V(nullptr);
 		}

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -2865,7 +2865,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		itype.cs_out = "%5return (%2)%0(%1);";
 
-		itype.c_arg_in = "(void*)%s";
+		itype.c_arg_in = "&%s";
 		itype.c_type = "IntPtr";
 		itype.c_type_in = itype.c_type;
 		itype.c_type_out = "GodotObject";


### PR DESCRIPTION
This is an attempt to implement "possible solution nr 2" from https://github.com/godotengine/godot-cpp/issues/1119

That issue is about problems in godot-cpp due to Godot using a different encoding of Object in two different situations:

- When calling normal methods, they are encoded as `Object *`
- When calling virtual GDExtension methods, they are encoded as `Object **`

This PR attempts to standardize on `Object **` per @vnen's suggestion:

> > For an object, `VariantInternal::get_opaque_pointer()` returns a plain `Object *`. Hence, we're encoding an `Object *` as `Object *`.
> 
> This seems like a problem in this method itself, it should return an `Object **`. The thing is that this is meant to return a pointer to the value inside the Variant. If it's a basic type, like `int` it returns an `int *`. For objects, the base type is `Object *` which is what is stored in Variant, so the method should return a pointer to this value, which is an `Object **`.
> 
> I do take the blame for this since I implemented the `VariantInternal::get_opaque_pointer()` initially. It should just call `VariantInternal::get_object()`, which does return an `Object **` (`get_object()` itself was added later, that's why it's not called there). But I probably did this way because it is what worked.
>
> [snip]
>
> If we change this, I would go with always using `Object **`, for the same reasoning as `Variant::get_opaque_pointer()` I mention above. Changing `PtrToArg` would indeed require changes in GDScript and C#, as this affect all calls, not only virtual ones.

It appears to work in very limited testing? And, when paired with PR https://github.com/godotengine/godot-cpp/pull/1123, it seems to fix the godot-cpp issues (both the original issues and the regressions).

However, I suspect this breaks some things I'm not aware of and/or didn't try - ~~in particular, this probably has an impact on C#, which I didn't test at all.~~ My limited testing of GDScript seems to work, but it's possible I'm just not testing in a way that would trigger issues.

UPDATE: I have now tested C# a little, and it seems to work in limited testing with the small change to C# bindings generator.

In any case, please let me know what you think :-)

Fixes #61967
