### PR TITLE
Docs: Add FileAccess.close, remove duplicate example

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -33,17 +33,7 @@
 		[/csharp]
 		[/codeblocks]
 		In the example above, the file will be saved in the user data folder as specified in the [url=$DOCS_URL/tutorials/io/data_paths.html]Data paths[/url] documentation.
-		[FileAccess] will close when it's freed, which happens when it goes out of scope or when it gets assigned with [code]null[/code]. In C# the reference must be disposed manually, which can be done with the [code]using[/code] statement or by calling the [code]Dispose[/code] method directly.
-		[codeblocks]
-		[gdscript]
-		var file = FileAccess.open("res://something") # File is opened and locked for use.
-		file = null # File is closed.
-		[/gdscript]
-		[csharp]
-		using var file = FileAccess.Open("res://something"); // File is opened and locked for use.
-		// The using statement calls Dispose when going out of scope.
-		[/csharp]
-		[/codeblocks]
+		[FileAccess] will close when it's freed, which happens when it goes out of scope or when it gets assigned with [code]null[/code]. [method close] can be used to close it before then explicitly. In C# the reference must be disposed manually, which can be done with the [code]using[/code] statement or by calling the [code]Dispose[/code] method directly.
 		[b]Note:[/b] To access project resources once exported, it is recommended to use [ResourceLoader] instead of [FileAccess], as some files are converted to engine-specific formats and their original source files might not be present in the exported PCK package.
 		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [b]Alt + F4[/b]). If you stop the project execution by pressing [b]F8[/b] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
 	</description>


### PR DESCRIPTION
Salvage of https://github.com/godotengine/godot/pull/74022, documenting the [re-added](https://github.com/godotengine/godot/pull/73435) `FileAccess.close` by pointing it out, and removing the duplicate/redundant example as the previous example just before that is plenty to show how FileAccess works.
