### PR TITLE
Add `agent` and `map` tests for 'NavigationServer3D'

### DIFF
--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -997,8 +997,10 @@ COMMAND_1(free, RID, p_object) {
 		}
 
 		int map_index = active_maps.find(map);
-		active_maps.remove_at(map_index);
-		active_maps_update_id.remove_at(map_index);
+		if (map_index >= 0) {
+			active_maps.remove_at(map_index);
+			active_maps_update_id.remove_at(map_index);
+		}
 		map_owner.free(p_object);
 
 	} else if (region_owner.owns(p_object)) {

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -40,6 +40,109 @@ TEST_SUITE("[Navigation]") {
 	TEST_CASE("[NavigationServer3D] Server should be empty when initialized") {
 		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
+
+		SUBCASE("'ProcessInfo' should report all counters empty as well") {
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_POLYGON_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_EDGE_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_EDGE_MERGE_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_EDGE_CONNECTION_COUNT), 0);
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_EDGE_FREE_COUNT), 0);
+		}
+	}
+
+	TEST_CASE("[NavigationServer3D] Server should manage agent properly") {
+		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
+		CHECK_EQ(navigation_server->get_maps().size(), 0);
+
+		RID agent = navigation_server->agent_create();
+		CHECK(agent.is_valid());
+
+		SUBCASE("'ProcessInfo' should not report dangling agent") {
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
+		}
+
+		SUBCASE("Setters/getters should work") {
+			bool initial_use_3d_avoidance = navigation_server->agent_get_use_3d_avoidance(agent);
+			navigation_server->agent_set_use_3d_avoidance(agent, !initial_use_3d_avoidance);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->agent_get_use_3d_avoidance(agent), !initial_use_3d_avoidance);
+			// TODO: Add remaining setters/getters once the missing getters are added.
+		}
+
+		SUBCASE("'ProcessInfo' should report agent with active map") {
+			RID map = navigation_server->map_create();
+			CHECK(map.is_valid());
+			navigation_server->map_set_active(map, true);
+			navigation_server->agent_set_map(agent, map);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 1);
+			navigation_server->agent_set_map(agent, RID());
+			navigation_server->free(map);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+		}
+
+		navigation_server->free(agent);
+
+		SUBCASE("'ProcessInfo' should not report removed agent") {
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
+		}
+	}
+
+	TEST_CASE("[NavigationServer3D] Server should manage map properly") {
+		NavigationServer3D *navigation_server = NavigationServer3D::get_singleton();
+		CHECK_EQ(navigation_server->get_maps().size(), 0);
+
+		RID map = navigation_server->map_create();
+		CHECK(map.is_valid());
+		CHECK_EQ(navigation_server->get_maps().size(), 1);
+
+		SUBCASE("'ProcessInfo' should not report inactive map") {
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
+		}
+
+		SUBCASE("Setters/getters should work") {
+			navigation_server->map_set_cell_size(map, 0.55);
+			navigation_server->map_set_edge_connection_margin(map, 0.66);
+			navigation_server->map_set_link_connection_radius(map, 0.77);
+			navigation_server->map_set_up(map, Vector3(1, 0, 0));
+			bool initial_use_edge_connections = navigation_server->map_get_use_edge_connections(map);
+			navigation_server->map_set_use_edge_connections(map, !initial_use_edge_connections);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->map_get_cell_size(map), doctest::Approx(0.55));
+			CHECK_EQ(navigation_server->map_get_edge_connection_margin(map), doctest::Approx(0.66));
+			CHECK_EQ(navigation_server->map_get_link_connection_radius(map), doctest::Approx(0.77));
+			CHECK_EQ(navigation_server->map_get_up(map), Vector3(1, 0, 0));
+			CHECK_EQ(navigation_server->map_get_use_edge_connections(map), !initial_use_edge_connections);
+		}
+
+		SUBCASE("'ProcessInfo' should report map iff active") {
+			navigation_server->map_set_active(map, true);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK(navigation_server->map_is_active(map));
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 1);
+			navigation_server->map_set_active(map, false);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_ACTIVE_MAPS), 0);
+		}
+
+		SUBCASE("Number of agents should be reported properly") {
+			RID agent = navigation_server->agent_create();
+			CHECK(agent.is_valid());
+			navigation_server->agent_set_map(agent, map);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->map_get_agents(map).size(), 1);
+			navigation_server->free(agent);
+			navigation_server->process(0.0); // Give server some cycles to commit.
+			CHECK_EQ(navigation_server->map_get_agents(map).size(), 0);
+		}
+
+		navigation_server->free(map);
+		navigation_server->process(0.0); // Give server some cycles to actually remove map.
+		CHECK_EQ(navigation_server->get_maps().size(), 0);
 	}
 }
 } //namespace TestNavigationServer3D


### PR DESCRIPTION
This commits fixes a bug in `free()` function as well.

This is just another PR which is part of https://github.com/godotengine/godot/issues/73132 activity I'm performing to properly cover the navigation area with tests.