### PR TITLE
[3.x] Bounds fixes in `TextureAtlas` import

### DIFF
--- a/editor/editor_atlas_packer.cpp
+++ b/editor/editor_atlas_packer.cpp
@@ -105,7 +105,7 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 
 		Ref<BitMap> src_bitmap;
 		src_bitmap.instance();
-		src_bitmap->create(aabb.size / divide_by);
+		src_bitmap->create(Size2(Math::ceil(aabb.size.x / (real_t)divide_by), Math::ceil(aabb.size.y / (real_t)divide_by)));
 
 		int w = src_bitmap->get_size().width;
 		int h = src_bitmap->get_size().height;


### PR DESCRIPTION
Partial backport of #68380, without any new properties, only ensures bounds are fixed, it also does not change the way the alpha threshold is managed, can add that here too if desired 

3.x will still suffer from some of the issues in `BitMap` solved by #68732, will see if I can backport them separately

* Fixes: #77400 [confirmed](https://github.com/godotengine/godot/issues/77400#issuecomment-1561780175)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
