### PR TITLE
Fix error when attempting to move a embedded window with a negative title height

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2837,7 +2837,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 				title_bar.position.y -= title_height;
 				title_bar.size.y = title_height;
 
-				if (title_bar.has_point(mb->get_position())) {
+				if (title_bar.size.y > 0 && title_bar.has_point(mb->get_position())) {
 					click_on_window = true;
 
 					int close_h_ofs = sw.window->get_theme_constant(SNAME("close_h_offset"));


### PR DESCRIPTION
Having the `title_height` of a embedded `Window` to be negative is a good workaround for those who want the borders to be visible, but don't want it to be moved. However, doing so results in an error being outputted each time a move is attempted because of a check with said negative value. This PR makes that the check is ignored in that case.