### PR TITLE
Don't update mouse cursor state on child order changed

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -216,14 +216,6 @@ void Node::_notification(int p_notification) {
 				memdelete(child);
 			}
 		} break;
-
-		case NOTIFICATION_CHILD_ORDER_CHANGED: {
-			// The order, in which canvas items are drawn gets rearranged.
-			// This makes it necessary to update mouse cursor and send according mouse_enter/mouse_exit signals for Control nodes.
-			if (get_viewport()) {
-				get_viewport()->update_mouse_cursor_state();
-			}
-		} break;
 	}
 }
 


### PR DESCRIPTION
Partially Revert "Create a virtual mouse move event after moving child nodes"

This partially reverts commit ce10ca69794900896a4162efc823386ce5bde3dd. (#66625)

The problem was that the the mouse-move event interacted in unexpected ways. I believe that a better way would be that `update_mouse_cursor_state` should not use InputEvents for its functionality, however this is a large change, that is unlikely to get merged quickly.

To my mind this revert is warranted, because the newly introduced problems are greater than the problem #40012, that the original PR fixed. The other changes of #66625 still make sense so I revert in this PR only the necessary changes.

resolve #77742
resolve #77773
resolve #77845

please reopen #40012 when this gets merged.
