### PR TITLE
Apply reprojection in multiview for our cluster lookup

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1451,6 +1451,11 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 	RD::get_singleton()->barrier(RD::BARRIER_MASK_ALL_BARRIERS, RD::BARRIER_MASK_ALL_BARRIERS);
 
 	if (current_cluster_builder) {
+		// Note: when rendering stereoscopic (multiview) we are using our combined frustum projection to create
+		// our cluster data. We use reprojection in the shader to adjust for our left/right eye.
+		// This only works as we don't filter our cluster by depth buffer.
+		// If we ever make this optimisation we should make it optional and only use it in mono.
+		// What we win by filtering out a few lights, we loose by having to do the work double for stereo.
 		current_cluster_builder->begin(p_render_data->scene_data->cam_transform, p_render_data->scene_data->cam_projection, !p_render_data->reflection_probe.is_valid());
 	}
 


### PR DESCRIPTION
When rendering in stereoscopic we're seeing decals being cutoff in our Forward+ renderer:
![image](https://github.com/godotengine/godot/assets/1945449/62aac1f5-cadb-4604-9442-522f976a2298)

This is caused by the way we filter which decals are processed when processing fragments. This is the bit that makes a forward+ renderer a forward+ renderer. In a pre-process we divide the screen into "tiles" and for each tile we determine which lights and decals effect fragments within that tile. It's a very efficient way of doing this however for multiview the current solution does this only in "combined frustum" space. As we lookup our tiles when rendering one of our eyes, we're lookup the wrong tile causing us to only partially see our decals.

Note that this issue also effects lights but it is often harder to spot.

This PR fixes this issue by performing an extra projection of our vertex in combined frustum space and using that to look up the correct tile.
![image](https://github.com/godotengine/godot/assets/1945449/570e6c4e-2a5c-45c7-867e-d26eed489441)

**Note**: this "reprojection" only works because we do not take the depth buffer into account while building our light cluster data. Using the depth buffer is an often used optimisation which would be possible if we move the cluster logic after our depth pre-pass. This would allow us to filter out lights/decals that are obscured and give a tiny potential performance boost.
IF we ever decide to implement this we need to make this optional as it will break the reprojection trick as lights/decals may be obscured in our combined frustum but not in one of the eyes. 

Sample project: 
[TestStereoDecal.zip](https://github.com/godotengine/godot/files/11811283/TestStereoDecal.zip)

Fixes #60680