### PR TITLE
Add syntax highlighting for ConfigFile/TSCN/TRES/project.godot

### DIFF
--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -137,6 +137,28 @@ public:
 	EditorMarkdownSyntaxHighlighter() { highlighter.instantiate(); }
 };
 
+class EditorConfigFileSyntaxHighlighter : public EditorSyntaxHighlighter {
+	GDCLASS(EditorConfigFileSyntaxHighlighter, EditorSyntaxHighlighter)
+
+private:
+	Ref<CodeHighlighter> highlighter;
+
+public:
+	virtual void _update_cache() override;
+	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override { return highlighter->get_line_syntax_highlighting(p_line); }
+
+	// While not explicitly designed for those formats, this highlighter happens
+	// to handle TSCN, TRES, `project.godot` well. We can expose it in case the
+	// user opens one of these using the script editor (which can be done using
+	// the All Files filter).
+	virtual PackedStringArray _get_supported_languages() const override { return PackedStringArray{ "ini", "cfg", "tscn", "tres", "godot" }; }
+	virtual String _get_name() const override { return TTR("ConfigFile"); }
+
+	virtual Ref<EditorSyntaxHighlighter> _create() const override;
+
+	EditorConfigFileSyntaxHighlighter() { highlighter.instantiate(); }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class ScriptEditorQuickOpen : public ConfirmationDialog {


### PR DESCRIPTION
A single highligher is used for all these formats, as they're fairly close to each other.

- This closes https://github.com/godotengine/godot-proposals/issues/5749 and partially addresses https://github.com/godotengine/godot-proposals/issues/6770.

## Preview

### ConfigFile

![Screenshot_20230607_185311](https://github.com/godotengine/godot/assets/180032/c2d77838-fe07-49ea-b325-e8c697a0ae43)

<details>

```ini
[foo]
bar = "baz"
bar2 = 1234
bar3 = false
stuff = Vector2(12.0, 34.0)

["example spaced section"]
test = ["test?"]

```
</details>

### TSCN

![Screenshot_20230607_185344](https://github.com/godotengine/godot/assets/180032/74395532-be08-42d7-bc1d-ddc56f752f5a)

<details>

```ini
[gd_scene load_steps=3 format=3 uid="uid://dx4ful8ifrpje"]

[ext_resource type="Script" path="res://Node2D.gd" id="1_2phpy"]
[ext_resource type="Material" uid="uid://bd0wyfc5cylks" path="res://new_canvas_item_material.tres" id="1_jvg7s"]

[node name="Node2D" type="Node2D"]
script = ExtResource("1_2phpy")

[node name="Sprite2D" type="Sprite2D" parent="." groups=["pretty_sprite"]]

[node name="Button" type="Button" parent="."]
material = ExtResource("1_jvg7s")
offset_right = 8.0
offset_bottom = 8.0
text = "Click me"

```
</details>

### `project.godot`

![Screenshot_20230607_185351](https://github.com/godotengine/godot/assets/180032/d13bba1b-271a-44c4-bdeb-954ab10998b6)

<details>

```ini
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; since the parameters that go here are not all obvious.
;
; Format:
;   [section] ; section goes between []
;   param=value ; assign values to parameters

config_version=5

[application]

run/main_scene="res://node_2d.tscn"
config/features=PackedStringArray("4.1")

```
</details>

### [TOML](https://toml.io/) *(not included in this PR)*

*This requires adding `#` as a comment character, which is valid in TOML but not in ConfigFile or other Godot formats. We could allow using `#` for comments in ConfigFile and Godot formats to resolve this inconsistency, but that's a topic for a separate proposal. (As a bonus, it would also allow parsing a large portion of TOML files out there directly using ConfigFile.)*

*VS Code's own INI highlighter also highlights lines starting with `#` as comments.*

Using <https://raw.githubusercontent.com/sharkdp/fd/master/Cargo.toml>:

![Screenshot_20230607_185329](https://github.com/godotengine/godot/assets/180032/aefd2760-bf96-4fe2-8be7-9064a8b1d046)
