### PR TITLE
Use cached hue for color picker when saturation is 0 

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -117,8 +117,13 @@ float ColorModeHSV::get_slider_max(int idx) const {
 
 float ColorModeHSV::get_slider_value(int idx) const {
 	switch (idx) {
-		case 0:
-			return color_picker->get_pick_color().get_h() * 360.0;
+		case 0: {
+			if (color_picker->get_pick_color().get_s() > 0) {
+				return color_picker->get_pick_color().get_h() * 360.0;
+			} else {
+				return color_picker->get_cached_hue();
+			}
+		}
 		case 1:
 			return color_picker->get_pick_color().get_s() * 100.0;
 		case 2:
@@ -165,7 +170,9 @@ void ColorModeHSV::slider_draw(int p_which) {
 		Color v_col;
 		s_col.set_hsv(color.get_h(), 0, color.get_v());
 		left_color = (p_which == 1) ? s_col : Color(0, 0, 0);
-		s_col.set_hsv(color.get_h(), 1, color.get_v());
+
+		float s_col_hue = (color.get_s() == 0.0) ? color_picker->get_cached_hue() / 360.0 : color.get_h();
+		s_col.set_hsv(s_col_hue, 1, color.get_v());
 		v_col.set_hsv(color.get_h(), color.get_s(), 1);
 		right_color = (p_which == 1) ? s_col : v_col;
 	}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -376,6 +376,12 @@ void ColorPicker::_value_changed(double) {
 
 	color = modes[current_mode]->get_color();
 
+	if (current_mode == MODE_HSV) {
+		if (sliders[1]->get_value() > 0 || sliders[0]->get_value() != cached_hue) {
+			cached_hue = sliders[0]->get_value();
+		}
+	}
+
 	if (current_mode == MODE_HSV || current_mode == MODE_OKHSL) {
 		h = sliders[0]->get_value() / 360.0;
 		s = sliders[1]->get_value() / 100.0;

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -204,6 +204,7 @@ private:
 	float h = 0.0;
 	float s = 0.0;
 	float v = 0.0;
+	float cached_hue = 0.0;
 	Color last_color;
 
 	struct ThemeCache {
@@ -294,6 +295,7 @@ public:
 #ifdef TOOLS_ENABLED
 	void set_editor_settings(Object *p_editor_settings);
 #endif
+	float get_cached_hue() { return cached_hue; };
 
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();


### PR DESCRIPTION
Hue is cached when the saturation in hsv mode is nonzero. When the saturation is 0, the cached hue is set as the slider in `_update_color`. This is to prevent #76968 from happening.

Fixes #76968
