### PR TITLE
[3.x] Linux: Cache TTS voice list.

### DIFF
--- a/platform/x11/tts_linux.cpp
+++ b/platform/x11/tts_linux.cpp
@@ -106,19 +106,6 @@ void TTS_Linux::speech_event_callback(size_t p_msg_id, size_t p_client_id, SPDNo
 
 			// Inject index mark after each word.
 			String text;
-			String language;
-			SPDVoice **voices = spd_list_synthesis_voices(tts->synth);
-			if (voices != nullptr) {
-				SPDVoice **voices_ptr = voices;
-				while (*voices_ptr != nullptr) {
-					if (String::utf8((*voices_ptr)->name) == message.voice) {
-						language = String::utf8((*voices_ptr)->language);
-						break;
-					}
-					voices_ptr++;
-				}
-				free_spd_voices(voices);
-			}
 			PoolIntArray breaks;
 			for (int i = 0; i < message.text.size(); i++) {
 				if (_is_whitespace(message.text[i])) {


### PR DESCRIPTION
Cherry-pick from 4.x.  Note that this simply removes the iteration through the voice list.  In 3.6 we do not use the language to do segmentation, so we do not need it at all (although later, it might be nice to pass it through to spd_set_language; it's unclear to me what precise effect this would have if we are already using a voice of the appropriate language).

Backport of #77767.

Thanks to @bruvzg for the really quick fix to #77754. 