### PR TITLE
Fix volumetric fog in stereo by projection vertex in combined space

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -139,26 +139,27 @@ private:
 public:
 	struct SkySceneState {
 		struct UBO {
-			float view_inv_projections[RendererSceneRender::MAX_RENDER_VIEWS][16]; // 2 x 64 - 128
-			float view_eye_offsets[RendererSceneRender::MAX_RENDER_VIEWS][4]; // 2 x 16 - 160
+			float combined_reprojection[RendererSceneRender::MAX_RENDER_VIEWS][16]; // 2 x 64 - 128
+			float view_inv_projections[RendererSceneRender::MAX_RENDER_VIEWS][16]; // 2 x 64 - 256
+			float view_eye_offsets[RendererSceneRender::MAX_RENDER_VIEWS][4]; // 2 x 16 - 288
 
-			uint32_t volumetric_fog_enabled; // 4 - 164
-			float volumetric_fog_inv_length; // 4 - 168
-			float volumetric_fog_detail_spread; // 4 - 172
-			float volumetric_fog_sky_affect; // 4 - 176
+			uint32_t volumetric_fog_enabled; // 4 - 292
+			float volumetric_fog_inv_length; // 4 - 296
+			float volumetric_fog_detail_spread; // 4 - 300
+			float volumetric_fog_sky_affect; // 4 - 304
 
-			uint32_t fog_enabled; // 4 - 180
-			float fog_sky_affect; // 4 - 184
-			float fog_density; // 4 - 188
-			float fog_sun_scatter; // 4 - 192
+			uint32_t fog_enabled; // 4 - 308
+			float fog_sky_affect; // 4 - 312
+			float fog_density; // 4 - 316
+			float fog_sun_scatter; // 4 - 320
 
-			float fog_light_color[3]; // 12 - 204
-			float fog_aerial_perspective; // 4 - 208
+			float fog_light_color[3]; // 12 - 332
+			float fog_aerial_perspective; // 4 - 336
 
-			float z_far; // 4 - 212
-			uint32_t directional_light_count; // 4 - 216
-			uint32_t pad1; // 4 - 220
-			uint32_t pad2; // 4 - 224
+			float z_far; // 4 - 340
+			uint32_t directional_light_count; // 4 - 344
+			uint32_t pad1; // 4 - 348
+			uint32_t pad2; // 4 - 352
 		};
 
 		UBO ubo;
@@ -295,7 +296,7 @@ public:
 	void set_texture_format(RD::DataFormat p_texture_format);
 	~SkyRD();
 
-	void setup_sky(RID p_env, Ref<RenderSceneBuffersRD> p_render_buffers, const PagedArray<RID> &p_lights, RID p_camera_attributes, uint32_t p_view_count, const Projection *p_view_projections, const Vector3 *p_view_eye_offsets, const Transform3D &p_cam_transform, const Size2i p_screen_size, RendererSceneRenderRD *p_scene_render);
+	void setup_sky(RID p_env, Ref<RenderSceneBuffersRD> p_render_buffers, const PagedArray<RID> &p_lights, RID p_camera_attributes, uint32_t p_view_count, const Projection *p_view_projections, const Vector3 *p_view_eye_offsets, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Size2i p_screen_size, RendererSceneRenderRD *p_scene_render);
 	void update_radiance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, const Vector3 &p_global_pos, double p_time, float p_luminance_multiplier = 1.0);
 	void update_res_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, double p_time, float p_luminance_multiplier = 1.0);
 	void draw_sky(RD::DrawListID p_draw_list, Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, RID p_fb, double p_time, float p_luminance_multiplier = 1.0);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1800,9 +1800,9 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 				correction.set_depth_correction(true);
 				Projection projection = correction * p_render_data->scene_data->cam_projection;
 
