### PR TITLE
Input - add get_action_peak_strength()

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -105,6 +105,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action", "exact_match"), &Input::is_action_just_released, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action", "exact_match"), &Input::get_action_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_raw_strength", "action", "exact_match"), &Input::get_action_raw_strength, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_action_peak_strength", "action", "exact_match"), &Input::get_action_peak_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_axis", "negative_action", "positive_action"), &Input::get_axis);
 	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"), &Input::get_vector, DEFVAL(-1.0f));
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
@@ -326,6 +327,20 @@ bool Input::is_action_just_released(const StringName &p_action, bool p_exact) co
 	} else {
 		return released_requirement && E->value.released_process_frame == Engine::get_singleton()->get_process_frames();
 	}
+}
+
+float Input::get_action_peak_strength(const StringName &p_action, bool p_exact) const {
+	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), 0.0, InputMap::get_singleton()->suggest_actions(p_action));
+	HashMap<StringName, Action>::ConstIterator E = action_state.find(p_action);
+	if (!E) {
+		return 0.0f;
+	}
+
+	if (p_exact && E->value.exact == false) {
+		return 0.0f;
+	}
+
+	return E->value.peak_strength;
 }
 
 float Input::get_action_strength(const StringName &p_action, bool p_exact) const {
@@ -699,6 +714,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 					action.pressed = true;
 					action.pressed_physics_frame = Engine::get_singleton()->get_physics_frames();
 					action.pressed_process_frame = Engine::get_singleton()->get_process_frames();
+					action.peak_strength = 0.0f;
 				} else {
 					action.pressed = false;
 					action.released_physics_frame = Engine::get_singleton()->get_physics_frames();
@@ -710,6 +726,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			}
 			action.strength = p_event->get_action_strength(E.key);
 			action.raw_strength = p_event->get_action_raw_strength(E.key);
+			action.peak_strength = MAX(action.peak_strength, action.strength);
 		}
 	}
 
@@ -832,6 +849,7 @@ void Input::action_press(const StringName &p_action, float p_strength) {
 	action.pressed = true;
 	action.strength = p_strength;
 	action.raw_strength = p_strength;
+	action.peak_strength = p_strength;
 	action.exact = true;
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -107,6 +107,7 @@ private:
 		bool exact = true;
 		float strength = 0.0f;
 		float raw_strength = 0.0f;
+		float peak_strength = 0.0f;
 	};
 
 	HashMap<StringName, Action> action_state;
@@ -263,6 +264,7 @@ public:
 	bool is_action_just_released(const StringName &p_action, bool p_exact = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;
+	float get_action_peak_strength(const StringName &p_action, bool p_exact = false) const;
 
 	float get_axis(const StringName &p_negative_action, const StringName &p_positive_action) const;
 	Vector2 get_vector(const StringName &p_negative_x, const StringName &p_positive_x, const StringName &p_negative_y, const StringName &p_positive_y, float p_deadzone = -1.0f) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -53,6 +53,16 @@
 				[b]Note:[/b] This method only works on iOS, Android, and UWP. On other platforms, it always returns [constant Vector3.ZERO].
 			</description>
 		</method>
+		<method name="get_action_peak_strength" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="action" type="StringName" />
+			<param index="1" name="exact_match" type="bool" default="false" />
+			<description>
+				Returns a value between 0 and 1 representing the peak intensity of the given action during the last press. In a joypad, for example, the further away the axis (analog sticks or L2, R2 triggers) is from the dead zone, the closer the value will be to 1. If the action is mapped to a control that has no axis as the keyboard, the value returned will be 0 or 1.
+				While similar to [method get_action_strength], this function provides the peak over the whole current (or previous) press, and is not reset to zero on release. This allows reliably reading pressure for short button presses detected using [method is_action_just_pressed], on controllers that report button pressure.
+				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+			</description>
+		</method>
 		<method name="get_action_raw_strength" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="action" type="StringName" />


### PR DESCRIPTION
This PR records the peak strength over each press, which can be read after release, and therefore enables the user to know how hard button was pushed in short presses. This was previously impossible to read after short presses, because strength is reset to zero on release.

Following from #77055 , I'm including this in a separate PR as it deserves separate scrutiny as it is a subtle issue.

## Discussion
Although #77055 allows detection of quick action presses and releases (for jump keys etc), there is one situation which it doesn't solve, that is, getting the action `strength` and `raw_strength` of these quick presses. The problem is that the existing code sets `action_strength` and `raw_action_strength` to ZERO on release. While this works in most situations, with a quick release, it means that if you attempt to find the `strength` of a button press, the result will be zero, and this information has effectively been lost.

This PR solves the problem by introducing a new function to get the peak strength of an action, which is not reset on release, and can thus be read after a short press (after release).

Storing the peak strength should provide a more reliable measure of how hard the button was pressed, in case several strengths are updated to an action before release.

## Notes
* Again this will require some bikeshedding, there are a number of ways of solving this problem.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
