### PR TITLE
Internally rename `parent` to `collision_object` in CollisionPolygon(2D/3D)

### DIFF
--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -39,7 +39,7 @@
 #include "thirdparty/misc/polypartition.h"
 
 void CollisionPolygon2D::_build_polygon() {
-	parent->shape_owner_clear_shapes(owner_id);
+	collision_object->shape_owner_clear_shapes(owner_id);
 
 	bool solids = build_mode == BUILD_SOLIDS;
 
@@ -54,7 +54,7 @@ void CollisionPolygon2D::_build_polygon() {
 		for (int i = 0; i < decomp.size(); i++) {
 			Ref<ConvexPolygonShape2D> convex = memnew(ConvexPolygonShape2D);
 			convex->set_points(decomp[i]);
-			parent->shape_owner_add_shape(owner_id, convex);
+			collision_object->shape_owner_add_shape(owner_id, convex);
 		}
 
 	} else {
@@ -75,7 +75,7 @@ void CollisionPolygon2D::_build_polygon() {
 
 		concave->set_segments(segments);
 
-		parent->shape_owner_add_shape(owner_id, concave);
+		collision_object->shape_owner_add_shape(owner_id, concave);
 	}
 }
 
@@ -85,44 +85,44 @@ Vector<Vector<Vector2>> CollisionPolygon2D::_decompose_in_convex() {
 }
 
 void CollisionPolygon2D::_update_in_shape_owner(bool p_xform_only) {
-	parent->shape_owner_set_transform(owner_id, get_transform());
+	collision_object->shape_owner_set_transform(owner_id, get_transform());
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
-	parent->shape_owner_set_one_way_collision(owner_id, one_way_collision);
-	parent->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
+	collision_object->shape_owner_set_disabled(owner_id, disabled);
+	collision_object->shape_owner_set_one_way_collision(owner_id, one_way_collision);
+	collision_object->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
 }
 
 void CollisionPolygon2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PARENTED: {
-			parent = Object::cast_to<CollisionObject2D>(get_parent());
-			if (parent) {
-				owner_id = parent->create_shape_owner(this);
+			collision_object = Object::cast_to<CollisionObject2D>(get_parent());
+			if (collision_object) {
+				owner_id = collision_object->create_shape_owner(this);
 				_build_polygon();
 				_update_in_shape_owner();
 			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			if (parent) {
+			if (collision_object) {
 				_update_in_shape_owner();
 			}
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (parent) {
+			if (collision_object) {
 				_update_in_shape_owner(true);
 			}
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {
-			if (parent) {
-				parent->remove_shape_owner(owner_id);
+			if (collision_object) {
+				collision_object->remove_shape_owner(owner_id);
 			}
 			owner_id = 0;
-			parent = nullptr;
+			collision_object = nullptr;
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -191,7 +191,7 @@ void CollisionPolygon2D::set_polygon(const Vector<Point2> &p_polygon) {
 		}
 	}
 
-	if (parent) {
+	if (collision_object) {
 		_build_polygon();
 		_update_in_shape_owner();
 	}
@@ -206,7 +206,7 @@ Vector<Point2> CollisionPolygon2D::get_polygon() const {
 void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
 	ERR_FAIL_INDEX((int)p_mode, 2);
 	build_mode = p_mode;
-	if (parent) {
+	if (collision_object) {
 		_build_polygon();
 		_update_in_shape_owner();
 	}
@@ -253,7 +253,7 @@ PackedStringArray CollisionPolygon2D::get_configuration_warnings() const {
 		}
 	}
 	if (one_way_collision && Object::cast_to<Area2D>(get_parent())) {
-		warnings.push_back(RTR("The One Way Collision property will be ignored when the parent is an Area2D."));
+		warnings.push_back(RTR("The One Way Collision property will be ignored when the collision object is an Area2D."));
 	}
 
 	return warnings;
@@ -262,8 +262,8 @@ PackedStringArray CollisionPolygon2D::get_configuration_warnings() const {
 void CollisionPolygon2D::set_disabled(bool p_disabled) {
 	disabled = p_disabled;
 	queue_redraw();
-	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+	if (collision_object) {
+		collision_object->shape_owner_set_disabled(owner_id, p_disabled);
 	}
 }
 
@@ -274,8 +274,8 @@ bool CollisionPolygon2D::is_disabled() const {
 void CollisionPolygon2D::set_one_way_collision(bool p_enable) {
 	one_way_collision = p_enable;
 	queue_redraw();
-	if (parent) {
-		parent->shape_owner_set_one_way_collision(owner_id, p_enable);
+	if (collision_object) {
+		collision_object->shape_owner_set_one_way_collision(owner_id, p_enable);
 	}
 	update_configuration_warnings();
 }
@@ -286,8 +286,8 @@ bool CollisionPolygon2D::is_one_way_collision_enabled() const {
 
 void CollisionPolygon2D::set_one_way_collision_margin(real_t p_margin) {
 	one_way_collision_margin = p_margin;
-	if (parent) {
-		parent->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
+	if (collision_object) {
+		collision_object->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
 	}
 }
 

--- a/scene/2d/collision_polygon_2d.h
+++ b/scene/2d/collision_polygon_2d.h
@@ -49,7 +49,7 @@ protected:
 	BuildMode build_mode = BUILD_SOLIDS;
 	Vector<Point2> polygon;
 	uint32_t owner_id = 0;
-	CollisionObject2D *parent = nullptr;
+	CollisionObject2D *collision_object = nullptr;
 	bool disabled = false;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -35,11 +35,11 @@
 #include "scene/resources/convex_polygon_shape_3d.h"
 
 void CollisionPolygon3D::_build_polygon() {
-	if (!parent) {
+	if (!collision_object) {
 		return;
 	}
 
-	parent->shape_owner_clear_shapes(owner_id);
+	collision_object->shape_owner_clear_shapes(owner_id);
 
 	if (polygon.size() == 0) {
 		return;
@@ -70,56 +70,56 @@ void CollisionPolygon3D::_build_polygon() {
 
 		convex->set_points(cp);
 		convex->set_margin(margin);
-		parent->shape_owner_add_shape(owner_id, convex);
-		parent->shape_owner_set_disabled(owner_id, disabled);
+		collision_object->shape_owner_add_shape(owner_id, convex);
+		collision_object->shape_owner_set_disabled(owner_id, disabled);
 	}
 }
 
 void CollisionPolygon3D::_update_in_shape_owner(bool p_xform_only) {
-	parent->shape_owner_set_transform(owner_id, get_transform());
+	collision_object->shape_owner_set_transform(owner_id, get_transform());
 	if (p_xform_only) {
 		return;
 	}
-	parent->shape_owner_set_disabled(owner_id, disabled);
+	collision_object->shape_owner_set_disabled(owner_id, disabled);
 }
 
 void CollisionPolygon3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PARENTED: {
-			parent = Object::cast_to<CollisionObject3D>(get_parent());
-			if (parent) {
-				owner_id = parent->create_shape_owner(this);
+			collision_object = Object::cast_to<CollisionObject3D>(get_parent());
+			if (collision_object) {
+				owner_id = collision_object->create_shape_owner(this);
 				_build_polygon();
 				_update_in_shape_owner();
 			}
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			if (parent) {
+			if (collision_object) {
 				_update_in_shape_owner();
 			}
 		} break;
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			if (parent) {
+			if (collision_object) {
 				_update_in_shape_owner(true);
 			}
 			update_configuration_warnings();
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {
-			if (parent) {
-				parent->remove_shape_owner(owner_id);
+			if (collision_object) {
+				collision_object->remove_shape_owner(owner_id);
 			}
 			owner_id = 0;
-			parent = nullptr;
+			collision_object = nullptr;
 		} break;
 	}
 }
 
 void CollisionPolygon3D::set_polygon(const Vector<Point2> &p_polygon) {
 	polygon = p_polygon;
-	if (parent) {
+	if (collision_object) {
 		_build_polygon();
 	}
 	update_configuration_warnings();
@@ -148,8 +148,8 @@ void CollisionPolygon3D::set_disabled(bool p_disabled) {
 	disabled = p_disabled;
 	update_gizmos();
 
-	if (parent) {
-		parent->shape_owner_set_disabled(owner_id, p_disabled);
+	if (collision_object) {
+		collision_object->shape_owner_set_disabled(owner_id, p_disabled);
 	}
 }
 
@@ -163,7 +163,7 @@ real_t CollisionPolygon3D::get_margin() const {
 
 void CollisionPolygon3D::set_margin(real_t p_margin) {
 	margin = p_margin;
-	if (parent) {
+	if (collision_object) {
 		_build_polygon();
 	}
 }

--- a/scene/3d/collision_polygon_3d.h
+++ b/scene/3d/collision_polygon_3d.h
@@ -45,7 +45,7 @@ protected:
 	Vector<Point2> polygon;
 
 	uint32_t owner_id = 0;
-	CollisionObject3D *parent = nullptr;
+	CollisionObject3D *collision_object = nullptr;
 
 	bool disabled = false;
 


### PR DESCRIPTION
Oops, I forgot that CollisionPolygon existed when I made #77971.

This PR is the same as #77971 but for CollisionPolygon(2D/3D) instead of CollisionShape(2D/3D). This is an internal rename to improve readability and clarity, it does not affect behavior.