### PR TITLE
Fix Curve Editor crash with null curve

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -978,9 +978,11 @@ void CurveEditor::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_READY: {
 			Ref<Curve> curve = curve_editor_rect->get_curve();
-			// Set snapping settings based on the curve's meta.
-			snap_button->set_pressed(curve->get_meta("_snap_enabled", false));
-			snap_count_edit->set_value(curve->get_meta("_snap_count", DEFAULT_SNAP));
+			if (curve.is_valid()) {
+				// Set snapping settings based on the curve's meta.
+				snap_button->set_pressed(curve->get_meta("_snap_enabled", false));
+				snap_count_edit->set_value(curve->get_meta("_snap_count", DEFAULT_SNAP));
+			}
 		} break;
 	}
 }

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -265,9 +265,11 @@ void GradientTexture2DEditor::_notification(int p_what) {
 			snap_button->set_icon(get_theme_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
 		} break;
 		case NOTIFICATION_READY: {
-			// Set snapping settings based on the texture's meta.
-			snap_button->set_pressed(texture->get_meta("_snap_enabled", false));
-			snap_count_edit->set_value(texture->get_meta("_snap_count", DEFAULT_SNAP));
+			if (texture.is_valid()) {
+				// Set snapping settings based on the texture's meta.
+				snap_button->set_pressed(texture->get_meta("_snap_enabled", false));
+				snap_count_edit->set_value(texture->get_meta("_snap_count", DEFAULT_SNAP));
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Applies bitsawer's fix https://github.com/godotengine/godot/issues/78080#issuecomment-1585644608

I copied the bug from GradientTexture2DEditor, so the PR fixes the unsafety there too, although it doesn't play out anywhere at the moment.

*Bugsquad edit:*
- Fixes #78080

*Mew Pur Pur edit:*
- Sorry for forgetting to do the "fixes" thing, bugsquad.