### PR TITLE
Fix editor log flicker.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -346,6 +346,15 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	}
 
 	log->add_newline();
+
+	if (p_replace_previous) {
+		// Force sync last line update (skip if number of unprocessed log messages is too large to avoid editor lag).
+		if (log->get_pending_paragraphs() < 100) {
+			while (!log->is_ready()) {
+				::OS::get_singleton()->delay_usec(1);
+			}
+		}
+	}
 }
 
 void EditorLog::_set_filter_active(bool p_active, MessageType p_message_type) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2741,7 +2741,16 @@ void RichTextLabel::_stop_thread() {
 	}
 }
 
+int RichTextLabel::get_pending_paragraphs() const {
+	int to_line = main->first_invalid_line.load();
+	int lines = main->lines.size();
+
+	return lines - to_line;
+}
+
 bool RichTextLabel::is_ready() const {
+	const_cast<RichTextLabel *>(this)->_validate_line_caches();
+
 	if (updating.load()) {
 		return false;
 	}
@@ -3177,7 +3186,8 @@ bool RichTextLabel::remove_paragraph(const int p_paragraph) {
 		main->lines[0].from = main;
 	}
 
-	main->first_invalid_line.store(0);
+	int to_line = main->first_invalid_line.load();
+	main->first_invalid_line.store(MIN(to_line, p_paragraph));
 	queue_redraw();
 
 	return true;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -684,6 +684,7 @@ public:
 	bool is_deselect_on_focus_loss_enabled() const;
 	void deselect();
 
+	int get_pending_paragraphs() const;
 	bool is_ready() const;
 	bool is_updating() const;
 


### PR DESCRIPTION
- When removing paragraph, instead of invalidation all RTL content only invalidate paragraphs starting from removed one.
- Force sync log RTL when adding collapsed line to the log.

Fixes https://github.com/godotengine/godot/issues/77961


https://github.com/godotengine/godot/assets/7645683/91d7dfdc-7f32-4ea3-b555-874f89301e9d

