### PR TITLE
Fix export of `Array[Node]`

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -244,35 +244,11 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
 						ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
 
-						const StringName &prop_name = snames[name_idx];
-						const Variant &prop_variant = props[nprops[j].value];
-
-						if (prop_variant.get_type() == Variant::ARRAY) {
-							const Array &array = prop_variant;
-							if (Engine::get_singleton()->is_editor_hint()) {
-								if (array.get_typed_builtin() == Variant::NODE_PATH) {
-									// If editor, simply set the original array of NodePaths.
-									node->set(prop_name, prop_variant);
-									continue;
-								}
-							}
-							for (int k = 0; k < array.size(); k++) {
-								DeferredNodePathProperties dnp;
-								dnp.path = array[k];
-								dnp.base = node;
-								// Use special property name to signify an array. This is only used in deferred_node_paths.
-								dnp.property = String(prop_name) + "/indices/" + itos(k);
-								deferred_node_paths.push_back(dnp);
-							}
-
-						} else {
-							// Do an actual deferred set of the property path.
-							DeferredNodePathProperties dnp;
-							dnp.path = prop_variant;
-							dnp.base = node;
-							dnp.property = prop_name;
-							deferred_node_paths.push_back(dnp);
-						}
+						DeferredNodePathProperties dnp;
+						dnp.value = props[nprops[j].value];
+						dnp.base = node;
+						dnp.property = snames[name_idx];
+						deferred_node_paths.push_back(dnp);
 						continue;
 					}
 
@@ -465,27 +441,21 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	for (const DeferredNodePathProperties &dnp : deferred_node_paths) {
 		// Replace properties stored as NodePaths with actual Nodes.
-		Node *other = dnp.base->get_node_or_null(dnp.path);
-
-		const String string_property = dnp.property;
-		if (string_property.contains("/indices/")) {
-			// For properties with "/indices/", the replacement takes place inside an Array.
-			const String base_property = string_property.get_slice("/", 0);
-			const int index = string_property.get_slice("/", 2).to_int();
+		if (dnp.value.get_type() == Variant::ARRAY) {
+			Array paths = dnp.value;
 
 			bool valid;
-			Array array = dnp.base->get(base_property, &valid);
+			Array array = dnp.base->get(dnp.property, &valid);
 			ERR_CONTINUE(!valid);
+			array = array.duplicate();
 
-			if (array.size() >= index) {
-				array.push_back(other);
-			} else {
-				array.set(index, other);
+			array.resize(paths.size());
+			for (int i = 0; i < array.size(); i++) {
+				array.set(i, dnp.base->get_node_or_null(paths[i]));
 			}
-
-			dnp.base->set(base_property, array);
+			dnp.base->set(dnp.property, array);
 		} else {
-			dnp.base->set(dnp.property, other);
+			dnp.base->set(dnp.property, dnp.base->get_node_or_null(dnp.value));
 		}
 	}
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -72,7 +72,7 @@ class SceneState : public RefCounted {
 	struct DeferredNodePathProperties {
 		Node *base = nullptr;
 		StringName property;
-		NodePath path;
+		Variant value;
 	};
 
 	Vector<NodeData> nodes;


### PR DESCRIPTION
The check was backwards, appending if the size was greater than or equal to the index, causing it to append at the end instead. 

Not sure if we should just use a resize to be safe (I assume the indices are in order, so it never technically is greater than only equal, so probably safe)

* Fixes: #77641
* Fixes: #78150 (needs further testing, [but appears to solve crash](https://github.com/godotengine/godot/issues/78150#issuecomment-1587957215))
* Fixes: #78330 (https://github.com/godotengine/godot/issues/78330#issuecomment-1594667888)
* Fixes: #78208 (confirmed https://github.com/godotengine/godot/issues/78208#issuecomment-1597738393)
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
