### PR TITLE
Add `@tool_button` annotation for easily creating inspector buttons.

### DIFF
--- a/editor/plugins/tool_button_editor_plugin.cpp
+++ b/editor/plugins/tool_button_editor_plugin.cpp
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  tool_button_editor_plugin.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tool_button_editor_plugin.h"
+#include "editor/editor_node.h"
+#include "editor/editor_property_name_processor.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "scene/gui/button.h"
+
+bool ToolButtonInspectorPlugin::can_handle(Object *p_object) {
+	Ref<Script> scr = Object::cast_to<Script>(p_object->get_script());
+	return scr.is_valid() && scr->is_tool();
+}
+
+void ToolButtonInspectorPlugin::update_action_icon(Button *p_action_button) {
+	p_action_button->set_icon(p_action_button->get_theme_icon(action_icon, SNAME("EditorIcons")));
+}
+
+void ToolButtonInspectorPlugin::call_action(Object *p_object, StringName p_do_method_name, StringName p_undo_method_name) {
+	if (!p_object->has_method(p_do_method_name)) {
+		print_error(vformat("Tool button do method is invalid. Could not find method '%s' on %s", p_do_method_name, p_object->get_class_name()));
+		return;
+	}
+
+	if (!p_object->has_method(p_undo_method_name)) {
+		print_error(vformat("Tool button undo method is invalid. Could not find method '%s' on %s", p_undo_method_name, p_object->get_class_name()));
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo_manager = EditorUndoRedoManager::get_singleton();
+	int history_id = undo_redo_manager->get_history_id_for_object(p_object);
+	UndoRedo *undo_redo = undo_redo_manager->get_history_undo_redo(history_id);
+
+	Callable do_callable(p_object, p_do_method_name);
+	Callable undo_callable(p_object, p_undo_method_name);
+
+	undo_redo->create_action(TTR("Call Tool Button Action"));
+	undo_redo->add_do_method(do_callable);
+	undo_redo->add_undo_method(undo_callable);
+	undo_redo->commit_action();
+}
+
+bool ToolButtonInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	if (p_type == Variant::CALLABLE) {
+		if (p_usage.has_flag(PROPERTY_USAGE_INTERNAL) && p_usage.has_flag(PROPERTY_USAGE_EDITOR)) {
+			Button *action_button = EditorInspector::create_inspector_action_button(EditorPropertyNameProcessor::get_singleton()->process_name(p_path, EditorPropertyNameProcessor::STYLE_CAPITALIZED));
+
+			PackedStringArray split = p_hint_text.split(",");
+			if (split.size() > 2) {
+				String icon = split[2];
+				action_icon = StringName(icon);
+				action_button->connect(SNAME("theme_changed"), callable_mp(this, &ToolButtonInspectorPlugin::update_action_icon).bind(action_button));
+			}
+			add_custom_control(action_button);
+
+			action_button->connect(SNAME("pressed"), callable_mp(this, &ToolButtonInspectorPlugin::call_action).bind(p_object, split[1]));
+			return true;
+		}
+	}
+	return false;
+}
+
+ToolButtonEditorPlugin::ToolButtonEditorPlugin() {
+	Ref<ToolButtonInspectorPlugin> plugin;
+	plugin.instantiate();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/tool_button_editor_plugin.h
+++ b/editor/plugins/tool_button_editor_plugin.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  tool_button_editor_plugin.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TOOL_BUTTON_EDITOR_PLUGIN_H
+#define TOOL_BUTTON_EDITOR_PLUGIN_H
+
+#include "editor/editor_inspector.h"
+#include "editor/editor_plugin.h"
+
+class ToolButtonInspectorPlugin : public EditorInspectorPlugin {
+	GDCLASS(ToolButtonInspectorPlugin, EditorInspectorPlugin);
+
+public:
+	StringName action_icon;
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
+	void update_action_icon(Button *p_action_button);
+	void call_action(Object *p_object, StringName p_do_method_name, StringName p_undo_method_name);
+};
+
+class ToolButtonEditorPlugin : public EditorPlugin {
+	GDCLASS(ToolButtonEditorPlugin, EditorPlugin);
+
+public:
+	virtual String get_name() const override { return "ToolButtonEditorPlugin"; }
+
+	ToolButtonEditorPlugin();
+};
+
+#endif // TOOL_BUTTON_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -122,6 +122,7 @@
 #include "editor/plugins/texture_region_editor_plugin.h"
 #include "editor/plugins/theme_editor_plugin.h"
 #include "editor/plugins/tiles/tiles_editor_plugin.h"
+#include "editor/plugins/tool_button_editor_plugin.h"
 #include "editor/plugins/version_control_editor_plugin.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
@@ -237,6 +238,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<TextureLayeredEditorPlugin>();
 	EditorPlugins::add_by_type<TextureRegionEditorPlugin>();
 	EditorPlugins::add_by_type<ThemeEditorPlugin>();
+	EditorPlugins::add_by_type<ToolButtonEditorPlugin>();
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
 
 	// 2D

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -655,6 +655,30 @@
 				[b]Note:[/b] As annotations describe their subject, the [code]@tool[/code] annotation must be placed before the class definition and inheritance.
 			</description>
 		</annotation>
+		<annotation name="@tool_button" qualifiers="vararg">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="icon" type="String" default="&quot;&quot;" />
+			<description>
+				Mark a function to be displayed in the Inspector as a button. The function must accept the do and undo method names.
+				[codeblock]
+				@tool
+				extends Sprite2D
+
+				@tool_button("Randomize Color", "ColorRect")
+				func rand_col(do_method_name, undo_method_name):
+				    var random_color = Color(randf_range(0, 1.0), randf_range(0, 1.0), randf_range(0, 1.0));
+				    call_action(self, do_method_name, undo_method_name);
+
+				func set_color(new_color):
+				    modulate = new_color
+
+				func reset_color(old_color):
+				    modulate = old_color
+				[/codeblock]
+				[b]Note:[/b] Make sure to provide separate `do` and `undo` methods that perform and reverse the action respectively.
+			</description>
+		</annotation>
 		<annotation name="@warning_ignore" qualifiers="vararg">
 			<return type="void" />
 			<param index="0" name="warning" type="String" />

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -561,7 +561,8 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 						}
 						_signals[member.signal->identifier->name] = parameters_names;
 					} break;
