### PR TITLE
Remove redundant check for `ENVIRONMENT_MODE_DISABLED` in LightmapGI

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1036,9 +1036,6 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		environment_transform = get_global_transform().basis;
 
 		switch (environment_mode) {
-			case ENVIRONMENT_MODE_DISABLED: {
-				//nothing
-			} break;
 			case ENVIRONMENT_MODE_SCENE: {
 				Ref<World3D> world = get_world_3d();
 				if (world.is_valid()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->

The aforementioned codes are unreachable. No idea why it's there, probably a result of a 3AM coding session.