### PR TITLE
Add note in `Callable` documentation about methods of native types (reverted)

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -46,6 +46,17 @@
 		    # Prints "Attack!", when the button_pressed signal is emitted.
 		    button_pressed.connect(func(): print("Attack!"))
 		[/codeblock]
+		[b]Note:[/b] Methods of native types such as [Signal], [Array], or [Dictionary] are not of type [Callable] in order to avoid unnecessary overhead. If you need to pass those methods as [Callable], use a lambda function as a wrapper.
+		[codeblock]
+		func _init():
+		    var my_dictionary = { "hello": "world" }
+
+		    # This will not work, `clear` is not a callable.
+		    create_tween().tween_callback(my_dictionary.clear)
+
+		    # This will work, as lambdas are custom callables.
+		    create_tween().tween_callback(func(): my_dictionary.clear())
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Adds a workaround/code example too.

Fixes #58912 (the issue itself is not a bug, but the solution was to add a documentation entry about the "issue")

