### PR TITLE
[3.x] Clarify `String.get_slice` behavior

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -358,7 +358,7 @@
 			<argument index="0" name="delimiter" type="String" />
 			<argument index="1" name="slice" type="int" />
 			<description>
-				Splits a string using a [code]delimiter[/code] and returns a substring at index [code]slice[/code]. Returns an empty string if the index doesn't exist.
+				Splits a string using a [code]delimiter[/code] and returns a substring at index [code]slice[/code]. Returns the original string if [code]delimiter[/code] does not occur in the string. Returns an empty string if the index doesn't exist.
 				This is a more performant alternative to [method split] for cases when you need only one element from the array at a fixed index.
 				Example:
 				[codeblock]


### PR DESCRIPTION
Clarify that the function returns the whole string if there is no instances of the delimiter in the string.

* 4.x version: #78463
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
