### PR TITLE
Fix `Ref<>.is_valid()` for ScriptInstanceExtension

### DIFF
--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -651,7 +651,7 @@ public:
 
 #ifdef TOOLS_ENABLED
 			Ref<Script> script = get_script();
-			if (script->is_valid() && pcount > 0) {
+			if (script.is_valid() && pcount > 0) {
 				p_list->push_back(script->get_class_category());
 			}
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
First, check the reference then check the value.

Fix #78116 
caused by #63712
https://github.com/godotengine/godot/pull/63712#discussion_r1233120685

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
