### PR TITLE
Fix auto-reparenting logic in the `ProgressDialog`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6981,6 +6981,7 @@ EditorNode::EditorNode() {
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);
 	progress_dialog = memnew(ProgressDialog);
+	progress_dialog->set_unparent_when_invisible(true);
 
 	// Take up all screen.
 	gui_base->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);

--- a/editor/progress_dialog.cpp
+++ b/editor/progress_dialog.cpp
@@ -134,29 +134,21 @@ void BackgroundProgress::end_task(const String &p_task) {
 
 ProgressDialog *ProgressDialog::singleton = nullptr;
 
-void ProgressDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (!is_visible()) {
-			Node *p = get_parent();
-			if (p) {
-				p->remove_child(this);
-			}
-		}
-	}
-}
-
 void ProgressDialog::_popup() {
 	Size2 ms = main->get_combined_minimum_size();
 	ms.width = MAX(500 * EDSCALE, ms.width);
 
 	Ref<StyleBox> style = main->get_theme_stylebox(SNAME("panel"), SNAME("PopupMenu"));
 	ms += style->get_minimum_size();
+
 	main->set_offset(SIDE_LEFT, style->get_margin(SIDE_LEFT));
 	main->set_offset(SIDE_RIGHT, -style->get_margin(SIDE_RIGHT));
 	main->set_offset(SIDE_TOP, style->get_margin(SIDE_TOP));
 	main->set_offset(SIDE_BOTTOM, -style->get_margin(SIDE_BOTTOM));
 
-	EditorInterface::get_singleton()->popup_dialog_centered(this, ms);
+	if (!is_inside_tree()) {
+		EditorInterface::get_singleton()->popup_dialog_centered(this, ms);
+	}
 }
 
 void ProgressDialog::add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -88,7 +88,6 @@ class ProgressDialog : public PopupPanel {
 	bool canceled = false;
 
 protected:
-	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -96,6 +96,7 @@ void Popup::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_UNPARENTED:
 		case NOTIFICATION_EXIT_TREE: {
 			if (!is_in_edited_scene_root()) {
 				_deinitialize_visible_parents();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -524,8 +524,6 @@ void Window::set_ime_position(const Point2i &p_pos) {
 
 bool Window::is_embedded() const {
 	ERR_READ_THREAD_GUARD_V(false);
-	ERR_FAIL_COND_V(!is_inside_tree(), false);
-
 	return get_embedder() != nullptr;
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77426.

This wasn't a regression per se. It's just that instead of ignoring the case I decided to report it, so that's exactly what we've got. I added the necessary check, but also noticed that I'd forgotten to remove the hacky unparenting logic for `ProgressDialog` in favor of the new method. So I did that as well.

That, however, uncovered one issue with `Popup`. Since unparenting is now done by `Window` and not by the final type in the inheritance chain, it happens before `Popup` receives the visibility changed notification. `Popup` had some logic to disconnect signals from parents when visibility changes, but that was no longer possible because the node would be unparented by that point by the `Window` notification handler. So I added a handler to the unparented notification.

More than that, `Popup` relied on `Window::is_embedded` which simply fails when called out of tree. I don't see why we'd need to explicitly fail, since when out of tree its call to `get_embedder()` would simply return either a valid viewport or a `nullptr` and the method would just return `false`. Since I don't see any reason for an error here, and it was getting in the way of the `Popup` logic, I removed the error.

Since this can be undesirable for some reason that I don't see yet, I put it all in a separate commit. So the first commit fixes the "Attempted to parent..." spam but adds a new error (only fired once, once the import is done). And the second fixes that new error. If my attempt at the second half is not appropriate, we can just keep the first commit for the time being.