### PR TITLE
[WIP] Added stencil function and depth function

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -150,6 +150,9 @@
 		<member name="depth_draw_mode" type="int" setter="set_depth_draw_mode" getter="get_depth_draw_mode" enum="BaseMaterial3D.DepthDrawMode" default="0">
 			Determines when depth rendering takes place. See [enum DepthDrawMode]. See also [member transparency].
 		</member>
+		<member name="depth_function" type="int" setter="set_depth_function" getter="get_depth_function" enum="BaseMaterial3D.DepthFunction" default="0">
+			Determines which comparison operator is used when testing depth. See [enum DepthFunction].
+		</member>
 		<member name="detail_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies the color of the detail overlay. [member detail_albedo]'s alpha channel is used as a mask, even when the material is opaque. To use a dedicated texture as a mask, see [member detail_mask].
 			[b]Note:[/b] [member detail_albedo] is [i]not[/i] modulated by [member albedo_color].
@@ -355,6 +358,20 @@
 			The method for rendering the specular blob. See [enum SpecularMode].
 			[b]Note:[/b] [member specular_mode] only applies to the specular blob. It does not affect specular reflections from the sky, screen-space reflections, [VoxelGI], SDFGI or [ReflectionProbe]s. To disable reflections from these sources as well, set [member metallic_specular] to [code]0.0[/code] instead.
 		</member>
+		<member name="stencil_bit" type="int" setter="set_stencil_bit" getter="get_stencil_bit" default="0">
+		</member>
+		<member name="stencil_compare" type="int" setter="set_stencil_compare" getter="get_stencil_compare" enum="BaseMaterial3D.StencilCompareOperator" default="0">
+		</member>
+		<member name="stencil_depth_fail" type="int" setter="set_stencil_depth_fail" getter="get_stencil_depth_fail" enum="BaseMaterial3D.StencilOperation" default="0">
+		</member>
+		<member name="stencil_enabled" type="bool" setter="set_stencil_enabled" getter="is_stencil_enabled" default="false">
+		</member>
+		<member name="stencil_fail" type="int" setter="set_stencil_fail" getter="get_stencil_fail" enum="BaseMaterial3D.StencilOperation" default="0">
+		</member>
+		<member name="stencil_pass" type="int" setter="set_stencil_pass" getter="get_stencil_pass" enum="BaseMaterial3D.StencilOperation" default="0">
+		</member>
+		<member name="stencil_reference" type="int" setter="set_stencil_reference" getter="get_stencil_reference" default="1">
+		</member>
 		<member name="subsurf_scatter_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], subsurface scattering is enabled. Emulates light that penetrates an object's surface, is scattered, and then emerges. Subsurface scattering quality is controlled by [member ProjectSettings.rendering/environment/subsurface_scattering/subsurface_scattering_quality].
 		</member>
@@ -440,6 +457,10 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="STENCIL_BIT_MAX" value="7">
+		</constant>
+		<constant name="STENCIL_BIT_MIN" value="0">
+		</constant>
 		<constant name="TEXTURE_ALBEDO" value="0" enum="TextureParam">
 			Texture specifying per-pixel color.
 		</constant>
@@ -624,6 +645,30 @@
 		<constant name="DEPTH_DRAW_DISABLED" value="2" enum="DepthDrawMode">
 			Objects will not write their depth to the depth buffer, even during the depth prepass (if enabled).
 		</constant>
+		<constant name="DEPTH_FUNCTION_LESS_OR_EQUAL" value="0" enum="DepthFunction">
+			Default depth function. Depth check succeeds if less than or equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_LESS" value="1" enum="DepthFunction">
+			Depth check succeeds if less than existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_GREATER_OR_EQUAL" value="2" enum="DepthFunction">
+			Depth check succeeds if greater than or equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_GREATER" value="3" enum="DepthFunction">
+			Depth check succeeds if greater than existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_EQUAL" value="4" enum="DepthFunction">
+			Depth check succeeds if equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_NOT_EQUAL" value="5" enum="DepthFunction">
+			Depth check succeeds if not equal to existing depth.
+		</constant>
+		<constant name="DEPTH_FUNCTION_ALWAYS" value="6" enum="DepthFunction">
+			Depth check always succeeds.
+		</constant>
+		<constant name="DEPTH_FUNCTION_NEVER" value="7" enum="DepthFunction">
+			Depth check never succeeds.
+		</constant>
 		<constant name="CULL_BACK" value="0" enum="CullMode">
 			Default cull mode. The back of the object is culled when not visible. Back face triangles will be culled when facing the camera. This results in only the front side of triangles being drawn. For closed-surface meshes, this means that only the exterior of the mesh will be visible.
 		</constant>
@@ -766,6 +811,38 @@
 		</constant>
 		<constant name="DISTANCE_FADE_OBJECT_DITHER" value="3" enum="DistanceFadeMode">
 			Smoothly fades the object out based on the object's distance from the camera using a dithering approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware, this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA] and [constant DISTANCE_FADE_PIXEL_DITHER].
+		</constant>
+		<constant name="STENCIL_OP_KEEP" value="0" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_ZERO" value="1" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_REPLACE" value="2" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_INCREMENT_AND_CLAMP" value="3" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_DECREMENT_AND_CLAMP" value="4" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_INVERT" value="5" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_INCREMENT_AND_WRAP" value="6" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_OP_DECREMENT_AND_WRAP" value="7" enum="StencilOperation">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_NEVER" value="0" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_LESS" value="1" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_EQUAL" value="2" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_LESS_OR_EQUAL" value="3" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_GREATER" value="4" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_NOT_EQUAL" value="5" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_GREATER_OR_EQUAL" value="6" enum="StencilCompareOperator">
+		</constant>
+		<constant name="STENCIL_COMPARE_OP_ALWAYS" value="7" enum="StencilCompareOperator">
 		</constant>
 	</constants>
 </class>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2007,6 +2007,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		RENDER_TIMESTAMP("Render Sky");
 
 		glEnable(GL_DEPTH_TEST);
