### PR TITLE
Prevent non-existent scene from being saved to persistent editor config

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4932,7 +4932,10 @@ void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout) {
 	p_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes", scenes);
 
 	String currently_edited_scene_path = editor_data.get_scene_path(editor_data.get_edited_scene());
-	p_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "current_scene", currently_edited_scene_path);
+	// Don't save a bad path to the config.
+	if (!currently_edited_scene_path.is_empty()) {
+		p_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "current_scene", currently_edited_scene_path);
+	}
 }
 
 void EditorNode::save_editor_layout_delayed() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78142

There are two issues.

Sometimes we save an empty path to the config:

```python
void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout) {
    // ...
    String currently_edited_scene_path = editor_data.get_scene_path(editor_data.get_edited_scene());
    p_layout->set_value(EDITOR_NODE_CONFIG_SECTION, "current_scene", currently_edited_scene_path);
}
```

we try to load whatever the config gives us, even if it's invalid:

```python
if (p_layout->has_section_key(EDITOR_NODE_CONFIG_SECTION, "current_scene")) {
    String current_scene = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene");
    int current_scene_idx = scenes.find(current_scene);
    set_current_scene(current_scene_idx);
}
```

I've opted to not set `"current_scene"` if the value is bad.