### PR TITLE
Fix mouse position with screen transform

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -669,6 +669,7 @@ public:
 	Transform2D get_screen_transform() const;
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const;
 	virtual Transform2D get_popup_base_transform() const { return Transform2D(); }
+	virtual bool is_directly_attached_to_screen() const { return false; };
 
 #ifndef _3D_DISABLED
 	bool use_xr = false;
@@ -800,6 +801,7 @@ public:
 
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
+	virtual bool is_directly_attached_to_screen() const override;
 
 	void _validate_property(PropertyInfo &p_property) const;
 	SubViewport();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2475,6 +2475,14 @@ Transform2D Window::get_popup_base_transform() const {
 	return popup_base_transform;
 }
 
+bool Window::is_directly_attached_to_screen() const {
+	if (get_embedder()) {
+		return get_embedder()->is_directly_attached_to_screen();
+	}
+	// Distinguish between the case that this is a native Window and not inside the tree.
+	return is_inside_tree();
+}
+
 void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -401,6 +401,7 @@ public:
 	virtual Transform2D get_final_transform() const override;
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
+	virtual bool is_directly_attached_to_screen() const override;
 
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;


### PR DESCRIPTION
When a Viewport is not in the scene tree or not a child of a `SubViewportContainer`, the function `Viewport::get_mouse_position` can't rely on `get_screen_transform`, because that function is ambiguous in these situations.
In these cases it is necessary to use the mouse position from the most recent mouse InputEvent.

resolve #74868