### PR TITLE
Clarify when things with _IDLE and _PHYSICS enums will run

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -319,10 +319,10 @@
 	</signals>
 	<constants>
 		<constant name="ANIMATION_PROCESS_PHYSICS" value="0" enum="AnimationProcessCallback">
-			Process animation during the physics process. This is especially useful when animating physics bodies.
+			Process animation during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]). This is especially useful when animating physics bodies.
 		</constant>
 		<constant name="ANIMATION_PROCESS_IDLE" value="1" enum="AnimationProcessCallback">
-			Process animation during the idle process.
+			Process animation during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 		<constant name="ANIMATION_PROCESS_MANUAL" value="2" enum="AnimationProcessCallback">
 			Do not process animation. Use [method advance] to process the animation manually.

--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -219,10 +219,10 @@
 	</signals>
 	<constants>
 		<constant name="ANIMATION_PROCESS_PHYSICS" value="0" enum="AnimationProcessCallback">
-			The animations will progress during the physics frame (i.e. [method Node._physics_process]).
+			The animations will progress during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]).
 		</constant>
 		<constant name="ANIMATION_PROCESS_IDLE" value="1" enum="AnimationProcessCallback">
-			The animations will progress during the idle frame (i.e. [method Node._process]).
+			The animations will progress during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 		<constant name="ANIMATION_PROCESS_MANUAL" value="2" enum="AnimationProcessCallback">
 			The animations will only progress manually (see [method advance]).

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -139,10 +139,10 @@
 			Disables doppler tracking.
 		</constant>
 		<constant name="DOPPLER_TRACKING_IDLE_STEP" value="1" enum="DopplerTracking">
-			Executes doppler tracking in idle step.
+			Executes doppler tracking during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 		<constant name="DOPPLER_TRACKING_PHYSICS_STEP" value="2" enum="DopplerTracking">
-			Executes doppler tracking in physics step.
+			Executes doppler tracking during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -189,10 +189,10 @@
 			The camera's position takes into account vertical/horizontal offsets and the screen size.
 		</constant>
 		<constant name="CAMERA2D_PROCESS_PHYSICS" value="0" enum="Camera2DProcessCallback">
-			The camera updates with the [code]_physics_process[/code] callback.
+			The camera updates during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]).
 		</constant>
 		<constant name="CAMERA2D_PROCESS_IDLE" value="1" enum="Camera2DProcessCallback">
-			The camera updates with the [code]_process[/code] callback.
+			The camera updates during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -83,6 +83,7 @@
 				[/csharp]
 				[/codeblocks]
 				The timer will be automatically freed after its time elapses.
+				[b]Note:[/b] The timer is processed after all of the nodes in the current frame, i.e. node's [method Node._process] method would be called before the timer (or [method Node._physics_process] if [param process_in_physics] is set to [code]true[/code]).
 			</description>
 		</method>
 		<method name="create_tween">

--- a/doc/classes/SceneTreeTimer.xml
+++ b/doc/classes/SceneTreeTimer.xml
@@ -23,6 +23,7 @@
 		[/csharp]
 		[/codeblocks]
 		The timer will be dereferenced after its time elapses. To preserve the timer, you can keep a reference to it. See [RefCounted].
+		[b]Note:[/b] The timer is processed after all of the nodes in the current frame, i.e. node's [method Node._process] method would be called before the timer (or [method Node._physics_process] if [code]process_in_physics[/code] in [method SceneTree.create_timer] has been set to [code]true[/code]).
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -65,10 +65,10 @@
 	</signals>
 	<constants>
 		<constant name="TIMER_PROCESS_PHYSICS" value="0" enum="TimerProcessCallback">
-			Update the timer during the physics step at each frame (fixed framerate processing).
+			Update the timer during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]).
 		</constant>
 		<constant name="TIMER_PROCESS_IDLE" value="1" enum="TimerProcessCallback">
-			Update the timer during the idle time at each frame.
+			Update the timer during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -90,7 +90,7 @@
 		Some [Tweener]s use transitions and eases. The first accepts a [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [constant EASE_IN_OUT], and use the one that looks best.
 		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.webp]Tween easing and transition types cheatsheet[/url]
 		[b]Note:[/b] Tweens are not designed to be re-used and trying to do so results in an undefined behavior. Create a new Tween for each animation and every time you replay an animation from start. Keep in mind that Tweens start immediately, so only create a Tween when you want to start animating.
-		[b]Note:[/b] Tweens are processing after all of nodes in the current frame, i.e. after [method Node._process] or [method Node._physics_process] (depending on [enum TweenProcessMode]).
+		[b]Note:[/b] The tween is processed after all of the nodes in the current frame, i.e. node's [method Node._process] method would be called before the timer (or [method Node._physics_process] depending on the value passed to [method set_process_mode]).
 	</description>
 	<tutorials>
 	</tutorials>
@@ -250,7 +250,7 @@
 			<return type="Tween" />
 			<param index="0" name="mode" type="int" enum="Tween.TweenProcessMode" />
 			<description>
-				Determines whether the [Tween] should run during idle frame (see [method Node._process]) or physics frame (see [method Node._physics_process].
+				Determines whether the [Tween] should run after process frames (see [method Node._process]) or physics frames (see [method Node._physics_process]).
 				Default value is [constant TWEEN_PROCESS_IDLE].
 			</description>
 		</method>
@@ -454,10 +454,10 @@
 	</signals>
 	<constants>
 		<constant name="TWEEN_PROCESS_PHYSICS" value="0" enum="TweenProcessMode">
-			The [Tween] updates during the physics frame.
+			The [Tween] updates after each physics frame (see [method Node._physics_process]).
 		</constant>
 		<constant name="TWEEN_PROCESS_IDLE" value="1" enum="TweenProcessMode">
-			The [Tween] updates during the idle frame.
+			The [Tween] updates after each process frame (see [method Node._process]).
 		</constant>
 		<constant name="TWEEN_PAUSE_BOUND" value="0" enum="TweenPauseMode">
 			If the [Tween] has a bound node, it will process when that node can process (see [member Node.process_mode]). Otherwise it's the same as [constant TWEEN_PAUSE_STOP].

--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -92,10 +92,10 @@
 	</signals>
 	<constants>
 		<constant name="VISIBILITY_PROCESS_IDLE" value="0" enum="VisibilityUpdateMode">
-			Visibility filters are updated every idle process frame.
+			Visibility filters are updated during process frames (see [constant Node.NOTIFICATION_INTERNAL_PROCESS]).
 		</constant>
 		<constant name="VISIBILITY_PROCESS_PHYSICS" value="1" enum="VisibilityUpdateMode">
-			Visibility filters are updated every physics process frame.
+			Visibility filters are updated during physics frames (see [constant Node.NOTIFICATION_INTERNAL_PHYSICS_PROCESS]).
 		</constant>
 		<constant name="VISIBILITY_PROCESS_NONE" value="2" enum="VisibilityUpdateMode">
 			Visibility filters are not updated automatically, and must be updated manually by calling [method update_visibility].


### PR DESCRIPTION
Clarified when objects using `*_IDLE` and `*_PHYSICS` enums will run their code. "idle frame", "idle step" and "idle process" are confusing terms that have caused confusion in the past.
Also clarified when SceneTreeTimers run, since they're similar to Tweens and those are clarified already.