### PR TITLE
[3.x] Add Android editor setting to control the window used to run the project

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -579,6 +579,10 @@
 		<member name="run/output/font_size" type="int" setter="" getter="">
 			The size of the font in the [b]Output[/b] panel at the bottom of the editor. This setting does not impact the font size of the script editor (see [member interface/editor/code_font_size]).
 		</member>
+		<member name="run/window_placement/android_window" type="int" setter="" getter="">
+			The Android window to display the project on when starting the project from the editor.
+			[b]Note:[/b] Only available in the Android editor.
+		</member>
 		<member name="run/window_placement/rect" type="int" setter="" getter="">
 			The window mode to use to display the project when starting the project from the editor.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -640,6 +640,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Run */
 
 	// Window placement
+#ifndef ANDROID_ENABLED
 	_initial_set("run/window_placement/rect", 1);
 	hints["run/window_placement/rect"] = PropertyInfo(Variant::INT, "run/window_placement/rect", PROPERTY_HINT_ENUM, "Top Left,Centered,Custom Position,Force Maximized,Force Fullscreen");
 	String screen_hints = "Same as Editor,Previous Monitor,Next Monitor";
@@ -649,6 +650,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("run/window_placement/rect_custom_position", Vector2());
 	_initial_set("run/window_placement/screen", 0);
 	hints["run/window_placement/screen"] = PropertyInfo(Variant::INT, "run/window_placement/screen", PROPERTY_HINT_ENUM, screen_hints);
+#endif
+	// Should match the ANDROID_WINDOW_* constants in 'platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt'
+	String android_window_hints = "Auto (based on screen size),Same as Editor,Side-by-side with Editor";
+	_initial_set("run/window_placement/android_window", 0);
+	hints["run/window_placement/android_window"] = PropertyInfo(Variant::INT, "run/window_placement/android_window", PROPERTY_HINT_ENUM, android_window_hints);
 
 	// Auto save
 	_initial_set("run/auto_save/save_before_running", true);

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -76,6 +76,16 @@ open class GodotEditor : FullScreenGodotApp() {
 		private const val PROJECT_MANAGER_ARG = "--project-manager"
 		private const val PROJECT_MANAGER_ARG_SHORT = "-p"
 		private const val PROJECT_MANAGER_PROCESS_NAME_SUFFIX = ":GodotProjectManager"
+
+		/**
+		 * Sets of constants to specify the window to use to run the project.
+		 *
+		 * Should match the values in 'editor/editor_settings.cpp' for the
+		 * 'run/window_placement/android_window' setting.
+		 */
+		private const val ANDROID_WINDOW_AUTO = 0
+		private const val ANDROID_WINDOW_SAME_AS_EDITOR = 1
+		private const val ANDROID_WINDOW_SIDE_BY_SIDE_WITH_EDITOR = 2
 	}
 
 	private val commandLineParams = ArrayList<String>()
@@ -142,8 +152,7 @@ open class GodotEditor : FullScreenGodotApp() {
 
 		// Whether we should launch the new godot instance in an adjacent window
 		// https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_LAUNCH_ADJACENT
-		var launchAdjacent =
-			Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && (isInMultiWindowMode || isLargeScreen)
+		var launchAdjacent = shouldGameLaunchAdjacent()
 
 		for (arg in args) {
 			if (EDITOR_ARG == arg || EDITOR_ARG_SHORT == arg) {
@@ -245,6 +254,26 @@ open class GodotEditor : FullScreenGodotApp() {
 	 */
 	protected open fun enablePanAndScaleGestures() =
 		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/enable_pan_and_scale_gestures"))
+
+	private fun shouldGameLaunchAdjacent(): Boolean {
+		return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			try {
+				when (Integer.parseInt(GodotLib.getEditorSetting("run/window_placement/android_window"))) {
+					ANDROID_WINDOW_SAME_AS_EDITOR -> false
+					ANDROID_WINDOW_SIDE_BY_SIDE_WITH_EDITOR -> true
+					else -> {
+						// ANDROID_WINDOW_AUTO
+						isInMultiWindowMode || isLargeScreen
+					}
+				}
+			} catch (e: NumberFormatException) {
+				// Fall-back to the 'Auto' behavior
+				isInMultiWindowMode || isLargeScreen
+			}
+		} else {
+			false
+		}
+	}
 
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
 		super.onActivityResult(requestCode, resultCode, data)


### PR DESCRIPTION
The follow options were added to the (new) `run/window_placement/android_window` editor setting:

- `Auto`: choose how to run the project based on the device screen size
- `Same as Editor`: run the project in the same window as the editor
- `Side-by-side with Editor`: run the project in an adjacent window to the editor

Fixes https://github.com/godotengine/godot/issues/72885

[main version](https://github.com/godotengine/godot/pull/77676)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
