### PR TITLE
Disable doc cache temporarily for pre-RC stabilization

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2309,6 +2309,9 @@ void EditorHelp::_gen_doc_thread(void *p_udata) {
 static bool doc_gen_use_threads = true;
 
 void EditorHelp::generate_doc(bool p_use_cache) {
+	// Temporarily disable use of cache for pre-RC stabilization.
+	p_use_cache = false;
+
 	OS::get_singleton()->benchmark_begin_measure("EditorHelp::generate_doc");
 	if (doc_gen_use_threads) {
 		// In case not the first attempt.


### PR DESCRIPTION
Alleviates #77878, but will be really fixed by an upcoming PR.