### PR TITLE
Deprecate push_unhandled_input

### DIFF
--- a/doc/classes/InputEventShortcut.xml
+++ b/doc/classes/InputEventShortcut.xml
@@ -4,7 +4,7 @@
 		Represents a triggered keyboard [Shortcut].
 	</brief_description>
 	<description>
-		InputEventShortcut is a special event that can be received in [method Node._unhandled_key_input]. It is typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_unhandled_input].
+		InputEventShortcut is a special event that can be received in [method Node._unhandled_key_input]. It is typically sent by the editor's Command Palette to trigger actions, but can also be sent manually using [method Viewport.push_input].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -173,7 +173,7 @@
 				Helper method which calls the [code]set_text()[/code] method on the currently focused [Control], provided that it is defined (e.g. if the focused Control is [Button] or [LineEdit]).
 			</description>
 		</method>
-		<method name="push_unhandled_input">
+		<method name="push_unhandled_input" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
 			<param index="1" name="in_local_coords" type="bool" default="false" />
@@ -187,6 +187,8 @@
 				- [method Node._unhandled_key_input]
 				If an earlier method marks the input as handled via [method set_input_as_handled], any later method in this list will not be called.
 				If none of the methods handle the event and [member physics_object_picking] is [code]true[/code], the event is used for physics object picking.
+				[b]Note:[/b] This method doesn't propagate input events to embedded [Window]s or [SubViewport]s.
+				[b]Note:[/b] This method is deprecated, use [method push_input] instead.
 			</description>
 		</method>
 		<method name="set_canvas_cull_mask_bit">

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -414,6 +414,8 @@ private:
 	void _perform_drop(Control *p_control = nullptr, Point2 p_pos = Point2());
 	void _gui_cleanup_internal_state(Ref<InputEvent> p_event);
 
+	void _push_unhandled_input_internal(const Ref<InputEvent> &p_event);
+
 	Ref<InputEvent> _make_input_local(const Ref<InputEvent> &ev);
 
 	friend class Control;
@@ -575,7 +577,9 @@ public:
 
 	void push_text_input(const String &p_text);
 	void push_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+#ifndef DISABLE_DEPRECATED
 	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+#endif // DISABLE_DEPRECATED
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;


### PR DESCRIPTION
The functionality of `push_unhandled_input` has changed so that it no longer propagates input events to SubViewports.
This makes it less predictable and it should be deprecated in favor of `push_input` which provides the same functionality and more.

Also this deprecation simplifies the Viewport-API by reducing the methods for pushing input events, so that users don't need to worry about when to use which function in order to insert input events.

Implement https://github.com/godotengine/godot/pull/76926#issuecomment-1545417632