### PR TITLE
Remember only permanent bottom tabs

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1050,7 +1050,7 @@ void EditorAudioBuses::_update_buses() {
 
 EditorAudioBuses *EditorAudioBuses::register_editor() {
 	EditorAudioBuses *audio_buses = memnew(EditorAudioBuses);
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Audio"), audio_buses);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Audio"), audio_buses, true);
 	return audio_buses;
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5256,7 +5256,7 @@ void EditorNode::_save_central_editor_layout_to_config(Ref<ConfigFile> p_config_
 
 	int selected_bottom_panel_item_idx = -1;
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		if (bottom_panel_items[i].button->is_pressed()) {
+		if (bottom_panel_items[i].permanent && bottom_panel_items[i].button->is_pressed()) {
 			selected_bottom_panel_item_idx = i;
 			break;
 		}
@@ -5663,7 +5663,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	set_current_scene(p_tab);
 }
 
-Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
+Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item, bool p_permanent) {
 	Button *tb = memnew(Button);
 	tb->set_flat(true);
 	tb->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch).bind(bottom_panel_items.size()));
@@ -5679,6 +5679,7 @@ Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 	bpi.button = tb;
 	bpi.control = p_item;
 	bpi.name = p_text;
+	bpi.permanent = p_permanent; // Serves as an information when saving editor layout.
 	bottom_panel_items.push_back(bpi);
 
 	return tb;
@@ -7755,7 +7756,7 @@ EditorNode::EditorNode() {
 	bottom_panel_raise->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_raise_toggled));
 
 	log = memnew(EditorLog);
-	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
+	Button *output_button = add_bottom_panel_item(TTR("Output"), log, true);
 	log->set_tool_button(output_button);
 
 	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -252,6 +252,7 @@ private:
 		String name;
 		Control *control = nullptr;
 		Button *button = nullptr;
+		bool permanent = false;
 	};
 
 	struct ExportDefer {
@@ -904,7 +905,7 @@ public:
 
 	bool is_exiting() const { return exiting; }
 
-	Button *add_bottom_panel_item(String p_text, Control *p_item);
+	Button *add_bottom_panel_item(String p_text, Control *p_item, bool p_permanent = false);
 	void make_bottom_panel_item_visible(Control *p_item);
 	void raise_bottom_panel_item(Control *p_item);
 	void hide_bottom_panel();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1998,7 +1998,7 @@ void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
 
 AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin() {
 	anim_editor = memnew(AnimationPlayerEditor(this));
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Animation"), anim_editor);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Animation"), anim_editor, true);
 }
 
 AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -53,7 +53,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	file_server = memnew(EditorFileServer);
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
-	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
+	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger, true);
 	// Add separation for the warning/error icon that is displayed later.
 	db->add_theme_constant_override("h_separation", 6 * EDSCALE);
 	debugger->set_tool_button(db);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -622,7 +622,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	empty.instantiate();
 	shader_tabs->add_theme_style_override("panel", empty);
 
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Shader Editor"), window_wrapper);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Shader Editor"), window_wrapper, true);
 
 	// Defer connect because Editor class is not in the binding system yet.
 	EditorNode::get_singleton()->call_deferred("connect", "resource_saved", callable_mp(this, &ShaderEditorPlugin::_resource_saved), CONNECT_DEFERRED);


### PR DESCRIPTION
Fixes #77249
Fixes #77013

All bottom tabs until shader editor are permanent; further tabs will not appear at start, so they shouldn't be remembered. Maybe there is a better way to enforce that than hard-coding a specific editor though .-.