### PR TITLE
C#: Add version defines to help users deal with breaking changes

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -74,8 +74,13 @@
 
   <!-- Godot DefineConstants. -->
   <PropertyGroup>
-    <!-- Define constant to identify Godot builds. -->
-    <GodotDefineConstants>GODOT</GodotDefineConstants>
+    <!-- Define constants to identify Godot builds and versions. -->
+    <GodotDefineConstants>
+      GODOT;
+      GODOT4;GODOT4_OR_GREATER;
+      GODOT4_1;GODOT4_1_OR_GREATER;GODOT4_0_OR_GREATER;
+      GODOT4_1_0;GODOT4_1_0_OR_GREATER;
+    </GodotDefineConstants>
 
     <!--
     Define constant to determine the target Godot platform. This includes the


### PR DESCRIPTION
Adds an easy way to write C# scripts that work with multiple godot versions with breaking changes between, for example for scripts distributed via the asset library.

Such version defines are pretty common for C# and both the .net runtime and Unity have them in pretty the same form (https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation, https://docs.unity3d.com/Manual/PlatformDependentCompilation.html)

While this can largely be done with runtime version checks and untyped code instead, in C# (unlike in GDScript) this is pretty painful and completely different from how code is normally written.

Example Usage:
```cs
public string[] GetObjectMetaList(GodotObject obj)
{
#if GODOT4_1_OR_GREATER
  return obj.GetMetaList().Select(e => (string)e).ToArray();
#else
  return obj.GetMetaList();
#endif
}
```

---

While it is pretty late for 4.1, this change is pretty much zero risk and the more versions don't support this the less useful this becomes.

The defines have to be manually updated when changing versions. It is probably possible to automatically generate these, but that is unnecessarily complex for a first version.

---

The defines added are one for the major, minor, and patch of the current version, and then OR_GREATER defines from 0 to the current value for each component, if these defines have existed in that version.

Examples: for 4.3.2: `GODOT4`, `GODOT4_OR_GREATER`, `GODOT4_3`, `GODOT4_1_OR_GREATER`, `GODOT4_2_OR_GREATER`, `GODOT4_3_OR_GREATER`, `GODOT4_3_2`, `GODOT4_3_0_OR_GREATER`, `GODOT4_3_1_OR_GREATER`, and `GODOT4_3_2_OR_GREATER`
for 5.0.1: `GODOT5`, `GODOT4_OR_GREATER`, `GODOT5_OR_GREATER`, `GODOT5_0`, `GODOT5_0_OR_GREATER`, `GODOT5_0_2`, `GODOT5_0_0_OR_GREATER`, and `GODOT5_0_1_OR_GREATER`