### PR TITLE
Minor improvements to sub-resource list

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3578,6 +3578,13 @@ void SceneTreeDock::_list_all_subresources(PopupMenu *p_menu) {
 			p_menu->set_item_metadata(-1, pair.first->get_instance_id());
 		}
 	}
+
+	if (resources_by_type.is_empty()) {
+		p_menu->add_item(TTR("None"));
+		p_menu->set_item_disabled(-1, true);
+	}
+
+	p_menu->reset_size();
 }
 
 void SceneTreeDock::_gather_resources(Node *p_node, List<Pair<Ref<Resource>, Node *>> &r_resources) {


### PR DESCRIPTION
When you switch scene after listing sub-resources, the dialog could be too long:

https://github.com/godotengine/godot/assets/2223172/f6b30420-bc97-4b4c-a208-9ed759deccd5

And if there are no sub-resources, you get this awkward popup:

![image](https://github.com/godotengine/godot/assets/2223172/9905a61d-5574-46e7-87a2-593818c786fa)

The PR resets the dialog size, so it's not too big, and adds a disabled None element when the list is empty:

![image](https://github.com/godotengine/godot/assets/2223172/205b728a-48bc-4aac-ae69-93a4d8011033)