### PR TITLE
Use bullet points in shader editor creation dialog

### DIFF
--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -464,7 +464,7 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 }
 
 void ShaderCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
-	error_label->set_text("- " + p_msg);
+	error_label->set_text(String::utf8("•  ") + p_msg);
 	if (valid) {
 		error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
@@ -473,7 +473,7 @@ void ShaderCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 }
 
 void ShaderCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
-	path_error_label->set_text("- " + p_msg);
+	path_error_label->set_text(String::utf8("•  ") + p_msg);
 	if (valid) {
 		path_error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {


### PR DESCRIPTION
This is consistent with the script creation dialog.

## Preview

### Script editor (current)

![Screenshot_20230624_021042](https://github.com/godotengine/godot/assets/180032/a12952f7-ecd7-4b4c-877f-132eca83d525)

### Shader editor (this PR)

![Screenshot_20230624_021156](https://github.com/godotengine/godot/assets/180032/0dcfed8d-c6ab-44a3-a0f1-016166ccbc19)
