### PR TITLE
Improve RayShape3D icon

### DIFF
--- a/editor/icons/SeparationRayShape3D.svg
+++ b/editor/icons/SeparationRayShape3D.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="m8 1-6 5 4 2.666v4.334l2 2v-5-2z" fill="#a2d2ff"/><path d="m8 1v7 2l-2-1.334v1.334l2 1.5v3.5l2-2v-4.334l4-2.666z" fill="#2998ff"/></g></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M8 1 3 6a5 2 0 0 0 3 1.8v6.4a2 .8 0 0 0 2 .8z" fill="#a2d2ff"/><path d="m8 1 5 5a5 2 0 0 1-3 1.8v6.4a2 .8 0 0 1-2 .8V9.5a5 2 0 0 1-2-.2V7.8A5 2 0 0 0 8 8z" fill="#2998ff"/></svg>


### PR DESCRIPTION
![image](https://github.com/godotengine/godot/assets/85438892/dbf71205-66b3-4cbe-a29a-d6e5f7e8f4c5)

I think this sells the arrow much better than the "pyramid on top of a cuboid" icon.