### PR TITLE
Fix errors destroying script with static variables

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1542,7 +1542,7 @@ GDScript::~GDScript() {
 	{
 		MutexLock lock(GDScriptLanguage::get_singleton()->mutex);
 
-		GDScriptLanguage::get_singleton()->script_list.remove(&script_list);
+		script_list.remove_from_list();
 	}
 }
 


### PR DESCRIPTION
Fixes #78376

After #78138 `script_list` is now cleared in `GDScriptLanguage::finish`. Because of that, we can safely remove the removal from that list that happens on `GDScript::~GDScript`. This removal was what was causing the error in #78376, since it was trying to remove an element from an empty list.

I tested by running a script that contained a static var declaration. After applying these changes, the `USER ERROR: Condition "p_elem->_root != this" is true.` no longer appears in the console while closing the project.