### PR TITLE
Fix non-functional Node3D `top_level` property

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -110,7 +110,7 @@ void Node3D::_propagate_transform_changed(Node3D *p_origin) {
 	}
 
 	for (Node3D *&E : data.children) {
-		if (E->data.top_level_active) {
+		if (E->data.top_level) {
 			continue; //don't propagate to a top_level
 		}
 		E->_propagate_transform_changed(p_origin);
@@ -153,7 +153,7 @@ void Node3D::_notification(int p_what) {
 					data.local_transform = data.parent->get_global_transform() * get_transform();
 					_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // As local transform was updated, rot/scale should be dirty.
 				}
-				data.top_level_active = true;
+				data.top_level = true;
 			}
 
 			_set_dirty_bits(DIRTY_GLOBAL_TRANSFORM); // Global is always dirty upon entering a scene.
@@ -173,7 +173,7 @@ void Node3D::_notification(int p_what) {
 			}
 			data.parent = nullptr;
 			data.C = nullptr;
-			data.top_level_active = false;
+			data.top_level = false;
 			_update_visibility_parent(true);
 		} break;
 
@@ -305,7 +305,7 @@ Quaternion Node3D::get_quaternion() const {
 
 void Node3D::set_global_transform(const Transform3D &p_transform) {
 	ERR_THREAD_GUARD;
-	Transform3D xform = (data.parent && !data.top_level_active)
+	Transform3D xform = (data.parent && !data.top_level)
 			? data.parent->get_global_transform().affine_inverse() * p_transform
 			: p_transform;
 
@@ -337,7 +337,7 @@ Transform3D Node3D::get_global_transform() const {
 		}
 
 		Transform3D new_global;
-		if (data.parent && !data.top_level_active) {
+		if (data.parent && !data.top_level) {
 			new_global = data.parent->get_global_transform() * data.local_transform;
 		} else {
 			new_global = data.local_transform;
@@ -727,12 +727,8 @@ void Node3D::set_as_top_level(bool p_enabled) {
 		} else if (data.parent) {
 			set_transform(data.parent->get_global_transform().affine_inverse() * get_global_transform());
 		}
-
-		data.top_level = p_enabled;
-		data.top_level_active = p_enabled;
-	} else {
-		data.top_level = p_enabled;
 	}
+	data.top_level = p_enabled;
 }
 
 bool Node3D::is_set_as_top_level() const {

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -101,7 +101,6 @@ private:
 
 		Viewport *viewport = nullptr;
 
-		bool top_level_active = false;
 		bool top_level = false;
 		bool inside_world = false;
 


### PR DESCRIPTION
Fix non functional Node3D `top_level` property

Fixes #50813.

maybe there have been some remaining properties from past code (speaking of `top_level_active` ) since it was still used at 3 places where actually `top_level` should already have been used.

This should fix the issue where top_level wouldn't lead to expected results in the editor.

I've done a full text search on  `top_level_active` and checked whether it was still in use somewhere else, but as it seems it might really just have been some left code from a past refactoring.