### PR TITLE
C#: Fix crash with `DisposablesTracker_OnGodotShuttingDown`

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -139,6 +139,10 @@ void CSharpLanguage::finalize() {
 		return;
 	}
 
+	if (gdmono && gdmono->is_runtime_initialized() && GDMonoCache::godot_api_cache_updated) {
+		GDMonoCache::managed_callbacks.DisposablesTracker_OnGodotShuttingDown();
+	}
+
 	finalizing = true;
 
 	// Make sure all script binding gchandles are released before finalizing GDMono

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -534,12 +534,6 @@ GDMono::GDMono() {
 GDMono::~GDMono() {
 	finalizing_scripts_domain = true;
 
-	if (is_runtime_initialized()) {
-		if (GDMonoCache::godot_api_cache_updated) {
-			GDMonoCache::managed_callbacks.DisposablesTracker_OnGodotShuttingDown();
-		}
-	}
-
 	if (hostfxr_dll_handle) {
 		OS::get_singleton()->close_dynamic_library(hostfxr_dll_handle);
 	}


### PR DESCRIPTION
Fixes #77486
Also Fixes #77305

As described in the issue, because `DisposablesTracker_OnGodotShuttingDown` is called after getting rid of all script bindings, if deleting an object also deletes other objects that are later in the queue of managed objects to delete, the later managed object isn't marked as deleted and later a use-after-free occurs.
Thus move the `DisposablesTracker_OnGodotShuttingDown` call to before deleting the script bindings.
(Also the `finalizing` member is probably no longer needed, but I didn't test that)
MRP for the original issue: [Test_77486_min.zip](https://github.com/godotengine/godot/files/11728404/Test_77486_min.zip) (ASAN only, simply start the project and close it again)

While I don't think this ha any side-effects beyond a slightly degraded shutdown performance, @neikeq should probably review this as there may be reasons to do things in the previous order that I missed.

Alternatively the root cause is that the managed shutdown deletes objects that are not owned by the managed side, but there is no way to check this.
