### PR TITLE
Improve `Window` documentation

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -74,7 +74,7 @@
 			<param index="3" name="callback" type="Callable" />
 			<description>
 				Shows a text input dialog which uses the operating system's native look-and-feel. [param callback] will be called with a [String] argument equal to the text field's contents when the dialog is closed for any reason.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="dialog_show">
@@ -85,7 +85,7 @@
 			<param index="3" name="callback" type="Callable" />
 			<description>
 				Shows a text dialog which uses the operating system's native look-and-feel. [param callback] will be called when the dialog is closed for any reason.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="enable_for_stealing_focus">
@@ -93,7 +93,7 @@
 			<param index="0" name="process_id" type="int" />
 			<description>
 				Allows the [param process_id] PID to steal focus from this window. In other words, this disables the operating system's focus stealing protection for the specified PID.
-				[b]Note:[/b] This method is implemented on Windows.
+				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
 		<method name="force_process_and_drop_events">
@@ -198,7 +198,7 @@
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -221,7 +221,7 @@
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -244,7 +244,7 @@
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -268,7 +268,7 @@
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] Radio-checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -290,7 +290,7 @@
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -316,7 +316,7 @@
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] By default, there's no indication of the current item state, it should be changed manually.
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -339,7 +339,7 @@
 				An [param accelerator] can optionally be defined, which is a keyboard shortcut that can be pressed to trigger the menu button even if it's not currently open. The [param accelerator] is generally a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
 				[b]Note:[/b] Radio-checkable items just display a checkmark, but don't have any built-in checking behavior and must be checked/unchecked manually. See [method global_menu_set_item_checked] for more info on how to control it.
 				[b]Note:[/b] The [param callback] and [param key_callback] Callables need to accept exactly one Variant parameter, the parameter passed to the Callables will be the value passed to [param tag].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -354,7 +354,7 @@
 			<description>
 				Adds a separator between items to the global menu with ID [param menu_root]. Separators also occupy an index.
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -371,7 +371,7 @@
 			<description>
 				Adds an item that will act as a submenu of the global menu [param menu_root]. The [param submenu] argument is the ID of the global menu root that will be shown when the item is clicked.
 				Returns index of the inserted item, it's not guaranteed to be the same as [param index] value.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -384,7 +384,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<description>
 				Removes all items from the global menu with ID [param menu_root].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Supported system menu IDs:[/b]
 				[codeblock]
 				"_main" - Main menu (macOS).
@@ -398,7 +398,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the accelerator of the item at index [param idx]. Accelerators are special combinations of keys that activate the item, no matter which control is focused.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_callback" qualifiers="const">
@@ -407,7 +407,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the callback of the item at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_count" qualifiers="const">
@@ -415,7 +415,7 @@
 			<param index="0" name="menu_root" type="String" />
 			<description>
 				Returns number of items in the global menu with ID [param menu_root].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_icon" qualifiers="const">
