### PR TITLE
CodeEditor: Make possible to select and copy error text

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -31,17 +31,17 @@
 #pragma once
 
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
-#include "scene/gui/check_box.h"
 #include "scene/gui/code_edit.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/label.h"
-#include "scene/gui/popup.h"
-#include "scene/main/timer.h"
 
-class MenuButton;
+class Button;
+class CheckBox;
 class CodeTextEditor;
+class Label;
 class LineEdit;
+class MenuButton;
+class RichTextLabel;
+class Timer;
 
 class GotoLinePopup : public PopupPanel {
 	GDCLASS(GotoLinePopup, PopupPanel);
@@ -138,7 +138,6 @@ public:
 	bool is_case_sensitive() const;
 	bool is_whole_words() const;
 	bool is_selection_only() const;
-	void set_error(const String &p_label);
 
 	void set_text_edit(CodeTextEditor *p_text_editor);
 
@@ -183,7 +182,7 @@ class CodeTextEditor : public VBoxContainer {
 
 	float zoom_factor = 1.0f;
 
-	Label *error = nullptr;
+	RichTextLabel *error = nullptr;
 	int error_line;
 	int error_column;
 
@@ -210,6 +209,8 @@ class CodeTextEditor : public VBoxContainer {
 	void _zoom_in();
 	void _zoom_out();
 	void _zoom_to(float p_zoom_factor);
+
+	void _update_error_content_height();
 
 	void _error_button_pressed();
 	void _warning_button_pressed();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -643,6 +643,7 @@ void ScriptEditorDebugger::_msg_error(uint64_t p_thread_id, const Array &p_data)
 	// item with the original error condition.
 	error_title += oe.error_descr.is_empty() ? oe.error : oe.error_descr;
 	error->set_text(1, error_title);
+	error->set_autowrap_mode(1, TextServer::AUTOWRAP_WORD_SMART);
 	tooltip += " " + error_title + "\n";
 
 	// Find the language of the error's source file.
@@ -980,15 +981,19 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
 	switch (p_type) {
 		case MESSAGE_ERROR:
-			reason->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
 			break;
 		case MESSAGE_WARNING:
-			reason->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 			break;
 		default:
-			reason->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("success_color"), EditorStringName(Editor)));
+			break;
 	}
+
 	reason->set_text(p_reason);
+
+	_update_reason_content_height();
 
 	const PackedInt32Array boundaries = TS->string_get_word_breaks(p_reason, "", 80);
 	PackedStringArray lines;
@@ -999,6 +1004,26 @@ void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType 
 	}
 
 	reason->set_tooltip_text(String("\n").join(lines));
