### PR TITLE
Fix filesystem cache split error

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -262,7 +262,7 @@ void EditorFileSystem::_scan_filesystem() {
 
 				} else {
 					Vector<String> split = l.split("::");
-					ERR_CONTINUE(split.size() != 9);
+					ERR_CONTINUE(split.size() < 9);
 					String name = split[0];
 					String file;
 


### PR DESCRIPTION
Fixes #78242
The code expected exactly 9 splits, but never used any splits above 9th, so it's fine if the number is higher.

Random thought after looking at the code, I wonder if maybe it's worth reworking dependencies to use `<>` as internal split 🤔