### PR TITLE
Fix update animation frame duration in every selected tile

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -271,10 +271,10 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 				} else {
 					if (components[1] == "duration") {
 						tile_set_atlas_source->set_tile_animation_frame_duration(tile.tile, frame, p_value);
-						return true;
 					}
 				}
 			}
+			return true;
 		}
 	}
 


### PR DESCRIPTION
## The bug 1

When multiple tiles are selected in the TileSet editor, frame length changes are only applied to the first tile.

![image](https://github.com/godotengine/godot/assets/7024016/ded89f62-5611-4d2a-8731-8d222701e3dd)

How to reproduce:
1. Create a tileset;
2. Add an atlas texture containing the animation of a group of tiles;
3. Remove all tiles from this animation in the tileset, except for the first group of tiles;
4. Select the first group of tiles;
5. Set the number of animation columns and separation. This will successfully applied to the entire group of tiles;
6. Add some frames in the list below. They will also be successfully added for each tile from the group.
7. Change the duration of one of the frames. This will only applied to the first tile in the group, although it must be applied to every tile in the group.

This leads to the fact that to set the frame duration, you have to select each tile separately and specify the duration of the frame.

The reason for this bug is a misplaced `return` statement that I moved in the right place in this commit.

## The (not a bug but the problem) 2

If you select multiple tiles, only the properties of the first tile will be displayed. If you change any of the properties, it will not be applied for each tile if the new value is equal to what is already in the input field.

This leads to the fact that if there are tiles in a group with different values of this property, then in order to update it for all the tiles, you must first set some other value, and then return the previous one.

How to fix it in future:

Do not display any property value in the input field if multiple objects with different values for this property are selected. You can even display the placeholder in this field and highlight it in a different color to make it clear that there are different values for this property in the object group.