+}
+
+void ScriptEditorDebugger::_update_reason_content_height() {
+	float margin_height = 0;
+	const Ref<StyleBox> style = reason->get_theme_stylebox(CoreStringName(normal));
+	if (style.is_valid()) {
+		margin_height += style->get_content_margin(SIDE_TOP) + style->get_content_margin(SIDE_BOTTOM);
+	}
+
+	const float content_height = margin_height + reason->get_content_height();
+
+	float content_max_height = margin_height;
+	for (int i = 0; i < 3; i++) {
+		if (i >= reason->get_line_count()) {
+			break;
+		}
+		content_max_height += reason->get_line_height(i);
+	}
+
+	reason->set_custom_minimum_size(Size2(0, CLAMP(content_height, 0, content_max_height)));
 }
 
 void ScriptEditorDebugger::_notification(int p_what) {
@@ -1031,7 +1056,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			vmem_export->set_button_icon(get_editor_theme_icon(SNAME("Save")));
 			search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
-			reason->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			reason->add_theme_color_override(SNAME("default_color"), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+			reason->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Label"))); // Empty stylebox.
 
 			TreeItem *error_root = error_tree->get_root();
 			if (error_root) {
@@ -1245,6 +1271,7 @@ void ScriptEditorDebugger::stop() {
 		peer.unref();
 		reason->set_text("");
 		reason->set_tooltip_text("");
+		reason->set_custom_minimum_size(Size2(0, 0));
 	}
 
 	node_path_cache.clear();
@@ -1966,14 +1993,14 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		HBoxContainer *hbc = memnew(HBoxContainer);
 		vbc->add_child(hbc);
 
-		reason = memnew(Label);
+		reason = memnew(RichTextLabel);
 		reason->set_focus_mode(FOCUS_ACCESSIBILITY);
-		reason->set_text("");
-		hbc->add_child(reason);
+		reason->set_selection_enabled(true);
+		reason->set_context_menu_enabled(true);
 		reason->set_h_size_flags(SIZE_EXPAND_FILL);
-		reason->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-		reason->set_max_lines_visible(3);
-		reason->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+		reason->set_v_size_flags(SIZE_SHRINK_CENTER);
+		reason->connect(SceneStringName(resized), callable_mp(this, &ScriptEditorDebugger::_update_reason_content_height));
+		hbc->add_child(reason);
 
 		hbc->add_child(memnew(VSeparator));
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -118,7 +118,7 @@ private:
 
 	TabContainer *tabs = nullptr;
 
-	Label *reason = nullptr;
+	RichTextLabel *reason = nullptr;
 
 	Button *skip_breakpoints = nullptr;
 	Button *ignore_error_breaks = nullptr;
@@ -231,6 +231,7 @@ private:
 
 	void _parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data);
 	void _set_reason_text(const String &p_reason, MessageType p_type);
+	void _update_reason_content_height();
 	void _update_buttons_state();
 	void _remote_object_selected(ObjectID p_object);
 	void _remote_objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -819,10 +819,12 @@ void ScriptTextEditor::_validate_script() {
 		}
 
 		if (errors.size() > 0) {
-			// TRANSLATORS: Script error pointing to a line and column number.
-			String error_text = vformat(TTR("Error at (%d, %d):"), errors.front()->get().line, errors.front()->get().column) + " " + errors.front()->get().message;
+			const int line = errors.front()->get().line;
+			const int column = errors.front()->get().column;
+			const String message = errors.front()->get().message.replace("[", "[lb]");
+			const String error_text = vformat(TTR("Error at ([hint=Line %d, column %d]%d, %d[/hint]):"), line, column, line, column) + " " + message;
 			code_editor->set_error(error_text);
-			code_editor->set_error_pos(errors.front()->get().line - 1, errors.front()->get().column - 1);
+			code_editor->set_error_pos(line - 1, column - 1);
 		}
 		script_is_valid = false;
 	} else {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -200,7 +200,7 @@ void TextEditor::_validate_script() {
 		code_editor->set_error("");
 
 		if (json_file->parse(te->get_text(), true) != OK) {
-			code_editor->set_error(json_file->get_error_message());
+			code_editor->set_error(json_file->get_error_message().replace("[", "[lb]"));
 			code_editor->set_error_pos(json_file->get_error_line(), 0);
 			te->set_line_background_color(code_editor->get_error_pos().x, EDITOR_GET("text_editor/theme/highlighting/mark_color"));
 		}

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -515,28 +515,35 @@ void ShaderTextEditor::_validate_script() {
 	set_error_count(0);
 
 	if (last_compile_result != OK) {
-		//preprocessor error
+		// Preprocessor error.
 		ERR_FAIL_COND(err_positions.is_empty());
 
-		String err_text = error_pp;
-		int err_line = err_positions.front()->get().line;
+		String err_text;
+		const int err_line = err_positions.front()->get().line;
 		if (err_positions.size() == 1) {
-			// Error in main file
-			err_text = "error(" + itos(err_line) + "): " + err_text;
+			// Error in the main file.
+			const String message = error_pp.replace("[", "[lb]");
+
+			err_text = vformat(TTR("Error at line %d:"), err_line) + " " + message;
 		} else {
-			err_text = "error(" + itos(err_line) + ") in include " + err_positions.back()->get().file.get_file() + ":" + itos(err_positions.back()->get().line) + ": " + err_text;
+			// Error in an included file.
+			const String inc_file = err_positions.back()->get().file.get_file();
+			const int inc_line = err_positions.back()->get().line;
+			const String message = error_pp.replace("[", "[lb]");
+
+			err_text = vformat(TTR("Error at line %d in include %s:%d:"), err_line, inc_file, inc_line) + " " + message;
 			set_error_count(err_positions.size() - 1);
 		}
 
 		set_error(err_text);
 		set_error_pos(err_line - 1, 0);
+
 		for (int i = 0; i < get_text_editor()->get_line_count(); i++) {
 			get_text_editor()->set_line_background_color(i, Color(0, 0, 0, 0));
 		}
 		get_text_editor()->set_line_background_color(err_line - 1, marked_line_color);
 
 		set_warning_count(0);
-
 	} else {
 		ShaderLanguage sl;
 
@@ -579,21 +586,33 @@ void ShaderTextEditor::_validate_script() {
 		last_compile_result = sl.compile(code, comp_info);
 
 		if (last_compile_result != OK) {
+			Vector<ShaderLanguage::FilePosition> include_positions = sl.get_include_positions();
+
 			String err_text;
 			int err_line;
-			Vector<ShaderLanguage::FilePosition> include_positions = sl.get_include_positions();
 			if (include_positions.size() > 1) {
-				//error is in an include
+				// Error in an included file.
 				err_line = include_positions[0].line;
-				err_text = "error(" + itos(err_line) + ") in include " + include_positions[include_positions.size() - 1].file + ":" + itos(include_positions[include_positions.size() - 1].line) + ": " + sl.get_error_text();
+
+				const String inc_file = include_positions[include_positions.size() - 1].file;
+				const int inc_line = include_positions[include_positions.size() - 1].line;
+				const String message = sl.get_error_text().replace("[", "[lb]");
+
+				err_text = vformat(TTR("Error at line %d in include %s:%d:"), err_line, inc_file, inc_line) + " " + message;
 				set_error_count(include_positions.size() - 1);
 			} else {
+				// Error in the main file.
 				err_line = sl.get_error_line();
-				err_text = "error(" + itos(err_line) + "): " + sl.get_error_text();
+
+				const String message = sl.get_error_text().replace("[", "[lb]");
+
+				err_text = vformat(TTR("Error at line %d:"), err_line) + " " + message;
 				set_error_count(0);
 			}
+
 			set_error(err_text);
 			set_error_pos(err_line - 1, 0);
+
 			get_text_editor()->set_line_background_color(err_line - 1, marked_line_color);
 		} else {
 			set_error("");
@@ -624,9 +643,12 @@ void ShaderTextEditor::_update_warning_panel() {
 	for (const ShaderWarning &w : warnings) {
 		if (warning_count == 0) {
 			if (saved_treat_warning_as_errors) {
-				String error_text = "error(" + itos(w.get_line()) + "): " + w.get_message() + " " + TTR("Warnings should be fixed to prevent errors.");
-				set_error_pos(w.get_line() - 1, 0);
+				const String message = (w.get_message() + " " + TTR("Warnings should be fixed to prevent errors.")).replace("[", "[lb]");
+				const String error_text = vformat(TTR("Error at line %d:"), w.get_line()) + " " + message;
+
 				set_error(error_text);
+				set_error_pos(w.get_line() - 1, 0);
+
 				get_text_editor()->set_line_background_color(w.get_line() - 1, marked_line_color);
 			}
 		}


### PR DESCRIPTION
* Closes godotengine/godot-proposals#6998.
* Closes godotengine/godot-proposals#9551.

![](https://github.com/godotengine/godot/assets/47700418/d89efbda-2daf-4ada-a162-68543ccb2b35)
![](https://github.com/godotengine/godot/assets/47700418/9a96a382-9644-4b9a-97f1-a0eb5bc7fcc8)
![](https://github.com/godotengine/godot/assets/47700418/5b10ec82-b457-4346-aa37-a2b44de39e0e)

* Replace `Label` with `RichTextLabel`, enable selection and context menu.
  * This also removes horizontal scrolling.
* Replace unnecessary includes with forward declaration.
* Remove unnecessary overrides in `_update_text_editor_theme()`.