### PR TITLE
Update the edited script resource only on save

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -611,13 +611,6 @@ void ScriptEditor::_save_history() {
 }
 
 void ScriptEditor::_go_to_tab(int p_idx) {
-	ScriptEditorBase *current = _get_current_editor();
-	if (current) {
-		if (current->is_unsaved()) {
-			current->apply_code();
-		}
-	}
-
 	Control *c = tab_container->get_tab_control(p_idx);
 	if (!c) {
 		return;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -469,8 +469,6 @@ void ScriptTextEditor::_validate_script() {
 	} else {
 		code_editor->set_error("");
 		if (!script->is_tool()) {
-			script->set_source_code(text);
-			script->update_exports();
 			te->get_syntax_highlighter()->update_cache();
 		}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

Currently, the script editor will update the cached script resource directly when the code idle timeout expires. This means an unsaved script can affect other aspects of the editor, leading to some issues (#50578, #78126). This is also quite surprising to me personally, as I would expect my changes to take effect only when I save the script, in line with an external code editor. To follow the principle of least surprise, I think this needs to be changed.

This PR (currently draft), changes the behaviour to only update the script resource when it is actually saved to disk. This fixes  #50578 and fixes #78126.