### PR TITLE
Update `.gitignore` for new xcode doc project creation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 *.xcodeproj/*
+doc/*.xcodeproj/*
 
 ##############################
 ### Visual Studio specific ###


### PR DESCRIPTION
With one of the recent Xcode update now dropping all elements of the godot project inside a xcode project will create a secondary xcode project inside the doc folder this just prevent it from being catched by git as a modification. 
First thought of making it `**/*.xcodeproj/*` to ignore any xcode project wherever it is but since we have one that we want to keep for ios export this is not possible.
