### PR TITLE
Fix ButtonGroup unpressing

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -366,11 +366,9 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (toggle_mode) {
 			status.pressed = !status.pressed;
 
-			if (status.pressed) {
-				_unpress_group();
-				if (button_group.is_valid()) {
-					button_group->emit_signal(SNAME("pressed"), this);
-				}
+			_unpress_group();
+			if (button_group.is_valid()) {
+				button_group->emit_signal(SNAME("pressed"), this);
 			}
 
 			_toggled(status.pressed);


### PR DESCRIPTION
It was possible to unpress a button group that had `allow_unpress = false` using shortcuts.
Adjust `BaseButton::shortcut_input` to use the same logic as `BaseButton::on_action_event`.

resolve #78224