### PR TITLE
Fix uninitialized Y-sort modulate for CanvasItems

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -311,6 +311,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 			int i = 1;
 			_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), child_items, i, p_z);
 			ci->ysort_xform = ci->xform.affine_inverse();
+			ci->ysort_modulate = Color(1, 1, 1, 1);
 
 			SortArray<Item *, ItemPtrSort> sorter;
 			sorter.sort(child_items, child_item_count);


### PR DESCRIPTION
Fix #78035.

All MRPs I've tested in #77079 had top most Y-sorted item without actual visuals so haven't noticed that such root CanvasItem's `ysort_modulate` remains not initialized to `Color(1, 1, 1, 1)`. And I must have not tested the simplest case of a single Y-sorted node. 🤦‍♂️

Marking as `cherrypick:4.0` as #77079 is still labelled as such.