### PR TITLE
Editor: Remove unused Class Name field from Create Script dialog

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -242,7 +242,9 @@ public:
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const = 0;
 	virtual String validate_path(const String &p_path) const { return ""; }
 	virtual Script *create_script() const = 0;
+#ifndef DISABLE_DEPRECATED
 	virtual bool has_named_classes() const = 0;
+#endif
 	virtual bool supports_builtin_mode() const = 0;
 	virtual bool supports_documentation() const { return false; }
 	virtual bool can_inherit_from_file() const { return false; }

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -98,7 +98,9 @@ void ScriptLanguageExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_validate_path, "path");
 	GDVIRTUAL_BIND(_create_script);
+#ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_has_named_classes);
+#endif
 	GDVIRTUAL_BIND(_supports_builtin_mode);
 	GDVIRTUAL_BIND(_supports_documentation);
 	GDVIRTUAL_BIND(_can_inherit_from_file);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -344,7 +344,9 @@ public:
 		GDVIRTUAL_REQUIRED_CALL(_create_script, ret);
 		return Object::cast_to<Script>(ret);
 	}
+#ifndef DISABLE_DEPRECATED
 	EXBIND0RC(bool, has_named_classes)
+#endif
 	EXBIND0RC(bool, supports_builtin_mode)
 	EXBIND0RC(bool, supports_documentation)
 	EXBIND0RC(bool, can_inherit_from_file)

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -197,9 +197,10 @@
 			<description>
 			</description>
 		</method>
-		<method name="_has_named_classes" qualifiers="virtual const">
+		<method name="_has_named_classes" qualifiers="virtual const" is_deprecated="true">
 			<return type="bool" />
 			<description>
