### PR TITLE
Mark deprecated methods of MultiMesh in the docs

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -89,10 +89,10 @@
 	<members>
 		<member name="buffer" type="PackedFloat32Array" setter="set_buffer" getter="get_buffer" default="PackedFloat32Array()">
 		</member>
-		<member name="color_array" type="PackedColorArray" setter="_set_color_array" getter="_get_color_array">
+		<member name="color_array" type="PackedColorArray" setter="_set_color_array" getter="_get_color_array" is_deprecated="true">
 			See [method set_instance_color].
 		</member>
-		<member name="custom_data_array" type="PackedColorArray" setter="_set_custom_data_array" getter="_get_custom_data_array">
+		<member name="custom_data_array" type="PackedColorArray" setter="_set_custom_data_array" getter="_get_custom_data_array" is_deprecated="true">
 			See [method set_instance_custom_data].
 		</member>
 		<member name="instance_count" type="int" setter="set_instance_count" getter="get_instance_count" default="0">
@@ -103,10 +103,10 @@
 			[Mesh] resource to be instanced.
 			The looks of the individual instances can be modified using [method set_instance_color] and [method set_instance_custom_data].
 		</member>
-		<member name="transform_2d_array" type="PackedVector2Array" setter="_set_transform_2d_array" getter="_get_transform_2d_array">
+		<member name="transform_2d_array" type="PackedVector2Array" setter="_set_transform_2d_array" getter="_get_transform_2d_array" is_deprecated="true">
 			See [method set_instance_transform_2d].
 		</member>
-		<member name="transform_array" type="PackedVector3Array" setter="_set_transform_array" getter="_get_transform_array">
+		<member name="transform_array" type="PackedVector3Array" setter="_set_transform_array" getter="_get_transform_array" is_deprecated="true">
 			See [method set_instance_transform].
 		</member>
 		<member name="transform_format" type="int" setter="set_transform_format" getter="get_transform_format" enum="MultiMesh.TransformFormat" default="0">


### PR DESCRIPTION
These aren't bound when `deprecated=no` so mark them as such in the docs.

https://github.com/godotengine/godot/blob/e7d2e49688bdaec65e326e7b2bfcc0642b4f2a8d/scene/resources/multimesh.cpp#L342-L357
