### PR TITLE
Add "requestor" to the ignore words list in codespell static checks

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -106,5 +106,5 @@ jobs:
         uses: codespell-project/actions-codespell@v1
         with:
           skip: "./bin,./thirdparty,*.desktop,*.gen.*,*.po,*.pot,*.rc,./AUTHORS.md,./COPYRIGHT.txt,./DONORS.md,./core/input/gamecontrollerdb.txt,./core/string/locales.h,./editor/project_converter_3_to_4.cpp,./misc/scripts/codespell.sh,./platform/android/java/lib/src/com,./platform/web/node_modules,./platform/web/package-lock.json"
-          ignore_words_list: "curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te,vai"
+          ignore_words_list: "curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,requestor,te,vai"
           path: ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
This is the name of an API in the X11 code, we need to skip it to make the checks pass. See #65843