### PR TITLE
Fix Clang `dev_mode` build const string conversion

### DIFF
--- a/platform/windows/gl_manager_windows.cpp
+++ b/platform/windows/gl_manager_windows.cpp
@@ -86,7 +86,7 @@ typedef int(__cdecl *NvAPI_DRS_SetSetting_t)(NvDRSSessionHandle, NvDRSProfileHan
 typedef int(__cdecl *NvAPI_DRS_FindProfileByName_t)(NvDRSSessionHandle, NvAPI_UnicodeString, NvDRSProfileHandle *);
 NvAPI_GetErrorMessage_t NvAPI_GetErrorMessage__;
 
-static bool nvapi_err_check(char *msg, int status) {
+static bool nvapi_err_check(const char *msg, int status) {
 	if (status != 0) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			NvAPI_ShortString err_desc = { 0 };


### PR DESCRIPTION
When passing a string literal to a function, it must have a `const char*` signature after ISO C++11. Looks like Clang is a bit stricter about this in dev_mode builds. Clang errors:

```
[ 97%] =====
[ 97%] platform\windows\gl_manager_windows.cpp:138:23: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
        if (!nvapi_err_check("NVAPI: Init failed", NvAPI_Initialize())) {
                             ^
platform\windows\gl_manager_windows.cpp:146:23: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
        if (!nvapi_err_check("NVAPI: Error creating DRS session", NvAPI_DRS_CreateSession(&session_handle))) {
                             ^
platform\windows\gl_manager_windows.cpp:151:23: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
        if (!nvapi_err_check("NVAPI: Error loading DRS settings", NvAPI_DRS_LoadSettings(session_handle))) {
                             ^
platform\windows\gl_manager_windows.cpp:181:24: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
                if (!nvapi_err_check("NVAPI: Error creating profile", NvAPI_DRS_CreateProfile(session_handle, &profile_info, &profile_handle))) {
                                     ^
platform\windows\gl_manager_windows.cpp:197:24: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
                if (!nvapi_err_check("NVAPI: Error creating application", NvAPI_DRS_CreateApplication(session_handle, profile_handle, &app))) {
                                     ^
platform\windows\gl_manager_windows.cpp:218:23: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
        if (!nvapi_err_check("NVAPI: Error calling NvAPI_DRS_SetSetting", NvAPI_DRS_SetSetting(session_handle, profile_handle, &setting))) {
                             ^
platform\windows\gl_manager_windows.cpp:224:23: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
        if (!nvapi_err_check("NVAPI: Error saving settings", NvAPI_DRS_SaveSettings(session_handle))) {
                             ^
7 errors generated.

[ 97%] =====
[ 97%] scons: *** [platform\windows\gl_manager_windows.windows.editor.dev.x86_64.llvm.o] Error 1
scons: building terminated because of errors.
```