### PR TITLE
Fix for SkeletonIK3D interpolation and bone roll

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -397,7 +397,7 @@ void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) 
 		real_t dot = p_start_direction.dot(p_end_direction);
 		dot = CLAMP(dot, -1.0f, 1.0f);
 		const real_t angle_rads = Math::acos(dot);
-		set_axis_angle(axis, angle_rads);
+		*this = Basis(axis, angle_rads) * (*this);
 	}
 }
 


### PR DESCRIPTION
Two changes:
Fix bug in internal Basis::rotate_to_align function (also used with identity Basis in scene/resources/curve.cpp)
Use ChainItem children rather than local bone rest to determine IK bone roll to match Godot 3.x behavior

Fixes #77271 by solving some other mistakes that were introduced in 4.0 and not in the equivalent code from 3.x

SkeletonIK3D should now behave identically to SkeletonIK in Godot 3.x
Does not address the root cause of #54891 (wow if only I had read the comments on that issue: they had so much diagnosis, and almost every function mentioned in the comments of that issue was the cause of a bug in it in 4.0)

cc @TwistedTwigleg @fire 

![Correct IK on example project](https://github.com/godotengine/godot/assets/39946030/16f80cbf-31f3-4ff8-bc54-28a61a95865b)
