### PR TITLE
Fix InputEvent being used twice

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1564,6 +1564,11 @@ bool Viewport::_gui_call_input(Control *p_control, const Ref<InputEvent> &p_inpu
 			}
 		}
 
+		if (is_input_handled()) {
+			// Break after Physics Picking in SubViewport.
+			break;
+		}
+
 		if (ci->is_set_as_top_level()) {
 			break;
 		}
@@ -3045,6 +3050,7 @@ void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local
 
 						)) {
 			physics_picking_events.push_back(ev);
+			set_input_as_handled();
 		}
 	}
 }

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -38,6 +38,7 @@
 namespace TestTextEdit {
 
 TEST_CASE("[SceneTree][TextEdit] text entry") {
+	SceneTree::get_singleton()->get_root()->set_physics_object_picking(false);
 	TextEdit *text_edit = memnew(TextEdit);
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 	text_edit->grab_focus();


### PR DESCRIPTION
In the following setting a single mouse click can cause multiple actions, which contradicts the paradigm that a single Input Event should cause only a single action.

- Control
  - SubViewportContainer
    - SubViewport (physics picking enabled)
      - Area2D (+CollisionShape2D)

MRP: [BugDoubleInputEventUsage.zip](https://github.com/godotengine/godot/files/11586082/BugDoubleInputEventUsage.zip)

When clicking in the Area2D within the SubViewport, the Input Event is used for physics picking within the SubViewport and afterwards used as a mouse-click in the root-Control. This leads to the situation, that both are executed:
- Control.gui_input
- Area2D.input_event

I would expect, that only Area2D.input_event gets executed, but not Control.gui_input.

This behavior is apparent in Godot 4 since #57894.

The solution consists of two parts:
1. Physics Picking as the last step during viewport input event handling, currently doesn't set the event as handled. This PR sets the event as handled in the case of physics picking.
2. After an InputEvent is processed by a SubVieportContainer, it is sent to its parent, even if it set as handled within the SubViewport. This PR adds an additional test to check if the event is handled before propagating the event to the parent Control.
