### PR TITLE
Check if the required texture format is imported in the export dialog

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
+#include "editor/import/resource_importer_texture_settings.h"
 
 EditorExport *EditorExport::singleton = nullptr;
 
@@ -136,20 +137,16 @@ void EditorExport::add_export_preset(const Ref<EditorExportPreset> &p_preset, in
 }
 
 String EditorExportPlatform::test_etc2() const {
-	const bool etc2_supported = GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc");
-
-	if (!etc2_supported) {
-		return TTR("Target platform requires 'ETC2/ASTC' texture compression. Enable 'Import ETC2 ASTC' in Project Settings.");
+	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
+		return TTR("Target platform requires 'ETC2/ASTC' texture compression. Enable 'Import ETC2 ASTC' in Project Settings.") + "\n";
 	}
 
 	return String();
 }
 
 String EditorExportPlatform::test_bc() const {
-	const bool bc_supported = GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc");
-
-	if (!bc_supported) {
-		return TTR("Target platform requires 'S3TC/BPTC' texture compression. Enable 'Import S3TC BPTC' in Project Settings.");
+	if (!ResourceImporterTextureSettings::should_import_s3tc_bptc()) {
+		return TTR("Target platform requires 'S3TC/BPTC' texture compression. Enable 'Import S3TC BPTC' in Project Settings.") + "\n";
 	}
 
 	return String();

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -37,7 +37,8 @@
 #include "core/object/ref_counted.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
-#include "resource_importer_texture.h"
+#include "editor/import/resource_importer_texture.h"
+#include "editor/import/resource_importer_texture_settings.h"
 #include "scene/resources/texture.h"
 
 String ResourceImporterLayeredTexture::get_importer_name() const {
@@ -491,8 +492,8 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 	// Must import in all formats, in order of priority (so platform choses the best supported one. IE, etc2 over etc).
 	// Android, GLES 2.x
 
-	const bool can_s3tc_bptc = GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
-	const bool can_etc2_astc = GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
+	const bool can_s3tc_bptc = ResourceImporterTextureSettings::should_import_s3tc_bptc();
+	const bool can_etc2_astc = ResourceImporterTextureSettings::should_import_etc2_astc();
 
 	// Add list of formats imported
 	if (can_s3tc_bptc) {

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/import/resource_importer_texture_settings.h"
 
 void ResourceImporterTexture::_texture_reimport_roughness(const Ref<CompressedTexture2D> &p_tex, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_channel) {
 	ERR_FAIL_COND(p_tex.is_null());
@@ -604,8 +605,8 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 		// Android, GLES 2.x
 
 		const bool is_hdr = (image->get_format() >= Image::FORMAT_RF && image->get_format() <= Image::FORMAT_RGBE9995);
-		const bool can_s3tc_bptc = GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
-		const bool can_etc2_astc = GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc") || OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
+		const bool can_s3tc_bptc = ResourceImporterTextureSettings::should_import_s3tc_bptc();
+		const bool can_etc2_astc = ResourceImporterTextureSettings::should_import_etc2_astc();
 
 		// Add list of formats imported
 		if (can_s3tc_bptc) {

--- a/editor/import/resource_importer_texture_settings.cpp
+++ b/editor/import/resource_importer_texture_settings.cpp
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  resource_importer_texture_settings.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_texture_settings.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+
+// ResourceImporterTextureSettings contains code used by
+// multiple texture importers and the export dialog.
+bool ResourceImporterTextureSettings::should_import_s3tc_bptc() {
+	if (GLOBAL_GET("rendering/textures/vram_compression/import_s3tc_bptc")) {
+		return true;
+	}
+	// If the project settings override is not enabled, import
+	// S3TC/BPTC only when the host operating system needs it.
+	return OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
+}
+
+bool ResourceImporterTextureSettings::should_import_etc2_astc() {
+	if (GLOBAL_GET("rendering/textures/vram_compression/import_etc2_astc")) {
+		return true;
+	}
+	// If the project settings override is not enabled, import
+	// ETC2/ASTC only when the host operating system needs it.
+	return OS::get_singleton()->get_preferred_texture_format() == OS::PREFERRED_TEXTURE_FORMAT_ETC2_ASTC;
+}

--- a/editor/import/resource_importer_texture_settings.h
+++ b/editor/import/resource_importer_texture_settings.h
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  resource_importer_texture_settings.h                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_TEXTURE_SETTINGS_H
+#define RESOURCE_IMPORTER_TEXTURE_SETTINGS_H
+
+// ResourceImporterTextureSettings contains code used by
+// multiple texture importers and the export dialog.
+namespace ResourceImporterTextureSettings {
+bool should_import_s3tc_bptc();
+bool should_import_etc2_astc();
+} //namespace ResourceImporterTextureSettings
+
+#endif // RESOURCE_IMPORTER_TEXTURE_SETTINGS_H


### PR DESCRIPTION
Before, the export dialog only cared about if the *setting* is enabled.

Now, it cares whether the format is actually imported. Fixes #78395.

I created 2 new files `resource_importer_texture_settings.{h,cpp}` for this, since I did not know if there was any better place for this to exist. Before reviewing you should also look at #78457 to see how it will be used in the near future.