### PR TITLE
Fix shader preprocessor cyclic include handling

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -700,7 +700,7 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 	if (!included.is_empty()) {
 		uint64_t code_hash = included.hash64();
 		if (state->cyclic_include_hashes.find(code_hash)) {
-			set_error(RTR("Cyclic include found."), line);
+			set_error(RTR("Cyclic include found") + ": " + path, line);
 			return;
 		}
 	}
@@ -733,7 +733,7 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 
 	FilePosition fp;
 	fp.file = state->current_filename;
-	fp.line = line;
+	fp.line = line + 1;
 	state->include_positions.push_back(fp);
 
 	String result;
@@ -1157,6 +1157,7 @@ void ShaderPreprocessor::set_error(const String &p_error, int p_line) {
 	if (state->error.is_empty()) {
 		state->error = p_error;
 		FilePosition fp;
+		fp.file = state->current_filename;
 		fp.line = p_line + 1;
 		state->include_positions.push_back(fp);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/75813

Normally, shader include dependencies are calculated starting from the root shader, but when editing a shader include directly in the editor the depencencies are not always fully known until a full compile is done. This PR adds a success check to preprocessing step and only updates dependencies if the preprocessing worked. Now a proper cyclic dependency error message is shown and the engine doesn't crash.

While investigating this I also made a few more minor fixes:

1) Use const references in range loop iterators to avoid excessive copying of Ref-objects.
2) Fix an off-by-one line numbering error highlight in some error cases.
3) Add the name of the file to the error message when reporting a cyclic include error.
4) Add forgotten file name when reporting certain errors to the editor.