### PR TITLE
Use a transparent background for code completion results in CodeEdit

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -605,7 +605,7 @@
 		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
 			[Color] for all icons related to line folding.
 		</theme_item>
-		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
+		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color(0.17, 0.16, 0.2, 0.4)">
 			Sets the background [Color] for the code completion popup.
 		</theme_item>
 		<theme_item name="completion_existing_color" data_type="color" type="Color" default="Color(0.87, 0.87, 0.87, 0.13)">
@@ -620,7 +620,7 @@
 		<theme_item name="completion_scroll_hovered_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.4)">
 			[Color] of the scrollbar in the code completion popup when hovered.
 		</theme_item>
-		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
+		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.1)">
 			Background highlight [Color] for the current selected option item in the code completion popup.
 		</theme_item>
 		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -816,8 +816,8 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/comment_color", Color(0.4, 0.4, 0.4));
 	_initial_set("text_editor/theme/highlighting/string_color", Color(0.94, 0.43, 0.75));
 	_initial_set("text_editor/theme/highlighting/background_color", Color(0.13, 0.12, 0.15));
-	_initial_set("text_editor/theme/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
-	_initial_set("text_editor/theme/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
+	_initial_set("text_editor/theme/highlighting/completion_background_color", Color(0.17, 0.16, 0.2, 0.4));
+	_initial_set("text_editor/theme/highlighting/completion_selected_color", Color(1.0, 1.0, 1.0, 0.1));
 	_initial_set("text_editor/theme/highlighting/completion_existing_color", Color(0.87, 0.87, 0.87, 0.13));
 	_initial_set("text_editor/theme/highlighting/completion_scroll_color", Color(1, 1, 1, 0.29));
 	_initial_set("text_editor/theme/highlighting/completion_scroll_hovered_color", Color(1, 1, 1, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -2051,8 +2051,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Use the brightest background color on a light theme (which generally uses a negative contrast rate).
 	const Color te_background_color = dark_theme ? background_color : dark_color_3;
-	const Color completion_background_color = dark_theme ? base_color : background_color;
-	const Color completion_selected_color = alpha1;
+	const Color completion_background_color = (dark_theme ? base_color : background_color) * Color(1, 1, 1, 0.4);
+	const Color completion_selected_color = Color(mono_value, mono_value, mono_value, 0.1);
 	const Color completion_existing_color = alpha2;
 	// Same opacity as the scroll grabber editor icon.
 	const Color completion_scroll_color = Color(mono_value, mono_value, mono_value, 0.29);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -484,8 +484,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_font_size("font_size", "CodeEdit", -1);
 
 	theme->set_color("background_color", "CodeEdit", Color(0, 0, 0, 0));
-	theme->set_color("completion_background_color", "CodeEdit", Color(0.17, 0.16, 0.2));
-	theme->set_color("completion_selected_color", "CodeEdit", Color(0.26, 0.26, 0.27));
+	theme->set_color("completion_background_color", "CodeEdit", Color(0.17, 0.16, 0.2, 0.4));
+	theme->set_color("completion_selected_color", "CodeEdit", Color(1.0, 1.0, 1.0, 0.1));
 	theme->set_color("completion_existing_color", "CodeEdit", Color(0.87, 0.87, 0.87, 0.13));
 	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color * Color(1, 1, 1, 0.29));
 	theme->set_color("completion_scroll_hovered_color", "CodeEdit", control_font_pressed_color * Color(1, 1, 1, 0.4));


### PR DESCRIPTION
This makes code in the background still slightly visible, which results in better awareness of the underlying code especially on smaller displays (where the code completion popup can take a large portion of the screen).

Contrast ratios for the line highlight were adjusted to ensure the line highlight remains easily visible.

This should help with some of the issues outlined in https://github.com/godotengine/godot/issues/68139. If you wish to revert this change, this only affects some default settings so you can revert the relevant color settings to their old values.

## Preview

*I'm not sure why the Light theme's popup appears so much darker – this is not intended.*

Theme | Before | After
-|-|-
Default | ![Screenshot_20230615_221009](https://github.com/godotengine/godot/assets/180032/31bbb70a-d34c-44fa-a0fe-0368abb53c7a) | ![Screenshot_20230615_220740](https://github.com/godotengine/godot/assets/180032/1231990a-5b2d-4ffc-85c3-c30590d67038)
Godot 2 | ![Screenshot_20230615_220951](https://github.com/godotengine/godot/assets/180032/6895e3d7-ab72-4af0-b01e-3e757b197fc0) | ![Screenshot_20230615_220757](https://github.com/godotengine/godot/assets/180032/7acace7f-e477-46a0-bed6-1d304d204e99)
Light | ![Screenshot_20230615_220932](https://github.com/godotengine/godot/assets/180032/44117a82-3c74-49b8-90d4-9bc150dd2426) | ![Screenshot_20230615_220824](https://github.com/godotengine/godot/assets/180032/a1b99fbc-ad8c-43c3-b7f0-a2e00f2bc7f5)