### PR TITLE
Ensure `RID`, `Callable`, and `Signal` are stored as strings

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1379,6 +1379,7 @@
 				    "b": 2
 				}
 				[/codeblock]
+				[b]Note:[/b] Converting [Signal] or [Callable] is not supported and will result in an empty value for these types, regardless of their data.
 			</description>
 		</method>
 		<method name="weakref">

--- a/doc/classes/CharFXTransform.xml
+++ b/doc/classes/CharFXTransform.xml
@@ -25,7 +25,7 @@
 			{"foo": "hello", "bar": true, "baz": 42, "color": Color(1, 1, 1, 1)}
 			[/codeblock]
 		</member>
-		<member name="font" type="RID" setter="set_font" getter="get_font">
+		<member name="font" type="RID" setter="set_font" getter="get_font" default="RID()">
 			Font resource used to render glyph.
 		</member>
 		<member name="glyph_count" type="int" setter="set_glyph_count" getter="get_glyph_count" default="0">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -188,8 +188,8 @@
 			<return type="int" />
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="label" type="String" />
-			<param index="2" name="callback" type="Callable" />
-			<param index="3" name="key_callback" type="Callable" />
+			<param index="2" name="callback" type="Callable" default="Callable()" />
+			<param index="3" name="key_callback" type="Callable" default="Callable()" />
 			<param index="4" name="tag" type="Variant" default="null" />
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />
@@ -211,8 +211,8 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="icon" type="Texture2D" />
 			<param index="2" name="label" type="String" />
-			<param index="3" name="callback" type="Callable" />
-			<param index="4" name="key_callback" type="Callable" />
+			<param index="3" name="callback" type="Callable" default="Callable()" />
+			<param index="4" name="key_callback" type="Callable" default="Callable()" />
 			<param index="5" name="tag" type="Variant" default="null" />
 			<param index="6" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="7" name="index" type="int" default="-1" />
@@ -234,8 +234,8 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="icon" type="Texture2D" />
 			<param index="2" name="label" type="String" />
-			<param index="3" name="callback" type="Callable" />
-			<param index="4" name="key_callback" type="Callable" />
+			<param index="3" name="callback" type="Callable" default="Callable()" />
+			<param index="4" name="key_callback" type="Callable" default="Callable()" />
 			<param index="5" name="tag" type="Variant" default="null" />
 			<param index="6" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="7" name="index" type="int" default="-1" />
@@ -257,8 +257,8 @@
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="icon" type="Texture2D" />
 			<param index="2" name="label" type="String" />
-			<param index="3" name="callback" type="Callable" />
-			<param index="4" name="key_callback" type="Callable" />
+			<param index="3" name="callback" type="Callable" default="Callable()" />
+			<param index="4" name="key_callback" type="Callable" default="Callable()" />
 			<param index="5" name="tag" type="Variant" default="null" />
 			<param index="6" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="7" name="index" type="int" default="-1" />
@@ -280,8 +280,8 @@
 			<return type="int" />
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="label" type="String" />
-			<param index="2" name="callback" type="Callable" />
-			<param index="3" name="key_callback" type="Callable" />
+			<param index="2" name="callback" type="Callable" default="Callable()" />
+			<param index="3" name="key_callback" type="Callable" default="Callable()" />
 			<param index="4" name="tag" type="Variant" default="null" />
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />
@@ -304,8 +304,8 @@
 			<param index="1" name="label" type="String" />
 			<param index="2" name="max_states" type="int" />
 			<param index="3" name="default_state" type="int" />
-			<param index="4" name="callback" type="Callable" />
-			<param index="5" name="key_callback" type="Callable" />
+			<param index="4" name="callback" type="Callable" default="Callable()" />
+			<param index="5" name="key_callback" type="Callable" default="Callable()" />
 			<param index="6" name="tag" type="Variant" default="null" />
 			<param index="7" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="8" name="index" type="int" default="-1" />
@@ -328,8 +328,8 @@
 			<return type="int" />
 			<param index="0" name="menu_root" type="String" />
 			<param index="1" name="label" type="String" />
-			<param index="2" name="callback" type="Callable" />
-			<param index="3" name="key_callback" type="Callable" />
+			<param index="2" name="callback" type="Callable" default="Callable()" />
+			<param index="3" name="key_callback" type="Callable" default="Callable()" />
 			<param index="4" name="tag" type="Variant" default="null" />
 			<param index="5" name="accelerator" type="int" enum="Key" default="0" />
 			<param index="6" name="index" type="int" default="-1" />

