### PR TITLE
Use NOTIFICATION_MOUSE_EXIT instead of a signal for a few editor plugins

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -51,12 +51,6 @@ CurveEdit::CurveEdit() {
 	set_clip_contents(true);
 }
 
-void CurveEdit::_on_mouse_exited() {
-	hovered_index = -1;
-	hovered_tangent_index = TANGENT_NONE;
-	queue_redraw();
-}
-
 void CurveEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_selected_index", "index"), &CurveEdit::set_selected_index);
 }
@@ -116,8 +110,12 @@ Size2 CurveEdit::get_minimum_size() const {
 
 void CurveEdit::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			connect("mouse_exited", callable_mp(this, &CurveEdit::_on_mouse_exited));
+		case NOTIFICATION_MOUSE_EXIT: {
+			if (hovered_index != -1 || hovered_tangent_index != TANGENT_NONE) {
+				hovered_index = -1;
+				hovered_tangent_index = TANGENT_NONE;
+				queue_redraw();
+			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -101,8 +101,6 @@ private:
 	Vector2 get_view_pos(Vector2 p_world_pos) const;
 	Vector2 get_world_pos(Vector2 p_view_pos) const;
 
-	void _on_mouse_exited();
-
 	void _redraw();
 
 private:

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -39,13 +39,6 @@
 #include "scene/gui/flow_container.h"
 #include "scene/gui/separator.h"
 
-void GradientTexture2DEdit::_on_mouse_exited() {
-	if (hovered != HANDLE_NONE) {
-		hovered = HANDLE_NONE;
-		queue_redraw();
-	}
-}
-
 Point2 GradientTexture2DEdit::_get_handle_pos(const Handle p_handle) {
 	// Get the handle's mouse position in pixels relative to offset.
 	return (p_handle == HANDLE_FROM ? texture->get_fill_from() : texture->get_fill_to()).clamp(Vector2(), Vector2(1, 1)) * size;
@@ -168,9 +161,12 @@ void GradientTexture2DEdit::set_snap_count(int p_snap_count) {
 
 void GradientTexture2DEdit::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
-			connect("mouse_exited", callable_mp(this, &GradientTexture2DEdit::_on_mouse_exited));
-			[[fallthrough]];
+		case NOTIFICATION_MOUSE_EXIT: {
+			if (hovered != HANDLE_NONE) {
+				hovered = HANDLE_NONE;
+				queue_redraw();
+			}
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			checkerboard->set_texture(get_theme_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
 		} break;

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -66,8 +66,6 @@ class GradientTexture2DEdit : public Control {
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
-	void _on_mouse_exited();
-
 	void _draw();
 
 protected:


### PR DESCRIPTION
Improves code style, length, and gets all the relevant mouse exit logic to be in a single place. Not using a signal might have other benefits but idk. I didn't realize the notification existed when I wrote this code and I wish I'd used it as it's consistent with other editor plugins.