### PR TITLE
Update NavigationObstacle API

### DIFF
--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -13,12 +13,6 @@
 		<link title="Using NavigationObstacles">$DOCS_URL/tutorials/navigation/navigation_using_navigationobstacles.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_agent_rid" qualifiers="const">
-			<return type="RID" />
-			<description>
-				Returns the [RID] of this agent on the [NavigationServer2D]. This [RID] is used for the moving avoidance "obstacle" component (using a fake avoidance agent) which size is defined by [member radius] and velocity set by using [member velocity].
-			</description>
-		</method>
 		<method name="get_avoidance_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -32,10 +26,10 @@
 				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
 			</description>
 		</method>
-		<method name="get_obstacle_rid" qualifiers="const">
+		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of this obstacle on the [NavigationServer2D]. This [RID] is used for the static avoidance obstacle component which shape is defined by [member vertices].
+				Returns the [RID] of this obstacle on the [NavigationServer2D].
 			</description>
 		</method>
 		<method name="set_avoidance_layer_value">
@@ -55,6 +49,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
+			If [code]true[/code] the obstacle affects avoidance using agents.
+		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agent's with a matching bit on the their avoidance mask will avoid this obstacle.
 		</member>

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -13,12 +13,6 @@
 		<link title="Using NavigationObstacles">$DOCS_URL/tutorials/navigation/navigation_using_navigationobstacles.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_agent_rid" qualifiers="const">
-			<return type="RID" />
-			<description>
-				Returns the [RID] of this agent on the [NavigationServer3D]. This [RID] is used for the moving avoidance "obstacle" component (using a fake avoidance agent) which size is defined by [member radius] and velocity set by using [member velocity].
-			</description>
-		</method>
 		<method name="get_avoidance_layer_value" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="layer_number" type="int" />
@@ -32,10 +26,10 @@
 				Returns the [RID] of the navigation map for this NavigationObstacle node. This function returns always the map set on the NavigationObstacle node and not the map of the abstract obstacle on the NavigationServer. If the obstacle map is changed directly with the NavigationServer API the NavigationObstacle node will not be aware of the map change. Use [method set_navigation_map] to change the navigation map for the NavigationObstacle and also update the obstacle on the NavigationServer.
 			</description>
 		</method>
-		<method name="get_obstacle_rid" qualifiers="const">
+		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of this obstacle on the [NavigationServer3D]. This [RID] is used for the static avoidance obstacle component which shape is defined by [member vertices].
+				Returns the [RID] of this obstacle on the [NavigationServer3D].
 			</description>
 		</method>
 		<method name="set_avoidance_layer_value">
@@ -55,6 +49,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="true">
+			If [code]true[/code] the obstacle affects avoidance using agents.
+		</member>
 		<member name="avoidance_layers" type="int" setter="set_avoidance_layers" getter="get_avoidance_layers" default="1">
 			A bitfield determining the avoidance layers for this obstacle. Agent's with a matching bit on the their avoidance mask will avoid this obstacle.
 		</member>

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -464,6 +464,13 @@
 				Creates a new navigation obstacle.
 			</description>
 		</method>
+		<method name="obstacle_get_avoidance_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns [code]true[/code] if the provided [param obstacle] has avoidance enabled.
+			</description>
+		</method>
 		<method name="obstacle_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
@@ -471,11 +478,20 @@
 				Returns the navigation map [RID] the requested [param obstacle] is currently assigned to.
 			</description>
 		</method>
+		<method name="obstacle_set_avoidance_enabled">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled] the provided [param obstacle] affects avoidance using agents.
+			</description>
+		</method>
 		<method name="obstacle_set_avoidance_layers">
 			<return type="void" />
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="layers" type="int" />
 			<description>
+				Set the obstacles's [code]avoidance_layers[/code] bitmask.
 			</description>
 		</method>
 		<method name="obstacle_set_map">
@@ -492,6 +508,22 @@
 			<param index="1" name="position" type="Vector2" />
 			<description>
 				Sets the position of the obstacle in world space.
