### PR TITLE
Prevent error at creating Control nodes in threads

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3105,6 +3105,9 @@ void Control::_notification(int p_notification) {
 	ERR_MAIN_THREAD_GUARD;
 	switch (p_notification) {
 		case NOTIFICATION_POSTINITIALIZE: {
+			if (!is_readable_from_caller_thread()) {
+				break;
+			}
 			data.initialized = true;
 
 			_invalidate_theme_cache();


### PR DESCRIPTION
This PR makes the Control skip theme cache initialization if it's created in a thread. The theme properties are not accessible anyway, so *I think* it's fine if they are not correct. We could maybe document that accessing theme in thread is not possible (but other properties should be fine).

Fixes #77764