### PR TITLE
Fix AnimationPlayer cumulative `speed_scale`

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1766,7 +1766,7 @@ void AnimationPlayer::set_current_animation(const String &p_anim) {
 	} else if (!is_playing()) {
 		play(p_anim);
 	} else if (playback.assigned != p_anim) {
-		float speed = get_playing_speed();
+		float speed = playback.current.speed_scale;
 		play(p_anim, -1.0, speed, signbit(speed));
 	} else {
 		// Same animation, do not replay from start
@@ -1779,7 +1779,7 @@ String AnimationPlayer::get_current_animation() const {
 
 void AnimationPlayer::set_assigned_animation(const String &p_anim) {
 	if (is_playing()) {
-		float speed = get_playing_speed();
+		float speed = playback.current.speed_scale;
 		play(p_anim, -1.0, speed, signbit(speed));
 	} else {
 		ERR_FAIL_COND_MSG(!animation_set.has(p_anim), vformat("Animation not found: %s.", p_anim));


### PR DESCRIPTION
Fixes #77484
`get_playing_speed()` returns custom speed multiplied by AnimationPlayer's speed and it was being supplied as custom speed, thus applying AnimationPlayer's speed each time.