### PR TITLE
Expose `Control::_get_drag_data()` as non-const function

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -75,7 +75,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="_get_drag_data" qualifiers="virtual const">
+		<method name="_get_drag_data" qualifiers="virtual">
 			<return type="Variant" />
 			<param index="0" name="at_position" type="Vector2" />
 			<description>

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -349,7 +349,7 @@ protected:
 	GDVIRTUAL0RC(Vector2, _get_minimum_size)
 	GDVIRTUAL1RC(String, _get_tooltip, Vector2)
 
-	GDVIRTUAL1RC(Variant, _get_drag_data, Vector2)
+	GDVIRTUAL1R(Variant, _get_drag_data, Vector2)
 	GDVIRTUAL2RC(bool, _can_drop_data, Vector2, Variant)
 	GDVIRTUAL2(_drop_data, Vector2, Variant)
 	GDVIRTUAL1RC(Object *, _make_custom_tooltip, String)


### PR DESCRIPTION
The documentation states that we could call `Control::set_drag_preview()` from inside `Control::_get_drag_data()`. 
<https://docs.godotengine.org/en/latest/classes/class_control.html#class-control-method-get-drag-data>

The function `Control::_get_drag_data()` is actually a non-const function 

https://github.com/godotengine/godot/blob/f581f21dd61a8fb581b80d07755cdf60c95d146d/scene/gui/control.h#L511

..whereas it's been (wrongly) exposed as a const function here:

https://github.com/godotengine/godot/blob/f581f21dd61a8fb581b80d07755cdf60c95d146d/scene/gui/control.h#L352

`GDVIRTUAL1RC` should be changed to `GDVIRTUAL1R` to match the signature.

This fix would allow GDExtension to set drag preview.