-				sky.setup_sky(p_render_data->environment, rb, *p_render_data->lights, p_render_data->camera_attributes, 1, &projection, &eye_offset, p_render_data->scene_data->cam_transform, screen_size, this);
+				sky.setup_sky(p_render_data->environment, rb, *p_render_data->lights, p_render_data->camera_attributes, 1, &projection, &eye_offset, p_render_data->scene_data->cam_transform, projection, screen_size, this);
 			} else {
-				sky.setup_sky(p_render_data->environment, rb, *p_render_data->lights, p_render_data->camera_attributes, p_render_data->scene_data->view_count, p_render_data->scene_data->view_projection, p_render_data->scene_data->view_eye_offset, p_render_data->scene_data->cam_transform, screen_size, this);
+				sky.setup_sky(p_render_data->environment, rb, *p_render_data->lights, p_render_data->camera_attributes, p_render_data->scene_data->view_count, p_render_data->scene_data->view_projection, p_render_data->scene_data->view_eye_offset, p_render_data->scene_data->cam_transform, p_render_data->scene_data->cam_projection, screen_size, this);
 			}
 
 			sky_energy_multiplier *= bg_energy_multiplier;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -856,9 +856,9 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				correction.set_depth_correction(true);
 				Projection projection = correction * p_render_data->scene_data->cam_projection;
 
-				sky.setup_sky(p_render_data->environment, p_render_data->render_buffers, *p_render_data->lights, p_render_data->camera_attributes, 1, &projection, &eye_offset, p_render_data->scene_data->cam_transform, screen_size, this);
+				sky.setup_sky(p_render_data->environment, p_render_data->render_buffers, *p_render_data->lights, p_render_data->camera_attributes, 1, &projection, &eye_offset, p_render_data->scene_data->cam_transform, projection, screen_size, this);
 			} else {
-				sky.setup_sky(p_render_data->environment, p_render_data->render_buffers, *p_render_data->lights, p_render_data->camera_attributes, p_render_data->scene_data->view_count, p_render_data->scene_data->view_projection, p_render_data->scene_data->view_eye_offset, p_render_data->scene_data->cam_transform, screen_size, this);
+				sky.setup_sky(p_render_data->environment, p_render_data->render_buffers, *p_render_data->lights, p_render_data->camera_attributes, p_render_data->scene_data->view_count, p_render_data->scene_data->view_projection, p_render_data->scene_data->view_eye_offset, p_render_data->scene_data->cam_transform, p_render_data->scene_data->cam_projection, screen_size, this);
 			}
 
 			sky_energy_multiplier *= bg_energy_multiplier;

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -83,6 +83,7 @@ layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalShaderUnifor
 global_shader_uniforms;
 
 layout(set = 0, binding = 2, std140) uniform SkySceneData {
+	mat4 combined_reprojection[2];
 	mat4 view_inv_projections[2];
 	vec4 view_eye_offsets[2];
 
@@ -169,7 +170,12 @@ vec3 interleaved_gradient_noise(vec2 pos) {
 #endif
 
 vec4 volumetric_fog_process(vec2 screen_uv) {
+#ifdef USE_MULTIVIEW
+	vec4 reprojected = sky_scene_data.combined_reprojection[ViewIndex] * (vec4(screen_uv * 2.0 - 1.0, 1.0, 1.0) * sky_scene_data.z_far);
+	vec3 fog_pos = vec3(reprojected.xy / reprojected.w, 1.0) * 0.5 + 0.5;
+#else
 	vec3 fog_pos = vec3(screen_uv, 1.0);
+#endif
 
 	return texture(sampler3D(volumetric_fog_texture, material_samplers[SAMPLER_LINEAR_CLAMP]), fog_pos);
 }


### PR DESCRIPTION
This PR fixes stereoscopic rendering of volumetric fog by projecting our vertex in combined frustum space and using that as our input for sampling our fog density map.
As the volumetric fog density map is rendered from the combined frustum this should lead to accurate fog.

It is important to note that this "shortcut" will only work if both eye matrices Z direction is parallel, if they are not each eye will require their own density map which would be a costly change.
I think this will work in the scenario where we have slanted panels.
This will need to be tested.
All in all the scenarios this might not work are edge cases, if they do turn out to be a problem we could test for this and take the expensive route.

This fixes #72331
