### PR TITLE
Remove unused variable `PopupMenu::parent_rect`

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -100,7 +100,6 @@ void EditorObjectSelector::_show_popup() {
 
 	sub_objects_menu->set_position(gp);
 	sub_objects_menu->set_size(Size2(size.width, 1));
-	sub_objects_menu->set_parent_rect(Rect2(Point2(gp - sub_objects_menu->get_position()), size));
 
 	sub_objects_menu->take_mouse_focus();
 	sub_objects_menu->popup();

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -131,7 +131,6 @@ void MenuBar::_open_popup(int p_index, bool p_focus_item) {
 		screen_pos.x += screen_size.x - pm->get_size().width;
 	}
 	pm->set_position(screen_pos);
-	pm->set_parent_rect(Rect2(Point2(screen_pos - pm->get_position()), Size2(screen_size.x, screen_pos.y)));
 	pm->popup();
 
 	if (p_focus_item) {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -106,7 +106,6 @@ void MenuButton::show_popup() {
 		gp.x += size.width - popup->get_size().width;
 	}
 	popup->set_position(gp);
-	popup->set_parent_rect(Rect2(Point2(gp - popup->get_position()), size));
 
 	// If not triggered by the mouse, start the popup with its first enabled item focused.
 	if (!_was_pressed_by_mouse()) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2033,10 +2033,6 @@ String PopupMenu::get_tooltip(const Point2 &p_pos) const {
 	return items[over].tooltip;
 }
 
-void PopupMenu::set_parent_rect(const Rect2 &p_rect) {
-	parent_rect = p_rect;
-}
-
 void PopupMenu::add_autohide_area(const Rect2 &p_area) {
 	autohide_areas.push_back(p_area);
 }

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -98,7 +98,6 @@ class PopupMenu : public Popup {
 	bool during_grabbed_click = false;
 	int mouse_over = -1;
 	int submenu_over = -1;
-	Rect2 parent_rect;
 	String _get_accel_text(const Item &p_item) const;
 	int _get_mouse_over(const Point2 &p_over) const;
 	virtual Size2 _get_contents_minimum_size() const override;
@@ -291,8 +290,6 @@ public:
 	void add_separator(const String &p_text = String(), int p_id = -1);
 
 	void clear();
-
-	void set_parent_rect(const Rect2 &p_rect);
 
 	virtual String get_tooltip(const Point2 &p_pos) const;
 


### PR DESCRIPTION
This private variable is not read anywhere.
Remove it and all places, where it is set.
