### PR TITLE
Cancel tooltip when mouse leaves viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -611,6 +611,7 @@ void Viewport::_notification(int p_what) {
 			gui.mouse_in_viewport = false;
 			_drop_physics_mouseover();
 			_drop_mouse_over();
+			_gui_cancel_tooltip();
 			// When the mouse exits the viewport, we want to end mouse_over, but
 			// not mouse_focus, because, for example, we want to continue
 			// dragging a scrollbar even if the mouse has left the viewport.


### PR DESCRIPTION
Fixes #48634
Supersedes #49015

The issue is not so much about focus, but the fact that the tooltip will still appear when cursor moves out of viewport or even when another window appears on top. Example:

https://github.com/godotengine/godot/assets/2223172/f44b7448-f12d-4565-bca6-01dcfef12bc6

This PR fixes it.