### PR TITLE
Change the "Physics Engine" project settings to prompt a restart

### DIFF
--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -912,6 +912,7 @@ void PhysicsServer2DManager::on_servers_changed() {
 		physics_servers += "," + get_server_name(i);
 	}
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, setting_property_name, PROPERTY_HINT_ENUM, physics_servers));
+	ProjectSettings::get_singleton()->set_restart_if_changed(setting_property_name, true);
 }
 
 void PhysicsServer2DManager::_bind_methods() {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -1079,6 +1079,7 @@ void PhysicsServer3DManager::on_servers_changed() {
 		physics_servers2 += "," + get_server_name(i);
 	}
 	ProjectSettings::get_singleton()->set_custom_property_info(PropertyInfo(Variant::STRING, setting_property_name, PROPERTY_HINT_ENUM, physics_servers2));
+	ProjectSettings::get_singleton()->set_restart_if_changed(setting_property_name, true);
 }
 
 void PhysicsServer3DManager::_bind_methods() {


### PR DESCRIPTION
When changing the physics engine in Godot, you currently aren't prompted to restart the editor, which can create some weird situations, where the editor will be running one physics engine, but when launching the actual game/application you will run with another physics engine.

In the case of Godot Jolt for example, this means the user won't receive some of the important warnings that might be emitted when changing certain unsupported properties in the editor.

This PR changes the "Physics Engine" project settings, found under `physics/2d` and `physics/3d`, to prompt a restart of the editor when changed.