### PR TITLE
Fix wrapping Object's in GDExtension that aren't exposed

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1719,6 +1719,30 @@ uint32_t Object::get_edited_version() const {
 }
 #endif
 
+StringName Object::get_class_name_for_extension(const GDExtension *p_library) const {
+	// Only return the class name per the extension if it matches the given p_library.
+	if (_extension && _extension->library == p_library) {
+		return _extension->class_name;
+	}
+
+	// Extensions only have wrapper classes for classes exposed in ClassDB.
+	const StringName *class_name = _get_class_namev();
+	if (ClassDB::is_class_exposed(*class_name)) {
+		return *class_name;
+	}
+
+	// Find the nearest parent class that's exposed.
+	StringName parent_class = ClassDB::get_parent_class(*class_name);
+	while (parent_class != StringName()) {
+		if (ClassDB::is_class_exposed(parent_class)) {
+			return parent_class;
+		}
+		parent_class = ClassDB::get_parent_class(parent_class);
+	}
+
+	return SNAME("Object");
+}
+
 void Object::set_instance_binding(void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
 	// This is only meant to be used on creation by the binder.
 	ERR_FAIL_COND(_instance_bindings != nullptr);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -800,17 +800,7 @@ public:
 		return *_class_name_ptr;
 	}
 
-	_FORCE_INLINE_ const StringName &get_class_name_for_extension(const GDExtension *p_library) const {
-		// Only return the class name per the extension if it matches the given p_library.
-		if (_extension && _extension->library == p_library) {
-			return _extension->class_name;
-		}
-		// Otherwise, return the name of the built-in class.
-		if (unlikely(!_class_name_ptr)) {
-			return *_get_class_namev();
-		}
-		return *_class_name_ptr;
-	}
+	StringName get_class_name_for_extension(const GDExtension *p_library) const;
 
 	/* IAPI */
 


### PR DESCRIPTION
This fixes a bug in PR https://github.com/godotengine/godot/pull/73511

The `Object::get_class_name_for_extension()` method is used to pick which wrapper class should be used to create the wrapper on the godot-cpp side. However, GDExtensions only have wrapper classes that are exposed, because those are the only ones listed in extension_api.json. For classes that aren't exposed, we should be creating the wrapper using the nearest parent class that is exposed.

For example, while working on an editor plugin in GDExtension, I was getting error spam in the console like:

```
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyCheck'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyVector2i'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyResource'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyText'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyInteger'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyFloat'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
ERROR: Cannot find instance binding callbacks for class 'EditorPropertyVector2'.
   at: get_instance_binding_callbacks (godot-cpp/src/core/class_db.cpp:320)
```

These are all child classes of `EditorProperty` which is exposed, so, on the GDExtension side, we want to create an `EditorProperty` wrapper for each of them.

This PR changes the `Object::get_class_name_for_extension()` method to check if the class is exposed, and if not, it walks up the classes parents until it finds one that is exposed.