### PR TITLE
Respect returned bool from virtual process methods in SceneTree

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -456,7 +456,9 @@ bool SceneTree::physics_process(double p_time) {
 
 	flush_transform_notifications();
 
-	MainLoop::physics_process(p_time);
+	if (MainLoop::physics_process(p_time)) {
+		_quit = true;
+	}
 	physics_process_time = p_time;
 
 	emit_signal(SNAME("physics_frame"));
@@ -484,7 +486,9 @@ bool SceneTree::physics_process(double p_time) {
 bool SceneTree::process(double p_time) {
 	root_lock++;
 
-	MainLoop::process(p_time);
+	if (MainLoop::process(p_time)) {
+		_quit = true;
+	}
 
 	process_time = p_time;
 


### PR DESCRIPTION
SceneTree overrides the virtual `process` and `physics_process` methods that it inherits from MainLoop. These methods return a boolean that determines if the main loop should end.

The SceneTree was ignoring the returned boolean, so scripts inheriting from SceneTree that override these methods and return true didn't exit the main loop. Now the boolean is checked.

---

Alternatively, we can keep ignoring it and add a note in the methods documentation that SceneTree will ignore the boolean and to use `SceneTree::quit` instead. But it feels odd that the method returns a boolean and it's just ignored.