### PR TITLE
Fix VideoStreamPlayer seamless loop

### DIFF
--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -281,6 +281,9 @@ void VideoStreamPlayer::play() {
 	set_process_internal(true);
 	last_audio_time = 0;
 
+	// We update the playback to render the first frame immediately.
+	playback->update(0);
+
 	if (!can_process()) {
 		_notification(NOTIFICATION_PAUSED);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Part of a group of three PRs (#77856 #77857 #77858) that solve https://github.com/godotengine/godot-proposals/issues/264.

This PR enables seamless looping in VideoStreamPlayer nodes with connecting the `on_finished` signal to the `play()` function. Currently doing this will result in a blank frame due to the fact that the internal processing trigger only fires again on the next frame, which means the draw call on the current frame will draw an empty texture. With this change the texture is already updated with the newly started playback, which renders the first frame to the texture instead of leaving it blank, eliminating the one frame flash of transparency of the previous implementation.

Before (note the flash of background when the loop restarts):

https://github.com/godotengine/godot/assets/129700584/f683ace6-32fc-435e-a246-01d5e7edf0d7



After (no flash of background):

https://github.com/godotengine/godot/assets/129700584/fc486406-0ec9-4985-8321-448dcbe8d7de


