### PR TITLE
Add options to show icon in Android TV and run app as Android launcher

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -104,6 +104,12 @@
 		<member name="package/retain_data_on_uninstall" type="bool" setter="" getter="">
 			If [code]true[/code], when the user uninstalls an app, a prompt to keep the app's data will be shown.
 		</member>
+		<member name="package/show_as_launcher_app" type="bool" setter="" getter="">
+			If [code]true[/code], the user will be able to set this app as the system launcher in Android preferences.
+		</member>
+		<member name="package/show_in_android_tv" type="bool" setter="" getter="">
+			If [code]true[/code], this app will show in Android TV launcher UI.
+		</member>
 		<member name="package/signed" type="bool" setter="" getter="">
 			If [code]true[/code], package signing is enabled.
 		</member>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1841,6 +1841,8 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "package/app_category", PROPERTY_HINT_ENUM, "Accessibility,Audio,Game,Image,Maps,News,Productivity,Social,Video"), APP_CATEGORY_GAME));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/exclude_from_recents"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_in_android_tv"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_as_launcher_app"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icon_option, PROPERTY_HINT_FILE, "*.png"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_adaptive_icon_foreground_option, PROPERTY_HINT_FILE, "*.png"), ""));

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -294,11 +294,12 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset, bool p_uses_xr
 			orientation,
 			bool_to_string(bool(GLOBAL_GET("display/window/size/resizable"))));
 
+	manifest_activity_text += "            <intent-filter>\n"
+							  "                <action android:name=\"android.intent.action.MAIN\" />\n"
+							  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n";
+
 	if (p_uses_xr) {
-		manifest_activity_text += "            <intent-filter>\n"
-								  "                <action android:name=\"android.intent.action.MAIN\" />\n"
-								  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n"
-								  "\n"
+		manifest_activity_text += "\n"
 								  "                <!-- Enable access to OpenXR on Oculus mobile devices, no-op on other Android\n"
 								  "                platforms. -->\n"
 								  "                <category android:name=\"com.oculus.intent.category.VR\" />\n"
@@ -308,16 +309,22 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset, bool p_uses_xr
 								  "                <category android:name=\"org.khronos.openxr.intent.category.IMMERSIVE_HMD\" />\n"
 								  "\n"
 								  "                <!-- Enable VR access on HTC Vive Focus devices. -->\n"
-								  "                <category android:name=\"com.htc.intent.category.VRAPP\" />\n"
-								  "            </intent-filter>\n";
-	} else {
-		manifest_activity_text += "            <intent-filter>\n"
-								  "                <action android:name=\"android.intent.action.MAIN\" />\n"
-								  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n"
-								  "            </intent-filter>\n";
+								  "                <category android:name=\"com.htc.intent.category.VRAPP\" />\n";
 	}
 
-	manifest_activity_text += "        </activity>\n";
+	bool uses_leanback_category = p_preset->get("package/show_in_android_tv");
+	if (uses_leanback_category) {
+		manifest_activity_text += "                <category android:name=\"android.intent.category.LEANBACK_LAUNCHER\" />\n";
+	}
+
+	bool uses_home_category = p_preset->get("package/show_as_launcher_app");
+	if (uses_home_category) {
+		manifest_activity_text += "                <category android:name=\"android.intent.category.HOME\" />\n";
+		manifest_activity_text += "                <category android:name=\"android.intent.category.DEFAULT\" />\n";
+	}
+
+	manifest_activity_text += "            </intent-filter>\n"
+							  "        </activity>\n";
 	return manifest_activity_text;
 }
 


### PR DESCRIPTION
For some reason AndroidManifest.xml files are not being used when building an app for Android. There are multiple reasons to add things to that file, but even though there are some places that tell the files are merged, it seems that it is always generated.

The reasons I had to modify this file are:
- Add the intent category LEANBACK_LAUNCHER so it adds an icon to Android TV launchers.
- Add the intent categories HOME and DEFAULT so a godot app can be used as a launcher itself (useful for kiosk experiences).

What I did in the end was to add these as export options, so the AndroidManifest generator adds these when the specific options are selected in the Export window.

Fixes part of https://github.com/godotengine/godot/issues/76963
Edit: doesn't actually fix that issue, as the AndroidManifest.xml problem persists. but it fixes the problem that the issue OP had.