### PR TITLE
Consider all triangles for retention in Delaunay Triangulation

### DIFF
--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -145,7 +145,7 @@ public:
 		// Filter out the triangles containing vertices of the bounding triangle.
 		int preserved_count = 0;
 		Triangle *triangles_ptrw = triangles.ptrw();
-		for (int i = 0; i < triangles.size() - 1; i++) {
+		for (int i = 0; i < triangles.size(); i++) {
 			if (!(triangles[i].points[0] >= point_count || triangles[i].points[1] >= point_count || triangles[i].points[2] >= point_count)) {
 				triangles_ptrw[preserved_count] = triangles[i];
 				preserved_count++;


### PR DESCRIPTION
A [previous change](https://github.com/godotengine/godot/pull/75805) in the Delaunay Triangulation code introduced a bug where the last potential triangle would automatically be disregarded, even if it was valid. This pull request fixes the loop condition to ensure that all triangles are properly considered and potentially kept.