### PR TITLE
Properly free core types in reverse order

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -365,21 +365,28 @@ void unregister_core_extensions() {
 void unregister_core_types() {
 	OS::get_singleton()->benchmark_begin_measure("unregister_core_types");
 
+	// Destroy singletons in reverse order to ensure dependencies are not broken.
+
+	memdelete(worker_thread_pool);
+
+	memdelete(_engine_debugger);
+	memdelete(_marshalls);
+	memdelete(_classdb);
+	memdelete(_engine);
+	memdelete(_os);
+	memdelete(_resource_saver);
+	memdelete(_resource_loader);
+
+	memdelete(_geometry_3d);
+	memdelete(_geometry_2d);
+
 	memdelete(gdextension_manager);
 
 	memdelete(resource_uid);
-	memdelete(_resource_loader);
-	memdelete(_resource_saver);
-	memdelete(_os);
-	memdelete(_engine);
-	memdelete(_classdb);
-	memdelete(_marshalls);
-	memdelete(_engine_debugger);
 
-	memdelete(_geometry_2d);
-	memdelete(_geometry_3d);
-
-	memdelete(worker_thread_pool);
+	if (ip) {
+		memdelete(ip);
+	}
 
 	ResourceLoader::remove_resource_format_loader(resource_format_image);
 	resource_format_image.unref();
@@ -409,10 +416,6 @@ void unregister_core_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_json);
 	resource_loader_json.unref();
-
-	if (ip) {
-		memdelete(ip);
-	}
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_gdextension);
 	resource_loader_gdextension.unref();


### PR DESCRIPTION
This fixes #62152.

Previously the order core type singletons are freed felt rather random with most of them being freed in the same order they were originally created. Since by default there's no direct cross-dependency between them, this didn't cause issues.

However, as far as I can tell, this was not the case as soon as a custom singleton was registered by a GDExtension.
This would result in a dependency to both Engine as well as the GDExtension Manager (via binding callbacks).
When the engine tried to unregister the core types, the GDExtension Manager was freed first (before Engine and together with the extension library).
Once the `Engine` object was freed, it once again referenced GDExtension code that's already been unloaded by the GDExtension Manager (upon its own destruction), causing the problem described in #62152.

So far I was only able to reproduce the issue and test this fix on Windows (MSVC 2022). My understanding of the core engine architecture is rather limited, so let me know in case there's any side effect of this change or if I'm missing anything here.