### PR TITLE
[3.x] Android editor: Fix issue causing the last edited project to open while switching to another one

### DIFF
--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <activity
             android:name=".GodotProjectManager"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstance"
             android:screenOrientation="userLandscape"
             android:exported="true"
             android:process=":GodotProjectManager">
@@ -53,7 +53,7 @@
             android:name=".GodotEditor"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:process=":GodotEditor"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstance"
             android:screenOrientation="userLandscape"
             android:exported="false">
             <layout android:defaultHeight="@dimen/editor_default_window_height"
@@ -65,7 +65,7 @@
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:label="@string/godot_project_name_string"
             android:process=":GodotGame"
-            android:launchMode="singleTask"
+            android:launchMode="singleInstance"
             android:exported="false"
             android:screenOrientation="userLandscape">
             <layout android:defaultHeight="@dimen/editor_default_window_height"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.kt
@@ -62,7 +62,8 @@ open class GodotEditor : FullScreenGodotApp() {
 
 		private const val WAIT_FOR_DEBUGGER = false
 
-		private const val COMMAND_LINE_PARAMS = "command_line_params"
+		private const val EXTRA_FORCE_QUIT = "force_quit_requested"
+		private const val EXTRA_COMMAND_LINE_PARAMS = "command_line_params"
 
 		private const val EDITOR_ID = 777
 		private const val EDITOR_ARG = "--editor"
@@ -95,14 +96,32 @@ open class GodotEditor : FullScreenGodotApp() {
 		// requested on demand based on use-cases.
 		PermissionsUtil.requestManifestPermissions(this, setOf(Manifest.permission.RECORD_AUDIO))
 
-		val params = intent.getStringArrayExtra(COMMAND_LINE_PARAMS)
-		updateCommandLineParams(params)
+		handleIntentParams(intent)
 
 		if (BuildConfig.BUILD_TYPE == "dev" && WAIT_FOR_DEBUGGER) {
 			Debug.waitForDebugger()
 		}
 
 		super.onCreate(savedInstanceState)
+	}
+
+	override fun onNewIntent(newIntent: Intent) {
+		intent = newIntent
+		handleIntentParams(newIntent)
+		super.onNewIntent(newIntent)
+	}
+
+	private fun handleIntentParams(receivedIntent: Intent) {
+		val forceQuitRequested = receivedIntent.getBooleanExtra(EXTRA_FORCE_QUIT, false)
+		if (forceQuitRequested) {
+			Log.d(TAG, "Force quit requested, terminating..")
+			ProcessPhoenix.forceQuit(this)
+			return
+		}
+
+		val params = receivedIntent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+		Log.d(TAG, "Received parameters ${params.contentToString()}")
+		updateCommandLineParams(params)
 	}
 
 	override fun onGodotSetupCompleted() {
@@ -173,33 +192,48 @@ open class GodotEditor : FullScreenGodotApp() {
 		// Launch a new activity
 		val newInstance = Intent(this, targetClass)
 			.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-			.putExtra(COMMAND_LINE_PARAMS, args)
+			.putExtra(EXTRA_COMMAND_LINE_PARAMS, args)
 		if (launchAdjacent) {
 			newInstance.addFlags(Intent.FLAG_ACTIVITY_LAUNCH_ADJACENT)
 		}
 		if (targetClass == javaClass) {
-			Log.d(TAG, "Restarting $targetClass")
+			Log.d(TAG, "Restarting $targetClass with parameters ${args.contentToString()}")
 			ProcessPhoenix.triggerRebirth(this, newInstance)
 		} else {
-			Log.d(TAG, "Starting $targetClass")
+			Log.d(TAG, "Starting $targetClass with parameters ${args.contentToString()}")
 			startActivity(newInstance)
 		}
 		return instanceId
 	}
 
 	override fun onGodotForceQuit(godotInstanceId: Int): Boolean {
-		val processNameSuffix = when (godotInstanceId) {
+		val targetClass: Class<*>?
+		val processNameSuffix: String
+		when (godotInstanceId) {
 			GAME_ID -> {
-				GAME_PROCESS_NAME_SUFFIX
+				processNameSuffix = GAME_PROCESS_NAME_SUFFIX
+				targetClass = GodotGame::class.java
 			}
 			EDITOR_ID -> {
-				EDITOR_PROCESS_NAME_SUFFIX
+				processNameSuffix = EDITOR_PROCESS_NAME_SUFFIX
+				targetClass = GodotEditor::class.java
 			}
 			PROJECT_MANAGER_ID -> {
-				PROJECT_MANAGER_PROCESS_NAME_SUFFIX
+				processNameSuffix = PROJECT_MANAGER_PROCESS_NAME_SUFFIX
+				targetClass = GodotProjectManager::class.java
 			}
-			else -> ""
+			else -> {
+				processNameSuffix = ""
+				targetClass = null
+			}
 		}
+
+		if (targetClass == javaClass) {
+			Log.d(TAG, "Force quitting $targetClass")
+			ProcessPhoenix.forceQuit(this)
+			return true
+		}
+
 		if (processNameSuffix.isBlank()) {
 			return false
 		}
@@ -208,8 +242,16 @@ open class GodotEditor : FullScreenGodotApp() {
 		val runningProcesses = activityManager.runningAppProcesses
 		for (runningProcess in runningProcesses) {
 			if (runningProcess.processName.endsWith(processNameSuffix)) {
-				Log.v(TAG, "Killing Godot process ${runningProcess.processName}")
-				Process.killProcess(runningProcess.pid)
+				if (targetClass == null) {
+					// Killing process directly
+					Log.v(TAG, "Killing Godot process ${runningProcess.processName}")
+					Process.killProcess(runningProcess.pid)
+				} else {
+					// Activity is running; sending a request for self termination.
+					Log.v(TAG, "Sending force quit request to $targetClass running on process ${runningProcess.processName}")
+					val forceQuitIntent = Intent(this, targetClass).putExtra(EXTRA_FORCE_QUIT, true)
+					startActivity(forceQuitIntent)
+				}
 				return true
 			}
 		}

--- a/platform/android/java/lib/src/org/godotengine/godot/utils/ProcessPhoenix.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/ProcessPhoenix.java
@@ -26,6 +26,7 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Process;
 import java.util.ArrayList;
@@ -90,8 +91,12 @@ public final class ProcessPhoenix extends Activity {
    */
   public static void forceQuit(Activity activity, int pid) {
     Process.killProcess(pid); // Kill original main process
-    activity.finish();
-    Runtime.getRuntime().exit(0); // Kill kill kill!
+	  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+		  activity.finishAndRemoveTask();
+	  } else {
+		  activity.finish();
+	  }
+	  Runtime.getRuntime().exit(0); // Kill kill kill!
   }
 
   // -- GODOT end --


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/76562

[main version](https://github.com/godotengine/godot/pull/78129)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
