### PR TITLE
Copy texture filter/repeat modes when replacing a texture in the GL Compatibility backend

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1070,7 +1070,7 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	Vector<RID> proxies_to_update = tex_to->proxies;
 	Vector<RID> proxies_to_redirect = tex_from->proxies;
 
-	tex_to->copy_from(*tex_from);
+	*tex_to = *tex_from;
 
 	tex_to->proxies = proxies_to_update; //restore proxies, so they can be updated
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/78228

When a GradientTexture1D is updated we use the ``texture_replace()`` function to place the contents of the new texture into the resource referenced by the old RID. The ``copy_from()`` copies all the Texture state except for the filter/repeat modes. This lead to a situation where the gl_texture's state got out of sync with the Texture referenced by the RID. This change ensures that we copy over all data from the new_texture so that the filter/repeat can get properly updated at draw time. 