### PR TITLE
Display a message about missing C# support on Android/iOS/Web platforms

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -49,7 +49,7 @@
 #include "editor/editor_settings.h"
 #include "main/splash.gen.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For mono and svg.
 #ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
 #endif
@@ -2231,6 +2231,14 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 	String err;
 	bool valid = false;
 	const bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
+
+#ifdef MODULE_MONO_ENABLED
+	err += TTR("Exporting to Android is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Android with C#/Mono instead.") + "\n";
+	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error = err;
+	return false;
+#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -37,7 +37,7 @@
 #include "editor/editor_scale.h"
 #include "editor/export/editor_export.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For mono and svg.
 #ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
 #endif
@@ -1902,6 +1902,14 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
 	String err;
 	bool valid = false;
+
+#ifdef MODULE_MONO_ENABLED
+	err += TTR("Exporting to iOS is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target iOS with C#/Mono instead.") + "\n";
+	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error = err;
+	return false;
+#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -38,7 +38,7 @@
 #include "editor/editor_settings.h"
 #include "editor/export/editor_export.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
+#include "modules/modules_enabled.gen.h" // For mono and svg.
 #ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
 #endif
@@ -362,6 +362,14 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	String err;
 	bool valid = false;
 	bool extensions = (bool)p_preset->get("variant/extensions_support");
+
+#ifdef MODULE_MONO_ENABLED
+	err += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
+	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error = err;
+	return false;
+#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 	bool dvalid = exists_export_template(_get_template_name(extensions, true), &err);


### PR DESCRIPTION
When trying to export a C# project, this displays an error message after creating a export preset for an unsupported platform.

Support for these platforms is planned for a future release.

- See https://github.com/godotengine/godot/issues/70796.

## Preview

![Export dialog with error message](https://github.com/godotengine/godot/assets/180032/0bb69b56-7f5e-4610-b09d-2de0131a1f2e)