### PR TITLE
Fix that the focus-out notification got sent deferred (reverted)

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1624,7 +1624,15 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		// Send a focus-out notification when opening a Window Manager Popup.
 		SceneTree *scene_tree = get_tree();
 		if (scene_tree) {
-			scene_tree->notify_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_viewports", NOTIFICATION_WM_WINDOW_FOCUS_OUT);
+			List<Node *> list;
+			scene_tree->get_nodes_in_group("_viewports", &list);
+			for (Node *n : list) {
+				Window *w = Object::cast_to<Window>(n);
+				if (w && !w->get_embedder() && w->has_focus()) {
+					w->_event_callback(DisplayServer::WINDOW_EVENT_FOCUS_OUT);
+					break;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently the window receives a focus-out notification, directly after its popup, because currently the signal is sent deferred.
The deferred call got introduced in #62220.

The original intention from #59568 was that the previously focused window must receive a focus-out notification. But with the deferred call, all windows receive it after the popup window is shown. That is incorrect, because despite the focus-out notification, the window still has focus.

This PR makes the notification more precise by sending the focus-out notification immediately only to the previously focused window.

I have tested, that this PR doesn't reintroduce  #59406.
I'm not entirely sure, how this affects  #61677, but since the amount of notifications decreases with this change, I assume, that it is fine.
