### PR TITLE
Update the minimum size of Label if necessary when resizing

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -654,7 +654,10 @@ void Label::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			lines_dirty = true;
+			if (autowrap_mode != TextServer::AUTOWRAP_OFF || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
+				lines_dirty = true;
+				update_minimum_size();
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Previously, the necessary call to update the minimum size was missing.

Fixes #74052. 
Supersedes #77568.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
