### PR TITLE
GDScript: Further restrict test error output for C++ errors

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -392,9 +392,9 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 
 	StringBuilder builder;
 	builder.append(">> ");
-	// Only include the file path and line for script errors, otherwise the test
-	// outputs include arbitrary data which can change when we edit engine code.
-	bool include_path = false;
+	// Only include the function, file and line for script errors, otherwise the
+	// test outputs changes based on the platform/compiler.
+	bool include_source_info = false;
 	switch (p_type) {
 		case ERR_HANDLER_ERROR:
 			builder.append("ERROR");
@@ -404,7 +404,7 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 			break;
 		case ERR_HANDLER_SCRIPT:
 			builder.append("SCRIPT ERROR");
-			include_path = true;
+			include_source_info = true;
 			break;
 		case ERR_HANDLER_SHADER:
 			builder.append("SHADER ERROR");
@@ -414,15 +414,15 @@ void GDScriptTest::error_handler(void *p_this, const char *p_function, const cha
 			break;
 	}
 
-	builder.append("\n>> on function: ");
-	builder.append(String::utf8(p_function));
-	builder.append("()\n>> ");
-	if (include_path) {
+	if (include_source_info) {
+		builder.append("\n>> on function: ");
+		builder.append(String::utf8(p_function));
+		builder.append("()\n>> ");
 		builder.append(String::utf8(p_file).trim_prefix(self->base_dir).replace("\\", "/"));
 		builder.append("\n>> ");
 		builder.append(itos(p_line));
-		builder.append("\n>> ");
 	}
+	builder.append("\n>> ");
 	builder.append(String::utf8(p_error));
 	if (strlen(p_explanation) > 0) {
 		builder.append("\n>> ");

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
@@ -1,5 +1,4 @@
 GDTEST_RUNTIME_ERROR
 >> ERROR
->> on function: assign()
 >> Method/function failed.
 not ok


### PR DESCRIPTION
MSVC and GCC/Clang also have different function names...

Follow-up to #75419 and #78216.

I remember we had this issue in the past while stabilizing 4.0, I don't remember what the workaround was. I guess we had just opted for not including a unit test that would trigger a C++ error? CC @godotengine/gdscript 