### PR TITLE
Add `String.strip_bbcode()` and `String.bbcode_escape()` BBCode methods

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4108,6 +4108,27 @@ String String::strip_escapes() const {
 	return new_string;
 }
 
+String String::strip_bbcode() const {
+	String result;
+	int from = 0;
+	while (true) {
+		int lb_pos = find_char('[', from);
+		if (lb_pos < 0) {
+			break;
+		}
+		int rb_pos = find_char(']', lb_pos + 1);
+		if (rb_pos < 0) {
+			break;
+		}
+		result += substr(from, lb_pos - from);
+		from = rb_pos + 1;
+	}
+	result += substr(from);
+
+	// Remove remaining special characters to avoid security issues with concatenation.
+	return result.replace("[", "").replace("]", "");
+}
+
 String String::lstrip(const String &p_chars) const {
 	int len = length();
 	int beg;
@@ -4505,6 +4526,13 @@ String String::json_escape() const {
 	escaped = escaped.replace("\t", "\\t");
 	escaped = escaped.replace("\v", "\\v");
 	escaped = escaped.replace("\"", "\\\"");
+
+	return escaped;
+}
+
+String String::bbcode_escape() const {
+	String escaped = *this;
+	escaped = escaped.replace("[", "[lb]");
 
 	return escaped;
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -506,6 +506,7 @@ public:
 	String dedent() const;
 	String strip_edges(bool left = true, bool right = true) const;
 	String strip_escapes() const;
+	String strip_bbcode() const;
 	String lstrip(const String &p_chars) const;
 	String rstrip(const String &p_chars) const;
 	String get_extension() const;
@@ -630,6 +631,7 @@ public:
 	String c_escape_multiline() const;
 	String c_unescape() const;
 	String json_escape() const;
+	String bbcode_escape() const;
 	Error parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path, String &r_fragment) const;
 
 	String property_name_encode() const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2064,6 +2064,7 @@ static void _register_variant_builtin_methods_string() {
 
 	bind_string_method(strip_edges, sarray("left", "right"), varray(true, true));
 	bind_string_method(strip_escapes, sarray(), varray());
+	bind_string_method(strip_bbcode, sarray(), varray());
 	bind_string_method(lstrip, sarray("chars"), varray());
 	bind_string_method(rstrip, sarray("chars"), varray());
 	bind_string_method(get_extension, sarray(), varray());
@@ -2096,6 +2097,7 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(c_escape, sarray(), varray());
 	bind_string_method(c_unescape, sarray(), varray());
 	bind_string_method(json_escape, sarray(), varray());
+	bind_string_method(bbcode_escape, sarray(), varray());
 
 	bind_string_method(validate_node_name, sarray(), varray());
 	bind_string_method(validate_filename, sarray(), varray());

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -875,6 +875,7 @@
 				GD.PrintRich("[color=green][b]Hello world![/b][/color]"); // Prints "Hello world!", in green with a bold font.
 				[/csharp]
 				[/codeblocks]
+				[b]Warning:[/b] Be careful about user input when using [method print_rich], as users may be able to inject arbitrary BBCode tags (which can break existing formatting). Use [method String.bbcode_escape] or [method String.strip_bbcode] when adding text to prevent users from injecting arbitrary BBCode tags.
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed.
 				[b]Note:[/b] Output displayed in the editor supports clickable [code skip-lint][url=address]text[/url][/code] tags. The [code skip-lint][url][/code] tag's [code]address[/code] value is handled by [method OS.shell_open] when clicked.
 			</description>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -722,6 +722,7 @@
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">
 			If [code]true[/code], the label uses BBCode formatting.
 			[b]Note:[/b] This only affects the contents of [member text], not the tag stack.
+			[b]Warning:[/b] Be careful about user input when [member bbcode_enabled] is [code]true[/code], as users may be able to inject arbitrary BBCode tags. This can be a security concern, since users could break formatting or create clickable links to malicious websites. Use [method String.bbcode_escape] or [method String.strip_bbcode] when adding text to prevent users from injecting arbitrary BBCode tags.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="context_menu_enabled" type="bool" setter="set_context_menu_enabled" getter="is_context_menu_enabled" default="false">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -42,6 +42,13 @@
 		</constructor>
 	</constructors>
 	<methods>
+		<method name="bbcode_escape" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the string with BBCode tags escaped to [code][lb][/code] and [code][rb][/code], which makes them ineffective when used in [RichTextLabel] with [member RichTextLabel.bbcode_enabled] set to [code]true[/code]. This is useful for handling user input to prevent BBCode injection. See also [method strip_bbcode].
+				[b]Note:[/b] [method bbcode_escape] is designed to work with Godot's BBCode implementation. Other implementations may not support the [code][lb][/code] and [code][rb][/code] tags used for escaping.
+			</description>
+		</method>
 		<method name="begins_with" qualifiers="const" keywords="starts_with">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />
@@ -990,6 +997,13 @@
 				var c = "1| ||4.5".split_floats("|")        # c is [1.0, 0.0, 0.0, 4.5]
 				var b = "1| ||4.5".split_floats("|", false) # b is [1.0, 4.5]
 				[/codeblock]
+			</description>
+		</method>
+		<method name="strip_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the string with all BBCode tags removed (regardless of whether these tags are valid or not). Extraneous brackets are also removed to avoid issues when several strings are concatenated together. See also [method bbcode_escape].
+				[b]Note:[/b] Removing BBCode tags entirely isn't advised for user input, as it can modify the displayed text without users understanding why part of their message was removed. Escaping user input with [method bbcode_escape] should be preferred instead.
 			</description>
 		</method>
 		<method name="strip_edges" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -36,6 +36,13 @@
 		</constructor>
 	</constructors>
 	<methods>
+		<method name="bbcode_escape" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the string with BBCode tags escaped, which makes them ineffective when used in [RichTextLabel] with [member RichTextLabel.bbcode_enabled] set to [code]true[/code]. This is useful for handling user input to prevent BBCode injection. See also [method strip_bbcode].
+				[b]Note:[/b] [method bbcode_escape] is designed to work with Godot's BBCode implementation. Other implementations may not support the [code][lb][/code] and [code][rb][/code] tags used for escaping.
+			</description>
+		</method>
 		<method name="begins_with" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />
@@ -889,6 +896,13 @@
 				var c = "1| ||4.5".split_floats("|")        # c is [1.0, 0.0, 0.0, 4.5]
 				var b = "1| ||4.5".split_floats("|", false) # b is [1.0, 4.5]
 				[/codeblock]
+			</description>
+		</method>
+		<method name="strip_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the string with all BBCode tags removed (regardless of whether these tags are valid or not). Extraneous brackets are also removed to avoid issues when several strings are concatenated together. See also [method bbcode_escape].
+				[b]Note:[/b] Removing BBCode tags entirely isn't advised for user input, as it can modify the displayed text without users understanding why part of their message was removed. Escaping user input with [method bbcode_escape] should be preferred instead.
 			</description>
 		</method>
 		<method name="strip_edges" qualifiers="const">

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -1957,6 +1957,26 @@ TEST_CASE("[String] Strip edges") {
 	CHECK(s.strip_edges(true, true) == "Test Test");
 }
 
+TEST_CASE("[String] Strip BBCode") {
+	CHECK(String().strip_bbcode() == "");
+	CHECK(String("Test").strip_bbcode() == "Test");
+	CHECK(String("[b][i][color=blue]Test[/color][/i][/b]").strip_bbcode() == "Test");
+	CHECK(String(" [b] [i] [color=blue]Test[/color] [/i] [/b] ").strip_bbcode() == "   Test   ");
+	CHECK(String("[nonexistent]Test[/nonexistent]").strip_bbcode() == "Test");
+	CHECK(String("[nonexistent]Test").strip_bbcode() == "Test");
+	CHECK(String("Test[/nonexistent]").strip_bbcode() == "Test");
+}
+
+TEST_CASE("[String] Escape BBCode") {
+	CHECK(String().bbcode_escape() == "");
+	CHECK(String("Test").bbcode_escape() == "Test");
+	CHECK(String("[b][i][color=blue]Test[/color][/i][/b]").bbcode_escape() == "[lb]b][lb]i][lb]color=blue]Test[lb]/color][lb]/i][lb]/b]");
+	CHECK(String(" [b] [i] [color=blue]Test[/color] [/i] [/b] ").bbcode_escape() == " [lb]b] [lb]i] [lb]color=blue]Test[lb]/color] [lb]/i] [lb]/b] ");
+	CHECK(String("[nonexistent]Test[/nonexistent]").bbcode_escape() == "[lb]nonexistent]Test[lb]/nonexistent]");
+	CHECK(String("[nonexistent]Test").bbcode_escape() == "[lb]nonexistent]Test");
+	CHECK(String("Test[/nonexistent]").bbcode_escape() == "Test[lb]/nonexistent]");
+}
+
 TEST_CASE("[String] Trim") {
 	String s = "aaaTestbbb";
 	MULTICHECK_STRING_EQ(s, trim_prefix, "aaa", "Testbbb");


### PR DESCRIPTION
`String.strip_bbcode()` can be used to display text from a RichTextLabel in places that don't support rich formatting.

`String.bbcode_escape()` can be used to prevent BBCode injection in RichTextLabels that display user input.

- This closes https://github.com/godotengine/godot-proposals/issues/5056. See also https://github.com/godotengine/godot/pull/65839, which provides an alternative implementation that only has `String.strip_bbcode()` implemented.

Thanks @dalexeev for providing the `String.strip_bbcode()` implementation :slightly_smiling_face: 

## Preview

*From top to bottom: unescaped, stripped, escaped*

![Screenshot_20230616_045732](https://github.com/godotengine/godot/assets/180032/1f3737e3-77cf-41dc-b5a8-88b2f115d963)

```
[b]hello[/b] [u][color=#f89]world[/color][/u]
```