### PR TITLE
Expose PropertyUsageFlags in GDExtension dump

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -860,6 +860,8 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 							d2["arguments"] = arguments;
 						}
 
+						d2["flags"] = mi.flags;
+
 						methods.push_back(d2);
 
 					} else if (F.name.begins_with("_")) {
@@ -955,6 +957,8 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 						d2["arguments"] = arguments;
 					}
 
+					d2["flags"] = F.flags;
+
 					signals.push_back(d2);
 				}
 
@@ -994,6 +998,11 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 					if (index != -1) {
 						d2["index"] = index;
 					}
+
+					if (F.usage != 0) {
+						d2["usage"] = F.usage;
+					}
+
 					properties.push_back(d2);
 				}
 


### PR DESCRIPTION
I'm working extensively on networking systems in Godot, specifically utilizing auto-generated code. While doing so, I've encountered the necessity to access the `PropertyUsageFlags` from the struct `PropertyInfo` from the class database from outside of Godot. These flags are critical to my work, providing insights on how each property is being used, whether for serialization, duplication, or other specific tasks.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/7150*