### PR TITLE
Fix profilers' GUI trees

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -660,15 +660,15 @@ EditorProfiler::EditorProfiler() {
 	variables->set_column_title(0, TTR("Name"));
 	variables->set_column_expand(0, true);
 	variables->set_column_clip_content(0, true);
-	variables->set_column_expand_ratio(0, 60);
+	variables->set_column_custom_minimum_width(0, 60);
 	variables->set_column_title(1, TTR("Time"));
 	variables->set_column_expand(1, false);
 	variables->set_column_clip_content(1, true);
-	variables->set_column_expand_ratio(1, 100);
+	variables->set_column_custom_minimum_width(1, 75 * EDSCALE);
 	variables->set_column_title(2, TTR("Calls"));
 	variables->set_column_expand(2, false);
 	variables->set_column_clip_content(2, true);
-	variables->set_column_expand_ratio(2, 60);
+	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -114,7 +114,7 @@ String EditorVisualProfiler::_get_time_as_text(float p_time) {
 	int dmode = display_mode->get_selected();
 
 	if (dmode == DISPLAY_FRAME_TIME) {
-		return TS->format_number(rtos(p_time)) + " " + RTR("ms");
+		return TS->format_number(String::num(p_time, 2)) + " " + RTR("ms");
 	} else if (dmode == DISPLAY_FRAME_PERCENT) {
 		return TS->format_number(String::num(p_time * 100 / graph_limit, 2)) + " " + TS->percent_sign();
 	}
@@ -790,11 +790,11 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_column_title(1, TTR("CPU"));
 	variables->set_column_expand(1, false);
 	variables->set_column_clip_content(1, true);
-	variables->set_column_custom_minimum_width(1, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(1, 75 * EDSCALE);
 	variables->set_column_title(2, TTR("GPU"));
 	variables->set_column_expand(2, false);
 	variables->set_column_clip_content(2, true);
-	variables->set_column_custom_minimum_width(2, 60 * EDSCALE);
+	variables->set_column_custom_minimum_width(2, 75 * EDSCALE);
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 
 	graph = memnew(TextureRect);


### PR DESCRIPTION
![image](https://github.com/godotengine/godot/assets/85438892/a97ab0d4-8fc4-4da1-85d2-05cab218dc26)

Fixes this by using 2 digits of precision and tweaking the minimum width.

-----

![image](https://github.com/godotengine/godot/assets/85438892/2e40ba63-dcec-4d6e-ae2a-64de3b3550c9)

Fixes this by using minimum width for the columns instead of expand ratio.

-----

Any two digit number is shown properly with this setup, but it's still messed up with more numbers. I don't think this is fixable with Tree's current API.