### PR TITLE
Directly expose `WebRTCPeerConnection::create_data_channel()` to GDExtension

### DIFF
--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -6,6 +6,10 @@ should instead be used to justify these changes and describe how users should wo
 
 ========================================================================================================================
 
+GH-78237
+--------
+Validate extension JSON: Error: Field 'classes/WebRTCPeerConnectionExtension/methods/_create_data_channel/return_value': type changed value in new API, from "Object" to "WebRTCDataChannel".
+
 GH-77757
 --------
 Validate extension JSON: Error: Field 'classes/Viewport/methods/gui_get_focus_owner': is_const changed value in new API, from false to true.

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -21,7 +21,7 @@
 			</description>
 		</method>
 		<method name="_create_data_channel" qualifiers="virtual">
-			<return type="Object" />
+			<return type="WebRTCDataChannel" />
 			<param index="0" name="p_label" type="String" />
 			<param index="1" name="p_config" type="Dictionary" />
 			<description>

--- a/modules/webrtc/webrtc_peer_connection_extension.cpp
+++ b/modules/webrtc/webrtc_peer_connection_extension.cpp
@@ -43,14 +43,3 @@ void WebRTCPeerConnectionExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
 }
-
-Ref<WebRTCDataChannel> WebRTCPeerConnectionExtension::create_data_channel(String p_label, Dictionary p_options) {
-	Object *ret = nullptr;
-	if (GDVIRTUAL_CALL(_create_data_channel, p_label, p_options, ret)) {
-		WebRTCDataChannel *ch = Object::cast_to<WebRTCDataChannel>(ret);
-		ERR_FAIL_COND_V_MSG(ret && !ch, nullptr, "Returned object must be an instance of WebRTCDataChannel.");
-		return ch;
-	}
-	WARN_PRINT_ONCE("WebRTCPeerConnectionExtension::_create_data_channel is unimplemented!");
-	return nullptr;
-}

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -45,17 +45,12 @@ protected:
 	static void _bind_methods();
 
 public:
-	// FIXME Can't be directly exposed due to issues in exchanging Ref(s) between godot and extensions.
-	// See godot-cpp GH-652 .
-	virtual Ref<WebRTCDataChannel> create_data_channel(String p_label, Dictionary p_options = Dictionary()) override;
-	GDVIRTUAL2R(Object *, _create_data_channel, String, Dictionary);
-	// EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, String, Dictionary);
-
 	/** GDExtension **/
 	EXBIND0RC(ConnectionState, get_connection_state);
 	EXBIND0RC(GatheringState, get_gathering_state);
 	EXBIND0RC(SignalingState, get_signaling_state);
 	EXBIND1R(Error, initialize, Dictionary);
+	EXBIND2R(Ref<WebRTCDataChannel>, create_data_channel, String, Dictionary);
 	EXBIND0R(Error, create_offer);
 	EXBIND2R(Error, set_remote_description, String, String);
 	EXBIND2R(Error, set_local_description, String, String);


### PR DESCRIPTION
Due to godot-cpp bug https://github.com/godotengine/godot-cpp/issues/652, rather than directly exposing `WebRTCPeerConnection::create_data_channel()`, an alternate version which returned an `Object *` (instead of `Ref<T>`) was exposed, with a custom `create_data_channel()` that called it.

Since that bug is now fixed, we can remove the workaround, and directly expose it!

I think this breaks compatibility, but since we're thoroughly breaking GDExtension compatibility for Godot 4.1 anyway, this seems like a good time to change this. :-)