### PR TITLE
MSVC: Disable ICF (Identical COMDAT Folding) for `optimize=speed_trace`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -572,9 +572,12 @@ if selected_platform in platform_list:
             env.Append(CCFLAGS=["/Zi", "/FS"])
             env.Append(LINKFLAGS=["/DEBUG:FULL"])
 
-        if env["optimize"] == "speed" or env["optimize"] == "speed_trace":
+        if env["optimize"] == "speed":
             env.Append(CCFLAGS=["/O2"])
             env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "speed_trace":
+            env.Append(CCFLAGS=["/O2"])
+            env.Append(LINKFLAGS=["/OPT:REF", "/OPT:NOICF"])
         elif env["optimize"] == "size":
             env.Append(CCFLAGS=["/O1"])
             env.Append(LINKFLAGS=["/OPT:REF"])


### PR DESCRIPTION
ICF means that methods (and readonly globals) with identical code get folded into a single version, which means that in stack traces the various methods cannot be distinguished and show up as any one of them, making the stack trace less useful.

Notable methods where this can be an issue are `memdelete<T>` and `CallableCustomMethodPointer<T>::get_object` (#77540) where the template argument(s) can be very important information that is not available with ICF enabled.

Changing this for `optimize=speed_trace` only as that optimization level is supposed to be better than `speed` for debugging, but MSVC generally doesn't have such an optimization level.

Docs: https://learn.microsoft.com/en-us/cpp/build/reference/opt-optimizations