### PR TITLE
Remove outdated warning when using screen texture in GL Compatibility renderer

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2968,10 +2968,6 @@ void SceneShaderData::set_code(const String &p_code) {
 		WARN_PRINT_ONCE_ED("Transmittance is only available when using the Forward+ rendering backend.");
 	}
 
-	if (uses_screen_texture) {
-		WARN_PRINT_ONCE_ED("Reading from the screen texture is not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
-	}
-
 	if (uses_depth_texture) {
 		WARN_PRINT_ONCE_ED("Reading from the depth texture is not supported when using the GL Compatibility backend yet. Support will be added in a future release.");
 	}


### PR DESCRIPTION
This fixes an unreported bug. But everytime a user uses the screen_texture they would get this warning which is not accurate anymore since we added screen support early in the 4.1 dev cycle. 

Since https://github.com/godotengine/godot/pull/72361 was cherrypicked, we should cherrypick this as well