### PR TITLE
Hide breakpoint indicator when mouse leaves CodeEdit

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -220,6 +220,10 @@ void CodeEdit::_notification(int p_what) {
 		case NOTIFICATION_DRAG_BEGIN: {
 			cancel_code_completion();
 		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			queue_redraw();
+		} break;
 	}
 }
 


### PR DESCRIPTION
CodeEdit only redraws on some specific actions and when the caret blinks. It also needs to redraw when the mouse exits it, because the breakpoint/bookmark indicators might not hide otherwise (i.e. if the mouse moves from the gutter area to outside of the CodeEdit in a single frame)

Addresses subpoint 3 in #65517

(I tested that it works)