### PR TITLE
Fix current field not updating after pasting value

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -954,6 +954,7 @@ void EditorProperty::menu_option(int p_option) {
 		} break;
 		case MENU_PASTE_VALUE: {
 			emit_changed(property, InspectorDock::get_inspector_singleton()->get_property_clipboard());
+			update_property();
 		} break;
 		case MENU_COPY_PROPERTY_PATH: {
 			DisplayServer::get_singleton()->clipboard_set(property_path);

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -208,9 +208,6 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 	array.set(index, p_value);
 	object->set_array(array);
 	emit_changed(get_edited_property(), array, "", true);
-	if (!p_changing) {
-		update_property();
-	}
 }
 
 void EditorPropertyArray::_change_type(Object *p_button, int p_index) {
@@ -740,9 +737,6 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 		object->set_dict(dict);
 		emit_changed(get_edited_property(), dict, "", true);
-	}
-	if (!p_changing) {
-		update_property();
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Reverts #76711 and supersedes #76711.
Fixes #75124, fixes #78578.

This commit only updates the field that is currently affected.
