### PR TITLE
Enhance icon fallback and their docs for exporters

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -268,7 +268,7 @@
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
-			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
+			Icon used for the project, set when project loads. Exporters will also use this icon as a fallback if necessary.
 		</member>
 		<member name="application/config/macos_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].icns[/code] format used on macOS to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -59,14 +59,17 @@
 		<member name="keystore/debug" type="String" setter="" getter="">
 			Path of the debug keystore file.
 			Can be overridden with the environment variable [code]GODOT_ANDROID_KEYSTORE_DEBUG_PATH[/code].
+			Fallbacks to [code]EditorSettings.export/android/debug_keystore[/code] if empty.
 		</member>
 		<member name="keystore/debug_password" type="String" setter="" getter="">
 			Password for the debug keystore file.
 			Can be overridden with the environment variable [code]GODOT_ANDROID_KEYSTORE_DEBUG_PASSWORD[/code].
+			Fallbacks to [code]EditorSettings.export/android/debug_keystore_pass[/code] if both it and [member keystore/debug] are empty.
 		</member>
 		<member name="keystore/debug_user" type="String" setter="" getter="">
 			User name for the debug keystore file.
 			Can be overridden with the environment variable [code]GODOT_ANDROID_KEYSTORE_DEBUG_USER[/code].
+			Fallbacks to [code]EditorSettings.export/android/debug_keystore_user[/code] if both it and [member keystore/debug] are empty.
 		</member>
 		<member name="keystore/release" type="String" setter="" getter="">
 			Path of the release keystore file.
@@ -87,7 +90,7 @@
 			Foreground layer of the application adaptive icon file.
 		</member>
 		<member name="launcher_icons/main_192x192" type="String" setter="" getter="">
-			Application icon file. If left empty, project icon is used instead.
+			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="package/app_category" type="int" setter="" getter="">
 			Application category for the Play Store.

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2542,7 +2542,6 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 		if (ep.step(vformat(TTR("Signing debug %s..."), export_label), 104)) {
 			return ERR_SKIP;
 		}
