### PR TITLE
Make `NinePatchRect` listen to texture changes

### DIFF
--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -30,6 +30,7 @@
 
 #include "nine_patch_rect.h"
 
+#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 #include "servers/rendering_server.h"
 
@@ -89,11 +90,26 @@ void NinePatchRect::_bind_methods() {
 	BIND_ENUM_CONSTANT(AXIS_STRETCH_MODE_TILE_FIT);
 }
 
+void NinePatchRect::_texture_changed() {
+	queue_redraw();
+	update_minimum_size();
+}
+
 void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 	if (texture == p_tex) {
 		return;
 	}
+
+	if (texture.is_valid()) {
+		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NinePatchRect::_texture_changed));
+	}
+
 	texture = p_tex;
+
+	if (texture.is_valid()) {
+		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NinePatchRect::_texture_changed));
+	}
+
 	queue_redraw();
 	update_minimum_size();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -51,6 +51,8 @@ public:
 	AxisStretchMode axis_h = AXIS_STRETCH_MODE_STRETCH;
 	AxisStretchMode axis_v = AXIS_STRETCH_MODE_STRETCH;
 
+	void _texture_changed();
+
 protected:
 	void _notification(int p_what);
 	virtual Size2 get_minimum_size() const override;


### PR DESCRIPTION
Tried to look but can't see any other cases of textures not being connected when they are singular (not counting things like the icons in `TabBar` which I'm not sure what to do with) 

* Fixes #78210

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