+			</description>
+		</method>
+		<method name="obstacle_set_radius">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="radius" type="float" />
+			<description>
+				Sets the radius of the dynamic obstacle.
+			</description>
+		</method>
+		<method name="obstacle_set_velocity">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="velocity" type="Vector2" />
+			<description>
+				Sets [param velocity] of the dynamic [param obstacle]. Allows other agents to better predict the movement of the dynamic obstacle. Only works in combination with the radius of the obstacle.
 			</description>
 		</method>
 		<method name="obstacle_set_vertices">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -529,11 +529,33 @@
 				Creates a new obstacle.
 			</description>
 		</method>
+		<method name="obstacle_get_avoidance_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns [code]true[/code] if the provided [param obstacle] has avoidance enabled.
+			</description>
+		</method>
 		<method name="obstacle_get_map" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="obstacle" type="RID" />
 			<description>
 				Returns the navigation map [RID] the requested [param obstacle] is currently assigned to.
+			</description>
+		</method>
+		<method name="obstacle_get_use_3d_avoidance" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="obstacle" type="RID" />
+			<description>
+				Returns [code]true[/code] if the provided [param obstacle] uses avoidance in 3D space Vector3(x,y,z) instead of horizontal 2D Vector2(x,y) / Vector3(x,0.0,z).
+			</description>
+		</method>
+		<method name="obstacle_set_avoidance_enabled">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled] the provided [param obstacle] affects avoidance using agents.
 			</description>
 		</method>
 		<method name="obstacle_set_avoidance_layers">
@@ -566,6 +588,30 @@
 			<param index="1" name="position" type="Vector3" />
 			<description>
 				Updates the [param position] in world space for the [param obstacle].
+			</description>
+		</method>
+		<method name="obstacle_set_radius">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="radius" type="float" />
+			<description>
+				Sets the radius of the dynamic obstacle.
+			</description>
+		</method>
+		<method name="obstacle_set_use_3d_avoidance">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Sets if the [param obstacle] uses the 2D avoidance or the 3D avoidance while avoidance is enabled.
+			</description>
+		</method>
+		<method name="obstacle_set_velocity">
+			<return type="void" />
+			<param index="0" name="obstacle" type="RID" />
+			<param index="1" name="velocity" type="Vector3" />
+			<description>
+				Sets [param velocity] of the dynamic [param obstacle]. Allows other agents to better predict the movement of the dynamic obstacle. Only works in combination with the radius of the obstacle.
 			</description>
 		</method>
 		<method name="obstacle_set_vertices">

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -85,11 +85,9 @@ Validate extension JSON: API was removed: classes/NavigationAgent3D/methods/set_
 Validate extension JSON: API was removed: classes/NavigationAgent3D/properties/agent_height_offset
 Validate extension JSON: API was removed: classes/NavigationAgent3D/properties/ignore_y
 Validate extension JSON: API was removed: classes/NavigationAgent3D/properties/time_horizon
-Validate extension JSON: API was removed: classes/NavigationObstacle2D/methods/get_rid
 Validate extension JSON: API was removed: classes/NavigationObstacle2D/methods/is_radius_estimated
 Validate extension JSON: API was removed: classes/NavigationObstacle2D/methods/set_estimate_radius
 Validate extension JSON: API was removed: classes/NavigationObstacle2D/properties/estimate_radius
