### PR TITLE
Fix NavigationMesh not clearing old polygons

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -738,6 +738,7 @@ void NavigationMeshGenerator::bake_from_source_geometry_data(Ref<NavigationMesh>
 		nav_vertices.push_back(Vector3(v[0], v[1], v[2]));
 	}
 	p_navigation_mesh->set_vertices(nav_vertices);
+	p_navigation_mesh->clear_polygons();
 
 	for (int i = 0; i < detail_mesh->nmeshes; i++) {
 		const unsigned int *detail_mesh_m = &detail_mesh->meshes[i * 4];


### PR DESCRIPTION
Fixes NavigationMesh not clearing old polygons.

Fixes https://github.com/godotengine/godot/issues/78576.

Regression from pr https://github.com/godotengine/godot/pull/77412.

Does not look like much but the testing that resulted in this pr was actually a journey that revealed multiple (older) issues that will be fixed in other prs.

Turned out the `NavigationRegion3D.region_bake_navigation()` was reliant on other bake functions to clear the navigation mesh polygons in the past. Since the function route changed, the polygons were now not cleared and would stack up with every (re)bake causing navigation map merge conflicts due to duplicated polygon edges.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
