### PR TITLE
Reset filter/repeat state of textures in GL Compatibility renderer when render target is cleared

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1938,6 +1938,8 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 			tex->active = false;
 			tex->render_target = nullptr;
 			tex->is_render_target = false;
+			tex->gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_MAX);
+			tex->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX);
 		}
 	} else {
 		Texture *tex = get_texture(rt->overridden.color);


### PR DESCRIPTION


Fixes: https://github.com/godotengine/godot/issues/78608

Might fix https://github.com/godotengine/godot/issues/78605 as well, but I can't reproduce the issue, so I can't confirm

The issue here came from caching the Filter/Repeat modes. The cache remained after clearing the rendertarget, so if the rendertarget was created, then resized (for example) the resized texture would fail to update its filter/repeat mode as the cache leads it to beleive that it is already the correct format.
