### PR TITLE
Fix a crash when hovering over "Favorites" in the FileSystem dock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2281,6 +2281,10 @@ void FileSystemDock::remove_resource_tooltip_plugin(const Ref<EditorResourceTool
 }
 
 Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
+	if (p_path == "Favorites") {
+		// No tooltip for the "Favorites" group.
+		return nullptr;
+	}
 	if (DirAccess::exists(p_path)) {
 		// No tooltip for directory.
 		return nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77425. Shouldn't conflict with https://github.com/godotengine/godot/pull/77208.

As mentioned in a comment, the logic based on strings seems flimsy to me, but we already rely on it, so... If someone wants to take a stab at improving its robustness, feel free to open a follow-up PR.