### PR TITLE
Expose method for editor plugins to get the canvas item editor transform

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -529,6 +529,13 @@
 				The callback should have 4 arguments: [Object] [code]undo_redo[/code], [Object] [code]modified_object[/code], [String] [code]property[/code] and [Variant] [code]new_value[/code]. They are, respectively, the [UndoRedo] object used by the inspector, the currently modified object, the name of the modified property and the new value the property is about to take.
 			</description>
 		</method>
+		<method name="get_canvas_item_editor_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<description>
+				Returns the transform of the 2D editor.
+				This can be used to position graphics drawn in [method _forward_canvas_draw_over_viewport] so that they move as the user scrolls the 2D editor.
+			</description>
+		</method>
 		<method name="get_editor_interface">
 			<return type="EditorInterface" />
 			<description>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -254,6 +254,10 @@ void EditorPlugin::forward_canvas_force_draw_over_viewport(Control *p_overlay) {
 	GDVIRTUAL_CALL(_forward_canvas_force_draw_over_viewport, p_overlay);
 }
 
+Transform2D EditorPlugin::get_canvas_item_editor_transform() const {
+	return CanvasItemEditor::get_singleton()->get_canvas_transform();
+}
+
 // Updates the overlays of the 2D viewport or, if in 3D mode, of every 3D viewport.
 int EditorPlugin::update_overlays() const {
 	if (Node3DEditor::get_singleton()->is_visible()) {
@@ -539,6 +543,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);
 
 	ClassDB::bind_method(D_METHOD("update_overlays"), &EditorPlugin::update_overlays);
+	ClassDB::bind_method(D_METHOD("get_canvas_item_editor_transform"), &EditorPlugin::get_canvas_item_editor_transform);
 
 	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "item"), &EditorPlugin::make_bottom_panel_item_visible);
 	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorPlugin::hide_bottom_panel);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -160,6 +160,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay);
+	Transform2D get_canvas_item_editor_transform() const;
 
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 	virtual void forward_3d_draw_over_viewport(Control *p_overlay);


### PR DESCRIPTION
I'm working on an editor plugin in GDExtension, that adds handles to a custom node to edit its shape.

Editor plugins built into core put their handles in the right place by getting the canvas item editor transform via:

```
CanvasItemEditor::get_singleton()->get_canvas_transform();
```

... however, `CanvasItemEditor` isn't exposed to script or GDExtension! This seems intentional - there a number of methods provided on `EditorPlugin` to access `CanvasItemEditor`.

I couldn't find any other way to get the canvas item editor's transform, so this PR adds a new method to `EditorPlugin` to get it.

(If there is already a way to get this from script or GDExtension, please let me know! :-))