### PR TITLE
Allow very large values for Code Complete Delay to disable suggestions

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -819,7 +819,7 @@
 			If [code]true[/code], automatically completes braces when making use of code completion.
 		</member>
 		<member name="text_editor/completion/code_complete_delay" type="float" setter="" getter="">
-			The delay in seconds after which autocompletion suggestions should be displayed when the user stops typing.
+			The delay in seconds after which autocompletion suggestions should be displayed when the user stops typing. To disable suggestions entirely, set this to a very high value by manually entering a very high number in the setting (such as [code]10000[/code]).
 		</member>
 		<member name="text_editor/completion/complete_file_paths" type="bool" setter="" getter="">
 			If [code]true[/code], provides autocompletion suggestions for file paths in methods such as [code]load()[/code] and [code]preload()[/code].

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -596,7 +596,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Completion
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 2.0, "0.1,10,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true);
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")
 	_initial_set("text_editor/completion/put_callhint_tooltip_below_current_line", true);
 	_initial_set("text_editor/completion/complete_file_paths", true);
 	_initial_set("text_editor/completion/add_type_hints", false);


### PR DESCRIPTION
This can be used to effectively disable autocompletion if you find it distracting.

We could choose to expose a separate boolean setting to toggle autocompletion, but given this is a uncommon use case, I'm not sure if it's worth adding another setting.

- This closes https://github.com/godotengine/godot/issues/68139.