-Validate extension JSON: API was removed: classes/NavigationObstacle3D/methods/get_rid
 Validate extension JSON: API was removed: classes/NavigationObstacle3D/methods/is_radius_estimated
 Validate extension JSON: API was removed: classes/NavigationObstacle3D/methods/set_estimate_radius
 Validate extension JSON: API was removed: classes/NavigationObstacle3D/properties/estimate_radius

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -802,7 +802,42 @@ RID GodotNavigationServer::obstacle_create() {
 	RID rid = obstacle_owner.make_rid();
 	NavObstacle *obstacle = obstacle_owner.get_or_null(rid);
 	obstacle->set_self(rid);
+
+	RID agent_rid = agent_owner.make_rid();
+	NavAgent *agent = agent_owner.get_or_null(agent_rid);
+	agent->set_self(agent_rid);
+
+	obstacle->set_agent(agent);
+
 	return rid;
+}
+
+COMMAND_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled) {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND(obstacle == nullptr);
+
+	obstacle->set_avoidance_enabled(p_enabled);
+}
+
+bool GodotNavigationServer::obstacle_get_avoidance_enabled(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND_V(obstacle == nullptr, false);
+
+	return obstacle->is_avoidance_enabled();
+}
+
+COMMAND_2(obstacle_set_use_3d_avoidance, RID, p_obstacle, bool, p_enabled) {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND(obstacle == nullptr);
+
+	obstacle->set_use_3d_avoidance(p_enabled);
+}
+
+bool GodotNavigationServer::obstacle_get_use_3d_avoidance(RID p_obstacle) const {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND_V(obstacle == nullptr, false);
+
+	return obstacle->get_use_3d_avoidance();
 }
 
 COMMAND_2(obstacle_set_map, RID, p_obstacle, RID, p_map) {
@@ -837,10 +872,25 @@ RID GodotNavigationServer::obstacle_get_map(RID p_obstacle) const {
 	return RID();
 }
 
+COMMAND_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius) {
+	ERR_FAIL_COND_MSG(p_radius < 0.0, "Radius must be positive.");
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND(obstacle == nullptr);
+
+	obstacle->set_radius(p_radius);
+}
+
 COMMAND_2(obstacle_set_height, RID, p_obstacle, real_t, p_height) {
 	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
 	ERR_FAIL_COND(obstacle == nullptr);
 	obstacle->set_height(p_height);
+}
+
+COMMAND_2(obstacle_set_velocity, RID, p_obstacle, Vector3, p_velocity) {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_obstacle);
+	ERR_FAIL_COND(obstacle == nullptr);
+
+	obstacle->set_velocity(p_velocity);
 }
 
 COMMAND_2(obstacle_set_position, RID, p_obstacle, Vector3, p_position) {
@@ -917,29 +967,42 @@ COMMAND_1(free, RID, p_object) {
 		link_owner.free(p_object);
 
 	} else if (agent_owner.owns(p_object)) {
-		NavAgent *agent = agent_owner.get_or_null(p_object);
+		internal_free_agent(p_object);
 
-		// Removes this agent from the map if assigned
+	} else if (obstacle_owner.owns(p_object)) {
+		internal_free_obstacle(p_object);
+
+	} else {
+		ERR_PRINT("Attempted to free a NavigationServer RID that did not exist (or was already freed).");
+	}
+}
+
+void GodotNavigationServer::internal_free_agent(RID p_object) {
+	NavAgent *agent = agent_owner.get_or_null(p_object);
+	if (agent) {
 		if (agent->get_map() != nullptr) {
 			agent->get_map()->remove_agent(agent);
 			agent->set_map(nullptr);
 		}
-
 		agent_owner.free(p_object);
+	}
+}
 
-	} else if (obstacle_owner.owns(p_object)) {
-		NavObstacle *obstacle = obstacle_owner.get_or_null(p_object);
-
-		// Removes this agent from the map if assigned
+void GodotNavigationServer::internal_free_obstacle(RID p_object) {
+	NavObstacle *obstacle = obstacle_owner.get_or_null(p_object);
+	if (obstacle) {
 		if (obstacle->get_map() != nullptr) {
 			obstacle->get_map()->remove_obstacle(obstacle);
 			obstacle->set_map(nullptr);
 		}
-
+		if (obstacle->get_agent()) {
+			if (obstacle->get_agent()->get_self() != RID()) {
+				RID _agent_rid = obstacle->get_agent()->get_self();
+				obstacle->set_agent(nullptr);
+				internal_free_agent(_agent_rid);
+			}
+		}
 		obstacle_owner.free(p_object);
-
-	} else {
-		ERR_PRINT("Attempted to free a NavigationServer RID that did not exist (or was already freed).");
 	}
 }
 

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -198,8 +198,14 @@ public:
 	COMMAND_2(agent_set_avoidance_priority, RID, p_agent, real_t, p_priority);
 
 	virtual RID obstacle_create() override;
+	COMMAND_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled);
+	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const override;
+	COMMAND_2(obstacle_set_use_3d_avoidance, RID, p_obstacle, bool, p_enabled);
+	virtual bool obstacle_get_use_3d_avoidance(RID p_obstacle) const override;
 	COMMAND_2(obstacle_set_map, RID, p_obstacle, RID, p_map);
 	virtual RID obstacle_get_map(RID p_obstacle) const override;
