### PR TITLE
Add a button in the export dialog to fix missing texture formats

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
-#include "editor/import/resource_importer_texture_settings.h"
 
 EditorExport *EditorExport::singleton = nullptr;
 
@@ -136,22 +135,6 @@ void EditorExport::add_export_preset(const Ref<EditorExportPreset> &p_preset, in
 	} else {
 		export_presets.insert(p_at_pos, p_preset);
 	}
-}
-
-String EditorExportPlatform::test_etc2() const {
-	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
-		return TTR("Target platform requires 'ETC2/ASTC' texture compression. Enable 'Import ETC2 ASTC' in Project Settings.") + "\n";
-	}
-
-	return String();
-}
-
-String EditorExportPlatform::test_bc() const {
-	if (!ResourceImporterTextureSettings::should_import_s3tc_bptc()) {
-		return TTR("Target platform requires 'S3TC/BPTC' texture compression. Enable 'Import S3TC BPTC' in Project Settings.") + "\n";
-	}
-
-	return String();
 }
 
 int EditorExport::get_export_preset_count() const {

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -237,8 +237,6 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, int p_debug_flags) { return OK; }
 	virtual Ref<Texture2D> get_run_icon() const { return get_logo(); }
 
-	String test_etc2() const;
-	String test_bc() const;
 	bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const;
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const = 0;
 	virtual bool has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const = 0;

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -41,6 +41,7 @@ class EditorFileSystemDirectory;
 class EditorInspector;
 class EditorPropertyPath;
 class ItemList;
+class LinkButton;
 class MenuButton;
 class OptionButton;
 class PopupMenu;
@@ -48,6 +49,23 @@ class RichTextLabel;
 class TabContainer;
 class Tree;
 class TreeItem;
+
+class ProjectExportTextureFormatError : public HBoxContainer {
+	GDCLASS(ProjectExportTextureFormatError, HBoxContainer);
+
+	Label *texture_format_error_label = nullptr;
+	LinkButton *fix_texture_format_button = nullptr;
+	String setting_identifier;
+	void _on_fix_texture_format_pressed();
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	void show_for_texture_format(const String &p_friendly_name, const String &p_setting_identifier);
+	ProjectExportTextureFormatError();
+};
 
 class ProjectExportDialog : public ConfirmationDialog {
 	GDCLASS(ProjectExportDialog, ConfirmationDialog);
@@ -86,12 +104,14 @@ private:
 	Button *export_all_button = nullptr;
 	AcceptDialog *export_all_dialog = nullptr;
 
+	RBSet<String> feature_set;
 	LineEdit *custom_features = nullptr;
 	RichTextLabel *custom_feature_display = nullptr;
 
 	LineEdit *script_key = nullptr;
 	Label *script_key_error = nullptr;
 
+	ProjectExportTextureFormatError *export_texture_format_error = nullptr;
 	Label *export_error = nullptr;
 	Label *export_warning = nullptr;
 	HBoxContainer *export_templates_error = nullptr;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -47,6 +47,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/import/resource_importer_texture_settings.h"
 #include "main/splash.gen.h"
 #include "scene/resources/image_texture.h"
 
@@ -2384,10 +2385,8 @@ bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<Edit
 		}
 	}
 
-	String etc_error = test_etc2();
-	if (!etc_error.is_empty()) {
+	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
 		valid = false;
-		err += etc_error;
 	}
 
 	String min_sdk_str = p_preset->get("gradle_build/min_sdk");

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -39,6 +39,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/export/editor_export.h"
+#include "editor/import/resource_importer_texture_settings.h"
 #include "editor/plugins/script_editor_plugin.h"
 
 #include "modules/modules_enabled.gen.h" // For mono and svg.
@@ -1984,10 +1985,8 @@ bool EditorExportPlatformIOS::has_valid_project_configuration(const Ref<EditorEx
 		}
 	}
 
-	const String etc_error = test_etc2();
-	if (!etc_error.is_empty()) {
+	if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
 		valid = false;
-		err += etc_error;
 	}
 
 	if (!err.is_empty()) {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
+#include "editor/import/resource_importer_texture_settings.h"
 #include "scene/resources/image_texture.h"
 
 #include "modules/modules_enabled.gen.h" // For svg and regex.
@@ -2124,16 +2125,12 @@ bool EditorExportPlatformMacOS::has_valid_export_configuration(const Ref<EditorE
 	// Check the texture formats, which vary depending on the target architecture.
 	String architecture = p_preset->get("binary_format/architecture");
 	if (architecture == "universal" || architecture == "x86_64") {
-		const String bc_error = test_bc();
-		if (!bc_error.is_empty()) {
+		if (!ResourceImporterTextureSettings::should_import_s3tc_bptc()) {
 			valid = false;
-			err += bc_error;
 		}
 	} else if (architecture == "arm64") {
-		const String etc_error = test_etc2();
-		if (!etc_error.is_empty()) {
+		if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
 			valid = false;
-			err += etc_error;
 		}
 	} else {
 		ERR_PRINT("Invalid architecture");

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/export/editor_export.h"
+#include "editor/import/resource_importer_texture_settings.h"
 #include "scene/resources/image_texture.h"
 
 #include "modules/modules_enabled.gen.h" // For mono and svg.
@@ -406,10 +407,8 @@ bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorEx
 	// Validate the project configuration.
 
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
-		String etc_error = test_etc2();
-		if (!etc_error.is_empty()) {
+		if (!ResourceImporterTextureSettings::should_import_etc2_astc()) {
 			valid = false;
-			err += etc_error;
 		}
 	}
 


### PR DESCRIPTION
This PR improves the error message about texture formats by adding a button to fix it. I was inspired by a similar "Auto Fix" button in VRChat and realized the same idea would work perfectly here. This will greatly help with #78395.

<img width="783" alt="Screenshot 2023-06-19 at 9 09 50 PM" src="https://github.com/godotengine/godot/assets/1646875/0fd923fe-84e6-473e-88d1-fc94b48d0753">

When the button is pressed, the project setting is enabled, the settings are saved, the editor file system is re-scanned (which reimports all textures as needed), and the export dialog is refreshed.