### PR TITLE
Fix crash when opening a TileSet with invalid tiles

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -108,9 +108,11 @@ void TilesEditorPlugin::_thread() {
 						Vector2i coords = tile_map->get_cell_atlas_coords(0, cell);
 						int alternative = tile_map->get_cell_alternative_tile(0, cell);
 
-						Vector2 center = world_pos - atlas_source->get_tile_data(coords, alternative)->get_texture_origin();
-						encompassing_rect.expand_to(center - atlas_source->get_tile_texture_region(coords).size / 2);
-						encompassing_rect.expand_to(center + atlas_source->get_tile_texture_region(coords).size / 2);
+						if (atlas_source->has_tile(coords) && atlas_source->has_alternative_tile(coords, alternative)) {
+							Vector2 center = world_pos - atlas_source->get_tile_data(coords, alternative)->get_texture_origin();
+							encompassing_rect.expand_to(center - atlas_source->get_tile_texture_region(coords).size / 2);
+							encompassing_rect.expand_to(center + atlas_source->get_tile_texture_region(coords).size / 2);
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixes #77673

`get_tile_data()` returns null for invalid identifiers so a check is needed. Checks `has_tile()` and `has_alternative_tile()` first so that `get_tile_data()` won't print errors.