### PR TITLE
minimp3: Add a .cpp file to simplify building the single-header implementation (reverted)

### DIFF
--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -5,13 +5,27 @@ Import("env_modules")
 
 env_minimp3 = env_modules.Clone()
 
-thirdparty_dir = "#thirdparty/minimp3/"
+# Thirdparty source files
 
-# Treat minimp3 headers as system headers to avoid raising warnings. Not supported on MSVC.
-if not env.msvc:
-    env_minimp3.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-else:
-    env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
+thirdparty_obj = []
+
+thirdparty_dir = "#thirdparty/minimp3/"
+thirdparty_sources = [thirdparty_dir + "minimp3_ex.cpp"]
+
+env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
+
+env_thirdparty = env_minimp3.Clone()
+env_thirdparty.disable_warnings()
+env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
+env.modules_sources += thirdparty_obj
+
 
 # Godot source files
-env_minimp3.add_source_files(env.modules_sources, "*.cpp")
+
+module_obj = []
+
+env_minimp3.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -28,11 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#define MINIMP3_ONLY_MP3
-#define MINIMP3_FLOAT_OUTPUT
-#define MINIMP3_IMPLEMENTATION
-#define MINIMP3_NO_STDIO
-
 #include "audio_stream_mp3.h"
 
 #include "core/io/file_access.h"

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -416,6 +416,7 @@ Files extracted from upstream repository:
 
 Some changes have been made in order to fix Windows on ARM build errors, and
 to solve some MSVC warnings. See the patches in the `patches` directory.
+`minimp3_ex.cpp` was created to simplify the use of the single header library.
 
 
 ## miniupnpc

--- a/thirdparty/minimp3/minimp3_ex.cpp
+++ b/thirdparty/minimp3/minimp3_ex.cpp
@@ -1,0 +1,5 @@
+#define MINIMP3_IMPLEMENTATION
+#define MINIMP3_FLOAT_OUTPUT
+#define MINIMP3_ONLY_MP3
+#define MINIMP3_NO_STDIO
+#include "minimp3_ex.h"


### PR DESCRIPTION
Single-header libraries like this require passing a bunch of defines _once_ before including the header, but not multiple times. This can make it tricky in user code to know when to request the implementation, if the header needs to be included in multiple files.

So properly compiling a .cpp file for the implementation solves this, and also enables us to properly disable warnings on thirdparty implementation code.

Follow-up to this discussion with @YuriSizov: https://github.com/godotengine/godot/pull/75944#discussion_r1230847566