@@ -424,7 +424,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the icon of the item at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_indentation_level" qualifiers="const">
@@ -433,7 +433,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the horizontal offset of the item at the given [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_index_from_tag" qualifiers="const">
@@ -442,7 +442,7 @@
 			<param index="1" name="tag" type="Variant" />
 			<description>
 				Returns the index of the item with the specified [param tag]. Index is automatically assigned to each item by the engine. Index can not be set manually.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_index_from_text" qualifiers="const">
@@ -451,7 +451,7 @@
 			<param index="1" name="text" type="String" />
 			<description>
 				Returns the index of the item with the specified [param text]. Index is automatically assigned to each item by the engine. Index can not be set manually.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_key_callback" qualifiers="const">
@@ -460,7 +460,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the callback of the item accelerator at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_max_states" qualifiers="const">
@@ -469,7 +469,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns number of states of a multistate item. See [method global_menu_add_multistate_item] for details.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_state" qualifiers="const">
@@ -478,7 +478,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the state of a multistate item. See [method global_menu_add_multistate_item] for details.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_submenu" qualifiers="const">
@@ -487,7 +487,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the submenu ID of the item at index [param idx]. See [method global_menu_add_submenu_item] for more info on how to add a submenu.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_tag" qualifiers="const">
@@ -496,7 +496,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the metadata of the specified item, which might be of any type. You can set it with [method global_menu_set_item_tag], which provides a simple way of assigning context data to items.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_text" qualifiers="const">
@@ -505,7 +505,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the text of the item at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_get_item_tooltip" qualifiers="const">
@@ -514,7 +514,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns the tooltip associated with the specified index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_checkable" qualifiers="const">
@@ -523,7 +523,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns [code]true[/code] if the item at index [param idx] is checkable in some way, i.e. if it has a checkbox or radio button.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_checked" qualifiers="const">
@@ -532,7 +532,7 @@
 			<param index="1" name="idx" type="int" />
 			<description>
 				Returns [code]true[/code] if the item at index [param idx] is checked.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_disabled" qualifiers="const">
@@ -542,7 +542,7 @@
 			<description>
 				Returns [code]true[/code] if the item at index [param idx] is disabled. When it is disabled it can't be selected, or its action invoked.
 				See [method global_menu_set_item_disabled] for more info on how to disable an item.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_is_item_radio_checkable" qualifiers="const">
@@ -552,7 +552,7 @@
 			<description>
 				Returns [code]true[/code] if the item at index [param idx] has radio button-style checkability.
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_remove_item">
@@ -562,7 +562,7 @@
 			<description>
 				Removes the item at index [param idx] from the global menu [param menu_root].
 				[b]Note:[/b] The indices of items after the removed item will be shifted by one.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_accelerator">
@@ -572,7 +572,7 @@
 			<param index="2" name="keycode" type="int" enum="Key" />
 			<description>
 				Sets the accelerator of the item at index [param idx]. [param keycode] can be a single [enum Key], or a combination of [enum KeyModifierMask]s and [enum Key]s using bitwise OR such as [code]KEY_MASK_CTRL | KEY_A[/code] ([kbd]Ctrl + A[/kbd]).
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_callback">
@@ -583,7 +583,7 @@
 			<description>
 				Sets the callback of the item at index [param idx]. Callback is emitted when an item is pressed.
 				[b]Note:[/b] The [param callback] Callable needs to accept exactly one Variant parameter, the parameter passed to the Callable will be the value passed to the [code]tag[/code] parameter when the menu item was created.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_checkable">
@@ -593,7 +593,7 @@
 			<param index="2" name="checkable" type="bool" />
 			<description>
 				Sets whether the item at index [param idx] has a checkbox. If [code]false[/code], sets the type of the item to plain text.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_checked">
@@ -603,7 +603,7 @@
 			<param index="2" name="checked" type="bool" />
 			<description>
 				Sets the checkstate status of the item at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_disabled">
@@ -613,7 +613,7 @@
 			<param index="2" name="disabled" type="bool" />
 			<description>
 				Enables/disables the item at index [param idx]. When it is disabled, it can't be selected and its action can't be invoked.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_icon">
@@ -623,7 +623,7 @@
 			<param index="2" name="icon" type="Texture2D" />
 			<description>
 				Replaces the [Texture2D] icon of the specified [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 				[b]Note:[/b] This method is not supported by macOS "_dock" menu items.
 			</description>
 		</method>
@@ -634,7 +634,7 @@
 			<param index="2" name="level" type="int" />
 			<description>
 				Sets the horizontal offset of the item at the given [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_key_callback">
@@ -645,7 +645,7 @@
 			<description>
 				Sets the callback of the item at index [param idx]. Callback is emitted when its accelerator is activated.
 				[b]Note:[/b] The [param key_callback] Callable needs to accept exactly one Variant parameter, the parameter passed to the Callable will be the value passed to the [code]tag[/code] parameter when the menu item was created.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_max_states">
@@ -655,7 +655,7 @@
 			<param index="2" name="max_states" type="int" />
 			<description>
 				Sets number of state of a multistate item. See [method global_menu_add_multistate_item] for details.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_radio_checkable">
@@ -666,7 +666,7 @@
 			<description>
 				Sets the type of the item at the specified index [param idx] to radio button. If [code]false[/code], sets the type of the item to plain text.
 				[b]Note:[/b] This is purely cosmetic; you must add the logic for checking/unchecking items in radio groups.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_state">
@@ -676,7 +676,7 @@
 			<param index="2" name="state" type="int" />
 			<description>
 				Sets the state of a multistate item. See [method global_menu_add_multistate_item] for details.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_submenu">
@@ -686,7 +686,7 @@
 			<param index="2" name="submenu" type="String" />
 			<description>
 				Sets the submenu of the item at index [param idx]. The submenu is the ID of a global menu root that would be shown when the item is clicked.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_tag">
@@ -696,7 +696,7 @@
 			<param index="2" name="tag" type="Variant" />
 			<description>
 				Sets the metadata of an item, which may be of any type. You can later get it with [method global_menu_get_item_tag], which provides a simple way of assigning context data to items.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_text">
@@ -706,7 +706,7 @@
 			<param index="2" name="text" type="String" />
 			<description>
 				Sets the text of the item at index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="global_menu_set_item_tooltip">
@@ -716,7 +716,7 @@
 			<param index="2" name="tooltip" type="String" />
 			<description>
 				Sets the [String] tooltip of the item at the specified index [param idx].
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="has_feature" qualifiers="const">
@@ -730,14 +730,14 @@
 			<return type="Vector2i" />
 			<description>
 				Returns the text selection in the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] composition string, with the [Vector2i]'s [code]x[/code] component being the caret position and [code]y[/code] being the length of the selection.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="ime_get_text" qualifiers="const">
 			<return type="String" />
 			<description>
 				Returns the composition string contained within the [url=https://en.wikipedia.org/wiki/Input_method]Input Method Editor[/url] window.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="is_dark_mode" qualifiers="const">
@@ -869,7 +869,7 @@
 			<description>
 				Returns the greatest scale factor of all screens.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] if there is at least one hiDPI (Retina) screen in the system, and [code]1.0[/code] in all other cases.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="screen_get_orientation" qualifiers="const">
@@ -925,7 +925,7 @@
 			<description>
 				Returns the scale factor of the specified screen by index.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] for hiDPI (Retina) screen, and [code]1.0[/code] for all other cases.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="screen_get_size" qualifiers="const">
@@ -981,14 +981,14 @@
 			<return type="String" />
 			<description>
 				Returns current active tablet driver name.
-				[b]Note:[/b] This method is implemented on Windows.
+				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
 		<method name="tablet_get_driver_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the total number of available tablet drivers.
-				[b]Note:[/b] This method is implemented on Windows.
+				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
 		<method name="tablet_get_driver_name" qualifiers="const">
@@ -996,7 +996,7 @@
 			<param index="0" name="idx" type="int" />
 			<description>
 				Returns the tablet driver name for the given index.
-				[b]Note:[/b] This method is implemented on Windows.
+				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
 		<method name="tablet_set_current_driver">
@@ -1004,7 +1004,7 @@
 			<param index="0" name="name" type="String" />
 			<description>
 				Set active tablet driver name.
-				[b]Note:[/b] This method is implemented on Windows.
+				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
 		<method name="tts_get_voices" qualifiers="const">
@@ -1160,7 +1160,7 @@
 			<return type="int" />
 			<param index="0" name="window_id" type="int" default="0" />
 			<description>
-				Returns the [method Object.get_instance_id] of the [Window] the [param window_id] is attached to. also [method window_get_attached_instance_id].
+				Returns the [method Object.get_instance_id] of the [Window] the [param window_id] is attached to.
 			</description>
 		</method>
 		<method name="window_get_current_screen" qualifiers="const">
@@ -1268,14 +1268,14 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code], if double-click on a window title should maximize it.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="window_minimize_on_title_dbl_click" qualifiers="const">
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code], if double-click on a window title should minimize it.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
 		<method name="window_move_to_foreground">
