### PR TITLE
X11: Fix vformat ambiguous int types for GCC 10 (again)

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -869,7 +869,7 @@ int default_window_error_handler(Display *display, XErrorEvent *error) {
 					  "\n   Major opcode of failed request: %d"
 					  "\n   Serial number of failed request: %d"
 					  "\n   Current serial number in output stream: %d",
-			String::utf8(message), error->request_code, error->minor_code, error->serial));
+			String::utf8(message), (uint64_t)error->request_code, (uint64_t)error->minor_code, (uint64_t)error->serial));
 	return 0;
 }
 


### PR DESCRIPTION
Fixup after #75099.

Same issue as we had to fix with 9dc286967fec1f902daedd2376bb0dbbd422a4af. I don't reproduce it locally with GCC 12, I wonder if there's a way we can ensure to catch this from CI. Or whether we should add relevant definitions to disambiguate. @bruvzg

*Edit:* Ah it's failing specifically on x86_32 builds, which we don't test as often.