### PR TITLE
Fix window resizing problems on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1384,6 +1384,8 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 		wd.multiwindow_fs = false;
 		wd.maximized = wd.was_maximized;
 
+		_update_window_style(p_window, false);
+
 		if (wd.pre_fs_valid) {
 			rect = wd.pre_fs_rect;
 		} else {
@@ -1393,8 +1395,6 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 			rect.bottom = wd.height;
 			wd.pre_fs_valid = true;
 		}
-
-		_update_window_style(p_window, false);
 
 		MoveWindow(wd.hWnd, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, TRUE);
 


### PR DESCRIPTION
Fixes #76847, Fixes #74286

### Changes

#76847 was caused by the `MoveWindow` call using a rect value that was calculated before the  `_update_window_style` call. This last function changes the `wd.width` and `wd.height` parameters to the required ones for windowed mode. Calling `MoveWindow` with values for `wd.width` and `wd.height` which corresponded to full screen mode would re-set the `wd.fullscreen` parameter to true. This caused the need to perform the resizing call twice as described in the issue.

Simply moving the `rect` calculation to after the `_update_window_style` call fixes the issue.

### Testing
Tested by creating a project with a root node that contains the following script:
``` gdscript
func _process(delta: float) -> void:
	if Input.is_action_just_released("ui_accept"):
		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
		DisplayServer.window_set_size(Vector2i(800,600))
```
Before these changes, the user would have to perform the input action twice to get the screen windowed and resized, now this action only needs to happen once. I tested with both fullscreen and exclusive fullscreen modes being enabled in the project settings.
I also tested with both `resizable` being on/off in the project settings, and both scenarios work correctly. The problem described in #74286 appears to also be fixed.