-
 	} else {
 		keystore = release_keystore;
 		password = release_password;

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -69,73 +69,73 @@
 			Path to the custom export template. If left empty, default template is used.
 		</member>
 		<member name="icons/app_store_1024x1024" type="String" setter="" getter="">
-			App Store application icon file. If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			App Store application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/ipad_76x76" type="String" setter="" getter="">
-			Home screen application icon file on iPad (1x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Home screen application icon file on iPad (1x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/ipad_152x152" type="String" setter="" getter="">
-			Home screen application icon file on iPad (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Home screen application icon file on iPad (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/ipad_167x167" type="String" setter="" getter="">
-			Home screen application icon file on iPad (3x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Home screen application icon file on iPad (3x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/iphone_120x120" type="String" setter="" getter="">
-			Home screen application icon file on iPhone (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Home screen application icon file on iPhone (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/iphone_180x180" type="String" setter="" getter="">
-			Home screen application icon file on iPhone (3x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Home screen application icon file on iPhone (3x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/notification_40x40" type="String" setter="" getter="">
-			Notification icon file on iPad and iPhone (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Notification icon file on iPad and iPhone (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/notification_60x60" type="String" setter="" getter="">
-			Notification icon file on iPhone (3x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Notification icon file on iPhone (3x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/settings_58x58" type="String" setter="" getter="">
-			Application settings icon file on iPad and iPhone (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Application settings icon file on iPad and iPhone (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/settings_87x87" type="String" setter="" getter="">
-			Application settings icon file on iPhone (3x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Application settings icon file on iPhone (3x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/spotlight_40x40" type="String" setter="" getter="">
-			Spotlight icon file on iPad (1x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Spotlight icon file on iPad (1x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="icons/spotlight_80x80" type="String" setter="" getter="">
-			Spotlight icon file on iPad and iPhone (2x DPI). If left empty, project icon is used instead. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
+			Spotlight icon file on iPad and iPhone (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].
 		</member>
 		<member name="landscape_launch_screens/ipad_1024x768" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="landscape_launch_screens/ipad_2048x1536" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="landscape_launch_screens/iphone_2208x1242" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="landscape_launch_screens/iphone_2436x1125" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/ipad_768x1024" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/ipad_1536x2048" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/iphone_640x960" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/iphone_640x1136" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/iphone_750x1334" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/iphone_1125x2436" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="portrait_launch_screens/iphone_1242x2208" type="String" setter="" getter="">
-			Application launch screen image file, if left empty project splash screen is used instead.
+			Application launch screen image file. If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="privacy/camera_usage_description" type="String" setter="" getter="">
 			A message displayed when requesting access to the device's camera (in English).
@@ -159,10 +159,10 @@
 			A custom background color of the storyboard launch screen.
 		</member>
 		<member name="storyboard/custom_image@2x" type="String" setter="" getter="">
-			Application launch screen image file (2x DPI), if left empty project splash screen is used instead.
+			Application launch screen image file (2x DPI). If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="storyboard/custom_image@3x" type="String" setter="" getter="">
-			Application launch screen image file (3x DPI), if left empty project splash screen is used instead.
+			Application launch screen image file (3x DPI). If left empty, it will fallback to [member ProjectSettings.application/boot_splash/image].
 		</member>
 		<member name="storyboard/image_scale_mode" type="int" setter="" getter="">
 			Launch screen image scaling mode.

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -23,7 +23,7 @@
 			Copyright notice for the bundle visible to the user (localized).
 		</member>
 		<member name="application/icon" type="String" setter="" getter="">
-			Application icon file. If left empty, project icon is used instead.
+			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/macos_native_icon], and  then to [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1677,6 +1677,8 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			String icon_path;
 			if (p_preset->get("application/icon") != "") {
 				icon_path = p_preset->get("application/icon");
+			} else if (GLOBAL_GET("application/config/macos_native_icon") != "") {
+				icon_path = GLOBAL_GET("application/config/macos_native_icon");
 			} else {
 				icon_path = GLOBAL_GET("application/config/icon");
 			}

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -13,7 +13,7 @@
 			Company that produced the application. Required. See [url=https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block]StringFileInfo[/url].
 		</member>
 		<member name="application/console_wrapper_icon" type="String" setter="" getter="">
-			Console wrapper icon file. If left empty, application icon is used instead.
+			Console wrapper icon file. If left empty, it will fallback to [member application/icon], then to [member ProjectSettings.application/config/windows_native_icon], and lastly, [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="application/copyright" type="String" setter="" getter="">
 			Copyright notice for the bundle visible to the user. Optional. See [url=https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block]StringFileInfo[/url].
@@ -25,7 +25,7 @@
 			Version number of the file. Required. See [url=https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block]StringFileInfo[/url].
 		</member>
 		<member name="application/icon" type="String" setter="" getter="">
-			Application icon file. If left empty, project icon is used instead.
+			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/windows_native_icon], and  then to [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -399,7 +399,16 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 	}
 #endif
 
-	String icon_path = ProjectSettings::get_singleton()->globalize_path(p_preset->get("application/icon"));
+	String icon_path;
+	if (p_preset->get("application/icon") != "") {
+		icon_path = p_preset->get("application/icon");
+	} else if (GLOBAL_GET("application/config/windows_native_icon") != "") {
+		icon_path = GLOBAL_GET("application/config/windows_native_icon");
+	} else {
+		icon_path = GLOBAL_GET("application/config/icon");
+	}
+	icon_path = ProjectSettings::get_singleton()->globalize_path(icon_path);
+
 	if (p_console_icon) {
 		String console_icon_path = ProjectSettings::get_singleton()->globalize_path(p_preset->get("application/console_wrapper_icon"));
 		if (!console_icon_path.is_empty() && FileAccess::exists(console_icon_path)) {


### PR DESCRIPTION
- Make Windows exporter fallback to other alternatives (first `application/config/windows_native_icon` then `application/config/icon`) if no icon was set.
- Make macOS exporter fallback to `application/config/macos_native_icon` first, and then `application/config/icon`.
- Improve exporter doc pages with references and better wording.