### PR TITLE
Improve string drawing in the tiledata editor

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1185,19 +1185,18 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 		int font_size = TileSetEditor::get_singleton()->get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 		String text;
+		// Round floating point precision to 2 digits, as tiles don't have that much space.
 		switch (value.get_type()) {
-			case Variant::INT:
-				text = vformat("%d", value);
-				break;
 			case Variant::FLOAT:
 				text = vformat("%.2f", value);
 				break;
-			case Variant::STRING:
-			case Variant::STRING_NAME:
-				text = value;
+			case Variant::VECTOR2:
+			case Variant::VECTOR3:
+			case Variant::VECTOR4:
+				text = vformat("%.2v", value);
 				break;
 			default:
-				return;
+				text = value.stringify();
 				break;
 		}
 
@@ -1216,8 +1215,8 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 		}
 
 		Vector2 string_size = font->get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size);
-		p_canvas_item->draw_string_outline(font, p_transform.xform(-texture_origin) + Vector2i(-string_size.x / 2, string_size.y / 2), text, HORIZONTAL_ALIGNMENT_CENTER, string_size.x, font_size, 1, Color(0, 0, 0, 1));
-		p_canvas_item->draw_string(font, p_transform.xform(-texture_origin) + Vector2i(-string_size.x / 2, string_size.y / 2), text, HORIZONTAL_ALIGNMENT_CENTER, string_size.x, font_size, color);
+		p_canvas_item->draw_string_outline(font, p_transform.xform(-texture_origin) + Vector2i(-string_size.x / 2, string_size.y / 4), text, HORIZONTAL_ALIGNMENT_CENTER, string_size.x, font_size, 3, Color(0, 0, 0));
+		p_canvas_item->draw_string(font, p_transform.xform(-texture_origin) + Vector2i(-string_size.x / 2, string_size.y / 4), text, HORIZONTAL_ALIGNMENT_CENTER, string_size.x, font_size, color);
 	}
 }
 


### PR DESCRIPTION
This PR makes 3 improvements to tiledata strings:
* Bump them up a little so they are vertically right in the middle, not a little under. (solution might not be ideal, but seems to look fine for our default font)
* Thicken the outline. Size 1 is so small it's practically useless for discerning numbers on all backgrounds, should be at least 3.
* Handle all variant types gracefully.

AABB example:

![image](https://github.com/godotengine/godot/assets/85438892/bf253724-e01c-4f56-aea6-440617fb2500)

Vector3i example:

![image](https://github.com/godotengine/godot/assets/85438892/0768511d-d9d5-433b-8fa9-9057361259f9)

String example:

![image](https://github.com/godotengine/godot/assets/85438892/67aa895c-97ac-41e0-adb6-1f45900abed2)