### PR TITLE
Add dotnet/project/solution_name project setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -808,11 +808,14 @@
 			[b]Note:[/b] This property is only read when the project starts. To change the V-Sync mode at runtime, call [method DisplayServer.window_set_vsync_mode] instead.
 		</member>
 		<member name="dotnet/project/assembly_name" type="String" setter="" getter="" default="&quot;&quot;">
-			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] and [code].sln[/code] files. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
+			Name of the .NET assembly. This name is used as the name of the [code].csproj[/code] file. By default, it's set to the name of the project ([member application/config/name]) allowing to change it in the future without affecting the .NET assembly.
 		</member>
 		<member name="dotnet/project/solution_directory" type="String" setter="" getter="" default="&quot;&quot;">
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
+		</member>
+		<member name="dotnet/project/solution_name" type="String" setter="" getter="" default="&quot;&quot;">
+			Name of the .NET solution. This name is used as the name of the [code].sln[/code] file. By default, it's set to the assembly name ([member dotnet/project/assembly_name]).
 		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resources are converted to a binary format on export. This decreases file sizes and speeds up loading slightly.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2723,6 +2723,7 @@ bool Main::start() {
 		// so that we don't lose their descriptions and default values in DocTools.
 		// Default values should be synced with mono_gd/gd_mono.cpp.
 		GLOBAL_DEF("dotnet/project/assembly_name", "");
+		GLOBAL_DEF("dotnet/project/solution_name", "");
 		GLOBAL_DEF("dotnet/project/solution_directory", "");
 #endif
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -111,6 +111,7 @@ void CSharpLanguage::init() {
 
 	GLOBAL_DEF("dotnet/project/assembly_name", "");
 #ifdef TOOLS_ENABLED
+	GLOBAL_DEF("dotnet/project/solution_name", "");
 	GLOBAL_DEF("dotnet/project/solution_directory", "");
 #endif
 

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -66,6 +66,13 @@ namespace GodotTools.Internals
                 ProjectSettings.SetSetting("dotnet/project/assembly_name", _projectAssemblyName);
             }
 
+            _projectSolutionName = (string)ProjectSettings.GetSetting("dotnet/project/solution_name");
+            if (string.IsNullOrEmpty(_projectSolutionName))
+            {
+                _projectSolutionName = _projectAssemblyName;
+                ProjectSettings.SetSetting("dotnet/project/solution_name", _projectSolutionName);
+            }
+
             string slnParentDir = (string)ProjectSettings.GetSetting("dotnet/project/solution_directory");
             if (string.IsNullOrEmpty(slnParentDir))
                 slnParentDir = "res://";
@@ -76,13 +83,14 @@ namespace GodotTools.Internals
             string csprojParentDir = "res://";
 
             _projectSlnPath = Path.Combine(ProjectSettings.GlobalizePath(slnParentDir),
-                string.Concat(_projectAssemblyName, ".sln"));
+                string.Concat(_projectSolutionName, ".sln"));
 
             _projectCsProjPath = Path.Combine(ProjectSettings.GlobalizePath(csprojParentDir),
                 string.Concat(_projectAssemblyName, ".csproj"));
         }
 
         private static string _projectAssemblyName;
+        private static string _projectSolutionName;
         private static string _projectSlnPath;
         private static string _projectCsProjPath;
 
@@ -93,6 +101,16 @@ namespace GodotTools.Internals
                 if (_projectAssemblyName == null)
                     DetermineProjectLocation();
                 return _projectAssemblyName;
+            }
+        }
+
+        public static string ProjectSolutionName
+        {
+            get
+            {
+                if (_projectSolutionName == null)
+                    DetermineProjectLocation();
+                return _projectSolutionName;
             }
         }
 


### PR DESCRIPTION
Adds dotnet/project/solution_name project setting for .NET projects where the filename of the `.sln` file is different to the file name for the `.csproj` file.

Godot Proposal: fixes https://github.com/godotengine/godot-proposals/issues/6985