### PR TITLE
[3.x] Improve touchpad and mouse support for the Android editor

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
@@ -145,10 +145,17 @@ public class GodotView extends GLSurfaceView {
 		inputHandler.onPointerCaptureChange(hasCapture);
 	}
 
+	@Keep
+	private boolean canCapturePointer() {
+		return inputHandler.canCapturePointer();
+	}
+
 	@Override
 	public void requestPointerCapture() {
-		super.requestPointerCapture();
-		inputHandler.onPointerCaptureChange(true);
+		if (canCapturePointer()) {
+			super.requestPointerCapture();
+			inputHandler.onPointerCaptureChange(true);
+		}
 	}
 
 	@Override

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -224,16 +224,14 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 				)
 				dragInProgress = false
 			}
-			return true
 		}
-
-		dragInProgress = true
 
 		val x = terminusEvent.x
 		val y = terminusEvent.y
 		if (terminusEvent.pointerCount >= 2 && panningAndScalingEnabled && !pointerCaptureInProgress) {
 			GodotLib.pan(x, y, distanceX / 5f, distanceY / 5f)
-		} else {
+		} else if (!scaleInProgress) {
+			dragInProgress = true
 			GodotInputHandler.handleMotionEvent(terminusEvent)
 		}
 		return true
@@ -243,11 +241,14 @@ internal class GodotGestureHandler : SimpleOnGestureListener(), OnScaleGestureLi
 		if (!panningAndScalingEnabled || pointerCaptureInProgress) {
 			return false
 		}
-		GodotLib.magnify(
-			detector.focusX,
-			detector.focusY,
-			detector.scaleFactor
-		)
+
+		if (detector.scaleFactor >= 0.8f && detector.scaleFactor != 1f && detector.scaleFactor <= 1.2f) {
+			GodotLib.magnify(
+					detector.focusX,
+					detector.focusY,
+					detector.scaleFactor
+			)
+		}
 		return true
 	}
 

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -47,6 +47,8 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 		_request_pointer_capture = env->GetMethodID(_cls, "requestPointerCapture", "()V");
 		_release_pointer_capture = env->GetMethodID(_cls, "releasePointerCapture", "()V");
 	}
+
+	_can_capture_pointer = env->GetMethodID(_cls, "canCapturePointer", "()Z");
 }
 
 bool GodotJavaViewWrapper::can_update_pointer_icon() const {
@@ -54,7 +56,16 @@ bool GodotJavaViewWrapper::can_update_pointer_icon() const {
 }
 
 bool GodotJavaViewWrapper::can_capture_pointer() const {
-	return _request_pointer_capture != nullptr && _release_pointer_capture != nullptr;
+	// We can capture the pointer if the other jni capture method ids are initialized,
+	// and GodotView#canCapturePointer() returns true.
+	if (_request_pointer_capture != nullptr && _release_pointer_capture != nullptr && _can_capture_pointer != nullptr) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+
+		return env->CallBooleanMethod(_godot_view, _can_capture_pointer);
+	}
+
+	return false;
 }
 
 void GodotJavaViewWrapper::request_pointer_capture() {

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -43,6 +43,7 @@ private:
 	jclass _cls;
 	jobject _godot_view;
 
+	jmethodID _can_capture_pointer = 0;
 	jmethodID _request_pointer_capture = 0;
 	jmethodID _release_pointer_capture = 0;
 


### PR DESCRIPTION
- Fix issues with using a touchpad to click, drag, interact with the navigation controls, etc..
- Fix issues with panning with 2+ fingers
- Fix issues with using double-tap to magnify on the spatial editor

[main version](https://github.com/godotengine/godot/pull/77498)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
