### PR TITLE
[3.x] Fix overwriting of Spatial's local transform

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -274,6 +274,7 @@ void Spatial::set_global_rotation(const Vector3 &p_euler_rad) {
 void Spatial::set_transform(const Transform &p_transform) {
 	data.local_transform = p_transform;
 	data.dirty |= DIRTY_VECTORS;
+	data.dirty &= ~DIRTY_LOCAL;
 	_change_notify("translation");
 	_change_notify("rotation");
 	_change_notify("rotation_degrees");


### PR DESCRIPTION
Modifies when 'DIRTY_LOCAL' flag is set to prevent a transform applied using `set_transform` to be overwritten by previous calls to change the node's rotation, translation or scale.

Redo of #44803 on `3.x`.
Fixes #43130.