### PR TITLE
Remove unused variable to fix Clang dev_mode build

### DIFF
--- a/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/post_import_plugin_skeleton_rest_fixer.cpp
@@ -610,7 +610,6 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 			// Fix skin.
 			{
 				TypedArray<Node> nodes = p_base_scene->find_children("*", "ImporterMeshInstance3D");
-				int skin_idx = 0;
 				while (nodes.size()) {
 					ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(nodes.pop_back());
 					ERR_CONTINUE(!mi);
@@ -638,8 +637,6 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 							skin->set_bind_pose(i, adjust_transform * skin->get_bind_pose(i));
 						}
 					}
-
-					skin_idx++;
 				}
 				nodes = src_skeleton->get_children();
 				while (nodes.size()) {


### PR DESCRIPTION
Refactoring in https://github.com/godotengine/godot/pull/77123 turned `skin_idx` into an unused variable, looks like Clang is a bit stricter about it and also considers a primitive variable unused if it is only written to.

Clang error message:
```
[ 79%] =====
[ 79%] editor\import\post_import_plugin_skeleton_rest_fixer.cpp:613:9: error: variable 'skin_idx' set but not used [-Werror,-Wunused-but-set-variable]
                                int skin_idx = 0;
                                    ^
1 error generated.
[ 79%] 
[ 79%] =====
```