### PR TITLE
Update extension API validation

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1065,7 +1065,57 @@ void GDExtensionAPIDump::generate_extension_json_file(const String &p_path) {
 	fa->store_string(text);
 }
 
-static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_new_api, const String &p_base_array, const String &p_name_field, const Vector<String> &p_fields_to_compare, bool p_compare_hashes, const String &p_outer_class = String(), bool p_compare_operators = false) {
+static bool compare_value(const String &p_path, const String &p_field, const Variant &p_old_value, const Variant &p_new_value, bool p_allow_name_change) {
+	bool failed = false;
+	String path = p_path + "/" + p_field;
+	if (p_old_value.get_type() == Variant::ARRAY && p_new_value.get_type() == Variant::ARRAY) {
+		Array old_array = p_old_value;
+		Array new_array = p_new_value;
+		if (!compare_value(path, "size", old_array.size(), new_array.size(), p_allow_name_change)) {
+			failed = true;
+		}
+		for (int i = 0; i < old_array.size() && i < new_array.size(); i++) {
+			if (!compare_value(path, itos(i), old_array[i], new_array[i], p_allow_name_change)) {
+				failed = true;
+			}
+		}
+	} else if (p_old_value.get_type() == Variant::DICTIONARY && p_new_value.get_type() == Variant::DICTIONARY) {
+		Dictionary old_dict = p_old_value;
+		Dictionary new_dict = p_new_value;
+		Array old_keys = old_dict.keys();
+		for (int i = 0; i < old_keys.size(); i++) {
+			Variant key = old_keys[i];
+			if (!new_dict.has(key)) {
+				failed = true;
+				print_error(vformat("Validate extension JSON: Error: Field '%s': %s was removed.", p_path, key));
+				continue;
+			}
+			if (p_allow_name_change && key == "name") {
+				continue;
+			}
+			if (!compare_value(path, key, old_dict[key], new_dict[key], p_allow_name_change)) {
+				failed = true;
+			}
+		}
+		Array new_keys = old_dict.keys();
+		for (int i = 0; i < new_keys.size(); i++) {
+			Variant key = new_keys[i];
+			if (!old_dict.has(key)) {
+				failed = true;
+				print_error(vformat("Validate extension JSON: Error: Field '%s': %s was added with value %s.", p_path, key, new_dict[key]));
+			}
+		}
+	} else {
+		bool equal = Variant::evaluate(Variant::OP_EQUAL, p_old_value, p_new_value);
+		if (!equal) {
+			print_error(vformat("Validate extension JSON: Error: Field '%s': %s changed value in new API, from %s to %s.", p_path, p_field, p_old_value.get_construct_string(), p_new_value.get_construct_string()));
+			return false;
+		}
+	}
+	return !failed;
+}
+
+static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_new_api, const String &p_base_array, const String &p_name_field, const Vector<String> &p_fields_to_compare, bool p_compare_hashes, const String &p_outer_class = String(), bool p_compare_operators = false, bool p_compare_enum_value = false) {
 	String base_array = p_outer_class + p_base_array;
 	if (!p_old_api.has(p_base_array)) {
 		return true; // May just not have this array and its still good. Probably added recently.
@@ -1077,7 +1127,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 
 	for (int i = 0; i < new_api.size(); i++) {
 		Dictionary elem = new_api[i];
-		ERR_FAIL_COND_V_MSG(!elem.has(p_name_field), false, "Validate extension JSON: Element of base_array '" + base_array + "' is missing field '" + p_name_field + "'. This is a bug.");
+		ERR_FAIL_COND_V_MSG(!elem.has(p_name_field), false, vformat("Validate extension JSON: Element of base_array '%s' is missing field '%s'. This is a bug.", base_array, p_name_field));
 		String name = elem[p_name_field];
 		if (p_compare_operators && elem.has("right_type")) {
 			name += " " + String(elem["right_type"]);
@@ -1090,7 +1140,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 		Dictionary old_elem = old_api[i];
 		if (!old_elem.has(p_name_field)) {
 			failed = true;
-			print_error("Validate extension JSON: JSON file: element of base array '" + base_array + "' is missing the field: '" + p_name_field + "'.");
+			print_error(vformat("Validate extension JSON: JSON file: element of base array '%s' is missing the field: '%s'.", base_array, p_name_field));
 			continue;
 		}
 		String name = old_elem[p_name_field];
@@ -1099,7 +1149,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 		}
 		if (!new_api_assoc.has(name)) {
 			failed = true;
-			print_error("Validate extension JSON: API was removed: " + base_array + "/" + name);
+			print_error(vformat("Validate extension JSON: API was removed: %s/%s", base_array, name));
 			continue;
 		}
 
@@ -1119,19 +1169,31 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 				field = field.substr(1, field.length());
 			}
 
+			bool enum_values = field.begins_with("$");
+			if (enum_values) {
+				// Meaning this field is a list of enum values.
+				field = field.substr(1, field.length());
+			}
+
+			bool allow_name_change = field.begins_with("@");
+			if (allow_name_change) {
+				// Meaning that when structurally comparing the old and new value, the dictionary entry 'name' may change.
+				field = field.substr(1, field.length());
+			}
+
 			Variant old_value;
 
 			if (!old_elem.has(field)) {
 				if (optional) {
 					if (new_elem.has(field)) {
 						failed = true;
-						print_error("Validate extension JSON: JSON file: Field was added in a way that breaks compatibility '" + base_array + "/" + name + "': " + field);
+						print_error(vformat("Validate extension JSON: JSON file: Field was added in a way that breaks compatibility '%s/%s': %s", base_array, name, field));
 					}
 				} else if (added && new_elem.has(field)) {
 					// Should be ok, field now exists, should not be verified in prior versions where it does not.
 				} else {
 					failed = true;
-					print_error("Validate extension JSON: JSON file: Missing filed in '" + base_array + "/" + name + "': " + field);
+					print_error(vformat("Validate extension JSON: JSON file: Missing field in '%s/%s': %s", base_array, name, field));
 				}
 				continue;
 			} else {
@@ -1140,17 +1202,24 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 
 			if (!new_elem.has(field)) {
 				failed = true;
-				ERR_PRINT("Validate extension JSON: Missing filed in current API '" + base_array + "/" + name + "': " + field + ". This is a bug.");
+				ERR_PRINT(vformat("Validate extension JSON: Missing field in current API '%s/%s': %s. This is a bug.", base_array, name, field));
 				continue;
 			}
 
 			Variant new_value = new_elem[field];
 
-			bool equal = Variant::evaluate(Variant::OP_EQUAL, old_value, new_value);
-			if (!equal) {
+			if (p_compare_enum_value && name.ends_with("_MAX")) {
+				if (static_cast<int64_t>(new_value) > static_cast<int64_t>(old_value)) {
+					// Ignore the _MAX value of an enum increasing.
+					continue;
+				}
+			}
+			if (enum_values) {
+				if (!compare_dict_array(old_elem, new_elem, field, "name", { "value" }, false, base_array + "/" + name + "/", false, true)) {
+					failed = true;
+				}
+			} else if (!compare_value(base_array + "/" + name, field, old_value, new_value, allow_name_change)) {
 				failed = true;
-				print_error("Validate extension JSON: Error: Field '" + base_array + "/" + name + "': " + field + " changed value in new API, from " + old_value.get_construct_string() + " to " + new_value.get_construct_string() + ".");
-				continue;
 			}
 		}
 
@@ -1161,7 +1230,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 				}
 
 				failed = true;
-				print_error("Validate extension JSON: JSON file: element of base array '" + base_array + "' is missing the field: 'hash'.");
+				print_error(vformat("Validate extension JSON: JSON file: element of base array '%s' is missing the field: 'hash'.", base_array));
 				continue;
 			}
 
@@ -1169,7 +1238,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 
 			if (!new_elem.has("hash")) {
 				failed = true;
-				print_error("Validate extension JSON: Error: Field '" + base_array + "' is missing the field: 'hash'.");
+				print_error(vformat("Validate extension JSON: Error: Field '%s' is missing the field: 'hash'.", base_array));
 				continue;
 			}
 
@@ -1190,7 +1259,7 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 
 			if (!hash_found) {
 				failed = true;
-				print_error("Validate extension JSON: Error: Hash mismatch for '" + base_array + "/" + name + "'. This means that the function has changed and no compatibility function was provided.");
+				print_error(vformat("Validate extension JSON: Error: Hash changed for '%s/%s', from %08X to %08X. This means that the function has changed and no compatibility function was provided.", base_array, name, old_hash, new_hash));
 				continue;
 			}
 		}
