### PR TITLE
Fix passive mouse hovering for physics

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -256,16 +256,6 @@ private:
 	Transform3D physics_last_object_transform;
 	Transform3D physics_last_camera_transform;
 	ObjectID physics_last_id;
-	bool physics_has_last_mousepos = false;
-	Vector2 physics_last_mousepos = Vector2(INFINITY, INFINITY);
-	struct {
-		bool alt = false;
-		bool control = false;
-		bool shift = false;
-		bool meta = false;
-		BitField<MouseButtonMask> mouse_mask;
-
-	} physics_last_mouse_state;
 
 	bool handle_input_locally = true;
 	bool local_input_handled = false;


### PR DESCRIPTION
Currently mouse hovering doesn't update the state, when collision objects or the camera move.
This PR fixes this problem by taking the mouse position from the viewport and not from a nonexistent previous event.

Since previous events could potentially be a long time ago, their modifier-key state might be outdated. This PR fetches the current status of modifier-keys from `Input`.

These changes allow the removal of some class-variables and making additional simplifications.

resolve #69708
resolve #75711