### PR TITLE
Clarify the return value of `Curve2D.sample_baked_with_rotation`

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -107,11 +107,16 @@
 			<param index="0" name="offset" type="float" default="0.0" />
 			<param index="1" name="cubic" type="bool" default="false" />
 			<description>
-				Similar to [method sample_baked], but returns [Transform2D] that includes a rotation along the curve. Returns empty transform if length of the curve is [code]0[/code].
+				Similar to [method sample_baked], but returns [Transform2D] that includes a rotation along the curve, with [member Transform2D.origin] as the point position, [member Transform2D.x] as the sideways vector, and [member Transform2D.y] as the forward vector. Returns an empty transform if the length of the curve is [code]0[/code].
 				[codeblock]
-				var transform = curve.sample_baked_with_rotation(offset)
-				position = transform.get_origin()
-				rotation = transform.get_rotation()
+				var baked = curve.sample_baked_with_rotation(offset)
+				# This will rotate and position the node with the up direction pointing along the curve.
+				position = baked.get_origin()
+				rotation = baked.get_rotation()
+				# Alternatively, not preserving scale.
+				transform = baked * Transform2D.FLIP_Y
+				# To match the rotation of PathFollow2D, not preserving scale.
+				transform = Transform2D(baked.y, baked.x, baked.origin)
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
The use of a `Transform2D` as the return makes it appear like this is a conventional transform, rather than a way to store the axes.

The 3D version should probably have some similar explanation for how to use this as a transform, but don't know how to do it so will leave for now.

The convention for how the return value is structured is also odd to me, but changing it would be breaking compatibility even if it was somehow wrong and not just unusual to my eyes.

* Partial solution to: #78361 (documentation part)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
