### PR TITLE
Added debug color and draw faces properties for CollisionShape3D

### DIFF
--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -29,6 +29,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="debug_color" type="Color" setter="set_debug_color" getter="get_debug_color" default="Color(0, 0, 0, 1)">
+		</member>
+		<member name="debug_draw_faces" type="bool" setter="set_debug_draw_faces" getter="get_debug_draw_faces" default="false">
+		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			A disabled collision shape has no effect in the world.
 		</member>

--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -139,6 +139,7 @@
 			<param index="1" name="material" type="Material" />
 			<param index="2" name="billboard" type="bool" default="false" />
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="4" name="modulate_is_vertex_color" type="bool" default="false" />
 			<description>
 				Adds lines to the gizmo (as sets of 2 points), with a given material. The lines are used for visualizing the gizmo. Call this method during [method _redraw].
 			</description>

--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -13,6 +13,8 @@
 	<methods>
 		<method name="get_debug_mesh">
 			<return type="ArrayMesh" />
+			<param index="0" name="vertex_color" type="Color" />
+			<param index="1" name="with_shape_faces" type="bool" />
 			<description>
 				Returns the [ArrayMesh] used to draw the debug collision for this [Shape3D].
 			</description>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -244,11 +244,11 @@ void EditorNode3DGizmo::add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p
 	instances.push_back(ins);
 }
 
-void EditorNode3DGizmo::add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard, const Color &p_modulate) {
-	add_vertices(p_lines, p_material, Mesh::PRIMITIVE_LINES, p_billboard, p_modulate);
+void EditorNode3DGizmo::add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard, const Color &p_modulate, bool p_mod_is_vertex_color) {
+	add_vertices(p_lines, p_material, Mesh::PRIMITIVE_LINES, p_billboard, p_modulate, p_mod_is_vertex_color);
 }
 
-void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard, const Color &p_modulate) {
+void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard, const Color &p_modulate, bool p_mod_is_vertex_color) {
 	if (p_vertices.is_empty()) {
 		return;
 	}
@@ -267,14 +267,17 @@ void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Re
 	{
 		Color *w = color.ptrw();
 		for (int i = 0; i < p_vertices.size(); i++) {
-			if (is_selected()) {
-				w[i] = Color(1, 1, 1, 0.8) * p_modulate;
+			if (p_mod_is_vertex_color) {
+				w[i] = p_modulate;
 			} else {
-				w[i] = Color(1, 1, 1, 0.2) * p_modulate;
+				if (is_selected()) {
+					w[i] = Color(1, 1, 1, 0.8) * p_modulate;
+				} else {
+					w[i] = Color(1, 1, 1, 0.2) * p_modulate;
+				}
 			}
 		}
 	}
-
 	a[Mesh::ARRAY_COLOR] = color;
 
 	mesh->add_surface_from_arrays(p_primitive_type, a);
@@ -806,7 +809,7 @@ void EditorNode3DGizmo::set_plugin(EditorNode3DGizmoPlugin *p_plugin) {
 }
 
 void EditorNode3DGizmo::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("add_lines", "lines", "material", "billboard", "modulate"), &EditorNode3DGizmo::add_lines, DEFVAL(false), DEFVAL(Color(1, 1, 1)));
+	ClassDB::bind_method(D_METHOD("add_lines", "lines", "material", "billboard", "modulate", "modulate_is_vertex_color"), &EditorNode3DGizmo::add_lines, DEFVAL(false), DEFVAL(Color(1, 1, 1)), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("add_mesh", "mesh", "material", "transform", "skeleton"), &EditorNode3DGizmo::add_mesh, DEFVAL(Variant()), DEFVAL(Transform3D()), DEFVAL(Ref<SkinReference>()));
 	ClassDB::bind_method(D_METHOD("add_collision_segments", "segments"), &EditorNode3DGizmo::add_collision_segments);
 	ClassDB::bind_method(D_METHOD("add_collision_triangles", "triangles"), &EditorNode3DGizmo::add_collision_triangles);

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -93,8 +93,8 @@ protected:
 	GDVIRTUAL2(_set_subgizmo_transform, int, Transform3D)
 	GDVIRTUAL3(_commit_subgizmos, Vector<int>, TypedArray<Transform3D>, bool)
 public:
-	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
-	void add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1));
+	void add_lines(const Vector<Vector3> &p_lines, const Ref<Material> &p_material, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1), bool p_mod_is_vertex_color = false);
+	void add_vertices(const Vector<Vector3> &p_vertices, const Ref<Material> &p_material, Mesh::PrimitiveType p_primitive_type, bool p_billboard = false, const Color &p_modulate = Color(1, 1, 1), bool p_mod_is_vertex_color = false);
 	void add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p_material = Ref<Material>(), const Transform3D &p_xform = Transform3D(), const Ref<SkinReference> &p_skin_reference = Ref<SkinReference>());
 	void add_collision_segments(const Vector<Vector3> &p_lines);
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -69,6 +69,10 @@ private:
 
 		Vector<ShapeBase> shapes;
 		bool disabled = false;
