### PR TITLE
Fix Skeleton3D dirty update notification

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -631,6 +631,8 @@ void Skeleton3D::_make_dirty() {
 		return;
 	}
 
+	MessageQueue::get_singleton()->push_notification(this, NOTIFICATION_UPDATE_SKELETON);
+
 	if (is_inside_tree()) {
 		notify_deferred_thread_group(NOTIFICATION_UPDATE_SKELETON);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78470 (second try, my first PR fixed the another issue only)

Bisected the regression to https://github.com/godotengine/godot/pull/75901 and the change it made to Skeleton3D. After some testing, it's seems that at least `push_notification(NOTIFICATION_UPDATE_SKELETON);` must be called to catch all skeleton update paths in my test projects and in the linked MRP (even if the node is not in the scene tree). I left `notify_deferred_thread_group(NOTIFICATION_UPDATE_SKELETON);`, but I'm not totally sure where it is needed. This place seems to be the only place in the entire Godot codebase where it is actually directly called so the behaviour is a bit hard to understand. reduz does discuss that in the node processing PR, but not very in-deph.

So, feedback very much appreciated.

**edit:**

After some more digging (see my second post here), I'm becoming more convinced that the real solution to this bug and possibly https://github.com/godotengine/godot/issues/77548 is to either fix or tweak some notification / thread group processing changes done in https://github.com/godotengine/godot/pull/75901. I'm keeping this PR open for discussion or in case we actually want to revert to the old way of handling notifications in some places.