### PR TITLE
SCU build - make paths relative to project folder

### DIFF
--- a/scu_builders.py
+++ b/scu_builders.py
@@ -51,7 +51,7 @@ def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exc
         if file.endswith(".gen.cpp"):
             continue
 
-        li = '#include "../' + sub_folder_slashed + file + '"'
+        li = '#include "' + folder + "/" + sub_folder_slashed + file + '"'
 
         if not simple_name in sought_exceptions:
             include_list.append(li)


### PR DESCRIPTION
Making paths relative to the project folder rather than the SCU directory helps make stack traces more readable.

Fixes stack trace mentioned in #77673

Changes scu file format from e.g.
```
#include "../a_star.cpp"
#include "../a_star_grid_2d.cpp"
#include "../aabb.cpp"
#include "../basis.cpp"
```
to
```
#include "core/math/a_star.cpp"
#include "core/math/a_star_grid_2d.cpp"
#include "core/math/aabb.cpp"
#include "core/math/basis.cpp"
```

## Notes
* Compiles fine on mine, could do with checking by one of you guys too.
* I haven't checked the resulting stack traces but I'm guessing they should be fixed.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
