### PR TITLE
GDExtension: Use `Uninitialized*Ptr` for constructors/converters using placement new

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -195,11 +195,11 @@ typedef struct {
 	int32_t expected;
 } GDExtensionCallError;
 
-typedef void (*GDExtensionVariantFromTypeConstructorFunc)(GDExtensionVariantPtr, GDExtensionTypePtr);
-typedef void (*GDExtensionTypeFromVariantConstructorFunc)(GDExtensionTypePtr, GDExtensionVariantPtr);
+typedef void (*GDExtensionVariantFromTypeConstructorFunc)(GDExtensionUninitializedVariantPtr, GDExtensionTypePtr);
+typedef void (*GDExtensionTypeFromVariantConstructorFunc)(GDExtensionUninitializedTypePtr, GDExtensionVariantPtr);
 typedef void (*GDExtensionPtrOperatorEvaluator)(GDExtensionConstTypePtr p_left, GDExtensionConstTypePtr p_right, GDExtensionTypePtr r_result);
 typedef void (*GDExtensionPtrBuiltInMethod)(GDExtensionTypePtr p_base, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_return, int p_argument_count);
-typedef void (*GDExtensionPtrConstructor)(GDExtensionTypePtr p_base, const GDExtensionConstTypePtr *p_args);
+typedef void (*GDExtensionPtrConstructor)(GDExtensionUninitializedTypePtr p_base, const GDExtensionConstTypePtr *p_args);
 typedef void (*GDExtensionPtrDestructor)(GDExtensionTypePtr p_base);
 typedef void (*GDExtensionPtrSetter)(GDExtensionTypePtr p_base, GDExtensionConstTypePtr p_value);
 typedef void (*GDExtensionPtrGetter)(GDExtensionConstTypePtr p_base, GDExtensionTypePtr r_value);


### PR DESCRIPTION
A few methods in the GDExtension header construct their destination in-place, but the parameters are not declared using the `Uninitialized*` pointer types.

See godot-cpp PR: https://github.com/godotengine/godot-cpp/pull/1148

---

Below are the relevant sections where placement new is used.

TypePtr constructors:

https://github.com/godotengine/godot/blob/116f783db73f4bf7e9e96ae54dd3d0a20337cc8a/core/variant/variant_construct.h#L45-L54

VariantPtr <-> TypePtr conversions:

https://github.com/godotengine/godot/blob/116f783db73f4bf7e9e96ae54dd3d0a20337cc8a/core/variant/variant_internal.h#L1535-L1546