### PR TITLE
[4.x] Add ARCore support

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -56,6 +56,9 @@
 		<constant name="FEED_YCBCR_SEP" value="3" enum="FeedDataType">
 			Feed supplies separate Y and CbCr images that need to be combined and converted to RGB.
 		</constant>
+		<constant name="FEED_EXTERNAL" value="4" enum="FeedDataType">
+			Feed external images.
+		</constant>
 		<constant name="FEED_UNSPECIFIED" value="0" enum="FeedPosition">
 			Unspecified position.
 		</constant>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2475,6 +2475,8 @@ void EditorExportPlatformAndroid::get_command_line_flags(const Ref<EditorExportP
 	int xr_mode_index = p_preset->get("xr_features/xr_mode");
 	if (xr_mode_index == XR_MODE_OPENXR) {
 		command_line_strings.push_back("--xr_mode_openxr");
+	} else if (xr_mode_index == XR_MODE_ARCORE) {
+		command_line_strings.push_back("--xr_mode_arcore");
 	} else { // XRMode.REGULAR is the default.
 		command_line_strings.push_back("--xr_mode_regular");
 	}

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -60,6 +60,7 @@ static const int APP_CATEGORY_VIDEO = 8;
 // This should match the entries in 'platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java'
 static const int XR_MODE_REGULAR = 0;
 static const int XR_MODE_OPENXR = 1;
+static const int XR_MODE_ARCORE = 2;
 
 struct CustomExportData {
 	String assets_directory;

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
@@ -250,6 +250,7 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 				break;
 
 			case REGULAR:
+			case ARCORE:
 			default:
 				/* By default, GLSurfaceView() creates a RGB_565 opaque surface.
 				 * If we want a translucent one, we should change the surface's

--- a/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
@@ -35,7 +35,8 @@ package org.godotengine.godot.xr;
  */
 public enum XRMode {
 	REGULAR(0, "Regular", "--xr_mode_regular", "Default Android Gamepad"), // Regular/flatscreen
-	OPENXR(1, "OpenXR", "--xr_mode_openxr", "");
+	OPENXR(1, "OpenXR", "--xr_mode_openxr", ""),
+	ARCORE(2, "AR Core", "--xr_mode_arcore", "Default Android Gamepad");
 
 	final int index;
 	final String label;

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -331,3 +331,13 @@ void GodotJavaWrapper::dump_benchmark(const String &benchmark_file) {
 		env->CallVoidMethod(godot_instance, _dump_benchmark, j_benchmark_file);
 	}
 }
+
+int GodotJavaWrapper::get_display_rotation() {
+	if (_get_display_rotation) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, 0);
+		return env->CallIntMethod(godot_instance, _get_display_rotation);
+	} else {
+		return 0;
+	}
+}

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -70,6 +70,7 @@ private:
 	jmethodID _begin_benchmark_measure = nullptr;
 	jmethodID _end_benchmark_measure = nullptr;
 	jmethodID _dump_benchmark = nullptr;
+	jmethodID _get_display_rotation = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -102,6 +103,7 @@ public:
 	void begin_benchmark_measure(const String &p_label);
 	void end_benchmark_measure(const String &p_label);
 	void dump_benchmark(const String &benchmark_file);
+	int get_display_rotation();
 };
 
 #endif // JAVA_GODOT_WRAPPER_H

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -53,6 +53,7 @@ void CameraFeed::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_RGB_img", "rgb_img"), &CameraFeed::set_RGB_img);
 	ClassDB::bind_method(D_METHOD("_set_YCbCr_img", "ycbcr_img"), &CameraFeed::set_YCbCr_img);
+	ClassDB::bind_method(D_METHOD("_set_external", "external_img"), &CameraFeed::set_external);
 
 	ClassDB::bind_method(D_METHOD("get_datatype"), &CameraFeed::get_datatype);
 
@@ -64,6 +65,7 @@ void CameraFeed::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEED_RGB);
 	BIND_ENUM_CONSTANT(FEED_YCBCR);
 	BIND_ENUM_CONSTANT(FEED_YCBCR_SEP);
+	BIND_ENUM_CONSTANT(FEED_EXTERNAL);
 
 	BIND_ENUM_CONSTANT(FEED_UNSPECIFIED);
 	BIND_ENUM_CONSTANT(FEED_FRONT);
