### PR TITLE
Hash ORM flag in BaseMaterial to differentiate between ORM and Standard materials

### DIFF
--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -327,6 +327,7 @@ private:
 		uint64_t deep_parallax : 1;
 		uint64_t grow : 1;
 		uint64_t proximity_fade : 1;
+		uint64_t orm : 1;
 
 		// flag bitfield
 		uint32_t feature_mask;
@@ -378,6 +379,7 @@ private:
 		mk.distance_fade = distance_fade;
 		mk.emission_op = emission_op;
 		mk.alpha_antialiasing_mode = alpha_antialiasing_mode;
+		mk.orm = orm;
 
 		for (int i = 0; i < FEATURE_MAX; i++) {
 			if (features[i]) {


### PR DESCRIPTION
Along with https://github.com/godotengine/godot/pull/77810, fixes https://github.com/godotengine/godot/issues/77659

The material key is used to cache variations of the BaseMaterial. i.e. there should be a unique key for each variation of shader code. Accordingly, any property which changes the generated shader code needs to be contained in the flag. Since ``orm`` changes the generated code, it needs to be factored into the key. 