### PR TITLE
Add NavigationRegion rotation warning

### DIFF
--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -105,9 +105,15 @@ void NavRegion::update_polygons() {
 		return;
 	}
 
+#ifdef DEBUG_ENABLED
 	if (!Math::is_equal_approx(double(map->get_cell_size()), double(mesh->get_cell_size()))) {
 		ERR_PRINT_ONCE("Navigation map synchronization error. Attempted to update a navigation region with a navigation mesh that uses a different `cell_size` than the `cell_size` set on the navigation map.");
 	}
+
+	if (map && Math::rad_to_deg(map->get_up().angle_to(transform.basis.get_column(1))) >= 90.0f) {
+		ERR_PRINT_ONCE("Navigation map synchronization error. Attempted to update a navigation region transform rotated 90 degrees or more away from the current navigation map UP orientation.");
+	}
+#endif // DEBUG_ENABLED
 
 	Vector<Vector3> vertices = mesh->get_vertices();
 	int len = vertices.size();


### PR DESCRIPTION
Adds NavigationRegion rotation warning.

Fixes https://github.com/godotengine/godot/issues/78145.

NavigationMeshes / navigation region can not be rotated 90 degree or more away from the current navigation map `up` vector without causing pathfinding and merge problems.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
