### PR TITLE
C#: Add `[Obsolete]` attribute to deprecated members

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1375,6 +1375,10 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 			output.append("/// </summary>\n");
 		}
+
+		if (class_doc->is_deprecated) {
+			output.append("[Obsolete(\"This class is deprecated.\")]\n");
+		}
 	}
 
 	// We generate a `GodotClassName` attribute if the engine class name is not the same as the
@@ -1426,6 +1430,10 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 
 				output.append(INDENT1 "/// </summary>");
 			}
+
+			if (iconstant.const_doc->is_deprecated) {
+				output.append(MEMBER_BEGIN "[Obsolete(\"This constant is deprecated.\")]");
+			}
 		}
 
 		output.append(MEMBER_BEGIN "public const long ");
@@ -1469,6 +1477,10 @@ Error BindingsGenerator::_generate_cs_type(const TypeInterface &itype, const Str
 					}
 
 					output.append(INDENT2 "/// </summary>\n");
+				}
+
+				if (iconstant.const_doc->is_deprecated) {
+					output.append(INDENT2 "[Obsolete(\"This enum member is deprecated.\")]\n");
 				}
 			}
 
@@ -1867,6 +1879,10 @@ Error BindingsGenerator::_generate_cs_property(const BindingsGenerator::TypeInte
 
 			p_output.append(INDENT1 "/// </summary>");
 		}
+
+		if (p_iprop.prop_doc->is_deprecated) {
+			p_output.append(MEMBER_BEGIN "[Obsolete(\"This property is deprecated.\")]");
+		}
 	}
 
 	p_output.append(MEMBER_BEGIN "public ");
@@ -2102,6 +2118,10 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 				p_output.append(INDENT1 "/// </summary>");
 			}
+
+			if (p_imethod.method_doc->is_deprecated) {
+				p_output.append(MEMBER_BEGIN "[Obsolete(\"This method is deprecated.\")]");
+			}
 		}
 
 		if (default_args_doc.get_string_length()) {
@@ -2313,6 +2333,10 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 				}
 
 				p_output.append(INDENT1 "/// </summary>");
+			}
+
+			if (p_isignal.method_doc->is_deprecated) {
+				p_output.append(MEMBER_BEGIN "[Obsolete(\"This signal is deprecated.\")]");
 			}
 		}
 


### PR DESCRIPTION
This uses the boolean in `DocData` to determine if a member is deprecated since this information doesn't seem to be available in `ClassDB`. Unfortunately, since it's only a boolean we can't add a deprecation message.

There is existing code in the C# binding generator for deprecating members. These fields have never been used, they were never populated. I think these fields were meant to be populated with deprecation information coming from `ClassDB`. I have left this code untouched but should probably be removed.