### PR TITLE
Split rendering of shadowmaps into a static and dynamic pass

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -61,6 +61,9 @@
 			The material override for the whole geometry.
 			If a material is assigned to this property, it will be used instead of any material set in any material slot of the mesh.
 		</member>
+		<member name="render_shadow" type="int" setter="set_shadow_render_setting" getter="get_shadow_render_setting" enum="GeometryInstance3D.ShadowRenderSetting" default="0">
+			Sets the render mode for shadow maps.
+		</member>
 		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency" default="0.0">
 			The transparency applied to the whole geometry (as a multiplier of the materials' existing transparency). [code]0.0[/code] is fully opaque, while [code]1.0[/code] is fully transparent. Values greater than [code]0.0[/code] (exclusive) will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [member transparency] to a value greater than [code]0.0[/code] (exclusive) will [i]not[/i] disable shadow rendering.
 			In spatial shaders, [code]1.0 - transparency[/code] is set as the default value of the [code]ALPHA[/code] built-in.
@@ -99,6 +102,16 @@
 		<constant name="SHADOW_CASTING_SETTING_SHADOWS_ONLY" value="3" enum="ShadowCastingSetting">
 			Will only show the shadows casted from this object.
 			In other words, the actual mesh will not be visible, only the shadows casted from the mesh will be.
+		</constant>
+		<constant name="SHADOW_RENDER_AUTO" value="0" enum="ShadowRenderSetting">
+			Let Godot determine whether this instance is dynamic. Objects are determined to be dynamic when altered after being rendered to a static shadow map.
+		</constant>
+		<constant name="SHADOW_RENDER_STATIC_MAP" value="1" enum="ShadowRenderSetting">
+			This instance is rendered to static shadow maps. This speeds up shadow map rendering for objects that do not move.
+			Note: if the objects position or orientation changes, its shadow will not be updated.
+		</constant>
+		<constant name="SHADOW_RENDER_DYNAMIC_MAP" value="2" enum="ShadowRenderSetting">
+			This instance is rendered to dynamic shadow maps. You must select this if the object changes position or orientation.
 		</constant>
 		<constant name="GI_MODE_DISABLED" value="0" enum="GIMode">
 			Disabled global illumination mode. Use for dynamic objects that do not contribute to global illumination (such as characters). When using [VoxelGI] and SDFGI, the geometry will [i]receive[/i] indirect lighting and reflections but the geometry will not be considered in GI baking. When using [LightmapGI], the object will receive indirect lighting using lightmap probes instead of using the baked lightmap texture.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2456,6 +2456,8 @@
 		<member name="rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/lights_and_shadows/positional_shadow/split_static_and_dynamic_shadows" type="bool" setter="" getter="" default="false">
+		</member>
 		<member name="rendering/lights_and_shadows/use_physical_light_units" type="bool" setter="" getter="" default="false">
 			Enables the use of physically based units for light sources. Physically based units tend to be much larger than the arbitrary units used by Godot, but they can be used to match lighting within Godot to real-world lighting. Due to the large dynamic range of lighting conditions present in nature, Godot bakes exposure into the various lighting quantities before rendering. Most light sources bake exposure automatically at run time based on the active [CameraAttributes] resource, but [LightmapGI] and [VoxelGI] require a [CameraAttributes] resource to be set at bake time to reduce the dynamic range. At run time, Godot will automatically reconcile the baked exposure with the active exposure to ensure lighting remains consistent.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1679,6 +1679,14 @@
 				Sets the per-instance shader uniform on the specified 3D geometry instance. Equivalent to [method GeometryInstance3D.set_instance_shader_parameter].
 			</description>
 		</method>
+		<method name="instance_geometry_set_shadow_mode">
+			<return type="void" />
+			<param index="0" name="instance" type="RID" />
+			<param index="1" name="shadow_mode" type="int" enum="RenderingServer.ShadowDynamicMode" />
+			<description>
+				Sets the shadow mode on the specified 3D geometry instance.
+			</description>
+		</method>
 		<method name="instance_geometry_set_transparency">
 			<return type="void" />
 			<param index="0" name="instance" type="RID" />
@@ -5020,6 +5028,15 @@
 		</constant>
 		<constant name="SHADOW_CASTING_SETTING_SHADOWS_ONLY" value="3" enum="ShadowCastingSetting">
 			Only render the shadows from the object. The object itself will not be drawn.
+		</constant>
+		<constant name="SHADOW_MODE_AUTO" value="0" enum="ShadowDynamicMode">
+			Shadow mode is automatically determined by changes to an instance.
+		</constant>
+		<constant name="SHADOW_MODE_STATIC" value="1" enum="ShadowDynamicMode">
+			Instance will be rendered to a static shadow map if applicable.
+		</constant>
+		<constant name="SHADOW_MODE_DYNAMIC" value="2" enum="ShadowDynamicMode">
+			Instance will be rendered to a dynamic shadow map if applicable.
 		</constant>
 		<constant name="VISIBILITY_RANGE_FADE_DISABLED" value="0" enum="VisibilityRangeFadeMode">
 			Disable visibility range fading for the given instance.

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -419,6 +419,7 @@ public:
 
 	/* SHADOW ATLAS API */
 
+	virtual bool shadow_atlas_get_split_shadows() const override { return false; }
 	virtual RID shadow_atlas_create() override;
 	virtual void shadow_atlas_free(RID p_atlas) override;
 	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) override;

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -331,6 +331,26 @@ GeometryInstance3D::ShadowCastingSetting GeometryInstance3D::get_cast_shadows_se
 	return shadow_casting_setting;
 }
 
