### PR TITLE
Fix text height for various GUI nodes when the font uses FontVariation

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -439,16 +439,6 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		}
 	}
 
-	if (!xl_text.is_empty() || !p_text.is_empty()) {
-		Ref<Font> font = theme_cache.font;
-		float font_height = font->get_height(theme_cache.font_size);
-		if (vertical_icon_alignment == VERTICAL_ALIGNMENT_CENTER) {
-			minsize.height = MAX(font_height, minsize.height);
-		} else {
-			minsize.height += font_height;
-		}
-	}
-
 	return theme_cache.normal->get_minimum_size() + minsize;
 }
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -667,10 +667,13 @@ Size2 Label::get_minimum_size() const {
 
 	Size2 min_size = minsize;
 
-	const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
-	int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
-
-	min_size.height = MAX(min_size.height, font->get_height(font_size) + font->get_spacing(TextServer::SPACING_TOP) + font->get_spacing(TextServer::SPACING_BOTTOM));
+	if (lines_rid.is_empty()) {
+		const Ref<Font> &font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
+		int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;
+		min_size.height = MAX(min_size.height, font->get_height(font_size) + font->get_spacing(TextServer::SPACING_TOP) + font->get_spacing(TextServer::SPACING_BOTTOM));
+	} else {
+		min_size.height = MAX(min_size.height, TS->shaped_text_get_size(lines_rid[0]).y);
+	}
 
 	Size2 min_style = theme_cache.normal_style->get_minimum_size();
 	if (autowrap_mode != TextServer::AUTOWRAP_OFF) {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -103,6 +103,7 @@ private:
 
 	RID text_rid;
 	float full_width = 0.0;
+	float last_text_height = 0.0;
 
 	bool selecting_enabled = true;
 	bool deselect_on_focus_loss_enabled = true;
@@ -216,6 +217,7 @@ private:
 	void _fit_to_width();
 	void _text_changed();
 	void _emit_text_change();
+	float _get_text_height() const;
 
 	void shift_selection_check_pre(bool);
 	void shift_selection_check_post(bool);


### PR DESCRIPTION
Fixes #77879 

Tested with `Label`, `Button`, `LinkButton`, `LineEdit`, `TextEdit`, `CodeEdit`, and creating new scripts (this revealed a bug during early iterations).
Also tested with and without the placeholder text for `LineEdit`, `TextEdit`, and `CodeEdit`.

I had the most difficulty with `TextEdit`, in particular calculating `line_height` for an empty `TextEdit`.  I also considered deleting `TextEdit::Text::_calculate_line_height` since I always saw its result equal to `line_height`.