### PR TITLE
Cancel autocomplete after initiating drag

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -217,6 +217,10 @@ void CodeEdit::_notification(int p_what) {
 				}
 			}
 		} break;
+
+		case NOTIFICATION_DRAG_BEGIN: {
+			cancel_code_completion();
+		} break;
 	}
 }
 


### PR DESCRIPTION
Autocomplete now cancels after performing a drag and drop into the script editor as it doesn't really make sense for autocompletion results to remain after dragging in a resource. This is my first commit and I attempted to stick to the guidelines so any feedback is much appreciated!

Fixes a portion of #77586.
*Bugsquad edit:* Fixes #77586 (the remaining part is covered by another issue)
