### PR TITLE
Allow base types in method params of connection dialog

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -303,7 +303,7 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 					break;
 				}
 
-				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && E->get().class_name != F->get().class_name) {
+				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && !ClassDB::is_parent_class(E->get().class_name, F->get().class_name)) {
 					type_mismatch = true;
 					break;
 				}


### PR DESCRIPTION
With _Compatible Methods Only_ enabled in the connection dialog, show methods when the parameter type is a parent of the type used by the signal.

```gdscript
signal my_signal(input: InputEvent)

func method_invalid_1(node: Node3D)
	# Method is not compatible because Node3D and InputEvent are not assignable to each other.
	pass

func  method_invalid_2(input: InputEventMouse)
	# Method is not compatible because the signal uses InputEvent so it may be emitted with InputEventKey.
	pass

func method_valid_1(input: InputEvent)
	# Method is compatible because it uses the exact same type used by the signal.
	pass

func method_valid_2(input: Resource)
	# Method is compatible because InputEvent derives from Resource.
	pass
```

- Related: https://github.com/godotengine/godot/issues/74862