--- a/doc/classes/NavigationMeshGenerator.xml
+++ b/doc/classes/NavigationMeshGenerator.xml
@@ -26,7 +26,7 @@
 			<return type="void" />
 			<param index="0" name="navigation_mesh" type="NavigationMesh" />
 			<param index="1" name="source_geometry_data" type="NavigationMeshSourceGeometryData3D" />
-			<param index="2" name="callback" type="Callable" />
+			<param index="2" name="callback" type="Callable" default="Callable()" />
 			<description>
 				Bakes the provided [param navigation_mesh] with the data from the provided [param source_geometry_data]. After the process is finished the optional [param callback] will be called.
 			</description>
@@ -43,7 +43,7 @@
 			<param index="0" name="navigation_mesh" type="NavigationMesh" />
 			<param index="1" name="source_geometry_data" type="NavigationMeshSourceGeometryData3D" />
 			<param index="2" name="root_node" type="Node" />
-			<param index="3" name="callback" type="Callable" />
+			<param index="3" name="callback" type="Callable" default="Callable()" />
 			<description>
 				Parses the [SceneTree] for source geometry according to the properties of [param navigation_mesh]. Updates the provided [param source_geometry_data] resource with the resulting data. The resource can then be used to bake a navigation mesh with [method bake_from_source_geometry_data]. After the process is finished the optional [param callback] will be called.
 				[b]Note:[/b] This function needs to run on the main thread or with a deferred call as the SceneTree is not thread-safe.

--- a/doc/classes/NavigationPathQueryParameters2D.xml
+++ b/doc/classes/NavigationPathQueryParameters2D.xml
@@ -10,7 +10,7 @@
 		<link title="Using NavigationPathQueryObjects">$DOCS_URL/tutorials/navigation/navigation_using_navigationpathqueryobjects.html</link>
 	</tutorials>
 	<members>
-		<member name="map" type="RID" setter="set_map" getter="get_map">
+		<member name="map" type="RID" setter="set_map" getter="get_map" default="RID()">
 			The navigation [code]map[/code] [RID] used in the path query.
 		</member>
 		<member name="metadata_flags" type="int" setter="set_metadata_flags" getter="get_metadata_flags" enum="NavigationPathQueryParameters2D.PathMetadataFlags" is_bitfield="true" default="7">

--- a/doc/classes/NavigationPathQueryParameters3D.xml
+++ b/doc/classes/NavigationPathQueryParameters3D.xml
@@ -10,7 +10,7 @@
 		<link title="Using NavigationPathQueryObjects">$DOCS_URL/tutorials/navigation/navigation_using_navigationpathqueryobjects.html</link>
 	</tutorials>
 	<members>
-		<member name="map" type="RID" setter="set_map" getter="get_map">
+		<member name="map" type="RID" setter="set_map" getter="get_map" default="RID()">
 			The navigation [code]map[/code] [RID] used in the path query.
 		</member>
 		<member name="metadata_flags" type="int" setter="set_metadata_flags" getter="get_metadata_flags" enum="NavigationPathQueryParameters3D.PathMetadataFlags" is_bitfield="true" default="7">

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -803,7 +803,7 @@
 			<param index="1" name="anchor_a" type="Vector2" />
 			<param index="2" name="anchor_b" type="Vector2" />
 			<param index="3" name="body_a" type="RID" />
-			<param index="4" name="body_b" type="RID" />
+			<param index="4" name="body_b" type="RID" default="RID()" />
 			<description>
 				Makes the joint a damped spring joint, attached at the point [param anchor_a] (given in global coordinates) on the body [param body_a] and at the point [param anchor_b] (given in global coordinates) on the body [param body_b]. To set the parameters which are specific to the damped spring, see [method damped_spring_joint_set_param].
 			</description>
@@ -814,8 +814,8 @@
 			<param index="1" name="groove1_a" type="Vector2" />
 			<param index="2" name="groove2_a" type="Vector2" />
 			<param index="3" name="anchor_b" type="Vector2" />
-			<param index="4" name="body_a" type="RID" />
-			<param index="5" name="body_b" type="RID" />
+			<param index="4" name="body_a" type="RID" default="RID()" />
+			<param index="5" name="body_b" type="RID" default="RID()" />
 			<description>
 				Makes the joint a groove joint.
 			</description>
@@ -825,7 +825,7 @@
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="anchor" type="Vector2" />
 			<param index="2" name="body_a" type="RID" />
