### PR TITLE
Bind Blender-style translate, rotate and scale shortcuts in the 3D editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -5381,9 +5381,9 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	ED_SHORTCUT("spatial_editor/lock_transform_xz", TTR("Lock Transformation to XZ plane"), KeyModifierMask::SHIFT | Key::Y);
 	ED_SHORTCUT("spatial_editor/lock_transform_xy", TTR("Lock Transformation to XY plane"), KeyModifierMask::SHIFT | Key::Z);
 	ED_SHORTCUT("spatial_editor/cancel_transform", TTR("Cancel Transformation"), Key::ESCAPE);
-	ED_SHORTCUT("spatial_editor/instant_translate", TTR("Begin Translate Transformation"));
-	ED_SHORTCUT("spatial_editor/instant_rotate", TTR("Begin Rotate Transformation"));
-	ED_SHORTCUT("spatial_editor/instant_scale", TTR("Begin Scale Transformation"));
+	ED_SHORTCUT("spatial_editor/instant_translate", TTR("Begin Translate Transformation"), Key::G);
+	ED_SHORTCUT("spatial_editor/instant_rotate", TTR("Begin Rotate Transformation"), Key::R);
+	ED_SHORTCUT("spatial_editor/instant_scale", TTR("Begin Scale Transformation"), Key::S);
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTR("Preview"));
@@ -8555,7 +8555,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_theme_type_variation("FlatButton");
 	tool_button[TOOL_MODE_SCALE]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_TOOL_SCALE));
-	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), Key::R));
+	tool_button[TOOL_MODE_SCALE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_scale", TTR("Scale Mode"), KeyModifierMask::CMD_OR_CTRL | Key::R));
 	tool_button[TOOL_MODE_SCALE]->set_shortcut_context(this);
 	tool_button[TOOL_MODE_SCALE]->set_tooltip_text(keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Drag: Use snap.") + "\n" + TTR("Alt+RMB: Show list of all nodes at position clicked, including locked."));
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/56543.

These used to have no binds by default, which severely limited their discoverability. I noticed this while testing https://github.com/godotengine/godot/pull/59467 locally.

The default bindings are the same as in Blender: <kbd>G</kbd> for translate, <kbd>R</kbd> for rotate, <kbd>S</kbd> for scale.

The default shortcut for the Rotate tool has been moved to <kbd>Ctrl + R</kbd> (<kbd>Cmd + R</kbd>) on macOS to accomodate for this change. While this makes the shortcut less consistent with the usual "<kbd>Q</kbd>-<kbd>W</kbd>-<kbd>E</kbd>-<kbd>R</kbd>-<kbd>T</kbd>" line of shortcuts, quick rotation with Blender-style transforms is arguably more convenient during day-to-day editor operation. To avoid breaking people's muscle memory, we should try to use shortcuts as similar as possible to Blender's.

The S key is only used for scaling if not currently in freelook mode.
