### PR TITLE
Make panning the 3D view with trackpad goes the right way

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2096,7 +2096,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 		switch (nav_mode) {
 			case NAVIGATION_PAN: {
-				_nav_pan(pan_gesture, pan_gesture->get_delta());
+				_nav_pan(pan_gesture, -pan_gesture->get_delta());
 
 			} break;
 
@@ -2106,7 +2106,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			} break;
 
 			case NAVIGATION_ORBIT: {
-				_nav_orbit(pan_gesture, pan_gesture->get_delta());
+				_nav_orbit(pan_gesture, -pan_gesture->get_delta());
 
 			} break;
 


### PR DESCRIPTION
Fixes #77848

Edit : realised that when rotation was locked it was still going the wrong way if you tried to rotate and that it would pan the view instead. So looked at it again and discovered that rotation was going the wrong way when panning too which in turn made panning the view when rotation is locked being in the wrong way. Fixed it by doing the same thing for rotation that i did for panning which is putting a minus 😄 

