### PR TITLE
C#: Add `PropertyHint.Enum` support to `Array<StringName>`

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -620,7 +620,7 @@ namespace Godot.SourceGenerators
 
                 bool isPresetHint = false;
 
-                if (elementVariantType == VariantType.String)
+                if (elementVariantType == VariantType.String || elementVariantType == VariantType.StringName)
                     isPresetHint = GetStringArrayEnumHint(elementVariantType, exportAttr, out hintString);
 
                 if (!isPresetHint)


### PR DESCRIPTION
Previously, only `StringName` was supported but not `Array<StringName>`, now it has been added.
```
    [Export(PropertyHint.Enum, "a,b,c")]
    public Godot.Collections.Array<StringName> Tests
```