+void GeometryInstance3D::set_shadow_render_setting(ShadowRenderSetting p_shadow_render_setting) {
+	shadow_render_setting = p_shadow_render_setting;
+
+	switch (p_shadow_render_setting) {
+		case SHADOW_RENDER_STATIC_MAP: {
+			RS::get_singleton()->instance_geometry_set_shadow_mode(get_instance(), RS::SHADOW_MODE_STATIC);
+		} break;
+		case SHADOW_RENDER_DYNAMIC_MAP: {
+			RS::get_singleton()->instance_geometry_set_shadow_mode(get_instance(), RS::SHADOW_MODE_DYNAMIC);
+		} break;
+		default: {
+			RS::get_singleton()->instance_geometry_set_shadow_mode(get_instance(), RS::SHADOW_MODE_AUTO);
+		} break;
+	}
+}
+
+GeometryInstance3D::ShadowRenderSetting GeometryInstance3D::get_shadow_render_setting() const {
+	return shadow_render_setting;
+}
+
 void GeometryInstance3D::set_extra_cull_margin(float p_margin) {
 	ERR_FAIL_COND(p_margin < 0);
 	extra_cull_margin = p_margin;
@@ -459,6 +479,9 @@ void GeometryInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_cast_shadows_setting", "shadow_casting_setting"), &GeometryInstance3D::set_cast_shadows_setting);
 	ClassDB::bind_method(D_METHOD("get_cast_shadows_setting"), &GeometryInstance3D::get_cast_shadows_setting);
 
+	ClassDB::bind_method(D_METHOD("set_shadow_render_setting", "shadow_render_setting"), &GeometryInstance3D::set_shadow_render_setting);
+	ClassDB::bind_method(D_METHOD("get_shadow_render_setting"), &GeometryInstance3D::get_shadow_render_setting);
+
 	ClassDB::bind_method(D_METHOD("set_lod_bias", "bias"), &GeometryInstance3D::set_lod_bias);
 	ClassDB::bind_method(D_METHOD("get_lod_bias"), &GeometryInstance3D::get_lod_bias);
 
@@ -505,6 +528,7 @@ void GeometryInstance3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_overlay", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE), "set_material_overlay", "get_material_overlay");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "transparency", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_transparency", "get_transparency");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows_setting", "get_cast_shadows_setting");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_shadow", PROPERTY_HINT_ENUM, "Auto,Static,Dynamic"), "set_shadow_render_setting", "get_shadow_render_setting");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "extra_cull_margin", PROPERTY_HINT_RANGE, "0,16384,0.01,suffix:m"), "set_extra_cull_margin", "get_extra_cull_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_custom_aabb", "get_custom_aabb");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lod_bias", PROPERTY_HINT_RANGE, "0.001,128,0.001"), "set_lod_bias", "get_lod_bias");
@@ -525,6 +549,10 @@ void GeometryInstance3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_ON);
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_DOUBLE_SIDED);
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+
+	BIND_ENUM_CONSTANT(SHADOW_RENDER_AUTO);
+	BIND_ENUM_CONSTANT(SHADOW_RENDER_STATIC_MAP);
+	BIND_ENUM_CONSTANT(SHADOW_RENDER_DYNAMIC_MAP);
 
 	BIND_ENUM_CONSTANT(GI_MODE_DISABLED);
 	BIND_ENUM_CONSTANT(GI_MODE_STATIC);

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -91,6 +91,13 @@ public:
 		SHADOW_CASTING_SETTING_SHADOWS_ONLY = RS::SHADOW_CASTING_SETTING_SHADOWS_ONLY
 	};
 
+	enum ShadowRenderSetting {
+		SHADOW_RENDER_AUTO,
+		SHADOW_RENDER_STATIC_MAP,
+		SHADOW_RENDER_DYNAMIC_MAP,
+		SHADOW_RENDER_MAX
+	};
+
 	enum GIMode {
 		GI_MODE_DISABLED,
 		GI_MODE_STATIC,
@@ -113,6 +120,7 @@ public:
 
 private:
 	ShadowCastingSetting shadow_casting_setting = SHADOW_CASTING_SETTING_ON;
+	ShadowRenderSetting shadow_render_setting = SHADOW_RENDER_AUTO;
 	Ref<Material> material_override;
 	Ref<Material> material_overlay;
 
@@ -148,6 +156,9 @@ protected:
 public:
 	void set_cast_shadows_setting(ShadowCastingSetting p_shadow_casting_setting);
 	ShadowCastingSetting get_cast_shadows_setting() const;
+
+	void set_shadow_render_setting(ShadowRenderSetting p_shadow_render_setting);
+	ShadowRenderSetting get_shadow_render_setting() const;
 
 	void set_transparency(float p_transparency);
 	float get_transparency() const;
@@ -200,6 +211,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(GeometryInstance3D::ShadowCastingSetting);
+VARIANT_ENUM_CAST(GeometryInstance3D::ShadowRenderSetting);
 VARIANT_ENUM_CAST(GeometryInstance3D::LightmapScale);
 VARIANT_ENUM_CAST(GeometryInstance3D::GIMode);
 VARIANT_ENUM_CAST(GeometryInstance3D::VisibilityRangeFadeMode);

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -168,6 +168,7 @@ public:
 	void lightmap_instance_set_transform(RID p_lightmap, const Transform3D &p_transform) override {}
 
 	/* SHADOW ATLAS API */
+	virtual bool shadow_atlas_get_split_shadows() const override { return false; }
 	virtual RID shadow_atlas_create() override { return RID(); }
 	virtual void shadow_atlas_free(RID p_atlas) override {}
 	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) override {}

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -209,6 +209,12 @@ private:
 
 	// Copy to DP
 
