### PR TITLE
Add NavigationPolygon `cell_size` property

### DIFF
--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -148,4 +148,9 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size" default="1.0">
+			The cell size used to rasterize the navigation mesh vertices. Must match with the cell size on the navigation map.
+		</member>
+	</members>
 </class>

--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -183,6 +183,7 @@ Ref<NavigationMesh> NavigationPolygon::get_navigation_mesh() {
 		for (int i(0); i < get_polygon_count(); i++) {
 			navigation_mesh->add_polygon(get_polygon(i));
 		}
+		navigation_mesh->set_cell_size(cell_size); // Needed to not fail the cell size check on the server
 	}
 
 	return navigation_mesh;
@@ -322,6 +323,15 @@ void NavigationPolygon::make_polygons_from_outlines() {
 	emit_changed();
 }
 
+void NavigationPolygon::set_cell_size(real_t p_cell_size) {
+	cell_size = p_cell_size;
+	get_navigation_mesh()->set_cell_size(cell_size);
+}
+
+real_t NavigationPolygon::get_cell_size() const {
+	return cell_size;
+}
+
 void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_vertices", "vertices"), &NavigationPolygon::set_vertices);
 	ClassDB::bind_method(D_METHOD("get_vertices"), &NavigationPolygon::get_vertices);
@@ -347,7 +357,11 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_outlines", "outlines"), &NavigationPolygon::_set_outlines);
 	ClassDB::bind_method(D_METHOD("_get_outlines"), &NavigationPolygon::_get_outlines);
 
+	ClassDB::bind_method(D_METHOD("set_cell_size", "cell_size"), &NavigationPolygon::set_cell_size);
+	ClassDB::bind_method(D_METHOD("get_cell_size"), &NavigationPolygon::get_cell_size);
+
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "outlines", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_outlines", "_get_outlines");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell_size", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater,suffix:px"), "set_cell_size", "get_cell_size");
 }

--- a/scene/resources/navigation_polygon.h
+++ b/scene/resources/navigation_polygon.h
@@ -51,6 +51,8 @@ class NavigationPolygon : public Resource {
 	// Navigation mesh
 	Ref<NavigationMesh> navigation_mesh;
 
+	real_t cell_size = 1.0f;
+
 protected:
 	static void _bind_methods();
 
@@ -86,6 +88,9 @@ public:
 	void clear_polygons();
 
 	Ref<NavigationMesh> get_navigation_mesh();
+
+	void set_cell_size(real_t p_cell_size);
+	real_t get_cell_size() const;
 
 	NavigationPolygon() {}
 	~NavigationPolygon() {}


### PR DESCRIPTION
Adds NavigationPolygon `cell_size` property, same as NavigationMesh already has.

Theoretically this was always needed but 2D navigation did just assume a default 1.0 cell_size behind the scene. It never updated the cell_size correctly on the internal NavigationMesh from the default 0.25. There was no way for 2D users to change it other can getting the NavigationMesh manually and changing the cell_size.

Needed now because 2D runs into the cell_size validation for the navigation map on the NavigationServer added with https://github.com/godotengine/godot/pull/77714.

In case someone wonders why not just remove the check when it requires so much extra ... all the other prs that also require a cell_size property on the NavigationPolygon are not in yet and strictly speaking not able to change the cell_size was always a bug.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