-			<param index="3" name="body_b" type="RID" />
+			<param index="3" name="body_b" type="RID" default="RID()" />
 			<description>
 				Makes the joint a pin joint. If [param body_b] is [code]RID()[/code], then [param body_a] is pinned to the point [param anchor] (given in global coordinates); otherwise, [param body_a] is pinned to [param body_b] at the point [param anchor] (given in global coordinates). To set the parameters which are specific to the pin joint, see [method pin_joint_set_param].
 			</description>

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -30,7 +30,7 @@
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape2D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
 		</member>
-		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
+		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -30,7 +30,7 @@
 		<member name="shape" type="Resource" setter="set_shape" getter="get_shape">
 			The [Shape3D] that will be used for collision/intersection queries. This stores the actual reference which avoids the shape to be released while being used for queries, so always prefer using this over [member shape_rid].
 		</member>
-		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid">
+		<member name="shape_rid" type="RID" setter="set_shape_rid" getter="get_shape_rid" default="RID()">
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -240,7 +240,7 @@
 			<param index="1" name="mesh" type="RID" />
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="modulate" type="Color" default="Color(1, 1, 1, 1)" />
-			<param index="4" name="texture" type="RID" />
+			<param index="4" name="texture" type="RID" default="RID()" />
 			<description>
 				Draws a mesh created with [method mesh_create] with given [param transform], [param modulate] color, and [param texture]. This is used internally by [MeshInstance2D].
 			</description>
@@ -273,7 +273,7 @@
 			<return type="void" />
 			<param index="0" name="item" type="RID" />
 			<param index="1" name="mesh" type="RID" />
-			<param index="2" name="texture" type="RID" />
+			<param index="2" name="texture" type="RID" default="RID()" />
 			<description>
 				Draws a 2D [MultiMesh] on the [CanvasItem] pointed to by the [param item] [RID]. See also [method CanvasItem.draw_multimesh].
 			</description>
@@ -309,7 +309,7 @@
 			<param index="1" name="points" type="PackedVector2Array" />
 			<param index="2" name="colors" type="PackedColorArray" />
 			<param index="3" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
-			<param index="4" name="texture" type="RID" />
+			<param index="4" name="texture" type="RID" default="RID()" />
 			<description>
 				Draws a 2D polygon on the [CanvasItem] pointed to by the [param item] [RID]. If you need more flexibility (such as being able to use bones), use [method canvas_item_add_triangle_array] instead. See also [method CanvasItem.draw_polygon].
 			</description>
@@ -387,7 +387,7 @@
 			<param index="4" name="uvs" type="PackedVector2Array" default="PackedVector2Array()" />
 			<param index="5" name="bones" type="PackedInt32Array" default="PackedInt32Array()" />
 			<param index="6" name="weights" type="PackedFloat32Array" default="PackedFloat32Array()" />
-			<param index="7" name="texture" type="RID" />
+			<param index="7" name="texture" type="RID" default="RID()" />
 			<param index="8" name="count" type="int" default="-1" />
 			<description>
 				Draws a triangle array on the [CanvasItem] pointed to by the [param item] [RID]. This is internally used by [Line2D] and [StyleBoxFlat] for rendering. [method canvas_item_add_triangle_array] is highly flexible, but more complex to use than [method canvas_item_add_polygon].
@@ -1797,7 +1797,7 @@
 		<method name="instances_cull_aabb" qualifiers="const">
 			<return type="PackedInt64Array" />
 			<param index="0" name="aabb" type="AABB" />
-			<param index="1" name="scenario" type="RID" />
+			<param index="1" name="scenario" type="RID" default="RID()" />
 			<description>
 				Returns an array of object IDs intersecting with the provided AABB. Only 3D nodes that inherit from [VisualInstance3D] are considered, such as [MeshInstance3D] or [DirectionalLight3D]. Use [method @GlobalScope.instance_from_id] to obtain the actual nodes. A scenario RID must be provided, which is available in the [World3D] you want to query. This forces an update for all resources queued to update.
 				[b]Warning:[/b] This function is primarily intended for editor usage. For in-game use cases, prefer physics collision.
@@ -1806,7 +1806,7 @@
 		<method name="instances_cull_convex" qualifiers="const">
 			<return type="PackedInt64Array" />
 			<param index="0" name="convex" type="Plane[]" />
-			<param index="1" name="scenario" type="RID" />
+			<param index="1" name="scenario" type="RID" default="RID()" />
 			<description>
 				Returns an array of object IDs intersecting with the provided convex shape. Only 3D nodes that inherit from [VisualInstance3D] are considered, such as [MeshInstance3D] or [DirectionalLight3D]. Use [method @GlobalScope.instance_from_id] to obtain the actual nodes. A scenario RID must be provided, which is available in the [World3D] you want to query. This forces an update for all resources queued to update.
 				[b]Warning:[/b] This function is primarily intended for editor usage. For in-game use cases, prefer physics collision.
