### PR TITLE
Properly handle wireframe mode in RendererRD pipeline cache

### DIFF
--- a/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
@@ -36,7 +36,7 @@ RID PipelineCacheRD::_generate_version(RD::VertexFormatID p_vertex_format_id, RD
 	RD::PipelineMultisampleState multisample_state_version = multisample_state;
 	multisample_state_version.sample_count = RD::get_singleton()->framebuffer_format_get_texture_samples(p_framebuffer_format_id, p_render_pass);
 
-	bool wireframe = p_wireframe || rasterization_state.wireframe;
+	bool wireframe = p_wireframe;
 
 	RD::PipelineRasterizationState raster_state_version = rasterization_state;
 	raster_state_version.wireframe = wireframe;

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.h
@@ -76,6 +76,8 @@ public:
 #endif
 
 		spin_lock.lock();
+		p_wireframe |= rasterization_state.wireframe;
+
 		RID result;
 		for (uint32_t i = 0; i < version_count; i++) {
 			if (versions[i].vertex_id == p_vertex_format_id && versions[i].framebuffer_id == p_framebuffer_format_id && versions[i].wireframe == p_wireframe && versions[i].render_pass == p_render_pass && versions[i].bool_specializations == p_bool_specializations) {


### PR DESCRIPTION
makes wireframe get cached properly so that it doesn't keep being recreated.
Bugsquad edit: fixes #76237