+	enum CopyToDPMode {
+		COPY_TO_DP_STATIC,
+		COPY_TO_DP_DYNAMIC,
+		COPY_TO_DP_MAX
+	};
+
 	struct CopyToDPPushConstant {
 		float z_far;
 		float z_near;
@@ -219,7 +225,7 @@ private:
 	struct CopyToDP {
 		CubeToDpShaderRD shader;
 		RID shader_version;
-		PipelineCacheRD pipeline;
+		PipelineCacheRD pipelines[COPY_TO_DP_MAX];
 	} cube_to_dp;
 
 	// Cubemap effects
@@ -341,7 +347,7 @@ public:
 	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);
 	void set_color_raster(RID p_dest_texture, const Color &p_color, const Rect2i &p_region);
 
-	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip, BitField<RD::BarrierMask> p_post_barrier = RD::BARRIER_MASK_RASTER | RD::BARRIER_MASK_TRANSFER);
+	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip, bool p_is_static, BitField<RD::BarrierMask> p_post_barrier = RD::BARRIER_MASK_RASTER | RD::BARRIER_MASK_TRANSFER);
 	void cubemap_downsample(RID p_source_cubemap, RID p_dest_cubemap, const Size2i &p_size);
 	void cubemap_downsample_raster(RID p_source_cubemap, RID p_dest_framebuffer, uint32_t p_face_id, const Size2i &p_size);
 	void cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubemap, bool p_use_array);

--- a/servers/rendering/renderer_rd/effects/debug_effects.h
+++ b/servers/rendering/renderer_rd/effects/debug_effects.h
@@ -32,6 +32,7 @@
 #define DEBUG_EFFECTS_RD_H
 
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shaders/effects/debug_combined_shadow_map.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/shadow_frustum.glsl.gen.h"
 #include "servers/rendering/renderer_scene_render.h"
 
