### PR TITLE
Use cached saturation for color picker when value is 0

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -124,8 +124,13 @@ float ColorModeHSV::get_slider_value(int idx) const {
 				return color_picker->get_cached_hue();
 			}
 		}
-		case 1:
-			return color_picker->get_pick_color().get_s() * 100.0;
+		case 1: {
+			if (color_picker->get_pick_color().get_v() > 0) {
+				return color_picker->get_pick_color().get_s() * 100.0;
+			} else {
+				return color_picker->get_cached_saturation();
+			}
+		}
 		case 2:
 			return color_picker->get_pick_color().get_v() * 100.0;
 		case 3:

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -380,6 +380,9 @@ void ColorPicker::_value_changed(double) {
 		if (sliders[1]->get_value() > 0 || sliders[0]->get_value() != cached_hue) {
 			cached_hue = sliders[0]->get_value();
 		}
+		if (sliders[2]->get_value() > 0 || sliders[1]->get_value() != cached_saturation) {
+			cached_saturation = sliders[1]->get_value();
+		}
 	}
 
 	if (current_mode == MODE_HSV || current_mode == MODE_OKHSL) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -205,6 +205,7 @@ private:
 	float s = 0.0;
 	float v = 0.0;
 	float cached_hue = 0.0;
+	float cached_saturation = 0.0;
 	Color last_color;
 
 	struct ThemeCache {
@@ -296,6 +297,7 @@ public:
 	void set_editor_settings(Object *p_editor_settings);
 #endif
 	float get_cached_hue() { return cached_hue; };
+	float get_cached_saturation() { return cached_saturation; };
 
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();


### PR DESCRIPTION
An update to #76968 and #77863 

The saturation slider also gets set to 0 when the value is 0. I implemented the same fix as before, using a cached saturation when the value is 0.

To test, 

1. Go into any color picker widget and go into hsv mode.
2. Set the saturation to a nonzero value and the value to 0.
3. If the issue is fixed, the value should stay the same after switching modes/closing and reopening the widget.

