### PR TITLE
Add support for the OpenXR Eye gaze interaction extension

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -95,6 +95,7 @@ if env["opengl3"]:
 
 env_openxr.add_source_files(module_obj, "extensions/openxr_palm_pose_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_composition_layer_depth_extension.cpp")
+env_openxr.add_source_files(module_obj, "extensions/openxr_eye_gaze_interaction.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_htc_controller_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_htc_vive_tracker_extension.cpp")
 env_openxr.add_source_files(module_obj, "extensions/openxr_huawei_controller_extension.cpp")

--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -206,7 +206,8 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/waist,"
 			"/user/vive_tracker_htcx/role/chest,"
 			"/user/vive_tracker_htcx/role/camera,"
-			"/user/vive_tracker_htcx/role/keyboard");
+			"/user/vive_tracker_htcx/role/keyboard,"
+			"/user/eyes_ext");
 	Ref<OpenXRAction> aim_pose = action_set->add_new_action("aim_pose", "Aim pose", OpenXRAction::OPENXR_ACTION_POSE, "/user/hand/left,/user/hand/right");
 	Ref<OpenXRAction> grip_pose = action_set->add_new_action("grip_pose", "Grip pose", OpenXRAction::OPENXR_ACTION_POSE, "/user/hand/left,/user/hand/right");
 	Ref<OpenXRAction> palm_pose = action_set->add_new_action("palm_pose", "Palm pose", OpenXRAction::OPENXR_ACTION_POSE, "/user/hand/left,/user/hand/right");
@@ -501,6 +502,11 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/chest/output/haptic,"
 			"/user/vive_tracker_htcx/role/camera/output/haptic,"
 			"/user/vive_tracker_htcx/role/keyboard/output/haptic");
+	add_interaction_profile(profile);
+
+	// Create our eye gaze interaction profile
+	profile = OpenXRInteractionProfile::new_profile("/interaction_profiles/ext/eye_gaze_interaction");
+	profile->add_new_binding(default_pose, "/user/eyes_ext/input/gaze_ext/pose");
 	add_interaction_profile(profile);
 }
 

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -30,6 +30,13 @@
 				Returns [code]true[/code] if the given action set is active.
 			</description>
 		</method>