+		glDepthFunc(GL_LEQUAL);
+		glDepthMask(GL_FALSE);
 		glDisable(GL_BLEND);
 		glEnable(GL_CULL_FACE);
 		glCullFace(GL_BACK);
@@ -2161,6 +2163,22 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				}
 				scene_state.current_depth_test = shader->depth_test;
 			}
+		}
+
+		if (scene_state.current_depth_function != shader->depth_function) {
+			GLenum depth_function_table[GLES3::SceneShaderData::DEPTH_FUNCTION_MAX] = {
+				GL_LEQUAL,
+				GL_LESS,
+				GL_GEQUAL,
+				GL_GREATER,
+				GL_EQUAL,
+				GL_NOTEQUAL,
+				GL_ALWAYS,
+				GL_NEVER,
+			};
+
+			glDepthFunc(depth_function_table[shader->depth_function]);
+			scene_state.current_depth_function = shader->depth_function;
 		}
 
 		if (scene_state.current_depth_draw != shader->depth_draw) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -369,6 +369,7 @@ private:
 		GLES3::SceneShaderData::BlendMode current_blend_mode = GLES3::SceneShaderData::BLEND_MODE_MIX;
 		GLES3::SceneShaderData::DepthDraw current_depth_draw = GLES3::SceneShaderData::DEPTH_DRAW_OPAQUE;
 		GLES3::SceneShaderData::DepthTest current_depth_test = GLES3::SceneShaderData::DEPTH_TEST_DISABLED;
+		GLES3::SceneShaderData::DepthFunction current_depth_function = GLES3::SceneShaderData::DEPTH_FUNCTION_LESS_OR_EQUAL;
 		GLES3::SceneShaderData::Cull cull_mode = GLES3::SceneShaderData::CULL_BACK;
 
 		bool texscreen_copied = false;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2833,6 +2833,7 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	int blend_modei = BLEND_MODE_MIX;
 	int depth_testi = DEPTH_TEST_ENABLED;
+	int depth_functioni = DEPTH_FUNCTION_LESS_OR_EQUAL;
 	int alpha_antialiasing_modei = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = CULL_BACK;
 	int depth_drawi = DEPTH_DRAW_OPAQUE;
@@ -2878,6 +2879,15 @@ void SceneShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["depth_draw_always"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_ALWAYS);
 
 	actions.render_mode_values["depth_test_disabled"] = Pair<int *, int>(&depth_testi, DEPTH_TEST_DISABLED);
+
+	actions.render_mode_values["depth_function_lequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_gequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_notequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
 
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, CULL_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, CULL_FRONT);
@@ -2934,6 +2944,7 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
+	depth_function = DepthFunction(depth_functioni);
 	cull_mode = Cull(cull_modei);
 	blend_mode = BlendMode(blend_modei);
 	alpha_antialiasing_mode = AlphaAntiAliasing(alpha_antialiasing_modei);

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -252,6 +252,18 @@ struct SceneShaderData : public ShaderData {
 		DEPTH_TEST_ENABLED
 	};
 
+	enum DepthFunction {
+		DEPTH_FUNCTION_LESS_OR_EQUAL,
+		DEPTH_FUNCTION_LESS,
+		DEPTH_FUNCTION_GREATER_OR_EQUAL,
+		DEPTH_FUNCTION_GREATER,
+		DEPTH_FUNCTION_EQUAL,
+		DEPTH_FUNCTION_NOT_EQUAL,
+		DEPTH_FUNCTION_ALWAYS,
+		DEPTH_FUNCTION_NEVER,
+		DEPTH_FUNCTION_MAX
+	};
+
 	enum Cull {
 		CULL_DISABLED,
 		CULL_FRONT,
@@ -278,6 +290,7 @@ struct SceneShaderData : public ShaderData {
 	AlphaAntiAliasing alpha_antialiasing_mode;
 	DepthDraw depth_draw;
 	DepthTest depth_test;
+	DepthFunction depth_function;
 	Cull cull_mode;
 
 	bool uses_point_size;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -710,6 +710,35 @@ void BaseMaterial3D::_update_shader() {
 			break; // Internal value, skip.
 	}
 
+	switch (depth_function) {
+		case DEPTH_FUNCTION_LESS_OR_EQUAL:
+			code += ",depth_function_lequal";
+			break;
+		case DEPTH_FUNCTION_LESS:
+			code += ",depth_function_less";
+			break;
+		case DEPTH_FUNCTION_GREATER_OR_EQUAL:
+			code += ",depth_function_gequal";
+			break;
+		case DEPTH_FUNCTION_GREATER:
+			code += ",depth_function_greater";
+			break;
+		case DEPTH_FUNCTION_EQUAL:
+			code += ",depth_function_equal";
+			break;
+		case DEPTH_FUNCTION_NOT_EQUAL:
+			code += ",depth_function_notequal";
+			break;
+		case DEPTH_FUNCTION_ALWAYS:
+			code += ",depth_function_always";
+			break;
+		case DEPTH_FUNCTION_NEVER:
+			code += ",depth_function_never";
+			break;
+		case DEPTH_FUNCTION_MAX:
+			break; // Internal value, skip.
+	}
+
 	switch (cull_mode) {
 		case CULL_BACK:
 			code += ",cull_back";
@@ -792,6 +821,125 @@ void BaseMaterial3D::_update_shader() {
 		} else if (alpha_antialiasing_mode == ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE) {
 			code += ",alpha_to_coverage_and_one";
 		}
+	}
+
+	if (stencil_enabled) {
+		switch (stencil_compare) {
+			case STENCIL_COMPARE_OP_NEVER:
+				code += ",stencil_compare_never";
+				break;
+			case STENCIL_COMPARE_OP_LESS:
+				code += ",stencil_compare_less";
+				break;
+			case STENCIL_COMPARE_OP_EQUAL:
+				code += ",stencil_compare_equal";
+				break;
+			case STENCIL_COMPARE_OP_LESS_OR_EQUAL:
+				code += ",stencil_compare_lequal";
+				break;
+			case STENCIL_COMPARE_OP_GREATER:
+				code += ",stencil_compare_greater";
+				break;
+			case STENCIL_COMPARE_OP_NOT_EQUAL:
+				code += ",stencil_compare_notequal";
+				break;
+			case STENCIL_COMPARE_OP_GREATER_OR_EQUAL:
+				code += ",stencil_compare_gequal";
+				break;
+			case STENCIL_COMPARE_OP_ALWAYS:
+				code += ",stencil_compare_always";
+				break;
+			default:
+				break;
+		}
+
+		switch (stencil_fail) {
+			case STENCIL_OP_KEEP:
+				break;
+			case STENCIL_OP_ZERO:
+				code += ",stencil_fail_zero";
+				break;
+			case STENCIL_OP_REPLACE:
+				code += ",stencil_fail_replace";
+				break;
+			case STENCIL_OP_INCREMENT_AND_CLAMP:
+				code += ",stencil_fail_incclamp";
+				break;
+			case STENCIL_OP_DECREMENT_AND_CLAMP:
+				code += ",stencil_fail_decclamp";
+				break;
+			case STENCIL_OP_INVERT:
+				code += ",stencil_fail_invert";
+				break;
+			case STENCIL_OP_INCREMENT_AND_WRAP:
+				code += ",stencil_fail_incwrap";
+				break;
+			case STENCIL_OP_DECREMENT_AND_WRAP:
+				code += ",stencil_fail_decwrap";
+				break;
+			default:
+				break;
+		}
+
+		switch (stencil_pass) {
+			case STENCIL_OP_KEEP:
+				break;
+			case STENCIL_OP_ZERO:
+				code += ",stencil_pass_zero";
+				break;
+			case STENCIL_OP_REPLACE:
+				code += ",stencil_pass_replace";
+				break;
+			case STENCIL_OP_INCREMENT_AND_CLAMP:
+				code += ",stencil_pass_incclamp";
+				break;
+			case STENCIL_OP_DECREMENT_AND_CLAMP:
+				code += ",stencil_pass_decclamp";
+				break;
+			case STENCIL_OP_INVERT:
+				code += ",stencil_pass_invert";
+				break;
+			case STENCIL_OP_INCREMENT_AND_WRAP:
+				code += ",stencil_pass_incwrap";
+				break;
+			case STENCIL_OP_DECREMENT_AND_WRAP:
+				code += ",stencil_pass_decwrap";
+				break;
+			default:
+				break;
+		}
+
+		switch (stencil_depth_fail) {
+			case STENCIL_OP_KEEP:
+				break;
+			case STENCIL_OP_ZERO:
+				code += ",stencil_depthfail_zero";
+				break;
+			case STENCIL_OP_REPLACE:
+				code += ",stencil_depthfail_replace";
+				break;
+			case STENCIL_OP_INCREMENT_AND_CLAMP:
+				code += ",stencil_depthfail_incclamp";
+				break;
+			case STENCIL_OP_DECREMENT_AND_CLAMP:
+				code += ",stencil_depthfail_decclamp";
+				break;
+			case STENCIL_OP_INVERT:
+				code += ",stencil_depthfail_invert";
+				break;
+			case STENCIL_OP_INCREMENT_AND_WRAP:
+				code += ",stencil_depthfail_incwrap";
+				break;
+			case STENCIL_OP_DECREMENT_AND_WRAP:
+				code += ",stencil_depthfail_decwrap";
+				break;
+			default:
+				break;
+		}
+
+		code += vformat(",stencil_comparemask %s", 1 << stencil_bit);
+		code += vformat(",stencil_writemask %s", 1 << stencil_bit);
+		code += vformat(",stencil_reference %s", stencil_reference);
 	}
 
 	code += ";\n";
@@ -1824,6 +1972,19 @@ BaseMaterial3D::DepthDrawMode BaseMaterial3D::get_depth_draw_mode() const {
 	return depth_draw_mode;
 }
 
+void BaseMaterial3D::set_depth_function(DepthFunction p_func) {
+	if (depth_function == p_func) {
+		return;
+	}
+
+	depth_function = p_func;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::DepthFunction BaseMaterial3D::get_depth_function() const {
+	return depth_function;
+}
+
 void BaseMaterial3D::set_cull_mode(CullMode p_mode) {
 	if (cull_mode == p_mode) {
 		return;
@@ -2489,6 +2650,95 @@ BaseMaterial3D::EmissionOperator BaseMaterial3D::get_emission_operator() const {
 	return emission_op;
 }
 
+void BaseMaterial3D::set_stencil_enabled(bool p_stencil_enabled) {
+	if (stencil_enabled == p_stencil_enabled) {
+		return;
+	}
+
+	stencil_enabled = p_stencil_enabled;
+	_queue_shader_change();
+}
+
+bool BaseMaterial3D::is_stencil_enabled() const {
+	return stencil_enabled;
+}
+
+void BaseMaterial3D::set_stencil_fail(BaseMaterial3D::StencilOperation p_op) {
+	if (stencil_fail == p_op) {
+		return;
+	}
+
+	stencil_fail = p_op;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::StencilOperation BaseMaterial3D::get_stencil_fail() const {
+	return stencil_fail;
+}
+
+void BaseMaterial3D::set_stencil_pass(BaseMaterial3D::StencilOperation p_op) {
+	if (stencil_pass == p_op) {
+		return;
+	}
+
+	stencil_pass = p_op;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::StencilOperation BaseMaterial3D::get_stencil_pass() const {
+	return stencil_pass;
+}
+
+void BaseMaterial3D::set_stencil_depth_fail(BaseMaterial3D::StencilOperation p_op) {
+	if (stencil_depth_fail == p_op) {
+		return;
+	}
+
+	stencil_depth_fail = p_op;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::StencilOperation BaseMaterial3D::get_stencil_depth_fail() const {
+	return stencil_depth_fail;
+}
+
+void BaseMaterial3D::set_stencil_compare(BaseMaterial3D::StencilCompareOperator p_op) {
+	if (stencil_compare == p_op) {
+		return;
+	}
+
+	stencil_compare = p_op;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::StencilCompareOperator BaseMaterial3D::get_stencil_compare() const {
+	return stencil_compare;
+}
+
+void BaseMaterial3D::set_stencil_bit(int p_bit) {
+	if (stencil_bit == p_bit) {
+		return;
+	}
+
+	ERR_FAIL_COND(p_bit < STENCIL_BIT_MIN);
+	ERR_FAIL_COND(p_bit > STENCIL_BIT_MAX);
+
+	stencil_bit = p_bit;
+	_queue_shader_change();
+}
+
+int BaseMaterial3D::get_stencil_bit() const {
+	return stencil_bit;
+}
+
+void BaseMaterial3D::set_stencil_reference(int p_reference) {
+	stencil_reference = p_reference;
+	_queue_shader_change();
+}
+int BaseMaterial3D::get_stencil_reference() const {
+	return stencil_reference;
+}
+
 RID BaseMaterial3D::get_shader_rid() const {
 	MutexLock lock(material_mutex);
 	if (element.in_list()) { // _is_shader_dirty() would create anoder mutex lock
@@ -2588,6 +2838,9 @@ void BaseMaterial3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_depth_draw_mode", "depth_draw_mode"), &BaseMaterial3D::set_depth_draw_mode);
 	ClassDB::bind_method(D_METHOD("get_depth_draw_mode"), &BaseMaterial3D::get_depth_draw_mode);
+
+	ClassDB::bind_method(D_METHOD("set_depth_function", "depth_function"), &BaseMaterial3D::set_depth_function);
+	ClassDB::bind_method(D_METHOD("get_depth_function"), &BaseMaterial3D::get_depth_function);
 
 	ClassDB::bind_method(D_METHOD("set_cull_mode", "cull_mode"), &BaseMaterial3D::set_cull_mode);
 	ClassDB::bind_method(D_METHOD("get_cull_mode"), &BaseMaterial3D::get_cull_mode);
@@ -2709,6 +2962,27 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_distance_fade_min_distance", "distance"), &BaseMaterial3D::set_distance_fade_min_distance);
 	ClassDB::bind_method(D_METHOD("get_distance_fade_min_distance"), &BaseMaterial3D::get_distance_fade_min_distance);
 
+	ClassDB::bind_method(D_METHOD("set_stencil_enabled", "stencil_enabled"), &BaseMaterial3D::set_stencil_enabled);
+	ClassDB::bind_method(D_METHOD("is_stencil_enabled"), &BaseMaterial3D::is_stencil_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_fail", "stencil_fail"), &BaseMaterial3D::set_stencil_fail);
+	ClassDB::bind_method(D_METHOD("get_stencil_fail"), &BaseMaterial3D::get_stencil_fail);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_pass", "stencil_pass"), &BaseMaterial3D::set_stencil_pass);
+	ClassDB::bind_method(D_METHOD("get_stencil_pass"), &BaseMaterial3D::get_stencil_pass);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_depth_fail", "stencil_depth_fail"), &BaseMaterial3D::set_stencil_depth_fail);
+	ClassDB::bind_method(D_METHOD("get_stencil_depth_fail"), &BaseMaterial3D::get_stencil_depth_fail);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_compare", "stencil_compare"), &BaseMaterial3D::set_stencil_compare);
+	ClassDB::bind_method(D_METHOD("get_stencil_compare"), &BaseMaterial3D::get_stencil_compare);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_bit", "stencil_bit"), &BaseMaterial3D::set_stencil_bit);
+	ClassDB::bind_method(D_METHOD("get_stencil_bit"), &BaseMaterial3D::get_stencil_bit);
+
+	ClassDB::bind_method(D_METHOD("set_stencil_reference", "stencil_ref"), &BaseMaterial3D::set_stencil_reference);
+	ClassDB::bind_method(D_METHOD("get_stencil_reference"), &BaseMaterial3D::get_stencil_reference);
+
 	ADD_GROUP("Transparency", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transparency", PROPERTY_HINT_ENUM, "Disabled,Alpha,Alpha Scissor,Alpha Hash,Depth Pre-Pass"), "set_transparency", "get_transparency");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_scissor_threshold", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_alpha_scissor_threshold", "get_alpha_scissor_threshold");
@@ -2718,6 +2992,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never"), "set_depth_draw_mode", "get_depth_draw_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "depth_function", PROPERTY_HINT_ENUM, "Less or Equal,Less,Greater or Equal,Greater,Equal,Not Equal,Always,Never"), "set_depth_function", "get_depth_function");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "no_depth_test"), "set_flag", "get_flag", FLAG_DISABLE_DEPTH_TEST);
 
 	ADD_GROUP("Shading", "");
@@ -2882,6 +3157,18 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance_fade_min_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:m"), "set_distance_fade_min_distance", "get_distance_fade_min_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance_fade_max_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:m"), "set_distance_fade_max_distance", "get_distance_fade_max_distance");
 
+	ADD_GROUP("Stencil", "stencil_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stencil_enabled"), "set_stencil_enabled", "is_stencil_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_fail", PROPERTY_HINT_ENUM, "Keep,Zero,Replace,IncrementAndClamp,DecrementAndClamp,Invert,IncrementAndWrap,DecrementAndWrap"), "set_stencil_fail", "get_stencil_fail");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_pass", PROPERTY_HINT_ENUM, "Keep,Zero,Replace,IncrementAndClamp,DecrementAndClamp,Invert,IncrementAndWrap,DecrementAndWrap"), "set_stencil_pass", "get_stencil_pass");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_depth_fail", PROPERTY_HINT_ENUM, "Keep,Zero,Replace,IncrementAndClamp,DecrementAndClamp,Invert,IncrementAndWrap,DecrementAndWrap"), "set_stencil_depth_fail", "get_stencil_depth_fail");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_compare", PROPERTY_HINT_ENUM, "Never,Less,Equal,LessOrEqual,Greater,NotEqual,GreaterOrEqual,Always"), "set_stencil_compare", "get_stencil_compare");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_bit", PROPERTY_HINT_RANGE, itos(STENCIL_BIT_MIN) + "," + itos(STENCIL_BIT_MAX) + ",1"), "set_stencil_bit", "get_stencil_bit");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stencil_reference"), "set_stencil_reference", "get_stencil_reference");
+
+	BIND_CONSTANT(STENCIL_BIT_MAX);
+	BIND_CONSTANT(STENCIL_BIT_MIN);
+
 	BIND_ENUM_CONSTANT(TEXTURE_ALBEDO);
 	BIND_ENUM_CONSTANT(TEXTURE_METALLIC);
 	BIND_ENUM_CONSTANT(TEXTURE_ROUGHNESS);
@@ -2952,6 +3239,15 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_DISABLED);
 
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_LESS_OR_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_LESS);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_GREATER);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_NOT_EQUAL);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_ALWAYS);
+	BIND_ENUM_CONSTANT(DEPTH_FUNCTION_NEVER);
+
 	BIND_ENUM_CONSTANT(CULL_BACK);
 	BIND_ENUM_CONSTANT(CULL_FRONT);
 	BIND_ENUM_CONSTANT(CULL_DISABLED);
