### PR TITLE
Fix click-selecting Sprites with repeated texture

### DIFF
--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -309,9 +309,9 @@ bool Sprite2D::is_pixel_opaque(const Point2 &p_point) const {
 		q.y = 1.0f - q.y;
 	}
 	q = q * src_rect.size + src_rect.position;
-	// TODO: This need to be obtained from CanvasItem new repeat mode (but it needs to guess it from hierarchy, need to add a function for that).
-	bool is_repeat = false;
-	bool is_mirrored_repeat = false;
+	TextureRepeat repeat_mode = get_texture_repeat_in_tree();
+	bool is_repeat = repeat_mode == TEXTURE_REPEAT_ENABLED || repeat_mode == TEXTURE_REPEAT_MIRROR;
+	bool is_mirrored_repeat = repeat_mode == TEXTURE_REPEAT_MIRROR;
 	if (is_repeat) {
 		int mirror_x = 0;
 		int mirror_y = 0;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1343,7 +1343,7 @@ bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	return (visibility_layer & (1 << p_visibility_layer));
 }
 
-void CanvasItem::_refresh_texture_filter_cache() {
+void CanvasItem::_refresh_texture_filter_cache() const {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -1394,7 +1394,7 @@ CanvasItem::TextureFilter CanvasItem::get_texture_filter() const {
 	return texture_filter;
 }
 
-void CanvasItem::_refresh_texture_repeat_cache() {
+void CanvasItem::_refresh_texture_repeat_cache() const {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -1465,13 +1465,13 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {
 	return texture_repeat;
 }
 
-CanvasItem::TextureFilter CanvasItem::get_texture_filter_in_tree() {
+CanvasItem::TextureFilter CanvasItem::get_texture_filter_in_tree() const {
 	ERR_READ_THREAD_GUARD_V(TEXTURE_FILTER_NEAREST);
 	_refresh_texture_filter_cache();
 	return (TextureFilter)texture_filter_cache;
 }
 
-CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() {
+CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() const {
 	ERR_READ_THREAD_GUARD_V(TEXTURE_REPEAT_DISABLED);
 	_refresh_texture_repeat_cache();
 	return (TextureRepeat)texture_repeat_cache;

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -110,8 +110,8 @@ private:
 
 	ClipChildrenMode clip_children_mode = CLIP_CHILDREN_DISABLED;
 
-	RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
-	RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+	mutable RS::CanvasItemTextureFilter texture_filter_cache = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
+	mutable RS::CanvasItemTextureRepeat texture_repeat_cache = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 	TextureFilter texture_filter = TEXTURE_FILTER_PARENT_NODE;
 	TextureRepeat texture_repeat = TEXTURE_REPEAT_PARENT_NODE;
 
@@ -143,9 +143,9 @@ private:
 
 	static CanvasItem *current_item_drawn;
 	friend class Viewport;
-	void _refresh_texture_repeat_cache();
+	void _refresh_texture_repeat_cache() const;
 	void _update_texture_repeat_changed(bool p_propagate);
-	void _refresh_texture_filter_cache();
+	void _refresh_texture_filter_cache() const;
 	void _update_texture_filter_changed(bool p_propagate);
 
 	void _notify_transform_deferred();
@@ -360,8 +360,8 @@ public:
 	virtual void set_texture_repeat(TextureRepeat p_texture_repeat);
 	TextureRepeat get_texture_repeat() const;
 
-	TextureFilter get_texture_filter_in_tree();
-	TextureRepeat get_texture_repeat_in_tree();
+	TextureFilter get_texture_filter_in_tree() const;
+	TextureRepeat get_texture_repeat_in_tree() const;
 
 	// Used by control nodes to retrieve the parent's anchorable area
 	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };


### PR DESCRIPTION
Should fix #60141 (haven't tested).

Needed to make `CanvasItem::get_texture_repeat_in_tree` be `const` so it could be called from a `const` method like `Sprite2D::is_pixel_opaque` (+changed `CanvasItem::get_texture_filter_in_tree` the same way for consistency). Hope it can be done / doesn't break anything (cc @akien-mga). :upside_down_face:

The change seems straighforward so likely is fine for 4.1? :thinking: