### PR TITLE
Fix tooltip of enum value without description

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3184,10 +3184,11 @@ void EditorInspector::update_tree() {
 										if (val.enumeration == enum_name && !val.name.ends_with("_MAX")) {
 											const String enum_value = EditorPropertyNameProcessor::get_singleton()->process_name(val.name, EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 											// Prettify the enum value display, so that "<ENUM NAME>_<VALUE>" becomes "Value".
+											String desc = DTR(val.description).trim_prefix("\n");
 											doc_info.description += vformat(
 													"\n[b]%s:[/b] %s",
 													enum_value.trim_prefix(EditorPropertyNameProcessor::get_singleton()->process_name(enum_name, EditorPropertyNameProcessor::STYLE_CAPITALIZED) + " "),
-													DTR(val.description).trim_prefix("\n"));
+													desc.is_empty() ? ("[i]" + TTR("No description.") + "[/i]") : desc);
 										}
 									}
 								}


### PR DESCRIPTION
Default enum descriptions to [i]No description.[/i] if empty.

![image](https://github.com/godotengine/godot/assets/85438892/64a90f7b-28fa-4972-be28-64c60d6a0645)