+	COMMAND_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius);
+	COMMAND_2(obstacle_set_velocity, RID, p_obstacle, Vector3, p_velocity);
 	COMMAND_2(obstacle_set_position, RID, p_obstacle, Vector3, p_position);
 	COMMAND_2(obstacle_set_height, RID, p_obstacle, real_t, p_height);
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) override;
@@ -215,6 +221,10 @@ public:
 	virtual NavigationUtilities::PathQueryResult _query_path(const NavigationUtilities::PathQueryParameters &p_parameters) const override;
 
 	int get_process_info(ProcessInfo p_info) const override;
+
+private:
+	void internal_free_agent(RID p_object);
+	void internal_free_obstacle(RID p_object);
 };
 
 #undef COMMAND_1

--- a/modules/navigation/nav_obstacle.h
+++ b/modules/navigation/nav_obstacle.h
@@ -33,18 +33,23 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/local_vector.h"
-#include "nav_agent.h"
 #include "nav_rid.h"
 
+class NavAgent;
 class NavMap;
 
 class NavObstacle : public NavRid {
+	NavAgent *agent = nullptr;
 	NavMap *map = nullptr;
+	Vector3 velocity;
 	Vector3 position;
 	Vector<Vector3> vertices;
 
+	real_t radius = 0.0;
 	real_t height = 0.0;
 
+	bool avoidance_enabled = false;
+	bool use_3d_avoidance = false;
 	uint32_t avoidance_layers = 1;
 
 	bool obstacle_dirty = true;
@@ -55,14 +60,29 @@ public:
 	NavObstacle();
 	~NavObstacle();
 
+	void set_avoidance_enabled(bool p_enabled);
+	bool is_avoidance_enabled() { return avoidance_enabled; }
+
+	void set_use_3d_avoidance(bool p_enabled);
+	bool get_use_3d_avoidance() { return use_3d_avoidance; }
+
 	void set_map(NavMap *p_map);
 	NavMap *get_map() { return map; }
+
+	void set_agent(NavAgent *p_agent);
+	NavAgent *get_agent() { return agent; }
 
 	void set_position(const Vector3 p_position);
 	const Vector3 &get_position() const { return position; }
 
+	void set_radius(real_t p_radius);
+	real_t get_radius() const { return radius; }
+
 	void set_height(const real_t p_height);
 	real_t get_height() const { return height; }
+
+	void set_velocity(const Vector3 p_velocity);
+	const Vector3 &get_velocity() const { return velocity; }
 
 	void set_vertices(const Vector<Vector3> &p_vertices);
 	const Vector<Vector3> &get_vertices() const { return vertices; }
@@ -73,6 +93,9 @@ public:
 	uint32_t get_avoidance_layers() const { return avoidance_layers; };
 
 	bool check_dirty();
+
+private:
+	void internal_update_agent();
 };
 
 #endif // NAV_OBSTACLE_H

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -45,7 +45,7 @@ class NavigationObstacle2D : public Node2D {
 
 	Vector<Vector2> vertices;
 
-	RID fake_agent;
+	bool avoidance_enabled = true;
 	uint32_t avoidance_layers = 1;
 
 	Transform2D previous_transform;
@@ -68,8 +68,10 @@ public:
 	NavigationObstacle2D();
 	virtual ~NavigationObstacle2D();
 
-	RID get_obstacle_rid() const { return obstacle; }
-	RID get_agent_rid() const { return fake_agent; }
+	RID get_rid() const { return obstacle; }
+
+	void set_avoidance_enabled(bool p_enabled);
+	bool get_avoidance_enabled() const;
 
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -46,7 +46,7 @@ class NavigationObstacle3D : public Node3D {
 
 	Vector<Vector3> vertices;
 
-	RID fake_agent;
+	bool avoidance_enabled = true;
 	uint32_t avoidance_layers = 1;
 
 	bool use_3d_avoidance = false;
@@ -77,8 +77,10 @@ public:
 	NavigationObstacle3D();
 	virtual ~NavigationObstacle3D();
 
-	RID get_obstacle_rid() const { return obstacle; }
-	RID get_agent_rid() const { return fake_agent; }
+	RID get_rid() const { return obstacle; }
+
+	void set_avoidance_enabled(bool p_enabled);
+	bool get_avoidance_enabled() const;
 
 	void set_navigation_map(RID p_navigation_map);
 	RID get_navigation_map() const;

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -449,8 +449,12 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_priority", "agent", "priority"), &NavigationServer2D::agent_set_avoidance_priority);
 
 	ClassDB::bind_method(D_METHOD("obstacle_create"), &NavigationServer2D::obstacle_create);
+	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_enabled", "obstacle", "enabled"), &NavigationServer2D::obstacle_set_avoidance_enabled);
+	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_enabled", "obstacle"), &NavigationServer2D::obstacle_get_avoidance_enabled);
 	ClassDB::bind_method(D_METHOD("obstacle_set_map", "obstacle", "map"), &NavigationServer2D::obstacle_set_map);
 	ClassDB::bind_method(D_METHOD("obstacle_get_map", "obstacle"), &NavigationServer2D::obstacle_get_map);
+	ClassDB::bind_method(D_METHOD("obstacle_set_radius", "obstacle", "radius"), &NavigationServer2D::obstacle_set_radius);
+	ClassDB::bind_method(D_METHOD("obstacle_set_velocity", "obstacle", "velocity"), &NavigationServer2D::obstacle_set_velocity);
 	ClassDB::bind_method(D_METHOD("obstacle_set_position", "obstacle", "position"), &NavigationServer2D::obstacle_set_position);
 	ClassDB::bind_method(D_METHOD("obstacle_set_vertices", "obstacle", "vertices"), &NavigationServer2D::obstacle_set_vertices);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_layers", "obstacle", "layers"), &NavigationServer2D::obstacle_set_avoidance_layers);
@@ -602,8 +606,12 @@ RID NavigationServer2D::obstacle_create() {
 	RID obstacle = NavigationServer3D::get_singleton()->obstacle_create();
 	return obstacle;
 }
+void FORWARD_2(obstacle_set_avoidance_enabled, RID, p_obstacle, bool, p_enabled, rid_to_rid, bool_to_bool);
+bool FORWARD_1_C(obstacle_get_avoidance_enabled, RID, p_obstacle, rid_to_rid);
 void FORWARD_2(obstacle_set_map, RID, p_obstacle, RID, p_map, rid_to_rid, rid_to_rid);
 RID FORWARD_1_C(obstacle_get_map, RID, p_obstacle, rid_to_rid);
+void FORWARD_2(obstacle_set_radius, RID, p_obstacle, real_t, p_radius, rid_to_rid, real_to_real);
+void FORWARD_2(obstacle_set_velocity, RID, p_obstacle, Vector2, p_velocity, rid_to_rid, v2_to_v3);
 void FORWARD_2(obstacle_set_position, RID, p_obstacle, Vector2, p_position, rid_to_rid, v2_to_v3);
 void FORWARD_2(obstacle_set_avoidance_layers, RID, p_obstacle, uint32_t, p_layers, rid_to_rid, uint32_to_uint32);
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -240,8 +240,12 @@ public:
 
 	/// Creates the obstacle.
 	virtual RID obstacle_create();
+	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled);
+	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const;
 	virtual void obstacle_set_map(RID p_obstacle, RID p_map);
 	virtual RID obstacle_get_map(RID p_obstacle) const;
+	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius);
+	virtual void obstacle_set_velocity(RID p_obstacle, Vector2 p_velocity);
 	virtual void obstacle_set_position(RID p_obstacle, Vector2 p_position);
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector2> &p_vertices);
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers);

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -128,9 +128,15 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_set_avoidance_priority", "agent", "priority"), &NavigationServer3D::agent_set_avoidance_priority);
 
 	ClassDB::bind_method(D_METHOD("obstacle_create"), &NavigationServer3D::obstacle_create);