@@ -3006,6 +3302,24 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DISTANCE_FADE_PIXEL_ALPHA);
 	BIND_ENUM_CONSTANT(DISTANCE_FADE_PIXEL_DITHER);
 	BIND_ENUM_CONSTANT(DISTANCE_FADE_OBJECT_DITHER);
+
+	BIND_ENUM_CONSTANT(STENCIL_OP_KEEP);
+	BIND_ENUM_CONSTANT(STENCIL_OP_ZERO);
+	BIND_ENUM_CONSTANT(STENCIL_OP_REPLACE);
+	BIND_ENUM_CONSTANT(STENCIL_OP_INCREMENT_AND_CLAMP);
+	BIND_ENUM_CONSTANT(STENCIL_OP_DECREMENT_AND_CLAMP);
+	BIND_ENUM_CONSTANT(STENCIL_OP_INVERT);
+	BIND_ENUM_CONSTANT(STENCIL_OP_INCREMENT_AND_WRAP);
+	BIND_ENUM_CONSTANT(STENCIL_OP_DECREMENT_AND_WRAP);
+
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_NEVER);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_LESS);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_EQUAL);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_LESS_OR_EQUAL);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_GREATER);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_NOT_EQUAL);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_GREATER_OR_EQUAL);
+	BIND_ENUM_CONSTANT(STENCIL_COMPARE_OP_ALWAYS);
 }
 
 BaseMaterial3D::BaseMaterial3D(bool p_orm) :

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -53,6 +53,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	int blend_mode = BLEND_MODE_MIX;
 	int depth_testi = DEPTH_TEST_ENABLED;
