### PR TITLE
GDScript: Only include script file path in test error output

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -392,6 +392,9 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 
 	StringBuilder builder;
 	builder.append(">> ");
+	// Only include the file path and line for script errors, otherwise the test
+	// outputs include arbitrary data which can change when we edit engine code.
+	bool include_path = false;
 	switch (p_type) {
 		case ERR_HANDLER_ERROR:
 			builder.append("ERROR");
@@ -401,6 +404,7 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 			break;
 		case ERR_HANDLER_SCRIPT:
 			builder.append("SCRIPT ERROR");
+			include_path = true;
 			break;
 		case ERR_HANDLER_SHADER:
 			builder.append("SHADER ERROR");
@@ -413,10 +417,12 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 	builder.append("\n>> on function: ");
 	builder.append(String::utf8(p_function));
 	builder.append("()\n>> ");
-	builder.append(String::utf8(p_file).trim_prefix(self->base_dir));
-	builder.append("\n>> ");
-	builder.append(itos(p_line));
-	builder.append("\n>> ");
+	if (include_path) {
+		builder.append(String::utf8(p_file).trim_prefix(self->base_dir).replace("\\", "/"));
+		builder.append("\n>> ");
+		builder.append(itos(p_line));
+		builder.append("\n>> ");
+	}
 	builder.append(String::utf8(p_error));
 	if (strlen(p_explanation) > 0) {
 		builder.append("\n>> ");

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
@@ -1,7 +1,5 @@
 GDTEST_RUNTIME_ERROR
 >> ERROR
 >> on function: assign()
->> core/variant/array.cpp
->> 222
 >> Method/function failed.
 not ok


### PR DESCRIPTION
Errors originating in C++ files cause unnecessary diffs whenever the engine is updated (line number changes, etc.) and would cause CI failures due to different formatting of the file path on Windows (backslashes, worked around here anyway) and when using SCU builds (`../scu` insert - that should be solved by #78063).

Fixes CI after #75419.