### PR TITLE
Reimplement support for bicubic sampling in LightmapGI

### DIFF
--- a/doc/classes/LightmapGIData.xml
+++ b/doc/classes/LightmapGIData.xml
@@ -15,8 +15,9 @@
 			<param index="1" name="uv_scale" type="Rect2" />
 			<param index="2" name="slice_index" type="int" />
 			<param index="3" name="sub_instance" type="int" />
+			<param index="4" name="texture_size" type="Vector2" />
 			<description>
-				Adds an object that is considered baked within this [LightmapGIData].
+				Adds an object that is considered baked within this [LightmapGIData]. [member texture_size] must match the size of the [i]entire[/i] lightmap texture, which is used for bicubic filtering when rendering the lightmap.
 			</description>
 		</method>
 		<method name="clear_users">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -125,7 +125,7 @@ void RasterizerSceneGLES3::GeometryInstanceGLES3::_mark_dirty() {
 	RasterizerSceneGLES3::get_singleton()->geometry_instance_dirty_list.add(&dirty_list_element);
 }
 
-void RasterizerSceneGLES3::GeometryInstanceGLES3::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) {
+void RasterizerSceneGLES3::GeometryInstanceGLES3::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) {
 }
 
 void RasterizerSceneGLES3::GeometryInstanceGLES3::set_lightmap_capture(const Color *p_sh9) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -259,7 +259,7 @@ private:
 				dirty_list_element(this) {}
 
 		virtual void _mark_dirty() override;
-		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;
+		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) override;
 		virtual void set_lightmap_capture(const Color *p_sh9) override;
 
 		virtual void pair_light_instances(const RID *p_light_instances, uint32_t p_light_instance_count) override;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -39,12 +39,13 @@
 #include "scene/resources/environment.h"
 #include "scene/resources/sky.h"
 
-void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance) {
+void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance, const Vector2 &p_texture_size) {
 	User user;
 	user.path = p_path;
 	user.uv_scale = p_uv_scale;
 	user.slice_index = p_slice_index;
 	user.sub_instance = p_sub_instance;
+	user.texture_size = p_texture_size;
 	users.push_back(user);
 }
 
@@ -72,6 +73,11 @@ int LightmapGIData::get_user_lightmap_slice_index(int p_user) const {
 	return users[p_user].slice_index;
 }
 
+Vector2 LightmapGIData::get_user_lightmap_texture_size(int p_user) const {
+	ERR_FAIL_INDEX_V(p_user, users.size(), Vector2());
+	return users[p_user].texture_size;
+}
+
 void LightmapGIData::clear_users() {
 	users.clear();
 }
@@ -92,6 +98,7 @@ Array LightmapGIData::_get_user_data() const {
 		ret.push_back(users[i].uv_scale);
 		ret.push_back(users[i].slice_index);
 		ret.push_back(users[i].sub_instance);
+		ret.push_back(users[i].texture_size);
 	}
 	return ret;
 }
@@ -1294,12 +1301,12 @@ void LightmapGI::_assign_lightmaps() {
 		if (instance_idx >= 0) {
 			RID instance_id = node->call("get_bake_mesh_instance", instance_idx);
 			if (instance_id.is_valid()) {
-				RS::get_singleton()->instance_geometry_set_lightmap(instance_id, get_instance(), light_data->get_user_lightmap_uv_scale(i), light_data->get_user_lightmap_slice_index(i));
+				RS::get_singleton()->instance_geometry_set_lightmap(instance_id, get_instance(), light_data->get_user_lightmap_uv_scale(i), light_data->get_user_lightmap_slice_index(i), light_data->get_user_lightmap_texture_size(i));
 			}
 		} else {
 			VisualInstance3D *vi = Object::cast_to<VisualInstance3D>(node);
 			ERR_CONTINUE(!vi);
-			RS::get_singleton()->instance_geometry_set_lightmap(vi->get_instance(), get_instance(), light_data->get_user_lightmap_uv_scale(i), light_data->get_user_lightmap_slice_index(i));
+			RS::get_singleton()->instance_geometry_set_lightmap(vi->get_instance(), get_instance(), light_data->get_user_lightmap_uv_scale(i), light_data->get_user_lightmap_slice_index(i), light_data->get_user_lightmap_texture_size(i));
 		}
 	}
 }
