### PR TITLE
Make system information for issue reports single-line

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   validations:
     required: true
 
-- type: textarea
+- type: input
   attributes:
     label: System information
     description: |
@@ -29,15 +29,8 @@ body:
       - For issues that are likely OS-specific and/or graphics-related, please specify the CPU model and architecture.
       - For graphics-related issues, specify the GPU model, driver version, and the rendering backend (GLES2, GLES3, Vulkan).
       - **Bug reports not including the required information may be closed at the maintainers' discretion.** If in doubt, always include all the requested information; it's better to include too much information than not enough information.
-      - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**```
-    placeholder: |
-      - OS: Windows 10
-      - Godot Version: 3.5.stable, 4.0.dev (3041becc6)
-      - Rendering Driver: GLES3, Vulkan
-      - Rendering Method: Forward+, Mobile, Compatibility
-      - Graphics Card: Intel HD Graphics 620 (27.20.100.9616)
-      - Graphics Card Driver: nvidia, version 510.85.02
-      - CPU: Intel Core i5-7200U
+      - **Starting from Godot 4.1, you can copy this information to your clipboard by using *Help > Copy System Info* at the top of the editor window.**
+    placeholder: Windows 10 - Godot v4.0.3.stable - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia, 510.85.02) - Intel Core i7-10700KF CPU @ 3.80GHz (16 Threads)
   validations:
     required: true
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4370,9 +4370,14 @@ String EditorNode::_get_system_info() const {
 	}
 	const String distribution_version = OS::get_singleton()->get_version();
 
-	const String godot_version = String(VERSION_FULL_BUILD);
+	String godot_version = "Godot v" + String(VERSION_FULL_CONFIG);
+	if (String(VERSION_BUILD) != "official") {
+		String hash = String(VERSION_HASH);
+		hash = hash.is_empty() ? String("unknown") : vformat("(%s)", hash.left(9));
+		godot_version += " " + hash;
+	}
 
-	const String driver_name = GLOBAL_GET("rendering/rendering_device/driver");
+	String driver_name = GLOBAL_GET("rendering/rendering_device/driver");
 	String rendering_method = GLOBAL_GET("rendering/renderer/rendering_method");
 
 	const String rendering_device_name = RenderingServer::get_singleton()->get_rendering_device()->get_device_name();
@@ -4390,7 +4395,7 @@ String EditorNode::_get_system_info() const {
 			device_type_string = "virtual";
 			break;
 		case RenderingDevice::DeviceType::DEVICE_TYPE_CPU:
-			device_type_string = "software emulation on CPU";
+			device_type_string = "(software emulation on CPU)";
 			break;
 		case RenderingDevice::DeviceType::DEVICE_TYPE_OTHER:
 		case RenderingDevice::DeviceType::DEVICE_TYPE_MAX:
@@ -4403,6 +4408,11 @@ String EditorNode::_get_system_info() const {
 	const int processor_count = OS::get_singleton()->get_processor_count();
 
 	// Prettify
+	if (driver_name == "vulkan") {
+		driver_name = "Vulkan";
+	} else if (driver_name == "opengl3") {
+		driver_name = "GLES3";
+	}
 	if (rendering_method == "forward_plus") {
 		rendering_method = "Forward+";
 	} else if (rendering_method == "mobile") {
@@ -4413,32 +4423,33 @@ String EditorNode::_get_system_info() const {
 
 	// Join info.
 	Vector<String> info;
-	const String prefix = "*";
+	info.push_back(godot_version);
 	if (!distribution_version.is_empty()) {
-		info.push_back(vformat("%s OS: %s %s", prefix, distribution_name, distribution_version));
+		info.push_back(distribution_name + " " + distribution_version);
 	} else {
-		info.push_back(vformat("%s OS: %s", prefix, distribution_name));
+		info.push_back(distribution_name);
 	}
-	info.push_back(vformat("%s Godot Version: %s", prefix, godot_version));
-	info.push_back(vformat("%s Rendering Driver: %s", prefix, driver_name));
-	info.push_back(vformat("%s Rendering Method: %s", prefix, rendering_method));
-	if (device_type_string.is_empty()) {
-		info.push_back(vformat("%s Graphics Card: %s", prefix, rendering_device_name));
-	} else {
-		info.push_back(vformat("%s Graphics Card: %s (%s)", prefix, rendering_device_name, device_type_string));
+	info.push_back(vformat("%s (%s)", driver_name, rendering_method));
+
+	String graphics;
+	if (!device_type_string.is_empty()) {
+		graphics = device_type_string + " ";
 	}
+	graphics += rendering_device_name;
 	if (video_adapter_driver_info.size() == 2) { // This vector is always either of length 0 or 2.
 		String vad_name = video_adapter_driver_info[0];
 		String vad_version = video_adapter_driver_info[1]; // Version could be potentially empty on Linux/BSD.
 		if (!vad_version.is_empty()) {
-			info.push_back(vformat("%s Graphics Card Driver: %s, version %s", prefix, vad_name, vad_version));
+			graphics += vformat(" (%s; %s)", vad_name, vad_version);
 		} else {
-			info.push_back(vformat("%s Graphics Card Driver: %s", prefix, vad_name));
+			graphics += vformat(" (%s)", vad_name);
 		}
 	}
-	info.push_back(vformat("%s CPU: %s (%d Threads)", prefix, processor_name, processor_count));
+	info.push_back(graphics);
 
-	return String("\n").join(info);
+	info.push_back(vformat("%s (%d Threads)", processor_name, processor_count));
+
+	return String(" - ").join(info);
 }
 
 Ref<Texture2D> EditorNode::_file_dialog_get_icon(const String &p_path) {
@@ -7505,6 +7516,7 @@ EditorNode::EditorNode() {
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ExternalLink"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/q&a", TTR("Questions & Answers")), HELP_QA);
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ExternalLink"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/report_a_bug", TTR("Report a Bug")), HELP_REPORT_A_BUG);
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/copy_system_info", TTR("Copy System Info")), HELP_COPY_SYSTEM_INFO);
+	help_menu->set_item_tooltip(-1, TTR("Copies the system info as a single-line text into the clipboard."));
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ExternalLink"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/suggest_a_feature", TTR("Suggest a Feature")), HELP_SUGGEST_A_FEATURE);
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ExternalLink"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/send_docs_feedback", TTR("Send Docs Feedback")), HELP_SEND_DOCS_FEEDBACK);
 	help_menu->add_icon_shortcut(gui_base->get_theme_icon(SNAME("ExternalLink"), SNAME("EditorIcons")), ED_SHORTCUT_AND_COMMAND("editor/community", TTR("Community")), HELP_COMMUNITY);


### PR DESCRIPTION
Context: Before https://github.com/godotengine/godot/pull/65902, the Bug Report Template had **System Info** as a single-line input field. Web browsers only cache values for auto-completion for input fields, not text areas.  
Using auto-completion is especially useful for contributors who commit daily/weekly, whose system specs shouldn't change that often to warrant using the copy button in the editor every single time.

This PR
* makes the Bug Report Template field an `input` type again, and
* adjusts the "Copy System Info" button to create a compact single-line output to fit the input field.  

See short exchange here: https://github.com/godotengine/godot/pull/65902#issuecomment-1565759846

@Calinou, @akien-mga: What do you think?

---

Editor

![image](https://github.com/godotengine/godot/assets/6639237/7feb3158-a678-4eee-8312-4adbe3506f56)


## Output Format Now

Godot v4.1.dev (bc19b5abf) - Ubuntu 20.04.6 LTS (Focal Fossa) - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia; 510.108.03) - Intel(R) Core(TM) i7-10700KF CPU @ 3.80GHz (16 Threads)


## Output Format Before

* OS: Ubuntu 20.04.5 LTS (Focal Fossa)
* Godot Version: 4.0.beta.custom_build
* Rendering Driver: vulkan
* Rendering Method: Forward+
* Graphics Card: NVIDIA GeForce GTX 970 (dedicated)
* Graphics Card Driver: nvidia, version 510.85.02
* CPU: Intel(R) Core(TM) i7-10700KF CPU @ 3.80GHz (16 Threads)