### PR TITLE
Fixing parameter order in the documentation of TLSOptions.server()

### DIFF
--- a/doc/classes/TLSOptions.xml
+++ b/doc/classes/TLSOptions.xml
@@ -15,7 +15,7 @@
 		# Create a TLS server configuration.
 		var server_certs = load("res://my_server_cas.crt")
 		var server_key = load("res://my_server_key.key")
-		var server_tls_options = TLSOptions.server(server_certs, server_key)
+		var server_tls_options = TLSOptions.server(server_key, server_certs)
 		[/gdscript]
 		[/codeblocks]
 	</description>


### PR DESCRIPTION
Hi! I've perceived that the order of parameters is wrong inside the TLSOptions.server() documentation. Took me a while to understand what was wrong. Hope no one needs to make this mistake anymore haha!