@@ -1312,12 +1319,12 @@ void LightmapGI::_clear_lightmaps() {
 		if (instance_idx >= 0) {
 			RID instance_id = node->call("get_bake_mesh_instance", instance_idx);
 			if (instance_id.is_valid()) {
-				RS::get_singleton()->instance_geometry_set_lightmap(instance_id, RID(), Rect2(), 0);
+				RS::get_singleton()->instance_geometry_set_lightmap(instance_id, RID(), Rect2(), 0, Vector2());
 			}
 		} else {
 			VisualInstance3D *vi = Object::cast_to<VisualInstance3D>(node);
 			ERR_CONTINUE(!vi);
-			RS::get_singleton()->instance_geometry_set_lightmap(vi->get_instance(), RID(), Rect2(), 0);
+			RS::get_singleton()->instance_geometry_set_lightmap(vi->get_instance(), RID(), Rect2(), 0, Vector2());
 		}
 	}
 }

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -56,6 +56,7 @@ class LightmapGIData : public Resource {
 		NodePath path;
 		int32_t sub_instance = 0;
 		Rect2 uv_scale;
+		Vector2 texture_size;
 		int slice_index = 0;
 	};
 
@@ -72,12 +73,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance = -1);
+	void add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance = -1, const Vector2 &p_texture_size = Vector2());
 	int get_user_count() const;
 	NodePath get_user_path(int p_user) const;
 	int32_t get_user_sub_instance(int p_user) const;
 	Rect2 get_user_lightmap_uv_scale(int p_user) const;
 	int get_user_lightmap_slice_index(int p_user) const;
+	Vector2 get_user_lightmap_texture_size(int p_user) const;
 	void clear_users();
 
 	void set_light_texture(const Ref<TextureLayered> &p_light_texture);

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -57,7 +57,7 @@ public:
 		virtual void set_transparency(float p_transparency) override {}
 		virtual void set_use_baked_light(bool p_enable) override {}
 		virtual void set_use_dynamic_gi(bool p_enable) override {}
-		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override {}
+		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) override {}
 		virtual void set_lightmap_capture(const Color *p_sh9) override {}
 		virtual void set_instance_shader_uniforms_offset(int32_t p_offset) override {}
 		virtual void set_cast_double_sided_shadows(bool p_enable) override {}

--- a/servers/rendering/renderer_geometry_instance.h
+++ b/servers/rendering/renderer_geometry_instance.h
@@ -58,7 +58,7 @@ public:
 	virtual void set_transparency(float p_transparency) = 0;
 	virtual void set_use_baked_light(bool p_enable) = 0;
 	virtual void set_use_dynamic_gi(bool p_enable) = 0;
-	virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) = 0;
+	virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) = 0;
 	virtual void set_lightmap_capture(const Color *p_sh9) = 0;
 	virtual void set_instance_shader_uniforms_offset(int32_t p_offset) = 0;
 	virtual void set_cast_double_sided_shadows(bool p_enable) = 0;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -745,6 +745,8 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		instance_data.lightmap_uv_scale[1] = inst->lightmap_uv_scale.position.y;
 		instance_data.lightmap_uv_scale[2] = inst->lightmap_uv_scale.size.x;
 		instance_data.lightmap_uv_scale[3] = inst->lightmap_uv_scale.size.y;
+		instance_data.lightmap_texture_size[0] = inst->lightmap_texture_size.x;
+		instance_data.lightmap_texture_size[1] = inst->lightmap_texture_size.y;
 
 		bool cant_repeat = instance_data.flags & INSTANCE_DATA_FLAG_MULTIMESH || inst->mesh_instance.is_valid();
 
@@ -3814,9 +3816,10 @@ void RenderForwardClustered::GeometryInstanceForwardClustered::set_transform(con
 	RenderGeometryInstanceBase::set_transform(p_transform, p_aabb, p_transformed_aabbb);
 }
 
-void RenderForwardClustered::GeometryInstanceForwardClustered::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) {
+void RenderForwardClustered::GeometryInstanceForwardClustered::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) {
 	lightmap_instance = p_lightmap_instance;
 	lightmap_uv_scale = p_lightmap_uv_scale;
+	lightmap_texture_size = p_lightmap_texture_size;
 	lightmap_slice_index = p_lightmap_slice_index;
 
 	_mark_dirty();

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -297,6 +297,7 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 			uint32_t gi_offset; //GI information when using lightmapping (VCT or lightmap index)
 			uint32_t layer_mask;
 			float lightmap_uv_scale[4];
+			float lightmap_texture_size[2];
 		};
 
 		UBO ubo;
@@ -448,6 +449,7 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 		// lightmap
 		RID lightmap_instance;
 		Rect2 lightmap_uv_scale;
