### PR TITLE
Fix crash when selecting lines in text edit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7161,7 +7161,9 @@ void TextEdit::_update_selection_mode_line() {
 	if (line < carets[caret_idx].selection.selecting_line) {
 		// Caret is above us.
 		set_caret_line(line - 1, false, true, 0, caret_idx);
-		carets.write[caret_idx].selection.selecting_column = text[get_selection_line(caret_idx)].length();
+		carets.write[caret_idx].selection.selecting_column = has_selection(caret_idx)
+				? text[get_selection_line(caret_idx)].length()
+				: 0;
 	} else {
 		// Caret is below us.
 		set_caret_line(line + 1, false, true, 0, caret_idx);


### PR DESCRIPTION
Fixes #77635

If a caret has no selection, get_selection_line returns -1, which is obviously out of bounds and leads to a crash.

I briefly experimented with different fallback values but it doesn't seem to make difference so I just picked 0. (Tho I did find that just replacing get_selection_line with get_caret_line leads to wonky selections, it fixes the crash tho)