@@ -1816,7 +1816,7 @@
 			<return type="PackedInt64Array" />
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
-			<param index="2" name="scenario" type="RID" />
+			<param index="2" name="scenario" type="RID" default="RID()" />
 			<description>
 				Returns an array of object IDs intersecting with the provided 3D ray. Only 3D nodes that inherit from [VisualInstance3D] are considered, such as [MeshInstance3D] or [DirectionalLight3D]. Use [method @GlobalScope.instance_from_id] to obtain the actual nodes. A scenario RID must be provided, which is available in the [World3D] you want to query. This forces an update for all resources queued to update.
 				[b]Warning:[/b] This function is primarily intended for editor usage. For in-game use cases, prefer physics collision.

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -6,6 +6,36 @@ should instead be used to justify these changes and describe how users should wo
 
 ========================================================================================================================
 
+GH-78517
+--------
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_check_item/arguments/2': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_check_item/arguments/4': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_item/arguments/4': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_radio_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_radio_check_item/arguments/4': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_item/arguments/2': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_multistate_item/arguments/4': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_multistate_item/arguments/5': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_radio_check_item/arguments/2': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_radio_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/joint_make_damped_spring/arguments/4': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/joint_make_groove/arguments/4': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/joint_make_groove/arguments/5': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/joint_make_pin/arguments/3': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/canvas_item_add_mesh/arguments/4': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/canvas_item_add_multimesh/arguments/2': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/canvas_item_add_polygon/arguments/4': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/canvas_item_add_triangle_array/arguments/7': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/instances_cull_aabb/arguments/1': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/instances_cull_convex/arguments/1': default_value changed value in new API, from "" to "RID()".
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/instances_cull_ray/arguments/2': default_value changed value in new API, from "" to "RID()".
+
+The previous argument was a serialization bug, there's no actual API change.
+
 GH-78237
 --------
 Validate extension JSON: Error: Field 'classes/WebRTCPeerConnectionExtension/methods/_create_data_channel/return_value': type changed value in new API, from "Object" to "WebRTCDataChannel".

--- a/modules/multiplayer/doc_classes/MultiplayerSpawner.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSpawner.xml
@@ -47,7 +47,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="spawn_function" type="Callable" setter="set_spawn_function" getter="get_spawn_function">
+		<member name="spawn_function" type="Callable" setter="set_spawn_function" getter="get_spawn_function" default="Callable()">
 			Method called on all peers when for every custom [method spawn] requested by the authority. Will receive the [code]data[/code] parameter, and should return a [Node] that is not in the scene tree.
 			[b]Note:[/b] The returned node should [b]not[/b] be added to the scene with [method Node.add_child]. This is done automatically.
 		</member>

--- a/modules/multiplayer/doc_classes/SceneMultiplayer.xml
+++ b/modules/multiplayer/doc_classes/SceneMultiplayer.xml
@@ -64,7 +64,7 @@
 			If [code]true[/code], the MultiplayerAPI will allow encoding and decoding of object during RPCs.
 			[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threat such as remote code execution.
 		</member>
-		<member name="auth_callback" type="Callable" setter="set_auth_callback" getter="get_auth_callback">
+		<member name="auth_callback" type="Callable" setter="set_auth_callback" getter="get_auth_callback" default="Callable()">
 			The callback to execute when when receiving authentication data sent via [method send_auth]. If the [Callable] is empty (default), peers will be automatically accepted as soon as they connect.
 		</member>
 		<member name="auth_timeout" type="float" setter="set_auth_timeout" getter="get_auth_timeout" default="3.0">


### PR DESCRIPTION
Prevents parser errors in `.tscn` and `.tres` files where the assignment would otherwise be empty.

Using just `RID()` instead of storing the value, might do so only for the empty `RID`, it is required for default values to work in `GDExtension` as `RID`s cannot be created from integers just like in `GDScript`, but since we weren't serializing them at all anyway I went for a simple solution. This also fixes that serializing an array containing any of these types is broken with `var_to_str`, currently `var_to_str([Callable(), Signal(), RID()])`, results in `[, , ]`, now it will instead give `[Callable(), Signal(), RID()]`, though it does so regardless of the value, not attempting to serialize, but `var_to_str` doesn't handle references anyway as it is.

This also fixes hints in the editor, where before hints for these types for functions with defaults would not print anything.

We should probably not serialize these types on default in `GDScript` exports, but I don't know how to approach that so just fixing the immediate issue here to start with.

* Fixes: #78380 (Fixes the immediate issue)
* Fixes: #64442
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