@@ -1503,7 +1503,7 @@
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
 				When [constant WINDOW_FLAG_EXTEND_TO_TITLE] flag is set, set offset to the center of the first titlebar button.
-				[b]Note:[/b] This flag is implemented on macOS.
+				[b]Note:[/b] This flag is implemented only on macOS.
 			</description>
 		</method>
 		<method name="window_set_window_event_callback">
@@ -1759,7 +1759,7 @@
 			Window content is expanded to the full size of the window. Unlike borderless window, the frame is left intact and can be used to resize the window, title bar is transparent, but have minimize/maximize/close buttons.
 			Use [method window_set_window_buttons_offset] to adjust minimize/maximize/close buttons offset.
 			Use [method window_get_safe_title_margins] to determine area under the title bar that is not covered by decorations.
-			[b]Note:[/b] This flag is implemented on macOS.
+			[b]Note:[/b] This flag is implemented only on macOS.
 		</constant>
 		<constant name="WINDOW_FLAG_MOUSE_PASSTHROUGH" value="7" enum="WindowFlags">
 			All mouse events are passed to the underlying window of the same application.
@@ -1784,15 +1784,15 @@
 		</constant>
 		<constant name="WINDOW_EVENT_GO_BACK_REQUEST" value="5" enum="WindowEvent">
 			Sent when the device "Back" button is pressed, see [method window_set_window_event_callback].
