### PR TITLE
Fix heap-use-after-free when editing project tags

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2486,8 +2486,6 @@ void ProjectManager::_delete_project_tag(const String &p_tag) {
 }
 
 void ProjectManager::_apply_project_tags() {
-	ProjectList::Item &item = _project_list->get_selected_projects().write[0];
-
 	PackedStringArray tags;
 	for (int i = 0; i < project_tags->get_child_count(); i++) {
 		ProjectTag *tag_control = Object::cast_to<ProjectTag>(project_tags->get_child(i));
@@ -2497,7 +2495,7 @@ void ProjectManager::_apply_project_tags() {
 	}
 
 	ConfigFile cfg;
-	String project_godot = item.path.path_join("project.godot");
+	const String project_godot = _project_list->get_selected_projects()[0].path.path_join("project.godot");
 	Error err = cfg.load(project_godot);
 	if (err != OK) {
 		tag_edit_error->set_text(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err));


### PR DESCRIPTION
When updating project tags, reference to an element inside a temporary `Vector` was obtained and used later.

<details><summary>Sanitizer Output</summary>

```
==225055==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000d3a6d8 at pc 0x55e20444ac5d bp 0x7ffd5c25ceb0 sp 0x7ffd5c25cea0
READ of size 8 at 0x60d000d3a6d8 thread T0
    #0 0x55e20444ac5c in CowData<char32_t>::_get_size() const core/templates/cowdata.h:81
    #1 0x55e204448ad9 in CowData<char32_t>::size() const core/templates/cowdata.h:131
    #2 0x55e204448797 in String::size() const core/string/ustring.h:216
    #3 0x55e2044487b1 in String::length() const core/string/ustring.h:272
    #4 0x55e2044487e1 in String::is_empty() const core/string/ustring.h:409
    #5 0x55e2115e16a8 in String::path_join(String const&) const core/string/ustring.cpp:4625
    #6 0x55e20a04bce9 in ProjectManager::_apply_project_tags() editor/project_manager.cpp:2500
    #7 0x55e20a08d3d7 in void call_with_variant_args_helper<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:303
    #8 0x55e20a08afaf in void call_with_variant_args<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #9 0x55e20a0814cb in CallableCustomMethodPointer<ProjectManager>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #10 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #11 0x55e21149c3d1 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1068
    #12 0x55e20bc5ab5e in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3571
    #13 0x55e2055f9c8b in Error Object::emit_signal<>(StringName const&) core/object/object.h:891
    #14 0x55e20bee9c98 in BaseButton::_pressed() scene/gui/base_button.cpp:138
    #15 0x55e20beea917 in BaseButton::on_action_event(Ref<InputEvent>) scene/gui/base_button.cpp:172
    #16 0x55e20bee9286 in BaseButton::gui_input(Ref<InputEvent> const&) scene/gui/base_button.cpp:69
    #17 0x55e20c079a1a in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1814
    #18 0x55e20bd4bfab in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1567
    #19 0x55e20bd4f971 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1839
    #20 0x55e20bd62a48 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3007
    #21 0x55e20be3d80d in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1465
    #22 0x55e20bed8082 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:303
    #23 0x55e20bec3e91 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #24 0x55e20beaf55d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #25 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #26 0x55e2044ac6c6 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3712
    #27 0x55e2044ac0f0 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3683
    #28 0x55e210b98cd4 in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:707
    #29 0x55e210b9cd21 in Input::flush_buffered_events() core/input/input.cpp:967
    #30 0x55e2044ba49a in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4780
    #31 0x55e20445b96e in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:900
    #32 0x55e204446811 in main platform/linuxbsd/godot_linuxbsd.cpp:74
    #33 0x7f8afcd4c84f  (/usr/lib/libc.so.6+0x2384f) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #34 0x7f8afcd4c909 in __libc_start_main (/usr/lib/libc.so.6+0x23909) (BuildId: 2f005a79cd1a8e385972f5a102f16adba414d75e)
    #35 0x55e2044463e4 in _start (/home/timothy/repos/godot-master/bin/godot.linuxbsd.editor.dev.x86_64.san+0x89ac3e4) (BuildId: 8adbf77370239cbac19b1475578e990f56fb891c)

0x60d000d3a6d8 is located 56 bytes inside of 144-byte region [0x60d000d3a6a0,0x60d000d3a730)
freed by thread T0 here:
    #0 0x7f8afd0dfdc2 in __interceptor_free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x55e21068bbea in Memory::free_static(void*, bool) core/os/memory.cpp:168
    #2 0x55e20a07b3ee in CowData<ProjectList::Item>::_unref(void*) core/templates/cowdata.h:218
    #3 0x55e20a077706 in CowData<ProjectList::Item>::~CowData() core/templates/cowdata.h:412
    #4 0x55e20a074033 in Vector<ProjectList::Item>::~Vector() core/templates/vector.h:290
    #5 0x55e20a04ba8e in ProjectManager::_apply_project_tags() editor/project_manager.cpp:2489
    #6 0x55e20a08d3d7 in void call_with_variant_args_helper<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:303
    #7 0x55e20a08afaf in void call_with_variant_args<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #8 0x55e20a0814cb in CallableCustomMethodPointer<ProjectManager>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #9 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #10 0x55e21149c3d1 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1068
    #11 0x55e20bc5ab5e in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3571
    #12 0x55e2055f9c8b in Error Object::emit_signal<>(StringName const&) core/object/object.h:891
    #13 0x55e20bee9c98 in BaseButton::_pressed() scene/gui/base_button.cpp:138
    #14 0x55e20beea917 in BaseButton::on_action_event(Ref<InputEvent>) scene/gui/base_button.cpp:172
    #15 0x55e20bee9286 in BaseButton::gui_input(Ref<InputEvent> const&) scene/gui/base_button.cpp:69
    #16 0x55e20c079a1a in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1814
    #17 0x55e20bd4bfab in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1567
    #18 0x55e20bd4f971 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1839
    #19 0x55e20bd62a48 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3007
    #20 0x55e20be3d80d in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1465
    #21 0x55e20bed8082 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:303
    #22 0x55e20bec3e91 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #23 0x55e20beaf55d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #24 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #25 0x55e2044ac6c6 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3712
    #26 0x55e2044ac0f0 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3683
    #27 0x55e210b98cd4 in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:707
    #28 0x55e210b9cd21 in Input::flush_buffered_events() core/input/input.cpp:967
    #29 0x55e2044ba49a in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4780

previously allocated by thread T0 here:
    #0 0x7f8afd0e1369 in __interceptor_malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55e21068b014 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:75
    #2 0x55e20a0779ae in Error CowData<ProjectList::Item>::resize<false>(int) core/templates/cowdata.h:288
    #3 0x55e20a07405b in Vector<ProjectList::Item>::resize(int) core/templates/vector.h:94
    #4 0x55e20a037331 in ProjectList::get_selected_projects() const editor/project_manager.cpp:1556
    #5 0x55e20a04ba64 in ProjectManager::_apply_project_tags() editor/project_manager.cpp:2489
    #6 0x55e20a08d3d7 in void call_with_variant_args_helper<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:303
    #7 0x55e20a08afaf in void call_with_variant_args<ProjectManager>(ProjectManager*, void (ProjectManager::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #8 0x55e20a0814cb in CallableCustomMethodPointer<ProjectManager>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #9 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #10 0x55e21149c3d1 in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1068
    #11 0x55e20bc5ab5e in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3571
    #12 0x55e2055f9c8b in Error Object::emit_signal<>(StringName const&) core/object/object.h:891
    #13 0x55e20bee9c98 in BaseButton::_pressed() scene/gui/base_button.cpp:138
    #14 0x55e20beea917 in BaseButton::on_action_event(Ref<InputEvent>) scene/gui/base_button.cpp:172
    #15 0x55e20bee9286 in BaseButton::gui_input(Ref<InputEvent> const&) scene/gui/base_button.cpp:69
    #16 0x55e20c079a1a in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1814
    #17 0x55e20bd4bfab in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1567
    #18 0x55e20bd4f971 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1839
    #19 0x55e20bd62a48 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3007
    #20 0x55e20be3d80d in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1465
    #21 0x55e20bed8082 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:303
    #22 0x55e20bec3e91 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:417
    #23 0x55e20beaf55d in CallableCustomMethodPointer<Window, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:104
    #24 0x55e210c9d81b in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:50
    #25 0x55e2044ac6c6 in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3712
    #26 0x55e2044ac0f0 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:3683
    #27 0x55e210b98cd4 in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:707
    #28 0x55e210b9cd21 in Input::flush_buffered_events() core/input/input.cpp:967
    #29 0x55e2044ba49a in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:4780

SUMMARY: AddressSanitizer: heap-use-after-free core/templates/cowdata.h:81 in CowData<char32_t>::_get_size() const
Shadow bytes around the buggy address:
  0x60d000d3a400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x60d000d3a480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x60d000d3a500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x60d000d3a580: fa fa fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x60d000d3a600: 00 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa
=>0x60d000d3a680: fa fa fa fa fd fd fd fd fd fd fd[fd]fd fd fd fd
  0x60d000d3a700: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fd fd
  0x60d000d3a780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x60d000d3a800: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x60d000d3a880: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0x60d000d3a900: fa fa fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==225055==ABORTING
```

</details>