### PR TITLE
[Unix] Fix temporary file permissions.

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -108,6 +108,10 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 			last_error = ERR_FILE_CANT_OPEN;
 			return last_error;
 		}
+		// Fix temporary file permissions (defaults to 0600 instead of 0666 & ~umask).
+		mode_t mask = umask(022);
+		umask(mask);
+		fchmod(fd, 0666 & ~mask);
 		path = String::utf8(cs.ptr());
 
 		f = fdopen(fd, mode_string);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78338

`mkstemp` default to `0600` instead of `0666` modified by the process's umask value, which is used by `fopen`.