### PR TITLE
Don't create a new scene when double-clicking empty space in scene tabs

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5582,11 +5582,8 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 			if (mb->get_button_index() == MouseButton::MIDDLE && mb->is_pressed()) {
 				_scene_tab_closed(scene_tabs->get_hovered_tab());
 			}
-		} else {
-			if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
-				_menu_option_confirm(FILE_NEW_SCENE, true);
-			}
 		}
+
 		if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 			// Context menu.
 			scene_tabs_context_menu->clear();


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/65302 and https://github.com/godotengine/godot/pull/70800.

This behavior was often accidentally triggered when using the scroll tab arrow buttons. Web browsers also lack equivalent behavior, which means that it's not an UX pattern that people often rely upon.

If you need to create a scene quickly from the scene tabs, a "+" button remains visible at the right of the last scene tab.

- This closes https://github.com/godotengine/godot/issues/72313.