+	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_enabled", "obstacle", "enabled"), &NavigationServer3D::obstacle_set_avoidance_enabled);
+	ClassDB::bind_method(D_METHOD("obstacle_get_avoidance_enabled", "obstacle"), &NavigationServer3D::obstacle_get_avoidance_enabled);
+	ClassDB::bind_method(D_METHOD("obstacle_set_use_3d_avoidance", "obstacle", "enabled"), &NavigationServer3D::obstacle_set_use_3d_avoidance);
+	ClassDB::bind_method(D_METHOD("obstacle_get_use_3d_avoidance", "obstacle"), &NavigationServer3D::obstacle_get_use_3d_avoidance);
 	ClassDB::bind_method(D_METHOD("obstacle_set_map", "obstacle", "map"), &NavigationServer3D::obstacle_set_map);
 	ClassDB::bind_method(D_METHOD("obstacle_get_map", "obstacle"), &NavigationServer3D::obstacle_get_map);
+	ClassDB::bind_method(D_METHOD("obstacle_set_radius", "obstacle", "radius"), &NavigationServer3D::obstacle_set_radius);
 	ClassDB::bind_method(D_METHOD("obstacle_set_height", "obstacle", "height"), &NavigationServer3D::obstacle_set_height);
+	ClassDB::bind_method(D_METHOD("obstacle_set_velocity", "obstacle", "velocity"), &NavigationServer3D::obstacle_set_velocity);
 	ClassDB::bind_method(D_METHOD("obstacle_set_position", "obstacle", "position"), &NavigationServer3D::obstacle_set_position);
 	ClassDB::bind_method(D_METHOD("obstacle_set_vertices", "obstacle", "vertices"), &NavigationServer3D::obstacle_set_vertices);
 	ClassDB::bind_method(D_METHOD("obstacle_set_avoidance_layers", "obstacle", "layers"), &NavigationServer3D::obstacle_set_avoidance_layers);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -260,7 +260,13 @@ public:
 	virtual RID obstacle_create() = 0;
 	virtual void obstacle_set_map(RID p_obstacle, RID p_map) = 0;
 	virtual RID obstacle_get_map(RID p_obstacle) const = 0;
