### PR TITLE
Add command-line option to run a `MainLoop` by its global class name

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -476,6 +476,7 @@ void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print("Standalone tools:\n");
 	OS::get_singleton()->print("  -s, --script <script>             Run a script.\n");
+	OS::get_singleton()->print("  --main-loop <main_loop_name>      Run a MainLoop specified by its global class name.\n");
 	OS::get_singleton()->print("  --check-only                      Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
 	OS::get_singleton()->print("  --export-release <preset> <path>  Export the project in release mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.\n");
@@ -2558,6 +2559,7 @@ bool Main::start() {
 	String positional_arg;
 	String game_path;
 	String script;
+	String main_loop_type;
 	bool check_only = false;
 
 #ifdef TOOLS_ENABLED
@@ -2621,6 +2623,8 @@ bool Main::start() {
 			bool parsed_pair = true;
 			if (args[i] == "-s" || args[i] == "--script") {
 				script = args[i + 1];
+			} else if (args[i] == "--main-loop") {
+				main_loop_type = args[i + 1];
 #ifdef TOOLS_ENABLED
 			} else if (args[i] == "--doctool") {
 				doc_tool_path = args[i + 1];
@@ -2839,7 +2843,9 @@ bool Main::start() {
 	if (editor) {
 		main_loop = memnew(SceneTree);
 	}
-	String main_loop_type = GLOBAL_GET("application/run/main_loop_type");
+	if (main_loop_type.is_empty()) {
+		main_loop_type = GLOBAL_GET("application/run/main_loop_type");
+	}
 
 	if (!script.is_empty()) {
 		Ref<Script> script_res = ResourceLoader::load(script);


### PR DESCRIPTION
This PR allows e.g. creating language bindings in the same way as C#, but without hacking `main.cpp`.

See https://github.com/godotengine/godot/commit/7f89a1c8b812a150aafc5f5895ff5821d64e22fe for an example of usage.

<details>
<summary>Original (outdated) description</summary>

Removes this hack from `main.cpp`:

https://github.com/godotengine/godot/blob/300748e52c03fd1761b716fc7eea2b9fb97b86f9/main/main.cpp#L2519-L2526

With this PR, the bindings generator can be run as:

    /bin/godot.linuxbsd.editor.dev.x86_64.llvm.mono --headless --main-loop CSharpBindingsGenerator --generate-mono-glue modules/mono/glue

Here I named the main loop class `CSharpBindingsGenerator`. The class could also be renamed `CSharpGlueGenerator`, and then the argument parsing could be simplified to use [`OS::get_cmdline_user_args`](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-cmdline-user-args):

    /bin/godot.linuxbsd.editor.dev.x86_64.llvm.mono --headless --main-loop CSharpGlueGenerator -- modules/mono/glue

This PR allows creating other language bindings in the same way without hacking `main.cpp` (which was my motivation).
</details>