@@ -1210,7 +1279,7 @@ static bool compare_sub_dict_array(HashSet<String> &r_removed_classes_registered
 
 	for (int i = 0; i < new_api.size(); i++) {
 		Dictionary elem = new_api[i];
-		ERR_FAIL_COND_V_MSG(!elem.has(p_outer_name), false, "Validate extension JSON: Element of base_array '" + p_outer + "' is missing field '" + p_outer_name + "'. This is a bug.");
+		ERR_FAIL_COND_V_MSG(!elem.has(p_outer_name), false, vformat("Validate extension JSON: Element of base_array '%s' is missing field '%s'. This is a bug.", p_outer, p_outer_name));
 		new_api_assoc.insert(elem[p_outer_name], elem);
 	}
 
@@ -1220,14 +1289,14 @@ static bool compare_sub_dict_array(HashSet<String> &r_removed_classes_registered
 		Dictionary old_elem = old_api[i];
 		if (!old_elem.has(p_outer_name)) {
 			failed = true;
-			print_error("Validate extension JSON: JSON file: element of base array '" + p_outer + "' is missing the field: '" + p_outer_name + "'.");
+			print_error(vformat("Validate extension JSON: JSON file: element of base array '%s' is missing the field: '%s'.", p_outer, p_outer_name));
 			continue;
 		}
 		String name = old_elem[p_outer_name];
 		if (!new_api_assoc.has(name)) {
 			failed = true;
 			if (!r_removed_classes_registered.has(name)) {
-				print_error("Validate extension JSON: API was removed: " + p_outer + "/" + name);
+				print_error(vformat("Validate extension JSON: API was removed: %s/%s", p_outer, name));
 				r_removed_classes_registered.insert(name);
 			}
 			continue;
@@ -1247,7 +1316,7 @@ Error GDExtensionAPIDump::validate_extension_json_file(const String &p_path) {
 	Error error;
 	String text = FileAccess::get_file_as_string(p_path, &error);
 	if (error != OK) {
-		ERR_PRINT("Validate extension JSON: Could not open file '" + p_path + "'.");
+		ERR_PRINT(vformat("Validate extension JSON: Could not open file '%s'.", p_path));
 		return error;
 	}
 
@@ -1255,7 +1324,7 @@ Error GDExtensionAPIDump::validate_extension_json_file(const String &p_path) {
 	json.instantiate();
 	error = json->parse(text);
 	if (error != OK) {
-		ERR_PRINT("Validate extension JSON: Error parsing '" + p_path + "' at line " + itos(json->get_error_line()) + ": " + json->get_error_message());
+		ERR_PRINT(vformat("Validate extension JSON: Error parsing '%s' at line %d: %s", p_path, json->get_error_line(), json->get_error_message()));
 		return error;
 	}
 
@@ -1269,19 +1338,23 @@ Error GDExtensionAPIDump::validate_extension_json_file(const String &p_path) {
 		int major = header["version_major"];
 		int minor = header["version_minor"];
 
-		ERR_FAIL_COND_V_MSG(major != VERSION_MAJOR, ERR_INVALID_DATA, "JSON API dump is for a different engine version (" + itos(major) + ") than this one (" + itos(major) + ")");
-		ERR_FAIL_COND_V_MSG(minor > VERSION_MINOR, ERR_INVALID_DATA, "JSON API dump is for a newer version of the engine: " + itos(major) + "." + itos(minor));
+		ERR_FAIL_COND_V_MSG(major != VERSION_MAJOR, ERR_INVALID_DATA, vformat("JSON API dump is for a different engine version (%d) than this one (%d)", major, VERSION_MAJOR));
+		ERR_FAIL_COND_V_MSG(minor > VERSION_MINOR, ERR_INVALID_DATA, vformat("JSON API dump is for a newer version of the engine: %d.%d", major, minor));
 	}
 
 	bool failed = false;
 
 	HashSet<String> removed_classes_registered;
 
-	if (!compare_dict_array(old_api, new_api, "constants", "name", Vector<String>({ "value", "is_bitfield" }), false)) {
+	if (!compare_dict_array(old_api, new_api, "global_constants", "name", Vector<String>({ "value", "is_bitfield" }), false)) {
 		failed = true;
 	}
 
-	if (!compare_dict_array(old_api, new_api, "utility_functions", "name", Vector<String>({ "category" }), true)) {
+	if (!compare_dict_array(old_api, new_api, "global_enums", "name", Vector<String>({ "$values", "is_bitfield" }), false)) {
+		failed = true;
+	}
+
+	if (!compare_dict_array(old_api, new_api, "utility_functions", "name", Vector<String>({ "category", "is_vararg", "*return_type", "*@arguments" }), true)) {
 		failed = true;
 	}
 
@@ -1297,11 +1370,11 @@ Error GDExtensionAPIDump::validate_extension_json_file(const String &p_path) {
 		failed = true;
 	}
 
-	if (!compare_sub_dict_array(removed_classes_registered, "builtin_classes", "name", old_api, new_api, "methods", "name", {}, true)) {
+	if (!compare_sub_dict_array(removed_classes_registered, "builtin_classes", "name", old_api, new_api, "methods", "name", { "is_vararg", "is_static", "is_const", "*return_type", "*@arguments" }, true)) {
 		failed = true;
 	}
 
-	if (!compare_sub_dict_array(removed_classes_registered, "builtin_classes", "name", old_api, new_api, "constructors", "index", { "*arguments" }, false)) {
+	if (!compare_sub_dict_array(removed_classes_registered, "builtin_classes", "name", old_api, new_api, "constructors", "index", { "*@arguments" }, false)) {
 		failed = true;
 	}
 
@@ -1309,11 +1382,15 @@ Error GDExtensionAPIDump::validate_extension_json_file(const String &p_path) {
 		failed = true;
 	}
 
-	if (!compare_sub_dict_array(removed_classes_registered, "classes", "name", old_api, new_api, "methods", "name", { "is_virtual", "is_vararg", "is_static" }, true)) { // is_const sometimes can change because they are added if someone forgot, but should not be a problem for the extensions.
+	if (!compare_sub_dict_array(removed_classes_registered, "classes", "name", old_api, new_api, "enums", "name", { "is_bitfield", "$values" }, false)) {
 		failed = true;
 	}
 
-	if (!compare_sub_dict_array(removed_classes_registered, "classes", "name", old_api, new_api, "signals", "name", { "*arguments" }, false)) {
+	if (!compare_sub_dict_array(removed_classes_registered, "classes", "name", old_api, new_api, "methods", "name", { "is_virtual", "is_vararg", "is_static", "is_const", "*return_value", "*@arguments" }, true)) {
+		failed = true;
+	}
+
+	if (!compare_sub_dict_array(removed_classes_registered, "classes", "name", old_api, new_api, "signals", "name", { "*@arguments" }, false)) {
 		failed = true;
 	}
 

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -23,35 +23,35 @@ The previous type was simply wrong and didn't match the actual C++ definition. C
 
 GH-74600
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimatedSprite2D/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimatedSprite3D/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Animation/methods/compress'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimationPlayer/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer2D/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AudioStreamPlayer3D/methods/play'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/CanvasItem/methods/draw_set_transform'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/sample_baked'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/sample_baked_with_rotation'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve2D/methods/tessellate_even_length'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/sample_baked'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/sample_baked_with_rotation'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Curve3D/methods/tessellate_even_length'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/DisplayServer/methods/tts_speak'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Font/methods/find_variation'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/GridMap/methods/make_baked_meshes'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/save_jpg_to_buffer'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/save_webp_to_buffer'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Image/methods/bump_map_to_normal_map'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody2D/methods/move_and_collide'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody3D/methods/move_and_collide'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/PhysicsBody3D/methods/test_move'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RandomNumberGenerator/methods/randfn'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/environment_set_ambient_light'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/canvas_item_set_canvas_group_mode'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/force_draw'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Window/methods/popup_centered_ratio'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Window/methods/popup_centered_clamped'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimatedSprite2D/methods/play', from 57037631 to 8D62DD1B. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimatedSprite3D/methods/play', from 57037631 to 8D62DD1B. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Animation/methods/compress', from 6B87C27F to D713F035. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimationPlayer/methods/play', from 846788DD to B9DCE17F. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AudioStreamPlayer/methods/play', from B54BA998 to 74B7272C. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AudioStreamPlayer2D/methods/play', from B54BA998 to 74B7272C. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AudioStreamPlayer3D/methods/play', from B54BA998 to 74B7272C. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/CanvasItem/methods/draw_set_transform', from F93CB735 to C3BC1B8B. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve2D/methods/sample_baked', from DF8CB3E7 to CE7C60AA. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve2D/methods/sample_baked_with_rotation', from 0F34F230 to C475D415. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve2D/methods/tessellate_even_length', from FC150C61 to 8A44C0E5. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve3D/methods/sample_baked', from FCBE3242 to 5078AD06. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve3D/methods/sample_baked_with_rotation', from 9431C26F to 7398459B. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Curve3D/methods/tessellate_even_length', from E96241BB to 07F10939. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/DisplayServer/methods/tts_speak', from DDE9B9D7 to DEFE6FA5. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Font/methods/find_variation', from DCDAC3C2 to 44828B18. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/GridMap/methods/make_baked_meshes', from 43AF36C6 to D72155A9. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Image/methods/bump_map_to_normal_map', from 1412C0CC to CC0E637C. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Image/methods/save_jpg_to_buffer', from 1285A12B to 234CCB09. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Image/methods/save_webp_to_buffer', from 49A857C1 to 4865C18E. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/PhysicsBody2D/methods/move_and_collide', from BE9F4C70 to 5B315D1A. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/PhysicsBody3D/methods/move_and_collide', from 44022073 to A86CD3DE. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/PhysicsBody3D/methods/test_move', from 7C246CBB to 288C8CC1. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RandomNumberGenerator/methods/randfn', from 839678C5 to 31E8912C. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RenderingServer/methods/canvas_item_set_canvas_group_mode', from 5D7655F8 to 0280768A. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RenderingServer/methods/environment_set_ambient_light', from 159C6D6E to 1D4E1F3F. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RenderingServer/methods/force_draw', from 359658A7 to 40254980. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Window/methods/popup_centered_clamped', from DE3D691D to 9BCAB29D. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Window/methods/popup_centered_ratio', from 71F7FFC1 to 3C7CD915. This means that the function has changed and no compatibility function was provided.
 
 None of these methods were actually changed, the hash changes only affects GDExtensions, no compatibility workaround exists currently.
 
@@ -105,96 +105,167 @@ Unsure where these come from; when dumping the interface, these do actually stil
 
 GH-76176
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_base_control'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_edited_scene_root'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_editor_main_screen'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_editor_paths'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_editor_settings'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_file_system_dock'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_resource_filesystem'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_resource_previewer'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_script_editor'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorInterface/methods/get_selection'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_base_control', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_edited_scene_root', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_main_screen', from 36955D8D to 65B2D3B5. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_paths', from FA334A57 to 5F1D5DC4. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_settings', from 932B4D2E to F399A3EB. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_file_system_dock', from 217210BD to DF93E7E7. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_resource_filesystem', from 1D5C1A47 to 2E802B7E. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_resource_previewer', from 5E161783 to 383C77ED. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_script_editor', from EB48A7D4 to 056A8923. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_selection', from 0302AF0B to A05A4D13. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_base_control': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_edited_scene_root': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_editor_main_screen': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_editor_paths': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_editor_settings': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_file_system_dock': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_resource_filesystem': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_resource_previewer': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_script_editor': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorInterface/methods/get_selection': is_const changed value in new API, from false to true.
 
 Functions were made `const`. No adjustments should be necessary.
 
 
 GH-76026
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorScript/methods/get_editor_interface'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/EditorScript/methods/get_scene'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_editor_interface', from FBC1084A to 75D179CC. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_scene', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/EditorScript/methods/get_editor_interface': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/EditorScript/methods/get_scene': is_const changed value in new API, from false to true.
 
 Functions were made `const`. No adjustments should be necessary.
 
 
 GH-76418
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/Object/methods/get_meta_list'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RDShaderFile/methods/get_version_list'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/RenderingServer/methods/global_shader_parameter_get_list'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Object/methods/get_meta_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RDShaderFile/methods/get_version_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RenderingServer/methods/global_shader_parameter_get_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
+Validate extension JSON: Error: Field 'classes/Object/methods/get_meta_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
+Validate extension JSON: Error: Field 'classes/RDShaderFile/methods/get_version_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/global_shader_parameter_get_list/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
+
+Validate extension JSON: Error: Field 'classes/Geometry3D/methods/segment_intersects_convex/arguments/2': type changed value in new API, from "Array" to "typedarray::Plane".
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': type changed value in new API, from "Array" to "typedarray::RID".
+Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/add_triangle_fan/arguments/5': default_value changed value in new API, from "[]" to "Array[Plane]([])".
+Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/add_triangle_fan/arguments/5': type changed value in new API, from "Array" to "typedarray::Plane".
 
 Return types change, fixed some internal type issues and unnecessarily changed the public type in the process.
 
 
 GH-72749
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/Area2D/methods/get_priority'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Area2D/methods/set_priority'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Area3D/methods/get_priority'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Area3D/methods/set_priority'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/set_priority', from 1647D661 to 4CAD1009. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Area3D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Area3D/methods/set_priority', from 1647D661 to 4CAD1009. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/Area2D/methods/get_priority/return_value': meta changed value in new API, from "float" to "int32".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/get_priority/return_value': type changed value in new API, from "float" to "int".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/set_priority/arguments/0': meta changed value in new API, from "float" to "int32".
+Validate extension JSON: Error: Field 'classes/Area2D/methods/set_priority/arguments/0': type changed value in new API, from "float" to "int".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/get_priority/return_value': meta changed value in new API, from "float" to "int32".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/get_priority/return_value': type changed value in new API, from "float" to "int".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/set_priority/arguments/0': meta changed value in new API, from "float" to "int32".
+Validate extension JSON: Error: Field 'classes/Area3D/methods/set_priority/arguments/0': type changed value in new API, from "float" to "int".
 
 Type changed from `float` to `int`. Previously the `float` values were internally converted to `int`s anyways and the type ways inconsistent with the type of the priority property, which already was `int`.
 
 
 GH-72152
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/MeshInstance3D/methods/create_multiple_convex_collisions'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/MeshInstance3D/methods/create_multiple_convex_collisions', from BFDD6D64 to 257A91A5. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/MeshInstance3D/methods/create_multiple_convex_collisions': arguments
 
 Added an optional parameter with a default value. No adjustments should be necessary.
 
 
 GH-75759
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimationNode/methods/blend_input'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/AnimationNode/methods/blend_node'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_input', from 5162412C to A178F700. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_node', from 1263CBA5 to 0FB30106. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/AnimationNode/methods/_process/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_input/arguments': size changed value in new API, from 7 to 8.
+Validate extension JSON: Error: Field 'classes/AnimationNode/methods/blend_node/arguments': size changed value in new API, from 8 to 9.
 
-Added an optional parameter with a default value. No adjustments should be necessary.
+`_process`: Added a parameter to a virtual method.
+`blend_input`, `blend_node`: Added an optional parameter with a default value. No adjustments should be necessary.
 
 
 GH-75017
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/RichTextLabel/methods/push_list'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_list', from 8593DF77 to F0951C19. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 3 to 4.
 
 Added an optional parameter with a default value. No adjustments should be necessary.
 
 
 GH-76794
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/Tree/methods/edit_selected'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Tree/methods/edit_selected', from 859196D4 to 9AB67ACD. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Tree/methods/edit_selected': arguments
 
 Added an optional parameter with a default value. No adjustments should be necessary.
 
 
 GH-75777
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/SyntaxHighlighter/methods/get_text_edit'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/SyntaxHighlighter/methods/get_text_edit', from 8248B40D to 70D54D11. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/SyntaxHighlighter/methods/get_text_edit': is_const changed value in new API, from false to true.
 
 Function was made `const`. No adjustments should be necessary.
 
 
-GH-75250
---------
-Validate extension JSON: Error: Hash mismatch for 'classes/RichTextLabel/methods/push_paragraph'. This means that the function has changed and no compatibility function was provided.
 
-Added an optional parameter with a default value. No adjustments should be necessary.
+GH-75250 & GH-76401
+-------------------
+Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_paragraph', from 3DD1D1C2 to BFDC71FE. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 4 to 6.
+
+Added a optional parameters with default values. No adjustments should be necessary.
 
 
 GH-77143
 --------
-Validate extension JSON: Error: Hash mismatch for 'classes/WorkerThreadPool/methods/wait_for_task_completion'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/WorkerThreadPool/methods/wait_for_task_completion', from 4CAD1009 to 32573865. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/WorkerThreadPool/methods/wait_for_task_completion': return_value
 
 Changed the return value from `void` to `Error`. No adjustments should be necessary.
+
+
+GH-64628
+--------
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate_from_path/arguments': size changed value in new API, from 2 to 3.
+
+Added parameters to virtual method.
+
+
+GH-76406
+--------
+Validate extension JSON: Error: Field 'classes/GDExtension/methods/open_library/arguments': size changed value in new API, from 2 to 3.
+
+Added an optional parameter with a default value. No adjustments should be necessary.
+
+
+GH-74242
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3DExtension/methods/_intersect_ray/arguments': size changed value in new API, from 8 to 9.
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3DExtension/methods/_intersect_ray/arguments/7': type changed value in new API, from "PhysicsServer3DExtensionRayResult*" to "bool".
+
+Added new second-to-last parameter to virtual method.
+
+
+GH-74707
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_body_test_motion/arguments': size changed value in new API, from 7 to 8.
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_body_test_motion/arguments/6': type changed value in new API, from "PhysicsServer3DExtensionMotionResult*" to "bool".
+
+Added new second-to-last parameter to virtual method.
 
 
 GH-72842
@@ -211,9 +282,28 @@ Validate extension JSON: Error: Field 'classes/GLTFSkin/properties/godot_skin': 
 
 GH-76082
 --------
-Validate extension JSON: Error: Hash mismatch for 'builtin_classes/Basis/methods/looking_at'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'builtin_classes/Transform3D/methods/looking_at'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Node3D/methods/look_at'. This means that the function has changed and no compatibility function was provided.
-Validate extension JSON: Error: Hash mismatch for 'classes/Node3D/methods/look_at_from_position'. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'builtin_classes/Basis/methods/looking_at', from 19076B74 to DE3FF159. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'builtin_classes/Transform3D/methods/looking_at', from 3018C31C to 056ADC36. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Node3D/methods/look_at', from 3BC64EA6 to BA2B4FA9. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/Node3D/methods/look_at_from_position', from 2BD0F953 to F2739FA7. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Field 'builtin_classes/Basis/methods/looking_at/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'builtin_classes/Transform3D/methods/looking_at/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Node3D/methods/look_at/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Node3D/methods/look_at_from_position/arguments': size changed value in new API, from 3 to 4.
 
 Added an optional parameter with a default value. No adjustments should be necessary.
+
+
+GH-77411
+--------
+Validate extension JSON: Error: Field 'classes/Control/methods/_get_drag_data': is_const changed value in new API, from true to false.
+
+`const` was removed from virtual method, it may be necessary to adjust the constness of implementing methods.
+
+
+GH-75260
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState2D/methods/collide_shape/return_value': type changed value in new API, from "typedarray::PackedVector2Array" to "typedarray::Vector2".
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3D/methods/collide_shape/return_value': type changed value in new API, from "typedarray::PackedVector3Array" to "typedarray::Vector3".
+
+The previous type declaration was simply wrong and the method did actually already return objects of the new type.


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/76647#issuecomment-1554519390, originally just trying to ensure that ignoring the hash change of one method does not hide any future changes to that method, but has somewhat grown in scope to tracking all changes that possibly interfere with compatibility, not just those that break gdextension binary compatibility.

Check `misc/extension_api_validation/4.0-stable.expected` for how the new errors look like currently.

Basically the only changes to existing APIs that it now doesn't try to complain about are changing parameter names and increasing the value of an enums `_MAX` value.
