### PR TITLE
C#: Fix dictionary key lookup documentation

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -41,7 +41,7 @@
 				{
 				    // Check position if it is relevant to you
 				    // Otherwise, just check data
-				    return data.VariantType == Variant.Type.Dictionary &amp;&amp; data.AsGodotDictionary().Contains("expected");
+				    return data.VariantType == Variant.Type.Dictionary &amp;&amp; data.AsGodotDictionary().ContainsKey("expected");
 				}
 				[/csharp]
 				[/codeblocks]
@@ -64,7 +64,7 @@
 				[csharp]
 				public override bool _CanDropData(Vector2 atPosition, Variant data)
 				{
-				    return data.VariantType == Variant.Type.Dictionary &amp;&amp; dict.AsGodotDictionary().Contains("color");
+				    return data.VariantType == Variant.Type.Dictionary &amp;&amp; dict.AsGodotDictionary().ContainsKey("color");
 				}
 
 				public override void _DropData(Vector2 atPosition, Variant data)

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -217,9 +217,9 @@
 				    { 210, default },
 				};
 
-				GD.Print(myDict.Contains("Godot")); // Prints true
-				GD.Print(myDict.Contains(210));     // Prints true
-				GD.Print(myDict.Contains(4));       // Prints false
+				GD.Print(myDict.ContainsKey("Godot")); // Prints true
+				GD.Print(myDict.ContainsKey(210));     // Prints true
+				GD.Print(myDict.ContainsKey(4));       // Prints false
 				[/csharp]
 				[/codeblocks]
 				In GDScript, this is equivalent to the [code]in[/code] operator:

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -93,7 +93,7 @@
 		            new Godot.Collections.Dictionary
 		            {
 		                { "name", "myOption" },
-		                { "defaultValue", false },
+		                { "default_value", false },
 		            }
 		        };
 		    }
@@ -157,12 +157,12 @@
 				    return true
 				[/gdscript]
 				[csharp]
-				public void GetOptionVisibility(string option, Godot.Collections.Dictionary options)
+				public void _GetOptionVisibility(string option, Godot.Collections.Dictionary options)
 				{
 				    // Only show the lossy quality setting if the compression mode is set to "Lossy".
-				    if (option == "compress/lossyQuality" &amp;&amp; options.Contains("compress/mode"))
+				    if (option == "compress/lossy_quality" &amp;&amp; options.ContainsKey("compress/mode"))
 				    {
-				        return (int)options["compress/mode"] == COMPRESS_LOSSY; // This is a constant you set
+				        return (int)options["compress/mode"] == CompressLossy; // This is a constant you set
 				    }
 
 				    return true;


### PR DESCRIPTION
The method to check if a key exists in the dictionary is called `ContainsKey`.

