### PR TITLE
Skeleton3D: Only reset `rest_dirty` after ALL bone transforms have finished update

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -906,6 +906,7 @@ void Skeleton3D::force_update_all_bone_transforms() {
 	for (int i = 0; i < parentless_bones.size(); i++) {
 		force_update_bone_children_transforms(parentless_bones[i]);
 	}
+	rest_dirty = false;
 }
 
 void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
@@ -963,7 +964,6 @@ void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
 
 		emit_signal(SceneStringNames::get_singleton()->bone_pose_changed, current_bone_idx);
 	}
-	rest_dirty = false;
 }
 
 void Skeleton3D::_bind_methods() {


### PR DESCRIPTION
Fixes #77995

Special thanks to @TokageItLab for identifying the line of code during a debug session. I wouldn't have found it without that.

cc @TokageItLab @fire