### PR TITLE
Fix potential crashes in navmesh bake geometry functions

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -92,12 +92,15 @@ void NavigationMeshGenerator::_add_mesh(const Ref<Mesh> &p_mesh, const Transform
 		int face_count = index_count / 3;
 
 		Array a = p_mesh->surface_get_arrays(i);
+		ERR_CONTINUE(a.is_empty() || (a.size() != Mesh::ARRAY_MAX));
 
 		Vector<Vector3> mesh_vertices = a[Mesh::ARRAY_VERTEX];
+		ERR_CONTINUE(mesh_vertices.is_empty());
 		const Vector3 *vr = mesh_vertices.ptr();
 
 		if (p_mesh->surface_get_format(i) & Mesh::ARRAY_FORMAT_INDEX) {
 			Vector<int> mesh_indices = a[Mesh::ARRAY_INDEX];
+			ERR_CONTINUE(mesh_indices.is_empty() || (mesh_indices.size() != index_count));
 			const int *ir = mesh_indices.ptr();
 
 			for (int j = 0; j < mesh_vertices.size(); j++) {
@@ -111,6 +114,7 @@ void NavigationMeshGenerator::_add_mesh(const Ref<Mesh> &p_mesh, const Transform
 				p_indices.push_back(current_vertex_count + (ir[j * 3 + 1]));
 			}
 		} else {
+			ERR_CONTINUE(mesh_vertices.size() != index_count);
 			face_count = mesh_vertices.size() / 3;
 			for (int j = 0; j < face_count; j++) {
 				_add_vertex(p_xform.xform(vr[j * 3 + 0]), p_vertices);
@@ -126,10 +130,14 @@ void NavigationMeshGenerator::_add_mesh(const Ref<Mesh> &p_mesh, const Transform
 }
 
 void NavigationMeshGenerator::_add_mesh_array(const Array &p_array, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices) {
+	ERR_FAIL_COND(p_array.size() != Mesh::ARRAY_MAX);
+
 	Vector<Vector3> mesh_vertices = p_array[Mesh::ARRAY_VERTEX];
+	ERR_FAIL_COND(mesh_vertices.is_empty());
 	const Vector3 *vr = mesh_vertices.ptr();
 
 	Vector<int> mesh_indices = p_array[Mesh::ARRAY_INDEX];
+	ERR_FAIL_COND(mesh_indices.is_empty());
 	const int *ir = mesh_indices.ptr();
 
 	const int face_count = mesh_indices.size() / 3;
@@ -148,6 +156,8 @@ void NavigationMeshGenerator::_add_mesh_array(const Array &p_array, const Transf
 }
 
 void NavigationMeshGenerator::_add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices) {
+	ERR_FAIL_COND(p_faces.is_empty());
+	ERR_FAIL_COND(p_faces.size() % 3 != 0);
 	int face_count = p_faces.size() / 3;
 	int current_vertex_count = p_vertices.size() / 3;
 

--- a/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/navigation_mesh_source_geometry_data_3d.cpp
@@ -70,12 +70,15 @@ void NavigationMeshSourceGeometryData3D::_add_mesh(const Ref<Mesh> &p_mesh, cons
 		int face_count = index_count / 3;
 
 		Array a = p_mesh->surface_get_arrays(i);
+		ERR_CONTINUE(a.is_empty() || (a.size() != Mesh::ARRAY_MAX));
 
 		Vector<Vector3> mesh_vertices = a[Mesh::ARRAY_VERTEX];
+		ERR_CONTINUE(mesh_vertices.is_empty());
 		const Vector3 *vr = mesh_vertices.ptr();
 
 		if (p_mesh->surface_get_format(i) & Mesh::ARRAY_FORMAT_INDEX) {
 			Vector<int> mesh_indices = a[Mesh::ARRAY_INDEX];
+			ERR_CONTINUE(mesh_indices.is_empty() || (mesh_indices.size() != index_count));
 			const int *ir = mesh_indices.ptr();
 
 			for (int j = 0; j < mesh_vertices.size(); j++) {
@@ -89,6 +92,7 @@ void NavigationMeshSourceGeometryData3D::_add_mesh(const Ref<Mesh> &p_mesh, cons
 				indices.push_back(current_vertex_count + (ir[j * 3 + 1]));
 			}
 		} else {
+			ERR_CONTINUE(mesh_vertices.size() != index_count);
 			face_count = mesh_vertices.size() / 3;
 			for (int j = 0; j < face_count; j++) {
 				_add_vertex(p_xform.xform(vr[j * 3 + 0]));
@@ -104,10 +108,14 @@ void NavigationMeshSourceGeometryData3D::_add_mesh(const Ref<Mesh> &p_mesh, cons
 }
 
 void NavigationMeshSourceGeometryData3D::_add_mesh_array(const Array &p_mesh_array, const Transform3D &p_xform) {
+	ERR_FAIL_COND(p_mesh_array.size() != Mesh::ARRAY_MAX);
+
 	Vector<Vector3> mesh_vertices = p_mesh_array[Mesh::ARRAY_VERTEX];
+	ERR_FAIL_COND(mesh_vertices.is_empty());
 	const Vector3 *vr = mesh_vertices.ptr();
 
 	Vector<int> mesh_indices = p_mesh_array[Mesh::ARRAY_INDEX];
+	ERR_FAIL_COND(mesh_indices.is_empty());
 	const int *ir = mesh_indices.ptr();
 
 	const int face_count = mesh_indices.size() / 3;
@@ -126,6 +134,8 @@ void NavigationMeshSourceGeometryData3D::_add_mesh_array(const Array &p_mesh_arr
 }
 
 void NavigationMeshSourceGeometryData3D::_add_faces(const PackedVector3Array &p_faces, const Transform3D &p_xform) {
+	ERR_FAIL_COND(p_faces.is_empty());
+	ERR_FAIL_COND(p_faces.size() % 3 != 0);
 	int face_count = p_faces.size() / 3;
 	int current_vertex_count = vertices.size() / 3;
 


### PR DESCRIPTION
Fixes potential crashes in navmesh geometry functions.

Adds some error checks where garbled data could show up.

Fixes https://github.com/godotengine/godot/issues/78428 ... maybe? Can't test on Windows.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
