### PR TITLE
Fix lossless formats in PortableCompressedTexture2D

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3013,6 +3013,7 @@ void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {
 }
 
 ImageMemLoadFunc Image::_png_mem_loader_func = nullptr;
+ImageMemLoadFunc Image::_png_mem_unpacker_func = nullptr;
 ImageMemLoadFunc Image::_jpg_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_webp_mem_loader_func = nullptr;
 ImageMemLoadFunc Image::_tga_mem_loader_func = nullptr;

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -145,6 +145,7 @@ public:
 	};
 
 	static ImageMemLoadFunc _png_mem_loader_func;
+	static ImageMemLoadFunc _png_mem_unpacker_func;
 	static ImageMemLoadFunc _jpg_mem_loader_func;
 	static ImageMemLoadFunc _webp_mem_loader_func;
 	static ImageMemLoadFunc _tga_mem_loader_func;

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -66,12 +66,14 @@ Ref<Image> ImageLoaderPNG::load_mem_png(const uint8_t *p_png, int p_size) {
 	return img;
 }
 
+Ref<Image> ImageLoaderPNG::unpack_mem_png(const uint8_t *p_png, int p_size) {
+	ERR_FAIL_COND_V(p_size < 4, Ref<Image>());
+	ERR_FAIL_COND_V(p_png[0] != 'P' || p_png[1] != 'N' || p_png[2] != 'G' || p_png[3] != ' ', Ref<Image>());
+	return load_mem_png(&p_png[4], p_size - 4);
+}
+
 Ref<Image> ImageLoaderPNG::lossless_unpack_png(const Vector<uint8_t> &p_data) {
-	const int len = p_data.size();
-	ERR_FAIL_COND_V(len < 4, Ref<Image>());
-	const uint8_t *r = p_data.ptr();
-	ERR_FAIL_COND_V(r[0] != 'P' || r[1] != 'N' || r[2] != 'G' || r[3] != ' ', Ref<Image>());
-	return load_mem_png(&r[4], len - 4);
+	return unpack_mem_png(p_data.ptr(), p_data.size());
 }
 
 Vector<uint8_t> ImageLoaderPNG::lossless_pack_png(const Ref<Image> &p_image) {
@@ -99,6 +101,7 @@ Vector<uint8_t> ImageLoaderPNG::lossless_pack_png(const Ref<Image> &p_image) {
 
 ImageLoaderPNG::ImageLoaderPNG() {
 	Image::_png_mem_loader_func = load_mem_png;
+	Image::_png_mem_unpacker_func = unpack_mem_png;
 	Image::png_unpacker = lossless_unpack_png;
 	Image::png_packer = lossless_pack_png;
 }

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -37,6 +37,7 @@ class ImageLoaderPNG : public ImageFormatLoader {
 private:
 	static Vector<uint8_t> lossless_pack_png(const Ref<Image> &p_image);
 	static Ref<Image> lossless_unpack_png(const Vector<uint8_t> &p_data);
+	static Ref<Image> unpack_mem_png(const uint8_t *p_png, int p_size);
 	static Ref<Image> load_mem_png(const uint8_t *p_png, int p_size);
 
 public:

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/compressed_texture.h"
 #include "scene/resources/image_texture.h"
+#include "scene/resources/portable_compressed_texture.h"
 
 TextureRect *TexturePreview::get_texture_display() {
 	return texture_display;
@@ -158,7 +159,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 }
 
 bool EditorInspectorPluginTexture::can_handle(Object *p_object) {
-	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<CompressedTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr || Object::cast_to<Image>(p_object) != nullptr;
+	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<CompressedTexture2D>(p_object) != nullptr || Object::cast_to<PortableCompressedTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr || Object::cast_to<Image>(p_object) != nullptr;
 }
 
 void EditorInspectorPluginTexture::parse_begin(Object *p_object) {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -40,6 +40,7 @@ class CompressedTexture2D : public Texture2D {
 
 public:
 	enum DataFormat {
+		DATA_FORMAT_UNDEFINED,
 		DATA_FORMAT_IMAGE,
 		DATA_FORMAT_PNG,
 		DATA_FORMAT_WEBP,


### PR DESCRIPTION
This is a right copy of my [previous wrong pull-request](https://github.com/godotengine/godot/pull/77047)

Sorry for my bad English(((

`PortableCompressedTexture2D` have a problem with creating from PNG images and some other little problems.
I want to use this resource type as the way to import animations from Aseprite in my [Aseprite importers plugin bundle](https://github.com/nklbdev/godot-4-aseprite-importers)

For now I am creating one PNG image near every `*.aseprite`-file that imported. Then call some methods to update filesystem and import the image. Then plugin is continuing it's work and embedding new image in an imported resource.

`PortableCompressedTexture2D` is a beautiful way to embed PNG data silently in `SpriteFrames` or other resources. But it is not usable now. Method `create_from_image` cannot load PNG image and shows errors in console:

```
WARNING: Not a PNG file
     at: PNGDriverCommon::check_error (drivers\png\png_driver_common.cpp:56)
ERROR: Condition "!success" is true. Returning: ERR_FILE_CORRUPT
   at: PNGDriverCommon::png_to_image (drivers\png\png_driver_common.cpp:69)
ERROR: Condition "err" is true. Returning: Ref<Image>()
   at: ImageLoaderPNG::load_mem_png (drivers\png\image_loader_png.cpp:64)
ERROR: It's not a reference to a valid Image object.
   at: (.\core/io/image.h:426)
ERROR: Condition "err" is true. Returning: Ref<Image>()
   at: _jpegd_mem_loader_func (modules\jpg\image_loader_jpegd.cpp:131)
ERROR: It's not a reference to a valid Image object.
   at: (.\core/io/image.h:426)
ERROR: Condition "p_width <= 0 || p_width > 16384" is true.
   at: GLES3::TextureStorage::texture_set_size_override (drivers\gles3\storage\texture_storage.cpp:1053)
```

This is because PNG image have not only PNG prefix `‰PNG`, but also [Godot's own `PNG ` prefix](https://github.com/godotengine/godot/blob/ffd32a244b43ff58c13819c2debf8cf3b58ecbdc/drivers/png/image_loader_png.cpp#L80)


I understand that this solution is not ideal.
Theoretically, there could be such a sequence of bytes PNG  in this memory location for some other reason. Not because Godot added it there. I don't know how to be completely sure of this. If you know such a criteria, please tell me and I will correct the code.

Result: It works! Now I use `PortableCompressedTexture2D` and save it directly in imported resource - `SpriteFrames` or `PackedScene`!

https://github.com/godotengine/godot/assets/7024016/79853566-1df0-4ac5-962b-49667a034b3e