### PR TITLE
Fix crash when removing SpinBox during text submit

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -115,7 +115,7 @@
 				Returns the drag data from the GUI, that was previously returned by [method Control._get_drag_data].
 			</description>
 		</method>
-		<method name="gui_get_focus_owner">
+		<method name="gui_get_focus_owner" qualifiers="const">
 			<return type="Control" />
 			<description>
 				Returns the [Control] having the focus within this viewport. If no [Control] has the focus, returns null.

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -6,6 +6,14 @@ should instead be used to justify these changes and describe how users should wo
 
 ========================================================================================================================
 
+GH-77757
+--------
+Validate extension JSON: Error: Field 'classes/Viewport/methods/gui_get_focus_owner': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Hash changed for 'classes/Viewport/methods/gui_get_focus_owner', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
+
+This method does not affect the state of Viewport so it should be const.
+
+
 GH-74736
 --------
 Validate extension JSON: Error: Field 'classes/MenuBar/properties/start_index': type changed value in new API, from "bool" to "int".

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -202,7 +202,8 @@ void SpinBox::_line_edit_focus_enter() {
 
 void SpinBox::_line_edit_focus_exit() {
 	// Discontinue because the focus_exit was caused by left-clicking the arrows.
-	if (get_viewport()->gui_get_focus_owner() == get_line_edit()) {
+	Viewport *viewport = get_viewport();
+	if (!viewport || viewport->gui_get_focus_owner() == get_line_edit()) {
 		return;
 	}
 	// Discontinue because the focus_exit was caused by right-click context menu.

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -202,7 +202,7 @@ void SpinBox::_line_edit_focus_enter() {
 
 void SpinBox::_line_edit_focus_exit() {
 	// Discontinue because the focus_exit was caused by left-clicking the arrows.
-	Viewport *viewport = get_viewport();
+	const Viewport *viewport = get_viewport();
 	if (!viewport || viewport->gui_get_focus_owner() == get_line_edit()) {
 		return;
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3156,7 +3156,7 @@ void Viewport::gui_release_focus() {
 	}
 }
 
-Control *Viewport::gui_get_focus_owner() {
+Control *Viewport::gui_get_focus_owner() const {
 	ERR_READ_THREAD_GUARD_V(nullptr);
 	return gui.key_focus;
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -599,7 +599,7 @@ public:
 	int gui_get_canvas_sort_index();
 
 	void gui_release_focus();
-	Control *gui_get_focus_owner();
+	Control *gui_get_focus_owner() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 


### PR DESCRIPTION
Fixes #77755.

This work was sponsored by The Mirror.