### PR TITLE
Fix error spam when a mesh with bone weights has an invalid skeleton

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3738,6 +3738,8 @@ void RenderForwardClustered::_geometry_instance_update(RenderGeometryInstance *p
 			if (ginstance->data->dirty_dependencies) {
 				mesh_storage->skeleton_update_dependency(ginstance->data->skeleton, &ginstance->data->dependency_tracker);
 			}
+		} else {
+			ginstance->transforms_uniform_set = RID();
 		}
 	}
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2667,6 +2667,8 @@ void RenderForwardMobile::_geometry_instance_update(RenderGeometryInstance *p_ge
 			if (ginstance->data->dirty_dependencies) {
 				mesh_storage->skeleton_update_dependency(ginstance->data->skeleton, &ginstance->data->dependency_tracker);
 			}
+		} else {
+			ginstance->transforms_uniform_set = RID();
 		}
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -690,7 +690,9 @@ public:
 	_FORCE_INLINE_ RID skeleton_get_3d_uniform_set(RID p_skeleton, RID p_shader, uint32_t p_set) const {
 		Skeleton *skeleton = skeleton_owner.get_or_null(p_skeleton);
 		ERR_FAIL_COND_V(!skeleton, RID());
-		ERR_FAIL_COND_V(skeleton->size == 0, RID());
+		if (skeleton->size == 0) {
+			return RID();
+		}
 		if (skeleton->use_2d) {
 			return RID();
 		}


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/77780
* Fixes https://github.com/godotengine/godot/issues/78470

This PR does two things. First, when a mesh with bone weights doesn't have a valid skeleton, clear `ginstance->transforms_uniform_set` so that it doesn't error out later as it is now invalid. This should be fine as the resource lifetime is tracked elsewhere. Applies to both Forward and Mobile renderers, GLES renderer doesn't need this fix. This one fixes the infinite error spam when a mesh like that is in the scene tree. 

The second fix is to silently ignore skeletons with zero bones. This error usually happens only once when creating a skeleton programmatically or during import process, because skeletons are updated asynchronously. So when creating a skeleton and adding its bones, they will be updated and sent for rendering later. However, the renderer will complain during this one frame. Eventually, the skeleton gets its bones updated and things work out, so it's nicer to avoid showing an error for that situation.