+#ifdef DEBUG_ENABLED
+		Color debug_color;
+		bool debug_draw_faces;
+#endif //DEBUG_ENABLED
 	};
 
 	int total_subshapes = 0;
@@ -152,6 +156,8 @@ public:
 
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
+
+	void shape_owner_set_debug(uint32_t p_owner, bool p_debug_show_faces, const Color &p_debug_color);
 
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -48,8 +48,16 @@ class CollisionShape3D : public Node3D {
 #endif
 	bool disabled = false;
 
+#ifdef DEBUG_ENABLED
+	Color debug_color;
+	bool debug_draw_faces = false;
+#endif //DEBUG_ENABLED
+
+	Color _get_default_debug_color() const;
+
 protected:
 	void _update_in_shape_owner(bool p_xform_only = false);
+	void _validate_property(PropertyInfo &p_property) const;
 
 protected:
 	void _notification(int p_what);
@@ -60,6 +68,12 @@ public:
 
 	void set_shape(const Ref<Shape3D> &p_shape);
 	Ref<Shape3D> get_shape() const;
+
+	Color get_debug_color() const;
+	void set_debug_colour(const Color &p_color);
+
+	bool get_debug_draw_faces() const;
+	void set_debug_draw_faces(bool p_debug_draw_faces);
 
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -810,11 +810,30 @@ Ref<Material> SceneTree::get_debug_collision_material() {
 	line_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
 	line_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	line_material->set_albedo(get_debug_collisions_color());
+	line_material->set_albedo(Color(1.0, 1.0, 1.0, 1.0));
 
 	collision_material = line_material;
 
 	return collision_material;
+}
+
+Ref<Material> SceneTree::get_debug_collision_face_material() {
+	_THREAD_SAFE_METHOD_
+
+	if (collision_face_material.is_valid()) {
+		return collision_face_material;
+	}
+
+	Ref<StandardMaterial3D> face_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	face_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	face_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	face_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
+	face_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+	face_material->set_albedo(Color(1.0, 1.0, 1.0, 0.25));
+
+	collision_face_material = face_material;
+
+	return collision_face_material;
 }
 
 Ref<ArrayMesh> SceneTree::get_debug_contact_mesh() {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -188,6 +188,7 @@ private:
 	Ref<ArrayMesh> debug_contact_mesh;
 	Ref<Material> debug_paths_material;
 	Ref<Material> collision_material;
+	Ref<Material> collision_face_material;
 	int collision_debug_contacts;
 
 	void _flush_scene_change();
@@ -372,6 +373,7 @@ public:
 
 	Ref<Material> get_debug_paths_material();
 	Ref<Material> get_debug_collision_material();
+	Ref<Material> get_debug_collision_face_material();
 	Ref<ArrayMesh> get_debug_contact_mesh();
 
 	int get_collision_debug_contact_count() { return collision_debug_contacts; }

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "box_shape_3d.h"
+
+#include "scene/resources/primitive_meshes.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> BoxShape3D::get_debug_mesh_lines() const {
@@ -54,6 +56,11 @@ real_t BoxShape3D::get_enclosing_radius() const {
 void BoxShape3D::_update_shape() {
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), size / 2);
 	Shape3D::_update_shape();
+}
+
+void BoxShape3D::get_debug_face_mesh_arrays(Array &p_arr) const {
+	BoxMesh box_mesh;
+	box_mesh.create_mesh_array(p_arr, size);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/resources/box_shape_3d.h
+++ b/scene/resources/box_shape_3d.h
@@ -45,6 +45,7 @@ protected:
 #endif // DISABLE_DEPRECATED
 
 	virtual void _update_shape() override;
+	void get_debug_face_mesh_arrays(Array &p_arr) const override;
 
 public:
 	void set_size(const Vector3 &p_size);

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "capsule_shape_3d.h"
 
+#include "scene/resources/primitive_meshes.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() const {
@@ -77,6 +78,11 @@ void CapsuleShape3D::_update_shape() {
 	d["height"] = height;
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), d);
 	Shape3D::_update_shape();
+}
+
+void CapsuleShape3D::get_debug_face_mesh_arrays(Array &p_arr) const {
+	CapsuleMesh capsule_mesh;
+	capsule_mesh.create_mesh_array(p_arr, radius, height, 32, 12);
 }
 
 void CapsuleShape3D::set_radius(float p_radius) {

--- a/scene/resources/capsule_shape_3d.h
+++ b/scene/resources/capsule_shape_3d.h
@@ -42,6 +42,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void _update_shape() override;
+	void get_debug_face_mesh_arrays(Array &p_arr) const override;
 
 public:
 	void set_radius(float p_radius);

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "cylinder_shape_3d.h"
 
+#include "scene/resources/primitive_meshes.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() const {
@@ -70,6 +71,11 @@ void CylinderShape3D::_update_shape() {
 	d["height"] = height;
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), d);
 	Shape3D::_update_shape();