+		Vector2 lightmap_texture_size; // Used for bicubic filtering in the scene shader.
 		uint32_t lightmap_slice_index;
 		GeometryInstanceLightmapSH *lightmap_sh = nullptr;
 
@@ -476,7 +478,7 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 		virtual void _mark_dirty() override;
 
 		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabbb) override;
-		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;
+		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) override;
 		virtual void set_lightmap_capture(const Color *p_sh9) override;
 
 		virtual void pair_light_instances(const RID *p_light_instances, uint32_t p_light_instance_count) override {}

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2264,9 +2264,10 @@ RenderGeometryInstance *RenderForwardMobile::geometry_instance_create(RID p_base
 	return ginstance;
 }
 
-void RenderForwardMobile::GeometryInstanceForwardMobile::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) {
+void RenderForwardMobile::GeometryInstanceForwardMobile::set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) {
 	lightmap_instance = p_lightmap_instance;
 	lightmap_uv_scale = p_lightmap_uv_scale;
+	lightmap_texture_size = p_lightmap_texture_size;
 	lightmap_slice_index = p_lightmap_slice_index;
 
 	_mark_dirty();

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -480,6 +480,7 @@ protected:
 		uint32_t gi_offset_cache = 0; // !BAS! Should rename this to lightmap_offset_cache, in forward clustered this was shared between gi and lightmap
 		RID lightmap_instance;
 		Rect2 lightmap_uv_scale;
+		Vector2 lightmap_texture_size; // Used for bicubic filtering in the scene shader.
 		uint32_t lightmap_slice_index;
 		GeometryInstanceLightmapSH *lightmap_sh = nullptr;
 
@@ -503,7 +504,7 @@ protected:
 
 		virtual void _mark_dirty() override;
 
-		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;
+		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index, const Vector2 &p_lightmap_texture_size) override;
 		virtual void set_lightmap_capture(const Color *p_sh9) override;
 
 		virtual void pair_light_instances(const RID *p_light_instances, uint32_t p_light_instance_count) override;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -224,6 +224,7 @@ struct InstanceData {
 	uint gi_offset; //GI information when using lightmapping (VCT or lightmap index)
 	uint layer_mask;
 	vec4 lightmap_uv_scale;
+	vec2 lightmap_texture_size; // Used for bicubic filtering in the scene shader.
 };
 
 layout(set = 1, binding = 2, std430) buffer restrict readonly InstanceDataBuffer {

--- a/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
@@ -64,6 +64,4 @@ struct SceneData {
 
 	bool pancake_shadows;
 	uint camera_visible_layers;
-	uint pad2;
-	uint pad3;
 };

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -564,7 +564,7 @@ void RendererSceneCull::instance_set_base(RID p_instance, RID p_base) {
 				InstanceLightmapData *lightmap_data = static_cast<InstanceLightmapData *>(instance->base_data);
 				//erase dependencies, since no longer a lightmap
 				while (lightmap_data->users.begin()) {
-					instance_geometry_set_lightmap((*lightmap_data->users.begin())->self, RID(), Rect2(), 0);
+					instance_geometry_set_lightmap((*lightmap_data->users.begin())->self, RID(), Rect2(), 0, Vector2());
 				}
 				RSG::light_storage->lightmap_instance_free(lightmap_data->instance);
 			} break;
@@ -651,7 +651,7 @@ void RendererSceneCull::instance_set_base(RID p_instance, RID p_base) {
 				geom->geometry_instance->set_transparency(instance->transparency);
 				geom->geometry_instance->set_use_baked_light(instance->baked_light);
 				geom->geometry_instance->set_use_dynamic_gi(instance->dynamic_gi);
-				geom->geometry_instance->set_use_lightmap(RID(), instance->lightmap_uv_scale, instance->lightmap_slice_index);
+				geom->geometry_instance->set_use_lightmap(RID(), instance->lightmap_uv_scale, instance->lightmap_slice_index, instance->lightmap_texture_size);
 				geom->geometry_instance->set_instance_shader_uniforms_offset(instance->instance_allocated_shader_uniforms_offset);
 				geom->geometry_instance->set_cast_double_sided_shadows(instance->cast_shadows == RS::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
 				if (instance->lightmap_sh.size() == 9) {
@@ -1423,7 +1423,7 @@ void RendererSceneCull::_update_instance_visibility_dependencies(Instance *p_ins
 	}
 }
 
-void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) {
+void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, const Vector2 &p_lightmap_texture_size) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_COND(!instance);
 
@@ -1438,6 +1438,7 @@ void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lig
 	instance->lightmap = lightmap_instance;
 	instance->lightmap_uv_scale = p_lightmap_uv_scale;
 	instance->lightmap_slice_index = p_slice_index;
+	instance->lightmap_texture_size = p_lightmap_texture_size;
 
 	RID lightmap_instance_rid;
 
@@ -1450,7 +1451,7 @@ void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lig
 	if ((1 << instance->base_type) & RS::INSTANCE_GEOMETRY_MASK && instance->base_data) {
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(instance->base_data);
 		ERR_FAIL_NULL(geom->geometry_instance);
-		geom->geometry_instance->set_use_lightmap(lightmap_instance_rid, p_lightmap_uv_scale, p_slice_index);
+		geom->geometry_instance->set_use_lightmap(lightmap_instance_rid, p_lightmap_uv_scale, p_slice_index, p_lightmap_texture_size);
 	}
 }
 
@@ -4053,7 +4054,7 @@ bool RendererSceneCull::free(RID p_rid) {
 
 		Instance *instance = instance_owner.get_or_null(p_rid);
 
-		instance_geometry_set_lightmap(p_rid, RID(), Rect2(), 0);
+		instance_geometry_set_lightmap(p_rid, RID(), Rect2(), 0, Vector2());
 		instance_set_scenario(p_rid, RID());
 		instance_set_base(p_rid, RID());
 		instance_geometry_set_material_override(p_rid, RID());

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -412,6 +412,7 @@ public:
 
 		Instance *lightmap = nullptr;
 		Rect2 lightmap_uv_scale;
+		Vector2 lightmap_texture_size; // Used for bicubic filtering in the scene shader.
 		int lightmap_slice_index;
 		uint32_t lightmap_cull_index;
 		Vector<Color> lightmap_sh; //spherical harmonic
@@ -993,7 +994,7 @@ public:
 
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, RS::VisibilityRangeFadeMode p_fade_mode);
 
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index);
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, const Vector2 &p_lightmap_texture_size = Vector2());
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias);
 
 	void _update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -100,7 +100,7 @@ public:
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, RS::VisibilityRangeFadeMode p_fade_mode) = 0;
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) = 0;
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, const Vector2 &p_lightmap_texture_size = Vector2()) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
 	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value) = 0;
 	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -792,7 +792,7 @@ public:
 	FUNC2(instance_geometry_set_material_overlay, RID, RID)
 
 	FUNC6(instance_geometry_set_visibility_range, RID, float, float, float, float, VisibilityRangeFadeMode)
