### PR TITLE
Expose EditorFileSystem.get_file_script_class_icon_path

### DIFF
--- a/doc/classes/EditorFileSystemDirectory.xml
+++ b/doc/classes/EditorFileSystemDirectory.xml
@@ -57,6 +57,13 @@
 				Returns the base class of the script class defined in the file at index [param idx]. If the file doesn't define a script class using the [code]class_name[/code] syntax, this will return an empty string.
 			</description>
 		</method>
+		<method name="get_file_script_class_icon_path" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="idx" type="int" />
+			<description>
+				Returns the icon path of the script class defined in the file at index [param idx]. If the file doesn't define an icon class using the [code]@icon("...")[/code] syntax, this will return an empty string.
+			</description>
+		</method>
 		<method name="get_file_script_class_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="idx" type="int" />

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -191,6 +191,7 @@ void EditorFileSystemDirectory::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_file_type", "idx"), &EditorFileSystemDirectory::get_file_type);
 	ClassDB::bind_method(D_METHOD("get_file_script_class_name", "idx"), &EditorFileSystemDirectory::get_file_script_class_name);
 	ClassDB::bind_method(D_METHOD("get_file_script_class_extends", "idx"), &EditorFileSystemDirectory::get_file_script_class_extends);
+	ClassDB::bind_method(D_METHOD("get_file_script_class_icon_path", "idx"), &EditorFileSystemDirectory::get_file_script_class_icon_path);
 	ClassDB::bind_method(D_METHOD("get_file_import_is_valid", "idx"), &EditorFileSystemDirectory::get_file_import_is_valid);
 	ClassDB::bind_method(D_METHOD("get_name"), &EditorFileSystemDirectory::get_name);
 	ClassDB::bind_method(D_METHOD("get_path"), &EditorFileSystemDirectory::get_path);


### PR DESCRIPTION
Expose the `EditorFileSystem.get_file_script_class_icon_path` method, like the other `get_file_script_class_*` methods.
This makes it possible to get the icon for a script in an arbitrary resource path (not just global classes), from script.
```
@tool
extends EditorScript

func _run():
        var fs := get_editor_interface().get_resource_filesystem()
        var p := fs.get_filesystem_path("res://items")
        var idx := p.find_file_index("GameItem.gd")
        print(p.get_file_script_class_icon_path(idx))
```

Also adds documentation. Targets master branch only.

See also #77546.

_Production edit: Closes https://github.com/godotengine/godot/issues/77546_.