### PR TITLE
Fix text_server_adv compiling as a GDExtension

### DIFF
--- a/modules/text_server_adv/gdextension_build/text_server_adv.gdextension
+++ b/modules/text_server_adv/gdextension_build/text_server_adv.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "textserver_advanced_init"
+compatibility_minimum = 4.1
 
 [libraries]
 

--- a/modules/text_server_adv/register_types.cpp
+++ b/modules/text_server_adv/register_types.cpp
@@ -62,8 +62,8 @@ using namespace godot;
 
 extern "C" {
 
-GDExtensionBool GDE_EXPORT textserver_advanced_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+GDExtensionBool GDE_EXPORT textserver_advanced_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
 	init_obj.register_initializer(&initialize_text_server_adv_module);
 	init_obj.register_terminator(&uninitialize_text_server_adv_module);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2112,10 +2112,12 @@ Dictionary TextServerAdvanced::_font_get_ot_name_strings(const RID &p_font_rid) 
 				name = vformat("unknown_%d", names[i].name_id);
 			} break;
 		}
-		String text;
 		unsigned int text_size = hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, nullptr, nullptr) + 1;
-		text.resize(text_size);
-		hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)text.ptrw());
+		// @todo After godot-cpp#1141 is fixed, use text.resize() and write directly to text.wptr() instead of using a temporary buffer.
+		char32_t *buffer = memnew_arr(char32_t, text_size);
+		hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)buffer);
+		String text(buffer);
+		memdelete_arr(buffer);
 		if (!text.is_empty()) {
 			Dictionary &id_string = names_for_lang[String(hb_language_to_string(names[i].language))];
 			id_string[name] = text;

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -150,10 +150,21 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 		}
 
 		String xml_code_str = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"" + rtos(min_x) + " " + rtos(min_y) + " " + rtos(new_w) + " " + rtos(new_h) + "\">" + xml_body;
+#ifndef GDEXTENSION
 		gl_state.xml_code = xml_code_str.utf8();
+#else
+		CharString xml_code = xml_code_str.utf8();
+		gl_state.xml_code_length = xml_code.length();
+		gl_state.xml_code = memnew_arr(char, gl_state.xml_code_length);
+		memcpy(gl_state.xml_code, xml_code.get_data(), gl_state.xml_code_length);
+#endif
 
 		picture = tvg::Picture::gen();
+#ifndef GDEXTENSION
 		result = picture->load(gl_state.xml_code.get_data(), gl_state.xml_code.length(), "svg+xml", false);
+#else
+		result = picture->load(gl_state.xml_code, gl_state.xml_code_length, "svg+xml", false);
+#endif
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (glyph metrics).");
 		}
@@ -241,7 +252,11 @@ FT_Error tvg_svg_in_ot_render(FT_GlyphSlot p_slot, FT_Pointer *p_state) {
 	ERR_FAIL_COND_V_MSG(!gl_state.ready, FT_Err_Invalid_SVG_Document, "SVG glyph not ready.");
 
 	std::unique_ptr<tvg::Picture> picture = tvg::Picture::gen();
+#ifndef GDEXTENSION
 	tvg::Result res = picture->load(gl_state.xml_code.get_data(), gl_state.xml_code.length(), "svg+xml", false);
+#else
+	tvg::Result res = picture->load(gl_state.xml_code, gl_state.xml_code_length, "svg+xml", false);
+#endif
 	if (res != tvg::Result::Success) {
 		ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (glyph rendering).");
 	}

--- a/modules/text_server_adv/thorvg_svg_in_ot.h
+++ b/modules/text_server_adv/thorvg_svg_in_ot.h
@@ -66,8 +66,22 @@ struct GL_State {
 	float y = 0;
 	float w = 0;
 	float h = 0;
+#ifndef GDEXTENSION
 	CharString xml_code;
+#else
+	// @todo After godot-cpp#1142 is fixed, use CharString just like when compiled as a Godot module.
+	char *xml_code = nullptr;
+	int xml_code_length = 0;
+#endif
 	tvg::Matrix m;
+
+#ifdef GDEXTENSION
+	~GL_State() {
+		if (xml_code) {
+			memdelete_arr(xml_code);
+		}
+	}
+#endif
 };
 
 struct TVG_State {


### PR DESCRIPTION
I started working on this when I noticed that text_server_adv can be compiled as a GDExtension, and that it needed to be updated for the changes to the entry symbol signature in Godot 4.1.

I made those changes, however, it seems there's more necessary to fix it compiling. :-/

In godot-cpp, there is no `String::resize()` method, so I replaced that with directly allocating a buffer and then creating a `String` from that - I haven't tested it yet.

However, there's also issues compiling `thorvg_svg_in_ot.cpp` because godot-cpp's `CharString` has no copy constructor (only a move constructor), and so has trouble being in the value of a `HashMap`. I'm not sure the right way to fix that.

Anyway, posting as a draft here for now!