### PR TITLE
Do not use relative includes for generated headers.

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -30,9 +30,9 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
-#include "../run_icon_svg.gen.h"
 #include "gradle_export_util.h"
+#include "platform/android/logo_svg.gen.h"
+#include "platform/android/run_icon_svg.gen.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
+#include "platform/ios/logo_svg.gen.h"
 
 #include "core/string/translation.h"
 #include "editor/editor_node.h"

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -30,8 +30,8 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
-#include "../run_icon_svg.gen.h"
+#include "platform/linuxbsd/logo_svg.gen.h"
+#include "platform/linuxbsd/run_icon_svg.gen.h"
 
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -30,11 +30,11 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
-#include "../run_icon_svg.gen.h"
 #include "codesign.h"
 #include "lipo.h"
 #include "macho.h"
+#include "platform/macos/logo_svg.gen.h"
+#include "platform/macos/run_icon_svg.gen.h"
 
 #include "core/io/image_loader.h"
 #include "core/string/translation.h"

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -30,7 +30,7 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
+#include "platform/uwp/logo_svg.gen.h"
 
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -30,8 +30,8 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
-#include "../run_icon_svg.gen.h"
+#include "platform/web/logo_svg.gen.h"
+#include "platform/web/run_icon_svg.gen.h"
 
 #include "core/config/project_settings.h"
 #include "editor/editor_scale.h"

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -30,8 +30,8 @@
 
 #include "export_plugin.h"
 
-#include "../logo_svg.gen.h"
-#include "../run_icon_svg.gen.h"
+#include "platform/windows/logo_svg.gen.h"
+#include "platform/windows/run_icon_svg.gen.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/image_loader.h"


### PR DESCRIPTION
[This commit](https://github.com/godotengine/godot/commit/9e4315bb502659e73b01eb5b40ce1cac10bea2c5) changed the way includes are done. This causes a problem with generated headers because the include directives now look like this;

    #include "../logo_svg.gen.h"

This forces the header to be relative to this source file, i.e. it has to be inside the source directory. This works fine with SCons because it does in-tree builds and writes the `.gen.h` files inside the source tree. This causes problems for the Meson port, which writes all generated files in a separate build directory so this include directive can not really work.

This patch restores the old behaviour that works with both systems but only for files that are generated during the build.