### PR TITLE
Clarify `String.get_slice` behavior

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -290,7 +290,7 @@
 			<param index="0" name="delimiter" type="String" />
 			<param index="1" name="slice" type="int" />
 			<description>
-				Splits the string using a [param delimiter] and returns the substring at index [param slice]. Returns an empty string if the [param slice] does not exist.
+				Splits the string using a [param delimiter] and returns the substring at index [param slice]. Returns the original string if [param delimiter] does not occur in the string. Returns an empty string if the [param slice] does not exist.
 				This is faster than [method split], if you only need one substring.
 				[b]Example:[/b]
 				[codeblock]


### PR DESCRIPTION
Clarify that the function returns the whole string if there is no instances of the delimiter in the string.

This method has been like this since pre-open source days, so best not to suddenly change the behavior

Will open a dedicated 3.x version as well soon

* 3.x version: #78464

* Fixes: #78459
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