-					case GDScriptParser::ClassNode::Member::GROUP: {
+					case GDScriptParser::ClassNode::Member::GROUP:
+					case GDScriptParser::ClassNode::Member::TOOL_BUTTON: {
 						members_cache.push_back(member.annotation->export_info);
 					} break;
 					default:

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1067,6 +1067,7 @@ void GDScriptAnalyzer::resolve_class_member(GDScriptParser::ClassNode *p_class, 
 				}
 				break;
 			case GDScriptParser::ClassNode::Member::GROUP:
+			case GDScriptParser::ClassNode::Member::TOOL_BUTTON:
 				// No-op, but needed to silence warnings.
 				break;
 			case GDScriptParser::ClassNode::Member::UNDEFINED:

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2727,7 +2727,8 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				p_script->constants.insert(name, enum_n->dictionary);
 			} break;
 
-			case GDScriptParser::ClassNode::Member::GROUP: {
+			case GDScriptParser::ClassNode::Member::GROUP:
+			case GDScriptParser::ClassNode::Member::TOOL_BUTTON: {
 				const GDScriptParser::AnnotationNode *annotation = member.annotation;
 				// Avoid name conflict. See GH-78252.
 				StringName name = vformat("@group_%d_%s", p_script->members.size(), annotation->export_info.name);
@@ -2739,6 +2740,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				PropertyInfo prop_info;
 				prop_info.name = annotation->export_info.name;
 				prop_info.usage = annotation->export_info.usage;
+				prop_info.type = annotation->export_info.type;
 				prop_info.hint_string = annotation->export_info.hint_string;
 
 				p_script->member_info[name] = prop_info;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1030,6 +1030,7 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						option = ScriptLanguage::CodeCompletionOption(member.signal->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
 						break;
 					case GDScriptParser::ClassNode::Member::GROUP:
+					case GDScriptParser::ClassNode::Member::TOOL_BUTTON:
 						break; // No-op, but silences warnings.
 					case GDScriptParser::ClassNode::Member::UNDEFINED:
 						break;
@@ -2236,6 +2237,7 @@ static bool _guess_identifier_type_from_base(GDScriptParser::CompletionContext &
 							r_type.type.class_type = member.m_class;
 							r_type.type.is_meta_type = true;
 							return true;
+						case GDScriptParser::ClassNode::Member::TOOL_BUTTON:
 						case GDScriptParser::ClassNode::Member::GROUP:
 							return false; // No-op, but silences warnings.
 						case GDScriptParser::ClassNode::Member::UNDEFINED:

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -549,6 +549,7 @@ public:
 				ENUM,
 				ENUM_VALUE, // For unnamed enums.
 				GROUP, // For member grouping.
+				TOOL_BUTTON,
 			};
 
 			Type type = UNDEFINED;
@@ -585,6 +586,7 @@ public:
 					case ENUM_VALUE:
 						return enum_value.identifier->name;
 					case GROUP:
+					case TOOL_BUTTON:
 						return annotation->export_info.name;
 				}
 				return "";
@@ -610,6 +612,8 @@ public:
 						return "enum value";
 					case GROUP:
 						return "group";
+					case TOOL_BUTTON:
+						return "tool button";
 				}
 				return "";
 			}