@@ -41,6 +42,8 @@ namespace RendererRD {
 
 class DebugEffects {
 private:
+	/* Shadow frustum */
+
 	struct {
 		RD::VertexFormatID vertex_format;
 		RID vertex_buffer;
@@ -72,12 +75,20 @@ private:
 
 	void _create_frustum_arrays();
 
+	/* Combined shadow map */
+	struct {
+		DebugCombinedShadowMapShaderRD shader;
+		RID shader_version;
+		PipelineCacheRD pipeline;
+	} combined_shadow_map;
+
 protected:
 public:
 	DebugEffects();
 	~DebugEffects();
 
 	void draw_shadow_frustum(RID p_light, const Projection &p_cam_projection, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect);
+	void draw_combined_shadow_map(RID p_static_texture, RID p_dynamic_texture, RID p_dest_fb, const Rect2 p_rect);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1335,6 +1335,9 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 	p_render_data->shadows.clear();
 	p_render_data->directional_shadows.clear();
 
+	LocalVector<int> static_cube_shadows;
+	LocalVector<int> static_positional_shadows;
+
 	Plane camera_plane(-p_render_data->scene_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->scene_data->cam_transform.origin);
 	float lod_distance_multiplier = p_render_data->scene_data->cam_projection.get_lod_multiplier();
 	{
@@ -1345,15 +1348,24 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 			if (light_storage->light_get_type(base) == RS::LIGHT_DIRECTIONAL) {
 				p_render_data->directional_shadows.push_back(i);
 			} else if (light_storage->light_get_type(base) == RS::LIGHT_OMNI && light_storage->light_omni_get_shadow_mode(base) == RS::LIGHT_OMNI_SHADOW_CUBE) {
+				if (p_render_data->render_shadows[i].redraw_staticmap) {
+					// Add this even if static_instances is empty, we still want to clear our map.
+					// Note that all 6 sides should be set with the same value.
+					static_cube_shadows.push_back(i);
+				}
+
+				// We render our cube maps even if we have no dynamic instances as we use an intermediate result and must render all 6 sides.
+				// We may change this if we ever rewrite this to render our cubemaps directly into our atlas.
 				p_render_data->cube_shadows.push_back(i);
 			} else {
-				p_render_data->shadows.push_back(i);
+				if (p_render_data->render_shadows[i].redraw_staticmap) {
+					// Add this even if static_instances is empty, we still want to clear our map.
+					static_positional_shadows.push_back(i);
+				}
+				if (p_render_data->render_shadows[i].dynamic_instances.size() > 0) {
+					p_render_data->shadows.push_back(i);
+				}
 			}
-		}
-
-		//cube shadows are rendered in their own way
-		for (const int &index : p_render_data->cube_shadows) {
-			_render_shadow_pass(p_render_data->render_shadows[index].light, p_render_data->shadow_atlas, p_render_data->render_shadows[index].pass, p_render_data->render_shadows[index].instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, true, true, true, p_render_data->render_info);
 		}
 
 		if (p_render_data->directional_shadows.size()) {
@@ -1364,10 +1376,34 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 		}
 	}
 
-	// Render GI
+	// Render GI.
 
-	bool render_shadows = p_render_data->directional_shadows.size() || p_render_data->shadows.size();
+	bool render_static_shadows = static_cube_shadows.size() > 0 || static_positional_shadows.size() > 0;
+	bool render_shadows = render_static_shadows || p_render_data->directional_shadows.size() || p_render_data->shadows.size() || p_render_data->cube_shadows.size();
 	bool render_gi = rb.is_valid() && p_use_gi;
+
+	// Prepare shadow rendering.
+	if (render_static_shadows) {
+		RENDER_TIMESTAMP("Render Static Shadows");
+
+		// Cube shadows are rendered in their own way so we do them first.
+		for (uint32_t i = 0; i < static_cube_shadows.size(); i++) {
+			int idx = static_cube_shadows[i];
+			_render_shadow_pass(p_render_data->render_shadows[idx].light, p_render_data->shadow_atlas, p_render_data->render_shadows[idx].pass, true, p_render_data->render_shadows[idx].static_instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, true, true, true, p_render_data->render_info);
+		}
+
+		_render_shadow_begin();
+
+		// Render positional shadows.
+		for (uint32_t i = 0; i < static_positional_shadows.size(); i++) {
+			int idx = static_positional_shadows[i];
+			_render_shadow_pass(p_render_data->render_shadows[idx].light, p_render_data->shadow_atlas, p_render_data->render_shadows[idx].pass, true, p_render_data->render_shadows[idx].static_instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, i == 0, i == (static_positional_shadows.size() - 1), true, p_render_data->render_info);
+		}
+
+		_render_shadow_process();
+
+		_render_shadow_end();
+	}
 
 	if (render_shadows && render_gi) {
 		RENDER_TIMESTAMP("Render GI + Render Shadows (Parallel)");
@@ -1377,28 +1413,45 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 		RENDER_TIMESTAMP("Render GI");
 	}
 
-	//prepare shadow rendering
 	if (render_shadows) {
+		// Note, if split shadow is false everything should have been loaded into our directional shadow lists.
+		// In this scenario we pass _render_shadow_pass.p_is_static_pass as true to trigger our correct clear logic.
+		bool split_shadows = light_storage->shadow_atlas_get_split_shadows();
+
+		if (split_shadows) {
+			// Copy our static map to our dynamic map
+			_render_shadow_copy_staticmap(p_render_data->shadow_atlas);
+		}
+
+		// Cube shadows are rendered in their own way so we do them first.
+		for (const int &idx : p_render_data->cube_shadows) {
+			_render_shadow_pass(p_render_data->render_shadows[idx].light, p_render_data->shadow_atlas, p_render_data->render_shadows[idx].pass, !split_shadows, p_render_data->render_shadows[idx].dynamic_instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, true, true, false, p_render_data->render_info);
+		}
+
+		// Now render our dynamic shadows, from here on we run parallel with GI
 		_render_shadow_begin();
 
-		//render directional shadows
+		// Render directional shadows.
 		for (uint32_t i = 0; i < p_render_data->directional_shadows.size(); i++) {
-			_render_shadow_pass(p_render_data->render_shadows[p_render_data->directional_shadows[i]].light, p_render_data->shadow_atlas, p_render_data->render_shadows[p_render_data->directional_shadows[i]].pass, p_render_data->render_shadows[p_render_data->directional_shadows[i]].instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, false, i == p_render_data->directional_shadows.size() - 1, false, p_render_data->render_info);
+			// Note: directional shadows are not split between static and dynamic instances (yet).
+			int idx = p_render_data->directional_shadows[i];
+			_render_shadow_pass(p_render_data->render_shadows[idx].light, p_render_data->shadow_atlas, p_render_data->render_shadows[idx].pass, !split_shadows, p_render_data->render_shadows[idx].dynamic_instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, false, i == p_render_data->directional_shadows.size() - 1, false, p_render_data->render_info);
 		}
-		//render positional shadows
+		// Render positional shadows.
 		for (uint32_t i = 0; i < p_render_data->shadows.size(); i++) {
-			_render_shadow_pass(p_render_data->render_shadows[p_render_data->shadows[i]].light, p_render_data->shadow_atlas, p_render_data->render_shadows[p_render_data->shadows[i]].pass, p_render_data->render_shadows[p_render_data->shadows[i]].instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, i == 0, i == p_render_data->shadows.size() - 1, true, p_render_data->render_info);
+			int idx = p_render_data->shadows[i];
+			_render_shadow_pass(p_render_data->render_shadows[idx].light, p_render_data->shadow_atlas, p_render_data->render_shadows[idx].pass, !split_shadows, p_render_data->render_shadows[idx].dynamic_instances, camera_plane, lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, false, i == p_render_data->shadows.size() - 1, !split_shadows, p_render_data->render_info);
 		}
 
 		_render_shadow_process();
 	}
 
-	//start GI
+	// Start GI.
 	if (render_gi) {
 		gi.process_gi(rb, p_normal_roughness_slices, p_voxel_gi_buffer, p_render_data->environment, p_render_data->scene_data->view_count, p_render_data->scene_data->view_projection, p_render_data->scene_data->view_eye_offset, p_render_data->scene_data->cam_transform, *p_render_data->voxel_gi_instances);
 	}
 
-	//Do shadow rendering (in parallel with GI)
+	// Do shadow rendering (in parallel with GI).
 	if (render_shadows) {
 		_render_shadow_end(RD::BARRIER_MASK_NO_BARRIER);
 	}
@@ -1428,7 +1481,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 		}
 	}
 
-	//full barrier here, we need raster, transfer and compute and it depends from the previous work
+	// Full barrier here, we need raster, transfer and compute and it depends from the previous work.
 	RD::get_singleton()->barrier(RD::BARRIER_MASK_ALL_BARRIERS, RD::BARRIER_MASK_ALL_BARRIERS);
 
 	if (current_cluster_builder) {
@@ -1447,7 +1500,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 			using_shadows = false;
 		}
 	} else {
-		//do not render reflections when rendering a reflection probe
+		// Do not render reflections when rendering a reflection probe.
 		light_storage->update_reflection_probe_buffer(p_render_data, *p_render_data->reflection_probes, p_render_data->scene_data->cam_transform.affine_inverse(), p_render_data->environment);
 	}
 
@@ -2147,7 +2200,7 @@ void RenderForwardClustered::_render_buffers_debug_draw(const RenderDataRD *p_re
 	}
 }
 
