### PR TITLE
Fix Tooltip getting removed instantly in embedded Window

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -287,7 +287,11 @@ void Viewport::_sub_window_register(Window *p_window) {
 	gui.sub_windows.push_back(sw);
 
 	if (gui.subwindow_drag == SUB_WINDOW_DRAG_DISABLED) {
-		_sub_window_grab_focus(p_window);
+		if (p_window->get_flag(Window::FLAG_NO_FOCUS)) {
+			_sub_window_update_order();
+		} else {
+			_sub_window_grab_focus(p_window);
+		}
 	} else {
 		int index = _sub_window_find(gui.currently_dragged_subwindow);
 		sw = gui.sub_windows[index];


### PR DESCRIPTION
Tooltips are unfocusable Windows. This case was not handled correctly in `Viewport::_sub_window_register`.

resolve #78087
followup to #77842
tested, that #53501 stays fixed