### PR TITLE
[4.0] regex: Add nullptr check in `_regex_free`, needed with PCRE2 10.42

### DIFF
--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -40,7 +40,9 @@ static void *_regex_malloc(PCRE2_SIZE size, void *user) {
 }
 
 static void _regex_free(void *ptr, void *user) {
-	memfree(ptr);
+	if (ptr) {
+		memfree(ptr);
+	}
 }
 
 int RegExMatch::_find(const Variant &p_name) const {


### PR DESCRIPTION
Fixes #76174.

Simpler alternative to #70472 to fix the issue caused by upgrading PCRE2 (when using Linux distro packages) for 4.0 and 3.5. For 4.1 and 3.6, #70472 does this + upgrades our vendored PCRE2 too, but for stable branches this library update might not be warranted at this late stage.