### PR TITLE
C#: Set `PropertyInfo.class_name` for method parameters

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2320,6 +2320,9 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 			Variant::Type param_type = (Variant::Type)(int)param["type"];
 			PropertyInfo arg_info = PropertyInfo(param_type, (String)param["name"]);
 			arg_info.usage = (uint32_t)param["usage"];
+			if (param.has("class_name")) {
+				arg_info.class_name = (StringName)param["class_name"];
+			}
 			mi.arguments.push_back(arg_info);
 		}
 
@@ -2350,6 +2353,9 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 			Variant::Type param_type = (Variant::Type)(int)param["type"];
 			PropertyInfo arg_info = PropertyInfo(param_type, (String)param["name"]);
 			arg_info.usage = (uint32_t)param["usage"];
+			if (param.has("class_name")) {
+				arg_info.class_name = (StringName)param["class_name"];
+			}
 			mi.arguments.push_back(arg_info);
 		}
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/PropertyInfo.cs
@@ -4,12 +4,17 @@ namespace Godot.SourceGenerators
     {
         public PropertyInfo(VariantType type, string name, PropertyHint hint,
             string? hintString, PropertyUsageFlags usage, bool exported)
+            : this(type, name, hint, hintString, usage, className: null, exported) { }
+
+        public PropertyInfo(VariantType type, string name, PropertyHint hint,
+            string? hintString, PropertyUsageFlags usage, string? className, bool exported)
         {
             Type = type;
             Name = name;
             Hint = hint;
             HintString = hintString;
             Usage = usage;
+            ClassName = className;
             Exported = exported;
         }
 
@@ -18,6 +23,7 @@ namespace Godot.SourceGenerators
         public PropertyHint Hint { get; }
         public string? HintString { get; }
         public PropertyUsageFlags Usage { get; }
+        public string? ClassName { get; }
         public bool Exported { get; }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
@@ -9,16 +9,22 @@ public readonly struct PropertyInfo
     public PropertyHint Hint { get; init; }
     public string HintString { get; init; }
     public PropertyUsageFlags Usage { get; init; }
+    public StringName? ClassName { get; init; }
     public bool Exported { get; init; }
 
     public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
         PropertyUsageFlags usage, bool exported)
+        : this(type, name, hint, hintString, usage, className: null, exported) { }
+
+    public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
+        PropertyUsageFlags usage, StringName? className, bool exported)
     {
         Type = type;
         Name = name;
         Hint = hint;
         HintString = hintString;
         Usage = usage;
+        ClassName = className;
         Exported = exported;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -655,12 +655,18 @@ namespace Godot.Bridge
                             {
                                 foreach (var param in method.Arguments)
                                 {
-                                    methodParams.Add(new Collections.Dictionary()
+                                    var pinfo = new Collections.Dictionary()
                                     {
                                         { "name", param.Name },
                                         { "type", (int)param.Type },
                                         { "usage", (int)param.Usage }
-                                    });
+                                    };
+                                    if (param.ClassName != null)
+                                    {
+                                        pinfo["class_name"] = param.ClassName;
+                                    }
+
+                                    methodParams.Add(pinfo);
                                 }
                             }
 
@@ -743,12 +749,18 @@ namespace Godot.Bridge
                             {
                                 foreach (var param in signal.Arguments)
                                 {
-                                    signalParams.Add(new Collections.Dictionary()
+                                    var pinfo = new Collections.Dictionary()
                                     {
                                         { "name", param.Name },
                                         { "type", (int)param.Type },
                                         { "usage", (int)param.Usage }
-                                    });
+                                    };
+                                    if (param.ClassName != null)
+                                    {
+                                        pinfo["class_name"] = param.ClassName;
+                                    }
+
+                                    signalParams.Add(pinfo);
                                 }
                             }
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/74862.