### PR TITLE
Fix OpenXR Passthrough mode

### DIFF
--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.h
@@ -212,27 +212,12 @@ private:
 
 	Viewport *get_main_viewport();
 
-	bool is_composition_passthrough_layer_ready();
-
 	static OpenXRFbPassthroughExtensionWrapper *singleton;
 
 	bool fb_passthrough_ext = false; // required for any passthrough functionality
 	bool fb_triangle_mesh_ext = false; // only use for projected passthrough
 
-	XrPassthroughCreateInfoFB passthrough_create_info = {
-		XR_TYPE_PASSTHROUGH_CREATE_INFO_FB,
-		nullptr,
-		0,
-	};
 	XrPassthroughFB passthrough_handle = XR_NULL_HANDLE;
-
-	XrPassthroughLayerCreateInfoFB passthrough_layer_config = {
-		XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB,
-		nullptr,
-		passthrough_handle,
-		XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB,
-		XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB,
-	};
 	XrPassthroughLayerFB passthrough_layer = XR_NULL_HANDLE;
 
 	XrCompositionLayerPassthroughFB composition_passthrough_layer = {


### PR DESCRIPTION
Passthrough mode was broken, the key change is that `passthrough_layer_config.passthrough` wasn't set correctly.
I've moved the structs that aren't needed to be kept as members of the class into the methods that use them just to make the code more readable.

This is now working properly on Quest using both the OpenGL and the Vulkan renderer.
It should also work properly on the PICO however the Vulkan renderer is still not working properly here and on OpenGL it's not respecting the Alpha.

Note that on OpenGL your background settings do override stuff so make sure you set the background mode to custom color and choose a color with alpha set to 0.