### PR TITLE
Handle contextual editors gracefully when restoring layout

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1050,7 +1050,7 @@ void EditorAudioBuses::_update_buses() {
 
 EditorAudioBuses *EditorAudioBuses::register_editor() {
 	EditorAudioBuses *audio_buses = memnew(EditorAudioBuses);
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Audio"), audio_buses, true);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Audio"), audio_buses);
 	return audio_buses;
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5263,6 +5263,8 @@ void EditorNode::_save_central_editor_layout_to_config(Ref<ConfigFile> p_config_
 	}
 	if (selected_bottom_panel_item_idx != -1) {
 		p_config_file->set_value(EDITOR_NODE_CONFIG_SECTION, "selected_bottom_panel_item", selected_bottom_panel_item_idx);
+	} else {
+		p_config_file->set_value(EDITOR_NODE_CONFIG_SECTION, "selected_bottom_panel_item", Variant());
 	}
 
 	// Debugger tab.
@@ -5281,6 +5283,8 @@ void EditorNode::_save_central_editor_layout_to_config(Ref<ConfigFile> p_config_
 	}
 	if (selected_main_editor_idx != -1) {
 		p_config_file->set_value(EDITOR_NODE_CONFIG_SECTION, "selected_main_editor_idx", selected_main_editor_idx);
+	} else {
+		p_config_file->set_value(EDITOR_NODE_CONFIG_SECTION, "selected_main_editor_idx", Variant());
 	}
 }
 
@@ -5295,7 +5299,10 @@ void EditorNode::_load_central_editor_layout_from_config(Ref<ConfigFile> p_confi
 	if (p_config_file->has_section_key(EDITOR_NODE_CONFIG_SECTION, "selected_bottom_panel_item")) {
 		int selected_bottom_panel_item_idx = p_config_file->get_value(EDITOR_NODE_CONFIG_SECTION, "selected_bottom_panel_item");
 		if (selected_bottom_panel_item_idx >= 0 && selected_bottom_panel_item_idx < bottom_panel_items.size()) {
-			_bottom_panel_switch(true, selected_bottom_panel_item_idx);
+			// Make sure we don't try to open contextual editors which are not enabled in the current context.
+			if (bottom_panel_items[selected_bottom_panel_item_idx].button->is_visible()) {
+				_bottom_panel_switch(true, selected_bottom_panel_item_idx);
+			}
 		}
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5256,7 +5256,7 @@ void EditorNode::_save_central_editor_layout_to_config(Ref<ConfigFile> p_config_
 
 	int selected_bottom_panel_item_idx = -1;
 	for (int i = 0; i < bottom_panel_items.size(); i++) {
-		if (bottom_panel_items[i].permanent && bottom_panel_items[i].button->is_pressed()) {
+		if (bottom_panel_items[i].button->is_pressed()) {
 			selected_bottom_panel_item_idx = i;
 			break;
 		}
@@ -5663,7 +5663,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	set_current_scene(p_tab);
 }
 
-Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item, bool p_permanent) {
+Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
 	Button *tb = memnew(Button);
 	tb->set_flat(true);
 	tb->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_switch).bind(bottom_panel_items.size()));
@@ -5679,7 +5679,6 @@ Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item, bool p
 	bpi.button = tb;
 	bpi.control = p_item;
 	bpi.name = p_text;
-	bpi.permanent = p_permanent; // Serves as an information when saving editor layout.
 	bottom_panel_items.push_back(bpi);
 
 	return tb;
@@ -7756,7 +7755,7 @@ EditorNode::EditorNode() {
 	bottom_panel_raise->connect("toggled", callable_mp(this, &EditorNode::_bottom_panel_raise_toggled));
 
 	log = memnew(EditorLog);
-	Button *output_button = add_bottom_panel_item(TTR("Output"), log, true);
+	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
 	log->set_tool_button(output_button);
 
 	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -252,7 +252,6 @@ private:
 		String name;
 		Control *control = nullptr;
 		Button *button = nullptr;
-		bool permanent = false;
 	};
 
 	struct ExportDefer {
@@ -905,7 +904,7 @@ public:
 
 	bool is_exiting() const { return exiting; }
 
-	Button *add_bottom_panel_item(String p_text, Control *p_item, bool p_permanent = false);
+	Button *add_bottom_panel_item(String p_text, Control *p_item);
 	void make_bottom_panel_item_visible(Control *p_item);
 	void raise_bottom_panel_item(Control *p_item);
 	void hide_bottom_panel();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1998,7 +1998,7 @@ void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
 
 AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin() {
 	anim_editor = memnew(AnimationPlayerEditor(this));
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Animation"), anim_editor, true);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Animation"), anim_editor);
 }
 
 AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -53,7 +53,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	file_server = memnew(EditorFileServer);
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
-	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger, true);
+	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
 	// Add separation for the warning/error icon that is displayed later.
 	db->add_theme_constant_override("h_separation", 6 * EDSCALE);
 	debugger->set_tool_button(db);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -622,7 +622,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	empty.instantiate();
 	shader_tabs->add_theme_style_override("panel", empty);
 
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Shader Editor"), window_wrapper, true);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Shader Editor"), window_wrapper);
 
 	// Defer connect because Editor class is not in the binding system yet.
 	EditorNode::get_singleton()->call_deferred("connect", "resource_saved", callable_mp(this, &ShaderEditorPlugin::_resource_saved), CONNECT_DEFERRED);


### PR DESCRIPTION
Reverts https://github.com/godotengine/godot/pull/78586 as unnecessary.

Still fixes https://github.com/godotengine/godot/issues/77249 and also still fixes https://github.com/godotengine/godot/issues/77013.
Fixes https://github.com/godotengine/godot/issues/78281.

While https://github.com/godotengine/godot/pull/78586 should prevent these invalid states from happening, it does so by simply ignoring contextual editors. And it doesn't handle existing stored layouts gracefully (so an already "corrupted" project can still result in these invalid states and lead to crashes). While looking into it, I figured this whole "permanent" trick wasn't necessary.

All we need to do, IMO, is check if the contextual editor is enabled (the button is visible on the bottom panel). If not, we just don't restore it. This handles both existing projects and future projects.

I also noticed that we don't remove stored information correctly about bottom panel and main screen editors. So I fixed it as well. https://github.com/godotengine/godot/pull/78586 introduced a similar problem, btw, where switching to a contextual editor and restarting the Godot editor would bring any previously stored "permanent" editor into focus. If we don't end up reverting it, this still would require fixing.

----

I noticed a couple of weird things which I don't think are related to either KoBeWi's or mine PR.

First, with the theme editor present I sometimes get `editor\editor_node.cpp:8199 - Condition "plugins_list.has(p_plugin)" is true.` on load (regardless if it's focused or not). It doesn't seem to lead to any problems.

Second, the MRP from https://github.com/godotengine/godot/issues/77249 had its `center_split_offset` permanently stored as -416. When you restored with a bottom panel editor opened, there were no visible problems. But if you closed all the editors and reloaded, the bottom panel would take too much space (about 416 pixels, or so :P) without any editor being open. And it wouldn't reset with consecutive reloads. Manually fixing the cached file to set it to 0 fixed the issue. But I wonder if there is an issue with the SplitContainer where it doesn't correctly reset its split value. 