### PR TITLE
Add `loop` property to VideoStreamPlayer

### DIFF
--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -61,6 +61,9 @@
 		<member name="expand" type="bool" setter="set_expand" getter="has_expand" default="false">
 			If [code]true[/code], the video scales to the control size. Otherwise, the control minimum size will be automatically adjusted to match the video stream's dimensions.
 		</member>
+		<member name="loop" type="bool" setter="set_loop" getter="has_loop" default="false">
+			If [code]true[/code], the video restarts when it reaches its end.
+		</member>
 		<member name="paused" type="bool" setter="set_paused" getter="is_paused" default="false">
 			If [code]true[/code], the video is paused.
 		</member>

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -159,6 +159,10 @@ void VideoStreamPlayer::_notification(int p_notification) {
 			playback->update(delta); // playback->is_playing() returns false in the last video frame
 
 			if (!playback->is_playing()) {
+				if (loop) {
+					play();
+					return;
+				}
 				emit_signal(SceneStringNames::get_singleton()->finished);
 			}
 		} break;
@@ -219,6 +223,14 @@ void VideoStreamPlayer::set_expand(bool p_expand) {
 
 bool VideoStreamPlayer::has_expand() const {
 	return expand;
+}
+
+void VideoStreamPlayer::set_loop(bool p_loop) {
+	loop = p_loop;
+}
+
+bool VideoStreamPlayer::has_loop() const {
+	return loop;
 }
 
 void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
@@ -458,6 +470,9 @@ void VideoStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_paused", "paused"), &VideoStreamPlayer::set_paused);
 	ClassDB::bind_method(D_METHOD("is_paused"), &VideoStreamPlayer::is_paused);
 
+	ClassDB::bind_method(D_METHOD("set_loop", "loop"), &VideoStreamPlayer::set_loop);
+	ClassDB::bind_method(D_METHOD("has_loop"), &VideoStreamPlayer::has_loop);
+
 	ClassDB::bind_method(D_METHOD("set_volume", "volume"), &VideoStreamPlayer::set_volume);
 	ClassDB::bind_method(D_METHOD("get_volume"), &VideoStreamPlayer::get_volume);
 
@@ -495,6 +510,7 @@ void VideoStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "has_autoplay");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_paused", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand"), "set_expand", "has_expand");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "loop"), "set_loop", "has_loop");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "buffering_msec", PROPERTY_HINT_RANGE, "10,1000,suffix:ms"), "set_buffering_msec", "get_buffering_msec");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stream_position", PROPERTY_HINT_RANGE, "0,1280000,0.1", PROPERTY_USAGE_NONE), "set_stream_position", "get_stream_position");
 

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -65,6 +65,7 @@ class VideoStreamPlayer : public Control {
 	float volume = 1.0;
 	double last_audio_time = 0.0;
 	bool expand = false;
+	bool loop = false;
 	int buffering_ms = 500;
 	int audio_track = 0;
 	int bus_index = 0;
@@ -93,6 +94,9 @@ public:
 	void play();
 	void stop();
 	bool is_playing() const;
+
+	void set_loop(bool p_loop);
+	bool has_loop() const;
 
 	void set_paused(bool p_paused);
 	bool is_paused() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Part of a group of three PRs (#77856 #77857 #77858) that solve https://github.com/godotengine/godot-proposals/issues/264.

Currently, the only way to get a VideoStreamPlayer to loop, is by connecting the `on_finished` signal to the `play()` function. This can be confusing for new users unfamiliar with signals and buries a feature that is commonly used behind a number of clicks. This PR creates a new toggle to enable looping on VideoStreamPlayer nodes. The effect is identical as connecting the signal, the change is only for making the UI more intuitive.