### PR TITLE
Allow customizing the drag&drop minimum distance

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1594,6 +1594,7 @@ ProjectSettings::ProjectSettings() {
 #ifdef TOOLS_ENABLED
 	GLOBAL_DEF("gui/timers/tooltip_delay_sec.editor_hint", 0.5);
 #endif
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/common/minimum_drag_distance", PROPERTY_HINT_RANGE, "0.1,200,0.1,or_greater"), 10.0);
 
 	GLOBAL_DEF_BASIC("gui/common/snap_controls_to_pixels", true);
 	GLOBAL_DEF_BASIC("gui/fonts/dynamic_fonts/use_oversampling", true);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1053,6 +1053,10 @@
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.
 		</member>
+		<member name="gui/common/minimum_drag_distance" type="float" setter="" getter="" default="10.0">
+			The default distance that the user must move the cursor until a drag event is started.
+			Can be changed for each individual [Viewport] via [member Viewport.gui_minimum_drag_distance].
+		</member>
 		<member name="gui/common/snap_controls_to_pixels" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], snaps [Control] node vertices to the nearest pixel to ensure they remain crisp even when the camera moves or zooms.
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -325,6 +325,9 @@
 		<member name="gui_embed_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
 			If [code]true[/code], sub-windows (popups and dialogs) will be embedded inside application window as control-like nodes. If [code]false[/code], they will appear as separate windows handled by the operating system.
 		</member>
+		<member name="gui_minimum_drag_distance" type="float" setter="set_minimum_drag_distance" getter="get_minimum_drag_distance" default="10.0">
+			The distance that the user must move the cursor until a drag event is started.
+		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.
 		</member>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1906,7 +1906,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (!gui.drag_attempted && gui.mouse_focus && section_root && !section_root->gui.global_dragging && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 			gui.drag_accum += mm->get_relative();
 			float len = gui.drag_accum.length();
-			if (len > 10) {
+			if (len > minimum_drag_distance) {
 				{ // Attempt grab, try parent controls too.
 					CanvasItem *ci = gui.mouse_focus;
 					while (ci) {
@@ -3657,6 +3657,16 @@ void Viewport::gui_cancel_drag() {
 	}
 }
 
+void Viewport::set_minimum_drag_distance(float p_distance) {
+	ERR_MAIN_THREAD_GUARD;
+	minimum_drag_distance = MAX(CMP_EPSILON, p_distance);
+}
+
+float Viewport::get_minimum_drag_distance() const {
+	ERR_READ_THREAD_GUARD_V(0);
+	return minimum_drag_distance;
+}
+
 void Viewport::set_input_as_handled() {
 	ERR_MAIN_THREAD_GUARD;
 	if (!handle_input_locally) {
@@ -4827,6 +4837,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gui_is_dragging"), &Viewport::gui_is_dragging);
 	ClassDB::bind_method(D_METHOD("gui_is_drag_successful"), &Viewport::gui_is_drag_successful);
 
+	ClassDB::bind_method(D_METHOD("set_minimum_drag_distance", "distance"), &Viewport::set_minimum_drag_distance);
+	ClassDB::bind_method(D_METHOD("get_minimum_drag_distance"), &Viewport::get_minimum_drag_distance);
+
 	ClassDB::bind_method(D_METHOD("gui_release_focus"), &Viewport::gui_release_focus);
 	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
 	ClassDB::bind_method(D_METHOD("gui_get_hovered_control"), &Viewport::gui_get_hovered_control);
@@ -4984,6 +4997,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_disable_input"), "set_disable_input", "is_input_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_embed_subwindows"), "set_embedding_subwindows", "is_embedding_subwindows");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gui_minimum_drag_distance", PROPERTY_HINT_RANGE, "0.1,200,0.1,or_greater"), "set_minimum_drag_distance", "get_minimum_drag_distance");
 	ADD_GROUP("SDF", "sdf_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"), "set_sdf_oversize", "get_sdf_oversize");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_scale", PROPERTY_HINT_ENUM, "100%,50%,25%"), "set_sdf_scale", "get_sdf_scale");
@@ -5149,6 +5163,8 @@ Viewport::Viewport() {
 
 	// Window tooltip.
 	gui.tooltip_delay = GLOBAL_GET("gui/timers/tooltip_delay_sec");
+
+	set_minimum_drag_distance(GLOBAL_GET("gui/common/minimum_drag_distance"));
 
 #ifndef _3D_DISABLED
 	set_scaling_3d_mode((Viewport::Scaling3DMode)(int)GLOBAL_GET("rendering/scaling_3d/mode"));

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -318,6 +318,7 @@ private:
 	bool use_debanding = false;
 	float mesh_lod_threshold = 1.0;
 	bool use_occlusion_culling = false;
+	float minimum_drag_distance = 10.0;
 
 	Ref<ViewportTexture> default_texture;
 	HashSet<ViewportTexture *> viewport_textures;
@@ -650,6 +651,9 @@ public:
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
 	void gui_cancel_drag();
+
+	void set_minimum_drag_distance(float p_distance);
+	float get_minimum_drag_distance() const;
 
 	Control *gui_find_control(const Point2 &p_global);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/10839

Adjust distance how much mouse has to move until a drag&drop event to start (triggered e.g. by overriding `_get_drag_data`).

Was previously hard-coded to 10, but might be increased or reduced based on the game's or application's resolution.

Example project: [DragThreshold.zip](https://github.com/godotengine/godot/files/11615614/DragThreshold.zip)
