### PR TITLE
Don't normalize TBN basis in pixel shader

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -976,15 +976,15 @@ void main() {
 	float alpha = 1.0;
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	vec3 binormal = normalize(binormal_interp);
-	vec3 tangent = normalize(tangent_interp);
+	vec3 binormal = binormal_interp;
+	vec3 tangent = tangent_interp;
 #else
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
 #endif
 
 #ifdef NORMAL_USED
-	vec3 normal = normalize(normal_interp);
+	vec3 normal = normal_interp;
 
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1059,12 +1059,17 @@ void main() {
 	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
+#elif defined(NORMAL_USED)
+	normal = normalize(normal);
 #endif
 
 #ifdef LIGHT_ANISOTROPY_USED
+	// Reconstructing orthonormal tangent frame from normal map result means that anisotropic specularity can be synced to the tangent basis.
+	// Without this, anisotropy can look wibbly-wobbly in extreme cases and dark around the edges otherwise.
+	tangent = normalize(cross(binormal, normal));
+	binormal = normalize(cross(normal, tangent));
 
-	if (anisotropy > 0.01) {
+	if (abs(anisotropy) > 0.01) {
 		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
 		//make local to space

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -884,12 +884,12 @@ void fragment_shader(in SceneData scene_data) {
 #endif
 
 #ifdef LIGHT_ANISOTROPY_USED
-	tangent = normalize(tangent);
-	binormal = normalize(binormal);
+	// Reconstructing orthonormal tangent frame from normal map result means that anisotropic specularity can be synced to the tangent basis.
+	// Without this, anisotropy can look wibbly-wobbly in extreme cases and dark around the edges otherwise.
+	tangent = normalize(cross(binormal, normal));
+	binormal = normalize(cross(normal, tangent));
 
 	if (abs(anisotropy) > 0.01) {
-		// Should normal be taken into rot here before normal mapping? Should tangent/binormal be reoriented based on normal map?
-		// Currently anisotropy causes a loss of normal map sync in the specular component of BRDF.
 		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
 		//make local to space

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -761,15 +761,15 @@ void fragment_shader(in SceneData scene_data) {
 	float alpha = float(instances.data[instance_index].flags >> INSTANCE_FLAGS_FADE_SHIFT) / float(255.0);
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	vec3 binormal = normalize(binormal_interp);
-	vec3 tangent = normalize(tangent_interp);
+	vec3 binormal = binormal_interp;
+	vec3 tangent = tangent_interp;
 #else
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
 #endif
 
 #ifdef NORMAL_USED
-	vec3 normal = normalize(normal_interp);
+	vec3 normal = normal_interp;
 
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -879,11 +879,17 @@ void fragment_shader(in SceneData scene_data) {
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
 
+#elif defined(NORMAL_USED)
+	normal = normalize(normal);
 #endif
 
 #ifdef LIGHT_ANISOTROPY_USED
+	tangent = normalize(tangent);
+	binormal = normalize(binormal);
 
-	if (anisotropy > 0.01) {
+	if (abs(anisotropy) > 0.01) {
+		// Should normal be taken into rot here before normal mapping? Should tangent/binormal be reoriented based on normal map?
+		// Currently anisotropy causes a loss of normal map sync in the specular component of BRDF.
 		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
 		//make local to space

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -832,11 +832,17 @@ void main() {
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
 
+#elif defined(NORMAL_USED)
+	normal = normalize(normal);
 #endif
 
 #ifdef LIGHT_ANISOTROPY_USED
+	// Reconstructing orthonormal tangent frame from normal map result means that anisotropic specularity can be synced to the tangent basis.
+	// Without this, anisotropy can look wibbly-wobbly in extreme cases and dark around the edges otherwise.
+	tangent = normalize(cross(binormal, normal));
+	binormal = normalize(cross(normal, tangent));
 
-	if (anisotropy > 0.01) {
+	if (abs(anisotropy) > 0.01) {
 		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
 		//make local to space

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -708,15 +708,15 @@ void main() {
 	float alpha = 1.0;
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	vec3 binormal = normalize(binormal_interp);
-	vec3 tangent = normalize(tangent_interp);
+	vec3 binormal = binormal_interp;
+	vec3 tangent = tangent_interp;
 #else
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
 #endif
 
 #ifdef NORMAL_USED
-	vec3 normal = normalize(normal_interp);
+	vec3 normal = normal_interp;
 
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {


### PR DESCRIPTION
Normalizing these vectors makes them subtly different from what the tangent space normal map expects from Mikktspace, leading to incorrect rendering results in the middle of faces when using tangent space normal maps.

This image shows a screenshot of Godot editor with my changes in normal buffer rendering mode. There are two cubes with identical vertex data. One uses a normal map baked with the box checked in xNormal tangent space settings, the other uses a normal map with the box unchecked in xNormal tangent space settings. I picked a color from the cube with correctly synced tangent space and painted over both cubes in Difference blending mode. This shows the error in normal mapping between this low poly cube with 6 sides and a high poly cube. All remaining errors are due to texture compression and you should bake with the box checked in xNormal to get a synced normal map (iirc.) In the master branch of Godot, the same scene will show similar-looking errors on both boxes in normal buffer rendering mode.

![thedifference](https://github.com/godotengine/godot/assets/136748430/a3d50246-daba-4dea-8a79-d18163724284)

Here is the test project if you want to investigate for yourself. You can turn up metallic and turn down roughness on the material to see the difference exaggerated. I haven't checked the results in any renderer except for forward clustered but it should be the same situation in all of them.

[godot_tstest.zip](https://github.com/godotengine/godot/files/11772172/godot_tstest.zip)

* *Bugsquad edit: fixes #78343*
