### PR TITLE
Remove unnecessary value assignments throughout the codebase

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -875,8 +875,6 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
 
-	float preview_len = preview->get_length();
-
 	int pixel_total_len = len * p_pixels_sec;
 
 	len -= end_ofs;
@@ -918,7 +916,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 	Vector<Vector2> points;
 	points.resize((to_x - from_x) * 2);
-	preview_len = preview->get_length();
+	float preview_len = preview->get_length();
 
 	for (int i = from_x; i < to_x; i++) {
 		float ofs = (i - pixel_begin) * preview_len / pixel_total_len;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -308,7 +308,7 @@ void EditorHelp::_add_type(const String &p_type, const String &p_enum, bool p_is
 	bool can_ref = !p_type.contains("*") || is_enum_type;
 
 	String link_t = p_type; // For links in metadata
-	String display_t = link_t; // For display purposes
+	String display_t; // For display purposes.
 	if (is_enum_type) {
 		link_t = p_enum; // The link for enums is always the full enum description
 		display_t = _contextualize_class_specifier(p_enum, edited_class);

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -88,7 +88,7 @@ void AndroidInputHandler::process_key_event(int p_physical_keycode, int p_unicod
 	ev.instantiate();
 
 	Key physical_keycode = godot_code_from_android_code(p_physical_keycode);
-	Key keycode = physical_keycode;
+	Key keycode;
 	if (unicode == '\b') { // 0x08
 		keycode = Key::BACKSPACE;
 	} else if (unicode == '\t') { // 0x09

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1265,9 +1265,6 @@ void ItemList::_notification(int p_what) {
 
 						if (rtl) {
 							text_ofs.x = size.width - width;
-						}
-
-						if (rtl) {
 							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 						} else {
 							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_LEFT);

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -453,7 +453,7 @@ void MenuBar::_draw_menu_item(int p_index) {
 	}
 
 	Color color;
-	Ref<StyleBox> style = theme_cache.normal;
+	Ref<StyleBox> style;
 	Rect2 item_rect = _get_menu_item_rect(p_index);
 
 	if (menu_cache[p_index].disabled) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1718,11 +1718,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.last_mouse_focus = gui.mouse_focus;
 
 				if (!gui.mouse_focus) {
-					gui.mouse_focus_mask.clear();
 					return;
 				}
 
-				gui.mouse_focus_mask.clear();
 				gui.mouse_focus_mask.set_flag(mouse_button_to_mask(mb->get_button_index()));
 
 				if (mb->get_button_index() == MouseButton::LEFT) {

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -77,10 +77,9 @@ SSEffects::SSEffects() {
 		for (int pass = 0; pass < 4; pass++) {
 			for (int subPass = 0; subPass < sub_pass_count; subPass++) {
 				int a = pass;
-				int b = subPass;
 
 				int spmap[5]{ 0, 1, 4, 3, 2 };
-				b = spmap[subPass];
+				int b = spmap[subPass];
 
 				float ca, sa;
 				float angle0 = (float(a) + float(b) / float(sub_pass_count)) * Math_PI * 0.5f;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -909,7 +909,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					//its a uniform!
 					const ShaderLanguage::ShaderNode::Uniform &u = shader->uniforms[vnode->name];
 					if (u.texture_order >= 0) {
-						StringName name = vnode->name;
+						StringName name;
 						if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_SCREEN_TEXTURE) {
 							name = "color_buffer";
 							if (u.filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP) {


### PR DESCRIPTION
CPPcheck found most of them.

no need to assign the variable twice:
- AnimationTrackEditTypeAudio
- SSEffects

variable is assigned in all if-else clauses:
- EditorHelp
- AndroidInputHandler
- MenuBar
- ShaderCompiler

same if clause:
- ItemList

clearing an empty bitfield has no effect:
- Viewport
