### PR TITLE
Add SceneTree.get_node_count_in_group()

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -117,6 +117,13 @@
 				Returns the number of nodes in this [SceneTree].
 			</description>
 		</method>
+		<method name="get_node_count_in_group" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="group" type="StringName" />
+			<description>
+				Returns the number of nodes assigned to the given group.
+			</description>
+		</method>
 		<method name="get_nodes_in_group">
 			<return type="Node[]" />
 			<param index="0" name="group" type="StringName" />

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1301,6 +1301,16 @@ bool SceneTree::has_group(const StringName &p_identifier) const {
 	return group_map.has(p_identifier);
 }
 
+int SceneTree::get_node_count_in_group(const StringName &p_group) const {
+	_THREAD_SAFE_METHOD_
+	HashMap<StringName, Group>::ConstIterator E = group_map.find(p_group);
+	if (!E) {
+		return 0;
+	}
+
+	return E->value.nodes.size();
+}
+
 Node *SceneTree::get_first_node_in_group(const StringName &p_group) {
 	_THREAD_SAFE_METHOD_
 	HashMap<StringName, Group>::Iterator E = group_map.find(p_group);
@@ -1589,6 +1599,7 @@ void SceneTree::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_nodes_in_group", "group"), &SceneTree::_get_nodes_in_group);
 	ClassDB::bind_method(D_METHOD("get_first_node_in_group", "group"), &SceneTree::get_first_node_in_group);
+	ClassDB::bind_method(D_METHOD("get_node_count_in_group", "group"), &SceneTree::get_node_count_in_group);
 
 	ClassDB::bind_method(D_METHOD("set_current_scene", "child_node"), &SceneTree::set_current_scene);
 	ClassDB::bind_method(D_METHOD("get_current_scene"), &SceneTree::get_current_scene);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -392,6 +392,7 @@ public:
 	void get_nodes_in_group(const StringName &p_group, List<Node *> *p_list);
 	Node *get_first_node_in_group(const StringName &p_group);
 	bool has_group(const StringName &p_identifier) const;
+	int get_node_count_in_group(const StringName &p_group) const;
 
 	//void change_scene(const String& p_path);
 	//Node *get_loaded_scene();


### PR DESCRIPTION
Adds a more efficient way to get the number of nodes in specified group.

This extra method is an alternative to a common `get_tree().get_nodes_in_group("group_name").size()` use case, but without creating a redundant array.

Closes https://github.com/godotengine/godot-proposals/issues/7080