-	FUNC4(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int)
+	FUNC5(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int, const Vector2 &)
 	FUNC2(instance_geometry_set_lod_bias, RID, float)
 	FUNC2(instance_geometry_set_transparency, RID, float)
 	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2511,7 +2511,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_override", "instance", "material"), &RenderingServer::instance_geometry_set_material_override);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_overlay", "instance", "material"), &RenderingServer::instance_geometry_set_material_overlay);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_visibility_range", "instance", "min", "max", "min_margin", "max_margin", "fade_mode"), &RenderingServer::instance_geometry_set_visibility_range);
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice"), &RenderingServer::instance_geometry_set_lightmap);
+	ClassDB::bind_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice", "lightmap_texture_size"), &RenderingServer::instance_geometry_set_lightmap, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_lod_bias", "instance", "lod_bias"), &RenderingServer::instance_geometry_set_lod_bias);
 
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_shader_parameter", "instance", "parameter", "value"), &RenderingServer::instance_geometry_set_shader_parameter);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1271,7 +1271,7 @@ public:
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, VisibilityRangeFadeMode p_fade_mode) = 0;
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice) = 0;
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice, const Vector2 &p_lightmap_texture_size = Vector2()) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
 


### PR DESCRIPTION
This brings it to feature parity with 3.x's lightmapping implementation.

Only supported in Forward+, not Forward Mobile as the push constant for instances is already full (128 bytes).

I won't have much time to work on this, so please look into continuing this in your own branch if possible. I don't even know if the way of passing the lightmap texture size is correct – as I understand it, it needs to be per-instance as multiple LightmapGIs can be used in the same scene at the same time. `3.x` used a uniform here, but we don't seem to use uniforms anymore in the 4.x scene shader.

- This closes https://github.com/godotengine/godot/issues/49935. See also https://github.com/godotengine/godot/pull/77284, which benefits from bicubic sampling.

## TODO

- [ ] Make it work correctly. Currently, it breaks scene rendering even though the shader compiles successfully:

![image](https://github.com/godotengine/godot/assets/180032/aae1a71b-0bf1-41de-b251-a7b5fc157a46)

- [ ] Add a project setting to disable bicubic sampling for low-end systems.
