### PR TITLE
Allow access to GDScriptNativeClass

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -159,6 +159,8 @@ void register_core_types() {
 
 	GDREGISTER_VIRTUAL_CLASS(ScriptExtension);
 	GDREGISTER_VIRTUAL_CLASS(ScriptLanguageExtension);
+	
+	GDREGISTER_CLASS(GDScriptNativeClass); //allow the tiny dev to make their security objects
 
 	GDREGISTER_CLASS(RefCounted);
 	GDREGISTER_CLASS(WeakRef);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

This is solely to allow modification/restriction of classes such as FileAccess and OS

#77611 