-void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, bool p_open_pass, bool p_close_pass, bool p_clear_region, RenderingMethod::RenderInfo *p_render_info) {
+void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, bool p_is_static_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, bool p_open_pass, bool p_close_pass, bool p_clear_region, RenderingMethod::RenderInfo *p_render_info) {
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 
 	ERR_FAIL_COND(!light_storage->owns_light_instance(p_light));
@@ -2265,7 +2318,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 				light_transform = light_storage->light_instance_get_shadow_transform(p_light, p_pass);
 				render_cubemap = true;
 				finalize_cubemap = p_pass == 5;
-				atlas_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas);
+				atlas_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas, p_is_static_pass);
 
 				atlas_size = shadow_atlas_size;
 
@@ -2286,7 +2339,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 
 				using_dual_paraboloid = true;
 				using_dual_paraboloid_flip = p_pass == 1;
-				render_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas);
+				render_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas, p_is_static_pass);
 				flip_y = true;
 			}
 
@@ -2294,7 +2347,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 			light_projection = light_storage->light_instance_get_shadow_camera(p_light, 0);
 			light_transform = light_storage->light_instance_get_shadow_transform(p_light, 0);
 
-			render_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas);
+			render_fb = light_storage->shadow_atlas_get_fb(p_shadow_atlas, p_is_static_pass);
 
 			flip_y = true;
 		}
@@ -2302,7 +2355,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 
 	if (render_cubemap) {
 		//rendering to cubemap
-		_render_shadow_append(render_fb, p_instances, light_projection, light_transform, zfar, 0, 0, reverse_cull_face, false, false, use_pancake, p_camera_plane, p_lod_distance_multiplier, p_screen_mesh_lod_threshold, Rect2(), false, true, true, true, p_render_info);
+		_render_shadow_append(render_fb, p_instances, light_projection, light_transform, zfar, 0, 0, reverse_cull_face, false, false, use_pancake, p_camera_plane, p_lod_distance_multiplier, p_screen_mesh_lod_threshold, Rect2(), false, RD::INITIAL_ACTION_CLEAR, RD::FINAL_ACTION_READ, p_render_info);
 		if (finalize_cubemap) {
 			_render_shadow_process();
 			_render_shadow_end();
@@ -2310,9 +2363,9 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 			Rect2 atlas_rect_norm = atlas_rect;
 			atlas_rect_norm.position /= float(atlas_size);
 			atlas_rect_norm.size /= float(atlas_size);
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), light_projection.get_z_far(), false);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), light_projection.get_z_far(), false, p_is_static_pass);
 			atlas_rect_norm.position += Vector2(dual_paraboloid_offset) * atlas_rect_norm.size;
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), light_projection.get_z_far(), true);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), light_projection.get_z_far(), true, p_is_static_pass);
 
 			//restore transform so it can be properly used
 			light_storage->light_instance_set_shadow_transform(p_light, Projection(), light_storage->light_instance_get_base_transform(p_light), zfar, 0, 0, 0);
@@ -2320,7 +2373,16 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 
 	} else {
 		//render shadow
-		_render_shadow_append(render_fb, p_instances, light_projection, light_transform, zfar, 0, 0, reverse_cull_face, using_dual_paraboloid, using_dual_paraboloid_flip, use_pancake, p_camera_plane, p_lod_distance_multiplier, p_screen_mesh_lod_threshold, atlas_rect, flip_y, p_clear_region, p_open_pass, p_close_pass, p_render_info);
+
+		RD::InitialAction initial_depth_action;
+		if (p_is_static_pass) {
+			initial_depth_action = p_open_pass ? (p_clear_region ? RD::INITIAL_ACTION_CLEAR_REGION : RD::INITIAL_ACTION_CLEAR) : (p_clear_region ? RD::INITIAL_ACTION_CLEAR_REGION_CONTINUE : RD::INITIAL_ACTION_CONTINUE);
+		} else {
+			initial_depth_action = p_open_pass ? RD::INITIAL_ACTION_KEEP : RD::INITIAL_ACTION_CONTINUE;
+		}
+		RD::FinalAction final_depth_action = p_close_pass ? RD::FINAL_ACTION_READ : RD::FINAL_ACTION_CONTINUE;
+
+		_render_shadow_append(render_fb, p_instances, light_projection, light_transform, zfar, 0, 0, reverse_cull_face, using_dual_paraboloid, using_dual_paraboloid_flip, use_pancake, p_camera_plane, p_lod_distance_multiplier, p_screen_mesh_lod_threshold, atlas_rect, flip_y, initial_depth_action, final_depth_action, p_render_info);
 	}
 }
 
@@ -2333,7 +2395,7 @@ void RenderForwardClustered::_render_shadow_begin() {
 	scene_state.instance_data[RENDER_LIST_SECONDARY].clear();
 }
 
