### PR TITLE
Draw materials in tile atlas view

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -89,7 +89,11 @@ private:
 	Control *base_tiles_drawing_root = nullptr;
 
 	Control *base_tiles_draw = nullptr;
+	HashMap<Ref<Material>, RID> material_tiles_draw;
+	HashMap<Ref<Material>, RID> material_alternatives_draw;
 	void _draw_base_tiles();
+	RID _get_canvas_item_to_draw(const TileData *p_for_data, const CanvasItem *p_base_item, HashMap<Ref<Material>, RID> &p_material_map);
+	void _clear_material_canvas_items();
 
 	Control *base_tiles_texture_grid = nullptr;
 	void _draw_base_tiles_texture_grid();
@@ -164,6 +168,7 @@ public:
 	void queue_redraw();
 
 	TileAtlasView();
+	~TileAtlasView();
 };
 
 #endif // TILE_ATLAS_VIEW_H


### PR DESCRIPTION
Fixes #77672

https://github.com/godotengine/godot/assets/2223172/a480886c-9860-4551-a5c4-9c168c9b5477

Test TileSet:
[Shaderset.tres.txt](https://github.com/godotengine/godot/files/11664753/Shaderset.tres.txt)
(requires icon.png)

There is also a separate (and unreported?) issue where the "ghost" tiles (i.e. when drawing on TileMap) are not using their material.