### PR TITLE
Add spring tween to `AnimationTrackEditor`

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6720,6 +6720,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	transition_selection->add_item(TTR("Circ", "Transition Type"), Tween::TRANS_CIRC);
 	transition_selection->add_item(TTR("Bounce", "Transition Type"), Tween::TRANS_BOUNCE);
 	transition_selection->add_item(TTR("Back", "Transition Type"), Tween::TRANS_BACK);
+	transition_selection->add_item(TTR("Spring", "Transition Type"), Tween::TRANS_SPRING);
 	transition_selection->select(Tween::TRANS_LINEAR); // Default
 	transition_selection->set_auto_translate(false); // Translation context is needed.
 	ease_selection = memnew(OptionButton);


### PR DESCRIPTION
Follow up #76899.

`AnimationTrackEditor` has the feature to bake Tweens and needs to add an item to the list.

![image](https://github.com/godotengine/godot/assets/61938263/6b4a9b20-8441-4b99-a106-78cb3158d361)
