### PR TITLE
Fix wrong order in autocompletion sorting with empty string to complete.

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -338,7 +338,7 @@ public:
 		Ref<Resource> icon;
 		Variant default_value;
 		Vector<Pair<int, int>> matches;
-		Vector<Pair<int, int>> last_matches;
+		Vector<Pair<int, int>> last_matches = { { -1, -1 } }; // This value correspond to an impossible match
 		int location = LOCATION_OTHER;
 
 		CodeCompletionOption() {}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3326,8 +3326,6 @@ CodeEdit::~CodeEdit() {
 
 // Return true if l should come before r
 bool CodeCompletionOptionCompare::operator()(const ScriptLanguage::CodeCompletionOption &l, const ScriptLanguage::CodeCompletionOption &r) const {
-	// Check if we are not completing an empty string in this case there is no reason to get matches characteristics.
-
 	TypedArray<int> lcharac = l.get_option_cached_characteristics();
 	TypedArray<int> rcharac = r.get_option_cached_characteristics();
 
@@ -3344,5 +3342,5 @@ bool CodeCompletionOptionCompare::operator()(const ScriptLanguage::CodeCompletio
 			return l.matches[i].second > r.matches[i].second;
 		}
 	}
-	return l.display < r.display;
+	return l.display.naturalnocasecmp_to(r.display) < 0;
 }


### PR DESCRIPTION
Fixes #78296
The problem is not really that it is sorted alphabetically but more that it isn't. It was sorting upper-case letters before lower-case ones which meant all constants would go at the top. 
This what now is shown for similar setup as the issue 
<img width="634" alt="Capture d’écran 2023-06-16 à 11 24 19" src="https://github.com/godotengine/godot/assets/66184050/7291a7be-babb-483e-b76c-9423e50fca4c">
I'm wondering about the `Import path` maybe I should remove underscores before sorting alphabetically, or at least the first one as with it they will always appear first (for empty string to complete).

Edit : There was also a bug about location created because of bad initialisation which resulted in option being ranked only by alphabetical order instead of first by location. Here is what it now shows : 
<img width="451" alt="Capture d’écran 2023-06-16 à 14 05 18" src="https://github.com/godotengine/godot/assets/66184050/bdb581d9-c87d-4c96-976b-9b852733b6f9">
