### PR TITLE
Fix adding bones with the same name after calling `Skeleton3D.clear_bones()`

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -548,6 +548,7 @@ bool Skeleton3D::is_show_rest_only() const {
 
 void Skeleton3D::clear_bones() {
 	bones.clear();
+	name_to_bone_index.clear();
 	process_order_dirty = true;
 	version++;
 	_make_dirty();


### PR DESCRIPTION
Adding a bone to a `Skeleton3D` with the same name after calling `clear_bones()` will fail and print `scene/3d/skeleton_3d.cpp:386 - Condition "p_name.is_empty() || p_name.contains(":") || p_name.contains("/") || name_to_bone_index.has(p_name)" is true.` as the bone name is still present in the bone name index:


```gdscript
@tool
extends EditorScript


func _run() -> void:
	var skeleton := Skeleton3D.new()

	skeleton.add_bone("some_bone")
	skeleton.clear_bones()
	skeleton.add_bone("some_bone")
```

This PR fixes this by clearing the bone name index.