### PR TITLE
[RTL] Fix parsing tags with multiple features.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4478,7 +4478,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 			int fnt_size = -1;
 			for (int i = 1; i < subtag.size(); i++) {
-				Vector<String> subtag_a = subtag[i].split("=", true, 2);
+				Vector<String> subtag_a = subtag[i].split("=", true, 1);
 				_normalize_subtags(subtag_a);
 
 				if (subtag_a.size() == 2) {


### PR DESCRIPTION
Fixes parsing of complex font variation/feature tags. `split` third argument is max. number of splits, not number of returned parts (which should be 2).

<img width="618" alt="Screenshot 2023-06-13 at 15 42 23" src="https://github.com/godotengine/godot/assets/7645683/dfd92e15-1aed-4510-a000-30ed9e1f97f2">

