### PR TITLE
Flush MessageQueue before NavigationServer processing

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3387,6 +3387,8 @@ bool Main::iteration() {
 			break;
 		}
 
+		message_queue->flush();
+
 		uint64_t navigation_begin = OS::get_singleton()->get_ticks_usec();
 
 		NavigationServer3D::get_singleton()->process(physics_step * time_scale);


### PR DESCRIPTION
Flushes MessageQueue before NavigationServer step/processing.

I don't see a technical reason why we shouldn't flush the MessageQueue before the NavigationServer3D step, there might be update commands stuck in the queue done with a deferred calls and we do the same for the PhysicsServer2D/3D.

The missing flush gives problems with update responsiveness when deferred calls are involved. It also gives users problems with using `await` for the NavigationServer sync as they expect the updates from _physics_process() to be applied at that point. All updates from deferred calls are stuck way longer in the MessageQueue than they need to be.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