-void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_reverse_cull_face, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, const Rect2i &p_rect, bool p_flip_y, bool p_clear_region, bool p_begin, bool p_end, RenderingMethod::RenderInfo *p_render_info) {
+void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_reverse_cull_face, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane, float p_lod_distance_multiplier, float p_screen_mesh_lod_threshold, const Rect2i &p_rect, bool p_flip_y, RD::InitialAction p_initial_depth_action, RD::FinalAction p_final_depth_action, RenderingMethod::RenderInfo *p_render_info) {
 	uint32_t shadow_pass_index = scene_state.shadow_passes.size();
 
 	SceneState::ShadowPass shadow_pass;
@@ -2395,8 +2457,8 @@ void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const Page
 		shadow_pass.lod_distance_multiplier = scene_data.lod_distance_multiplier;
 
 		shadow_pass.framebuffer = p_framebuffer;
-		shadow_pass.initial_depth_action = p_begin ? (p_clear_region ? RD::INITIAL_ACTION_CLEAR_REGION : RD::INITIAL_ACTION_CLEAR) : (p_clear_region ? RD::INITIAL_ACTION_CLEAR_REGION_CONTINUE : RD::INITIAL_ACTION_CONTINUE);
-		shadow_pass.final_depth_action = p_end ? RD::FINAL_ACTION_READ : RD::FINAL_ACTION_CONTINUE;
+		shadow_pass.initial_depth_action = p_initial_depth_action;
+		shadow_pass.final_depth_action = p_final_depth_action;
 		shadow_pass.rect = p_rect;
 
 		scene_state.shadow_passes.push_back(shadow_pass);
@@ -2415,6 +2477,21 @@ void RenderForwardClustered::_render_shadow_process() {
 
 	RD::get_singleton()->draw_command_end_label();
 }
+
+void RenderForwardClustered::_render_shadow_copy_staticmap(RID p_shadow_atlas) {
+	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
+	RD::get_singleton()->draw_command_begin_label("Copy static shadow map");
+
+	// Copy static to dynamic shadow
+	RID static_atlas = light_storage->shadow_atlas_get_texture(p_shadow_atlas, true);
+	RID dynamic_atlas = light_storage->shadow_atlas_get_texture(p_shadow_atlas, false);
+	int size = light_storage->shadow_atlas_get_size(p_shadow_atlas);
+
+	RD::get_singleton()->texture_copy(static_atlas, dynamic_atlas, Vector3(), Vector3(), Vector3(size, size, 0.0), 0, 0, 0, 0, RD::BARRIER_MASK_RASTER);
+
+	RD::get_singleton()->draw_command_end_label();
+}
+
 void RenderForwardClustered::_render_shadow_end(uint32_t p_barrier) {
 	RD::get_singleton()->draw_command_begin_label("Shadow Render");
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -581,10 +581,11 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 
 	/* Render shadows */
 
-	void _render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_mesh_lod_threshold = 0.0, bool p_open_pass = true, bool p_close_pass = true, bool p_clear_region = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
+	void _render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, bool p_is_static_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_mesh_lod_threshold = 0.0, bool p_open_pass = true, bool p_close_pass = true, bool p_clear_region = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
 	void _render_shadow_begin();
-	void _render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_reverse_cull_face, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, const Rect2i &p_rect = Rect2i(), bool p_flip_y = false, bool p_clear_region = true, bool p_begin = true, bool p_end = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
+	void _render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_reverse_cull_face, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, const Rect2i &p_rect = Rect2i(), bool p_flip_y = false, RD::InitialAction p_initial_depth_action = RD::INITIAL_ACTION_KEEP, RD::FinalAction p_final_depth_action = RD::FINAL_ACTION_READ, RenderingMethod::RenderInfo *p_render_info = nullptr);
 	void _render_shadow_process();
+	void _render_shadow_copy_staticmap(RID p_shadow_atlas);
 	void _render_shadow_end(uint32_t p_barrier = RD::BARRIER_MASK_ALL_BARRIERS);
 
 	/* Render Scene */

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -187,10 +187,11 @@ private:
 
 	/* Render shadows */
 
-	void _render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_mesh_lod_threshold = 0.0, bool p_open_pass = true, bool p_close_pass = true, bool p_clear_region = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
+	void _render_shadow_pass(RID p_light, RID p_shadow_atlas, int p_pass, bool p_is_static_pass, const PagedArray<RenderGeometryInstance *> &p_instances, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0, float p_screen_mesh_lod_threshold = 0.0, bool p_open_pass = true, bool p_close_pass = true, bool p_clear_region = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
 	void _render_shadow_begin();
-	void _render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, const Rect2i &p_rect = Rect2i(), bool p_flip_y = false, bool p_clear_region = true, bool p_begin = true, bool p_end = true, RenderingMethod::RenderInfo *p_render_info = nullptr);
+	void _render_shadow_append(RID p_framebuffer, const PagedArray<RenderGeometryInstance *> &p_instances, const Projection &p_projection, const Transform3D &p_transform, float p_zfar, float p_bias, float p_normal_bias, bool p_use_dp, bool p_use_dp_flip, bool p_use_pancake, const Plane &p_camera_plane = Plane(), float p_lod_distance_multiplier = 0.0, float p_screen_mesh_lod_threshold = 0.0, const Rect2i &p_rect = Rect2i(), bool p_flip_y = false, RD::InitialAction p_initial_depth_action = RD::INITIAL_ACTION_KEEP, RD::FinalAction p_final_depth_action = RD::FINAL_ACTION_READ, RenderingMethod::RenderInfo *p_render_info = nullptr);
 	void _render_shadow_process();
+	void _render_shadow_copy_staticmap(RID p_shadow_atlas);
 	void _render_shadow_end(uint32_t p_barrier = RD::BARRIER_MASK_ALL_BARRIERS);
 
 	/* Render Scene */

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -674,14 +674,28 @@ void RendererSceneRenderRD::_render_buffers_debug_draw(const RenderDataRD *p_ren
 
 	if (debug_draw == RS::VIEWPORT_DEBUG_DRAW_SHADOW_ATLAS) {
 		if (p_render_data->shadow_atlas.is_valid()) {
-			RID shadow_atlas_texture = RendererRD::LightStorage::get_singleton()->shadow_atlas_get_texture(p_render_data->shadow_atlas);
+			RID static_shadow_atlas_texture = RendererRD::LightStorage::get_singleton()->shadow_atlas_get_texture(p_render_data->shadow_atlas, true);
+			RID dynamic_shadow_atlas_texture = RendererRD::LightStorage::get_singleton()->shadow_atlas_get_texture(p_render_data->shadow_atlas);
 
-			if (shadow_atlas_texture.is_null()) {
-				shadow_atlas_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
+			if (static_shadow_atlas_texture.is_null()) {
+				static_shadow_atlas_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
+			}
+
+			if (dynamic_shadow_atlas_texture.is_null()) {
+				dynamic_shadow_atlas_texture = texture_storage->texture_rd_get_default(RendererRD::TextureStorage::DEFAULT_RD_TEXTURE_BLACK);
 			}
 
 			Size2 rtsize = texture_storage->render_target_get_size(render_target);
-			copy_effects->copy_to_fb_rect(shadow_atlas_texture, texture_storage->render_target_get_rd_framebuffer(render_target), Rect2i(Vector2(), rtsize / 2), false, true);
+
+			// Determine our display size, try and keep square by using the smallest edge.
+			Size2i size = 2 * rtsize / 3;
+			if (size.x < size.y) {
+				size.y = size.x;
+			} else if (size.y < size.x) {
+				size.x = size.y;
+			}
+
+			debug_effects->draw_combined_shadow_map(static_shadow_atlas_texture, dynamic_shadow_atlas_texture, texture_storage->render_target_get_rd_framebuffer(render_target), Rect2i(Vector2(), size));
 		}
 	}
 

--- a/servers/rendering/renderer_rd/shaders/effects/debug_combined_shadow_map.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/debug_combined_shadow_map.glsl
@@ -1,0 +1,38 @@
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(location = 0) out vec2 uv_interp;
+
+void main() {
+	vec2 base_arr[4] = vec2[](vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0));
+	uv_interp.xy = base_arr[gl_VertexIndex];
+	uv_interp.y = 1.0 - uv_interp.y; // invert Y
+	gl_Position = vec4(uv_interp.xy * 2.0 - 1.0, 0.0, 1.0);
+}
+
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(set = 0, binding = 0) uniform sampler2D static_shadow_map;
+layout(set = 1, binding = 0) uniform sampler2D dynamic_shadow_map;
+
+layout(location = 0) in vec2 uv_interp;
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+	float static_depth = textureLod(static_shadow_map, uv_interp, 0.0).r;
+	float dynamic_depth = textureLod(dynamic_shadow_map, uv_interp, 0.0).r;
+	if (static_depth <= dynamic_depth) {
+		vec3 static_color = vec3(static_depth);
+		frag_color = vec4(static_color, 1.0);
+	} else {
+		vec3 dynamic_color = vec3(0.25, 0.25, 0.5 + 0.5 * (1.0 - dynamic_depth));
+		frag_color = vec4(dynamic_color, 1.0);
+	}
+}

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -400,6 +400,7 @@ public:
 		Vector<RID> materials;
 
 		RS::ShadowCastingSetting cast_shadows;
+		RS::ShadowDynamicMode dynamic_shadow_mode = RS::SHADOW_MODE_AUTO;
 
 		uint32_t layer_mask;
 		//fit in 32 bits
@@ -676,7 +677,8 @@ public:
 		uint64_t last_version;
 		List<Instance *>::Element *D; // directional light in scenario
 
-		bool shadow_dirty;
+		bool shadow_dirty = true; // mark that shadow map needs to be updated fully
+		bool shadow_split_update = false; // if shadow split is on, marked as true if a static object moved while shadow_dirty is false
 		bool uses_projector = false;
 		bool uses_softshadow = false;
 
@@ -689,7 +691,6 @@ public:
 
 		InstanceLightData() {
 			bake_mode = RS::LIGHT_BAKE_DISABLED;
-			shadow_dirty = true;
 			D = nullptr;
 			last_version = 0;
 			baked_light = nullptr;
@@ -988,6 +989,7 @@ public:
 
 	virtual void instance_geometry_set_flag(RID p_instance, RS::InstanceFlags p_flags, bool p_enabled);
 	virtual void instance_geometry_set_cast_shadows_setting(RID p_instance, RS::ShadowCastingSetting p_shadow_casting_setting);
+	virtual void instance_geometry_set_shadow_mode(RID p_instance, RS::ShadowDynamicMode p_shadow_dynamic_mode);
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material);
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material);
 
