### PR TITLE
Unify debug/non-debug behavior of `ClassDB::get_method_info()`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -462,11 +462,11 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 			continue;
 		}
 
-#ifdef DEBUG_METHODS_ENABLED
-
 		for (const MethodInfo &E : type->virtual_methods) {
 			p_methods->push_back(E);
 		}
+
+#ifdef DEBUG_METHODS_ENABLED
 
 		for (const StringName &E : type->method_order) {
 			if (p_exclude_from_properties && type->methods_in_properties.has(E)) {
@@ -512,7 +512,6 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			continue;
 		}
 
-#ifdef DEBUG_METHODS_ENABLED
 		MethodBind **method = type->method_map.getptr(p_method);
 		if (method && *method) {
 			if (r_info != nullptr) {
@@ -526,16 +525,6 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			}
 			return true;
 		}
-#else
-		if (type->method_map.has(p_method)) {
-			if (r_info) {
-				MethodBind *m = type->method_map[p_method];
-				MethodInfo minfo = info_from_bind(m);
-				*r_info = minfo;
-			}
-			return true;
-		}
-#endif
 
 		if (p_no_inheritance) {
 			break;
@@ -1465,7 +1454,6 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 
 	OBJTYPE_WLOCK;
 
-#ifdef DEBUG_METHODS_ENABLED
 	MethodInfo mi = p_method;
 	if (p_virtual) {
 		mi.flags |= METHOD_FLAG_VIRTUAL;
@@ -1490,14 +1478,10 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 	}
 	classes[p_class].virtual_methods.push_back(mi);
 	classes[p_class].virtual_methods_map[p_method.name] = mi;
-
-#endif
 }
 
 void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance) {
 	ERR_FAIL_COND_MSG(!classes.has(p_class), "Request for nonexistent class '" + p_class + "'.");
-
-#ifdef DEBUG_METHODS_ENABLED
 
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
@@ -1511,8 +1495,6 @@ void ClassDB::get_virtual_methods(const StringName &p_class, List<MethodInfo> *p
 		}
 		check = check->inherits_ptr;
 	}
-
-#endif
 }
 
 void ClassDB::set_class_enabled(const StringName &p_class, bool p_enable) {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -116,12 +116,12 @@ public:
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
+		List<MethodInfo> virtual_methods;
+		HashMap<StringName, MethodInfo> virtual_methods_map;
 #ifdef DEBUG_METHODS_ENABLED
 		List<StringName> constant_order;
 		List<StringName> method_order;
 		HashSet<StringName> methods_in_properties;
-		List<MethodInfo> virtual_methods;
-		HashMap<StringName, MethodInfo> virtual_methods_map;
 		HashMap<StringName, Vector<Error>> method_error_values;
 		HashMap<StringName, List<StringName>> linked_properties;
 #endif


### PR DESCRIPTION
Currently only debug builds allow `ClassDB::get_method_info()` to check for virtual methods. As a result, debug builds will not generate errors when e.g. calling virtual methods (meant to act as a no-op). Non-debug builds, however, will complain that those methods do not exist, when they should also behave as a no-op.

Fixes #76938 (again).

This is failing release builds because the information about virtual methods currently does not get stored in release builds. For this to work, we'd need to store that information, which doesn't feel great - but there might not be a way around that.

Thoughts?

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
