### PR TITLE
Add TextFile to editor property capitalizations

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -263,6 +263,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["svg"] = "SVG";
 	capitalize_string_remaps["taa"] = "TAA";
 	capitalize_string_remaps["tcp"] = "TCP";
+	capitalize_string_remaps["textfile"] = "TextFile";
 	capitalize_string_remaps["tls"] = "TLS";
 	capitalize_string_remaps["ui"] = "UI";
 	capitalize_string_remaps["uri"] = "URI";


### PR DESCRIPTION
This is used in the TextFile Extensions editor setting.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/7ea7a295-cd28-4793-a0ff-498c0c5f1a4d)