### PR TITLE
Link to Code style guidelines in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,7 @@ PRs can target `3.x` if the same change was done in `master`, or is not relevant
 
 Relevant fixes are cherry-picked for stable branches as needed by maintainers.
 You can mention in the description if the change is compatible with `3.x`.
+
+To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
+https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
 -->


### PR DESCRIPTION
This is a common pain point for new contributors, as setting up pre-commit hooks will save a lot of time spent on CI.
