### PR TITLE
Update list of known breaking changes compared to 4.0-stable (3)

### DIFF
--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -314,3 +314,13 @@ Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState2D/methods
 Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3D/methods/collide_shape/return_value': type changed value in new API, from "typedarray::PackedVector3Array" to "typedarray::Vector3".
 
 The previous type declaration was simply wrong and the method did actually already return objects of the new type.
+
+
+GH-76688
+--------
+Validate extension JSON: Error: Field 'classes/EditorUndoRedoManager/methods/create_action/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/UndoRedo/methods/create_action/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Hash changed for 'classes/EditorUndoRedoManager/methods/create_action', from E07DA3CD to D543BA91. This means that the function has changed and no compatibility function was provided.
+Validate extension JSON: Error: Hash changed for 'classes/UndoRedo/methods/create_action', from 0AEC1BFC to E87757EB. This means that the function has changed and no compatibility function was provided.
+
+Added a optional parameters with default values. No adjustments should be necessary.

--- a/misc/scripts/validate_extension_api.sh
+++ b/misc/scripts/validate_extension_api.sh
@@ -50,7 +50,7 @@ while read -r file; do
         make_annotation "The following validation errors no longer occur (compared to $reference_tag):" "$obsolete_validation_error" warning "$file"
     fi
     if [ -n "$new_validation_error" ]; then
-        make_annotation "Compatibility to $reference_tag is broken in the following ways:" "$new_validation_error" error README.md
+        make_annotation "Compatibility to $reference_tag is broken in the following ways:" "$new_validation_error" error "$file"
         has_problems=1
     fi
 


### PR DESCRIPTION
Also moves the error annotation from `README.md` to the `4.0-stable.expected` file.