### PR TITLE
Add debugging option to execute arbitrary GDScript statements at game start

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1329,6 +1329,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "compression/formats/zlib/compression_level", PROPERTY_HINT_RANGE, "-1,9,1"), Compression::zlib_level);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "compression/formats/gzip/compression_level", PROPERTY_HINT_RANGE, "-1,9,1"), Compression::gzip_level);
 
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, "debug/hooks/ready", PROPERTY_HINT_MULTILINE_TEXT), "");
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, "debug/hooks/process", PROPERTY_HINT_MULTILINE_TEXT), "");
+
 	GLOBAL_DEF("debug/settings/crash_handler/message",
 			String("Please include this when reporting the bug to the project developer."));
 	GLOBAL_DEF("debug/settings/crash_handler/message.editor",

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -550,6 +550,12 @@
 		<member name="debug/gdscript/warnings/unused_variable" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a local variable is unused.
 		</member>
+		<member name="debug/hooks/process" type="String" setter="" getter="" default="&quot;&quot;">
+			Sets a [code]_process()[/code] hook that runs in debug mode.
+		</member>
+		<member name="debug/hooks/ready" type="String" setter="" getter="" default="&quot;&quot;">
+			Sets a [code]_ready()[/code] hook that runs in debug mode.
+		</member>
 		<member name="debug/settings/crash_handler/message" type="String" setter="" getter="" default="&quot;Please include this when reporting the bug to the project developer.&quot;">
 			Message to be displayed before the backtrace when the engine crashes. By default, this message is only used in exported projects due to the editor-only override applied to this setting.
 		</member>


### PR DESCRIPTION
This can be used to enable any of the 20+ `Viewport::DEBUG_DRAW_*` modes at runtime from the command line (which probably would have been excessive as a normal project setting). Almost certainly has other use cases.

See https://github.com/godotengine/godot-proposals/issues/7064 for the accompanying proposal.

Implemented as a set of project settings that get stitched together into a hidden autoload script, using the standard `_ready()` and `_process(delta)` functions. Command line usage requires environment variable support: #72689
