### PR TITLE
Fix SVG tag closing for OT font glyphs

### DIFF
--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -121,7 +121,12 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 				for (int i = 0; i < parser->get_attribute_count(); i++) {
 					xml_body += vformat(" %s=\"%s\"", parser->get_attribute_name(i), parser->get_attribute_value(i));
 				}
-				xml_body += ">";
+
+				if (parser->is_empty()) {
+					xml_body += "/>";
+				} else {
+					xml_body += ">";
+				}
 			} else if (parser->get_node_type() == XMLParser::NODE_TEXT) {
 				xml_body += parser->get_node_data();
 			} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END) {

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -121,7 +121,12 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 				for (int i = 0; i < parser->get_attribute_count(); i++) {
 					xml_body += vformat(" %s=\"%s\"", parser->get_attribute_name(i), parser->get_attribute_value(i));
 				}
-				xml_body += ">";
+
+				if (parser->is_empty()) {
+					xml_body += "/>";
+				} else {
+					xml_body += ">";
+				}
 			} else if (parser->get_node_type() == XMLParser::NODE_TEXT) {
 				xml_body += parser->get_node_data();
 			} else if (parser->get_node_type() == XMLParser::NODE_ELEMENT_END) {


### PR DESCRIPTION
Prevent ThorVG "Failed to create SVG canvas" errors by self-closing empty SVG tags in OpenType fonts,
so the glyphs are renderred correctly in Controls.

Fixes #78374 