### PR TITLE
Fix minimize button missing in non-resizable projects

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1325,7 +1325,7 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_fullscre
 				r_style = WS_OVERLAPPEDWINDOW;
 			}
 		} else {
-			r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU;
+			r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77603.
On Windows, disabling the 'resizable' flag on the project settings would also remove the minimize button from the window.

### Testing
Tested by disabling the `display/window/size/resizable` flag in the project settings and we can now see the minimize button present in the window along with the the greyed out maximize button:
![image](https://github.com/godotengine/godot/assets/38991758/65a0d3d9-91f6-41c3-81d4-99fd449e82fa)

Enabling `display/window/size/resizable` back on behaves as expected.