@@ -1011,7 +1013,7 @@ public:
 
 	void _light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect);
 
-	_FORCE_INLINE_ bool _light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, Scenario *p_scenario, float p_scren_mesh_lod_threshold, uint32_t p_visible_layers = 0xFFFFFF);
+	_FORCE_INLINE_ bool _light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, bool p_atlas_changed, Scenario *p_scenario, float p_scren_mesh_lod_threshold, uint32_t p_visible_layers = 0xFFFFFF);
 
 	RID _render_get_environment(RID p_camera, RID p_scenario);
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -244,7 +244,9 @@ public:
 	struct RenderShadowData {
 		RID light;
 		int pass = 0;
-		PagedArray<RenderGeometryInstance *> instances;
+		bool redraw_staticmap = false;
+		PagedArray<RenderGeometryInstance *> static_instances;
+		PagedArray<RenderGeometryInstance *> dynamic_instances;
 	};
 
 	struct RenderSDFGIData {

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -96,6 +96,7 @@ public:
 
 	virtual void instance_geometry_set_flag(RID p_instance, RS::InstanceFlags p_flags, bool p_enabled) = 0;
 	virtual void instance_geometry_set_cast_shadows_setting(RID p_instance, RS::ShadowCastingSetting p_shadow_casting_setting) = 0;
+	virtual void instance_geometry_set_shadow_mode(RID p_instance, RS::ShadowDynamicMode p_shadow_dynamic_mode) = 0;
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -795,6 +795,7 @@ public:
 
 	FUNC3(instance_geometry_set_flag, RID, InstanceFlags, bool)
 	FUNC2(instance_geometry_set_cast_shadows_setting, RID, ShadowCastingSetting)
+	FUNC2(instance_geometry_set_shadow_mode, RID, ShadowDynamicMode)
 	FUNC2(instance_geometry_set_material_override, RID, RID)
 	FUNC2(instance_geometry_set_material_overlay, RID, RID)
 

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -177,6 +177,8 @@ public:
 
 	/* SHADOW ATLAS */
 
+	virtual bool shadow_atlas_get_split_shadows() const = 0;
+
 	virtual RID shadow_atlas_create() = 0;
 	virtual void shadow_atlas_free(RID p_atlas) = 0;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2513,6 +2513,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_flag", "instance", "flag", "enabled"), &RenderingServer::instance_geometry_set_flag);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_cast_shadows_setting", "instance", "shadow_casting_setting"), &RenderingServer::instance_geometry_set_cast_shadows_setting);
