### PR TITLE
Add missing `stdint.h` includes for GCC 13+

### DIFF
--- a/thirdparty/glslang/glslang/Include/Common.h
+++ b/thirdparty/glslang/glslang/Include/Common.h
@@ -45,6 +45,7 @@
 #include <cmath>
 #endif
 #include <cstdio>
+#include <cstdint>
 #include <cstdlib>
 #include <list>
 #include <map>

--- a/thirdparty/openxr/patches/fix-gcc13-stdint.patch
+++ b/thirdparty/openxr/patches/fix-gcc13-stdint.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty/openxr/src/common/platform_utils.hpp b/thirdparty/openxr/src/common/platform_utils.hpp
+index 85d5cdab10..2d870cfea7 100644
+--- a/thirdparty/openxr/src/common/platform_utils.hpp
++++ b/thirdparty/openxr/src/common/platform_utils.hpp
+@@ -11,6 +11,7 @@
+ 
+ #include "xr_dependencies.h"
+ #include <string>
++#include <stdint.h>
+ #include <stdlib.h>
+ 
+ // OpenXR paths and registry key locations

--- a/thirdparty/openxr/src/common/platform_utils.hpp
+++ b/thirdparty/openxr/src/common/platform_utils.hpp
@@ -11,6 +11,7 @@
 
 #include "xr_dependencies.h"
 #include <string>
+#include <stdint.h>
 #include <stdlib.h>
 
 // OpenXR paths and registry key locations

--- a/thirdparty/vhacd/0006-fix-gcc13.patch
+++ b/thirdparty/vhacd/0006-fix-gcc13.patch
@@ -13,3 +13,26 @@ index 132bdcfb3e..925584cf52 100644
  namespace VHACD {
  //!    Incremental Convex Hull algorithm (cf. http://cs.smith.edu/~orourke/books/ftp.html ).
  enum ICHullError {
+diff --git a/thirdparty/vhacd/inc/vhacdManifoldMesh.h b/thirdparty/vhacd/inc/vhacdManifoldMesh.h
+index a48f53c5c5..5eed4e13aa 100644
+--- a/thirdparty/vhacd/inc/vhacdManifoldMesh.h
++++ b/thirdparty/vhacd/inc/vhacdManifoldMesh.h
+@@ -18,6 +18,11 @@ All rights reserved.
+ #include "vhacdCircularList.h"
+ #include "vhacdSArray.h"
+ #include "vhacdVector.h"
++
++// -- GODOT start --
++#include <cstdint>
++// -- GODOT end --
++
+ namespace VHACD {
+ class TMMTriangle;
+ class TMMEdge;
+@@ -139,4 +144,4 @@ private:
+     friend class ICHull;
+ };
+ }
+-#endif // VHACD_MANIFOLD_MESH_H
+\ No newline at end of file
++#endif // VHACD_MANIFOLD_MESH_H

--- a/thirdparty/vhacd/inc/vhacdManifoldMesh.h
+++ b/thirdparty/vhacd/inc/vhacdManifoldMesh.h
@@ -18,6 +18,11 @@ All rights reserved.
 #include "vhacdCircularList.h"
 #include "vhacdSArray.h"
 #include "vhacdVector.h"
+
+// -- GODOT start --
+#include <cstdint>
+// -- GODOT end --
+
 namespace VHACD {
 class TMMTriangle;
 class TMMEdge;


### PR DESCRIPTION
Fixes #77927.

Thanks @germanbv for finding and documenting the fixes. FYI, you could have made a PR with those changes directly :)
That being said, we're a bit peculiar with how we handle modifications to thirdparty code vendored in Godot, so I went ahead and did the PR myself.

Added patch files for v-hacd (the issue seems fixed upstream, but we're on an outdated version so making the difference clear is still important) and openxr (PR'ed the fix upstream, might be included in the next release if accepted: https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/406). It's already fixed upstream in glslang so I didn't add a patch file, it will be included next time we update (it's included in #77898 which will supersede this for 4.1, but we still need the patch for 4.0 and earlier).