### PR TITLE
Increase vertical size of `CurveEdit` when `Inspector` widens

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -105,7 +105,7 @@ void CurveEdit::set_snap_count(int p_snap_count) {
 }
 
 Size2 CurveEdit::get_minimum_size() const {
-	return Vector2(64, 135) * EDSCALE;
+	return Vector2(64, MAX(135, get_size().x * ASPECT_RATIO)) * EDSCALE;
 }
 
 void CurveEdit::_notification(int p_what) {
@@ -986,6 +986,9 @@ void CurveEditor::_notification(int p_what) {
 				snap_count_edit->set_value(curve->get_meta("_snap_count", DEFAULT_SNAP));
 			}
 		} break;
+		case NOTIFICATION_RESIZED:
+			curve_editor_rect->update_minimum_size();
+			break;
 	}
 }
 

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -104,6 +104,8 @@ private:
 	void _redraw();
 
 private:
+	const float ASPECT_RATIO = 6.f / 13.f;
+
 	Transform2D _world_to_view;
 
 	Ref<Curve> curve;


### PR DESCRIPTION
This should allow users to edit points in a less constrained space, which feels like a UX improvement.

![image](https://github.com/godotengine/godot/assets/1133892/450e0aec-a11a-47fb-a0c7-612e850c365e)


That said, per @YuriSizov, changing minimum size according to current size might be a hack that causes issues in certain situations, so there's a good chance this shouldn't be accepted :)

Also: known issue that if you open the curve editor then maximize the entire editor window, this does not appear to take effect until you actually resize the inspector tab. Possibly a symptom of the above issue?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