+}
+
+void CylinderShape3D::get_debug_face_mesh_arrays(Array &p_arr) const {
+	CylinderMesh cylinder_mesh;
+	cylinder_mesh.create_mesh_array(p_arr, radius, radius, height, 32, 1);
 }
 
 void CylinderShape3D::set_radius(float p_radius) {

--- a/scene/resources/cylinder_shape_3d.h
+++ b/scene/resources/cylinder_shape_3d.h
@@ -41,6 +41,7 @@ class CylinderShape3D : public Shape3D {
 protected:
 	static void _bind_methods();
 	virtual void _update_shape() override;
+	void get_debug_face_mesh_arrays(Array &p_arr) const override;
 
 public:
 	void set_radius(float p_radius);

--- a/scene/resources/shape_3d.h
+++ b/scene/resources/shape_3d.h
@@ -43,7 +43,10 @@ class Shape3D : public Resource {
 	real_t custom_bias = 0.0;
 	real_t margin = 0.04;
 
-	Ref<ArrayMesh> debug_mesh_cache;
+#ifdef DEBUG_ENABLED
+	HashMap<Color, Ref<ArrayMesh>> debug_mesh_lines_cache;
+	HashMap<Color, Ref<ArrayMesh>> debug_mesh_face_cache;
+#endif // DEBUG_ENABLED
 
 protected:
 	static void _bind_methods();
@@ -53,11 +56,14 @@ protected:
 
 	virtual void _update_shape();
 
+	virtual void get_debug_face_mesh_arrays(Array &p_arr) const {}
+
 public:
 	virtual RID get_rid() const override { return shape; }
 
-	Ref<ArrayMesh> get_debug_mesh();
+	Ref<ArrayMesh> get_debug_mesh(const Color &p_debug_color = Color(), bool p_with_shape_faces = false);
 	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }
+	virtual Ref<ArrayMesh> get_debug_face_mesh(const Color &p_vertex_color) const;
 	/// Returns the radius of a sphere that fully enclose this shape
 	virtual real_t get_enclosing_radius() const = 0;
 
@@ -70,7 +76,7 @@ public:
 	void set_margin(real_t p_margin);
 
 	Shape3D();
-	~Shape3D();
+	virtual ~Shape3D() override;
 };
 
 #endif // SHAPE_3D_H

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "sphere_shape_3d.h"
 
+#include "scene/resources/primitive_meshes.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> SphereShape3D::get_debug_mesh_lines() const {
@@ -61,6 +62,11 @@ real_t SphereShape3D::get_enclosing_radius() const {
 void SphereShape3D::_update_shape() {
 	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), radius);
 	Shape3D::_update_shape();
+}
+
+void SphereShape3D::get_debug_face_mesh_arrays(Array &p_arr) const {
+	SphereMesh sphere_mesh;
+	sphere_mesh.create_mesh_array(p_arr, radius, radius * 2.0, 32, 16);
 }
 
 void SphereShape3D::set_radius(float p_radius) {

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -41,6 +41,7 @@ protected:
 	static void _bind_methods();
 
 	virtual void _update_shape() override;
+	void get_debug_face_mesh_arrays(Array &p_arr) const override;
 
 public:
 	void set_radius(float p_radius);

--- a/scene/resources/world_boundary_shape_3d.cpp
+++ b/scene/resources/world_boundary_shape_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "world_boundary_shape_3d.h"
 
+#include "scene/resources/mesh.h"
 #include "servers/physics_server_3d.h"
 
 Vector<Vector3> WorldBoundaryShape3D::get_debug_mesh_lines() const {
@@ -59,6 +60,47 @@ Vector<Vector3> WorldBoundaryShape3D::get_debug_mesh_lines() const {
 	};
 
 	return points;
+}
+
+Ref<ArrayMesh> WorldBoundaryShape3D::get_debug_face_mesh(const Color &p_vertex_color) const {
+	Plane p = get_plane();
+
+	Vector3 n1 = p.get_any_perpendicular_normal();
+	Vector3 n2 = p.normal.cross(n1).normalized();
+
+	PackedVector3Array pface = {
+		p.normal * p.d + n1 * 10.0 + n2 * 10.0,
+		p.normal * p.d + n1 * 10.0 + n2 * -10.0,
+		p.normal * p.d + n1 * -10.0 + n2 * -10.0,
+		p.normal * p.d + n1 * -10.0 + n2 * 10.0,
+	};
+
+	PackedInt32Array indices = {
+		0,
+		1,
+		2,
+		2,
+		3,
+		0,
+	};
+	Vector<Color> colors = {
+		p_vertex_color,
+		p_vertex_color,
+		p_vertex_color,
+		p_vertex_color
+	};
+
+	Array arr;
+	arr.resize(Mesh::ARRAY_MAX);
+
+	arr[Mesh::ARRAY_VERTEX] = pface;
+	arr[Mesh::ARRAY_INDEX] = indices;
+	arr[Mesh::ARRAY_COLOR] = colors;
+
+	Ref<ArrayMesh> array_mesh = memnew(ArrayMesh);
+	array_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arr);
+
+	return array_mesh;
 }
 
 void WorldBoundaryShape3D::_update_shape() {

--- a/scene/resources/world_boundary_shape_3d.h
+++ b/scene/resources/world_boundary_shape_3d.h
@@ -46,6 +46,7 @@ public:
 	const Plane &get_plane() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
+	virtual Ref<ArrayMesh> get_debug_face_mesh(const Color &p_vertex_color) const override;
 	virtual real_t get_enclosing_radius() const override {
 		// Should be infinite?
 		return 0;


### PR DESCRIPTION
Partially closes godotengine/godot-proposals/issues/906

Currently does not support drawing faces for HeightMap, Concave or Convex Shapes
![Editor](https://github.com/godotengine/godot/assets/50963453/244274a5-e404-4521-9a4e-89c7c6de2c04)

![Demo](https://github.com/godotengine/godot/assets/50963453/fcc6c75d-008f-4152-8d74-5cff3abb58ff)

![Game](https://github.com/godotengine/godot/assets/50963453/bb8d53f7-7af6-45a3-8c4c-18e2d4e02073)


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
