### PR TITLE
Documentation: Unify deprecations

### DIFF
--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -161,9 +161,9 @@
 		<member name="region" type="Rect2i" setter="set_region" getter="get_region" default="Rect2i(0, 0, 0, 0)">
 			The region of grid cells available for pathfinding. If changed, [method update] needs to be called before finding the next path.
 		</member>
-		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(0, 0)">
+		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(0, 0)" is_deprecated="true">
 			The size of the grid (number of cells of size [member cell_size] on each axis). If changed, [method update] needs to be called before finding the next path.
-			[b]Note:[/b] This property is deprecated, use [member region] instead.
+			[i]Deprecated.[/i] Use [member region] instead.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/AnimatedTexture.xml
+++ b/doc/classes/AnimatedTexture.xml
@@ -8,7 +8,8 @@
 		The playback of the animation is controlled by the [member speed_scale] property, as well as each frame's duration (see [method set_frame_duration]). The animation loops, i.e. it will restart at frame 0 automatically after playing the last frame.
 		[AnimatedTexture] currently requires all frame textures to have the same size, otherwise the bigger ones will be cropped to match the smallest one.
 		[b]Note:[/b] AnimatedTexture doesn't support using [AtlasTexture]s. Each frame needs to be a separate [Texture2D].
-		[b]Warning:[/b] AnimatedTexture is deprecated, and might be removed in a future release. Its current implementation is not efficient for the modern renderers.
+		[b]Warning:[/b] The current implementation is not efficient for the modern renderers.
+		[i]Deprecated.[/i] This class is deprecated, and might be removed in a future release.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -321,11 +321,11 @@
 		<constant name="RESPONSE_NOT_MODIFIED" value="304" enum="ResponseCode">
 			HTTP status code [code]304 Not Modified[/code]. A conditional GET or HEAD request has been received and would have resulted in a 200 OK response if it were not for the fact that the condition evaluated to [code]false[/code].
 		</constant>
-		<constant name="RESPONSE_USE_PROXY" value="305" enum="ResponseCode">
-			HTTP status code [code]305 Use Proxy[/code]. [i]Deprecated. Do not use.[/i]
+		<constant name="RESPONSE_USE_PROXY" value="305" enum="ResponseCode" is_deprecated="true">
+			[i]Deprecated.[/i] HTTP status code [code]305 Use Proxy[/code].
 		</constant>
-		<constant name="RESPONSE_SWITCH_PROXY" value="306" enum="ResponseCode">
-			HTTP status code [code]306 Switch Proxy[/code]. [i]Deprecated. Do not use.[/i]
+		<constant name="RESPONSE_SWITCH_PROXY" value="306" enum="ResponseCode" is_deprecated="true">
+			[i]Deprecated.[/i] HTTP status code [code]306 Switch Proxy[/code].
 		</constant>
 		<constant name="RESPONSE_TEMPORARY_REDIRECT" value="307" enum="ResponseCode">
 			HTTP status code [code]307 Temporary Redirect[/code]. The target resource resides temporarily under a different URI and the user agent MUST NOT change the request method if it performs an automatic redirection to that URI.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -946,7 +946,7 @@
 			This notification is emitted [i]after[/i] the related [signal tree_exiting].
 		</constant>
 		<constant name="NOTIFICATION_MOVED_IN_PARENT" value="12" is_deprecated="true">
-			This notification is deprecated and is no longer emitted. Use [constant NOTIFICATION_CHILD_ORDER_CHANGED] instead.
+			[i]Deprecated.[/i] This notification is no longer emitted. Use [constant NOTIFICATION_CHILD_ORDER_CHANGED] instead.
 		</constant>
 		<constant name="NOTIFICATION_READY" value="13">
 			Notification received when the node is ready. See [method _ready].

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -909,7 +909,7 @@
 				- [constant SHAPE_CAPSULE]: an array of length two (or a [Vector2]) containing a [code]float[/code] [code]height[/code] and a [code]float[/code] [code]radius[/code],
 				- [constant SHAPE_CONVEX_POLYGON]: either a [PackedVector2Array] of points defining a convex polygon in counterclockwise order (the clockwise outward normal of each segment formed by consecutive points is calculated internally), or a [PackedFloat32Array] of length divisible by four so that every 4-tuple of [code]float[/code]s contains the coordinates of a point followed by the coordinates of the clockwise outward normal vector to the segment between the current point and the next point,
 				- [constant SHAPE_CONCAVE_POLYGON]: a [PackedVector2Array] of length divisible by two (each pair of points forms one segment).
-				[b]Warning[/b]: In the case of [constant SHAPE_CONVEX_POLYGON], this method does not check if the points supplied actually form a convex polygon (unlike the [member CollisionPolygon2D.polygon] property).
+				[b]Warning:[/b] In the case of [constant SHAPE_CONVEX_POLYGON], this method does not check if the points supplied actually form a convex polygon (unlike the [member CollisionPolygon2D.polygon] property).
 			</description>
 		</method>
 		<method name="space_create">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3304,14 +3304,14 @@
 				Returns a texture [RID] that can be used with [RenderingDevice].
 			</description>
 		</method>
-		<method name="texture_proxy_create">
+		<method name="texture_proxy_create" is_deprecated="true">
 			<return type="RID" />
 			<param index="0" name="base" type="RID" />
 			<description>
