### PR TITLE
Check for null in `set_pattern()`

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -2334,7 +2334,8 @@ Vector2i TileMap::map_pattern(const Vector2i &p_position_in_tilemap, const Vecto
 
 void TileMap::set_pattern(int p_layer, const Vector2i &p_position, const Ref<TileMapPattern> p_pattern) {
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
+	ERR_FAIL_COND(p_pattern.is_null());
 
 	TypedArray<Vector2i> used_cells = p_pattern->get_used_cells();
 	for (int i = 0; i < used_cells.size(); i++) {


### PR DESCRIPTION
Fixes #77422
The last argument of the method is a reference to TileMapPattern, not an int.

This exposed a deeper issue. The method is called with `0` used as `Ref<TileMapPattern>` (effectively null). GDScript will call it without any validation and cause a crash. After I added the null check, only then you will get an error about invalid arguments (only after the method is called and fails).