### PR TITLE
Update GridMap editor grid location when required

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -704,6 +704,9 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
+		// Update the grid, to check if the grid needs to be moved to a tile cursor.
+		update_grid();
+
 		if (do_input_action(p_camera, mm->get_position(), false)) {
 			return EditorPlugin::AFTER_GUI_INPUT_STOP;
 		}
@@ -951,7 +954,8 @@ void GridMapEditor::update_grid() {
 
 	grid_ofs[edit_axis] = edit_floor[edit_axis] * node->get_cell_size()[edit_axis];
 
-	edit_grid_xform.origin = grid_ofs;
+	// If there's a valid tile cursor, offset the grid, otherwise move it back to the node.
+	edit_grid_xform.origin = cursor_instance.is_valid() ? grid_ofs : Vector3();
 	edit_grid_xform.basis = Basis();
 
 	for (int i = 0; i < 3; i++) {
@@ -1076,6 +1080,9 @@ void GridMapEditor::_notification(int p_what) {
 			Ref<MeshLibrary> cgmt = node->get_mesh_library();
 			if (cgmt.operator->() != last_mesh_library) {
 				update_palette();
+				// Update the cursor and grid in case the library is changed or removed.
+				_update_cursor_instance();
+				update_grid();
 			}
 		} break;
 


### PR DESCRIPTION
The GridMap editor's grid previously did not not move when moving the tile cursor, only on certain menu actions.

This commit adds an update_grid call for valid mouse movement in the editor, changes update_grid to only offset if there's a valid
cursor, and adds updates for the grid and cursor when a mesh library is changed since we need the new RID for the update_grid check, and if we remove the mesh library we want to make sure it gets recentered. As a nice side-effect, it also updates to the new cursor mesh if you load a new mesh library.

Fixes #57068

Similar changes might also fix this in 3.x, I think the relevant lines around the changes are mostly the same.
