### PR TITLE
Re-enable docs cache with fixes

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -53,7 +53,7 @@ MethodDefinition D_METHODP(const char *p_name, const char *const **p_args, uint3
 #endif
 
 ClassDB::APIType ClassDB::current_api = API_CORE;
-HashMap<ClassDB::APIType, uint64_t> ClassDB::api_hashes_cache;
+HashMap<ClassDB::APIType, uint32_t> ClassDB::api_hashes_cache;
 
 void ClassDB::set_current_api(APIType p_api) {
 	DEV_ASSERT(!api_hashes_cache.has(p_api)); // This API type may not be suitable for caching of hash if it can change later.
@@ -163,7 +163,7 @@ ClassDB::APIType ClassDB::get_api_type(const StringName &p_class) {
 	return ti->api;
 }
 
-uint64_t ClassDB::get_api_hash(APIType p_api) {
+uint32_t ClassDB::get_api_hash(APIType p_api) {
 	OBJTYPE_RLOCK;
 #ifdef DEBUG_METHODS_ENABLED
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -155,7 +155,7 @@ public:
 #endif
 
 	static APIType current_api;
-	static HashMap<APIType, uint64_t> api_hashes_cache;
+	static HashMap<APIType, uint32_t> api_hashes_cache;
 
 	static void _add_class2(const StringName &p_class, const StringName &p_inherits);
 
@@ -246,7 +246,7 @@ public:
 
 	static APIType get_api_type(const StringName &p_class);
 
-	static uint64_t get_api_hash(APIType p_api);
+	static uint32_t get_api_hash(APIType p_api);
 
 	template <typename>
 	struct member_function_traits;

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -49,33 +49,6 @@
 // Might this be a problem?
 DocTools *EditorHelp::doc = nullptr;
 
-class DocCache : public Resource {
-	GDCLASS(DocCache, Resource);
-	RES_BASE_EXTENSION("doc_cache");
-
-	String version_hash;
-	Array classes;
-
-protected:
-	static void _bind_methods() {
-		ClassDB::bind_method(D_METHOD("set_version_hash", "version_hash"), &DocCache::set_version_hash);
-		ClassDB::bind_method(D_METHOD("get_version_hash"), &DocCache::get_version_hash);
-
-		ClassDB::bind_method(D_METHOD("set_classes", "classes"), &DocCache::set_classes);
-		ClassDB::bind_method(D_METHOD("get_classes"), &DocCache::get_classes);
-
-		ADD_PROPERTY(PropertyInfo(Variant::STRING, "version_hash"), "set_version_hash", "get_version_hash");
-		ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "classes"), "set_classes", "get_classes");
-	}
-
-public:
-	String get_version_hash() const { return version_hash; }
-	void set_version_hash(const String &p_version_hash) { version_hash = p_version_hash; }
-
-	Array get_classes() const { return classes; }
-	void set_classes(const Array &p_classes) { classes = p_classes; }
-};
-
 static bool _attempt_doc_load(const String &p_class) {
 	// Docgen always happens in the outer-most class: it also generates docs for inner classes.
 	String outer_class = p_class.get_slice(".", 0);
@@ -2264,21 +2237,23 @@ void EditorHelp::_wait_for_thread() {
 }
 
 String EditorHelp::get_cache_full_path() {
-	return EditorPaths::get_singleton()->get_cache_dir().path_join("editor.doc_cache");
+	return EditorPaths::get_singleton()->get_cache_dir().path_join("editor_doc_cache.res");
 }
 
 static bool first_attempt = true;
 
 static String _compute_doc_version_hash() {
-	return vformat("%d/%d/%s", ClassDB::get_api_hash(ClassDB::API_CORE), ClassDB::get_api_hash(ClassDB::API_EDITOR), _doc_data_hash);
+	uint32_t version_hash = Engine::get_singleton()->get_version_info().hash();
+	return vformat("%d/%d/%d/%s", version_hash, ClassDB::get_api_hash(ClassDB::API_CORE), ClassDB::get_api_hash(ClassDB::API_EDITOR), _doc_data_hash);
 }
 
 void EditorHelp::_load_doc_thread(void *p_udata) {
 	DEV_ASSERT(first_attempt);
-	Ref<DocCache> cache_res = ResourceLoader::load(get_cache_full_path());
-	if (cache_res.is_valid() && cache_res->get_version_hash() == _compute_doc_version_hash()) {
-		for (int i = 0; i < cache_res->get_classes().size(); i++) {
-			doc->add_doc(DocData::ClassDoc::from_dict(cache_res->get_classes()[i]));
+	Ref<Resource> cache_res = ResourceLoader::load(get_cache_full_path());
+	if (cache_res.is_valid() && cache_res->get_meta("version_hash", "") == _compute_doc_version_hash()) {
+		Array classes = cache_res->get_meta("classes", Array());
+		for (int i = 0; i < classes.size(); i++) {
+			doc->add_doc(DocData::ClassDoc::from_dict(classes[i]));
 		}
 	} else {
 		// We have to go back to the main thread to start from scratch.
@@ -2292,14 +2267,14 @@ void EditorHelp::_gen_doc_thread(void *p_udata) {
 	compdoc.load_compressed(_doc_data_compressed, _doc_data_compressed_size, _doc_data_uncompressed_size);
 	doc->merge_from(compdoc); // Ensure all is up to date.
 
-	Ref<DocCache> cache_res;
+	Ref<Resource> cache_res;
 	cache_res.instantiate();
-	cache_res->set_version_hash(_compute_doc_version_hash());
+	cache_res->set_meta("version_hash", _compute_doc_version_hash());
 	Array classes;
 	for (const KeyValue<String, DocData::ClassDoc> &E : doc->class_list) {
 		classes.push_back(DocData::ClassDoc::to_dict(E.value));
 	}
-	cache_res->set_classes(classes);
+	cache_res->set_meta("classes", classes);
 	Error err = ResourceSaver::save(cache_res, get_cache_full_path(), ResourceSaver::FLAG_COMPRESS);
 	if (err) {
 		ERR_PRINT("Cannot save editor help cache (" + get_cache_full_path() + ").");
@@ -2309,9 +2284,6 @@ void EditorHelp::_gen_doc_thread(void *p_udata) {
 static bool doc_gen_use_threads = true;
 
 void EditorHelp::generate_doc(bool p_use_cache) {
-	// Temporarily disable use of cache for pre-RC stabilization.
-	p_use_cache = false;
-
 	OS::get_singleton()->benchmark_begin_measure("EditorHelp::generate_doc");
 	if (doc_gen_use_threads) {
 		// In case not the first attempt.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6732,7 +6732,8 @@ EditorNode::EditorNode() {
 	// No scripting by default if in editor.
 	ScriptServer::set_scripting_enabled(false);
 
-	EditorHelp::generate_doc(); // Before any editor classes are created.
+	EditorSettings::ensure_class_registered();
+	EditorHelp::generate_doc();
 	SceneState::set_disable_placeholders(true);
 	ResourceLoader::clear_translation_remaps(); // Using no remaps if in editor.
 	ResourceLoader::clear_path_remaps();

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -877,6 +877,13 @@ EditorSettings *EditorSettings::get_singleton() {
 	return singleton.ptr();
 }
 
+void EditorSettings::ensure_class_registered() {
+	ClassDB::APIType prev_api = ClassDB::get_current_api();
+	ClassDB::set_current_api(ClassDB::API_EDITOR);
+	GDREGISTER_CLASS(EditorSettings); // Otherwise it can't be unserialized.
+	ClassDB::set_current_api(prev_api);
+}
+
 void EditorSettings::create() {
 	// IMPORTANT: create() *must* create a valid EditorSettings singleton,
 	// as the rest of the engine code will assume it. As such, it should never
@@ -887,7 +894,7 @@ void EditorSettings::create() {
 		return;
 	}
 
-	GDREGISTER_CLASS(EditorSettings); // Otherwise it can't be unserialized.
+	ensure_class_registered();
 
 	String config_file_path;
 	Ref<ConfigFile> extra_config = memnew(ConfigFile);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -117,6 +117,7 @@ public:
 
 	static EditorSettings *get_singleton();
 
+	static void ensure_class_registered();
 	static void create();
 	void setup_language();
 	void setup_network();


### PR DESCRIPTION
~This is built on top of #78614, to be tested after 4.1 is out.~

- No more custom resource type.
- Fixed the API scope of `EditorSettings`.

Fixes #77878.
Fixes #78647.