### PR TITLE
Add wrapping support to `AStarGrid2D`

### DIFF
--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -64,6 +64,8 @@ private:
 	bool dirty = false;
 
 	bool jumping_enabled = false;
+	bool wrapping_x_enabled = false;
+	bool wrapping_y_enabled = false;
 	DiagonalMode diagonal_mode = DIAGONAL_MODE_ALWAYS;
 	Heuristic default_compute_heuristic = HEURISTIC_EUCLIDEAN;
 	Heuristic default_estimate_heuristic = HEURISTIC_EUCLIDEAN;
@@ -74,6 +76,7 @@ private:
 		bool solid = false;
 		Vector2 pos;
 		real_t weight_scale = 1.0;
+		real_t wrapping_weight_scale = 1.0;
 
 		// Used for pathfinding.
 		Point *prev_point = nullptr;
@@ -162,6 +165,12 @@ public:
 	void set_jumping_enabled(bool p_enabled);
 	bool is_jumping_enabled() const;
 
+	void set_wrapping_x_enabled(bool p_enabled);
+	bool is_wrapping_x_enabled() const;
+
+	void set_wrapping_y_enabled(bool p_enabled);
+	bool is_wrapping_y_enabled() const;
+
 	void set_diagonal_mode(DiagonalMode p_diagonal_mode);
 	DiagonalMode get_diagonal_mode() const;
 
@@ -176,6 +185,9 @@ public:
 
 	void set_point_weight_scale(const Vector2i &p_id, real_t p_weight_scale);
 	real_t get_point_weight_scale(const Vector2i &p_id) const;
+
+	void set_point_wrapping_weight_scale(const Vector2i &p_id, real_t p_wrapping_weight_scale);
+	real_t get_point_wrapping_weight_scale(const Vector2i &p_id) const;
 
 	void clear();
 

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -84,6 +84,13 @@
 				Returns the weight scale of the point associated with the given [param id].
 			</description>
 		</method>
+		<method name="get_point_wrapping_weight_scale" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="id" type="Vector2i" />
+			<description>
+				Returns the wrapping weight scale of the point associated with the given [param id].
+			</description>
+		</method>
 		<method name="is_dirty" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -130,6 +137,15 @@
 				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
 			</description>
 		</method>
+		<method name="set_point_wrapping_weight_scale">
+			<return type="void" />
+			<param index="0" name="id" type="Vector2i" />
+			<param index="1" name="wrapping_weight_scale" type="float" />
+			<description>
+				Sets the [param wrapping_weight_scale] for the point with the given [param id]. The [param wrapping_weight_scale] is multiplied by the result of [method _compute_cost] if wrapping is detected and when determining the overall cost of traveling across a segment from a neighboring point to this point.
+				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
+			</description>
+		</method>
 		<method name="update">
 			<return type="void" />
 			<description>
@@ -154,6 +170,7 @@
 		<member name="jumping_enabled" type="bool" setter="set_jumping_enabled" getter="is_jumping_enabled" default="false">
 			Enables or disables jumping to skip up the intermediate points and speeds up the searching algorithm.
 			[b]Note:[/b] Currently, toggling it on disables the consideration of weight scaling in pathfinding.
+			[b]Note:[/b] Currently, may not work completely correctly if either [member wrapping_x_enabled] or [member wrapping_y_enabled] are enabled.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The offset of the grid which will be applied to calculate the resulting point position returned by [method get_point_path]. If changed, [method update] needs to be called before finding the next path.
@@ -164,6 +181,12 @@
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(0, 0)" is_deprecated="true">
 			The size of the grid (number of cells of size [member cell_size] on each axis). If changed, [method update] needs to be called before finding the next path.
 			[i]Deprecated.[/i] Use [member region] instead.
+		</member>
+		<member name="wrapping_x_enabled" type="bool" setter="set_wrapping_x_enabled" getter="is_wrapping_x_enabled" default="false">
+			If [code]true[/code], enables pathfinding wrapping around x-axis.
+		</member>
+		<member name="wrapping_y_enabled" type="bool" setter="set_wrapping_y_enabled" getter="is_wrapping_y_enabled" default="false">
+			If [code]true[/code], enables pathfinding wrapping around y-axis.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Adds `wrapping_x_enabled` and `wrapping_y_enabled` properties to `AStarGrid2D`.
This will allow the user to create wrap-around behaviour with that class:

![wrapping](https://github.com/godotengine/godot/assets/3036176/42dcd6fe-336c-48d1-8572-0f5190a791f8)

If anyone wants to play with it, here is a project: [astargrid2d.zip](https://github.com/godotengine/godot/files/11704008/astargrid2d.zip)  (modified version of demo project by @theshaggydev - https://github.com/theshaggydev/the-shaggy-dev-projects/tree/main/projects/godot-4/astargrid2d).

PS: This new modes may not work completely correctly when the <b>jumping mode</b> is enabled:

<details>
<summary>Sometimes it works incorrectly.</summary>

![image](https://github.com/godotengine/godot/assets/3036176/c0fdaa22-be3c-49c3-885b-b726fef9b918)

</details>

<details>
<summary>Or it's not worked at all.</summary>

![image](https://github.com/godotengine/godot/assets/3036176/790ef189-eb2c-4ee4-b589-f34046e64f54)

</details>

This need to be investigated and fixed, but this may be done in later PR (I think).