### PR TITLE
Add a position scale factor to AnimationTree

### DIFF
--- a/doc/classes/AnimationTree.xml
+++ b/doc/classes/AnimationTree.xml
@@ -185,6 +185,9 @@
 			The number of possible simultaneous sounds for each of the assigned AudioStreamPlayers.
 			For example, if this value is [code]32[/code] and the animation has two audio tracks, the two [AudioStreamPlayer]s assigned can play simultaneously up to [code]32[/code] voices each.
 		</member>
+		<member name="position_scale" type="float" setter="set_position_scale" getter="get_position_scale" default="1.0">
+			The scale factor for position tracks. This can be used to apply the same set of animations to characters of different scales. Note that this must be a position track to work (Add Track → 3D Position Track), not a value track named position (clicking the key icon in the inspector).
+		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="AnimationTree.AnimationProcessCallback" default="1">
 			The process mode of this [AnimationTree]. See [enum AnimationProcessCallback] for available modes.
 		</member>

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1728,7 +1728,7 @@ void AnimationTree::_process_graph(double p_delta) {
 						root_motion_scale_accumulator = t->scale;
 					} else if (t->skeleton && t->bone_idx >= 0) {
 						if (t->loc_used) {
-							t->skeleton->set_bone_pose_position(t->bone_idx, t->loc);
+							t->skeleton->set_bone_pose_position(t->bone_idx, t->loc * position_scale);
 						}
 						if (t->rot_used) {
 							t->skeleton->set_bone_pose_rotation(t->bone_idx, t->rot);
@@ -1739,7 +1739,7 @@ void AnimationTree::_process_graph(double p_delta) {
 
 					} else if (!t->skeleton) {
 						if (t->loc_used) {
-							t->node_3d->set_position(t->loc);
+							t->node_3d->set_position(t->loc * position_scale);
 						}
 						if (t->rot_used) {
 							t->node_3d->set_rotation(t->rot.get_euler());
@@ -1954,6 +1954,14 @@ void AnimationTree::set_animation_player(const NodePath &p_player) {
 
 NodePath AnimationTree::get_animation_player() const {
 	return animation_player;
+}
+
+void AnimationTree::set_position_scale(real_t p_position_scale) {
+	position_scale = p_position_scale;
+}
+
+real_t AnimationTree::get_position_scale() const {
+	return position_scale;
 }
 
 void AnimationTree::set_advance_expression_base_node(const NodePath &p_advance_expression_base_node) {
@@ -2216,6 +2224,9 @@ void AnimationTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_animation_player", "root"), &AnimationTree::set_animation_player);
 	ClassDB::bind_method(D_METHOD("get_animation_player"), &AnimationTree::get_animation_player);
 
+	ClassDB::bind_method(D_METHOD("set_position_scale", "position_scale"), &AnimationTree::set_position_scale);
+	ClassDB::bind_method(D_METHOD("get_position_scale"), &AnimationTree::get_position_scale);
+
 	ClassDB::bind_method(D_METHOD("set_advance_expression_base_node", "node"), &AnimationTree::set_advance_expression_base_node);
 	ClassDB::bind_method(D_METHOD("get_advance_expression_base_node"), &AnimationTree::get_advance_expression_base_node);
 
@@ -2242,6 +2253,7 @@ void AnimationTree::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "anim_player", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AnimationPlayer"), "set_animation_player", "get_animation_player");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "advance_expression_base_node", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node"), "set_advance_expression_base_node", "get_advance_expression_base_node");
 
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "position_scale"), "set_position_scale", "get_position_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "active"), "set_active", "is_active");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_callback", PROPERTY_HINT_ENUM, "Physics,Idle,Manual"), "set_process_callback", "get_process_callback");
 	ADD_GROUP("Audio", "audio_");

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -318,6 +318,7 @@ private:
 	AnimationProcessCallback process_callback = ANIMATION_PROCESS_IDLE;
 	bool active = false;
 	NodePath animation_player;
+	real_t position_scale = 1.0;
 	int audio_max_polyphony = 32;
 
 	AnimationNode::State state;
@@ -392,6 +393,9 @@ public:
 
 	void set_animation_player(const NodePath &p_player);
 	NodePath get_animation_player() const;
+
+	void set_position_scale(real_t p_position_scale);
+	real_t get_position_scale() const;
 
 	void set_advance_expression_base_node(const NodePath &p_advance_expression_base_node);
 	NodePath get_advance_expression_base_node() const;


### PR DESCRIPTION
Implements this proposal: https://github.com/godotengine/godot-proposals/issues/7022 This can be used to apply the same set of animations to characters of different scales. Note that this must be a position track to work (Add Track → 3D Position Track), not a value track named position (clicking the key icon in the inspector).

This should be risk-free if we want it in 4.1, but it's in feature freeze so I think 4.2 is more appropriate.