### PR TITLE
Remove legacy navigation debug materials

### DIFF
--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -185,12 +185,8 @@ private:
 	Color debug_collision_contact_color;
 	Color debug_paths_color;
 	float debug_paths_width = 1.0f;
-	Color debug_navigation_color;
-	Color debug_navigation_disabled_color;
 	Ref<ArrayMesh> debug_contact_mesh;
 	Ref<Material> debug_paths_material;
-	Ref<Material> navigation_material;
-	Ref<Material> navigation_disabled_material;
 	Ref<Material> collision_material;
 	int collision_debug_contacts;
 


### PR DESCRIPTION
Removes legacy navigation debug materials.

Those are unused by now as navigation debug, including materials, has been moved to the NavigationServer.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
