### PR TITLE
Changed error tree initialization to allow reselection

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1901,6 +1901,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		error_tree->set_hide_root(true);
 		error_tree->set_v_size_flags(SIZE_EXPAND_FILL);
 		error_tree->set_allow_rmb_select(true);
+		error_tree->set_allow_reselect(true);
 		error_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_error_tree_item_rmb_selected));
 		errors_tab->add_child(error_tree);
 


### PR DESCRIPTION
Fixes #77944
A line was added where the error tree is initialized allowing for items to be reselected.