### PR TITLE
Fix that button presses don't set event as handled in AcceptDialog

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -125,6 +125,7 @@ void AcceptDialog::_ok_pressed() {
 	}
 	ok_pressed();
 	emit_signal(SNAME("confirmed"));
+	set_input_as_handled();
 }
 
 void AcceptDialog::_cancel_pressed() {
@@ -143,6 +144,7 @@ void AcceptDialog::_cancel_pressed() {
 	if (parent_window) {
 		//parent_window->grab_focus();
 	}
+	set_input_as_handled();
 }
 
 String AcceptDialog::get_text() const {


### PR DESCRIPTION
resolve #77752
alternative to #77763

When clicking with the mouse on the OK-button of an `AcceptDialog`, the mouse event is not set to as handled.
This bug got uncovered by #77452, which removed a redundant `is_inside_tree`-check.
This is a more localized approach in comparison to #77763.