+	virtual void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) = 0;
+	virtual bool obstacle_get_avoidance_enabled(RID p_obstacle) const = 0;
+	virtual void obstacle_set_use_3d_avoidance(RID p_obstacle, bool p_enabled) = 0;
+	virtual bool obstacle_get_use_3d_avoidance(RID p_obstacle) const = 0;
+	virtual void obstacle_set_radius(RID p_obstacle, real_t p_radius) = 0;
 	virtual void obstacle_set_height(RID p_obstacle, real_t p_height) = 0;
+	virtual void obstacle_set_velocity(RID p_obstacle, Vector3 p_velocity) = 0;
 	virtual void obstacle_set_position(RID p_obstacle, Vector3 p_position) = 0;
 	virtual void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) = 0;
 	virtual void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) = 0;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -123,7 +123,13 @@ public:
 	RID obstacle_create() override { return RID(); }
 	void obstacle_set_map(RID p_obstacle, RID p_map) override {}
 	RID obstacle_get_map(RID p_obstacle) const override { return RID(); }
+	void obstacle_set_avoidance_enabled(RID p_obstacle, bool p_enabled) override {}
+	bool obstacle_get_avoidance_enabled(RID p_obstacle) const override { return false; }
+	void obstacle_set_use_3d_avoidance(RID p_obstacle, bool p_enabled) override {}
+	bool obstacle_get_use_3d_avoidance(RID p_obstacle) const override { return false; }
+	void obstacle_set_radius(RID p_obstacle, real_t p_radius) override {}
 	void obstacle_set_height(RID p_obstacle, real_t p_height) override {}
+	void obstacle_set_velocity(RID p_obstacle, Vector3 p_velocity) override {}
 	void obstacle_set_position(RID p_obstacle, Vector3 p_position) override {}
 	void obstacle_set_vertices(RID p_obstacle, const Vector<Vector3> &p_vertices) override {}
 	void obstacle_set_avoidance_layers(RID p_obstacle, uint32_t p_layers) override {}


### PR DESCRIPTION
Updates NavigationObstacle API.

Fixes https://github.com/godotengine/godot/issues/78062.
(needs a small documentation update as well that I will do later.)

As mentioned in the linked issue there was some parts of the avoidance API that did not make the cut or some parts were simply forgotten in all the changes of the avoidance rework https://github.com/godotengine/godot/pull/69988.

This pr not only adds the missing functions for the obstacle_xyz API but also hides the fake_agent that the dynamic obstacles use internally from the user.

Everything regarding the fake_agent is now handled inside the server. The user only has to use obstacle functions to control obstacles, not work with a confusing mix of agent_xyz and obstacle_xyz functions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
