### PR TITLE
Build `JoypadLinux` sandbox detection method only with udev

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -74,6 +74,7 @@ void JoypadLinux::Joypad::reset() {
 	events.clear();
 }
 
+#ifdef UDEV_ENABLED
 // This function is derived from SDL:
 // https://github.com/libsdl-org/SDL/blob/main/src/core/linux/SDL_sandbox.c#L28-L45
 static bool detect_sandbox() {
@@ -93,6 +94,7 @@ static bool detect_sandbox() {
 
 	return false;
 }
+#endif // UDEV_ENABLED
 
 JoypadLinux::JoypadLinux(Input *in) {
 #ifdef UDEV_ENABLED


### PR DESCRIPTION
Fixes an `unused-function` warning when building with `udev=no`.

As usual, I've tested this on my Wayland branch. I'm saying this just in case something weird happens.