### PR TITLE
Remove unused SVG icons

### DIFF
--- a/editor/icons/KeyXform.svg
+++ b/editor/icons/KeyXform.svg
@@ -1,1 +1,0 @@
-<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><rect fill="#ea7940" height="6.1027" ry=".76286" transform="matrix(.70710678 -.70710678 .70710678 .70710678 0 -1042.4)" width="6.1027" x="-740.13947" y="741.10779"/></svg>

--- a/editor/icons/Navigation2D.svg
+++ b/editor/icons/Navigation2D.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m3 1050.4 5-2 5 2-5-12z" fill="#8da5f3" fill-rule="evenodd" transform="translate(0 -1036.4)"/></svg>

--- a/editor/icons/Navigation3D.svg
+++ b/editor/icons/Navigation3D.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m3 1050.4 5-2 5 2-5-12z" fill="#fc7f7f" fill-rule="evenodd" transform="translate(0 -1036.4)"/></svg>


### PR DESCRIPTION
- Navigation2D and Navigation3D don't seem to be a thing in Godot 4, and these icons don't appear to be used elsewhere.
- KeyTrackXForm doesn't seem to be used anywhere either. It looks identical to KeyTrackPosition, which is is used.