### PR TITLE
Fix 3D `top_level` resetting

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -153,7 +153,6 @@ void Node3D::_notification(int p_what) {
 					data.local_transform = data.parent->get_global_transform() * get_transform();
 					_replace_dirty_mask(DIRTY_EULER_ROTATION_AND_SCALE); // As local transform was updated, rot/scale should be dirty.
 				}
-				data.top_level = true;
 			}
 
 			_set_dirty_bits(DIRTY_GLOBAL_TRANSFORM); // Global is always dirty upon entering a scene.
@@ -173,7 +172,6 @@ void Node3D::_notification(int p_what) {
 			}
 			data.parent = nullptr;
 			data.C = nullptr;
-			data.top_level = false;
 			_update_visibility_parent(true);
 		} break;
 


### PR DESCRIPTION
There is no need to erase the top_level flag on EXIT_TREE. (fix #78572)
During ENTER_TREE, `top_level = true` is not necessary, because it is already set to true.

Looks like a regression from #77629, which consolidated `top_level_active` with `top_level`.

Have tested this PR with the MRP of #50813.
