### PR TITLE
Fix problems reloading MeshLibrary

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2027,6 +2027,9 @@ void EditorNode::_dialog_action(String p_file) {
 			if (err) {
 				show_accept(TTR("Error saving MeshLibrary!"), TTR("OK"));
 				return;
+			} else if (ResourceCache::has(p_file)) {
+				// Make sure MeshLibrary is updated in the editor.
+				ResourceLoader::load(p_file)->reload_from_file();
 			}
 
 		} break;

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -301,6 +301,7 @@ void MeshLibraryEditorPlugin::edit(Object *p_node) {
 		mesh_library_editor->edit(Object::cast_to<MeshLibrary>(p_node));
 		mesh_library_editor->show();
 	} else {
+		mesh_library_editor->edit(Ref<MeshLibrary>());
 		mesh_library_editor->hide();
 	}
 }


### PR DESCRIPTION
Fixes #26775
Fixes #25896

There were 2 problems with reloading MeshLibrary:
- the MeshLibraryEditor was holding a reference to MeshLibrary, so scene reload had no effect
- the editor actually has a way to reload externally changed resources, but it does not work when using ResourceSaver

One remaining issue is that the GridMap editor doesn't reload when the library is changed externally while editing (i.e. by external editor). #76468 will fix that (it seems to crash tho xd).