### PR TITLE
Convert `_scene_cull()` to use parallel `foreach()`

### DIFF
--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -937,7 +937,6 @@ public:
 	};
 
 	InstanceCullResult scene_cull_result;
-	LocalVector<InstanceCullResult> scene_cull_result_threads;
 
 	RendererSceneRender::RenderShadowData render_shadow_data[MAX_UPDATE_SHADOWS];
 	uint32_t max_shadows_used = 0;
@@ -1048,8 +1047,6 @@ public:
 
 		} sdfgi;
 
-		SpinLock lock;
-
 		Frustum frustum;
 	} cull;
 
@@ -1078,7 +1075,6 @@ public:
 		uint64_t visibility_viewport_mask;
 	};
 
-	void _scene_cull_threaded(uint32_t p_thread, CullData *cull_data);
 	void _scene_cull(CullData &cull_data, InstanceCullResult &cull_result, uint64_t p_from, uint64_t p_to);
 	_FORCE_INLINE_ bool _visibility_parent_check(const CullData &p_cull_data, const InstanceData &p_instance_data);
 


### PR DESCRIPTION
Follow-up to #74118

Reduces the amount of code in the multithreaded culling path, which decreases lock contention and reduces the chances of any hidden race conditions lurking around (see #71705).

As a bonus, culling performance improves slightly for me (going from 1 -> 2 threads results in an average of 1.4x speedup rather than 1.3x), although obviously YMMV.

Depends on #74118 and #72784, marking as draft until those two are merged. Also has a soft dependency on #72716 (this PR works without it, but will likely result in performance regressions)