+	ClassDB::bind_method(D_METHOD("instance_geometry_set_shadow_mode", "instance", "shadow_mode"), &RenderingServer::instance_geometry_set_shadow_mode);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_override", "instance", "material"), &RenderingServer::instance_geometry_set_material_override);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_overlay", "instance", "material"), &RenderingServer::instance_geometry_set_material_overlay);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_visibility_range", "instance", "min", "max", "min_margin", "max_margin", "fade_mode"), &RenderingServer::instance_geometry_set_visibility_range);
@@ -2555,6 +2556,10 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_ON);
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_DOUBLE_SIDED);
 	BIND_ENUM_CONSTANT(SHADOW_CASTING_SETTING_SHADOWS_ONLY);
+
+	BIND_ENUM_CONSTANT(SHADOW_MODE_AUTO);
+	BIND_ENUM_CONSTANT(SHADOW_MODE_STATIC);
+	BIND_ENUM_CONSTANT(SHADOW_MODE_DYNAMIC);
 
 	BIND_ENUM_CONSTANT(VISIBILITY_RANGE_FADE_DISABLED);
 	BIND_ENUM_CONSTANT(VISIBILITY_RANGE_FADE_SELF);
@@ -2898,6 +2903,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality.mobile", 0);
 	GLOBAL_DEF("rendering/lights_and_shadows/directional_shadow/16_bits", true);
 
+	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/split_static_and_dynamic_shadows", false);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"), 2);
 	GLOBAL_DEF("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality.mobile", 0);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1264,6 +1264,12 @@ public:
 		SHADOW_CASTING_SETTING_SHADOWS_ONLY,
 	};
 
+	enum ShadowDynamicMode {
+		SHADOW_MODE_AUTO,
+		SHADOW_MODE_STATIC,
+		SHADOW_MODE_DYNAMIC,
+	};
+
 	enum VisibilityRangeFadeMode {
 		VISIBILITY_RANGE_FADE_DISABLED,
 		VISIBILITY_RANGE_FADE_SELF,
@@ -1272,6 +1278,7 @@ public:
 
 	virtual void instance_geometry_set_flag(RID p_instance, InstanceFlags p_flags, bool p_enabled) = 0;
 	virtual void instance_geometry_set_cast_shadows_setting(RID p_instance, ShadowCastingSetting p_shadow_casting_setting) = 0;
+	virtual void instance_geometry_set_shadow_mode(RID p_instance, ShadowDynamicMode p_shadow_dynamic_mode) = 0;
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, VisibilityRangeFadeMode p_fade_mode) = 0;
@@ -1685,6 +1692,7 @@ VARIANT_ENUM_CAST(RenderingServer::ShadowQuality);
 VARIANT_ENUM_CAST(RenderingServer::InstanceType);
 VARIANT_ENUM_CAST(RenderingServer::InstanceFlags);
 VARIANT_ENUM_CAST(RenderingServer::ShadowCastingSetting);
+VARIANT_ENUM_CAST(RenderingServer::ShadowDynamicMode);
 VARIANT_ENUM_CAST(RenderingServer::VisibilityRangeFadeMode);
 VARIANT_ENUM_CAST(RenderingServer::NinePatchAxisMode);
 VARIANT_ENUM_CAST(RenderingServer::CanvasItemTextureFilter);


### PR DESCRIPTION
This PR changes the shadow map rendering logic so static objects (objects marked as not moving) are rendered to a static shadow map. This static shadow map is only updated if the light changes or if the light is assigned a new region in the shadow map.

> This PR is now rebased on top of #77085 as I'm building on some of the debug changes in that PR

This functionality can be enabled through a new project settings:

![image](https://github.com/godotengine/godot/assets/1945449/ab4c51e3-d979-4158-9213-9de9beb374d0)

Each frame the static shadow map is copied and we render dynamic objects (objects marked as potentially moving) into this shadow map. This is this shadow map that is used to render shadows.

This removes a lot of overhead in rendering shadow maps when there are many static objects.

Geometry can be marked as static or dynamic to determine whether they need to be rendered to shadow maps every frame (if applicable). There is an automatic mode that, with a little overhead, figures out which objects move after the static shadow map is rendered and marks those objects as dynamic automatically. After a few frames dynamic objects are identified and the efficiency is applied.

![image](https://github.com/godotengine/godot/assets/1945449/bbcda32c-949b-405d-99b8-cad9759a7e75)
The property name is currently named `Render shadow`.
See the discussion in the comments about possible changes with an approach for using an "inherit from parent" approach though the automatic mode seems to work well enough.

**Note** if animations are linked to a mesh, we automatically recognize it as dynamic.

Our debug display will overlap the static and dynamic results.
- Static shadows are shown in black and white (black is close) 
- Dynamic shadows are shown in black and blue (blue is close)

![image](https://github.com/godotengine/godot/assets/1945449/adc3b812-89a0-4a29-aeee-3936993a064a)

_Currently_ only the Vulkan renderer supports this feature.

Todos:
- y-flip the debug image, everything is upside down atm
- Make this work for directional shadows (this may become a separate PR or part of #76291)

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/4635.*