### PR TITLE
Add annotations support for property setter & getter functions

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1234,11 +1234,21 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 		} else if (member.type == GDScriptParser::ClassNode::Member::VARIABLE && member.variable->property != GDScriptParser::VariableNode::PROP_NONE) {
 			if (member.variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
 				if (member.variable->getter != nullptr) {
+					// Apply annotations.
+					for (GDScriptParser::AnnotationNode *&E : member.variable->getter->annotations) {
+						resolve_annotation(E);
+						E->apply(parser, member.variable->getter);
+					}
 					member.variable->getter->set_datatype(member.variable->datatype);
 
 					resolve_function_body(member.variable->getter);
 				}
 				if (member.variable->setter != nullptr) {
+					// Apply annotations.
+					for (GDScriptParser::AnnotationNode *&E : member.variable->setter->annotations) {
+						resolve_annotation(E);
+						E->apply(parser, member.variable->setter);
+					}
 					resolve_function_signature(member.variable->setter);
 
 					if (member.variable->setter->parameters.size() > 0) {

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
@@ -2,6 +2,26 @@
 var _unused = 2
 
 @warning_ignore("unused_variable")
+var value:
+	@warning_ignore("unused_variable")
+	@warning_ignore("unassigned_variable")
+	set(new_value):
+		var unused = 3
+		var unassigned
+		print(unassigned)
+		value=new_value
+
+
+	@warning_ignore("unused_variable")
+	@warning_ignore("unassigned_variable")
+	get:
+		var unused = 3
+		var unassigned
+		print(unassigned)
+		return value
+
+
+@warning_ignore("unused_variable")
 func test():
 	print("test")
 	var unused = 3


### PR DESCRIPTION
- Update error messages of setter/getter functions.
   -  When setter is defined and an unexpected identifier appears:
      `Error at (10, 5): Expected "get" for property declaration.`
   -  When getter is defined and an unexpected identifier appears:
      `Error at (10, 5): Expected "set" for property declaration.`
- Add annotation support for setter/getter functions.
```gdscript
var value:int:
	@warning_ignore(unused_variable,unused_local_constant)
	get:
		const x=1
		var y
		return value

	@warning_ignore(unused_local_constant)
	@warning_ignore(unused_variable)
	set(a):
		var y
		const x=1
		value=a
```