-			[b]Note:[/b] This event is implemented on Android.
+			[b]Note:[/b] This event is implemented only on Android.
 		</constant>
 		<constant name="WINDOW_EVENT_DPI_CHANGE" value="6" enum="WindowEvent">
 			Sent when the window is moved to the display with different DPI, or display DPI is changed, see [method window_set_window_event_callback].
-			[b]Note:[/b] This flag is implemented on macOS.
+			[b]Note:[/b] This flag is implemented only on macOS.
 		</constant>
 		<constant name="WINDOW_EVENT_TITLEBAR_CHANGE" value="7" enum="WindowEvent">
 			Sent when the window title bar decoration is changed (e.g. [constant WINDOW_FLAG_EXTEND_TO_TITLE] is set or window entered/exited full screen mode), see [method window_set_window_event_callback].
-			[b]Note:[/b] This flag is implemented on macOS.
+			[b]Note:[/b] This flag is implemented only on macOS.
 		</constant>
 		<constant name="VSYNC_DISABLED" value="0" enum="VSyncMode">
 			No vertical synchronization, which means the engine will display frames as fast as possible (tearing may be visible). Framerate is unlimited (nonwithstanding [member Engine.max_fps]).

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -241,7 +241,7 @@
 			<return type="PackedStringArray" />
 			<description>
 				With this function, you can get the list of dangerous permissions that have been granted to the Android application.
-				[b]Note:[/b] This method is implemented on Android.
+				[b]Note:[/b] This method is implemented only on Android.
 			</description>
 		</method>
 		<method name="get_keycode_string" qualifiers="const">
@@ -599,7 +599,7 @@
 			<return type="bool" />
 			<description>
 				With this function, you can request dangerous permissions since normal permissions are automatically granted at install time in Android applications.
-				[b]Note:[/b] This method is implemented on Android.
+				[b]Note:[/b] This method is implemented only on Android.
 			</description>
 		</method>
 		<method name="set_environment" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -747,7 +747,7 @@
 			[b]Note:[/b] This setting is implemented only on macOS.
 		</member>
 		<member name="display/window/size/initial_position" type="Vector2i" setter="" getter="" default="Vector2i(0, 0)">
