### PR TITLE
Fix IME doesn't work under Popup on Windows.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -835,9 +835,12 @@ void DisplayServerWindows::show_window(WindowID p_id) {
 		SetFocus(wd.hWnd); // Set keyboard focus.
 	} else if (wd.minimized) {
 		ShowWindow(wd.hWnd, SW_SHOWMINIMIZED);
-	} else if (wd.no_focus || wd.is_popup) {
+	} else if (wd.no_focus) {
 		// https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
 		ShowWindow(wd.hWnd, SW_SHOWNA);
+	} else if (wd.is_popup) {
+		ShowWindow(wd.hWnd, SW_SHOWNA);
+		SetFocus(wd.hWnd); // Set keyboard focus.
 	} else {
 		ShowWindow(wd.hWnd, SW_SHOW);
 		SetForegroundWindow(wd.hWnd); // Slightly higher priority.


### PR DESCRIPTION
Fix #77837 and fix #73591

![ime_fix](https://github.com/godotengine/godot/assets/12966814/acbcc888-3757-4245-9315-c300d5a27650)

Set keyboard focus for `is_popup` window otherwise it won't produce `WM_IME_STARTCOMPOSITION` and IME won't work.

See https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setfocus:

> If a window is active but does not have the focus, any key pressed produces the [WM_SYSCHAR](https://learn.microsoft.com/en-us/windows/desktop/menurc/wm-syschar), [WM_SYSKEYDOWN](https://learn.microsoft.com/en-us/windows/desktop/inputdev/wm-syskeydown), or [WM_SYSKEYUP](https://learn.microsoft.com/en-us/windows/desktop/inputdev/wm-syskeyup) message. If the VK_MENU key is also pressed, bit 30 of the lParam parameter of the message is set. Otherwise, the messages produced do not have this bit set.