### PR TITLE
Fix Physics Picking captured Object initialization

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -839,6 +839,9 @@ void Viewport::_process_picking() {
 			capture_object = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_capture));
 			if (!capture_object || !camera_3d || (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed())) {
 				physics_object_capture = ObjectID();
+			} else {
+				last_id = physics_object_capture;
+				last_object = capture_object;
 			}
 		}
 


### PR DESCRIPTION
Initialize variables when a captured object is known.

Without this initialization, the following lines will fail, resulting in some events not being sent to the collision object:
https://github.com/godotengine/godot/blob/a83eb16fba5bb3da086b41cbd79e6f95b09eb8ee/scene/main/viewport.cpp#L846-L847

MRP: https://github.com/godotengine/godot-demo-projects/pull/925
1. Drag one of the sliders.
2. Drop while moving the mouse (sometimes the Mouse-button-up event is not registered)