### PR TITLE
Fix transform for transposed tiles in compatibility mode (from 3.x)

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3086,7 +3086,7 @@ void TileMap::_build_runtime_update_tile_data(SelfList<TileMapQuadrant>::List &r
 
 							// Create the runtime TileData.
 							TileData *tile_data_runtime_use = tile_data->duplicate();
-							tile_data->set_allow_transform(true);
+							tile_data_runtime_use->set_allow_transform(true);
 							q.runtime_tile_data_cache[E_cell.value] = tile_data_runtime_use;
 
 							GDVIRTUAL_CALL(_tile_data_runtime_update, q.layer, E_cell.value, tile_data_runtime_use);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2563,7 +2563,7 @@ void TileSet::_compatibility_conversion() {
 					Transform2D xform;
 					xform = flip_h ? xform.scaled(Size2(-1, 1)) : xform;
 					xform = flip_v ? xform.scaled(Size2(1, -1)) : xform;
-					xform = transpose ? xform.rotated(Math_PI).scaled(Size2(-1, -1)) : xform;
+					xform = transpose ? Transform2D(xform[1], xform[0], Vector2()) : xform;
 
 					int alternative_tile = 0;
 					if (!atlas_source->has_tile(coords)) {
@@ -2677,7 +2677,7 @@ void TileSet::_compatibility_conversion() {
 							Transform2D xform;
 							xform = flip_h ? xform.scaled(Size2(-1, 1)) : xform;
 							xform = flip_v ? xform.scaled(Size2(1, -1)) : xform;
-							xform = transpose ? xform.rotated(Math_PI).scaled(Size2(-1, -1)) : xform;
+							xform = transpose ? Transform2D(xform[1], xform[0], Vector2()) : xform;
 
 							int alternative_tile = 0;
 							if (!atlas_source->has_tile(coords)) {


### PR DESCRIPTION
When converting a TileSet from 3.x. the Transform2D used for transforming collision shapes etc. was incorrectly calculated for transposed tiles.

`xform.rotated(Math_PI).scaled(Size2(-1, -1))` previously used is a no-op, as that's a rotation by 180 degrees followed by flipping both axes.

If anything, e.g. a rotation by 90 degrees followed by the x-axis (post rotation) flip could be used as transposition (`xform.rotated(Math_PI * 0.5).scaled(Size2(-1, 1))`). But the rotation would result in slight inaccurancy (y-axis could become something like `(1.00000000000000000000, -0.00000004371138828674)`) and hence it should be avoided. This PR makes the axes be actually swapped, without additional calculations.

Probably fixes #73517 (not fully sure if that's what reported in there).