### PR TITLE
Fix suspicious code related to text rendering

### DIFF
--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -858,7 +858,7 @@ bool DynamicFontImportSettings::_char_update(int32_t p_char) {
 	if (import_variation_data->selected_chars.has(p_char)) {
 		import_variation_data->selected_chars.erase(p_char);
 		return false;
-	} else if (font_main.is_valid() && font_main.is_valid() && import_variation_data->selected_glyphs.has(font_main->get_glyph_index(16, p_char))) {
+	} else if (font_main.is_valid() && import_variation_data->selected_glyphs.has(font_main->get_glyph_index(16, p_char))) {
 		import_variation_data->selected_glyphs.erase(font_main->get_glyph_index(16, p_char));
 		return false;
 	} else {
@@ -1083,7 +1083,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 	font_preview_label->set_text(sample);
 
 	Ref<Font> bold_font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
-	if (bold_font.is_valid() && bold_font.is_valid()) {
+	if (bold_font.is_valid()) {
 		font_name_label->add_theme_font_override("bold_font", bold_font);
 	}
 	font_name_label->set_text(font_name);

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -525,11 +525,7 @@ Size2 TextParagraph::get_non_wrapped_size() const {
 	_THREAD_SAFE_METHOD_
 
 	const_cast<TextParagraph *>(this)->_shape_lines();
-	if (TS->shaped_text_get_orientation(rid) == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(TS->shaped_text_get_size(rid).x, TS->shaped_text_get_size(rid).y);
-	} else {
-		return Size2(TS->shaped_text_get_size(rid).x, TS->shaped_text_get_size(rid).y);
-	}
+	return TS->shaped_text_get_size(rid);
 }
 
 Size2 TextParagraph::get_size() const {
@@ -675,11 +671,7 @@ Size2 TextParagraph::get_line_size(int p_line) const {
 
 	const_cast<TextParagraph *>(this)->_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Size2());
-	if (TS->shaped_text_get_orientation(lines_rid[p_line]) == TextServer::ORIENTATION_HORIZONTAL) {
-		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y);
-	} else {
-		return Size2(TS->shaped_text_get_size(lines_rid[p_line]).x, TS->shaped_text_get_size(lines_rid[p_line]).y);
-	}
+	return TS->shaped_text_get_size(lines_rid[p_line]);
 }
 
 Vector2i TextParagraph::get_line_range(int p_line) const {


### PR DESCRIPTION
Fixes sub-issues 5, 6 and 9 in https://github.com/godotengine/godot/issues/74344

The changes in `dynamic_font_import_settings.cpp` are trivial, but code in `text_paragraph.cpp` is more interesting. As far as I can see, the changes in this PR will keep the old behavior with less code and mutex locking. However, the question is: was the code correct in the original commit?

This PR change in `get_line_size()` seems to now match the other getters below it pretty well, they are basically just forwarding the calls. `get_non_wrapped_size()` is a bit trickier. it will now match other getters as well, but there is `get_size()` right below it which does have special logic for checking the text orientation.

Cautious ping at @bruvzg, who seems to be the expert in this area.