### PR TITLE
Remove inaccuracy about re-using `Thread`s in its doc

### DIFF
--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -54,7 +54,6 @@
 				Joins the [Thread] and waits for it to finish. Returns the output of the [Callable] passed to [method start].
 				Should either be used when you want to retrieve the value returned from the method called by the [Thread] or before freeing the instance that contains the [Thread].
 				To determine if this can be called without blocking the calling thread, check if [method is_alive] is [code]false[/code].
-				[b]Note:[/b] After the [Thread] finishes joining it will be disposed. If you want to use it again you will have to create a new instance of it.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
From my tests, I didn't found any problems re-using a finished `Thread`, unless that's a bug.