### PR TITLE
Properly update array textures when using the OpenGL backend to avoid crash

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -789,14 +789,14 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	texture.format = image->get_format();
 	texture.type = Texture::TYPE_LAYERED;
 	texture.layered_type = p_layered_type;
-	texture.target = GL_TEXTURE_2D_ARRAY;
+	texture.target = p_layered_type == RS::TEXTURE_LAYERED_CUBEMAP ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D_ARRAY;
 	texture.layers = p_layers.size();
 	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);
 	texture.active = true;
 	glGenTextures(1, &texture.tex_id);
 	texture_owner.initialize_rid(p_texture, texture);
 	for (int i = 0; i < p_layers.size(); i++) {
-		_texture_set_data(p_texture, p_layers[i], 1, i == 0);
+		_texture_set_data(p_texture, p_layers[i], i, i == 0);
 	}
 }
 
@@ -1310,7 +1310,7 @@ void TextureStorage::_texture_set_data(RID p_texture, const Ref<Image> &p_image,
 				if (initialize) {
 					glTexImage3D(GL_TEXTURE_2D_ARRAY, i, internal_format, w, h, texture->layers, 0, format, type, nullptr);
 				}
-				glTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, 0, 0, p_layer, w, h, 0, format, type, &read[ofs]);
+				glTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, 0, 0, p_layer, w, h, 1, format, type, &read[ofs]);
 			} else {
 				glTexImage2D(blit_target, i, internal_format, w, h, 0, format, type, &read[ofs]);
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/77760

Thanks to @RedworkDE for bisecting and identifying the problem.

https://github.com/godotengine/godot/pull/77224 introduced some invalid OpenGL API usage that appears to be gracefully handled on most GPU drivers. However, on Windows + AMD, it led to a hard crash in the GPU driver. 

There are things in this code that I am still unhappy with. But I am refraining from doing a rewrite right now. Soon I will revisit this code and clean it up.
