### PR TITLE
Fix focusloss of non-exclusive `AcceptDialog` with `close_on_escape`

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -44,12 +44,6 @@ void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void AcceptDialog::_parent_focused() {
-	if (close_on_escape && !is_exclusive()) {
-		_cancel_pressed();
-	}
-}
-
 void AcceptDialog::_update_theme_item_cache() {
 	Window::_update_theme_item_cache();
 
@@ -70,16 +64,6 @@ void AcceptDialog::_notification(int p_what) {
 					get_ok_button()->grab_focus();
 				}
 				_update_child_rects();
-
-				parent_visible = get_parent_visible_window();
-				if (parent_visible) {
-					parent_visible->connect("focus_entered", callable_mp(this, &AcceptDialog::_parent_focused));
-				}
-			} else {
-				if (parent_visible) {
-					parent_visible->disconnect("focus_entered", callable_mp(this, &AcceptDialog::_parent_focused));
-					parent_visible = nullptr;
-				}
 			}
 		} break;
 
@@ -92,10 +76,9 @@ void AcceptDialog::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_EXIT_TREE: {
-			if (parent_visible) {
-				parent_visible->disconnect("focus_entered", callable_mp(this, &AcceptDialog::_parent_focused));
-				parent_visible = nullptr;
+		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			if (close_on_escape && !is_exclusive()) {
+				_cancel_pressed();
 			}
 		} break;
 
@@ -129,21 +112,9 @@ void AcceptDialog::_ok_pressed() {
 }
 
 void AcceptDialog::_cancel_pressed() {
-	Window *parent_window = parent_visible;
-	if (parent_visible) {
-		parent_visible->disconnect("focus_entered", callable_mp(this, &AcceptDialog::_parent_focused));
-		parent_visible = nullptr;
-	}
-
 	call_deferred(SNAME("hide"));
-
 	emit_signal(SNAME("canceled"));
-
 	cancel_pressed();
-
-	if (parent_window) {
-		//parent_window->grab_focus();
-	}
 	set_input_as_handled();
 }
 

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -44,8 +44,6 @@ class LineEdit;
 class AcceptDialog : public Window {
 	GDCLASS(AcceptDialog, Window);
 
-	Window *parent_visible = nullptr;
-
 	Panel *bg_panel = nullptr;
 	Label *message_label = nullptr;
 	HBoxContainer *buttons_hbox = nullptr;
@@ -65,7 +63,6 @@ class AcceptDialog : public Window {
 	static bool swap_cancel_ok;
 
 	void _input_from_window(const Ref<InputEvent> &p_event);
-	void _parent_focused();
 
 protected:
 	virtual Size2 _get_contents_minimum_size() const override;


### PR DESCRIPTION
Fix, that a non-exclusive AcceptDialog with `close_on_escape == true` gets closed, when the parent window of the parent window receives focus.

There is no need to rely on the focus of the parent visible window. Instead check if the `AcceptDialog` loses focus.

This is also a prerequisite for #72686

Tested:
- Embedded windows
- Linux X11
- Windows

MRP: [AcceptDialogFocus.zip](https://github.com/godotengine/godot/files/11778457/AcceptDialogFocus.zip)
1. Load and run MRP
2. Click on the Button to create the AcceptDialog
3. Click on the MainWindow
 
The AcceptDialog shoud now close, because it is non-exclusive and  `close_on_escape == true`.
Current behavior is, that it doesn't close.

Alternative:
3. Click on the secondary window (now the AcceptDialog closes itself as expected)