### PR TITLE
Fix compilation of basis unit test

### DIFF
--- a/main/tests/test_basis.cpp
+++ b/main/tests/test_basis.cpp
@@ -315,11 +315,11 @@ void test_euler_conversion() {
 	}
 }
 
-void check_test(std::string test_case_name, bool condition) {
+void check_test(const char *test_case_name, bool condition) {
 	if (!condition) {
-		OS::get_singleton()->print("FAILED - %s\n", test_case_name.c_str());
+		OS::get_singleton()->print("FAILED - %s\n", test_case_name);
 	} else {
-		OS::get_singleton()->print("PASSED - %s\n", test_case_name.c_str());
+		OS::get_singleton()->print("PASSED - %s\n", test_case_name);
 	}
 }
 


### PR DESCRIPTION
`std::string` was being used in https://github.com/godotengine/godot/pull/72127 when there's no need to use it, as `const char *` does the job just fine. This broke the build on my Linux setup:

```
Compiling ==> main/tests/test_basis.cpp
main/tests/test_basis.cpp:318:6: error: variable or field 'check_test' declared void
  318 | void check_test(std::string test_case_name, bool condition) {
      |      ^~~~~~~~~~
main/tests/test_basis.cpp:318:22: error: 'string' is not a member of 'std'
  318 | void check_test(std::string test_case_name, bool condition) {
      |                      ^~~~~~
main/tests/test_basis.cpp:35:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
   34 | #include "core/os/os.h"
  +++ |+#include <string>
   35 | #include "core/ustring.h"
main/tests/test_basis.cpp:318:45: error: expected primary-expression before 'bool'
  318 | void check_test(std::string test_case_name, bool condition) {
      |                                             ^~~~
main/tests/test_basis.cpp: In function 'void TestBasis::test_set_axis_angle()':
main/tests/test_basis.cpp:334:9: error: 'check_test' was not declared in this scope
  334 |         check_test("Testing the singularity when the angle is 0.", angle == 0);
      |         ^~~~~~~~~~
```

The test still runs successfully:

```
❯ bin/godot.x11.tools.64 --test basis
Godot Engine v3.6.beta.custom_build.b82246396 - https://godotengine.org
OpenGL ES 3.0 Renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
Async. shader compilation: OFF

Start euler conversion checks.
1052 passed tests for rotation order: XYZ.
1052 passed tests for rotation order: XZY.
1052 passed tests for rotation order: YZX.
1052 passed tests for rotation order: YXZ.
1052 passed tests for rotation order: ZXY.
1052 passed tests for rotation order: ZYX.
Euler conversion checks passed.

---------------
Start set axis angle checks.
PASSED - Testing the singularity when the angle is 0.
PASSED - Testing the singularity when the angle is 180.
PASSED - Testing reversing the an axis (of an 30 angle).
PASSED - Testing reversing the an axis (of an 30 angle).
PASSED - Testing reversing the an axis (of an 30 angle).
PASSED - Testing reversing the an axis (of an 30 angle).
PASSED - Testing a rotation of 90 on x-y-z.
PASSED - Testing a rotation of 90 on x-y-z.
PASSED - Testing a rotation of 90 on x-y-z.
PASSED - Testing a rotation of 90 on x-y-z.
PASSED - Regression test: checks that the method returns a small angle (not 0).
PASSED - Regression test: checks that the method returns an angle which is a number (not NaN)
```

The `master` version of https://github.com/godotengine/godot/pull/72127 (https://github.com/godotengine/godot/pull/63428) does not have this issue.