### PR TITLE
Fix incorrect node placement in RTL layout when parent is non-Control canvas item.

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1712,7 +1712,7 @@ void Control::_size_changed() {
 	}
 
 	if (is_layout_rtl()) {
-		new_pos_cache.x = parent_rect.size.x - new_pos_cache.x - new_size_cache.x;
+		new_pos_cache.x = parent_rect.size.x + 2 * parent_rect.position.x - new_pos_cache.x - new_size_cache.x;
 	}
 
 	if (minimum_size.height > new_size_cache.height) {


### PR DESCRIPTION
Partially fix https://github.com/godotengine/godot/issues/77262 (for Nodes with visible size).

https://github.com/godotengine/godot/assets/7645683/f4003cf1-39d6-47fa-ab60-07d1c539d303

