### PR TITLE
Use depth pass mode with normals if required, even if Environment is null

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1699,6 +1699,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 					scene_state.used_normal_texture) {
 				depth_pass_mode = PASS_MODE_DEPTH_NORMAL_ROUGHNESS;
 			}
+		} else if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_NORMAL_BUFFER || scene_state.used_normal_texture) {
+			depth_pass_mode = PASS_MODE_DEPTH_NORMAL_ROUGHNESS;
 		}
 
 		switch (depth_pass_mode) {


### PR DESCRIPTION
If using normal buffer debugging or if the normal texture was used, we should use `PASS_MODE_DEPTH_NORMAL_ROUGHNESS` regardless of whether there is a valid Environment or not. Otherwise, shaders reading the normal texture will not work without a valid Environment (and possibly other problems), even though we don't actually need to use one.

![image](https://github.com/godotengine/godot/assets/48544263/718b91ac-185e-4648-86a9-86024524965a)

Fixes #75794 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
