### PR TITLE
Fix `turbulence_noise_scale` for Particle Turbulence

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1356,7 +1356,11 @@ float ParticleProcessMaterial::get_turbulence_noise_strength() const {
 
 void ParticleProcessMaterial::set_turbulence_noise_scale(float p_turbulence_noise_scale) {
 	turbulence_noise_scale = p_turbulence_noise_scale;
-	float shader_turbulence_noise_scale = (pow(p_turbulence_noise_scale, 0.25) * 5.6234 / 10.0) * 4.0 - 3.0;
+	const float noise_frequency_when_slider_is_zero = 4.0;
+	const float max_slider_value = 10.0;
+	const float curve_exponent = 0.25;
+	const float curve_rescale = noise_frequency_when_slider_is_zero / pow(max_slider_value, curve_exponent);
+	float shader_turbulence_noise_scale = pow(p_turbulence_noise_scale, curve_exponent) * curve_rescale - noise_frequency_when_slider_is_zero;
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->turbulence_noise_scale, shader_turbulence_noise_scale);
 }
 


### PR DESCRIPTION
Fixes #77491 / my own oversight from #64606/#77154: `turbulence_noise_scale` needs to have 1 subtracted from it for parity with 4.0.

Curl evaluation in 4.0 [here](https://github.com/godotengine/godot/pull/77154/files#diff-cd7d117372baf45c8f1f294bc3107bd098d1436cdb22f3a89c2f8bd1dbeaac84L362-L364) is
`curl_3d(noise_pos + noise_time - diff, ...)`

`= (pos * turbulence_noise_scale - emission_pos) + noise_time - (pos - emission_pos)`
`= pos * turbulence_noise_scale - emission_pos + noise_time - pos + emission_pos`
`= pos * turbulence_noise_scale + noise_time - pos`
`= pos * (turbulence_noise_scale - 1) + noise_time`

The position is being effectively multipled by `turbulence_noise_scale - 1`, but in [4.1](https://github.com/godotengine/godot/pull/77154/files#diff-cd7d117372baf45c8f1f294bc3107bd098d1436cdb22f3a89c2f8bd1dbeaac84R386-R387) it's only multiplied by `turbulence_noise_scale`.

The 4.0 formula in `set_turbulence_noise_scale` is `(pow(p_turbulence_noise_scale, 0.25) * 5.6234 / 10.0) * 4.0 - 3.0`. This PR changes it to `(pow(p_turbulence_noise_scale, 0.25) * 5.6234 / 10.0) * 4.0 - 4.0` to compensate, then simplifies the successive multiplications and divisions to `(pow(p_turbulence_noise_scale, 0.25) * 2.24936) - 4.0`.

Curve: https://www.desmos.com/calculator/xyzbgqaggw (correctly matches slider range of 0 to 10 again)

![image](https://github.com/godotengine/godot/assets/8829856/b98317e9-b0e6-4abc-aa29-d21cc6039f9a)
![image](https://github.com/godotengine/godot/assets/8829856/8a3dbe76-b9ef-4947-8649-e74fb54d73e7)
![image](https://github.com/godotengine/godot/assets/8829856/0fdc12f0-2cc2-443a-b499-06f40b8ba7be)
