### PR TITLE
Allow `ENetConnection` to send a packet to an arbitrary destination

### DIFF
--- a/modules/enet/doc_classes/ENetConnection.xml
+++ b/modules/enet/doc_classes/ENetConnection.xml
@@ -145,6 +145,17 @@
 				Call this function regularly to handle connections, disconnections, and to receive new packets.
 			</description>
 		</method>
+		<method name="socket_send">
+			<return type="void" />
+			<param index="0" name="destination_address" type="String" />
+			<param index="1" name="destination_port" type="int" />
+			<param index="2" name="packet" type="PackedByteArray" />
+			<description>
+				Sends a [param packet] toward a destination from the address and port currently bound by this ENetConnection instance. 
+				This is useful as it serves to establish entries in NAT routing tables on all devices between this bound instance and the public facing internet, allowing a prospective client's connection packets to be routed backward through the NAT device(s) between the public internet and this host.
+				This requires forward knowledge of a prospective client's address and communication port as seen by the public internet - after any NAT devices have handled their connection request. This information can be obtained by a [url=https://en.wikipedia.org/wiki/STUN]STUN[/url] service, and must be handed off to your host by an entity that is not the prospective client. This will never work for a client behind a Symmetric NAT due to the nature of the Symmetric NAT routing algorithm, as their IP and Port cannot be known beforehand.
+			</description>
+		</method>
 	</methods>
 	<constants>
 		<constant name="COMPRESS_NONE" value="0" enum="CompressionMode">

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -342,6 +342,39 @@ void ENetConnection::_broadcast(int p_channel, PackedByteArray p_packet, int p_f
 	broadcast(p_channel, pkt);
 }
 
+void ENetConnection::socket_send(const String &p_address, int p_port, const PackedByteArray &p_packet) {
+	ERR_FAIL_COND_MSG(!host, "The ENetConnection instance isn't currently active.");
+	ERR_FAIL_COND_MSG(!(host->socket), "The ENetConnection instance isn't currently bound");
+	ERR_FAIL_COND_MSG(p_port < 1 || p_port > 65535, "The remote port number must be between 1 and 65535 (inclusive).");
+
+	IPAddress ip;
+	if (p_address.is_valid_ip_address()) {
+		ip = p_address;
+	} else {
+#ifdef GODOT_ENET
+		ip = IP::get_singleton()->resolve_hostname(p_address);
+#else
+		ip = IP::get_singleton()->resolve_hostname(p_address, IP::TYPE_IPV4);
+#endif
+		ERR_FAIL_COND_MSG(!ip.is_valid(), "Couldn't resolve the server IP address or domain name.");
+	}
+
+	ENetAddress address;
+#ifdef GODOT_ENET
+	enet_address_set_ip(&address, ip.get_ipv6(), 16);
+#else
+	ERR_FAIL_COND_MSG(!ip.is_ipv4(), "Connecting to an IPv6 server isn't supported when using vanilla ENet. Recompile Godot with the bundled ENet library.");
+	address.host = *(uint32_t *)ip.get_ipv4();
+#endif
+	address.port = p_port;
+
+	ENetBuffer enet_buffers[1];
+	enet_buffers[0].data = (void *)p_packet.ptr();
+	enet_buffers[0].dataLength = p_packet.size();
+
+	enet_socket_send(host->socket, &address, enet_buffers, 1);
+}
+
 void ENetConnection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_host_bound", "bind_address", "bind_port", "max_peers", "max_channels", "in_bandwidth", "out_bandwidth"), &ENetConnection::create_host_bound, DEFVAL(32), DEFVAL(0), DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("create_host", "max_peers", "max_channels", "in_bandwidth", "out_bandwidth"), &ENetConnection::create_host, DEFVAL(32), DEFVAL(0), DEFVAL(0), DEFVAL(0));
@@ -360,6 +393,7 @@ void ENetConnection::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_channels"), &ENetConnection::get_max_channels);
 	ClassDB::bind_method(D_METHOD("get_local_port"), &ENetConnection::get_local_port);
 	ClassDB::bind_method(D_METHOD("get_peers"), &ENetConnection::_get_peers);
