### PR TITLE
Fix typo in CS notification example of the Object class

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -175,7 +175,7 @@
 				        print("Goodbye!")
 				[/gdscript]
 				[csharp]
-				public override void _Notification(long what)
+				public override void _Notification(int what)
 				{
 				    if (what == NotificationPredelete)
 				    {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77462
Changed parameter type of _Notification function in CS example from  ```long``` to ```int```.

As per object class documentation (https://github.com/godotengine/godot/blob/master/doc/classes/Object.xml#L21) the correct datatype for the notifications is indeed ```int```.

