### PR TITLE
Fix invalid RID errors when freeing a mesh with blend shapes

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -633,6 +633,12 @@ void MeshStorage::mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) {
 void MeshStorage::mesh_clear(RID p_mesh) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_COND(!mesh);
+
+	// Clear instance data before mesh data.
+	for (MeshInstance *mi : mesh->instances) {
+		_mesh_instance_clear(mi);
+	}
+
 	for (uint32_t i = 0; i < mesh->surface_count; i++) {
 		Mesh::Surface &s = *mesh->surfaces[i];
 
@@ -704,10 +710,6 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 	mesh->surfaces = nullptr;
 	mesh->surface_count = 0;
 	mesh->material_cache.clear();
-	//clear instance data
-	for (MeshInstance *mi : mesh->instances) {
-		_mesh_instance_clear(mi);
-	}
 	mesh->has_bone_weights = false;
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -727,6 +727,12 @@ void MeshStorage::mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) {
 void MeshStorage::mesh_clear(RID p_mesh) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_COND(!mesh);
+
+	// Clear instance data before mesh data.
+	for (MeshInstance *mi : mesh->instances) {
+		_mesh_instance_clear(mi);
+	}
+
 	for (uint32_t i = 0; i < mesh->surface_count; i++) {
 		Mesh::Surface &s = *mesh->surfaces[i];
 		if (s.vertex_buffer.is_valid()) {
@@ -766,10 +772,6 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 	mesh->surfaces = nullptr;
 	mesh->surface_count = 0;
 	mesh->material_cache.clear();
-	//clear instance data
-	for (MeshInstance *mi : mesh->instances) {
-		_mesh_instance_clear(mi);
-	}
 	mesh->has_bone_weights = false;
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MESH);
 
@@ -860,6 +862,7 @@ void MeshStorage::_mesh_instance_clear(MeshInstance *mi) {
 
 	if (mi->blend_weights_buffer.is_valid()) {
 		RD::get_singleton()->free(mi->blend_weights_buffer);
+		mi->blend_weights_buffer = RID();
 	}
 	mi->blend_weights.clear();
 	mi->weights_dirty = false;


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/78406

Currently, the mesh storage can attempt to free the same RID multiple times when freeing meshes that have blend shapes. One of the issues is solved simply by adding line:

`mi->blend_weights_buffer = RID();`

to mesh_storage.cpp (similar thing is alread done in GLES mesh_storage, so it's not added there). Another, more subtle issue is that mesh instance data should be freed before mesh data, so that RID dependencies are broken in correct order (in `RenderingDeviceVulkan::_free_dependencies()`) to avoid double freeing() some mesh RID's, as this line:

https://github.com/godotengine/godot/blob/116f783db73f4bf7e9e96ae54dd3d0a20337cc8a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp#L733

can in some situations already free() certain RID's, unless these dependencies are broken before that call. I'm not an expert on this area and there might be an alternative way to do this, but this PR fixes the problem.