### PR TITLE
GDScript: Fix conflict between property and group names

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2581,20 +2581,21 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 
 			case GDScriptParser::ClassNode::Member::GROUP: {
 				const GDScriptParser::AnnotationNode *annotation = member.annotation;
-				StringName name = annotation->export_info.name;
+				// Avoid name conflict. See GH-78252.
+				StringName name = vformat("@group_%d_%s", p_script->members.size(), annotation->export_info.name);
 
 				// This is not a normal member, but we need this to keep indices in order.
 				GDScript::MemberInfo minfo;
 				minfo.index = p_script->member_indices.size();
 
 				PropertyInfo prop_info;
-				prop_info.name = name;
+				prop_info.name = annotation->export_info.name;
 				prop_info.usage = annotation->export_info.usage;
 				prop_info.hint_string = annotation->export_info.hint_string;
 
 				p_script->member_info[name] = prop_info;
 				p_script->member_indices[name] = minfo;
-				p_script->members.insert(name);
+				p_script->members.insert(Variant());
 			} break;
 
 			default:

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -749,7 +749,9 @@ public:
 			members.push_back(Member(p_enum_value));
 		}
 		void add_member_group(AnnotationNode *p_annotation_node) {
-			members_indices[p_annotation_node->export_info.name] = members.size();
+			// Avoid name conflict. See GH-78252.
+			StringName name = vformat("@group_%d_%s", members.size(), p_annotation_node->export_info.name);
+			members_indices[name] = members.size();
 			members.push_back(Member(p_annotation_node));
 		}
 

--- a/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.gd
@@ -1,0 +1,17 @@
+extends RefCounted # TODO: Fix standalone annotations parsing.
+
+# GH-73843
+@export_group("Resource")
+
+# GH-78252
+@export var prop_1: int
+@export_category("prop_1")
+@export var prop_2: int
+
+func test():
+	var resource := Resource.new()
+	prints("Not shadowed:", resource.get_class())
+
+	for property in get_property_list():
+		if property.name in ["prop_1", "prop_2"]:
+			print(property)

--- a/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.out
+++ b/modules/gdscript/tests/scripts/runtime/features/export_group_no_name_conflict_with_properties.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+Not shadowed: Resource
+{ "name": "prop_1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }
+{ "name": "prop_1", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 128 }
+{ "name": "prop_2", "class_name": &"", "type": 2, "hint": 0, "hint_string": "int", "usage": 4102 }


### PR DESCRIPTION
* Closes #67865.
* Closes #68030.
* Closes #73843.
* Closes #78252.
* Closes #79804.
* Closes #79861.
