### PR TITLE
Document behaviour of `AudioServer.get_bus_index()` if name doesn't exist

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -70,7 +70,7 @@
 			<return type="int" />
 			<param index="0" name="bus_name" type="StringName" />
 			<description>
-				Returns the index of the bus with the name [param bus_name].
+				Returns the index of the bus with the name [param bus_name]. Returns [code]-1[/code] if no bus with the specified name exist.
 			</description>
 		</method>
 		<method name="get_bus_name" qualifiers="const">


### PR DESCRIPTION
This adds a small note to the documentation of `AudioServer.get_bus_index()` that it will return `-1` if the bus does not exist.
