### PR TITLE
GLTF: Document `gltf_skeleton->godot_bone_node` is unused when importing

### DIFF
--- a/modules/gltf/doc_classes/GLTFSkeleton.xml
+++ b/modules/gltf/doc_classes/GLTFSkeleton.xml
@@ -21,6 +21,7 @@
 		<method name="get_godot_bone_node">
 			<return type="Dictionary" />
 			<description>
+				Returns a [Dictionary] that maps skeleton bone indices to the indices of GLTF nodes. This property is unused during import, and only set during export. In a GLTF file, a bone is a node, so Godot converts skeleton bones to GLTF nodes.
 			</description>
 		</method>
 		<method name="get_godot_skeleton">
@@ -37,6 +38,7 @@
 			<return type="void" />
 			<param index="0" name="godot_bone_node" type="Dictionary" />
 			<description>
+				Sets a [Dictionary] that maps skeleton bone indices to the indices of GLTF nodes. This property is unused during import, and only set during export. In a GLTF file, a bone is a node, so Godot converts skeleton bones to GLTF nodes.
 			</description>
 		</method>
 		<method name="set_unique_names">


### PR DESCRIPTION
Old description:

<details>

In the current master, `gltf_skeleton->godot_bone_node` is only used when exporting a GLTF file from Godot, but when importing it is always empty. This PR populates it during import so you can use it during the import process. I also renamed `skeleton` to `godot_skeleton` to improve the clarity of the code.

Note: This maps a bone index to a GLTF node index, but for my uses I actually need it the other way around, starting with a GLTF node index and getting the bone index. If desired I could add another data structure that maps the other way. Right now I have code that is just iterating through until it finds the right value.

</details>