### PR TITLE
Clarify doc for Color.hex

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -203,8 +203,8 @@
 			<return type="Color" />
 			<param index="0" name="hex" type="int" />
 			<description>
-				Returns the [Color] associated with the provided [param hex] integer in 32-bit RGBA format (8 bits per channel, alpha channel first).
-				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix).
+				Returns the [Color] associated with the provided [param hex] integer in 32-bit RGBA format (8 bits per channel).
+				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix, making it [code]"0xRRGGBBAA"[/code]).
 				[codeblocks]
 				[gdscript]
 				var red = Color.hex(0xff0000ff)
@@ -223,8 +223,8 @@
 			<return type="Color" />
 			<param index="0" name="hex" type="int" />
 			<description>
-				Returns the [Color] associated with the provided [param hex] integer in 64-bit RGBA format (16 bits per channel, alpha channel first).
-				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix).
+				Returns the [Color] associated with the provided [param hex] integer in 64-bit RGBA format (16 bits per channel).
+				In GDScript and C#, the [int] is best visualized with hexadecimal notation ([code]"0x"[/code] prefix, making it [code]"0xRRRRGGGGBBBBAAAA"[/code]).
 			</description>
 		</method>
 		<method name="html" qualifiers="static">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -556,7 +556,7 @@ namespace Godot
         /// Constructs a <see cref="Color"/> from an unsigned 32-bit integer in RGBA format
         /// (each byte represents a color channel).
         /// </summary>
-        /// <param name="rgba">The <see langword="uint"/> representing the color.</param>
+        /// <param name="rgba">The <see langword="uint"/> representing the color as 0xRRGGBBAA.</param>
         public Color(uint rgba)
         {
             A = (rgba & 0xFF) / 255.0f;
@@ -572,7 +572,7 @@ namespace Godot
         /// Constructs a <see cref="Color"/> from an unsigned 64-bit integer in RGBA format
         /// (each word represents a color channel).
         /// </summary>
-        /// <param name="rgba">The <see langword="ulong"/> representing the color.</param>
+        /// <param name="rgba">The <see langword="ulong"/> representing the color as 0xRRRRGGGGBBBBAAAA.</param>
         public Color(ulong rgba)
         {
             A = (rgba & 0xFFFF) / 65535.0f;


### PR DESCRIPTION
The "alpha channel first" seems misleading to me. It doesn't match with the examples, so remove it. Add a more detailed specification of the expected number format in hex.