### PR TITLE
Ensure that `_drop_physics_mouseover` only happens when necessary

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1872,13 +1872,13 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		}
 
 		if (over != gui.mouse_over) {
+			if (!gui.mouse_over) {
+				_drop_physics_mouseover();
+			}
 			_drop_mouse_over();
 			_gui_cancel_tooltip();
 
 			if (over) {
-				if (!gui.mouse_over) {
-					_drop_physics_mouseover();
-				}
 				_gui_call_notification(over, Control::NOTIFICATION_MOUSE_ENTER);
 				gui.mouse_over = over;
 			}


### PR DESCRIPTION
Previously the call was executed every time, because in the `_drop_mouse_over();` a few lines above, `gui.mouse_over = nullptr;` was set. With this change, it gets executed only the first time, the mouse is moved to a Control.

I have noticed this while investigating coverage-tests for Viewport.