### PR TITLE
Expose VideoStreamPlayer video length

### DIFF
--- a/doc/classes/VideoStreamPlayer.xml
+++ b/doc/classes/VideoStreamPlayer.xml
@@ -12,6 +12,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_stream_length" qualifiers="const">
+			<return type="float" />
+			<description>
+				The length of the current stream, in seconds.
+				[b]Note:[/b] For [VideoStreamTheora] streams (the built-in format supported by Godot), this value will always be zero, as getting the stream length is not implemented yet. The feature may be supported by video formats implemented by a GDExtension add-on.
+			</description>
+		</method>
 		<method name="get_stream_name" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -386,6 +386,13 @@ String VideoStreamPlayer::get_stream_name() const {
 	return stream->get_name();
 }
 
+double VideoStreamPlayer::get_stream_length() const {
+	if (playback.is_null()) {
+		return 0;
+	}
+	return playback->get_length();
+}
+
 double VideoStreamPlayer::get_stream_position() const {
 	if (playback.is_null()) {
 		return 0;
@@ -468,6 +475,7 @@ void VideoStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_audio_track"), &VideoStreamPlayer::get_audio_track);
 
 	ClassDB::bind_method(D_METHOD("get_stream_name"), &VideoStreamPlayer::get_stream_name);
+	ClassDB::bind_method(D_METHOD("get_stream_length"), &VideoStreamPlayer::get_stream_length);
 
 	ClassDB::bind_method(D_METHOD("set_stream_position", "position"), &VideoStreamPlayer::set_stream_position);
 	ClassDB::bind_method(D_METHOD("get_stream_position"), &VideoStreamPlayer::get_stream_position);

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -104,6 +104,7 @@ public:
 	float get_volume_db() const;
 
 	String get_stream_name() const;
+	double get_stream_length() const;
 	double get_stream_position() const;
 	void set_stream_position(double p_position);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Part of a group of three PRs (#77856 #77857 #77858) that solve https://github.com/godotengine/godot-proposals/issues/264.

Currently, there is no way to determine the length of the video file being played in a VideoStreamPlayer. This PR exposes the get_length function of the VideoStreamPlayback to the VideoStreamPlayer in the editor. Right now this function returns 0 on Theora streams, however, GDExtension based VideoStreams may implement it.

In the future I might implement getting the length of Theora streams in a separate PR. 