### PR TITLE
Clamp `PathFollow3D` progress when not looping

### DIFF
--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -361,6 +361,8 @@ void PathFollow3D::set_progress(real_t p_progress) {
 				if (!Math::is_zero_approx(p_progress) && Math::is_zero_approx(progress)) {
 					progress = path_length;
 				}
+			} else {
+				progress = CLAMP(progress, 0, path_length);
 			}
 		}
 


### PR DESCRIPTION
- I'm not sure why this was removed. The clamp still exists in `PathFollow2D`.
- Without it, it would be as if the `loop` property is always `false`.
- The clamp was removed in https://github.com/godotengine/godot/pull/64212.