-				[i]Deprecated.[/i] As ProxyTexture was removed in Godot 4, this method does nothing when called and always returns a null [RID].
+				[i]Deprecated.[/i] ProxyTexture was removed in Godot 4, so this method does nothing when called and always returns a null [RID].
 			</description>
 		</method>
-		<method name="texture_proxy_update">
+		<method name="texture_proxy_update" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="texture" type="RID" />
 			<param index="1" name="proxy_to" type="RID" />
@@ -3960,8 +3960,8 @@
 		<constant name="MAX_GLOW_LEVELS" value="7">
 			The maximum number of glow levels that can be used with the glow post-processing effect.
 		</constant>
-		<constant name="MAX_CURSORS" value="8">
-			[i]Deprecated.[/i] This constant is unused.
+		<constant name="MAX_CURSORS" value="8" is_deprecated="true">
+			[i]Deprecated.[/i] This constant is unused internally.
 		</constant>
 		<constant name="MAX_2D_DIRECTIONAL_LIGHTS" value="8">
 			The maximum number of directional lights that can be rendered at a given time in 2D.

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -49,6 +49,7 @@
 			<return type="void" />
 			<description>
 				Force updates the bone transforms/poses for all bones in the skeleton.
+				[i]Deprecated.[/i] Do not use.
 			</description>
 		</method>
 		<method name="force_update_bone_child_transform">

--- a/doc/classes/SkeletonIK3D.xml
+++ b/doc/classes/SkeletonIK3D.xml
@@ -24,6 +24,7 @@
 		# Apply zero IK effect (a value at or below 0.01 also removes bones_global_pose_override on Skeleton)
 		skeleton_ik_node.set_interpolation(0.0)
 		[/codeblock]
+		[i]Deprecated.[/i] This class is deprecated, and might be removed in a future release.
 	</description>
 	<tutorials>
 		<link title="3D Inverse Kinematics Demo">https://godotengine.org/asset-library/asset/523</link>

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -124,7 +124,7 @@
 			<param index="1" name="target_index_count" type="int" default="3" />
 			<description>
 				Generates a LOD for a given [param nd_threshold] in linear units (square root of quadric error metric), using at most [param target_index_count] indices.
-				Deprecated. Unused internally and neglects to preserve normals or UVs. Consider using [method ImporterMesh.generate_lods] instead.
+				[i]Deprecated.[/i] Unused internally and neglects to preserve normals or UVs. Consider using [method ImporterMesh.generate_lods] instead.
 			</description>
 		</method>
 		<method name="generate_normals">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -188,7 +188,7 @@
 				If an earlier method marks the input as handled via [method set_input_as_handled], any later method in this list will not be called.
 				If none of the methods handle the event and [member physics_object_picking] is [code]true[/code], the event is used for physics object picking.
 				[b]Note:[/b] This method doesn't propagate input events to embedded [Window]s or [SubViewport]s.
-				[b]Note:[/b] This method is deprecated, use [method push_input] instead.
+				[i]Deprecated.[/i] Use [method push_input] instead.
 			</description>
 		</method>
 		<method name="set_canvas_cull_mask_bit">

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3008,9 +3008,9 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 #ifndef DISABLE_DEPRECATED
 void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(p_event.is_null());
+	WARN_DEPRECATED_MSG(R"*(The "push_unhandled_input()" method is deprecated, use "push_input()" instead.)*");
 	ERR_FAIL_COND(!is_inside_tree());
-	WARN_DEPRECATED_MSG(R"(The "push_unhandled_input" method is deprecated, use "push_input" instead.)");
+	ERR_FAIL_COND(p_event.is_null());
 
 	local_input_handled = false;
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1304,6 +1304,8 @@ AABB SurfaceTool::get_aabb() const {
 	return aabb;
 }
 Vector<int> SurfaceTool::generate_lod(float p_threshold, int p_target_index_count) {
+	WARN_DEPRECATED_MSG(R"*(The "SurfaceTool.generate_lod()" method is deprecated. Consider using "ImporterMesh.generate_lods()" instead.)*");
+
 	Vector<int> lod;
 
 	ERR_FAIL_COND_V(simplify_func == nullptr, lod);


### PR DESCRIPTION
* Add `is_deprecated="true"` in xml to all deprecated members.
* Add a note about the alternative and/or reason for deprecating the member.
* Add runtime warning (`WARN_DEPRECATED_MSG`) if applicable (method or property setter).

![](https://github.com/godotengine/godot/assets/47700418/636225e8-d791-4836-801b-5e0e00b77edf)

According to [the docs](https://docs.godotengine.org/en/stable/contributing/documentation/class_reference_primer.html), for deprecations italic is used, not bold.

For the deprecated classes (`AnimatedTexture` and `SkeletonIK3D`), I think it makes no sense to duplicate the message that the class may be removed in the future, since it is written at the very top.

![](https://github.com/godotengine/godot/assets/47700418/954fe552-f2f3-4382-bd68-f5143b2dfe98)

I wanted to add `WARN_DEPRECATED_MSG` to the `texture_proxy_create()`, `texture_proxy_update()` and `force_update_all_bone_transforms()` methods, but they seem to still be used internally. I'm not sure if this is an error.
