### PR TITLE
GDScript: Fix `_get_script_name()` function collision for SCU build

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1354,7 +1354,7 @@ GDScript::GDScript() :
 	path = vformat("gdscript://%d.gd", get_instance_id());
 }
 
-void GDScript::_save_orphaned_subclasses(GDScript::ClearData *p_clear_data) {
+void GDScript::_save_orphaned_subclasses(ClearData *p_clear_data) {
 	struct ClassRefWithName {
 		ObjectID id;
 		String fully_qualified_name;
@@ -1411,7 +1411,31 @@ void GDScript::_init_rpc_methods_properties() {
 	}
 }
 
-void GDScript::clear(GDScript::ClearData *p_clear_data) {
+#ifdef DEBUG_ENABLED
+String GDScript::debug_get_script_name(const Ref<Script> &p_script) {
+	if (p_script.is_valid()) {
+		Ref<GDScript> gdscript = p_script;
+		if (gdscript.is_valid()) {
+			if (!gdscript->get_script_class_name().is_empty()) {
+				return gdscript->get_script_class_name();
+			}
+			return gdscript->get_fully_qualified_name().get_file();
+		}
+
+		if (p_script->get_global_name() != StringName()) {
+			return p_script->get_global_name();
+		} else if (!p_script->get_path().is_empty()) {
+			return p_script->get_path().get_file();
+		} else if (!p_script->get_name().is_empty()) {
+			return p_script->get_name(); // Resource name.
+		}
+	}
+
+	return "<unknown script>";
+}
+#endif
+
+void GDScript::clear(ClearData *p_clear_data) {
 	if (clearing) {
 		return;
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -104,7 +104,6 @@ class GDScript : public Script {
 	Dictionary rpc_config;
 
 #ifdef TOOLS_ENABLED
-
 	// For static data storage during hot-reloading.
 	HashMap<StringName, MemberInfo> old_static_variables_indices;
 	Vector<Variant> old_static_variables;
@@ -125,8 +124,8 @@ class GDScript : public Script {
 	Vector<DocData::ClassDoc> docs;
 	void _clear_doc();
 	void _add_doc(const DocData::ClassDoc &p_inner_class);
-
 #endif
+
 	HashMap<StringName, PropertyInfo> member_info;
 
 	GDScriptFunction *implicit_initializer = nullptr;
@@ -162,9 +161,7 @@ class GDScript : public Script {
 #endif
 
 #ifdef DEBUG_ENABLED
-
 	HashMap<ObjectID, List<Pair<StringName, Variant>>> pending_reload_state;
-
 #endif
 
 	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr);
@@ -192,6 +189,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef DEBUG_ENABLED
+	static String debug_get_script_name(const Ref<Script> &p_script);
+#endif
+
 	void clear(GDScript::ClearData *p_clear_data = nullptr);
 
 	virtual bool is_valid() const override { return valid; }

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -35,22 +35,6 @@
 
 #include "core/string/string_builder.h"
 
-static String _get_script_name(const Ref<Script> &p_script) {
-	if (p_script.is_valid()) {
-		if (p_script->get_global_name() != StringName()) {
-			return p_script->get_global_name();
-		}
-		GDScript *gdscript = Object::cast_to<GDScript>(p_script.ptr());
-		if (gdscript) {
-			return gdscript->get_fully_qualified_name().get_file();
-		}
-		if (!p_script->get_path().is_empty()) {
-			return p_script->get_path().get_file();
-		}
-	}
-	return "<unknown script>";
-}
-
 static String _get_variant_string(const Variant &p_variant) {
 	String txt;
 	if (p_variant.get_type() == Variant::STRING) {
@@ -70,11 +54,11 @@ static String _get_variant_string(const Variant &p_variant) {
 			} else {
 				Script *script = Object::cast_to<Script>(obj);
 				if (script) {
-					txt = "script(" + _get_script_name(script) + ")";
+					txt = "script(" + GDScript::debug_get_script_name(script) + ")";
 				} else {
 					txt = "object(" + obj->get_class();
 					if (obj->get_script_instance()) {
-						txt += ", " + _get_script_name(obj->get_script_instance()->get_script());
+						txt += ", " + GDScript::debug_get_script_name(obj->get_script_instance()->get_script());
 					}
 					txt += ")";
 				}
@@ -179,7 +163,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				if (script_type.is_valid() && script_type->is_valid()) {
 					text += "script(";
-					text += _get_script_name(script_type);
+					text += GDScript::debug_get_script_name(script_type);
 					text += ")";
 				} else if (native_type != StringName()) {
 					text += native_type;
@@ -339,7 +323,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Ref<GDScript> gdscript = get_constant(_code_ptr[ip + 2] & ADDR_MASK);
 
 				text += "set_static_variable script(";
-				text += _get_script_name(gdscript);
+				text += GDScript::debug_get_script_name(gdscript);
 				text += ")";
 				if (gdscript.is_valid()) {
 					text += "[\"" + gdscript->debug_get_static_var_by_index(_code_ptr[ip + 3]) + "\"]";
@@ -357,7 +341,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += "get_static_variable ";
 				text += DADDR(1);
 				text += " = script(";
-				text += _get_script_name(gdscript);
+				text += GDScript::debug_get_script_name(gdscript);
 				text += ")";
 				if (gdscript.is_valid()) {
 					text += "[\"" + gdscript->debug_get_static_var_by_index(_code_ptr[ip + 3]) + "\"]";
@@ -421,7 +405,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Ref<Script> script = get_constant(_code_ptr[ip + 3] & ADDR_MASK);
 
 				text += "assign typed script (";
-				text += _get_script_name(script);
+				text += GDScript::debug_get_script_name(script);
 				text += ") ";
 				text += DADDR(1);
 				text += " = ";
@@ -527,7 +511,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				String type_name;
 				if (script_type.is_valid() && script_type->is_valid()) {
-					type_name = "script(" + _get_script_name(script_type) + ")";
+					type_name = "script(" + GDScript::debug_get_script_name(script_type) + ")";
 				} else if (native_type != StringName()) {
 					type_name = native_type;
 				} else {
@@ -994,7 +978,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				Ref<Script> script = get_constant(_code_ptr[ip + 2] & ADDR_MASK);
 
 				text += "return typed script (";
-				text += _get_script_name(script);
+				text += GDScript::debug_get_script_name(script);
 				text += ") ";
 				text += DADDR(1);
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -36,20 +36,9 @@
 #include "core/os/os.h"
 
 #ifdef DEBUG_ENABLED
-static String _get_script_name(const Ref<Script> p_script) {
-	Ref<GDScript> gdscript = p_script;
-	if (gdscript.is_valid()) {
-		return gdscript->get_script_class_name();
-	} else if (p_script->get_name().is_empty()) {
-		return p_script->get_path().get_file();
-	} else {
-		return p_script->get_name();
-	}
-}
-
 static String _get_element_type(Variant::Type builtin_type, const StringName &native_type, const Ref<Script> &script_type) {
 	if (script_type.is_valid() && script_type->is_valid()) {
-		return _get_script_name(script_type);
+		return GDScript::debug_get_script_name(script_type);
 	} else if (native_type != StringName()) {
 		return native_type.operator String();
 	} else {
@@ -75,7 +64,7 @@ static String _get_var_type(const Variant *p_var) {
 			} else {
 				basestr = bobj->get_class();
 				if (bobj->get_script_instance()) {
-					basestr += " (" + _get_script_name(bobj->get_script_instance()->get_script()) + ")";
+					basestr += " (" + GDScript::debug_get_script_name(bobj->get_script_instance()->get_script()) + ")";
 				}
 			}
 		}
@@ -2684,7 +2673,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (r->get_type() != Variant::OBJECT && r->get_type() != Variant::NIL) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return value of type "%s" from a function which the return type is "%s".)",
-							Variant::get_type_name(r->get_type()), _get_script_name(Ref<Script>(base_type)));
+							Variant::get_type_name(r->get_type()), GDScript::debug_get_script_name(Ref<Script>(base_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
@@ -2706,7 +2695,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (!ret_inst) {
 #ifdef DEBUG_ENABLED
 						err_text = vformat(R"(Trying to return value of type "%s" from a function which the return type is "%s".)",
-								ret_obj->get_class_name(), _get_script_name(Ref<GDScript>(base_type)));
+								ret_obj->get_class_name(), GDScript::debug_get_script_name(Ref<GDScript>(base_type)));
 #endif // DEBUG_ENABLED
 						OPCODE_BREAK;
 					}
@@ -2725,7 +2714,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (!valid) {
 #ifdef DEBUG_ENABLED
 						err_text = vformat(R"(Trying to return value of type "%s" from a function which the return type is "%s".)",
-								_get_script_name(ret_obj->get_script_instance()->get_script()), _get_script_name(Ref<GDScript>(base_type)));
+								GDScript::debug_get_script_name(ret_obj->get_script_instance()->get_script()), GDScript::debug_get_script_name(Ref<GDScript>(base_type)));
 #endif // DEBUG_ENABLED
 						OPCODE_BREAK;
 					}

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_pass_basic_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_pass_basic_to_typed.out
@@ -3,4 +3,4 @@ GDTEST_RUNTIME_ERROR
 >> on function: test()
 >> runtime/errors/typed_array_pass_basic_to_typed.gd
 >> 6
->> Invalid type in function 'expect_typed' in base 'RefCounted ()'. The array of argument 1 (Array) does not have the same element type as the expected typed array argument.
+>> Invalid type in function 'expect_typed' in base 'RefCounted (typed_array_pass_basic_to_typed.gd)'. The array of argument 1 (Array) does not have the same element type as the expected typed array argument.

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_pass_differently_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_pass_differently_to_typed.out
@@ -3,4 +3,4 @@ GDTEST_RUNTIME_ERROR
 >> on function: test()
 >> runtime/errors/typed_array_pass_differently_to_typed.gd
 >> 6
->> Invalid type in function 'expect_typed' in base 'RefCounted ()'. The array of argument 1 (Array[float]) does not have the same element type as the expected typed array argument.
+>> Invalid type in function 'expect_typed' in base 'RefCounted (typed_array_pass_differently_to_typed.gd)'. The array of argument 1 (Array[float]) does not have the same element type as the expected typed array argument.


### PR DESCRIPTION
![](https://github.com/godotengine/godot/assets/47700418/2dfff19d-ee1f-42f1-aeff-ac802014dbdd)

I'm not sure where to put this function, so I made it a static `GDScript` method.