+	int depth_functioni = DEPTH_FUNCTION_LESS_OR_EQUAL;
 	int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	int cull_modei = CULL_BACK;
 
@@ -79,6 +80,14 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	int depth_drawi = DEPTH_DRAW_OPAQUE;
 
+	int stencil_comparei = -1;
+	int stencil_faili = STENCIL_OP_KEEP;
+	int stencil_passi = STENCIL_OP_KEEP;
+	int stencil_depthfaili = STENCIL_OP_KEEP;
+	int stencil_comparemaski = 255;
+	int stencil_writemaski = 255;
+	int stencil_referencei = 1;
+
 	ShaderCompiler::IdentifierActions actions;
 	actions.entry_point_stages["vertex"] = ShaderCompiler::STAGE_VERTEX;
 	actions.entry_point_stages["fragment"] = ShaderCompiler::STAGE_FRAGMENT;
@@ -98,6 +107,15 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	actions.render_mode_values["depth_test_disabled"] = Pair<int *, int>(&depth_testi, DEPTH_TEST_DISABLED);
 
+	actions.render_mode_values["depth_function_lequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_gequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_notequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
+
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull_modei, CULL_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull_modei, CULL_FRONT);
 	actions.render_mode_values["cull_back"] = Pair<int *, int>(&cull_modei, CULL_BACK);
@@ -112,6 +130,46 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	actions.usage_flag_pointers["ALPHA_ANTIALIASING_EDGE"] = &uses_alpha_antialiasing;
 	actions.usage_flag_pointers["ALPHA_TEXTURE_COORDINATE"] = &uses_alpha_antialiasing;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_prepass_alpha;
