### PR TITLE
Add `get_edited_property_value()` shorthand method

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -149,6 +149,7 @@ public:
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;
+	inline Variant get_edited_property_value() const { return object->get(property); }
 	EditorInspector *get_parent_inspector() const;
 
 	void set_doc_path(const String &p_doc_path);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -95,7 +95,7 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 }
 
 void EditorPropertyText::update_property() {
-	String s = get_edited_object()->get(get_edited_property());
+	String s = get_edited_property_value();
 	updating = true;
 	if (text->get_text() != s) {
 		int caret = text->get_caret_column();
@@ -167,7 +167,7 @@ void EditorPropertyMultilineText::_open_big_text() {
 }
 
 void EditorPropertyMultilineText::update_property() {
-	String t = get_edited_object()->get(get_edited_property());
+	String t = get_edited_property_value();
 	if (text->get_text() != t) {
 		text->set_text(t);
 		if (big_text && big_text->is_visible_in_tree()) {
@@ -270,14 +270,14 @@ void EditorPropertyTextEnum::_custom_value_accepted() {
 }
 
 void EditorPropertyTextEnum::_custom_value_canceled() {
-	custom_value_edit->set_text(get_edited_object()->get(get_edited_property()));
+	custom_value_edit->set_text(get_edited_property_value());
 
 	edit_custom_layout->hide();
 	default_layout->show();
 }
 
 void EditorPropertyTextEnum::update_property() {
-	String current_value = get_edited_object()->get(get_edited_property());
+	String current_value = get_edited_property_value();
 	int default_option = options.find(current_value);
 
 	// The list can change in the loose mode.
@@ -405,13 +405,13 @@ void EditorPropertyLocale::_locale_pressed() {
 		add_child(dialog);
 	}
 
-	String locale_code = get_edited_object()->get(get_edited_property());
+	String locale_code = get_edited_property_value();
 	dialog->set_locale(locale_code);
 	dialog->popup_locale_dialog();
 }
 
 void EditorPropertyLocale::update_property() {
-	String locale_code = get_edited_object()->get(get_edited_property());
+	String locale_code = get_edited_property_value();
 	locale->set_text(locale_code);
 	locale->set_tooltip_text(locale_code);
 }
@@ -472,7 +472,7 @@ void EditorPropertyPath::_path_pressed() {
 		add_child(dialog);
 	}
 
-	String full_path = get_edited_object()->get(get_edited_property());
+	String full_path = get_edited_property_value();
 
 	dialog->clear_filters();
 
@@ -500,7 +500,7 @@ void EditorPropertyPath::_path_pressed() {
 }
 
 void EditorPropertyPath::update_property() {
-	String full_path = get_edited_object()->get(get_edited_property());
+	String full_path = get_edited_property_value();
 	path->set_text(full_path);
 	path->set_tooltip_text(full_path);
 }
@@ -603,7 +603,7 @@ void EditorPropertyClassName::setup(const String &p_base_type, const String &p_s
 }
 
 void EditorPropertyClassName::update_property() {
-	String s = get_edited_object()->get(get_edited_property());
+	String s = get_edited_property_value();
 	property->set_text(s);
 	selected_type = s;
 }
@@ -645,7 +645,7 @@ void EditorPropertyCheck::_checkbox_pressed() {
 }
 
 void EditorPropertyCheck::update_property() {
-	bool c = get_edited_object()->get(get_edited_property());
+	bool c = get_edited_property_value();
 	checkbox->set_pressed(c);
 	checkbox->set_disabled(is_read_only());
 }
@@ -673,7 +673,7 @@ void EditorPropertyEnum::_option_selected(int p_which) {
 }
 
 void EditorPropertyEnum::update_property() {
-	Variant current = get_edited_object()->get(get_edited_property());
+	Variant current = get_edited_property_value();
 	if (current.get_type() == Variant::NIL) {
 		options->select(-1);
 		return;
@@ -728,7 +728,7 @@ void EditorPropertyFlags::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyFlags::_flag_toggled(int p_index) {
-	uint32_t value = get_edited_object()->get(get_edited_property());
+	uint32_t value = get_edited_property_value();
 	if (flags[p_index]->is_pressed()) {
 		value |= flag_values[p_index];
 	} else {
@@ -739,7 +739,7 @@ void EditorPropertyFlags::_flag_toggled(int p_index) {
 }
 
 void EditorPropertyFlags::update_property() {
-	uint32_t value = get_edited_object()->get(get_edited_property());
+	uint32_t value = get_edited_property_value();
 
 	for (int i = 0; i < flags.size(); i++) {
 		flags[i]->set_pressed((value & flag_values[i]) == flag_values[i]);
@@ -1110,7 +1110,7 @@ void EditorPropertyLayers::_grid_changed(uint32_t p_grid) {
 }
 
 void EditorPropertyLayers::update_property() {
-	uint32_t value = get_edited_object()->get(get_edited_property());
+	uint32_t value = get_edited_property_value();
 
 	grid->set_flag(value);
 }
@@ -1292,7 +1292,7 @@ void EditorPropertyInteger::_value_changed(int64_t val) {
 }
 
 void EditorPropertyInteger::update_property() {
-	int64_t val = get_edited_object()->get(get_edited_property());
+	int64_t val = get_edited_property_value();
 	setting = true;
 	spin->set_value(val);
 	setting = false;
@@ -1332,7 +1332,7 @@ void EditorPropertyObjectID::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyObjectID::_edit_pressed() {
-	emit_signal(SNAME("object_id_selected"), get_edited_property(), get_edited_object()->get(get_edited_property()));
+	emit_signal(SNAME("object_id_selected"), get_edited_property(), get_edited_property_value());
 }
 
 void EditorPropertyObjectID::update_property() {
@@ -1341,7 +1341,7 @@ void EditorPropertyObjectID::update_property() {
 		type = "Object";
 	}
 
-	ObjectID id = get_edited_object()->get(get_edited_property());
+	ObjectID id = get_edited_property_value();
 	if (id.is_valid()) {
 		edit->set_text(type + " ID: " + uitos(id));
 		edit->set_tooltip_text(type + " ID: " + uitos(id));
@@ -1373,14 +1373,14 @@ EditorPropertyObjectID::EditorPropertyObjectID() {
 ///////////////////// SIGNAL /////////////////////////
 
 void EditorPropertySignal::_edit_pressed() {
-	Signal signal = get_edited_object()->get(get_edited_property());
+	Signal signal = get_edited_property_value();
 	emit_signal(SNAME("object_id_selected"), get_edited_property(), signal.get_object_id());
 }
 
 void EditorPropertySignal::update_property() {
 	String type = base_type;
 
-	Signal signal = get_edited_object()->get(get_edited_property());
+	Signal signal = get_edited_property_value();
 
 	edit->set_text("Signal: " + signal.get_name());
 	edit->set_disabled(false);
@@ -1402,7 +1402,7 @@ EditorPropertySignal::EditorPropertySignal() {
 void EditorPropertyCallable::update_property() {
 	String type = base_type;
 
-	Callable callable = get_edited_object()->get(get_edited_property());
+	Callable callable = get_edited_property_value();
 
 	edit->set_text("Callable");
 	edit->set_disabled(true);
@@ -1436,7 +1436,7 @@ void EditorPropertyFloat::_value_changed(double val) {
 }
 
 void EditorPropertyFloat::update_property() {
-	double val = get_edited_object()->get(get_edited_property());
+	double val = get_edited_property_value();
 	if (angle_in_radians) {
 		val = Math::rad_to_deg(val);
 	}
@@ -1513,7 +1513,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 			rel = -rel;
 		}
 
-		float val = get_edited_object()->get(get_edited_property());
+		float val = get_edited_property_value();
 		bool sg = val < 0;
 		val = Math::absf(val);
 
@@ -1548,7 +1548,7 @@ void EditorPropertyEasing::_draw_easing() {
 
 	const int point_count = 48;
 
-	const float exp = get_edited_object()->get(get_edited_property());
+	const float exp = get_edited_property_value();
 
 	const Ref<Font> f = get_theme_font(SNAME("font"), SNAME("Label"));
 	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
@@ -1602,7 +1602,7 @@ void EditorPropertyEasing::_set_preset(int p_preset) {
 void EditorPropertyEasing::_setup_spin() {
 	setting = true;
 	spin->setup_and_show();
-	spin->get_line_edit()->set_text(TS->format_number(rtos(get_edited_object()->get(get_edited_property()))));
+	spin->get_line_edit()->set_text(TS->format_number(rtos(get_edited_property_value())));
 	setting = false;
 	spin->show();
 }
@@ -1721,7 +1721,7 @@ void EditorPropertyVector2::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector2::update_property() {
-	Vector2 val = get_edited_object()->get(get_edited_property());
+	Vector2 val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -1842,7 +1842,7 @@ void EditorPropertyRect2::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyRect2::update_property() {
-	Rect2 val = get_edited_object()->get(get_edited_property());
+	Rect2 val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.position.x);
 	spin[1]->set_value(val.position.y);
@@ -1968,7 +1968,7 @@ void EditorPropertyVector3::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector3::update_property() {
-	update_using_vector(get_edited_object()->get(get_edited_property()));
+	update_using_vector(get_edited_property_value());
 	_update_ratio();
 }
 
@@ -2134,7 +2134,7 @@ void EditorPropertyVector2i::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector2i::update_property() {
-	Vector2i val = get_edited_object()->get(get_edited_property());
+	Vector2i val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -2254,7 +2254,7 @@ void EditorPropertyRect2i::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyRect2i::update_property() {
-	Rect2i val = get_edited_object()->get(get_edited_property());
+	Rect2i val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.position.x);
 	spin[1]->set_value(val.position.y);
@@ -2374,7 +2374,7 @@ void EditorPropertyVector3i::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector3i::update_property() {
-	Vector3i val = get_edited_object()->get(get_edited_property());
+	Vector3i val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -2506,7 +2506,7 @@ void EditorPropertyPlane::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyPlane::update_property() {
-	Plane val = get_edited_object()->get(get_edited_property());
+	Plane val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.normal.x);
 	spin[1]->set_value(val.normal.y);
@@ -2647,7 +2647,7 @@ bool EditorPropertyQuaternion::is_grabbing_euler() {
 }
 
 void EditorPropertyQuaternion::update_property() {
-	Quaternion val = get_edited_object()->get(get_edited_property());
+	Quaternion val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -2815,7 +2815,7 @@ void EditorPropertyVector4::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector4::update_property() {
-	Vector4 val = get_edited_object()->get(get_edited_property());
+	Vector4 val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -2905,7 +2905,7 @@ void EditorPropertyVector4i::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyVector4i::update_property() {
-	Vector4i val = get_edited_object()->get(get_edited_property());
+	Vector4i val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.x);
 	spin[1]->set_value(val.y);
@@ -2997,7 +2997,7 @@ void EditorPropertyAABB::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyAABB::update_property() {
-	AABB val = get_edited_object()->get(get_edited_property());
+	AABB val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val.position.x);
 	spin[1]->set_value(val.position.y);
@@ -3080,7 +3080,7 @@ void EditorPropertyTransform2D::_value_changed(double val, const String &p_name)
 }
 
 void EditorPropertyTransform2D::update_property() {
-	Transform2D val = get_edited_object()->get(get_edited_property());
+	Transform2D val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val[0][0]);
 	spin[1]->set_value(val[1][0]);
@@ -3174,7 +3174,7 @@ void EditorPropertyBasis::_value_changed(double val, const String &p_name) {
 }
 
 void EditorPropertyBasis::update_property() {
-	Basis val = get_edited_object()->get(get_edited_property());
+	Basis val = get_edited_property_value();
 	setting = true;
 	spin[0]->set_value(val[0][0]);
 	spin[1]->set_value(val[0][1]);
@@ -3267,7 +3267,7 @@ void EditorPropertyTransform3D::_value_changed(double val, const String &p_name)
 }
 
 void EditorPropertyTransform3D::update_property() {
-	update_using_transform(get_edited_object()->get(get_edited_property()));
+	update_using_transform(get_edited_property_value());
 }
 
 void EditorPropertyTransform3D::update_using_transform(Transform3D p_transform) {
@@ -3369,7 +3369,7 @@ void EditorPropertyProjection::_value_changed(double val, const String &p_name) 
 }
 
 void EditorPropertyProjection::update_property() {
-	update_using_transform(get_edited_object()->get(get_edited_property()));
+	update_using_transform(get_edited_property_value());
 }
 
 void EditorPropertyProjection::update_using_transform(Projection p_transform) {
@@ -3447,7 +3447,7 @@ void EditorPropertyColor::_set_read_only(bool p_read_only) {
 
 void EditorPropertyColor::_color_changed(const Color &p_color) {
 	// Cancel the color change if the current color is identical to the new one.
-	if (get_edited_object()->get(get_edited_property()) == p_color) {
+	if (get_edited_property_value() == p_color) {
 		return;
 	}
 
@@ -3474,7 +3474,7 @@ void EditorPropertyColor::_notification(int p_what) {
 }
 
 void EditorPropertyColor::update_property() {
-	picker->set_pick_color(get_edited_object()->get(get_edited_property()));
+	picker->set_pick_color(get_edited_property_value());
 	const Color color = picker->get_pick_color();
 
 	// Add a tooltip to display each channel's values without having to click the ColorPickerButton
@@ -3642,7 +3642,7 @@ void EditorPropertyNodePath::update_property() {
 	if (pointer_mode) {
 		p = get_edited_object()->get(_get_meta_pointer_property());
 	} else {
-		p = get_edited_object()->get(get_edited_property());
+		p = get_edited_property_value();
 	}
 
 	assign->set_tooltip_text(p);
@@ -3726,7 +3726,7 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 ///////////////////// RID /////////////////////////
 
 void EditorPropertyRID::update_property() {
-	RID rid = get_edited_object()->get(get_edited_property());
+	RID rid = get_edited_property_value();
 	if (rid.is_valid()) {
 		uint64_t id = rid.get_id();
 		label->set_text("RID: " + uitos(id));
@@ -3927,7 +3927,7 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 }
 
 void EditorPropertyResource::_open_editor_pressed() {
-	Ref<Resource> res = get_edited_object()->get(get_edited_property());
+	Ref<Resource> res = get_edited_property_value();
 	if (res.is_valid()) {
 		// May clear the editor so do it deferred.
 		callable_mp(EditorNode::get_singleton(), &EditorNode::edit_item).bind(res.ptr(), this).call_deferred();
@@ -4052,7 +4052,7 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 }
 
 void EditorPropertyResource::update_property() {
-	Ref<Resource> res = get_edited_object()->get(get_edited_property());
+	Ref<Resource> res = get_edited_property_value();
 
 	if (use_sub_inspector) {
 		if (res.is_valid() != resource_picker->is_toggle_mode()) {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -250,7 +250,7 @@ void EditorPropertyArray::_object_id_selected(const StringName &p_property, Obje
 }
 
 void EditorPropertyArray::update_property() {
-	Variant array = get_edited_object()->get(get_edited_property());
+	Variant array = get_edited_property_value();
 
 	String array_type_name = Variant::get_type_name(array_type);
 	if (array_type == Variant::ARRAY && subtype != Variant::NIL) {
@@ -568,7 +568,7 @@ void EditorPropertyArray::_notification(int p_what) {
 }
 
 void EditorPropertyArray::_edit_pressed() {
-	Variant array = get_edited_object()->get(get_edited_property());
+	Variant array = get_edited_property_value();
 	if (!array.is_array() && edit->is_pressed()) {
 		initialize_array(array);
 		get_edited_object()->set(get_edited_property(), array);
@@ -808,7 +808,7 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint) {
 }
 
 void EditorPropertyDictionary::update_property() {
-	Variant updated_val = get_edited_object()->get(get_edited_property());
+	Variant updated_val = get_edited_property_value();
 
 	if (updated_val.get_type() == Variant::NIL) {
 		edit->set_text(TTR("Dictionary (Nil)")); // This provides symmetry with the array property.
@@ -1217,7 +1217,7 @@ void EditorPropertyDictionary::_notification(int p_what) {
 }
 
 void EditorPropertyDictionary::_edit_pressed() {
-	Variant prop_val = get_edited_object()->get(get_edited_property());
+	Variant prop_val = get_edited_property_value();
 	if (prop_val.get_type() == Variant::NIL && edit->is_pressed()) {
 		VariantInternal::initialize(&prop_val, Variant::DICTIONARY);
 		get_edited_object()->set(get_edited_property(), prop_val);
@@ -1299,7 +1299,7 @@ void EditorPropertyLocalizableString::_remove_item(Object *p_button, int p_index
 }
 
 void EditorPropertyLocalizableString::update_property() {
-	Variant updated_val = get_edited_object()->get(get_edited_property());
+	Variant updated_val = get_edited_property_value();
 
 	if (updated_val.get_type() == Variant::NIL) {
 		edit->set_text(TTR("Localizable String (Nil)")); // This provides symmetry with the array property.
@@ -1431,7 +1431,7 @@ void EditorPropertyLocalizableString::_notification(int p_what) {
 }
 
 void EditorPropertyLocalizableString::_edit_pressed() {
-	Variant prop_val = get_edited_object()->get(get_edited_property());
+	Variant prop_val = get_edited_property_value();
 	if (prop_val.get_type() == Variant::NIL && edit->is_pressed()) {
 		VariantInternal::initialize(&prop_val, Variant::DICTIONARY);
 		get_edited_object()->set(get_edited_property(), prop_val);

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -164,7 +164,7 @@ void EditorPropertyAnchorsPreset::_option_selected(int p_which) {
 }
 
 void EditorPropertyAnchorsPreset::update_property() {
-	int64_t which = get_edited_object()->get(get_edited_property());
+	int64_t which = get_edited_property_value();
 
 	for (int i = 0; i < options->get_item_count(); i++) {
 		Variant val = options->get_item_metadata(i);
@@ -255,7 +255,7 @@ void EditorPropertySizeFlags::_preset_selected(int p_which) {
 }
 
 void EditorPropertySizeFlags::_expand_toggled() {
-	uint32_t value = get_edited_object()->get(get_edited_property());
+	uint32_t value = get_edited_property_value();
 
 	if (flag_expand->is_visible() && flag_expand->is_pressed()) {
 		value |= Control::SIZE_EXPAND;
@@ -288,7 +288,7 @@ void EditorPropertySizeFlags::_flag_toggled() {
 }
 
 void EditorPropertySizeFlags::update_property() {
-	uint32_t value = get_edited_object()->get(get_edited_property());
+	uint32_t value = get_edited_property_value();
 
 	for (int i = 0; i < flag_checks.size(); i++) {
 		int flag_value = flag_checks[i]->get_meta("_value");

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -227,7 +227,7 @@ void EditorPropertyFontMetaOverride::_object_id_selected(const StringName &p_pro
 }
 
 void EditorPropertyFontMetaOverride::update_property() {
-	Variant updated_val = get_edited_object()->get(get_edited_property());
+	Variant updated_val = get_edited_property_value();
 
 	Dictionary dict = updated_val;
 
@@ -330,7 +330,7 @@ void EditorPropertyFontMetaOverride::update_property() {
 }
 
 void EditorPropertyFontMetaOverride::_edit_pressed() {
-	Variant prop_val = get_edited_object()->get(get_edited_property());
+	Variant prop_val = get_edited_property_value();
 	if (prop_val.get_type() == Variant::NIL) {
 		Callable::CallError ce;
 		Variant::construct(Variant::DICTIONARY, prop_val, nullptr, 0, ce);
@@ -415,7 +415,7 @@ void EditorPropertyOTVariation::_object_id_selected(const StringName &p_property
 }
 
 void EditorPropertyOTVariation::update_property() {
-	Variant updated_val = get_edited_object()->get(get_edited_property());
+	Variant updated_val = get_edited_property_value();
 
 	Dictionary dict = updated_val;
 
@@ -511,7 +511,7 @@ void EditorPropertyOTVariation::update_property() {
 }
 
 void EditorPropertyOTVariation::_edit_pressed() {
-	Variant prop_val = get_edited_object()->get(get_edited_property());
+	Variant prop_val = get_edited_property_value();
 	if (prop_val.get_type() == Variant::NIL) {
 		Callable::CallError ce;
 		Variant::construct(Variant::DICTIONARY, prop_val, nullptr, 0, ce);
@@ -607,7 +607,7 @@ void EditorPropertyOTFeatures::_object_id_selected(const StringName &p_property,
 }
 
 void EditorPropertyOTFeatures::update_property() {
-	Variant updated_val = get_edited_object()->get(get_edited_property());
+	Variant updated_val = get_edited_property_value();
 
 	Dictionary dict = updated_val;
 
@@ -814,7 +814,7 @@ void EditorPropertyOTFeatures::update_property() {
 }
 
 void EditorPropertyOTFeatures::_edit_pressed() {
-	Variant prop_val = get_edited_object()->get(get_edited_property());
+	Variant prop_val = get_edited_property_value();
 	if (prop_val.get_type() == Variant::NIL) {
 		Callable::CallError ce;
 		Variant::construct(Variant::DICTIONARY, prop_val, nullptr, 0, ce);

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -169,7 +169,7 @@ void EditorPropertyRootMotion::_node_clear() {
 }
 
 void EditorPropertyRootMotion::update_property() {
-	NodePath p = get_edited_object()->get(get_edited_property());
+	NodePath p = get_edited_property_value();
 	assign->set_tooltip_text(p);
 	if (p == NodePath()) {
 		assign->set_icon(Ref<Texture2D>());

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2719,14 +2719,14 @@ void EditorPropertyTilePolygon::update_property() {
 	if (String(count_property).is_empty()) {
 		if (base_type == "OccluderPolygon2D") {
 			// Single OccluderPolygon2D.
-			Ref<OccluderPolygon2D> occluder = get_edited_object()->get(get_edited_property());
+			Ref<OccluderPolygon2D> occluder = get_edited_property_value();
 			generic_tile_polygon_editor->clear_polygons();
 			if (occluder.is_valid()) {
 				generic_tile_polygon_editor->add_polygon(occluder->get_polygon());
 			}
 		} else if (base_type == "NavigationPolygon") {
 			// Single OccluderPolygon2D.
-			Ref<NavigationPolygon> navigation_polygon = get_edited_object()->get(get_edited_property());
+			Ref<NavigationPolygon> navigation_polygon = get_edited_property_value();
 			generic_tile_polygon_editor->clear_polygons();
 			if (navigation_polygon.is_valid()) {
 				for (int i = 0; i < navigation_polygon->get_outline_count(); i++) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6620,7 +6620,7 @@ void EditorPropertyVisualShaderMode::_option_selected(int p_which) {
 }
 
 void EditorPropertyVisualShaderMode::update_property() {
-	int which = get_edited_object()->get(get_edited_property());
+	int which = get_edited_property_value();
 	options->select(which);
 }
 


### PR DESCRIPTION
I noticed editor properties do `get_edited_object()->get(get_edited_property())` in many places, so I added a shorter method: `get_edited_property_value()`. Aside from being shorter and easier to write, it's inline and accesses the fields directly, so there is a chance for minimal performance gain.