### PR TITLE
Clarify the docs on Node.queue_free

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -654,7 +654,8 @@
 		<method name="queue_free">
 			<return type="void" />
 			<description>
-				Queues a node for deletion at the end of the current frame. When deleted, all of its child nodes will be deleted as well. This method ensures it's safe to delete the node, contrary to [method Object.free]. Use [method Object.is_queued_for_deletion] to check whether a node will be deleted at the end of the frame.
+				Queues a node for deletion at the end of the current frame. When deleted, all of its child nodes will be deleted as well, and all references to the node and its children will become invalid, see [method Object.free].
+				It is safe to call [method queue_free] multiple times per frame on a node, and to [method Object.free] a node that is currently queued for deletion. Use [method Object.is_queued_for_deletion] to check whether a node will be deleted at the end of the frame.
 			</description>
 		</method>
 		<method name="remove_child">


### PR DESCRIPTION
Fixes #77793

`This method ensures it's safe to delete the node, contrary to [method Object.free].`  can interpreted to mean basically anything so instead list what (deletion related things) you can safely do with the method.