### PR TITLE
Android: Set pending intent flag to stop insta-crash

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -711,8 +711,14 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				Intent notifierIntent = new Intent(activity, activity.getClass());
 				notifierIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
-				PendingIntent pendingIntent = PendingIntent.getActivity(activity, 0,
-						notifierIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+				PendingIntent pendingIntent;
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+					pendingIntent = PendingIntent.getActivity(activity, 0,
+							notifierIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+				} else {
+					pendingIntent = PendingIntent.getActivity(activity, 0,
+							notifierIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+				}
 
 				int startResult;
 				try {


### PR DESCRIPTION
To fix https://github.com/godotengine/godot/issues/78105

Specifically, setting the flag for PendingIntent to fix error:

`Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.`