### PR TITLE
Fix position and size of MenuButton popup

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -97,15 +97,14 @@ void MenuButton::show_popup() {
 	}
 
 	emit_signal(SNAME("about_to_popup"));
-	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
-
-	popup->set_size(Size2(size.width, 0));
-	Point2 gp = get_screen_position();
-	gp.y += size.y;
+	Rect2 rect = get_screen_rect();
+	rect.position.y += rect.size.height;
+	rect.size.height = 0;
+	popup->set_size(rect.size);
 	if (is_layout_rtl()) {
-		gp.x += size.width - popup->get_size().width;
+		rect.position.x += rect.size.width - popup->get_size().width;
 	}
-	popup->set_position(gp);
+	popup->set_position(rect.position);
 
 	// If not triggered by the mouse, start the popup with its first enabled item focused.
 	if (!_was_pressed_by_mouse()) {


### PR DESCRIPTION
resolve #76194
resolve part of #69749 (placement and size)

Use the same logic as in `OptionButton::show_popup`, which got introduced in #69185

Please don't merge at the same time as #78268 and merge after #78268.