### PR TITLE
Fix incorrect depth buffer option in OpenXR

### DIFF
--- a/modules/openxr/extensions/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/openxr_vulkan_extension.cpp
@@ -233,9 +233,9 @@ void OpenXRVulkanExtension::get_usable_swapchain_formats(Vector<int64_t> &p_usab
 }
 
 void OpenXRVulkanExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) {
-	p_usable_swap_chains.push_back(VK_FORMAT_R32_SFLOAT);
 	p_usable_swap_chains.push_back(VK_FORMAT_D24_UNORM_S8_UINT);
 	p_usable_swap_chains.push_back(VK_FORMAT_D32_SFLOAT_S8_UINT);
+	p_usable_swap_chains.push_back(VK_FORMAT_D32_SFLOAT);
 }
 
 bool OpenXRVulkanExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, void **r_swapchain_graphics_data) {
@@ -308,8 +308,8 @@ bool OpenXRVulkanExtension::get_swapchain_image_data(XrSwapchain p_swapchain, in
 			format = RenderingDevice::DATA_FORMAT_B8G8R8A8_UINT;
 			usage_flags |= RenderingDevice::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 			break;
-		case VK_FORMAT_R32_SFLOAT:
-			format = RenderingDevice::DATA_FORMAT_R32_SFLOAT;
+		case VK_FORMAT_D32_SFLOAT:
+			format = RenderingDevice::DATA_FORMAT_D32_SFLOAT;
 			usage_flags |= RenderingDevice::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 			break;
 		case VK_FORMAT_D24_UNORM_S8_UINT:


### PR DESCRIPTION
Noticed by @ChristophHaag and reported on our XR chat channel, we were using `VK_FORMAT_R32_SFLOAT` as an option when OpenXR takes ownership of the depth buffer. This is an incorrect format.

Its been awhile but we likely chose this because the formats used in Godot, `VK_FORMAT_D24_UNORM_S8_UINT` and `VK_FORMAT_D32_SFLOAT_S8_UINT` contain a second component and most likely aren't supported by most OpenXR runtimes. This second component is only needed when certain effects are enabled in the Forward+ renderer.

We will need to further test this on various devices with the "submit depth buffer" feature enabled (see project settings) to see if this now works correctly.

I've also changed the code so that if none of the requested formats is supported by the OpenXR runtime, we get a message in the logs and the feature is disabled and we just render as per normal. 

Note:
- If we can get this tested and confirmed in the next couple days it would be nice to have it merged into 4.1
- On the mobile renderer, if MSAA is used, we don't have a resolve into the depth buffer and this functionality does not work. I am working on fixing this in a separate PR but that will be a 4.2 fix