### PR TITLE
Add warnings and fallbacks for particles sub emitters when using the GL Compatibility rendering backend

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -947,7 +947,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 					}
 				} break;
 				case ShaderLanguage::TYPE_SAMPLERCUBEARRAY: {
-					ERR_PRINT_ONCE("Type: SamplerCubeArray not supported in OpenGL renderer, please use another type.");
+					ERR_PRINT_ONCE("Type: SamplerCubeArray not supported in GL Compatibility rendering backend, please use another type.");
 				} break;
 
 				case ShaderLanguage::TYPE_ISAMPLER3D:
@@ -1396,21 +1396,24 @@ MaterialStorage::MaterialStorage() {
 		//actions.renames["GRAVITY"] = "current_gravity";
 		actions.renames["EMISSION_TRANSFORM"] = "emission_transform";
 		actions.renames["RANDOM_SEED"] = "random_seed";
-		actions.renames["FLAG_EMIT_POSITION"] = "EMISSION_FLAG_HAS_POSITION";
-		actions.renames["FLAG_EMIT_ROT_SCALE"] = "EMISSION_FLAG_HAS_ROTATION_SCALE";
-		actions.renames["FLAG_EMIT_VELOCITY"] = "EMISSION_FLAG_HAS_VELOCITY";
-		actions.renames["FLAG_EMIT_COLOR"] = "EMISSION_FLAG_HAS_COLOR";
-		actions.renames["FLAG_EMIT_CUSTOM"] = "EMISSION_FLAG_HAS_CUSTOM";
 		actions.renames["RESTART_POSITION"] = "restart_position";
 		actions.renames["RESTART_ROT_SCALE"] = "restart_rotation_scale";
 		actions.renames["RESTART_VELOCITY"] = "restart_velocity";
 		actions.renames["RESTART_COLOR"] = "restart_color";
 		actions.renames["RESTART_CUSTOM"] = "restart_custom";
-		actions.renames["emit_subparticle"] = "emit_subparticle";
 		actions.renames["COLLIDED"] = "collided";
 		actions.renames["COLLISION_NORMAL"] = "collision_normal";
 		actions.renames["COLLISION_DEPTH"] = "collision_depth";
 		actions.renames["ATTRACTOR_FORCE"] = "attractor_force";
+
+		// These are unsupported, but may be used by users. To avoid compile time overhead, we add the stub only when used.
+		actions.renames["FLAG_EMIT_POSITION"] = "uint(1)";
+		actions.renames["FLAG_EMIT_ROT_SCALE"] = "uint(2)";
+		actions.renames["FLAG_EMIT_VELOCITY"] = "uint(4)";
+		actions.renames["FLAG_EMIT_COLOR"] = "uint(8)";
+		actions.renames["FLAG_EMIT_CUSTOM"] = "uint(16)";
+		actions.renames["emit_subparticle"] = "emit_subparticle";
+		actions.usage_defines["emit_subparticle"] = "\nbool emit_subparticle(mat4 p_xform, vec3 p_velocity, vec4 p_color, vec4 p_custom, uint p_flags) {\n\treturn false;\n}\n";
 
 		actions.render_mode_defines["disable_force"] = "#define DISABLE_FORCE\n";
 		actions.render_mode_defines["disable_velocity"] = "#define DISABLE_VELOCITY\n";

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -271,13 +271,13 @@ void ParticlesStorage::particles_set_fractional_delta(RID p_particles, bool p_en
 
 void ParticlesStorage::particles_set_trails(RID p_particles, bool p_enable, double p_length) {
 	if (p_enable) {
-		WARN_PRINT_ONCE("The OpenGL 3 renderer does not support particle trails");
+		WARN_PRINT_ONCE_ED("The GL Compatibility rendering backend does not support particle trails.");
 	}
 }
 
 void ParticlesStorage::particles_set_trail_bind_poses(RID p_particles, const Vector<Transform3D> &p_bind_poses) {
 	if (p_bind_poses.size() != 0) {
-		WARN_PRINT_ONCE("The OpenGL 3 renderer does not support particle trails");
+		WARN_PRINT_ONCE_ED("The GL Compatibility rendering backend does not support particle trails.");
 	}
 }
 
@@ -341,12 +341,12 @@ void ParticlesStorage::particles_restart(RID p_particles) {
 
 void ParticlesStorage::particles_set_subemitter(RID p_particles, RID p_subemitter_particles) {
 	if (p_subemitter_particles.is_valid()) {
-		WARN_PRINT_ONCE("The OpenGL 3 renderer does not support particle sub emitters");
+		WARN_PRINT_ONCE_ED("The GL Compatibility rendering backend does not support particle sub-emitters.");
 	}
 }
 
 void ParticlesStorage::particles_emit(RID p_particles, const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {
-	WARN_PRINT_ONCE("The OpenGL 3 renderer does not support manually emitting particles");
+	WARN_PRINT_ONCE_ED("The GL Compatibility rendering backend does not support manually emitting particles.");
 }
 
 void ParticlesStorage::particles_request_process(RID p_particles) {
@@ -613,7 +613,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 						attr.extents[2] = extents.z;
 					} break;
 					case RS::PARTICLES_COLLISION_TYPE_VECTOR_FIELD_ATTRACT: {
-						WARN_PRINT_ONCE("Vector field particle attractors are not available in the OpenGL2 renderer.");
+						WARN_PRINT_ONCE_ED("Vector field particle attractors are not available in the GL Compatibility rendering backend.");
 					} break;
 					default: {
 					}
@@ -646,7 +646,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 						col.extents[2] = extents.z;
 					} break;
 					case RS::PARTICLES_COLLISION_TYPE_SDF_COLLIDE: {
-						WARN_PRINT_ONCE("SDF Particle Colliders are not available in the OpenGL 3 renderer.");
+						WARN_PRINT_ONCE_ED("SDF Particle Colliders are not available in the GL Compatibility rendering backend.");
 					} break;
 					case RS::PARTICLES_COLLISION_TYPE_HEIGHTFIELD_COLLIDE: {
 						if (collision_heightmap_texture != 0) { //already taken
@@ -1304,7 +1304,7 @@ void ParticlesStorage::particles_collision_set_attractor_attenuation(RID p_parti
 }
 
 void ParticlesStorage::particles_collision_set_field_texture(RID p_particles_collision, RID p_texture) {
-	WARN_PRINT_ONCE("The OpenGL 3 renderer does not support SDF collisions in 3D particle shaders");
+	WARN_PRINT_ONCE_ED("The GL Compatibility rendering backend does not support SDF collisions in 3D particle shaders");
 }
 
 void ParticlesStorage::particles_collision_height_field_update(RID p_particles_collision) {

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -644,7 +644,7 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 			}
 		} break;
 		default: {
-			ERR_FAIL_V_MSG(Ref<Image>(), "Image Format: " + itos(p_format) + " is not supported by the OpenGL3 Renderer");
+			ERR_FAIL_V_MSG(Ref<Image>(), "The image format " + itos(p_format) + " is not supported by the GL Compatibility rendering backend.");
 		}
 	}
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -319,6 +319,10 @@ PackedStringArray GPUParticles2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("Particle trails are only available when using the Forward+ or Mobile rendering backends."));
 	}
 
+	if (sub_emitter != NodePath() && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Particle sub-emitters are not available when using the GL Compatibility rendering backend."));
+	}
+
 	return warnings;
 }
 