+		<method name="is_eye_gaze_interaction_supported">
+			<return type="bool" />
+			<description>
+				Returns the capabilities of the eye gaze interaction extension.
+				Note: this only returns a valid value after OpenXR has been initialized.
+			</description>
+		</method>
 		<method name="set_action_set_active">
 			<return type="void" />
 			<param index="0" name="name" type="String" />

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -1,0 +1,90 @@
+/**************************************************************************/
+/*  openxr_eye_gaze_interaction.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_eye_gaze_interaction.h"
+#include "../action_map/openxr_interaction_profile_meta_data.h"
+
+OpenXREyeGazeInteractionExtension *OpenXREyeGazeInteractionExtension::singleton = nullptr;
+
+OpenXREyeGazeInteractionExtension *OpenXREyeGazeInteractionExtension::get_singleton() {
+	ERR_FAIL_NULL_V(singleton, nullptr);
+	return singleton;
+}
+
+OpenXREyeGazeInteractionExtension::OpenXREyeGazeInteractionExtension() {
+	singleton = this;
+}
+
+OpenXREyeGazeInteractionExtension::~OpenXREyeGazeInteractionExtension() {
+	singleton = nullptr;
+}
+
+HashMap<String, bool *> OpenXREyeGazeInteractionExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}
+
+void *OpenXREyeGazeInteractionExtension::set_system_properties_and_get_next_pointer(void *p_next_pointer) {
+	if (!available) {
+		return p_next_pointer;
+	}
+
+	properties.type = XR_TYPE_SYSTEM_EYE_GAZE_INTERACTION_PROPERTIES_EXT;
+	properties.next = p_next_pointer;
+	properties.supportsEyeGazeInteraction = false;
+
+	return &properties;
+}
+
+bool OpenXREyeGazeInteractionExtension::is_available() {
+	return available;
+}
+
+bool OpenXREyeGazeInteractionExtension::supports_eye_gaze_interaction() {
+	// The extension being available only means that the OpenXR Runtime supports the extension.
+	// The `supportsEyeGazeInteraction` is set to true if the device also supports this.
+	// Thus both need to be true.
+	return available && properties.supportsEyeGazeInteraction;
+}
+
+void OpenXREyeGazeInteractionExtension::on_register_metadata() {
+	OpenXRInteractionProfileMetaData *metadata = OpenXRInteractionProfileMetaData::get_singleton();
+	ERR_FAIL_NULL(metadata);
+
+	// Eyes top path
+	metadata->register_top_level_path("Eye gaze tracker", "/user/eyes_ext", XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME);
+
+	// Eye gaze interaction
+	metadata->register_interaction_profile("Eye gaze", "/interaction_profiles/ext/eye_gaze_interaction", XR_EXT_EYE_GAZE_INTERACTION_EXTENSION_NAME);
+	metadata->register_io_path("/interaction_profiles/ext/eye_gaze_interaction", "Gaze pose", "/user/eyes_ext", "/user/eyes_ext/input/gaze_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+}

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.h
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  openxr_eye_gaze_interaction.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_EYE_GAZE_INTERACTION_H
+#define OPENXR_EYE_GAZE_INTERACTION_H
+
+#include "openxr_extension_wrapper.h"
+
+class OpenXREyeGazeInteractionExtension : public OpenXRExtensionWrapper {
+public:
+	static OpenXREyeGazeInteractionExtension *get_singleton();
+
+	OpenXREyeGazeInteractionExtension();
+	~OpenXREyeGazeInteractionExtension();
+
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
+
+	bool is_available();
+	bool supports_eye_gaze_interaction();
+
+	virtual void on_register_metadata() override;
+
+private:
+	static OpenXREyeGazeInteractionExtension *singleton;
+
+	bool available = false;
+	XrSystemEyeGazeInteractionPropertiesEXT properties;
+};
+
+#endif // OPENXR_EYE_GAZE_INTERACTION_H

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -34,6 +34,8 @@
 #include "core/io/resource_saver.h"
 #include "servers/rendering/rendering_server_globals.h"
 
+#include "extensions/openxr_eye_gaze_interaction.h"
+
 void OpenXRInterface::_bind_methods() {
 	// lifecycle signals
 	ADD_SIGNAL(MethodInfo("session_begun"));
@@ -57,6 +59,8 @@ void OpenXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_action_sets"), &OpenXRInterface::get_action_sets);
 
 	ClassDB::bind_method(D_METHOD("get_available_display_refresh_rates"), &OpenXRInterface::get_available_display_refresh_rates);
+
+	ClassDB::bind_method(D_METHOD("is_eye_gaze_interaction_supported"), &OpenXRInterface::is_eye_gaze_interaction_supported);
 }
 
 StringName OpenXRInterface::get_name() const {
@@ -90,7 +94,9 @@ PackedStringArray OpenXRInterface::get_suggested_tracker_names() const {
 		"/user/vive_tracker_htcx/role/waist",
 		"/user/vive_tracker_htcx/role/chest",
 		"/user/vive_tracker_htcx/role/camera",
-		"/user/vive_tracker_htcx/role/keyboard"
+		"/user/vive_tracker_htcx/role/keyboard",
+
+		"/user/eyes_ext",
 	};
 
 	return arr;
@@ -638,6 +644,21 @@ Array OpenXRInterface::get_available_display_refresh_rates() const {
 		return Array();
 	} else {
 		return openxr_api->get_available_display_refresh_rates();
+	}
+}
+
+bool OpenXRInterface::is_eye_gaze_interaction_supported() {
+	if (openxr_api == nullptr) {
+		return false;
+	} else if (!openxr_api->is_initialized()) {
+		return false;
+	} else {
+		OpenXREyeGazeInteractionExtension *eye_gaze_ext = OpenXREyeGazeInteractionExtension::get_singleton();
+		if (eye_gaze_ext == nullptr) {
+			return false;
+		} else {
+			return eye_gaze_ext->supports_eye_gaze_interaction();
+		}
 	}
 }
 

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -107,6 +107,8 @@ public:
 	virtual PackedStringArray get_suggested_tracker_names() const override;
 	virtual TrackingStatus get_tracking_status() const override;
 
+	bool is_eye_gaze_interaction_supported();
+
 	bool initialize_on_startup() const;
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -39,6 +39,7 @@
 #include "scene/openxr_hand.h"
 
 #include "extensions/openxr_composition_layer_depth_extension.h"
+#include "extensions/openxr_eye_gaze_interaction.h"
 #include "extensions/openxr_fb_display_refresh_rate_extension.h"
 #include "extensions/openxr_fb_passthrough_extension_wrapper.h"
 #include "extensions/openxr_hand_tracking_extension.h"
@@ -96,6 +97,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 #endif
 
 			// register our other extensions
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXREyeGazeInteractionExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPalmPoseExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPicoControllerExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRCompositionLayerDepthExtension));


### PR DESCRIPTION
With eye tracking becoming a more prevalent feature, it's time we add support for this.

This PR adds support for the core [OpenXR eye gaze extension](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_EXT_eye_gaze_interaction).

This is mostly untested at the moment:
- see @tom95 feedback below on this working on Quest Pro, we're still discussing how to include the permissions
- this likely also works on Pico 4 Pro but crashes on a normal Pico 4 due to an issue on Picos side.

This PR will remain in draft until the above are resolved.

In order to use this feature a new interaction profile needs to be added to the action map:
![image](https://github.com/godotengine/godot/assets/1945449/dd01f48a-f244-4683-a80c-c9274b01ce0d)

Than in your XR setup a new `XRController3D` node can be added like so:
![image](https://github.com/godotengine/godot/assets/1945449/9fa0be11-1c54-49ab-8399-2a948a023932)

This node will be positioned correctly and "point" in a direction where the user is looking. For HMD based eye tracking the location will be centred between the eyes of the user.

As an example a ray cast was added in the above screenshot, this could be used to detect the object the user is looking at.

Todos:
- Wait on improvements by @m4gr3d that allow control over feature flags and permissions from the loader plugins
- Add project setting to enable (opt-in) this extension
- Add checks in code to only enable extension if required permissions are given (this may require platform dependent code, need to investigate how we do this)