### PR TITLE
Allow CollisionShape nodes to be indirect children of bodies

### DIFF
--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -338,13 +338,16 @@ CollisionObject3D *_generate_shape_with_body(Ref<GLTFState> p_state, Ref<GLTFNod
 #endif // DISABLE_DEPRECATED
 
 CollisionObject3D *_get_ancestor_collision_object(Node *p_scene_parent) {
-	// Note: Despite the name of the method, at the moment this only checks
-	// the direct parent. Only check more later if Godot adds support for it.
-	if (p_scene_parent) {
+	while (p_scene_parent) {
+		Node3D *parent_3d = Object::cast_to<Node3D>(p_scene_parent);
+		if (unlikely(!parent_3d)) {
+			return nullptr;
+		}
 		CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_scene_parent);
 		if (likely(co)) {
 			return co;
 		}
+		p_scene_parent = p_scene_parent->get_parent();
 	}
 	return nullptr;
 }

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -43,43 +43,99 @@ void CollisionShape2D::_shape_changed() {
 	queue_redraw();
 }
 
-void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
-	collision_object->shape_owner_set_transform(owner_id, get_transform());
-	if (p_xform_only) {
+CollisionObject2D *CollisionShape2D::_get_ancestor_collision_object() const {
+	Node *parent = get_parent();
+	while (parent) {
+		CanvasItem *parent_2d = Object::cast_to<CanvasItem>(parent);
+		if (unlikely(!parent_2d)) {
+			return nullptr;
+		}
+		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(parent);
+		if (likely(co)) {
+			return co;
+		}
+		parent = parent->get_parent();
+	}
+	return nullptr;
+}
+
+Transform2D CollisionShape2D::_get_transform_to_collision_object() const {
+	Transform2D transform_to_col_obj = get_transform();
+	Node *parent = get_parent();
+	while (parent != collision_object) {
+		CanvasItem *parent_2d = Object::cast_to<CanvasItem>(parent);
+		if (unlikely(!parent_2d)) {
+			break;
+		}
+		transform_to_col_obj = parent_2d->get_transform() * transform_to_col_obj;
+		parent = parent->get_parent();
+	}
+	return transform_to_col_obj;
+}
+
+void CollisionShape2D::_set_transform_notifications() {
+	if (collision_object == get_parent()) {
+		set_notify_local_transform(true);
+		set_notify_transform(false);
+	} else {
+		set_notify_local_transform(false);
+		set_notify_transform(true);
+	}
+}
+
+void CollisionShape2D::_update_transform_in_shape_owner() {
+	const Transform2D transform_to_col_obj = _get_transform_to_collision_object();
+	const Transform2D shape_owner_transform = collision_object->shape_owner_get_transform(owner_id);
+	if (transform_to_col_obj == transform_to_col_obj_cache && transform_to_col_obj == shape_owner_transform) {
 		return;
 	}
+	transform_to_col_obj_cache = transform_to_col_obj;
+	collision_object->shape_owner_set_transform(owner_id, transform_to_col_obj);
+}
+
+void CollisionShape2D::_update_in_shape_owner() {
+	_update_transform_in_shape_owner();
 	collision_object->shape_owner_set_disabled(owner_id, disabled);
 	collision_object->shape_owner_set_one_way_collision(owner_id, one_way_collision);
 	collision_object->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
 	collision_object->shape_owner_set_one_way_collision_direction(owner_id, one_way_collision_direction);
 }
 
+void CollisionShape2D::_create_shape_owner_in_collision_object() {
+	owner_id = collision_object->create_shape_owner(this);
+	if (shape.is_valid()) {
+		collision_object->shape_owner_add_shape(owner_id, shape);
+	}
+	_set_transform_notifications();
+	_update_in_shape_owner();
+}
+
 void CollisionShape2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PARENTED: {
-			collision_object = Object::cast_to<CollisionObject2D>(get_parent());
+			collision_object = _get_ancestor_collision_object();
 			if (collision_object) {
-				owner_id = collision_object->create_shape_owner(this);
-				if (shape.is_valid()) {
-					collision_object->shape_owner_add_shape(owner_id, shape);
-				}
-				_update_in_shape_owner();
+				_create_shape_owner_in_collision_object();
 			}
 		} break;
-
 		case NOTIFICATION_ENTER_TREE: {
-			if (collision_object) {
-				_update_in_shape_owner();
+			CollisionObject2D *ancestor_col_obj = _get_ancestor_collision_object();
+			if (ancestor_col_obj != collision_object) {
+				collision_object = ancestor_col_obj;
+				if (collision_object) {
+					_create_shape_owner_in_collision_object();
+				}
 			}
 		} break;
 
-		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (collision_object) {
-				_update_in_shape_owner(true);
+				_update_transform_in_shape_owner();
 			}
 		} break;
 
-		case NOTIFICATION_UNPARENTED: {
+		case NOTIFICATION_EXIT_TREE: {
 			if (collision_object) {
 				collision_object->remove_shape_owner(owner_id);
 			}
@@ -177,9 +233,9 @@ bool CollisionShape2D::_edit_is_selected_on_click(const Point2 &p_point, double 
 PackedStringArray CollisionShape2D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
-	CollisionObject2D *col_object = Object::cast_to<CollisionObject2D>(get_parent());
+	CollisionObject2D *col_object = _get_ancestor_collision_object();
 	if (col_object == nullptr) {
-		warnings.push_back(RTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node.\nPlease only use it as a child of Area2D, StaticBody2D, RigidBody2D, CharacterBody2D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node.\nPlease only use it as a descendant of Area2D, StaticBody2D, RigidBody2D, CharacterBody2D, etc. to give them a shape."));
 	}
 	if (shape.is_null()) {
 		warnings.push_back(RTR("A shape must be provided for CollisionShape2D to function. Please create a shape resource for it!"));
@@ -324,7 +380,6 @@ void CollisionShape2D::_bind_methods() {
 }
 
 CollisionShape2D::CollisionShape2D() {
-	set_notify_local_transform(true);
 	set_hide_clip_children(true);
 	debug_color = _get_default_debug_color();
 }

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -41,13 +41,20 @@ class CollisionShape2D : public Node2D {
 	Rect2 rect = Rect2(-Point2(10, 10), Point2(20, 20));
 	uint32_t owner_id = 0;
 	CollisionObject2D *collision_object = nullptr;
+	Transform2D transform_to_col_obj_cache;
 	bool disabled = false;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;
 	Vector2 one_way_collision_direction = Vector2(0.0, 1.0);
 
+	CollisionObject2D *_get_ancestor_collision_object() const;
+	Transform2D _get_transform_to_collision_object() const;
+	void _set_transform_notifications();
+
 	void _shape_changed();
-	void _update_in_shape_owner(bool p_xform_only = false);
+	void _update_transform_in_shape_owner();
+	void _update_in_shape_owner();
+	void _create_shape_owner_in_collision_object();
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -72,42 +72,97 @@ void CollisionShape3D::make_convex_from_siblings() {
 	set_shape(shape_new);
 }
 
-void CollisionShape3D::_update_in_shape_owner(bool p_xform_only) {
-	collision_object->shape_owner_set_transform(owner_id, get_transform());
-	if (p_xform_only) {
+CollisionObject3D *CollisionShape3D::_get_ancestor_collision_object() const {
+	Node *parent = get_parent();
+	while (parent) {
+		Node3D *parent_3d = Object::cast_to<Node3D>(parent);
+		if (unlikely(!parent_3d)) {
+			return nullptr;
+		}
+		CollisionObject3D *co = Object::cast_to<CollisionObject3D>(parent);
+		if (likely(co)) {
+			return co;
+		}
+		parent = parent->get_parent();
+	}
+	return nullptr;
+}
+
+Transform3D CollisionShape3D::_get_transform_to_collision_object() const {
+	Transform3D transform_to_col_obj = get_transform();
+	Node *parent = get_parent();
+	while (parent != collision_object) {
+		Node3D *parent_3d = Object::cast_to<Node3D>(parent);
+		if (unlikely(!parent_3d)) {
+			break;
+		}
+		transform_to_col_obj = parent_3d->get_transform() * transform_to_col_obj;
+		parent = parent->get_parent();
+	}
+	return transform_to_col_obj;
+}
+
+void CollisionShape3D::_set_transform_notifications() {
+	if (collision_object == get_parent()) {
+		set_notify_local_transform(true);
+		set_notify_transform(false);
+	} else {
+		set_notify_local_transform(false);
+		set_notify_transform(true);
+	}
+}
+
+void CollisionShape3D::_update_transform_in_shape_owner() {
+	const Transform3D transform_to_col_obj = _get_transform_to_collision_object();
+	const Transform3D shape_owner_transform = collision_object->shape_owner_get_transform(owner_id);
+	if (transform_to_col_obj == transform_to_col_obj_cache && transform_to_col_obj == shape_owner_transform) {
 		return;
 	}
+	transform_to_col_obj_cache = transform_to_col_obj;
+	collision_object->shape_owner_set_transform(owner_id, transform_to_col_obj);
+}
+
+void CollisionShape3D::_update_in_shape_owner() {
+	_update_transform_in_shape_owner();
 	collision_object->shape_owner_set_disabled(owner_id, disabled);
+}
+
+void CollisionShape3D::_create_shape_owner_in_collision_object() {
+	owner_id = collision_object->create_shape_owner(this);
+	if (shape.is_valid()) {
+		collision_object->shape_owner_add_shape(owner_id, shape);
+	}
+	_set_transform_notifications();
+	_update_in_shape_owner();
 }
 
 void CollisionShape3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PARENTED: {
-			collision_object = Object::cast_to<CollisionObject3D>(get_parent());
+			collision_object = _get_ancestor_collision_object();
 			if (collision_object) {
-				owner_id = collision_object->create_shape_owner(this);
-				if (shape.is_valid()) {
-					collision_object->shape_owner_add_shape(owner_id, shape);
-				}
-
-				_update_in_shape_owner();
+				_create_shape_owner_in_collision_object();
 			}
 		} break;
-
 		case NOTIFICATION_ENTER_TREE: {
-			if (collision_object) {
-				_update_in_shape_owner();
+			CollisionObject3D *ancestor_col_obj = _get_ancestor_collision_object();
+			if (ancestor_col_obj != collision_object) {
+				collision_object = ancestor_col_obj;
+				if (collision_object) {
+					_create_shape_owner_in_collision_object();
+				}
 			}
 		} break;
 
-		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED:
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (collision_object) {
-				_update_in_shape_owner(true);
+				_update_transform_in_shape_owner();
 			}
 			update_configuration_warnings();
 		} break;
 
-		case NOTIFICATION_UNPARENTED: {
+		case NOTIFICATION_EXIT_TREE: {
 			if (collision_object) {
 				collision_object->remove_shape_owner(owner_id);
 			}
@@ -125,9 +180,9 @@ void CollisionShape3D::resource_changed(Ref<Resource> res) {
 PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node3D::get_configuration_warnings();
 
-	CollisionObject3D *col_object = Object::cast_to<CollisionObject3D>(get_parent());
+	CollisionObject3D *col_object = _get_ancestor_collision_object();
 	if (col_object == nullptr) {
-		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node.\nPlease only use it as a child of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node.\nPlease only use it as a descendant of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));
 	}
 
 	if (shape.is_null()) {
@@ -226,7 +281,7 @@ void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
 
 	if (is_inside_tree() && collision_object) {
 		// If this is a heightfield shape our center may have changed
-		_update_in_shape_owner(true);
+		_update_transform_in_shape_owner();
 	}
 	update_configuration_warnings();
 }
@@ -323,7 +378,6 @@ void CollisionShape3D::_shape_changed() {
 #endif // DEBUG_ENABLED
 
 CollisionShape3D::CollisionShape3D() {
-	set_notify_local_transform(true);
 	debug_color = _get_default_debug_color();
 }
 

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -41,6 +41,7 @@ class CollisionShape3D : public Node3D {
 
 	uint32_t owner_id = 0;
 	CollisionObject3D *collision_object = nullptr;
+	Transform3D transform_to_col_obj_cache;
 
 	Color debug_color;
 	bool debug_fill = true;
@@ -56,8 +57,14 @@ class CollisionShape3D : public Node3D {
 #endif
 	bool disabled = false;
 
+	CollisionObject3D *_get_ancestor_collision_object() const;
+	Transform3D _get_transform_to_collision_object() const;
+	void _set_transform_notifications();
+	void _create_shape_owner_in_collision_object();
+
 protected:
-	void _update_in_shape_owner(bool p_xform_only = false);
+	void _update_transform_in_shape_owner();
+	void _update_in_shape_owner();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
EDIT: Note that when this PR was first opened there were some caveats, but those have been resolved now. It should now be fully working including supporting when any node in the tree updates its transform, and should be fast.

Implements and closes https://github.com/godotengine/godot-proposals/issues/535

This PR allows CollisionShape2D and CollisionShape3D nodes to be indirect children of bodies (CollisionObject2D and CollisionObject3D). A shape can only be connected to one body.

<img width="406" alt="Screenshot 2023-06-06 at 10 03 24 PM" src="https://github.com/godotengine/godot/assets/1646875/1da81fbd-cb16-4c5c-8298-4d3581001715">

This is a highly demanded feature, see the discussion in https://github.com/godotengine/godot-proposals/issues/535, https://github.com/godotengine/godot/issues/2174, https://github.com/godotengine/godot-proposals/issues/1049, https://github.com/godotengine/godot-proposals/issues/4559, https://github.com/godotengine/godot-proposals/issues/5746 and https://ask.godotengine.org/31701/possible-rigidbody-have-colliders-that-not-direct-children.

Recently, Eoin from Microsoft has convinced me [here](https://github.com/KhronosGroup/glTF/pull/2258) that this is a vital feature. While I did debate with him about whether that's something worth standardizing... in terms of just whether the feature is good, I agree with him full stop, I don't see any reason to not have this. It just seems like a universally good idea.

The current code has the CollisionShape(2D/3D) looking for the CollisionObject(2D/3D) by running `get_parent()` and casting it to CollisionObject(2D/3D). So I made this a loop in the case that this cast fails, continue going up the tree until a body is found. All the code in CollisionObject(2D/3D) already works with a cached body reference and notifies it when things about the shape change like the transform.

_Production edit: closes godotengine/godot-roadmap#43_