@@ -391,6 +395,7 @@ void GPUParticles2D::set_sub_emitter(const NodePath &p_path) {
 	if (is_inside_tree() && sub_emitter != NodePath()) {
 		_attach_sub_emitter();
 	}
+	update_configuration_warnings();
 }
 
 NodePath GPUParticles2D::get_sub_emitter() const {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -363,6 +363,10 @@ PackedStringArray GPUParticles3D::get_configuration_warnings() const {
 		}
 	}
 
+	if (sub_emitter != NodePath() && OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		warnings.push_back(RTR("Particle sub-emitters are only available when using the Forward+ or Mobile rendering backends."));
+	}
+
 	return warnings;
 }
 
@@ -409,6 +413,7 @@ void GPUParticles3D::set_sub_emitter(const NodePath &p_path) {
 	if (is_inside_tree() && sub_emitter != NodePath()) {
 		_attach_sub_emitter();
 	}
+	update_configuration_warnings();
 }
 
 NodePath GPUParticles3D::get_sub_emitter() const {

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -229,7 +229,7 @@ void ParticleProcessMaterial::_update_shader() {
 		}
 	}
 
-	if (sub_emitter_mode != SUB_EMITTER_DISABLED) {
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_low_end()) {
 		if (sub_emitter_mode == SUB_EMITTER_CONSTANT) {
 			code += "uniform float sub_emitter_frequency;\n";
 		}
@@ -880,7 +880,7 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	}\n";
 	}
 
-	if (sub_emitter_mode != SUB_EMITTER_DISABLED) {
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_low_end()) {
 		code += "	int emit_count = 0;\n";
 		switch (sub_emitter_mode) {
 			case SUB_EMITTER_CONSTANT: {
@@ -1487,6 +1487,9 @@ void ParticleProcessMaterial::set_sub_emitter_mode(SubEmitterMode p_sub_emitter_
 	sub_emitter_mode = p_sub_emitter_mode;
 	_queue_shader_change();
 	notify_property_list_changed();
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && RenderingServer::get_singleton()->is_low_end()) {
+		WARN_PRINT_ONCE_ED("Sub-emitter modes other than SUB_EMITTER_DISABLED are not supported in the GL Compatibility rendering backend.");
+	}
 }
 
 ParticleProcessMaterial::SubEmitterMode ParticleProcessMaterial::get_sub_emitter_mode() const {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/78483

This PR does the following:
1. Adds a configuration warning when assigning a subemitter to a Particles node (both 2D and 3D)
2. Adds a printed warning when enabling a subemitters in the ParticleProcessMaterial
3. Avoids inserting subemitter related code into ParticlesProcessMaterial shader
4. Adds fallbacks when subemitter functionality is used in a shader
5. Cleans up error messages relating to GL Compatibility renderer (many of these should have been exposed to toasts, and many also referenced OpenGL 2 or 3)