### PR TITLE
Add null checking when finding a lightmap baking path

### DIFF
--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -79,7 +79,7 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 		switch (err) {
 			case LightmapGI::BAKE_ERROR_NO_SAVE_PATH: {
 				String scene_path = lightmap->get_scene_file_path();
-				if (scene_path.is_empty()) {
+				if (scene_path.is_empty() && lightmap->get_owner()) {
 					scene_path = lightmap->get_owner()->get_scene_file_path();
 				}
 				if (scene_path.is_empty()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
Fixes #74625.
The crash is caused by when accessing a null String from a null Node object by calling `lightmap->get_owner()`.