-			Main window initial position (in virtual desktop coordinates), this settings is used only if [member display/window/size/initial_position_type] is set to "Absolute" ([code]0[/code]).
+			Main window initial position (in virtual desktop coordinates), this setting is used only if [member display/window/size/initial_position_type] is set to "Absolute" ([code]0[/code]).
 		</member>
 		<member name="display/window/size/initial_position_type" type="int" setter="" getter="" default="1">
 			Main window initial position.
@@ -756,7 +756,7 @@
 			[code]2[/code] - "Other Screen Center", [member display/window/size/initial_screen] is used to set the screen.
 		</member>
 		<member name="display/window/size/initial_screen" type="int" setter="" getter="" default="0">
-			Main window initial screen, this settings is used only if [member display/window/size/initial_position_type] is set to "Other Screen Center" ([code]2[/code]).
+			Main window initial screen, this setting is used only if [member display/window/size/initial_position_type] is set to "Other Screen Center" ([code]2[/code]).
 		</member>
 		<member name="display/window/size/mode" type="int" setter="" getter="" default="0">
 			Main window mode. See [enum DisplayServer.WindowMode] for possible values and how each mode behaves.

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -570,8 +570,11 @@
 		</member>
 		<member name="extend_to_title" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] contents is expanded to the full size of the window, window title bar is transparent.
+			[b]Note:[/b] This property is implemented only on macOS.
+			[b]Note:[/b] This property only works with native windows.
 		</member>
 		<member name="initial_position" type="int" setter="set_initial_position" getter="get_initial_position" enum="Window.WindowInitialPosition" default="0">
+			Specifies the initial type of position for the [Window]. See [enum WindowInitialPosition] constants.
 		</member>
 		<member name="max_size" type="Vector2i" setter="set_max_size" getter="get_max_size" default="Vector2i(0, 0)">
 			If non-zero, the [Window] can't be resized to be bigger than this size.
@@ -584,10 +587,12 @@
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Window.Mode" default="0">
 			Set's the window's current mode.
 			[b]Note:[/b] Fullscreen mode is not exclusive full screen on Windows and Linux.
+			[b]Note:[/b] This method only works with native windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
 		</member>
 		<member name="mouse_passthrough" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], all mouse events will be passed to the underlying window of the same application. See also [member mouse_passthrough_polygon].
 			[b]Note:[/b] This property is implemented on Linux (X11), macOS and Windows.
+			[b]Note:[/b] This property only works with native windows.
 		</member>
 		<member name="mouse_passthrough_polygon" type="PackedVector2Array" setter="set_mouse_passthrough_polygon" getter="get_mouse_passthrough_polygon" default="PackedVector2Array()">
 			Sets a polygonal region of the window which accepts mouse events. Mouse events outside the region will be passed through.
@@ -620,10 +625,12 @@
 		</member>
 		<member name="popup_window" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] will be considered a popup. Popups are sub-windows that don't show as separate windows in system's window manager's window list and will send close request when anything is clicked outside of them (unless [member exclusive] is enabled).
+			[b]Note:[/b] This property only works with native windows.
 		</member>
 		<member name="position" type="Vector2i" setter="set_position" getter="get_position" default="Vector2i(0, 0)">
 			The window's position in pixels.
-			If [member ProjectSettings.display/window/subwindows/embed_subwindows] is [code]false[/code], the position is in absolute screen coordinates. This typically applies to editor plugins. If the setting is [code]false[/code], the window's position is in the coordinates of its parent [Viewport].
+			If [member ProjectSettings.display/window/subwindows/embed_subwindows] is [code]false[/code], the position is in absolute screen coordinates. This typically applies to editor plugins. If the setting is [code]true[/code], the window's position is in the coordinates of its parent [Viewport].
+			[b]Note:[/b] This property only works if [member initial_position] is set to [constant WINDOW_INITIAL_POSITION_ABSOLUTE].
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(100, 100)">
 			The window's size in pixels.
