### PR TITLE
Remove SceneTree debug avoidance hint

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2965,19 +2965,14 @@ bool Main::start() {
 		}
 		if (debug_navigation) {
 			sml->set_debug_navigation_hint(true);
+			NavigationServer3D::get_singleton()->set_debug_navigation_enabled(true);
 		}
 		if (debug_avoidance) {
-			sml->set_debug_avoidance_hint(true);
+			NavigationServer3D::get_singleton()->set_debug_avoidance_enabled(true);
 		}
 		if (debug_navigation || debug_avoidance) {
 			NavigationServer3D::get_singleton()->set_active(true);
 			NavigationServer3D::get_singleton()->set_debug_enabled(true);
-			if (debug_navigation) {
-				NavigationServer3D::get_singleton()->set_debug_navigation_enabled(true);
-			}
-			if (debug_avoidance) {
-				NavigationServer3D::get_singleton()->set_debug_avoidance_enabled(true);
-			}
 		}
 #endif
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -737,14 +737,6 @@ void SceneTree::set_debug_navigation_hint(bool p_enabled) {
 bool SceneTree::is_debugging_navigation_hint() const {
 	return debug_navigation_hint;
 }
-
-void SceneTree::set_debug_avoidance_hint(bool p_enabled) {
-	debug_avoidance_hint = p_enabled;
-}
-
-bool SceneTree::is_debugging_avoidance_hint() const {
-	return debug_avoidance_hint;
-}
 #endif
 
 void SceneTree::set_debug_collisions_color(const Color &p_color) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -132,7 +132,6 @@ private:
 	bool debug_collisions_hint = false;
 	bool debug_paths_hint = false;
 	bool debug_navigation_hint = false;
-	bool debug_avoidance_hint = false;
 #endif
 	bool paused = false;
 	int root_lock = 0;
@@ -347,9 +346,6 @@ public:
 
 	void set_debug_navigation_hint(bool p_enabled);
 	bool is_debugging_navigation_hint() const;
-
-	void set_debug_avoidance_hint(bool p_enabled);
-	bool is_debugging_avoidance_hint() const;
 #else
 	void set_debug_collisions_hint(bool p_enabled) {}
 	bool is_debugging_collisions_hint() const { return false; }


### PR DESCRIPTION
Removes SceneTree debug avoidance hint.

This was added recently with the avoidance rework https://github.com/godotengine/godot/pull/69988 so should be good to remove again while in beta.

In retrospect there is no point in adding this hint to the SceneTree like with the legacy debug.
All the debug happens on the NavigationServer and can be set directly.

At some point the navigation debug hints should be removed / moved as well but this would break compatibility so I avoided that.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
