### PR TITLE
Revert "Fix paste value not updated in dictionaries/arrays"

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -208,9 +208,6 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 	array.set(index, p_value);
 	object->set_array(array);
 	emit_changed(get_edited_property(), array, "", true);
-	if (!p_changing) {
-		update_property();
-	}
 }
 
 void EditorPropertyArray::_change_type(Object *p_button, int p_index) {
@@ -740,9 +737,6 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 		object->set_dict(dict);
 		emit_changed(get_edited_property(), dict, "", true);
-	}
-	if (!p_changing) {
-		update_property();
 	}
 }
 


### PR DESCRIPTION
- Reverts godotengine/godot#76711
- Fixes https://github.com/godotengine/godot/issues/78628