### PR TITLE
Simplify linked vector ratio logic

### DIFF
--- a/editor/editor_properties_vector.h
+++ b/editor/editor_properties_vector.h
@@ -51,7 +51,6 @@ class EditorPropertyVectorN : public EditorProperty {
 	bool angle_in_radians = false;
 
 	void _update_ratio();
-	int _get_ratio_component(int p_idx, int p_component) const;
 	void _store_link(bool p_linked);
 	void _value_changed(double p_val, const String &p_name);
 


### PR DESCRIPTION
This PR simplifies the ratio logic of linked vector properties and removes `_get_ratio_component()` method.

The ratio array looks like this (for Vector3):
y/x
z/x
z/y
x/y
x/z
y/z

The base idea is that the array is divided in "sections" where each section corresponds to a changed component. So e.g. when you change `x` component, it will use the first section of the array, which is the ratio of the other components in relation to this component. The math is still magical, but I wrote it in a more explicit way, so it's *somewhat* readable.