### PR TITLE
Some code simplifications

### DIFF
--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -820,9 +820,7 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 
 			String error;
 
-			if (!tree) {
-				error = TTR("BlendSpace2D does not belong to an AnimationTree node.");
-			} else if (!tree->is_active()) {
+			if (!tree->is_active()) {
 				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
 			} else if (tree->is_state_invalid()) {
 				error = tree->get_invalid_state_reason();

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -860,7 +860,7 @@ void CurveEdit::_redraw() {
 		const Color selected_point_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 
 		// Draw tangents if not dragging a point, or if holding a point without having moved it yet.
-		if (grabbing == GRAB_NONE || (grabbing != GRAB_NONE && (initial_grab_pos == point_pos || selected_tangent_index != TANGENT_NONE))) {
+		if (grabbing == GRAB_NONE || initial_grab_pos == point_pos || selected_tangent_index != TANGENT_NONE) {
 			const Color selected_tangent_color = get_theme_color(SNAME("accent_color"), SNAME("Editor")).darkened(0.25);
 			const Color tangent_color = get_theme_color(SNAME("font_color"), SNAME("Editor")).darkened(0.25);
 

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -213,8 +213,8 @@ void GradientTexture2DEdit::_draw() {
 
 	// Draw handles.
 	const Color focus_modulate = Color(0.5, 1, 2);
-	bool modulate_handle_from = grabbed == HANDLE_FROM || (grabbed != HANDLE_FROM && hovered == HANDLE_FROM);
-	bool modulate_handle_to = grabbed == HANDLE_TO || (grabbed != HANDLE_TO && hovered == HANDLE_TO);
+	bool modulate_handle_from = grabbed == HANDLE_FROM || hovered == HANDLE_FROM;
+	bool modulate_handle_to = grabbed == HANDLE_TO || hovered == HANDLE_TO;
 	draw_texture(fill_from_icon, (_get_handle_pos(HANDLE_FROM) - handle_size / 2).round(), modulate_handle_from ? focus_modulate : Color(1, 1, 1));
 	draw_texture(fill_to_icon, (_get_handle_pos(HANDLE_TO) - handle_size / 2).round(), modulate_handle_to ? focus_modulate : Color(1, 1, 1));
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -356,7 +356,6 @@ void Viewport::_sub_window_grab_focus(Window *p_window) {
 		SubWindow sw = gui.sub_windows[index];
 		gui.sub_windows.remove_at(index);
 		gui.sub_windows.push_back(sw);
-		index = gui.sub_windows.size() - 1;
 		_sub_window_update_order();
 		return;
 	}
@@ -1741,6 +1740,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					gui.drag_attempted = false;
 				}
 			}
+			DEV_ASSERT(gui.mouse_focus);
 
 			mb = mb->xformed_by(Transform2D()); // Make a copy of the event.
 
@@ -1748,7 +1748,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			mb->set_position(pos);
 
 #ifdef DEBUG_ENABLED
-			if (EngineDebugger::get_singleton() && gui.mouse_focus) {
+			if (EngineDebugger::get_singleton()) {
 				Array arr;
 				arr.push_back(gui.mouse_focus->get_path());
 				arr.push_back(gui.mouse_focus->get_class());
@@ -1781,10 +1781,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				}
 			}
 
-			bool stopped = false;
-			if (gui.mouse_focus && gui.mouse_focus->can_process()) {
-				stopped = _gui_call_input(gui.mouse_focus, mb);
-			}
+			bool stopped = gui.mouse_focus->can_process() && _gui_call_input(gui.mouse_focus, mb);
 
 			if (stopped) {
 				set_input_as_handled();
@@ -1822,11 +1819,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.forced_mouse_focus = false;
 			}
 
-			bool stopped = false;
-			if (mouse_focus && mouse_focus->can_process()) {
-				stopped = _gui_call_input(mouse_focus, mb);
-			}
-
+			bool stopped = mouse_focus && mouse_focus->can_process() && _gui_call_input(mouse_focus, mb);
 			if (stopped) {
 				set_input_as_handled();
 			}
@@ -1985,11 +1978,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 			ds_cursor_shape = (DisplayServer::CursorShape)cursor_shape;
 
-			bool stopped = false;
-			if (over && over->can_process()) {
-				stopped = _gui_call_input(over, mm);
-			}
-
+			bool stopped = over->can_process() && _gui_call_input(over, mm);
 			if (stopped) {
 				set_input_as_handled();
 			}


### PR DESCRIPTION
AnimationNodeBlendSpace2DEditor:
- `!tree` is always false, because it is checked a few lines above

CurveEdit:
- grabbing != GRAB_NONE is redundant

GradientTexture2DEdit:
- grabbed != HANDLE_FROM is redundant
- grabbed != HANDLE_TO is redundant

Viewport:
- index is not used afterwards
- In these cases `gui.mouse_focus` is always valid. Move check to a DEV_ASSERT
- simplify `stopped` calculation
