### PR TITLE
Fix center of mass when importing GLTF physics bodies

### DIFF
--- a/modules/gltf/extensions/physics/gltf_physics_body.cpp
+++ b/modules/gltf/extensions/physics/gltf_physics_body.cpp
@@ -112,6 +112,9 @@ Ref<GLTFPhysicsBody> GLTFPhysicsBody::from_node(const CollisionObject3D *p_body_
 		physics_body->linear_velocity = body->get_linear_velocity();
 		physics_body->angular_velocity = body->get_angular_velocity();
 		physics_body->inertia = body->get_inertia();
+		if (body->get_center_of_mass() != Vector3()) {
+			WARN_PRINT("GLTFPhysicsBody: This rigid body has a center of mass offset from the origin, which will be ignored when exporting to GLTF.");
+		}
 		if (cast_to<VehicleBody3D>(p_body_node)) {
 			physics_body->body_type = "vehicle";
 		} else {
@@ -140,6 +143,7 @@ CollisionObject3D *GLTFPhysicsBody::to_node() const {
 		body->set_linear_velocity(linear_velocity);
 		body->set_angular_velocity(angular_velocity);
 		body->set_inertia(inertia);
+		body->set_center_of_mass_mode(RigidBody3D::CENTER_OF_MASS_MODE_CUSTOM);
 		return body;
 	}
 	if (body_type == "rigid") {
@@ -148,6 +152,7 @@ CollisionObject3D *GLTFPhysicsBody::to_node() const {
 		body->set_linear_velocity(linear_velocity);
 		body->set_angular_velocity(angular_velocity);
 		body->set_inertia(inertia);
+		body->set_center_of_mass_mode(RigidBody3D::CENTER_OF_MASS_MODE_CUSTOM);
 		return body;
 	}
 	if (body_type == "static") {


### PR DESCRIPTION
See also this PR where I am making the behavior explicit in the spec https://github.com/omigroup/gltf-extensions/pull/167

The one thing I'm unsure of is with exporting, if we want to bake in a custom center of mass when exporting a GLTF from Godot, or not. I would tend towards keeping the node positions the same instead of moving them around, but it would also make sense to adjust the node positions. In this PR I only changed the import behavior, and made a warning on export, but if it's desired I can also change the export behavior to bake in the center of mass. In either case I'm not worried about it, since it's not common to need this when building a physics object in the editor.