+
+	actions.render_mode_values["stencil_compare_never"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_NEVER);
+	actions.render_mode_values["stencil_compare_less"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_LESS);
+	actions.render_mode_values["stencil_compare_equal"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_EQUAL);
+	actions.render_mode_values["stencil_compare_lequal"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_LESS_OR_EQUAL);
+	actions.render_mode_values["stencil_compare_greater"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_GREATER);
+	actions.render_mode_values["stencil_compare_notequal"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_NOT_EQUAL);
+	actions.render_mode_values["stencil_compare_gequal"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_GREATER_OR_EQUAL);
+	actions.render_mode_values["stencil_compare_always"] = Pair<int *, int>(&stencil_comparei, STENCIL_COMPARE_OP_ALWAYS);
+
+	actions.render_mode_values["stencil_fail_keep"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_KEEP);
+	actions.render_mode_values["stencil_fail_zero"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_ZERO);
+	actions.render_mode_values["stencil_fail_replace"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_REPLACE);
+	actions.render_mode_values["stencil_fail_incclamp"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_INCREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_fail_decclamp"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_DECREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_fail_invert"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_INVERT);
+	actions.render_mode_values["stencil_fail_incwrap"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_INCREMENT_AND_WRAP);
+	actions.render_mode_values["stencil_fail_decwrap"] = Pair<int *, int>(&stencil_faili, STENCIL_OP_DECREMENT_AND_WRAP);
+
+	actions.render_mode_values["stencil_pass_keep"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_KEEP);
+	actions.render_mode_values["stencil_pass_zero"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_ZERO);
+	actions.render_mode_values["stencil_pass_replace"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_REPLACE);
+	actions.render_mode_values["stencil_pass_incclamp"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_INCREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_pass_decclamp"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_DECREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_pass_invert"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_INVERT);
+	actions.render_mode_values["stencil_pass_incwrap"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_INCREMENT_AND_WRAP);
+	actions.render_mode_values["stencil_pass_decwrap"] = Pair<int *, int>(&stencil_passi, STENCIL_OP_DECREMENT_AND_WRAP);
+
+	actions.render_mode_values["stencil_depthfail_keep"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_KEEP);
+	actions.render_mode_values["stencil_depthfail_zero"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_ZERO);
+	actions.render_mode_values["stencil_depthfail_replace"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_REPLACE);
+	actions.render_mode_values["stencil_depthfail_incclamp"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_INCREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_depthfail_decclamp"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_DECREMENT_AND_CLAMP);
+	actions.render_mode_values["stencil_depthfail_invert"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_INVERT);
+	actions.render_mode_values["stencil_depthfail_incwrap"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_INCREMENT_AND_WRAP);
+	actions.render_mode_values["stencil_depthfail_decwrap"] = Pair<int *, int>(&stencil_depthfaili, STENCIL_OP_DECREMENT_AND_WRAP);
+
+	actions.render_mode_params["stencil_comparemask"] = &stencil_comparemaski;
+	actions.render_mode_params["stencil_writemask"] = &stencil_writemaski;
+	actions.render_mode_params["stencil_reference"] = &stencil_referencei;
 
 	actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;
 	actions.usage_flag_pointers["SSS_TRANSMITTANCE_DEPTH"] = &uses_transmittance;
@@ -142,6 +200,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
+	depth_function = DepthFunction(depth_functioni);
 	cull_mode = Cull(cull_modei);
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
 	uses_screen_texture = gen_code.uses_screen_texture;
@@ -149,6 +208,17 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	uses_normal_texture = gen_code.uses_normal_roughness_texture;
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
+
+	stencil_enabled = stencil_comparei != -1;
+	if (stencil_enabled) {
+		stencil_fail = StencilOperation(stencil_faili);
+		stencil_pass = StencilOperation(stencil_passi);
+		stencil_depth_fail = StencilOperation(stencil_depthfaili);
+		stencil_compare = StencilCompareOperator(stencil_comparei);
+		stencil_compare_mask = stencil_comparemaski;
+		stencil_write_mask = stencil_writemaski;
+		stencil_reference = stencil_referencei;
+	}
 
 #if 0
 	print_line("**compiling shader:");
@@ -250,9 +320,59 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	if (depth_test != DEPTH_TEST_DISABLED) {
 		depth_stencil_state.enable_depth_test = true;
-		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
 		depth_stencil_state.enable_depth_write = depth_draw != DEPTH_DRAW_DISABLED ? true : false;
+
+		RD::CompareOperator depth_function_rd_table[DEPTH_FUNCTION_MAX] = {
+			RD::COMPARE_OP_LESS_OR_EQUAL,
+			RD::COMPARE_OP_LESS,
+			RD::COMPARE_OP_GREATER_OR_EQUAL,
+			RD::COMPARE_OP_GREATER,
+			RD::COMPARE_OP_EQUAL,
+			RD::COMPARE_OP_NOT_EQUAL,
+			RD::COMPARE_OP_ALWAYS,
+			RD::COMPARE_OP_NEVER,
+		};
+
+		depth_stencil_state.depth_compare_operator = depth_function_rd_table[depth_function];
 	}
+
+	depth_stencil_state.enable_stencil = stencil_enabled;
+	if (stencil_enabled) {
+		RD::CompareOperator stencil_compare_operator_rd_table[STENCIL_COMPARE_OP_MAX] = {
+			RD::COMPARE_OP_NEVER,
+			RD::COMPARE_OP_LESS,
+			RD::COMPARE_OP_EQUAL,
+			RD::COMPARE_OP_LESS_OR_EQUAL,
+			RD::COMPARE_OP_GREATER,
+			RD::COMPARE_OP_NOT_EQUAL,
+			RD::COMPARE_OP_GREATER_OR_EQUAL,
+			RD::COMPARE_OP_ALWAYS,
+		};
+
+		RD::StencilOperation stencil_operation_rd_table[STENCIL_OP_MAX] = {
+			RD::STENCIL_OP_KEEP,
+			RD::STENCIL_OP_ZERO,
+			RD::STENCIL_OP_REPLACE,
+			RD::STENCIL_OP_INCREMENT_AND_CLAMP,
+			RD::STENCIL_OP_DECREMENT_AND_CLAMP,
+			RD::STENCIL_OP_INVERT,
+			RD::STENCIL_OP_INCREMENT_AND_WRAP,
+			RD::STENCIL_OP_DECREMENT_AND_WRAP,
+		};
+
+		RD::PipelineDepthStencilState::StencilOperationState op;
+		op.fail = stencil_operation_rd_table[stencil_fail];
+		op.pass = stencil_operation_rd_table[stencil_pass];
+		op.depth_fail = stencil_operation_rd_table[stencil_depth_fail];
+		op.compare = stencil_compare_operator_rd_table[stencil_compare];
+		op.compare_mask = stencil_compare_mask;
+		op.write_mask = stencil_write_mask;
+		op.reference = stencil_reference;
+
+		depth_stencil_state.front_op = op;
+		depth_stencil_state.back_op = op;
+	}
+
 	bool depth_pre_pass_enabled = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable"));
 
 	for (int i = 0; i < CULL_VARIANT_MAX; i++) {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -113,6 +113,18 @@ public:
 			DEPTH_TEST_ENABLED
 		};
 
+		enum DepthFunction {
+			DEPTH_FUNCTION_LESS_OR_EQUAL,
+			DEPTH_FUNCTION_LESS,
+			DEPTH_FUNCTION_GREATER_OR_EQUAL,
+			DEPTH_FUNCTION_GREATER,
+			DEPTH_FUNCTION_EQUAL,
+			DEPTH_FUNCTION_NOT_EQUAL,
+			DEPTH_FUNCTION_ALWAYS,
+			DEPTH_FUNCTION_NEVER,
+			DEPTH_FUNCTION_MAX
+		};
+
 		enum Cull {
 			CULL_DISABLED,
 			CULL_FRONT,
@@ -133,6 +145,30 @@ public:
 			ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE
 		};
 
+		enum StencilOperation {
+			STENCIL_OP_KEEP,
+			STENCIL_OP_ZERO,
+			STENCIL_OP_REPLACE,
+			STENCIL_OP_INCREMENT_AND_CLAMP,
+			STENCIL_OP_DECREMENT_AND_CLAMP,
+			STENCIL_OP_INVERT,
+			STENCIL_OP_INCREMENT_AND_WRAP,
+			STENCIL_OP_DECREMENT_AND_WRAP,
+			STENCIL_OP_MAX // not an actual operator, just the amount of operators
+		};
+
+		enum StencilCompareOperator {
+			STENCIL_COMPARE_OP_NEVER,
+			STENCIL_COMPARE_OP_LESS,
+			STENCIL_COMPARE_OP_EQUAL,
+			STENCIL_COMPARE_OP_LESS_OR_EQUAL,
+			STENCIL_COMPARE_OP_GREATER,
+			STENCIL_COMPARE_OP_NOT_EQUAL,
+			STENCIL_COMPARE_OP_GREATER_OR_EQUAL,
+			STENCIL_COMPARE_OP_ALWAYS,
+			STENCIL_COMPARE_OP_MAX // not an actual operator, just the amount of operators
+		};
+
 		bool valid = false;
 		RID version;
 		uint32_t vertex_input_mask = 0;
@@ -147,6 +183,7 @@ public:
 		String code;
 
 		DepthDraw depth_draw = DEPTH_DRAW_OPAQUE;
+		DepthFunction depth_function = DEPTH_FUNCTION_LESS_OR_EQUAL;
 		DepthTest depth_test = DEPTH_TEST_ENABLED;
 
 		bool uses_point_size = false;
@@ -175,6 +212,15 @@ public:
 		bool uses_world_coordinates = false;
 		bool uses_screen_texture_mipmaps = false;
 		Cull cull_mode = CULL_DISABLED;
+
+		bool stencil_enabled = false;
+		StencilOperation stencil_fail = STENCIL_OP_KEEP;
+		StencilOperation stencil_pass = STENCIL_OP_KEEP;
+		StencilOperation stencil_depth_fail = STENCIL_OP_KEEP;
+		StencilCompareOperator stencil_compare = STENCIL_COMPARE_OP_NEVER;
+		uint32_t stencil_compare_mask = 255;
+		uint32_t stencil_write_mask = 255;
+		uint32_t stencil_reference = 1;
 
 		uint64_t last_pass = 0;
 		uint32_t index = 0;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -55,6 +55,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	int blend_mode = BLEND_MODE_MIX;
 	int depth_testi = DEPTH_TEST_ENABLED;
+	int depth_functioni = DEPTH_FUNCTION_LESS_OR_EQUAL;
 	int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	int cull = CULL_BACK;
 
@@ -98,6 +99,15 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["depth_draw_always"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_ALWAYS);
 
 	actions.render_mode_values["depth_test_disabled"] = Pair<int *, int>(&depth_testi, DEPTH_TEST_DISABLED);
+
+	actions.render_mode_values["depth_function_lequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS_OR_EQUAL);
+	actions.render_mode_values["depth_function_less"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_LESS);
+	actions.render_mode_values["depth_function_gequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER_OR_EQUAL);
+	actions.render_mode_values["depth_function_greater"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_GREATER);
+	actions.render_mode_values["depth_function_equal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_EQUAL);
+	actions.render_mode_values["depth_function_notequal"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NOT_EQUAL);
+	actions.render_mode_values["depth_function_always"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_ALWAYS);
+	actions.render_mode_values["depth_function_never"] = Pair<int *, int>(&depth_functioni, DEPTH_FUNCTION_NEVER);
 
 	actions.render_mode_values["cull_disabled"] = Pair<int *, int>(&cull, CULL_DISABLED);
 	actions.render_mode_values["cull_front"] = Pair<int *, int>(&cull, CULL_FRONT);
@@ -143,6 +153,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	depth_draw = DepthDraw(depth_drawi);
 	depth_test = DepthTest(depth_testi);
+	depth_function = DepthFunction(depth_functioni);
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
 	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
@@ -261,8 +272,20 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	if (depth_test != DEPTH_TEST_DISABLED) {
 		depth_stencil_state.enable_depth_test = true;
-		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS_OR_EQUAL;
 		depth_stencil_state.enable_depth_write = depth_draw != DEPTH_DRAW_DISABLED ? true : false;
+
+		RD::CompareOperator depth_function_rd_table[DEPTH_FUNCTION_MAX] = {
+			RD::COMPARE_OP_LESS_OR_EQUAL,
+			RD::COMPARE_OP_LESS,
+			RD::COMPARE_OP_GREATER_OR_EQUAL,
+			RD::COMPARE_OP_GREATER,
+			RD::COMPARE_OP_EQUAL,
+			RD::COMPARE_OP_NOT_EQUAL,
+			RD::COMPARE_OP_ALWAYS,
+			RD::COMPARE_OP_NEVER,
+		};
+
+		depth_stencil_state.depth_compare_operator = depth_function_rd_table[depth_function];
 	}
 
 	for (int i = 0; i < CULL_VARIANT_MAX; i++) {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -70,6 +70,18 @@ public:
 			DEPTH_DRAW_ALWAYS
 		};
 
+		enum DepthFunction {
+			DEPTH_FUNCTION_LESS_OR_EQUAL,
+			DEPTH_FUNCTION_LESS,
+			DEPTH_FUNCTION_GREATER_OR_EQUAL,
+			DEPTH_FUNCTION_GREATER,
+			DEPTH_FUNCTION_EQUAL,
+			DEPTH_FUNCTION_NOT_EQUAL,
+			DEPTH_FUNCTION_ALWAYS,
+			DEPTH_FUNCTION_NEVER,
+			DEPTH_FUNCTION_MAX
+		};
+
 		enum DepthTest {
 			DEPTH_TEST_DISABLED,
 			DEPTH_TEST_ENABLED
@@ -108,6 +120,7 @@ public:
 		String code;
 
 		DepthDraw depth_draw;
+		DepthFunction depth_function;
 		DepthTest depth_test;
 
 		bool uses_point_size = false;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -453,6 +453,16 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					Pair<int *, int> &p = p_actions.render_mode_values[pnode->render_modes[i]];
 					*p.first = p.second;
 				}
+
+				if (p_actions.render_mode_params.has(pnode->render_modes[i])) {
+					int *p = p_actions.render_mode_params[pnode->render_modes[i]];
+
+					if (pnode->render_mode_params.has(pnode->render_modes[i])) {
+						*p = pnode->render_mode_params[pnode->render_modes[i]];
+					} else {
+						*p = 0;
+					}
+				}
 			}
 
 			// structs

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -48,6 +48,7 @@ public:
 		HashMap<StringName, Stage> entry_point_stages;
 
 		HashMap<StringName, Pair<int *, int>> render_mode_values;
+		HashMap<StringName, int *> render_mode_params;
 		HashMap<StringName, bool *> render_mode_flags;
 		HashMap<StringName, bool *> usage_flag_pointers;
 		HashMap<StringName, bool *> write_flag_pointers;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8108,6 +8108,12 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					shader->render_modes.push_back(mode);
 
 					tk = _get_token();
+
+					if (tk.is_integer_constant()) {
+						shader->render_mode_params.insert(mode, (int64_t)tk.constant);
+						tk = _get_token();
+					}
+
 					if (tk.type == TK_COMMA) {
 						//all good, do nothing
 					} else if (tk.type == TK_SEMICOLON) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -712,6 +712,7 @@ public:
 		HashMap<StringName, Uniform> uniforms;
 		HashMap<StringName, Struct> structs;
 		Vector<StringName> render_modes;
+		HashMap<StringName, int64_t> render_mode_params;
 
 		Vector<Function> functions;
 		Vector<Constant> vconstants;
@@ -873,6 +874,13 @@ public:
 			options.push_back(p_arg4);
 			options.push_back(p_arg5);
 			options.push_back(p_arg6);
+		}
+
+		ModeInfo(const StringName &p_name, std::initializer_list<StringName> p_args) :
+				name(p_name) {
+			for (const StringName &arg : p_args) {
+				options.push_back(arg);
+			}
 		}
 	};
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -208,6 +208,7 @@ ShaderTypes::ShaderTypes() {
 	{
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul" });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_draw"), "opaque", "always", "never" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_function"), { "lequal", "less", "gequal", "greater", "equal", "notequal", "always", "never" } });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_prepass_alpha") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("depth_test_disabled") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("sss_mode_skin") });
@@ -227,6 +228,13 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("alpha_to_coverage") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("alpha_to_coverage_and_one") });
 		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("debug_shadow_splits") });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_compare"), { "never", "less", "equal", "lequal", "greater", "notequal", "gequal", "always" } });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_fail"), { "keep", "zero", "replace", "incclamp", "decclamp", "invert", "incwrap", "decwrap" } });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_pass"), { "keep", "zero", "replace", "incclamp", "decclamp", "invert", "incwrap", "decwrap" } });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_depthfail"), { "keep", "zero", "replace", "incclamp", "decclamp", "invert", "incwrap", "decwrap" } });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_comparemask") });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_writemask") });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ PNAME("stencil_reference") });
 	}
 
 	/************ CANVAS ITEM **************************/


### PR DESCRIPTION
This is a rebase on latest master of @apples 's stencil work on https://github.com/apples/godot/tree/depth-function+stencil-buffer

**This PR is not here to be merged**

This PR is here to give people the opportunity to test it out by easily downloading it via github actions. The goal is to simplify the interface of the stencil operation (interface in the broader human-machine interaction layer sense) and to then create a new PR with the gathered knowledge.

Many thanks to apples for doing the initial bulk of the work and everyone else that participated over the years to this discussion in multiple issues. Last discussion: https://github.com/godotengine/godot-proposals/issues/3373

I'm hoping that by testing it with more people we can come to a common understanding for a simpler and more intuitive interface, language and defaults.

Here's my test project where i tried to achieve the windwaker effect and outlines.

https://github.com/godotengine/godot/assets/7917475/04a349fd-535e-458b-9db9-bdf71004e24b


[stencil.zip](https://github.com/godotengine/godot/files/11827071/stencil.zip)