@@ -631,6 +635,7 @@ public:
 					case SIGNAL:
 						return signal->start_line;
 					case GROUP:
+					case TOOL_BUTTON:
 						return annotation->start_line;
 					case UNDEFINED:
 						ERR_FAIL_V_MSG(-1, "Reaching undefined member type.");
@@ -655,6 +660,7 @@ public:
 					case SIGNAL:
 						return signal->get_datatype();
 					case GROUP:
+					case TOOL_BUTTON:
 						return DataType();
 					case UNDEFINED:
 						return DataType();
@@ -679,6 +685,7 @@ public:
 					case SIGNAL:
 						return signal;
 					case GROUP:
+					case TOOL_BUTTON:
 						return annotation;
 					case UNDEFINED:
 						return nullptr;
@@ -716,8 +723,8 @@ public:
 				type = ENUM_VALUE;
 				enum_value = p_enum_value;
 			}
-			Member(AnnotationNode *p_annotation) {
-				type = GROUP;
+			Member(AnnotationNode *p_annotation, Member::Type p_type) {
+				type = p_type;
 				annotation = p_annotation;
 			}
 		};
@@ -770,7 +777,11 @@ public:
 			// Avoid name conflict. See GH-78252.
 			StringName name = vformat("@group_%d_%s", members.size(), p_annotation_node->export_info.name);
 			members_indices[name] = members.size();
-			members.push_back(Member(p_annotation_node));
+			members.push_back(Member(p_annotation_node, Member::Type::GROUP));
+		}
+		void add_tool_button_member(AnnotationNode *p_annotation_node) {
+			members_indices[p_annotation_node->export_info.name] = members.size();
+			members.push_back(Member(p_annotation_node, Member::Type::TOOL_BUTTON));
 		}
 
 		ClassNode() {
@@ -1459,6 +1470,7 @@ private:
 	template <PropertyUsageFlags t_usage>
 	bool export_group_annotations(const AnnotationNode *p_annotation, Node *p_target);
 	bool warning_annotations(const AnnotationNode *p_annotation, Node *p_target);
+	bool tool_button_annotation(const AnnotationNode *p_annotation, Node *p_node);
 	bool rpc_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	bool static_unload_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	// Statements.

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -307,6 +307,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				r_symbol.children.push_back(symbol);
 			} break;
 			case ClassNode::Member::GROUP:
+			case ClassNode::Member::TOOL_BUTTON:
 				break; // No-op, but silences warnings.
 			case ClassNode::Member::UNDEFINED:
 				break; // Unreachable.
@@ -828,6 +829,7 @@ Dictionary ExtendGDScriptParser::dump_class_api(const GDScriptParser::ClassNode 
 					methods.append(dump_function_api(m.function));
 				}
 			} break;
+			case ClassNode::Member::TOOL_BUTTON:
 			case ClassNode::Member::GROUP:
 				break; // No-op, but silences warnings.
 			case ClassNode::Member::UNDEFINED:


### PR DESCRIPTION
Supersedes: https://github.com/godotengine/godot/pull/59289
Closes: https://github.com/godotengine/godot-proposals/issues/2149

![tool_button demo](https://user-images.githubusercontent.com/12436824/234841599-fb982ec7-3d49-4e29-858e-6589adc0c9b9.png)

- [x] I see you replaced UndoRedo with EditorUndoRedoManager in response to my comment. Unfortunately it won't work, because all actions should go through EditorUndoRedoManager.
- [ ] Need to test api changes