### PR TITLE
Remove GDScript code completion for literals

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2344,8 +2344,11 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_literal(ExpressionNode *p_
 	}
 
 	LiteralNode *literal = alloc_node<LiteralNode>();
-	complete_extents(literal);
 	literal->value = previous.literal;
+	reset_extents(literal, p_previous_operand);
+	update_extents(literal);
+	make_completion_context(COMPLETION_NONE, literal, -1, true);
+	complete_extents(literal);
 	return literal;
 }
 


### PR DESCRIPTION
When asking for code completion inside quotes (CTRL+space), the editor don't suggest anymore every identifier with quotes.

Fixes (partially) #62945, the issue still exists when you open the autocomplete window, then add quotes