### PR TITLE
Implement `TreeItem.add_child`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -22,6 +22,13 @@
 				Adds a button with [Texture2D] [param button] at column [param column]. The [param id] is used to identify the button in the according [signal Tree.button_clicked] signal and can be different from the buttons index. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip_text].
 			</description>
 		</method>
+		<method name="add_child">
+			<return type="void" />
+			<param index="0" name="child" type="TreeItem" />
+			<description>
+				Adds a previously unparented [TreeItem] as a direct child of this one. The [param child] item must not be a part of any [Tree] or parented to any [TreeItem]. See also [method remove_child].
+			</description>
+		</method>
 		<method name="call_recursive" qualifiers="vararg">
 			<return type="void" />
 			<param index="0" name="method" type="StringName" />
@@ -430,7 +437,8 @@
 			<return type="void" />
 			<param index="0" name="child" type="TreeItem" />
 			<description>
-				Removes the given child [TreeItem] and all its children from the [Tree]. Note that it doesn't free the item from memory, so it can be reused later. To completely remove a [TreeItem] use [method Object.free].
+				Removes the given child [TreeItem] and all its children from the [Tree]. Note that it doesn't free the item from memory, so it can be reused later (see [method add_child]). To completely remove a [TreeItem] use [method Object.free].
+				[b]Note:[/b] If you want to move a child from one [Tree] to another, then instead of removing and adding it manually you can use [method move_before] or [method move_after].
 			</description>
 		</method>
 		<method name="select">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -336,6 +336,8 @@ public:
 	/* Item manipulation */
 
 	TreeItem *create_child(int p_index = -1);
+	void add_child(TreeItem *p_item);
+	void remove_child(TreeItem *p_item);
 
 	Tree *get_tree() const;
 
@@ -354,6 +356,7 @@ public:
 	int get_visible_child_count();
 	int get_child_count();
 	TypedArray<TreeItem> get_children();
+	void clear_children();
 	int get_index();
 
 #ifdef DEV_ENABLED
@@ -366,11 +369,7 @@ public:
 	void move_before(TreeItem *p_item);
 	void move_after(TreeItem *p_item);
 
-	void remove_child(TreeItem *p_item);
-
 	void call_recursive(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-
-	void clear_children();
 
 	~TreeItem();
 };


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/46773 implemented some of the requested item management methods, but one thing was amiss — a way to add an unparented `TreeItem` back to the `Tree` (or move it to another `Tree`). The issue was made worse by the fact that we have a `TreeItem::remove_child` method, but no `TreeItem::add_child` method. Documentation for `remove_child` states that the unparented item can be reused, but how?

At the same time, aforementioned PR added `move_before`/`move_after`, which actually support moving items between different trees. So the implementation of the `add_child` method was on the surface. And it was explicitly asked for in https://github.com/godotengine/godot-proposals/issues/3607.

Personally, I thought about using it for some sort of cache in the editor. For example, in the editor help search dialog we could create every `TreeItem` that we need and then reuse them, instead of recreating them on the fly, constantly. I was working on that, but decided to split `Tree` improvements for now.

Additional changes in this PR include:

* Better names for the `create_child` method variables;
* Add a missing (I think) call to `_change_tree(nullptr)` to the `remove_child` method;
* Move some methods around to group them logically;
* Small style improvements in the files.

Closes https://github.com/godotengine/godot-proposals/issues/3607.


https://github.com/godotengine/godot/assets/11782833/e730cf9c-1812-4cd5-a430-f37023fa72b4