+				[i]Deprecated.[/i] This method is not called by the engine.
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -43,6 +43,8 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_validation_panel.h"
+#include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
 
 static String _get_parent_class_of_script(String p_path) {
 	if (!ResourceLoader::exists(p_path, "Script")) {
@@ -165,11 +167,9 @@ bool ScriptCreateDialog::_can_be_built_in() {
 }
 
 void ScriptCreateDialog::config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled, bool p_load_enabled) {
-	class_name->set_text("");
-	class_name->deselect();
 	parent_name->set_text(p_base_name);
 	parent_name->deselect();
-	internal_name->set_text("");
+	built_in_name->set_text("");
 
 	if (!p_base_path.is_empty()) {
 		initial_bp = p_base_path.get_basename();
@@ -185,7 +185,6 @@ void ScriptCreateDialog::config(const String &p_base_name, const String &p_base_
 	load_enabled = p_load_enabled;
 
 	_language_changed(current_language);
-	_class_name_changed("");
 	_path_changed(file_path->get_text());
 }
 
@@ -206,29 +205,6 @@ bool ScriptCreateDialog::_validate_parent(const String &p_string) {
 	}
 
 	return EditorNode::get_editor_data().is_type_recognized(p_string);
-}
-
-bool ScriptCreateDialog::_validate_class(const String &p_string) {
-	if (p_string.length() == 0) {
-		return false;
-	}
-
-	for (int i = 0; i < p_string.length(); i++) {
-		if (i == 0) {
-			// Cannot start with a number.
-			if (p_string[0] >= '0' && p_string[0] <= '9') {
-				return false;
-			}
-		}
-
-		bool valid_char = is_ascii_identifier_char(p_string[i]) || p_string[i] == '.';
-
-		if (!valid_char) {
-			return false;
-		}
-	}
-
-	return true;
 }
 
 String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must_exist) {
@@ -302,19 +278,6 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	return ScriptServer::get_language(language_menu->get_selected())->validate_path(p);
 }
 
-String ScriptCreateDialog::_get_class_name() const {
-	if (has_named_classes) {
-		return class_name->get_text();
-	} else {
-		return ProjectSettings::get_singleton()->localize_path(file_path->get_text()).get_file().get_basename();
-	}
-}
-
-void ScriptCreateDialog::_class_name_changed(const String &p_name) {
-	is_class_name_valid = _validate_class(class_name->get_text());
-	validation_panel->update();
-}
-
 void ScriptCreateDialog::_parent_name_changed(const String &p_parent) {
 	is_parent_name_valid = _validate_parent(parent_name->get_text());
 	validation_panel->update();
@@ -369,8 +332,6 @@ void ScriptCreateDialog::ok_pressed() {
 }
 
 void ScriptCreateDialog::_create_new() {
-	String cname_param = _get_class_name();
-
 	Ref<Script> scr;
 
 	const ScriptLanguage::ScriptTemplate sinfo = _get_current_template();
@@ -383,17 +344,11 @@ void ScriptCreateDialog::_create_new() {
 		parent_class = "\"" + type->script->get_path() + "\"";
 	}
 
-	scr = ScriptServer::get_language(language_menu->get_selected())->make_template(sinfo.content, cname_param, parent_class);
-
-	if (has_named_classes) {
-		String cname = class_name->get_text();
-		if (cname.length()) {
-			scr->set_name(cname);
-		}
-	}
+	String class_name = file_path->get_text().get_file().get_basename();
+	scr = ScriptServer::get_language(language_menu->get_selected())->make_template(sinfo.content, class_name, parent_class);
 
 	if (is_built_in) {
-		scr->set_name(internal_name->get_text());
+		scr->set_name(built_in_name->get_text());
 		// Make sure the script is compiled to make its type recognizable.
 		scr->reload();
 	} else {
@@ -427,7 +382,6 @@ void ScriptCreateDialog::_load_exist() {
 void ScriptCreateDialog::_language_changed(int l) {
 	language = ScriptServer::get_language(l);
 
-	has_named_classes = language->has_named_classes();
 	can_inherit_from_file = language->can_inherit_from_file();
 	supports_built_in = language->supports_builtin_mode();
 	if (!supports_built_in) {
@@ -475,7 +429,7 @@ void ScriptCreateDialog::_language_changed(int l) {
 }
 
 void ScriptCreateDialog::_built_in_pressed() {
-	if (internal->is_pressed()) {
+	if (built_in->is_pressed()) {
 		is_built_in = true;
 		is_new_script_created = true;
 	} else {
@@ -676,9 +630,7 @@ void ScriptCreateDialog::_update_dialog() {
 	if (!is_built_in && !is_path_valid) {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid path."), EditorValidationPanel::MSG_ERROR);
 	}
-	if (has_named_classes && (is_new_script_created && !is_class_name_valid)) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid class name."), EditorValidationPanel::MSG_ERROR);
-	}
+
 	if (!is_parent_name_valid && is_new_script_created) {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
 	}
@@ -689,27 +641,6 @@ void ScriptCreateDialog::_update_dialog() {
 
 	if (!path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
-	}
-
-	// Does script have named classes?
-
-	if (has_named_classes) {
-		if (is_new_script_created) {
-			class_name->set_editable(true);
-			class_name->set_placeholder(TTR("Allowed: a-z, A-Z, 0-9, _ and ."));
-			Color placeholder_color = class_name->get_theme_color(SNAME("font_placeholder_color"));
-			placeholder_color.a = 0.3;
-			class_name->add_theme_color_override("font_placeholder_color", placeholder_color);
-		} else {
-			class_name->set_editable(false);
-		}
-	} else {
-		class_name->set_editable(false);
-		class_name->set_placeholder(TTR("N/A"));
-		Color placeholder_color = class_name->get_theme_color(SNAME("font_placeholder_color"));
-		placeholder_color.a = 1;
-		class_name->add_theme_color_override("font_placeholder_color", placeholder_color);
-		class_name->set_text("");
 	}
 
 	// Is script Built-in?
@@ -728,15 +659,15 @@ void ScriptCreateDialog::_update_dialog() {
 	}
 
 	if (!_can_be_built_in()) {
-		internal->set_pressed(false);
+		built_in->set_pressed(false);
 	}
-	internal->set_disabled(!_can_be_built_in());
+	built_in->set_disabled(!_can_be_built_in());
 
 	// Is Script created or loaded from existing file?
 
 	if (is_built_in) {
 		validation_panel->set_message(MSG_ID_BUILT_IN, TTR("Note: Built-in scripts have some limitations and can't be edited using an external editor."), EditorValidationPanel::MSG_INFO, false);
-	} else if (_get_class_name() == parent_name->get_text()) {
+	} else if (file_path->get_text().get_file().get_basename() == parent_name->get_text()) {
 		validation_panel->set_message(MSG_ID_BUILT_IN, TTR("Warning: Having the script name be the same as a built-in type is usually not desired."), EditorValidationPanel::MSG_WARNING, false);
 	}
 
@@ -744,9 +675,6 @@ void ScriptCreateDialog::_update_dialog() {
 	path_controls[1]->set_visible(!is_built_in);
 	name_controls[0]->set_visible(is_built_in);
 	name_controls[1]->set_visible(is_built_in);
-
-	// Check if the script name is the same as the parent class.
-	// This warning isn't relevant if the script is built-in.
 
 	bool is_new_file = is_built_in || is_new_script_created;
 
@@ -997,14 +925,6 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	gc->add_child(memnew(Label(TTR("Inherits:"))));
 	gc->add_child(hb);
 
-	/* Class Name */
-
-	class_name = memnew(LineEdit);
-	class_name->connect("text_changed", callable_mp(this, &ScriptCreateDialog::_class_name_changed));
-	class_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	gc->add_child(memnew(Label(TTR("Class Name:"))));
-	gc->add_child(class_name);
-
 	/* Templates */
 	gc->add_child(memnew(Label(TTR("Template:"))));
 	HBoxContainer *template_hb = memnew(HBoxContainer);
@@ -1026,11 +946,11 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	/* Built-in Script */
 
-	internal = memnew(CheckBox);
-	internal->set_text(TTR("On"));
-	internal->connect("pressed", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
+	built_in = memnew(CheckBox);
+	built_in->set_text(TTR("On"));
+	built_in->connect("pressed", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
-	gc->add_child(internal);
+	gc->add_child(built_in);
 
 	/* Path */
 
@@ -1051,16 +971,16 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	/* Name */
 
-	internal_name = memnew(LineEdit);
-	internal_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	internal_name->connect("text_submitted", callable_mp(this, &ScriptCreateDialog::_path_submitted));
+	built_in_name = memnew(LineEdit);
+	built_in_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	built_in_name->connect("text_submitted", callable_mp(this, &ScriptCreateDialog::_path_submitted));
 	label = memnew(Label(TTR("Name:")));
 	gc->add_child(label);
-	gc->add_child(internal_name);
+	gc->add_child(built_in_name);
 	name_controls[0] = label;
-	name_controls[1] = internal_name;
+	name_controls[1] = built_in_name;
 	label->hide();
-	internal_name->hide();
+	built_in_name->hide();
 
 	/* Dialog Setup */
 

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -34,14 +34,13 @@
 #include "core/object/script_language.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/grid_container.h"
-#include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 
 class CreateDialog;
 class EditorFileDialog;
 class EditorValidationPanel;
+class LineEdit;
 
 class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
@@ -53,7 +52,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 		MSG_ID_TEMPLATE,
 	};
 
-	LineEdit *class_name = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 	LineEdit *parent_name = nullptr;
 	Button *parent_browse_button = nullptr;
@@ -61,21 +59,21 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	OptionButton *language_menu = nullptr;
 	OptionButton *template_menu = nullptr;
 	LineEdit *file_path = nullptr;
-	LineEdit *internal_name = nullptr;
+	LineEdit *built_in_name = nullptr;
 	Button *path_button = nullptr;
 	EditorFileDialog *file_browse = nullptr;
-	CheckBox *internal = nullptr;
+	CheckBox *built_in = nullptr;
 	CheckBox *use_templates = nullptr;
 	VBoxContainer *path_vb = nullptr;
 	AcceptDialog *alert = nullptr;
 	CreateDialog *select_class = nullptr;
+
 	bool is_browsing_parent = false;
 	String path_error;
 	String template_inactive_message;
 	String initial_bp;
 	bool is_new_script_created = true;
 	bool is_path_valid = false;
-	bool has_named_classes = false;
 	bool supports_built_in = false;
 	bool can_inherit_from_file = false;
 	bool is_parent_name_valid = false;
@@ -104,10 +102,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	void _built_in_pressed();
 	void _use_template_pressed();
 	bool _validate_parent(const String &p_string);
-	bool _validate_class(const String &p_string);
 	String _validate_path(const String &p_path, bool p_file_must_exist);
-	String _get_class_name() const;
-	void _class_name_changed(const String &p_name);
 	void _parent_name_changed(const String &p_parent);
 	void _template_changed(int p_template = 0);
 	void _browse_path(bool browse_parent, bool p_save);

--- a/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
@@ -15,7 +15,7 @@ func _physics_process(delta: float) -> void:
 	if not is_on_floor():
 		velocity.y += gravity * delta
 
-	# Handle Jump.
+	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
 

--- a/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
@@ -15,7 +15,7 @@ func _physics_process(delta: float) -> void:
 	if not is_on_floor():
 		velocity.y -= gravity * delta
 
-	# Handle Jump.
+	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
 

--- a/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
+++ b/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic plugin template
+
 @tool
-extends EditorPlugin
+extends _BASE_
 
 
 func _enter_tree() -> void:

--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic import script template
+
 @tool
-extends EditorScenePostImport
+extends _BASE_
 
 
 # Called by the editor when a scene has this script set as the import script in the import tab.

--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic import script template (no comments)
+
 @tool
-extends EditorScenePostImport
+extends _BASE_
 
 
 func _post_import(scene: Node) -> Object:

--- a/modules/gdscript/editor/script_templates/EditorScript/basic_editor_script.gd
+++ b/modules/gdscript/editor/script_templates/EditorScript/basic_editor_script.gd
@@ -1,6 +1,7 @@
 # meta-description: Basic editor script template
+
 @tool
-extends EditorScript
+extends _BASE_
 
 
 # Called when the script is executed (using File -> Run in Script Editor).

--- a/modules/gdscript/editor/script_templates/RichTextEffect/default.gd
+++ b/modules/gdscript/editor/script_templates/RichTextEffect/default.gd
@@ -1,15 +1,16 @@
 # meta-description: Base template for rich text effects
 
 @tool
-class_name _CLASS_
+# Having a class name is handy for picking the effect in the Inspector.
+class_name RichText_CLASS_
 extends _BASE_
 
 
 # To use this effect:
 # - Enable BBCode on a RichTextLabel.
 # - Register this effect on the label.
-# - Use [_CLASS_ param=2.0]hello[/_CLASS_] in text.
-var bbcode := "_CLASS_"
+# - Use [_CLASS_SNAKE_CASE_ param=2.0]hello[/_CLASS_SNAKE_CASE_] in text.
+var bbcode := "_CLASS_SNAKE_CASE_"
 
 
 func _process_custom_fx(char_fx: CharFXTransform) -> bool:

--- a/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
+++ b/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
@@ -1,6 +1,7 @@
 # meta-description: Visual shader's node plugin template
 
 @tool
+# Having a class name is required for a custom node.
 class_name VisualShaderNode_CLASS_
 extends _BASE_
 
@@ -17,7 +18,7 @@ func _get_description() -> String:
 	return ""
 
 
-func _get_return_icon_type() -> int:
+func _get_return_icon_type() -> PortType:
 	return PORT_TYPE_SCALAR
 
 
@@ -29,7 +30,7 @@ func _get_input_port_name(port: int) -> String:
 	return ""
 
 
-func _get_input_port_type(port: int) -> int:
+func _get_input_port_type(port: int) -> PortType:
 	return PORT_TYPE_SCALAR
 
 
@@ -41,10 +42,10 @@ func _get_output_port_name(port: int) -> String:
 	return "result"
 
 
-func _get_output_port_type(port: int) -> int:
+func _get_output_port_type(port: int) -> PortType:
 	return PORT_TYPE_SCALAR
 
 
 func _get_code(input_vars: Array[String], output_vars: Array[String],
-		mode: int, type: int) -> String:
+		mode: Shader.Mode, type: VisualShader.Type) -> String:
 	return output_vars[0] + " = 0.0;"

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -501,7 +501,9 @@ public:
 	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) override;
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override;
 	virtual Script *create_script() const override;
-	virtual bool has_named_classes() const override;
+#ifndef DISABLE_DEPRECATED
+	virtual bool has_named_classes() const override { return false; }
+#endif
 	virtual bool supports_builtin_mode() const override;
 	virtual bool supports_documentation() const override;
 	virtual bool can_inherit_from_file() const override { return true; }

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -75,19 +75,25 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 #endif
 	if (!type_hints) {
 		processed_template = processed_template.replace(": int", "")
+									 .replace(": Shader.Mode", "")
+									 .replace(": VisualShader.Type", "")
+									 .replace(": float", "")
 									 .replace(": String", "")
 									 .replace(": Array[String]", "")
-									 .replace(": float", "")
+									 .replace(": Node", "")
 									 .replace(": CharFXTransform", "")
 									 .replace(":=", "=")
-									 .replace(" -> String", "")
-									 .replace(" -> int", "")
+									 .replace(" -> void", "")
 									 .replace(" -> bool", "")
-									 .replace(" -> void", "");
+									 .replace(" -> int", "")
+									 .replace(" -> PortType", "")
+									 .replace(" -> String", "")
+									 .replace(" -> Object", "");
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)
-								 .replace("_CLASS_", p_class_name.to_pascal_case())
+								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_identifier())
+								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_identifier())
 								 .replace("_TS_", _get_indentation());
 	scr->set_source_code(processed_template);
 	return scr;
@@ -188,10 +194,6 @@ bool GDScriptLanguage::validate(const String &p_script, const String &p_path, Li
 #endif
 
 	return true;
-}
-
-bool GDScriptLanguage::has_named_classes() const {
-	return false;
 }
 
 bool GDScriptLanguage::supports_builtin_mode() const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -392,10 +392,6 @@ Script *CSharpLanguage::create_script() const {
 	return memnew(CSharpScript);
 }
 
-bool CSharpLanguage::has_named_classes() const {
-	return false;
-}
-
 bool CSharpLanguage::supports_builtin_mode() const {
 	return false;
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -424,7 +424,9 @@ public:
 	}
 	String validate_path(const String &p_path) const override;
 	Script *create_script() const override;
-	bool has_named_classes() const override;
+#ifndef DISABLE_DEPRECATED
+	virtual bool has_named_classes() const override { return false; }
+#endif
 	bool supports_builtin_mode() const override;
 	/* TODO? */ int find_function(const String &p_function, const String &p_code) const override {
 		return -1;


### PR DESCRIPTION
It looks like the field hasn't done anything for a very long time, either with GDScript or C# ([link](https://github.com/godotengine/godot/pull/12365/files#diff-42f5e0775f4f420d4c05168dc6db0c61d58ea2fda2c7481a5ddc9df4ab4f3955L296-R301)).

* Closes #75071.
* Closes godotengine/godot-proposals#208.