### PR TITLE
Override window_get_vsync_mode in DisplayServerWeb to prevent warning spam

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1080,6 +1080,10 @@ bool DisplayServerWeb::can_any_window_draw() const {
 	return true;
 }
 
+DisplayServer::VSyncMode DisplayServerWeb::window_get_vsync_mode(WindowID p_vsync_mode) const {
+	return DisplayServer::VSYNC_ENABLED;
+}
+
 void DisplayServerWeb::process_events() {
 	Input::get_singleton()->flush_buffered_events();
 	if (godot_js_input_gamepad_sample() == OK) {

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -216,6 +216,8 @@ public:
 
 	virtual bool can_any_window_draw() const override;
 
+	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
+
 	// events
 	virtual void process_events() override;
 


### PR DESCRIPTION
Hello!

In my Godot 4.1.dev3 web exports the misleading warning in the attached image is reported every frame. The message appears to be from the base method `window_get_vsync_mode` of `DisplayServer` even though it refers to 'Changing the V-Sync mode'. I have overridden this method in the `DisplayServerWeb` as a means to remove the warning. This will prevent it from spamming the console.

I have tried to test this fix, but I'm unsure how to work with web export templates for builds such as 4.1.dev nor 4.0.4-rc.

I am new to contributing to open source projects and have tried my best to review the guidelines. Feedback is welcome.

![Screenshot 2023-05-31 at 9 22 47 PM](https://github.com/godotengine/godot/assets/109843144/f8a73e2e-efb0-4232-8de7-ed880f54b149)

