### PR TITLE
Fix Import Tracks import setting for single clip

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -995,7 +995,7 @@ Node *ResourceImporterScene::_pre_fix_animations(Node *p_node, Node *p_root, con
 			AnimationImportTracks(int(node_settings["import_tracks/scale"]))
 		};
 
-		if (anims.size() > 1 && (import_tracks_mode[0] != ANIMATION_IMPORT_TRACKS_IF_PRESENT || import_tracks_mode[1] != ANIMATION_IMPORT_TRACKS_IF_PRESENT || import_tracks_mode[2] != ANIMATION_IMPORT_TRACKS_IF_PRESENT)) {
+		if (!anims.is_empty() && (import_tracks_mode[0] != ANIMATION_IMPORT_TRACKS_IF_PRESENT || import_tracks_mode[1] != ANIMATION_IMPORT_TRACKS_IF_PRESENT || import_tracks_mode[2] != ANIMATION_IMPORT_TRACKS_IF_PRESENT)) {
 			_optimize_track_usage(ap, import_tracks_mode);
 		}
 	}


### PR DESCRIPTION
Supersedes #59312

The issue was a greater than symbol. that's why it works for `Simple Bone.dae` (3 animation clips) but not `v2_bone_animation_test.glb` (1 animation clip)

MRP: [single_track_glb.zip](https://github.com/godotengine/godot/files/11808469/single_track_glb.zip)
