### PR TITLE
Add a `get_partial_path` method to NodePath

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -295,6 +295,21 @@ NodePath NodePath::get_as_property_path() const {
 	}
 }
 
+NodePath NodePath::get_partial_path(int p_name_count) const {
+	ERR_FAIL_COND_V(!data, NodePath());
+	int size = data->path.size();
+	if (p_name_count > size) {
+		WARN_PRINT("NodePath: The partial path was requested to have more names than are available. Returning the full path.");
+		return NodePath(*this);
+	}
+	Vector<StringName> new_path;
+	new_path.resize(p_name_count);
+	for (int i = 0; i < p_name_count; i++) {
+		new_path.set(i, data->path[i]);
+	}
+	return NodePath(new_path, data->absolute);
+}
+
 bool NodePath::is_empty() const {
 	return !data;
 }
@@ -331,7 +346,7 @@ NodePath NodePath::simplified() const {
 }
 
 NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
-	if (p_path.size() == 0) {
+	if (p_path.size() == 0 && !p_absolute) {
 		return;
 	}
 
@@ -343,7 +358,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 }
 
 NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p_subpath, bool p_absolute) {
-	if (p_path.size() == 0 && p_subpath.size() == 0) {
+	if (p_path.size() == 0 && p_subpath.size() == 0 && !p_absolute) {
 		return;
 	}
 

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -64,6 +64,7 @@ public:
 
 	NodePath rel_path_to(const NodePath &p_np) const;
 	NodePath get_as_property_path() const;
+	NodePath get_partial_path(int p_name_count) const;
 
 	void prepend_period();
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2022,6 +2022,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(NodePath, get_concatenated_names, sarray(), varray());
 	bind_method(NodePath, get_concatenated_subnames, sarray(), varray());
 	bind_method(NodePath, get_as_property_path, sarray(), varray());
+	bind_method(NodePath, get_partial_path, sarray("name_count"), varray());
 	bind_method(NodePath, is_empty, sarray(), varray());
 
 	/* Callable */

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -138,6 +138,13 @@
 				For example, [code]"Path2D/PathFollow2D/Sprite2D"[/code] has 3 names.
 			</description>
 		</method>
+		<method name="get_partial_path" qualifiers="const">
+			<return type="NodePath" />
+			<param index="0" name="name_count" type="int" />
+			<description>
+				Gets a partial path out of this [NodePath]. The [code]name_count[/code] parameter must be non-negative and less than or equal to the NodePath's name count (see [method get_name_count]). The returned value has the same name count as the parameter, except when the name count parameter is invalid (negative or greater than the available names). This discards any subnames if present (for example, property names on a node).
+			</description>
+		</method>
 		<method name="get_subname" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="idx" type="int" />

--- a/tests/core/string/test_node_path.h
+++ b/tests/core/string/test_node_path.h
@@ -167,6 +167,37 @@ TEST_CASE("[NodePath] Empty path") {
 			node_path_empty.is_empty(),
 			"The node path should be considered empty.");
 }
+
+TEST_CASE("[NodePath] Get Partial Path") {
+	const NodePath node_path_absolute = NodePath("/root/A");
+	const NodePath node_path_relative = NodePath("A/B");
+
+	CHECK_MESSAGE(
+			node_path_absolute.get_partial_path(0) == NodePath("/"),
+			"The returned partial path with a name count of 0 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_absolute.get_partial_path(1) == NodePath("/root"),
+			"The returned partial path with a name count of 1 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_absolute.get_partial_path(2) == NodePath("/root/A"),
+			"The returned partial path with a name count of 2 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_absolute.get_partial_path(3) == NodePath("/root/A"),
+			"The returned partial path with an invalid name count of 3 should match the expected value.");
+
+	CHECK_MESSAGE(
+			node_path_relative.get_partial_path(0) == NodePath(""),
+			"The returned partial path with a name count of 0 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_relative.get_partial_path(1) == NodePath("A"),
+			"The returned partial path with a name count of 1 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_relative.get_partial_path(2) == NodePath("A/B"),
+			"The returned partial path with a name count of 2 should match the expected value.");
+	CHECK_MESSAGE(
+			node_path_relative.get_partial_path(3) == NodePath("A/B"),
+			"The returned partial path with an invalid name count of 3 should match the expected value.");
+}
 } // namespace TestNodePath
 
 #endif // TEST_NODE_PATH_H


### PR DESCRIPTION
Implements this proposal and closes https://github.com/godotengine/godot-proposals/issues/7148

This PR adds a `get_partial_path` method to NodePath for getting the first X parts of a path. Discussion: Would it be worth specifying the start index too, or getting the last parts of a path? I only need the first parts for my uses.

I added some test cases to ensure the behavior is correct, and I ran into a minor bug where the internal constructors with the StringName arrays will discard the absolute flag if the path is empty. So I added a check to continue with the construction whenever absolute is set to true (return only when absolute is set to false).