### PR TITLE
Tree: Add ability to configure text autowrap mode for individual cells

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -73,6 +73,13 @@
 				Removes the button at index [param button_index] in column [param column].
 			</description>
 		</method>
+		<method name="get_autowrap_mode" qualifiers="const">
+			<return type="int" enum="TextServer.AutowrapMode" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the text autowrap mode in the given [param column]. By default it is [constant TextServer.AUTOWRAP_OFF].
+			</description>
+		</method>
 		<method name="get_button" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="column" type="int" />
@@ -446,6 +453,14 @@
 			<param index="0" name="column" type="int" />
 			<description>
 				Selects the given [param column].
+			</description>
+		</method>
+		<method name="set_autowrap_mode">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="autowrap_mode" type="int" enum="TextServer.AutowrapMode" />
+			<description>
+				Sets the autowrap mode in the given [param column]. If set to something other than [constant TextServer.AUTOWRAP_OFF], the text gets wrapped inside the cell's bounding rectangle.
 			</description>
 		</method>
 		<method name="set_button">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -69,6 +69,7 @@ private:
 		TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 		Array st_args;
 		Control::TextDirection text_direction = Control::TEXT_DIRECTION_INHERITED;
+		TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 		bool dirty = true;
 		double min = 0.0;
 		double max = 100.0;
@@ -226,6 +227,9 @@ public:
 
 	void set_text_direction(int p_column, Control::TextDirection p_text_direction);
 	Control::TextDirection get_text_direction(int p_column) const;
+
+	void set_autowrap_mode(int p_column, TextServer::AutowrapMode p_mode);
+	TextServer::AutowrapMode get_autowrap_mode(int p_column) const;
 
 	void set_structured_text_bidi_override(int p_column, TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override(int p_column) const;


### PR DESCRIPTION
#76532 fixed a regression caused by adding support for multiline cells (#61714), but introduced a non-configurable autowrapping, which might not be desirable. This PR restores the old behavior by default (no autowrapping, unless explicit newlines) and adds the ability to customize the mode.

Testing is very welcome, since i can't believe the solution can be so simple.

Closes #77067.