### PR TITLE
Enabled processing for TexturePreview on AnimatedTexture

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -56,6 +56,9 @@ void TexturePreview::_notification(int p_what) {
 
 			checkerboard->set_texture(get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons")));
 		} break;
+		case NOTIFICATION_PROCESS: {
+			queue_redraw();
+		} break;
 	}
 }
 
@@ -148,6 +151,11 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		metadata_label->set_v_size_flags(Control::SIZE_SHRINK_END);
 
 		add_child(metadata_label);
+	}
+
+	Ref<AnimatedTexture> at = texture_display->get_texture();
+	if (!at.is_null()) {
+		set_process(true);
 	}
 }
 


### PR DESCRIPTION
Fixes #77415

## Problem
The issue was, that the TexturePreview would only get redrawn when the redraw was issued from another place (like the viewport calling `queue_redraw()`.

## My solution
In the contructor of TexturePreview, I check if the "previewed" Texture is an AnimatedTexture, and if so, I `set_process(true)` and then handle the `NOTIFICATION_PROCESS` by queuing a redraw there.

Here are two videos showing the end result (second one is to show, that the preview updates even when the mouse isnt moving).

https://github.com/godotengine/godot/assets/75789249/a006bcda-5bd7-4c6e-99a9-7df28730fcd7

https://github.com/godotengine/godot/assets/75789249/84197618-f184-4025-a5d4-a8c6119d6e0e

