### PR TITLE
Internally rename `parent` to `collision_object` in CollisionShape(2D/3D)

### DIFF
--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -41,7 +41,7 @@ class CollisionShape2D : public Node2D {
 	Ref<Shape2D> shape;
 	Rect2 rect = Rect2(-Point2(10, 10), Point2(20, 20));
 	uint32_t owner_id = 0;
-	CollisionObject2D *parent = nullptr;
+	CollisionObject2D *collision_object = nullptr;
 	bool disabled = false;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -41,7 +41,7 @@ class CollisionShape3D : public Node3D {
 	Ref<Shape3D> shape;
 
 	uint32_t owner_id = 0;
-	CollisionObject3D *parent = nullptr;
+	CollisionObject3D *collision_object = nullptr;
 
 	void resource_changed(Ref<Resource> res);
 	bool disabled = false;


### PR DESCRIPTION
This is an internal rename to improve readability and clarity, split off from #77937 so we can merge this first.