### PR TITLE
Fix some invalid plugin edit calls

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -925,6 +925,7 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 	for (Node *E : es.selection) {
 		p_selection->add_node(E);
 	}
+	p_selection->cancel_update(); // Selection update results in redundant Node edit, so we cancel it.
 	set_editor_plugin_states(es.editor_states);
 
 	return es.custom_state;
@@ -1324,6 +1325,10 @@ void EditorSelection::clear() {
 
 	changed = true;
 	node_list_changed = true;
+}
+
+void EditorSelection::cancel_update() {
+	changed = false;
 }
 
 EditorSelection::EditorSelection() {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -312,6 +312,7 @@ public:
 
 	void update();
 	void clear();
+	void cancel_update();
 
 	// Returns all the selected nodes.
 	TypedArray<Node> get_selected_nodes();

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -46,12 +46,6 @@
 #include "scene/gui/separator.h"
 #include "scene/main/window.h"
 
-void GridMapEditor::_node_removed(Node *p_node) {
-	if (p_node == node) {
-		node = nullptr;
-	}
-}
-
 void GridMapEditor::_configure() {
 	if (!node) {
 		return;
@@ -1030,7 +1024,6 @@ void GridMapEditor::_update_theme() {
 void GridMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			get_tree()->connect("node_removed", callable_mp(this, &GridMapEditor::_node_removed));
 			mesh_library_palette->connect("item_selected", callable_mp(this, &GridMapEditor::_item_selected_cbk));
 			for (int i = 0; i < 3; i++) {
 				grid[i] = RS::get_singleton()->mesh_create();
@@ -1051,7 +1044,6 @@ void GridMapEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			get_tree()->disconnect("node_removed", callable_mp(this, &GridMapEditor::_node_removed));
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
@@ -1471,7 +1463,6 @@ void GridMapEditorPlugin::make_visible(bool p_visible) {
 	} else {
 		grid_map_editor->spatial_editor_hb->hide();
 		grid_map_editor->hide();
-		grid_map_editor->edit(nullptr);
 		grid_map_editor->set_process(false);
 	}
 }

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -222,7 +222,6 @@ class GridMapEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
-	void _node_removed(Node *p_node);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
While making #78124 I noticed that GridMap spams errors about signal connections when you change scenes (repro = select GridMap, change scene, change back).

The cause was, again, two-fold:
- `restore_edited_scene_state()` changed editor selection, which caused the current node to be edited. This was wrong, because the state also restores inspected object, which causes the node to be edited twice
- GridMap editor plugin used some archaic ways to keep track of the edited node. This is no longer necessary, so I removed it