@@ -147,6 +149,7 @@ CameraFeed::CameraFeed() {
 	transform = Transform2D(1.0, 0.0, 0.0, -1.0, 0.0, 1.0);
 	texture[CameraServer::FEED_Y_IMAGE] = RenderingServer::get_singleton()->texture_2d_placeholder_create();
 	texture[CameraServer::FEED_CBCR_IMAGE] = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+	texture[CameraServer::FEED_EXTERNAL] = RenderingServer::get_singleton()->texture_2d_placeholder_create();
 }
 
 CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
@@ -241,6 +244,28 @@ void CameraFeed::set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_c
 		}
 
 		datatype = CameraFeed::FEED_YCBCR_SEP;
+	}
+}
+
+void CameraFeed::set_external(const Ref<Image> &p_external_img) {
+	ERR_FAIL_COND(p_external_img.is_null());
+
+	if (active) {
+		int new_external_width = p_external_img->get_width();
+		int new_external_height = p_external_img->get_height();
+
+		if ((base_width != new_external_width) || (base_height != new_external_height)) {
+			// assume that camera image doesn't change formats etc.
+			base_width = new_external_width;
+			base_height = new_external_height;
+
+			{
+				RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_external_img);
+				RenderingServer::get_singleton()->texture_replace(texture[CameraServer::FEED_EXTERNAL], new_texture);
+			}
+		} else {
+			RenderingServer::get_singleton()->texture_2d_update(texture[CameraServer::FEED_EXTERNAL], p_external_img);
+		}
 	}
 }
 

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -49,7 +49,8 @@ public:
 		FEED_NOIMAGE, // we don't have an image yet
 		FEED_RGB, // our texture will contain a normal RGB texture that can be used directly
 		FEED_YCBCR, // our texture will contain a YCbCr texture that needs to be converted to RGB before output
-		FEED_YCBCR_SEP // our camera is split into two textures, first plane contains Y data, second plane contains CbCr data
+		FEED_YCBCR_SEP, // our camera is split into two textures, first plane contains Y data, second plane contains CbCr data
+		FEED_EXTERNAL // specific for android, camera feed is managed externally, assumed RGB
 	};
 
 	enum FeedPosition {
@@ -101,6 +102,7 @@ public:
 	void set_RGB_img(const Ref<Image> &p_rgb_img);
 	void set_YCbCr_img(const Ref<Image> &p_ycbcr_img);
 	void set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img);
+	void set_external(const Ref<Image> &p_external_img);
 
 	virtual bool activate_feed();
 	virtual void deactivate_feed();

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -56,7 +56,8 @@ public:
 		FEED_YCBCR_IMAGE = 0,
 		FEED_Y_IMAGE = 0,
 		FEED_CBCR_IMAGE = 1,
-		FEED_IMAGES = 2
+		FEED_EXTERNAL = 2,
+		FEED_IMAGES = 3
 	};
 
 	typedef CameraServer *(*CreateFunc)();


### PR DESCRIPTION
This is an updated version for ARCore support of https://github.com/godotengine/godot/pull/47455 but for 4.x.

This is a WIP and feedback is very much appreciated

## Procedure for building:
Generally follow this build instruction: https://github.com/GodotVR/godot_arcore

My 4.x branch of godot_arcore: https://github.com/paddy-exe/godot_arcore/tree/4.x

NDK version: 21.4.7075529
Android Studio Electric Eel (latest archived version)

### Build the updated engine

1. Clone the repository with the necessary changes:
```shell
git clone --branch 4.x-arcore-support git@github.com:paddy-exe/godot.git
```

2. Build the engine
```shell
cd godot
scons platform=<PLATFORM>
```

3. Generate the extension files
```shell
cd bin
./godot.<PLATFORM>.editor.x86_64 --dump-extension-api --dump-gdextension-interface
```


### Build the Plugin

1. Clone the repository of the plugin:
```shell
cd ../..
git clone --branch 4.x git@github.com:paddy-exe/godot_arcore.git
```

2. Download the godot-cpp submodule
```shell
cd godot_arcore
git submodule update --init --recursive
```

3. Copy the extension files to the godot-cpp submodule:
```shell
cd ..
cp godot/bin/extension_api.json godot/bin/gdextension_interface.h godot_arcore/plugin/libs/godot-cpp/gdextension/ 
```

4. Generate the binding classes
```shell
cd godot_arcore
python ./generate.py
```

5. Build the plugin
```shell
./gradlew :generatePluginBinary   
```