### PR TITLE
Unfocus Control by clicking somwehere else

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1718,6 +1718,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.last_mouse_focus = gui.mouse_focus;
 
 				if (!gui.mouse_focus) {
+					if (gui.key_focus && mb->get_button_index() == MouseButton::LEFT) {
+						gui.key_focus->release_focus();
+					}
 					gui.mouse_focus_mask.clear();
 					return;
 				}
@@ -1748,6 +1751,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 			if (mb->get_button_index() == MouseButton::LEFT) { // Assign focus.
 				CanvasItem *ci = gui.mouse_focus;
+				Control *focus_to_release = gui.key_focus;
 				while (ci) {
 					Control *control = Object::cast_to<Control>(ci);
 					if (control) {
@@ -1755,6 +1759,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 							if (control != gui.key_focus) {
 								control->grab_focus();
 							}
+							focus_to_release = nullptr;
 							break;
 						}
 
@@ -1768,6 +1773,10 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					}
 
 					ci = ci->get_parent_item();
+				}
+
+				if (focus_to_release) {
+					focus_to_release->release_focus();
 				}
 			}
 

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -257,7 +257,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(Point2i(15, 105), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			}
 
-			SUBCASE("[Viewport][GuiInputEvent] No Focus change when clicking in background.") {
+			SUBCASE("[Viewport][GuiInputEvent] Focus release when clicking in background.") {
 				CHECK_FALSE(root->gui_get_focus_owner());
 
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_background, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
@@ -269,7 +269,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 				SEND_GUI_MOUSE_BUTTON_EVENT(on_background, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 				SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_background, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-				CHECK(node_a->has_focus());
+				CHECK_FALSE(root->gui_get_focus_owner());
 			}
 
 			SUBCASE("[Viewport][GuiInputEvent] Mouse Button No Focus Steal while other Mouse Button is pressed.") {
@@ -370,13 +370,17 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 					CHECK(node_b->has_focus());
 					SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_d + Point2i(20, 20), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 
+					SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
+					SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
+					CHECK(node_a->has_focus());
+
 					// Verify break condition for Root Control.
 					node_a->set_focus_mode(Control::FOCUS_NONE);
 					node_a->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 
 					SEND_GUI_MOUSE_BUTTON_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
 					SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(on_a, MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
-					CHECK(node_b->has_focus());
+					CHECK_FALSE(root->gui_get_focus_owner());
 				}
 
 				SUBCASE("[Viewport][GuiInputEvent] Top Level CanvasItem stops focus propagation.") {


### PR DESCRIPTION
A left MouseButton press should unfocus a Control, when pressed outside of it.
Adjust Unit-Tests to new behavior.

resolve no longer #78251

Please label as 4.2, since this change in behavior needs discussion and testing.