### PR TITLE
[3.x] Fix `PopupMenu`'s automatic max height

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -100,6 +100,8 @@ Size2 PopupMenu::get_minimum_size() const {
 		minsize.width += check_w;
 	}
 
+	minsize.height = MIN(minsize.height, OS::get_singleton()->get_window_size().height);
+
 	if (max_height > 0 && minsize.height > max_height) {
 		minsize.height = max_height;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Fixes #76289.

`PopupMenu`s now have an implicit maximum height set to the current window height, mimicking the current behavior on 4.0.

![image](https://github.com/godotengine/godot/assets/6501975/d5018615-e899-4774-bcf0-34673e313b5a)
