### PR TITLE
Fix condition blocking .NET project build

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -206,16 +206,16 @@ namespace GodotTools.Build
 
         private static bool BuildProjectBlocking(BuildInfo buildInfo)
         {
-            if (!File.Exists(buildInfo.Solution))
-                return true; // No solution to build
+            if (!File.Exists(buildInfo.Project))
+                return true; // No project to build.
 
             using var pr = new EditorProgress("dotnet_build_project", "Building .NET project...", 1);
 
-            pr.Step("Building project solution", 0);
+            pr.Step("Building project", 0);
 
             if (!Build(buildInfo))
             {
-                ShowBuildErrorDialog("Failed to build project solution");
+                ShowBuildErrorDialog("Failed to build project");
                 return false;
             }
 
@@ -224,16 +224,16 @@ namespace GodotTools.Build
 
         private static bool CleanProjectBlocking(BuildInfo buildInfo)
         {
-            if (!File.Exists(buildInfo.Solution))
-                return true; // No solution to clean
+            if (!File.Exists(buildInfo.Project))
+                return true; // No project to clean.
 
             using var pr = new EditorProgress("dotnet_clean_project", "Cleaning .NET project...", 1);
 
-            pr.Step("Cleaning project solution", 0);
+            pr.Step("Cleaning project", 0);
 
             if (!Build(buildInfo))
             {
-                ShowBuildErrorDialog("Failed to clean project solution");
+                ShowBuildErrorDialog("Failed to clean project");
                 return false;
             }
 
@@ -322,11 +322,11 @@ namespace GodotTools.Build
 
         public static bool EditorBuildCallback()
         {
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
-                return true; // No solution to build
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
+                return true; // No project to build.
 
             if (GodotSharpEditor.Instance.SkipBuildBeforePlaying)
-                return true; // Requested play from an external editor/IDE which already built the project
+                return true; // Requested play from an external editor/IDE which already built the project.
 
             return BuildProjectBlocking("Debug");
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -29,46 +29,46 @@ namespace GodotTools.Build
             BuildOutputView.UpdateIssuesList();
         }
 
-        public void BuildSolution()
+        public void BuildProject()
         {
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
-                return; // No solution to build
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
+                return; // No project to build.
 
             if (!BuildManager.BuildProjectBlocking("Debug"))
-                return; // Build failed
+                return; // Build failed.
 
-            // Notify running game for hot-reload
+            // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
 
-            // Hot-reload in the editor
+            // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
 
             if (Internal.IsAssembliesReloadingNeeded())
                 Internal.ReloadAssemblies(softReload: false);
         }
 
-        private void RebuildSolution()
+        private void RebuildProject()
         {
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
-                return; // No solution to build
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
+                return; // No project to build.
 
             if (!BuildManager.BuildProjectBlocking("Debug", rebuild: true))
-                return; // Build failed
+                return; // Build failed.
 
-            // Notify running game for hot-reload
+            // Notify running game for hot-reload.
             Internal.EditorDebuggerNodeReloadScripts();
 
-            // Hot-reload in the editor
+            // Hot-reload in the editor.
             GodotSharpEditor.Instance.GetNode<HotReloadAssemblyWatcher>("HotReloadAssemblyWatcher").RestartTimer();
 
             if (Internal.IsAssembliesReloadingNeeded())
                 Internal.ReloadAssemblies(softReload: false);
         }
 
-        private void CleanSolution()
+        private void CleanProject()
         {
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
-                return; // No solution to build
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
+                return; // No project to build.
 
             _ = BuildManager.CleanProjectBlocking("Debug");
         }
@@ -83,14 +83,14 @@ namespace GodotTools.Build
         {
             switch ((BuildMenuOptions)id)
             {
-                case BuildMenuOptions.BuildSolution:
-                    BuildSolution();
+                case BuildMenuOptions.BuildProject:
+                    BuildProject();
                     break;
-                case BuildMenuOptions.RebuildSolution:
-                    RebuildSolution();
+                case BuildMenuOptions.RebuildProject:
+                    RebuildProject();
                     break;
-                case BuildMenuOptions.CleanSolution:
-                    CleanSolution();
+                case BuildMenuOptions.CleanProject:
+                    CleanProject();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(id), id, "Invalid build menu option");
@@ -99,9 +99,9 @@ namespace GodotTools.Build
 
         private enum BuildMenuOptions
         {
-            BuildSolution,
-            RebuildSolution,
-            CleanSolution
+            BuildProject,
+            RebuildProject,
+            CleanProject
         }
 
         public override void _Ready()
@@ -118,9 +118,9 @@ namespace GodotTools.Build
             toolBarHBox.AddChild(_buildMenuBtn);
 
             var buildMenu = _buildMenuBtn.GetPopup();
-            buildMenu.AddItem("Build Solution".TTR(), (int)BuildMenuOptions.BuildSolution);
-            buildMenu.AddItem("Rebuild Solution".TTR(), (int)BuildMenuOptions.RebuildSolution);
-            buildMenu.AddItem("Clean Solution".TTR(), (int)BuildMenuOptions.CleanSolution);
+            buildMenu.AddItem("Build Project".TTR(), (int)BuildMenuOptions.BuildProject);
+            buildMenu.AddItem("Rebuild Project".TTR(), (int)BuildMenuOptions.RebuildProject);
+            buildMenu.AddItem("Clean Project".TTR(), (int)BuildMenuOptions.CleanProject);
             buildMenu.IdPressed += BuildMenuOptionPressed;
 
             _errorsBtn = new Button

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -140,15 +140,15 @@ namespace GodotTools
             }
         }
 
-        private void BuildSolutionPressed()
+        private void BuildProjectPressed()
         {
-            if (!File.Exists(GodotSharpDirs.ProjectSlnPath))
+            if (!File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
                 if (!CreateProjectSolution())
-                    return; // Failed to create solution
+                    return; // Failed to create project.
             }
 
-            Instance.MSBuildPanel.BuildSolution();
+            Instance.MSBuildPanel.BuildProject();
         }
 
         private enum MenuOptions
@@ -507,10 +507,10 @@ namespace GodotTools
                 Shortcut = buildSolutionShortcut,
                 ShortcutInTooltip = true
             };
-            _toolBarBuildButton.Pressed += BuildSolutionPressed;
+            _toolBarBuildButton.Pressed += BuildProjectPressed;
             AddControlToContainer(CustomControlContainer.Toolbar, _toolBarBuildButton);
 
-            if (File.Exists(GodotSharpDirs.ProjectSlnPath) && File.Exists(GodotSharpDirs.ProjectCsProjPath))
+            if (File.Exists(GodotSharpDirs.ProjectCsProjPath))
             {
                 ApplyNecessaryChangesToSolution();
             }


### PR DESCRIPTION
Since #73015, the build commands are called on project files instead of solution ones. Still, we gate those calls behind a check on the solution files, not the project ones.