### PR TITLE
Prevent disappearance of mouse when SpinBox is hidden while dragging

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -249,6 +249,9 @@ void SpinBox::_notification(int p_what) {
 			_update_text();
 		} break;
 
+		case NOTIFICATION_VISIBILITY_CHANGED:
+			drag.allowed = false;
+			[[fallthrough]];
 		case NOTIFICATION_EXIT_TREE: {
 			_release_mouse();
 		} break;


### PR DESCRIPTION
Fixes #77803. Fixes https://github.com/godotengine/godot/issues/76729.