### PR TITLE
Ensure that controls update all their sizing information when required

### DIFF
--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -34,8 +34,6 @@
 #include "scene/scene_string_names.h"
 
 void Container::_child_minsize_changed() {
-	//Size2 ms = get_combined_minimum_size();
-	//if (ms.width > get_size().width || ms.height > get_size().height) {
 	update_minimum_size();
 	queue_sort();
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1579,6 +1579,7 @@ Vector2 Control::get_pivot_offset() const {
 
 void Control::_update_minimum_size() {
 	if (!is_inside_tree()) {
+		data.updating_last_minimum_size = false;
 		return;
 	}
 
@@ -1598,9 +1599,8 @@ void Control::update_minimum_size() {
 		return;
 	}
 
-	Control *invalidate = this;
-
 	// Invalidate cache upwards.
+	Control *invalidate = this;
 	while (invalidate && invalidate->data.minimum_size_valid) {
 		invalidate->data.minimum_size_valid = false;
 		if (invalidate->is_set_as_top_level()) {
@@ -1623,10 +1623,9 @@ void Control::update_minimum_size() {
 	if (data.updating_last_minimum_size) {
 		return;
 	}
-
 	data.updating_last_minimum_size = true;
 
-	MessageQueue::get_singleton()->push_call(this, "_update_minimum_size");
+	MessageQueue::get_singleton()->push_callable(callable_mp(this, &Control::_update_minimum_size));
 }
 
 void Control::set_block_minimum_size_adjust(bool p_block) {
@@ -1666,17 +1665,8 @@ void Control::_update_minimum_size_cache() {
 	minsize.x = MAX(minsize.x, data.custom_minimum_size.x);
 	minsize.y = MAX(minsize.y, data.custom_minimum_size.y);
 
-	bool size_changed = false;
-	if (data.minimum_size_cache != minsize) {
-		size_changed = true;
-	}
-
 	data.minimum_size_cache = minsize;
 	data.minimum_size_valid = true;
-
-	if (size_changed) {
-		update_minimum_size();
-	}
 }
 
 Size2 Control::get_combined_minimum_size() const {
@@ -3140,8 +3130,8 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_POST_ENTER_TREE: {
-			data.minimum_size_valid = false;
 			data.is_rtl_dirty = true;
+			update_minimum_size();
 			_size_changed();
 		} break;
 
@@ -3257,10 +3247,13 @@ void Control::_notification(int p_notification) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->theme_changed);
+
 			_invalidate_theme_cache();
 			_update_theme_item_cache();
-			update_minimum_size();
 			queue_redraw();
+
+			update_minimum_size();
+			_size_changed();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -3269,8 +3262,7 @@ void Control::_notification(int p_notification) {
 					get_viewport()->_gui_hide_control(this);
 				}
 			} else {
-				data.minimum_size_valid = false;
-				_update_minimum_size();
+				update_minimum_size();
 				_size_changed();
 			}
 		} break;
@@ -3279,8 +3271,12 @@ void Control::_notification(int p_notification) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			if (is_inside_tree()) {
 				data.is_rtl_dirty = true;
+
 				_invalidate_theme_cache();
 				_update_theme_item_cache();
+				queue_redraw();
+
+				update_minimum_size();
 				_size_changed();
 			}
 		} break;
@@ -3288,8 +3284,6 @@ void Control::_notification(int p_notification) {
 }
 
 void Control::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_update_minimum_size"), &Control::_update_minimum_size);
-
 	ClassDB::bind_method(D_METHOD("accept_event"), &Control::accept_event);
 	ClassDB::bind_method(D_METHOD("get_minimum_size"), &Control::get_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_combined_minimum_size"), &Control::get_combined_minimum_size);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1582,6 +1582,22 @@ void Control::_update_minimum_size() {
 		return;
 	}
 
+	Size2 minsize = get_combined_minimum_size();
+	data.updating_last_minimum_size = false;
+
+	if (minsize != data.last_minimum_size) {
+		data.last_minimum_size = minsize;
+		_size_changed();
+		emit_signal(SceneStringNames::get_singleton()->minimum_size_changed);
+	}
+}
+
+void Control::update_minimum_size() {
+	ERR_MAIN_THREAD_GUARD;
+	if (!is_inside_tree() || data.block_minimum_size_adjust) {
+		return;
+	}
+
 	Control *invalidate = this;
 
 	// Invalidate cache upwards.
@@ -1601,21 +1617,6 @@ void Control::_update_minimum_size() {
 	}
 
 	if (!is_visible_in_tree()) {
-		return;
-	}
-
-	Size2 minsize = get_combined_minimum_size();
-	data.updating_last_minimum_size = false;
-	if (minsize != data.last_minimum_size) {
-		data.last_minimum_size = minsize;
-		_size_changed();
-		emit_signal(SceneStringNames::get_singleton()->minimum_size_changed);
-	}
-}
-
-void Control::update_minimum_size() {
-	ERR_MAIN_THREAD_GUARD;
-	if (!is_inside_tree() || data.block_minimum_size_adjust) {
 		return;
 	}
 
@@ -3139,6 +3140,7 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_POST_ENTER_TREE: {
+			data.minimum_size_valid = false;
 			data.is_rtl_dirty = true;
 			_size_changed();
 		} break;
@@ -3267,7 +3269,9 @@ void Control::_notification(int p_notification) {
 					get_viewport()->_gui_hide_control(this);
 				}
 			} else {
+				data.minimum_size_valid = false;
 				_update_minimum_size();
+				_size_changed();
 			}
 		} break;
 


### PR DESCRIPTION
This PR reverts https://github.com/godotengine/godot/pull/77651 and supersedes https://github.com/godotengine/godot/pull/77825.

It still fixes https://github.com/godotengine/godot/issues/74052, the original issue from https://github.com/godotengine/godot/pull/77651. It also fixes regressions from that PR:
- Fixes https://github.com/godotengine/godot/issues/77815.
- Fixes https://github.com/godotengine/godot/issues/77885.
- Fixes https://github.com/godotengine/godot/issues/77787 (though I couldn't reproduce it even with the current master, so please double-check).
- Fixes #78118 (tested by Sauermann)
- Fixes https://github.com/godotengine/godot/issues/78091

I decided to take the approach of reverting and refixing the issue because I wasn't confident in the original solution. I had my doubts initially, but it looked sensible enough and fixed the issue at hand, so I approved and merged it. However, given all the new issues that popped up, I thought it would be better for me to investigate the problem further and try a safer approach.

My idea here is that instead of changing the order in which the data is invalidated, we should instead make sure that all the necessary routines are called when we think that the size might've changed. This happens on tree entry, but also on global changes, such as themes and translations. Previously we would only do some of the updates in these situations, but I'm not sure it was appropriate to do it like that.

I have a suspicion, that for the most part it worked thanks to a very nasty hidden side-effect of `get_combined_minimum_size()`, which could in turn trigger a complete invalidation of the minimum size information. Yes, from an innocent getter. This wasn't originally the case, however, this was bolted on later, in https://github.com/godotengine/godot/pull/19871 (a follow up to https://github.com/godotengine/godot/pull/19334). I don't think this was a proper solution, but once again it solved the problems at hand at the time. I removed that side-effect, and with all the other changes haven't noticed any obvious regressions, testing the editor and the test scenes from all the linked issues.

This brings things closer to the original state of this commit: https://github.com/godotengine/godot/commit/005b69cf6e276209464cc8c36ebc7376679925b6#diff-2b7ba034670859ced66e442b9ec59f7351febc3b4352e535bc85da804bcca266

-----

I was faced with one regression of my own, where opening a scene in the editor in the background caused size calculations to misbehave once you switched to it. Turns out that when we request an update with `_update_minimum_size()` we set a guard flag to prevent doing it multiple times. However, when the node is out of the scene tree, this method hits an early return. Which means that the guard flag is never reset and the method cannot be triggered again either.

For some reason, this only happened in editor and only under those specific circumstances (instanced scenes weren't affected, for example). Changing the size of the control in the editor would also cause it to finally update, somehow. So it's still a bit of a mystery, but the logic seems flawed without this fix.

Edit: Well, I guess for this situation to happen, the call to `update_minimum_size` must happen while the nodes are inside of the tree, and then the call to `_update_minimum_size` (with the underscore, the actual routine) needs to happen while the nodes are out of the tree. Which is... interesting? I guess as scenes are opened in the editor, the nodes are briefly added to the tree and then removed?

-----

All in all, a lot of the original issue comes down to the old problem of cascading updates in labels (see https://github.com/godotengine/godot/pull/73809). Basically, when we do shaping of a text label, we use its current size. But shaping itself affects the minimum size, which in turn further affects the current size. This means that shaping is an unstable and unreliable operation whenever we have wrapping enabled (and thus cannot enforce any minimum size based on the contents).

This probably affects more stuff than labels, but somehow the entire GUI system manages to work to this day, and this PR seems to address the particular issue with auto-wrapping by doing just enough updates to make things right.