### PR TITLE
Export non global custom resources.

### DIFF
--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -93,6 +93,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _get_allowed_types(bool p_with_convert, HashSet<StringName> *p_vector) const;
 	bool _is_drop_valid(const Dictionary &p_drag_data) const;
 	bool _is_type_valid(const String p_type_name, HashSet<StringName> p_allowed_types) const;
+	bool _is_script_valid(const Ref<Script> p_script, HashSet<StringName> p_allowed_types) const;
+	bool _is_resource_valid(const Ref<Resource> p_resource, HashSet<StringName> p_allowed_types) const;
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
Fixes #73205

This PR adds support to export custom resources that are not available as global classes. As the issue points out: everything works fine with `class_name` but this functionality can still be very usefull for plugin development, as the use of `class_name` should be avoided at all costs. Instead custom resources can be added via `add_custom_type`. The Resources added in this way are not available as global names. Exporting them is only possible with `preload`.

If the exported variable has a preloaded resource type the base type will be the path to the preloaded script. This PR adds various checks to load this script and work with it instead of failing, as the path is no valid global type.

Some notes on the bahaviour:
- if the exported type is not added via `add_custom_type` it will get a `Script` icon to distinguish it from other resources. Also the display name is determined by taking the file name and converting it to PascalCase. (Displaying the internal variable name would require changes at the GDScript level)
- if the exported type is identical to a script added via `add_custom_type` the icon and name from there will be used
- if the exported type is preloaded script, the editor will loop through all global and custom types and will check whether they inherit from this script and display them in the create dialogue if so
- drag and drop as well as loading will accept resources which inherit the exported script, even if they are not global or added as custom types
- quick loading does not work

The PR unifies some duplicated validity checks in `_is_resource_valid`.

TODO:
- check whether #82528 has an influence on this