### PR TITLE
Fixed Subtract blend mode of Forward+ and Mobile renderers

### DIFF
--- a/doc/classes/RDPipelineColorBlendStateAttachment.xml
+++ b/doc/classes/RDPipelineColorBlendStateAttachment.xml
@@ -32,8 +32,8 @@
 		[codeblock]
 		var attachment = RDPipelineColorBlendStateAttachment.new()
 		attachment.enable_blend = true
-		attachment.alpha_blend_op = RenderingDevice.BLEND_OP_SUBTRACT
-		attachment.color_blend_op = RenderingDevice.BLEND_OP_SUBTRACT
+		attachment.alpha_blend_op = RenderingDevice.BLEND_OP_REVERSE_SUBTRACT
+		attachment.color_blend_op = RenderingDevice.BLEND_OP_REVERSE_SUBTRACT
 		attachment.src_color_blend_factor = RenderingDevice.BLEND_FACTOR_SRC_ALPHA
 		attachment.dst_color_blend_factor = RenderingDevice.BLEND_FACTOR_ONE
 		attachment.src_alpha_blend_factor = RenderingDevice.BLEND_FACTOR_SRC_ALPHA

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -207,8 +207,8 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 		} break;
 		case BLEND_MODE_SUB: {
 			blend_attachment.enable_blend = true;
-			blend_attachment.alpha_blend_op = RD::BLEND_OP_SUBTRACT;
-			blend_attachment.color_blend_op = RD::BLEND_OP_SUBTRACT;
+			blend_attachment.alpha_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
+			blend_attachment.color_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
 			blend_attachment.src_color_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;
 			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE;
 			blend_attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -218,8 +218,8 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 		} break;
 		case BLEND_MODE_SUB: {
 			blend_attachment.enable_blend = true;
-			blend_attachment.alpha_blend_op = RD::BLEND_OP_SUBTRACT;
-			blend_attachment.color_blend_op = RD::BLEND_OP_SUBTRACT;
+			blend_attachment.alpha_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
+			blend_attachment.color_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
 			blend_attachment.src_color_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;
 			blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE;
 			blend_attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2121,8 +2121,8 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 		} break;
 		case BLEND_MODE_SUB: {
 			attachment.enable_blend = true;
-			attachment.alpha_blend_op = RD::BLEND_OP_SUBTRACT;
-			attachment.color_blend_op = RD::BLEND_OP_SUBTRACT;
+			attachment.alpha_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
+			attachment.color_blend_op = RD::BLEND_OP_REVERSE_SUBTRACT;
 			attachment.src_color_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;
 			attachment.dst_color_blend_factor = RD::BLEND_FACTOR_ONE;
 			attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_SRC_ALPHA;


### PR DESCRIPTION
Changed Subtract blend mode of Forward+ and Mobile renderers to match behaviour of the Godot 3 and Compatibility renderers.

The OpenGL implementation has used GL_FUNC_REVERSE_SUBTRACT for a long time, but the new RenderingDevice abstraction used by the Vulkan renderers had been mistakenly set to BLEND_OP_SUBTRACT instead of BLEND_OP_REVERSE_SUBTRACT.

Fixes #77448