### PR TITLE
Fix outdated C# code example for class AnimationNodeOneShot

### DIFF
--- a/doc/classes/AnimationNodeOneShot.xml
+++ b/doc/classes/AnimationNodeOneShot.xml
@@ -35,13 +35,13 @@
 		[/gdscript]
 		[csharp]
 		// Play child animation connected to "shot" port.
-		animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE);
+		animationTree.Set("parameters/OneShot/request", (int)AnimationNodeOneShot.OneShotRequest.Fire);
 
 		// Abort child animation connected to "shot" port.
-		animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_ABORT);
+		animationTree.Set("parameters/OneShot/request", (int)AnimationNodeOneShot.OneShotRequest.Abort);
 
 		// Abort child animation with fading out connected to "shot" port.
-		animationTree.Set("parameters/OneShot/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FADE_OUT);
+		animationTree.Set("parameters/OneShot/request", (int)AnimationNodeOneShot.OneShotRequest.FadeOut);
 
 		// Get current state (read-only).
 		animationTree.Get("parameters/OneShot/active");


### PR DESCRIPTION
Updates C# code example for [AnimationNodeOneShot](https://docs.godotengine.org/en/stable/classes/class_animationnodeoneshot.html). `AnimationNodeOneShot.OneShotRequest` enum needs to be cast to an int, because AnimationTree.Set() method second parameter requires `Variant` type.