### PR TITLE
Fix for Win+M crashing the editor

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2276,6 +2276,7 @@ Error VulkanContext::prepare_buffers() {
 				// presentation engine will still present the image correctly.
 				print_verbose("Vulkan: Early suboptimal swapchain, recreating.");
 				_update_swap_chain(w);
+				break;
 			} else if (err != VK_SUCCESS) {
 				ERR_BREAK_MSG(err != VK_SUCCESS, "Vulkan: Did not create swapchain successfully. Error code: " + String(string_VkResult(err)));
 			} else {


### PR DESCRIPTION
Fixes #77790
Adds missing `break` statement to `VulkanContext::prepare_buffers` function. It was mistakenly removed in #72859.
Further discussion on why it needs to be there can be found in #77790 's comments.
cc @clayjohn 
### Testing
Tested by performing Win+M in the editor, which no longer produces a crash.