### PR TITLE
Remove unnecessary Clipper lib includes

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,7 +30,6 @@
 
 #include "geometry_3d.h"
 
-#include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
 
 void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt) {

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -36,7 +36,6 @@
 #include "scene/2d/mesh_instance_2d.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/menu_button.h"
-#include "thirdparty/misc/clipper.hpp"
 
 void Skeleton2DEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -35,7 +35,6 @@
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering_server.h"
-#include "thirdparty/misc/clipper.hpp"
 #include "thirdparty/misc/polypartition.h"
 
 #define PADDING_REF_SIZE 1024.0


### PR DESCRIPTION
Removes unnecessary Clipper lib includes.

Leftovers from previous refactoring or class splitting.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
