### PR TITLE
Fix compilation on gcc13

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3690,8 +3690,9 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		Variant v_undo_redo = undo_redo;
 		Variant v_object = object;
 		Variant v_name = p_name;
-		for (int i = 0; i < EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback().size(); i++) {
-			const Callable &callback = EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback()[i];
+		const Vector<Callable> &callbacks = EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback();
+		for (int i = 0; i < callbacks.size(); i++) {
+			const Callable &callback = callbacks[i];
 
 			const Variant *p_arguments[] = { &v_undo_redo, &v_object, &v_name, &p_value };
 			Variant return_value;


### PR DESCRIPTION
Fixes compilation on gcc13. Wihtout it, it would not compile with this scons command: `scons platform=linuxbsd verbose=yes target=editor dev_build=yes -j4 warnings=extra werror=yes`

The error was:
```
editor/editor_inspector.cpp: In member function 'void EditorInspector::_edit_set(const String&, const Variant&, bool, const String&)':
editor/editor_inspector.cpp:3694:41: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 3694 |                         const Callable &callback = EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback()[i];
      |                                         ^~~~~~~~
editor/editor_inspector.cpp:3694:140: note: the temporary was destroyed at the end of the full expression 'EditorData::get_undo_redo_inspector_hook_callback()().Vector<Callable>::operator[](i)'
 3694 |                         const Callable &callback = EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback()[i];
      |   
```

This PR seems to have fixed it on my computer.