### PR TITLE
Make the dragging connections more user-friendly in visual shaders

### DIFF
--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -16,6 +16,13 @@
 				Clears the default input ports value.
 			</description>
 		</method>
+		<method name="get_default_input_port" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="type" type="int" enum="VisualShaderNode.PortType" />
+			<description>
+				Returns the input port which should be connected by default when this node is created as a result of dragging a connection from an existing node to the empty space on the graph.
+			</description>
+		</method>
 		<method name="get_default_input_values" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -37,6 +37,14 @@
 				Defining this method is [b]required[/b].
 			</description>
 		</method>
+		<method name="_get_default_input_port" qualifiers="virtual const">
+			<return type="int" />
+			<param index="0" name="type" type="int" enum="VisualShaderNode.PortType" />
+			<description>
+				Override this method to define the input port which should be connected by default when this node is created as a result of dragging a connection from an existing node to the empty space on the graph.
+				Defining this method is [b]optional[/b]. If not overridden, the connection will be created to the first valid port.
+			</description>
+		</method>
 		<method name="_get_description" qualifiers="virtual const">
 			<return type="String" />
 			<description>

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -46,6 +46,10 @@ bool VisualShaderNode::is_simple_decl() const {
 	return simple_decl;
 }
 
+int VisualShaderNode::get_default_input_port(PortType p_type) const {
+	return 0;
+}
+
 void VisualShaderNode::set_output_port_for_preview(int p_index) {
 	port_preview = p_index;
 }
@@ -378,6 +382,8 @@ bool VisualShaderNode::is_input_port_default(int p_port, Shader::Mode p_mode) co
 }
 
 void VisualShaderNode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_default_input_port", "type"), &VisualShaderNode::get_default_input_port);
+
 	ClassDB::bind_method(D_METHOD("set_output_port_for_preview", "port"), &VisualShaderNode::set_output_port_for_preview);
 	ClassDB::bind_method(D_METHOD("get_output_port_for_preview"), &VisualShaderNode::get_output_port_for_preview);
 
@@ -479,6 +485,12 @@ VisualShaderNodeCustom::PortType VisualShaderNodeCustom::get_input_port_type(int
 String VisualShaderNodeCustom::get_input_port_name(int p_port) const {
 	ERR_FAIL_INDEX_V(p_port, input_ports.size(), "");
 	return input_ports[p_port].name;
+}
+
+int VisualShaderNodeCustom::get_default_input_port(PortType p_type) const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_default_input_port, p_type, ret);
+	return ret;
 }
 
 int VisualShaderNodeCustom::get_output_port_count() const {
@@ -649,6 +661,7 @@ void VisualShaderNodeCustom::_bind_methods() {
 	GDVIRTUAL_BIND(_get_input_port_count);
 	GDVIRTUAL_BIND(_get_input_port_type, "port");
 	GDVIRTUAL_BIND(_get_input_port_name, "port");
+	GDVIRTUAL_BIND(_get_default_input_port, "type");
 	GDVIRTUAL_BIND(_get_output_port_count);
 	GDVIRTUAL_BIND(_get_output_port_type, "port");
 	GDVIRTUAL_BIND(_get_output_port_name, "port");

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -289,6 +289,7 @@ public:
 	virtual int get_input_port_count() const = 0;
 	virtual PortType get_input_port_type(int p_port) const = 0;
 	virtual String get_input_port_name(int p_port) const = 0;
+	virtual int get_default_input_port(PortType p_type) const;
 
 	virtual void set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value = Variant());
 	Variant get_input_port_default_value(int p_port) const; // if NIL (default if node does not set anything) is returned, it means no default value is wanted if disconnected, thus no input var must be supplied (empty string will be supplied)
@@ -367,6 +368,7 @@ protected:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
+	virtual int get_default_input_port(PortType p_type) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -384,6 +386,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_input_port_count)
 	GDVIRTUAL1RC(PortType, _get_input_port_type, int)
 	GDVIRTUAL1RC(String, _get_input_port_name, int)
+	GDVIRTUAL1RC(int, _get_default_input_port, PortType)
 	GDVIRTUAL0RC(int, _get_output_port_count)
 	GDVIRTUAL1RC(PortType, _get_output_port_type, int)
 	GDVIRTUAL1RC(String, _get_output_port_name, int)

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4137,6 +4137,10 @@ String VisualShaderNodeStep::get_input_port_name(int p_port) const {
 	return String();
 }
 
+int VisualShaderNodeStep::get_default_input_port(PortType p_type) const {
+	return 1;
+}
+
 int VisualShaderNodeStep::get_output_port_count() const {
 	return 1;
 }
@@ -4290,6 +4294,10 @@ String VisualShaderNodeSmoothStep::get_input_port_name(int p_port) const {
 			return "x";
 	}
 	return String();
+}
+
+int VisualShaderNodeSmoothStep::get_default_input_port(PortType p_type) const {
+	return 2;
 }
 
 int VisualShaderNodeSmoothStep::get_output_port_count() const {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1661,6 +1661,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
+	virtual int get_default_input_port(PortType p_type) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -1707,6 +1708,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
+	virtual int get_default_input_port(PortType p_type) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;


### PR DESCRIPTION
This implements the `get_default_input_port` function to `VisualShaderNode`, so now nodes can be connected to specified port by default when the new node created from dragging from output ports. Implemented the overrides for `smoothstep`/`step` nodes. Closes https://github.com/godotengine/godot-proposals/issues/5090

![vs_drag_enchancement](https://github.com/godotengine/godot/assets/3036176/6b75e17e-f70c-4b55-af5c-8a70585b4506)


