### PR TITLE
Add a way to invalidate preview cache

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -118,8 +118,6 @@ Variant EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() const {
 	return Variant(); // Needed because of how the callback is used.
 }
 
-EditorResourcePreview *EditorResourcePreview::singleton = nullptr;
-
 bool EditorResourcePreview::is_threaded() const {
 	return RSG::texture_storage->can_create_resources_async();
 }
@@ -291,11 +289,15 @@ void EditorResourcePreview::_iterate() {
 		bool has_small_texture;
 		uint64_t last_modtime;
 		String hash;
-		_read_preview_cache(f, &tsize, &has_small_texture, &last_modtime, &hash, &preview_metadata);
+		bool outdated;
+		_read_preview_cache(f, &tsize, &has_small_texture, &last_modtime, &hash, &preview_metadata, &outdated);
 
 		bool cache_valid = true;
 
 		if (tsize != thumbnail_size) {
+			cache_valid = false;
+			f.unref();
+		} else if (outdated) {
 			cache_valid = false;
 			f.unref();
 		} else if (last_modtime != modtime) {
@@ -357,14 +359,16 @@ void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_t
 	p_file->store_line(itos(p_modified_time));
 	p_file->store_line(p_hash);
 	p_file->store_line(VariantUtilityFunctions::var_to_str(p_metadata).replace("\n", " "));
+	p_file->store_line(itos(CURRENT_METADATA_VERSION));
 }
 
-void EditorResourcePreview::_read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata) {
+void EditorResourcePreview::_read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata, bool *r_outdated) {
 	*r_thumbnail_size = p_file->get_line().to_int();
 	*r_has_small_texture = p_file->get_line().to_int();
 	*r_modified_time = p_file->get_line().to_int();
 	*r_hash = p_file->get_line();
 	*r_metadata = VariantUtilityFunctions::str_to_var(p_file->get_line());
+	*r_outdated = p_file->get_line().to_int() < CURRENT_METADATA_VERSION;
 }
 
 void EditorResourcePreview::_thread() {

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -76,7 +76,8 @@ public:
 class EditorResourcePreview : public Node {
 	GDCLASS(EditorResourcePreview, Node);
 
-	static EditorResourcePreview *singleton;
+	inline static constexpr int CURRENT_METADATA_VERSION = 1; // Increment this number to invalidate all previews.
+	inline static EditorResourcePreview *singleton = nullptr;
 
 	struct QueueItem {
 		Ref<Resource> resource;
@@ -118,7 +119,7 @@ class EditorResourcePreview : public Node {
 	void _iterate();
 
 	void _write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata);
-	void _read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata);
+	void _read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata, bool *r_outdated);
 
 	Vector<Ref<EditorResourcePreviewGenerator>> preview_generators;
 


### PR DESCRIPTION
The new tooltips for textures and audio streams rely on preview metadata. But for previews generated before the metadata was added it will be empty, so the tooltips will display 0x0 dimensions or 0 length. It will display as that until the resource is modified (i.e. its hash changes).

This PR adds a mechanism to force refreshing the previews, so that correct metadata is loaded. Preview cache gets a new field: `version`. To invalidate previews we just need to increase the current version. Note that it forces all exiting previews to be generated again, which is rather costly in terms of I/O in big projects. Also some previews seem to be generated only on demand, so their tooltips are invalid and print an error when displayed for the first time.
