### PR TITLE
Expose `save_all_scenes` method to EditorInterface

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -262,10 +262,16 @@
 				Restarts the editor. This closes the editor and then opens the same project. If [param save] is [code]true[/code], the project will be saved before restarting.
 			</description>
 		</method>
+		<method name="save_all_scenes">
+			<return type="void" />
+			<description>
+				Saves all opened scenes in the editor.
+			</description>
+		</method>
 		<method name="save_scene">
 			<return type="int" enum="Error" />
 			<description>
-				Saves the scene. Returns either [constant OK] or [constant ERR_CANT_CREATE].
+				Saves the currently active scene. Returns either [constant OK] or [constant ERR_CANT_CREATE].
 			</description>
 		</method>
 		<method name="save_scene_as">
@@ -273,7 +279,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="with_preview" type="bool" default="true" />
 			<description>
-				Saves the scene as a file at [param path].
+				Saves the currently active scene as a file at [param path].
 			</description>
 		</method>
 		<method name="select_file">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -337,6 +337,10 @@ void EditorInterface::mark_scene_as_unsaved() {
 	EditorUndoRedoManager::get_singleton()->set_history_as_unsaved(EditorNode::get_editor_data().get_current_edited_scene_history_id());
 }
 
+void EditorInterface::save_all_scenes() {
+	EditorNode::get_singleton()->save_all_scenes();
+}
+
 // Scene playback.
 
 void EditorInterface::play_main_scene() {
@@ -434,6 +438,7 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("save_all_scenes"), &EditorInterface::save_all_scenes);
 
 	ClassDB::bind_method(D_METHOD("mark_scene_as_unsaved"), &EditorInterface::mark_scene_as_unsaved);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -130,6 +130,7 @@ public:
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 	void mark_scene_as_unsaved();
+	void save_all_scenes();
 
 	// Scene playback.
 


### PR DESCRIPTION
This PR exposes `save_all_scenes` method to the `EditorInterface` class. It's a very simple change, but I don't think there were other ways to do this in the editor.

I added the documentation for this method and changed, but I wanted to propose changing `save_scene` to `save_edited_scene` (and `save_scene_as` to `save_edited_scene_as`). It's a breaking change, but the previous method names gives the wrong impression on what they do, since it's not possible to use them to save an arbitrary editor scene. Is it okay to add this on this PR, or should I ignore this?

PS: My use-case is a very simple addon with pre-configured resolutions for different mobile devices. I need to change the resolution in the inspector quickly, without the hassle of opening Project Settings multiple times, and I need the addon to reload every open scene to see the changes. Problem is, when the scenes reload, any modification not saved is lost, so I need to save them first. Before this PR, I was saving all scenes by running `play` and `stop` via code, because by default the editor saves all scenes before playing the game - but that certainly wasn't efficient nor the best way to do this.