### PR TITLE
Improve some tile editor hint labels

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -2187,7 +2187,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	tiles_bottom_panel->set_name(TTR("Tiles"));
 
 	missing_source_label = memnew(Label);
-	missing_source_label->set_text(TTR("This TileMap's TileSet has no source configured. Edit the TileSet resource to add one."));
+	missing_source_label->set_text(TTR("This TileMap's TileSet has no source configured. Go to the TileSet bottom tab to add one."));
 	missing_source_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	missing_source_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -4069,7 +4069,7 @@ TileMapEditor::TileMapEditor() {
 	tile_map_toolbar->add_child(advanced_menu_button);
 
 	missing_tileset_label = memnew(Label);
-	missing_tileset_label->set_text(TTR("The edited TileMap node has no TileSet resource."));
+	missing_tileset_label->set_text(TTR("The edited TileMap node has no TileSet resource.\nCreate or load a TileSet resource in the Tile Set property in the inspector."));
 	missing_tileset_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	missing_tileset_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	missing_tileset_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -822,7 +822,7 @@ TileSetEditor::TileSetEditor() {
 
 	// No source selected.
 	no_source_selected_label = memnew(Label);
-	no_source_selected_label->set_text(TTR("No TileSet source selected. Select or create a TileSet source."));
+	no_source_selected_label->set_text(TTR("No TileSet source selected. Select or create a TileSet source.\nYou can create a new source by using the Add button on the left or by dropping a tileset texture onto the source list."));
 	no_source_selected_label->set_h_size_flags(SIZE_EXPAND_FILL);
 	no_source_selected_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	no_source_selected_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot-proposals/issues/1769#issuecomment-1021703712

This PR improves some editor texts to point users towards what they should do.

No TileSet
![image](https://github.com/godotengine/godot/assets/2223172/91be3a28-037c-4a4e-bc68-1e64f5e206f5)

Empty TileSet
![image](https://github.com/godotengine/godot/assets/2223172/76432e6b-0ba7-451f-b20b-d0189d7064f6)

No source selected/exists
![image](https://github.com/godotengine/godot/assets/2223172/226a5f16-118d-41e0-9647-c78709be2239)

I kind of like the idea of adding buttons under the labels that would perform some of these actions, but [as groud noted in a comment](https://github.com/godotengine/godot-proposals/issues/1769#issuecomment-1022047238), it might hide some details from the user on what is happening. It's something we could think about later, this PR is just a quick solution I came up with.