### PR TITLE
Display toasts when using `push_error()` or `push_warning()` in a script

### DIFF
--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -902,7 +902,8 @@ struct VariantUtilityFunctions {
 			}
 		}
 
-		ERR_PRINT(s);
+		// Display a toast for editor plugins or `@tool` scripts.
+		ERR_PRINT_ED(s);
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
@@ -922,7 +923,8 @@ struct VariantUtilityFunctions {
 			}
 		}
 
-		WARN_PRINT(s);
+		// Display a toast for editor plugins or `@tool` scripts.
+		WARN_PRINT_ED(s);
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -908,7 +908,7 @@
 		</method>
 		<method name="push_error" qualifiers="vararg">
 			<description>
-				Pushes an error message to Godot's built-in debugger and to the OS terminal.
+				Pushes an error message to Godot's built-in debugger and to the OS terminal. When used in an [EditorPlugin] or [code]@tool[/code] script, this also displays an error toast in the editor.
 				[codeblocks]
 				[gdscript]
 				push_error("test error") # Prints "test error" to debugger and terminal as error call
@@ -922,7 +922,7 @@
 		</method>
 		<method name="push_warning" qualifiers="vararg">
 			<description>
-				Pushes a warning message to Godot's built-in debugger and to the OS terminal.
+				Pushes a warning message to Godot's built-in debugger and to the OS terminal. When used in an [EditorPlugin] or [code]@tool[/code] script, this also displays a warning toast in the editor.
 				[codeblocks]
 				[gdscript]
 				push_warning("test warning") # Prints "test warning" to debugger and terminal as warning call


### PR DESCRIPTION
This only applies to scripts running within the editor itself, such as editor plugins and `@tool` scripts.

Text-based logging will also display those errors as userspace errors, as opposed to internal engine errors.

- This partially addresses https://github.com/godotengine/godot-proposals/discussions/6452 (there's no way to create "info" toasts until we implement https://github.com/godotengine/godot-proposals/issues/1378).

**Testing project:** [test_toast.zip](https://github.com/godotengine/godot/files/11656079/test_toast.zip)

## Preview

![Screenshot_20230605_212519](https://github.com/godotengine/godot/assets/180032/770bbf63-5f59-44d7-befa-f0c9358a2613)