+	ClassDB::bind_method(D_METHOD("socket_send", "destination_address", "destination_port", "packet"), &ENetConnection::socket_send);
 
 	BIND_ENUM_CONSTANT(COMPRESS_NONE);
 	BIND_ENUM_CONSTANT(COMPRESS_RANGE_CODER);

--- a/modules/enet/enet_connection.h
+++ b/modules/enet/enet_connection.h
@@ -109,6 +109,7 @@ private:
 
 public:
 	void broadcast(enet_uint8 p_channel, ENetPacket *p_packet);
+	void socket_send(const String &p_address, int p_port, const PackedByteArray &p_packet);
 	Error create_host_bound(const IPAddress &p_bind_address = IPAddress("*"), int p_port = 0, int p_max_peers = 32, int p_max_channels = 0, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 	Error create_host(int p_max_peers = 32, int p_max_channels = 0, int p_in_bandwidth = 0, int p_out_bandwidth = 0);
 	void destroy();


### PR DESCRIPTION
## Problem
Godot's ENet implementation currently requires server hosts to be publicly addressable on the internet, and also requires all ports be forwarded if the host is behind a NAT. Godot implements some UPnP features, but many computers are behind multiple NAT devices - especially those with ISPs in rural areas that do not have enough IPv4 addresses to serve their customers.

This means that some users cannot possibly have an "Open" NAT resolution, meaning they can never host a game under the current ENet solution. We want users to be able to host while they are either behind an "Open" or "Limited" NAT firewall.

In order for two computers behind NATs to communicate with each other, they must both send a packet toward each other at the same time. _The tolerance here is pretty high, around 5 minutes on average_. However, it's not enough for Machine A to send a packet to Machine B - the packet must be sent from an anchored port. If Machine A sends a packet to Machine B from port 19020, Machine B will receive return information and be able to communicate with Machine A on the received port - but will always map back to port 19020 on Machine A.

If Machine A is hosting an ENetMultilplayerPeer server on port 19020, then in order to enable a reciprocal P2P connection between A and prospective Client B, then A **must** send a packet toward client B from port 19020.

## Solution
Implement a simple method that takes in a target destination and port and sends a dummy packet to that address. The content of the packet is completely arbitrary and not meant to be consumed by anything. Its purpose is only to establish NAT routing table entries on the way out toward the client, so that messages from the client can be received by the running host instance. Once the NAT routing table entries are set, any future client connection requests from B, within the tolerance window, will be able to reach A as if it were a stock-standard request/response a la any other service on the internet. 

## Limitations
This doesn't solve the issue by itself, and will never be able to. It still requires the assistance of a third party service to handle identification of public-facing IP and communication ports, as well as a service to hand off this information to the host so that it can prepare the NAT. The first part is solved by free and public STUN servers. The second part requires developers to create or use a shared service that can store and retrieve these pieces of data.

The second limitation is that a client behind a Symmetric NAT cannot have its IP:port information known before a request to a host is made, by design. A client behind a Symmetric NAT cannot ever connect to a host behind a "Limited" NAT. And a server hosted behind a Symmetric NAT cannot ever have any clients connect to it.

## Definitions
**"Open" NAT** - A machine with an "Open" NAT is publicly addressable on the internet. They have a clear path, ports are forwarded and/or the host is DMZd. A reciprocal connection isn't required.

**"Limited" NAT** - A machine with a "Limited" NAT is not publicly addressable, but is behind a NAT that has a funnel-type NAT allocation strategy, meaning its communication ip and ports are stable when reaching out to different services. Some NAT devices in this category still require that the machine has sent a request to a particular destination before accepting packets from that as a source. So although A -> B and A -> C have the same address and port, if A has not sent a request to C, then it cannot receive a packet from C.

**"Closed" NAT / Symmetric NAT** - A machine with a "Closed" or Symmetric NAT is like attempting to mark a sand dune. Every time a request is made to a new destination the request comes from a different IP:port combination. Cell phone internet is a pretty common example of a Symmetric NAT.