### PR TITLE
Fix crash with typed array of objects in scene

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -477,7 +477,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			Array array = dnp.base->get(base_property, &valid);
 			ERR_CONTINUE(!valid);
 
-			if (array.size() >= index) {
+			if (index >= array.size()) {
 				array.push_back(other);
 			} else {
 				array.set(index, other);


### PR DESCRIPTION
This commit fixes https://github.com/godotengine/godot/issues/78330

This my analysis of this bug.
https://github.com/godotengine/godot/issues/78330#issuecomment-1596031470