### PR TITLE
Reinstate NoiseTexture2D's icon

### DIFF
--- a/modules/noise/icons/NoiseTexture.svg
+++ b/modules/noise/icons/NoiseTexture.svg
@@ -1,1 +1,0 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m2 1c-.55228 0-1 .44772-1 1v12c0 .55228.44772 1 1 1h12c.55228 0 1-.44772 1-1v-12c0-.55228-.44772-1-1-1zm1 2h10v8h-10zm3 1v2h2v-2zm2 2v2h2v2h2v-6h-2v2zm0 2h-2v-2h-2v4h4z" fill="#e0e0e0" fill-opacity=".99608"/></svg>

--- a/modules/noise/icons/NoiseTexture2D.svg
+++ b/modules/noise/icons/NoiseTexture2D.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zm1 2h10v8H3zm3 1v2h2V4zm2 2v2h2v2h2V4h-2v2zm0 2H6V6H4v4h4z" fill="#e0e0e0"/></svg>


### PR DESCRIPTION
We forgot to rename the icon when we renamed NoiseTexture to NoiseTexture2D. Also optimizes it a bit (we didn't svg-clean it with everything else because it's not in editor/icons).