### PR TITLE
[3.x] C#: Avoid GodotSharp as project assembly name

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -59,6 +59,7 @@
 #include "mono_gd/gd_mono_utils.h"
 #include "signal_awaiter_utils.h"
 #include "utils/macros.h"
+#include "utils/path_utils.h"
 #include "utils/string_utils.h"
 #include "utils/thread_local.h"
 
@@ -721,16 +722,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 
 	GDMonoAssembly *proj_assembly = gdmono->get_project_assembly();
 
-	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String assembly_name = ProjectSettings::get_singleton()->get_setting("mono/project/assembly_name");
-
-	if (assembly_name.empty()) {
-		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-		if (appname_safe.empty()) {
-			appname_safe = "UnnamedProject";
-		}
-		assembly_name = appname_safe;
-	}
+	String assembly_name = path::get_csharp_project_name();
 
 	assembly_name += ".dll";
 

--- a/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.Core/StringExtensions.cs
@@ -77,6 +77,12 @@ namespace GodotTools.Core
             foreach (string invalidChar in invalidChars)
                 safeDirName = safeDirName.Replace(invalidChar, "-");
 
+            // Avoid reserved names that conflict with Godot assemblies
+            if (safeDirName == "GodotSharp" || safeDirName == "GodotSharpEditor")
+            {
+                safeDirName += "_";
+            }
+
             return safeDirName;
         }
     }

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include "mono_gd/gd_mono.h"
+#include "utils/path_utils.h"
 
 namespace GodotSharpDirs {
 
@@ -149,15 +150,9 @@ private:
 		GLOBAL_DEF_RST("mono/project/solution_directory", "");
 		GLOBAL_DEF_RST("mono/project/c#_project_directory", "");
 
-		String appname = ProjectSettings::get_singleton()->get("application/config/name");
-		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-		if (appname_safe.empty()) {
-			appname_safe = "UnnamedProject";
-		}
-
 		project_assembly_name = ProjectSettings::get_singleton()->get("mono/project/assembly_name");
 		if (project_assembly_name.empty()) {
-			project_assembly_name = appname_safe;
+			project_assembly_name = path::get_csharp_project_name();
 			ProjectSettings::get_singleton()->set("mono/project/assembly_name", project_assembly_name);
 		}
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -987,13 +987,7 @@ bool GDMono::_load_project_assembly() {
 	if (project_assembly)
 		return true;
 
-	String assembly_name = ProjectSettings::get_singleton()->get("mono/project/assembly_name");
-
-	if (assembly_name.empty()) {
-		String appname = ProjectSettings::get_singleton()->get("application/config/name");
-		String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-		assembly_name = appname_safe;
-	}
+	String assembly_name = path::get_csharp_project_name();
 
 	bool success = load_assembly(assembly_name, &project_assembly);
 

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -208,4 +208,23 @@ String relative_to(const String &p_path, const String &p_relative_to) {
 	return relative_to_impl(path_abs_norm, relative_to_abs_norm);
 }
 
+String get_csharp_project_name() {
+	String name = GLOBAL_GET("mono/project/assembly_name");
+	if (name.empty()) {
+		name = GLOBAL_GET("application/config/name");
+		name = OS::get_singleton()->get_safe_dir_name(name);
+	}
+
+	if (name.empty()) {
+		name = "UnnamedProject";
+	}
+
+	// Avoid reserved names that conflict with Godot assemblies.
+	if (name == "GodotSharp" || name == "GodotSharpEditor") {
+		name += "_";
+	}
+
+	return name;
+}
+
 } // namespace path

--- a/modules/mono/utils/path_utils.h
+++ b/modules/mono/utils/path_utils.h
@@ -59,6 +59,8 @@ String realpath(const String &p_path);
 
 String relative_to(const String &p_path, const String &p_relative_to);
 
+String get_csharp_project_name();
+
 } // namespace path
 
 #endif // MONO_PATH_UTILS_H


### PR DESCRIPTION
- `3.x` version of https://github.com/godotengine/godot/pull/78218.
- Partially backports https://github.com/godotengine/godot/pull/74516.