### PR TITLE
Improve GodotBody2D::apply_force torque and force computation

### DIFF
--- a/servers/physics_2d/godot_body_2d.h
+++ b/servers/physics_2d/godot_body_2d.h
@@ -254,8 +254,18 @@ public:
 	}
 
 	_FORCE_INLINE_ void apply_force(const Vector2 &p_force, const Vector2 &p_position = Vector2()) {
-		applied_force += p_force;
-		applied_torque += (p_position - center_of_mass).cross(p_force);
+		const Vector2 lever = p_position - center_of_mass;
+
+		if (lever.is_zero_approx()) {
+			applied_force += p_force;
+			return;
+		}
+
+		const real_t torque = lever.cross(p_force) / 2;
+		Vector2 lever_normal_counterclockwise = -lever.orthogonal().normalized();
+		Vector2 force_for_torque = torque / lever.length() * lever_normal_counterclockwise;
+		applied_torque += torque;
+		applied_force += p_force - force_for_torque;
 	}
 
 	_FORCE_INLINE_ void apply_torque(real_t p_torque) {


### PR DESCRIPTION
See #78243
The original expression `lever.cross(p_force)` for torque implies that the lever starts at the center of rotation and ends in the point of application. However, the center of mass of the body is not a center of rotation, because it is not pinned and receives linear momentum. `lever.cross(p_force)` *assumes pinned center of rotation*. To measure torque around the center of mass, we have to add a coupled force on the other side with the same magnitude and opposite direction. This force will cancel out the movement of the center and now we get pure torque according to r.cross(f) (as used currently). This second force performs the same role as a pin joint in the center. But in original situation we do not have neither a second force nor a pin joint, hence we get half of that - r.cross(f)/2. ~~Now that we have torque value, we simply compute a vector of force needed to create such torque, which is `torque / lever length * (unit orthogonal to lever)`, and substract it from original force while adding torque to applied_torque.~~ I ~~may~~ have got something wrong, but at least it makes way more sense than what we had before and looks more realistic.
Also, it seems the corresponding GodotBody3D function has the same issue so if this gets accepted, we need to change 3D too.

[Demo comparison of old/new physics in gdscript.](https://github.com/godotengine/godot/files/11737526/test.zip)
A stick which camera follows uses computation from this PR, while the other uses current logic.
<!--
Please target the `master` branch in priority.
PRs can target

 `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
