### PR TITLE
[3.x] Expose the TextEdit control of the script editor

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -25,6 +25,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_base_editor" qualifiers="const">
+			<return type="Control" />
+			<description>
+				Returns the underlying [Control] used for editing scripts. For text scripts, this is a [TextEdit].
+			</description>
+		</method>
 		<method name="get_current_script">
 			<return type="Script" />
 			<description>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -343,6 +343,10 @@ ScriptEditorBase *ScriptEditor::_get_current_editor() const {
 	return Object::cast_to<ScriptEditorBase>(tab_container->get_child(selected));
 }
 
+Control *ScriptEditor::_get_base_editor() const {
+	return Object::cast_to<ScriptTextEditor>(_get_current_editor())->get_code_editor_text_edit();
+}
+
 void ScriptEditor::_update_history_arrows() {
 	script_back->set_disabled(history_pos <= 0);
 	script_forward->set_disabled(history_pos >= history.size() - 1);
@@ -3235,6 +3239,7 @@ void ScriptEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_open_scripts"), &ScriptEditor::_get_open_scripts);
 	ClassDB::bind_method(D_METHOD("open_script_create_dialog", "base_name", "base_path"), &ScriptEditor::open_script_create_dialog);
 	ClassDB::bind_method(D_METHOD("reload_scripts"), &ScriptEditor::reload_scripts);
+	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditor::_get_base_editor);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -338,6 +338,7 @@ class ScriptEditor : public PanelContainer {
 	void _script_created(Ref<Script> p_script);
 
 	ScriptEditorBase *_get_current_editor() const;
+	Control *_get_base_editor() const;
 
 	void _save_layout();
 	void _editor_settings_changed();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1432,6 +1432,10 @@ Control *ScriptTextEditor::get_edit_menu() {
 	return edit_hb;
 }
 
+Control *ScriptTextEditor::get_code_editor_text_edit() {
+	return code_editor->get_text_edit();
+}
+
 void ScriptTextEditor::clear_edit_menu() {
 	memdelete(edit_hb);
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -236,6 +236,7 @@ public:
 	virtual void set_debugger_active(bool p_active);
 
 	Control *get_edit_menu();
+	Control *get_code_editor_text_edit();
 	virtual void clear_edit_menu();
 	static void register_editor();
 


### PR DESCRIPTION
Refactor ScriptEditor and ScriptTextEditor with added method to retrieve the script editor's TextEdit control.

Update
doc/classes/ScriptEditor.xml
script_editor_plugin.cpp
script_editor_plugin.h
script_text_editor.cpp
script_text_editor.h

_Bugsquad edit:_ This PR is a 3.x version of 4.x's `get_base_editor()`.
this PR comes from https://github.com/godotengine/godot/pull/77119
