### PR TITLE
Unify item indexing in `PopupMenu`

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -47,8 +47,8 @@ String PopupMenu::_get_accel_text(const Item &p_item) const {
 	return String();
 }
 
-Size2 PopupMenu::_get_item_icon_size(int p_item) const {
-	const PopupMenu::Item &item = items[p_item];
+Size2 PopupMenu::_get_item_icon_size(int p_idx) const {
+	const PopupMenu::Item &item = items[p_idx];
 	Size2 icon_size = item.get_icon_size();
 
 	int max_width = 0;
@@ -126,22 +126,22 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 	return minsize;
 }
 
-int PopupMenu::_get_item_height(int p_item) const {
-	ERR_FAIL_INDEX_V(p_item, items.size(), 0);
+int PopupMenu::_get_item_height(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), 0);
 
-	Size2 icon_size = _get_item_icon_size(p_item);
+	Size2 icon_size = _get_item_icon_size(p_idx);
 	int icon_height = icon_size.height;
-	if (items[p_item].checkable_type && !items[p_item].separator) {
+	if (items[p_idx].checkable_type && !items[p_idx].separator) {
 		icon_height = MAX(icon_height, MAX(theme_cache.checked->get_height(), theme_cache.radio_checked->get_height()));
 	}
 
-	int text_height = items[p_item].text_buf->get_size().height;
-	if (text_height == 0 && !items[p_item].separator) {
+	int text_height = items[p_idx].text_buf->get_size().height;
+	if (text_height == 0 && !items[p_idx].separator) {
 		text_height = theme_cache.font->get_height(theme_cache.font_size);
 	}
 
 	int separator_height = 0;
-	if (items[p_item].separator) {
+	if (items[p_idx].separator) {
 		separator_height = MAX(theme_cache.separator_style->get_minimum_size().height, MAX(theme_cache.labeled_separator_left->get_minimum_size().height, theme_cache.labeled_separator_right->get_minimum_size().height));
 	}
 
@@ -769,24 +769,24 @@ void PopupMenu::_close_pressed() {
 	}
 }
 
-void PopupMenu::_shape_item(int p_item) {
-	if (items.write[p_item].dirty) {
-		items.write[p_item].text_buf->clear();
+void PopupMenu::_shape_item(int p_idx) {
+	if (items.write[p_idx].dirty) {
+		items.write[p_idx].text_buf->clear();
 
-		Ref<Font> font = items[p_item].separator ? theme_cache.font_separator : theme_cache.font;
-		int font_size = items[p_item].separator ? theme_cache.font_separator_size : theme_cache.font_size;
+		Ref<Font> font = items[p_idx].separator ? theme_cache.font_separator : theme_cache.font;
+		int font_size = items[p_idx].separator ? theme_cache.font_separator_size : theme_cache.font_size;
 
-		if (items[p_item].text_direction == Control::TEXT_DIRECTION_INHERITED) {
-			items.write[p_item].text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
+		if (items[p_idx].text_direction == Control::TEXT_DIRECTION_INHERITED) {
+			items.write[p_idx].text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 		} else {
-			items.write[p_item].text_buf->set_direction((TextServer::Direction)items[p_item].text_direction);
+			items.write[p_idx].text_buf->set_direction((TextServer::Direction)items[p_idx].text_direction);
 		}
-		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].language);
+		items.write[p_idx].text_buf->add_string(items.write[p_idx].xl_text, font, font_size, items[p_idx].language);
 
-		items.write[p_item].accel_text_buf->clear();
-		items.write[p_item].accel_text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
-		items.write[p_item].accel_text_buf->add_string(_get_accel_text(items.write[p_item]), font, font_size);
-		items.write[p_item].dirty = false;
+		items.write[p_idx].accel_text_buf->clear();
+		items.write[p_idx].accel_text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
+		items.write[p_idx].accel_text_buf->add_string(_get_accel_text(items.write[p_idx]), font, font_size);
+		items.write[p_idx].dirty = false;
 	}
 }
 
@@ -1192,27 +1192,27 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 	_menu_changed();
 }
 
-void PopupMenu::set_item_text_direction(int p_item, Control::TextDirection p_text_direction) {
-	if (p_item < 0) {
-		p_item += get_item_count();
+void PopupMenu::set_item_text_direction(int p_idx, Control::TextDirection p_text_direction) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
 	}
-	ERR_FAIL_INDEX(p_item, items.size());
+	ERR_FAIL_INDEX(p_idx, items.size());
 	ERR_FAIL_COND((int)p_text_direction < -1 || (int)p_text_direction > 3);
-	if (items[p_item].text_direction != p_text_direction) {
-		items.write[p_item].text_direction = p_text_direction;
-		items.write[p_item].dirty = true;
+	if (items[p_idx].text_direction != p_text_direction) {
+		items.write[p_idx].text_direction = p_text_direction;
+		items.write[p_idx].dirty = true;
 		control->queue_redraw();
 	}
 }
 
-void PopupMenu::set_item_language(int p_item, const String &p_language) {
-	if (p_item < 0) {
-		p_item += get_item_count();
+void PopupMenu::set_item_language(int p_idx, const String &p_language) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
 	}
-	ERR_FAIL_INDEX(p_item, items.size());
-	if (items[p_item].language != p_language) {
-		items.write[p_item].language = p_language;
-		items.write[p_item].dirty = true;
+	ERR_FAIL_INDEX(p_idx, items.size());
+	if (items[p_idx].language != p_language) {
+		items.write[p_idx].language = p_language;
+		items.write[p_idx].dirty = true;
 		control->queue_redraw();
 	}
 }
@@ -1378,14 +1378,14 @@ String PopupMenu::get_item_text(int p_idx) const {
 	return items[p_idx].text;
 }
 
-Control::TextDirection PopupMenu::get_item_text_direction(int p_item) const {
-	ERR_FAIL_INDEX_V(p_item, items.size(), Control::TEXT_DIRECTION_INHERITED);
-	return items[p_item].text_direction;
+Control::TextDirection PopupMenu::get_item_text_direction(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), Control::TEXT_DIRECTION_INHERITED);
+	return items[p_idx].text_direction;
 }
 
-String PopupMenu::get_item_language(int p_item) const {
-	ERR_FAIL_INDEX_V(p_item, items.size(), "");
-	return items[p_item].language;
+String PopupMenu::get_item_language(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), "");
+	return items[p_idx].language;
 }
 
 int PopupMenu::get_item_idx_from_text(const String &text) const {
@@ -1697,17 +1697,17 @@ int PopupMenu::get_item_count() const {
 	return items.size();
 }
 
-void PopupMenu::scroll_to_item(int p_item) {
-	ERR_FAIL_INDEX(p_item, items.size());
+void PopupMenu::scroll_to_item(int p_idx) {
+	ERR_FAIL_INDEX(p_idx, items.size());
 
 	// Scroll item into view (upwards).
-	if (items[p_item]._ofs_cache - scroll_container->get_v_scroll() < -control->get_position().y) {
-		scroll_container->set_v_scroll(items[p_item]._ofs_cache + control->get_position().y);
+	if (items[p_idx]._ofs_cache - scroll_container->get_v_scroll() < -control->get_position().y) {
+		scroll_container->set_v_scroll(items[p_idx]._ofs_cache + control->get_position().y);
 	}
 
 	// Scroll item into view (downwards).
-	if (items[p_item]._ofs_cache + items[p_item]._height_cache - scroll_container->get_v_scroll() > -control->get_position().y + scroll_container->get_size().height) {
-		scroll_container->set_v_scroll(items[p_item]._ofs_cache + items[p_item]._height_cache + control->get_position().y);
+	if (items[p_idx]._ofs_cache + items[p_idx]._height_cache - scroll_container->get_v_scroll() > -control->get_position().y + scroll_container->get_size().height) {
+		scroll_container->set_v_scroll(items[p_idx]._ofs_cache + items[p_idx]._height_cache + control->get_position().y);
 	}
 }
 
@@ -1768,10 +1768,10 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 	return false;
 }
 
-void PopupMenu::activate_item(int p_item) {
-	ERR_FAIL_INDEX(p_item, items.size());
-	ERR_FAIL_COND(items[p_item].separator);
-	int id = items[p_item].id >= 0 ? items[p_item].id : p_item;
+void PopupMenu::activate_item(int p_idx) {
+	ERR_FAIL_INDEX(p_idx, items.size());
+	ERR_FAIL_COND(items[p_idx].separator);
+	int id = items[p_idx].id >= 0 ? items[p_idx].id : p_idx;
 
 	//hide all parent PopupMenus
 	Node *next = get_parent();
@@ -1780,11 +1780,11 @@ void PopupMenu::activate_item(int p_item) {
 		// We close all parents that are chained together,
 		// with hide_on_item_selection enabled
 
-		if (items[p_item].checkable_type) {
+		if (items[p_idx].checkable_type) {
 			if (!hide_on_checkable_item_selection || !pop->is_hide_on_checkable_item_selection()) {
 				break;
 			}
-		} else if (0 < items[p_item].max_states) {
+		} else if (0 < items[p_idx].max_states) {
 			if (!hide_on_multistate_item_selection || !pop->is_hide_on_multistate_item_selection()) {
 				break;
 			}
@@ -1802,11 +1802,11 @@ void PopupMenu::activate_item(int p_item) {
 
 	bool need_hide = true;
 
-	if (items[p_item].checkable_type) {
+	if (items[p_idx].checkable_type) {
 		if (!hide_on_checkable_item_selection) {
 			need_hide = false;
 		}
-	} else if (0 < items[p_item].max_states) {
+	} else if (0 < items[p_idx].max_states) {
 		if (!hide_on_multistate_item_selection) {
 			need_hide = false;
 		}
@@ -1819,7 +1819,7 @@ void PopupMenu::activate_item(int p_item) {
 	}
 
 	emit_signal(SNAME("id_pressed"), id);
-	emit_signal(SNAME("index_pressed"), p_item);
+	emit_signal(SNAME("index_pressed"), p_idx);
 }
 
 void PopupMenu::remove_item(int p_idx) {

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -103,11 +103,11 @@ class PopupMenu : public Popup {
 	int _get_mouse_over(const Point2 &p_over) const;
 	virtual Size2 _get_contents_minimum_size() const override;
 
-	int _get_item_height(int p_item) const;
+	int _get_item_height(int p_idx) const;
 	int _get_items_total_height() const;
-	Size2 _get_item_icon_size(int p_item) const;
+	Size2 _get_item_icon_size(int p_idx) const;
 
-	void _shape_item(int p_item);
+	void _shape_item(int p_idx);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event);
 	void _activate_submenu(int p_over, bool p_by_keyboard = false);
@@ -277,10 +277,10 @@ public:
 	void set_item_count(int p_count);
 	int get_item_count() const;
 
-	void scroll_to_item(int p_item);
+	void scroll_to_item(int p_idx);
 
 	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false);
-	void activate_item(int p_item);
+	void activate_item(int p_idx);
 
 	void remove_item(int p_idx);
 


### PR DESCRIPTION
In c++ some methods used `p_idx` and some `p_item` as there was no actual difference in how these values were used the difference just become confusing, they are already unified as `index` in GDScript, same could be done for `TabBar`

Might be considered a nitpick but parameter names differing can be easily read as that something of value differs

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
