### PR TITLE
Replace get_rendering_device() call to prevent crashes on OpenGL.

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -180,8 +180,7 @@ typedef void (*DEBUGPROCARB)(GLenum source,
 typedef void (*DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userParam);
 
 void RasterizerGLES3::initialize() {
-	// NVIDIA suffixes all GPU model names with "/PCIe/SSE2" in OpenGL (but not Vulkan). This isn't necessary to display nowadays, so it can be trimmed.
-	print_line(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name().trim_suffix("/PCIe/SSE2")));
+	print_line(vformat("OpenGL API %s - Compatibility - Using Device: %s - %s", RS::get_singleton()->get_video_adapter_api_version(), RS::get_singleton()->get_video_adapter_vendor(), RS::get_singleton()->get_video_adapter_name()));
 }
 
 void RasterizerGLES3::finalize() {

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -328,11 +328,15 @@ uint64_t Utilities::get_rendering_info(RS::RenderingInfo p_info) {
 }
 
 String Utilities::get_video_adapter_name() const {
-	return (const char *)glGetString(GL_RENDERER);
+	const String rendering_device_name = (const char *)glGetString(GL_RENDERER);
+	// NVIDIA suffixes all GPU model names with "/PCIe/SSE2" in OpenGL (but not Vulkan). This isn't necessary to display nowadays, so it can be trimmed.
+	return rendering_device_name.trim_suffix("/PCIe/SSE2");
 }
 
 String Utilities::get_video_adapter_vendor() const {
-	return (const char *)glGetString(GL_VENDOR);
+	const String rendering_device_vendor = (const char *)glGetString(GL_VENDOR);
+	// NVIDIA suffixes its vendor name with " Corporation". This is neither necessary to process nor display.
+	return rendering_device_vendor.trim_suffix(" Corporation");
 }
 
 RenderingDevice::DeviceType Utilities::get_video_adapter_type() const {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4382,7 +4382,7 @@ String EditorNode::_get_system_info() const {
 	String driver_name = GLOBAL_GET("rendering/rendering_device/driver");
 	String rendering_method = GLOBAL_GET("rendering/renderer/rendering_method");
 
-	const String rendering_device_name = RenderingServer::get_singleton()->get_rendering_device()->get_device_name();
+	const String rendering_device_name = RenderingServer::get_singleton()->get_video_adapter_name();
 
 	RenderingDevice::DeviceType device_type = RenderingServer::get_singleton()->get_video_adapter_type();
 	String device_type_string;

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -252,7 +252,7 @@ String OS_LinuxBSD::get_version() const {
 }
 
 Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
-	if (RenderingServer::get_singleton()->get_rendering_device() == nullptr) {
+	if (RenderingServer::get_singleton() == nullptr) {
 		return Vector<String>();
 	}
 
@@ -261,8 +261,8 @@ Vector<String> OS_LinuxBSD::get_video_adapter_driver_info() const {
 		return info;
 	}
 
-	const String rendering_device_name = RenderingServer::get_singleton()->get_rendering_device()->get_device_name(); // e.g. `NVIDIA GeForce GTX 970`
-	const String rendering_device_vendor = RenderingServer::get_singleton()->get_rendering_device()->get_device_vendor_name(); // e.g. `NVIDIA`
+	const String rendering_device_name = RenderingServer::get_singleton()->get_video_adapter_name(); // e.g. `NVIDIA GeForce GTX 970`
+	const String rendering_device_vendor = RenderingServer::get_singleton()->get_video_adapter_vendor(); // e.g. `NVIDIA`
 	const String card_name = rendering_device_name.trim_prefix(rendering_device_vendor).strip_edges(); // -> `GeForce GTX 970`
 
 	String vendor_device_id_mappings;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -449,7 +449,7 @@ String OS_Windows::get_version() const {
 }
 
 Vector<String> OS_Windows::get_video_adapter_driver_info() const {
-	if (RenderingServer::get_singleton()->get_rendering_device() == nullptr) {
+	if (RenderingServer::get_singleton() == nullptr) {
 		return Vector<String>();
 	}
 
@@ -467,7 +467,7 @@ Vector<String> OS_Windows::get_video_adapter_driver_info() const {
 	String driver_name;
 	String driver_version;
 
-	const String device_name = RenderingServer::get_singleton()->get_rendering_device()->get_device_name();
+	const String device_name = RenderingServer::get_singleton()->get_video_adapter_name();
 	if (device_name.is_empty()) {
 		return Vector<String>();
 	}


### PR DESCRIPTION
And make OpenGL video adapter info align with Vulkan:
* trim suffix for video adapter name: "/PCIe/SSE2"
* trim suffix for video adapter vendor: " Corporation"


---

* fixes https://github.com/godotengine/godot/issues/77644
* supersedes https://github.com/godotengine/godot/pull/73529

cc @Calinou, as he worked on https://github.com/godotengine/godot/pull/73529


## Test results on linuxbsd

**Results are equivalent for all render methods** (except in Compatibility -> OpenGL cannot deliver device type info (integrated/dedicated/etc.))

Godot v4.1.dev (2c5e2196b) - Ubuntu 20.04.6 LTS (Focal Fossa) - Vulkan (Compatibility) - NVIDIA GeForce GTX 970 (nvidia; 510.108.03) - Intel(R) Core(TM) i7-10700KF CPU @ 3.80GHz (16 Threads)


Godot v4.1.dev (2c5e2196b) - Ubuntu 20.04.6 LTS (Focal Fossa) - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 970 (nvidia; 510.108.03) - Intel(R) Core(TM) i7-10700KF CPU @ 3.80GHz (16 Threads)


Godot v4.1.dev (2c5e2196b) - Ubuntu 20.04.6 LTS (Focal Fossa) - Vulkan (Mobile) - dedicated NVIDIA GeForce GTX 970 (nvidia; 510.108.03) - Intel(R) Core(TM) i7-10700KF CPU @ 3.80GHz (16 Threads)


Output of `void RasterizerGLES3::initialize()`:
`OpenGL API 3.3.0 NVIDIA 510.108.03 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce GTX 970`

just for comparison sake, here the Vulkan output:
`Vulkan API 1.3.194 - Forward+ - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 970`

before ([source](https://github.com/godotengine/godot/pull/72690)):
`OpenGL API 3.3.0 NVIDIA 525.85.05 - Compatibility - Using Device: NVIDIA Corporation - NVIDIA GeForce RTX 4090`