### PR TITLE
Ensure filter/repeat is cached by Viewport texture in GL Compatibility renderer

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1698,10 +1698,8 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 				glTexImage2D(texture_target, 0, rt->color_internal_format, rt->size.x, rt->size.y, 0, rt->color_format, rt->color_type, nullptr);
 			}
 
-			glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			glTexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-			glTexParameteri(texture_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-			glTexParameteri(texture_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			texture->gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
+			texture->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 		}
 #ifndef IOS_ENABLED
 		if (use_multiview) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/76006

Since we were setting repeat/filter manually the state wasn't properly tracked in the Texture class. So when we go to update the state at draw time the GL calls weren't getting made. 