### PR TITLE
Add a `get_node_index` method to GLTFState

### DIFF
--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -90,6 +90,14 @@
 				Returns an array of all [GLTFMesh]es in the GLTF file. These are the meshes that the [member GLTFNode.mesh] index refers to.
 			</description>
 		</method>
+		<method name="get_node_index">
+			<return type="int" />
+			<param index="0" name="scene_node" type="Node" />
+			<description>
+				Returns the index of the [GLTFNode] corresponding to this Godot scene node. This is the inverse of [method get_scene_node]. Useful during the export process.
+				[b]Note:[/b] Not every Godot scene node will have a corresponding [GLTFNode], and not every [GLTFNode] will have a scene node generated. If there is no [GLTFNode] index for this scene node, [code]-1[/code] is returned.
+			</description>
+		</method>
 		<method name="get_nodes">
 			<return type="GLTFNode[]" />
 			<description>
@@ -100,7 +108,8 @@
 			<return type="Node" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the Godot scene node that corresponds to the same index as the [GLTFNode] it was generated from. Not every [GLTFNode] will have a scene node generated, and not every generated scene node will have a corresponding [GLTFNode].
+				Returns the Godot scene node that corresponds to the same index as the [GLTFNode] it was generated from. This is the inverse of [method get_node_index]. Useful during the import process.
+				[b]Note:[/b] Not every [GLTFNode] will have a scene node generated, and not every generated scene node will have a corresponding [GLTFNode]. If there is no scene node for this [GLTFNode] index, [code]null[/code] is returned.
 			</description>
 		</method>
 		<method name="get_skeletons">

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -87,6 +87,7 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_animations"), &GLTFState::get_animations);
 	ClassDB::bind_method(D_METHOD("set_animations", "animations"), &GLTFState::set_animations);
 	ClassDB::bind_method(D_METHOD("get_scene_node", "idx"), &GLTFState::get_scene_node);
+	ClassDB::bind_method(D_METHOD("get_node_index", "scene_node"), &GLTFState::get_node_index);
 	ClassDB::bind_method(D_METHOD("get_additional_data", "extension_name"), &GLTFState::get_additional_data);
 	ClassDB::bind_method(D_METHOD("set_additional_data", "extension_name", "additional_data"), &GLTFState::set_additional_data);
 	ClassDB::bind_method(D_METHOD("get_handle_binary_image"), &GLTFState::get_handle_binary_image);
@@ -333,6 +334,15 @@ Node *GLTFState::get_scene_node(GLTFNodeIndex idx) {
 		return nullptr;
 	}
 	return scene_nodes[idx];
+}
+
+GLTFNodeIndex GLTFState::get_node_index(Node *p_node) {
+	for (KeyValue<GLTFNodeIndex, Node *> x : scene_nodes) {
+		if (x.value == p_node) {
+			return x.key;
+		}
+	}
+	return -1;
 }
 
 int GLTFState::get_animation_players_count(int idx) {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -204,7 +204,7 @@ public:
 	void set_animations(TypedArray<GLTFAnimation> p_animations);
 
 	Node *get_scene_node(GLTFNodeIndex idx);
-	ImporterMeshInstance3D *get_scene_mesh_instance(GLTFNodeIndex idx);
+	GLTFNodeIndex get_node_index(Node *p_node);
 
 	int get_animation_players_count(int idx);
 


### PR DESCRIPTION
While working on GLTFDocumentExtension classes in GDScript, I have already encountered 2 places where this method would be useful during the export process, so I think it's time to add it to Godot. Technically it's not vital, previously I was implementing it on top of `get_scene_node`, but this PR is faster and cleaner. And yes I tested it.