### PR TITLE
Clarify `move_towards` does not go past final value

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -725,11 +725,12 @@
 			<param index="1" name="to" type="float" />
 			<param index="2" name="delta" type="float" />
 			<description>
-				Moves [param from] toward [param to] by the [param delta] value.
+				Moves [param from] toward [param to] by the [param delta] amount. Will not go past [param to].
 				Use a negative [param delta] value to move away.
 				[codeblock]
 				move_toward(5, 10, 4)    # Returns 9
 				move_toward(10, 5, 4)    # Returns 6
+				move_toward(5, 10, 9)    # Returns 10
 				move_toward(10, 5, -1.5) # Returns 11.5
 				[/codeblock]
 			</description>


### PR DESCRIPTION
This behavior is already mentioned in `Vector{2,3}.move_towards()`, and is what makes `move_towards(a, b, c)` different from `a + c * direction(a, b)`.