### PR TITLE
Fix: hidden folder .godot/imported is allowed in _find_file function.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1366,7 +1366,7 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 	EditorFileSystemDirectory *fs = filesystem;
 
 	for (int i = 0; i < path.size(); i++) {
-		if (path[i].begins_with(".")) {
+		if (path[i].begins_with(".") && !path[i].match(".godot")) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #74037 

The problem was that if people where using blend files for their assets directly in the godot project, the assets would be without material, if the textures aren't saved in a folder of the godot project.

For assets that don't have their textures in the project, these are imported to .godot/imported, but hidden folders are excluded as locations to find files from.

I still wonder if the .godot/imported folder is to be excluded or if it was for other hidden folder but the .godot folder in the godot project.