### PR TITLE
[3.x] Add RIDReferences

### DIFF
--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -34,6 +34,7 @@
 #include "mesh_instance.h"
 #include "scene/scene_string_names.h"
 #include "servers/physics_server.h"
+#include "servers/rid_reference.h"
 
 void CollisionObject::_notification(int p_what) {
 	switch (p_what) {
@@ -587,5 +588,6 @@ CollisionObject::CollisionObject() {
 }
 
 CollisionObject::~CollisionObject() {
+	RIDReferences::notify_free_RID(RIDReferences::SERVER_PHYSICS, rid);
 	PhysicsServer::get_singleton()->free(rid);
 }

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -35,6 +35,7 @@
 #include "scene/3d/collision_object.h"
 #include "scene/resources/physics_material.h"
 #include "servers/physics_server.h"
+#include "servers/rid_reference.h"
 #include "skeleton.h"
 
 class PhysicsBody : public CollisionObject {
@@ -292,7 +293,7 @@ private:
 
 	Vector3 floor_normal;
 	Vector3 floor_velocity;
-	RID on_floor_body;
+	RIDRef<RIDReferences::SERVER_PHYSICS> on_floor_body;
 	bool on_floor;
 	bool on_ceiling;
 	bool on_wall;

--- a/servers/rid_reference.cpp
+++ b/servers/rid_reference.cpp
@@ -1,0 +1,73 @@
+/**************************************************************************/
+/*  rid_reference.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rid_reference.h"
+
+RIDReferences::Server RIDReferences::_servers[SERVER_COUNT];
+
+uint32_t RIDReferences::request_reference(ServerType p_server_type) {
+	uint32_t id = UINT32_MAX;
+	MutexLock(_servers[p_server_type]._mutex);
+	RIDReference *ref = _servers[p_server_type]._pool.request(id);
+	ref->rid = RID();
+	return id;
+}
+
+void RIDReferences::free_reference(ServerType p_server_type, uint32_t p_id) {
+	MutexLock(_servers[p_server_type]._mutex);
+	_servers[p_server_type]._pool.free(p_id);
+}
+
+void RIDReferences::set_reference(ServerType p_server_type, uint32_t p_id, RID p_rid) {
+	MutexLock(_servers[p_server_type]._mutex);
+	_servers[p_server_type]._pool[p_id].rid = p_rid;
+}
+
+RID RIDReferences::get_reference(ServerType p_server_type, uint32_t p_id) {
+	MutexLock(_servers[p_server_type]._mutex);
+	return _servers[p_server_type]._pool[p_id].rid;
+}
+
+// The important function, when deleting a RID, Null out any references to it,
+// so no dangling references will be used.
+// Note that this assumes single threaded use from client to server.
+// If another thread frees a RID BEFORE the first thread uses it, then a dangling
+// RID can still be used in the server.
+void RIDReferences::notify_free_RID(ServerType p_server_type, RID p_rid) {
+	ERR_FAIL_COND(p_rid == RID());
+	MutexLock(_servers[p_server_type]._mutex);
+	uint32_t active_size = _servers[p_server_type]._pool.active_size();
+	for (uint32_t n = 0; n < active_size; n++) {
+		RIDReference &ref = _servers[p_server_type]._pool.get_active(n);
+		if (ref.rid == p_rid) {
+			ref.rid = RID();
+		}
+	}
+}

--- a/servers/rid_reference.h
+++ b/servers/rid_reference.h
@@ -1,0 +1,100 @@
+/**************************************************************************/
+/*  rid_reference.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RID_REFERENCES_H
+#define RID_REFERENCES_H
+
+#include "core/os/mutex.h"
+#include "core/pooled_list.h"
+#include "core/rid.h"
+
+class RIDReferences {
+public:
+	enum ServerType {
+		SERVER_PHYSICS,
+		SERVER_COUNT,
+	};
+	template <RIDReferences::ServerType>
+	friend class RIDRef;
+
+private:
+	struct RIDReference {
+		RID rid;
+	};
+	struct Server {
+		TrackedPooledList<RIDReference> _pool;
+		Mutex _mutex;
+	};
+
+	static Server _servers[SERVER_COUNT];
+
+	static uint32_t request_reference(ServerType p_server_type);
+	static void free_reference(ServerType p_server_type, uint32_t p_id);
+	static void set_reference(ServerType p_server_type, uint32_t p_id, RID p_rid);
+	static RID get_reference(ServerType p_server_type, uint32_t p_id);
+
+public:
+	static void notify_free_RID(ServerType p_server_type, RID p_rid);
+};
+
+template <RIDReferences::ServerType TYPE>
+class RIDRef {
+	uint32_t id = UINT32_MAX;
+
+public:
+	bool is_valid() const { return id != UINT32_MAX; }
+	void set(RID p_rid) {
+		if (p_rid.is_valid()) {
+			if (!is_valid()) {
+				id = RIDReferences::request_reference(TYPE);
+			}
+			RIDReferences::set_reference(TYPE, id, p_rid);
+		} else {
+			if (is_valid()) {
+				RIDReferences::free_reference(TYPE, id);
+				id = UINT32_MAX;
+			}
+		}
+	}
+	RID get() const {
+		if (is_valid()) {
+			return RIDReferences::get_reference(TYPE, id);
+		}
+		return RID();
+	}
+	~RIDRef() {
+		if (is_valid()) {
+			RIDReferences::free_reference(TYPE, id);
+			id = UINT32_MAX;
+		}
+	}
+};
+
+#endif // RID_REFERENCES_H


### PR DESCRIPTION
Storing RIDs scene side can lead to dangling RIDs if a RID is freed elsewhere.

RIDReference allows scene side code to reference a RID indirectly, which will automatically be set to NULL when the object is freed, and thus help prevent dangling RIDs.

Fixes #74732

## Discussion
While #74732 may seem like an innocuous issue, it is the symptom of a major safety problem in the 3.x codebase, and so some care should be taken over the solution, rather than attempting a quick fix.

Keeping a `RID` longterm in the scene side code is a very dangerous pattern (outside of outright ownership). The reason is that `RID` (in regular, non RID handles builds) is a glorified pointer, and deleting the RID object from elsewhere can lead to a dangling RID, which, like a dangling pointer, can lead to crashes.

The physics was using this dangerous pattern to keep a RID to `on_floor_body`, used in the `move_and_slide()` function. Deletion of `on_floor_body` leads to a crash the next time `move_and_slide()` is called.

## How to solve
There are number of ways of addressing this problem, some of the main ones I considered:
1) Maintain an indirect (instead of direct) reference to the RID, and NULL any of these references as objects are freed, to prevent dangling references. (This is the approach in this PR)
2) Maintain a two way reference to the RID object, so that the object in the server knows which objects maintain a reference, so these can be cleared up on free. There are a number of problems with this approach as it crosses server boundaries.
An example is a pending delete in the message queue to the server that will be executed _before_ our call using the RID, but _after_ we make this call (because of the order in the queue).
3) Total safety - change to using the RID handles build as standard, and allow detection of dangling RIDs. This may worth doing at some point as it is probably the most thread safe, but it delays the response until server side, and ideally we would want to detect the dangling RID _before_ the server functions were called. We could query the RID database client side, but it is still possible the RID could be freed from another thread between the client and server function calls (as there is a message queue between them).
4) Store an `ObjectID` instead of a `RID` where persistent storage of an object is required. (This method appears _partly_ used in Godot 4 for `CharacterBody3D`, although master still stores a `RID` and looks like it will crash with similar circumstances to #74732.)

## This PR
This PR is quite a simple solution - it is a move towards a paradigm of disallowing client code from retaining direct references to RIDs (outside outright ownership) and instead holding `RIDRef`s, which are indirect, and can be NULLed as objects are deleted.

This works for the linked issue but there is a caveat - it assumes a single threaded pattern. If another thread were to jump in and free a RID _between_ the check for validity and the call to the server, then you could still theoretically get a dangling RID.

However, in 3.x at least, this client physics code I am hoping will be called from the same thread, so this race condition shouldn't happen.

This is something I'll need to double check with @reduz and confirm whether this is the best approach to this class of problem (at least in Godot 3.x).

Whatever approach we use here can probably be extended easily to cover the whole class of these bugs. For instance if we have a look at all the places RIDs are stored scene side, aside from ownership, we can convert these to use `RIDRef`s for extra safety. At the moment I've just added `SERVER_PHYSICS` but it's trivial to support the other servers by adding to the enum.

## Runtime performance
There is also a small cost, when deleting RIDs, it needs to run through the list of references to NULL out any dangling references. This is made more efficient by separating these lists _per server_ rather than having them all lumped together. If a physics RID is being deleted, there's no need to search through e.g. Render RID references.

The lists are fairly simple to start with, so there is the possibility of being slow in extreme situations like benchmarks with thousands of references and lots of object "churn". If necessary things can be optimized further (with e.g. hash table for looking up the RIDs on deletion), but it is usually better to use a simple solution to start with, unless profiling shows more complexity is needed. (Also I want to discuss whether this is the best way to go before proceeding further.)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
