### PR TITLE
Update size according to the order of entering tree

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3128,6 +3128,8 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+			data.is_rtl_dirty = true;
+			_size_changed();
 #ifdef TOOLS_ENABLED
 			if (is_part_of_edited_scene()) {
 				// Don't translate Controls on scene when inside editor.
@@ -3136,11 +3138,6 @@ void Control::_notification(int p_notification) {
 			}
 #endif
 			notification(NOTIFICATION_THEME_CHANGED);
-		} break;
-
-		case NOTIFICATION_POST_ENTER_TREE: {
-			data.is_rtl_dirty = true;
-			_size_changed();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {


### PR DESCRIPTION
To calculate the size of a control, it is necessary to first calculate the size of the parent control.

Previously, the `size` was actually calculated on first display, and the call in `NOTIFICATION_POST_ENTER_TREE` was not necessary. In other words, `size` is not calculated correctly if it is hidden.



Fixes #77815.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