@@ -636,7 +643,7 @@
 			The name of a theme type variation used by this [Window] to look up its own theme items. See [member Control.theme_type_variation] for more details.
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
-			The window's title. If the [Window] is non-embedded, title styles set in [Theme] will have no effect.
+			The window's title. If the [Window] is native, title styles set in [Theme] will have no effect.
 		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
 			If [code]true[/code], the [Window] is transient, i.e. it's considered a child of another [Window]. The transient window will be destroyed with its transient parent and will return focus to their parent when closed. The transient window is displayed on top of a non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
@@ -644,8 +651,8 @@
 		</member>
 		<member name="transparent" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window]'s background can be transparent. This is best used with embedded windows.
-			[b]Note:[/b] For native windows, this flag has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] is set to [code]false[/code].
 			[b]Note:[/b] Transparency support is implemented on Linux, macOS and Windows, but availability might vary depending on GPU driver, display manager, and compositor capabilities.
+			[b]Note:[/b] This property has no effect if either [member ProjectSettings.display/window/per_pixel_transparency/allowed], or the window's [member Viewport.transparent_bg] is set to [code]false[/code].
 		</member>
 		<member name="unfocusable" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] can't be focused nor interacted with. It can still be visible.
@@ -683,7 +690,7 @@
 			<param index="0" name="files" type="PackedStringArray" />
 			<description>
 				Emitted when files are dragged from the OS file manager and dropped in the game window. The argument is a list of file paths.
-				Note that this method only works with non-embedded windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
+				Note that this method only works with native windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
 				Example usage:
 				[codeblock]
 				func _ready():
@@ -780,21 +787,24 @@
 			The window is floating on top of all other windows. This flag is ignored for full-screen windows. Set with [member always_on_top].
 		</constant>
 		<constant name="FLAG_TRANSPARENT" value="3" enum="Flags">
-			The window background can be transparent.
-			[b]Note:[/b] This flag has no effect if [member ProjectSettings.display/window/per_pixel_transparency/allowed] is set to [code]false[/code]. Set with [member transparent].
+			The window background can be transparent. Set with [member transparent].
+			[b]Note:[/b] This flag has no effect if either [member ProjectSettings.display/window/per_pixel_transparency/allowed], or the window's [member Viewport.transparent_bg] is set to [code]false[/code].
 		</constant>
 		<constant name="FLAG_NO_FOCUS" value="4" enum="Flags">
 			The window can't be focused. No-focus window will ignore all input, except mouse clicks. Set with [member unfocusable].
 		</constant>
 		<constant name="FLAG_POPUP" value="5" enum="Flags">
 			Window is part of menu or [OptionButton] dropdown. This flag can't be changed when the window is visible. An active popup window will exclusively receive all input, without stealing focus from its parent. Popup windows are automatically closed when uses click outside it, or when an application is switched. Popup window must have transient parent set (see [member transient]).
+			[b]Note:[/b] This flag has no effect in embedded windows (unless said window is a [Popup]).
 		</constant>
 		<constant name="FLAG_EXTEND_TO_TITLE" value="6" enum="Flags">
 			Window content is expanded to the full size of the window. Unlike borderless window, the frame is left intact and can be used to resize the window, title bar is transparent, but have minimize/maximize/close buttons. Set with [member extend_to_title].
-			[b]Note:[/b] This flag is implemented on macOS.
+			[b]Note:[/b] This flag is implemented only on macOS.
+			[b]Note:[/b] This flag has no effect in embedded windows.
 		</constant>
 		<constant name="FLAG_MOUSE_PASSTHROUGH" value="7" enum="Flags">
 			All mouse events are passed to the underlying window of the same application.
+			[b]Note:[/b] This flag has no effect in embedded windows.
 		</constant>
 		<constant name="FLAG_MAX" value="8" enum="Flags">
 			Max value of the [enum Flags].


### PR DESCRIPTION
This PR adds some extra info about some properties/flags, mainly which works only with native windows or not. It also adds a description to `initial_position`.