### PR TITLE
Unexpose `DocCache` class

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2321,7 +2321,6 @@ void EditorHelp::generate_doc(bool p_use_cache) {
 	DEV_ASSERT(first_attempt == (doc == nullptr));
 
 	if (!doc) {
-		GDREGISTER_CLASS(DocCache);
 		doc = memnew(DocTools);
 	}
 


### PR DESCRIPTION
* Closes #78647.

I tested and did not notice any issues. Perhaps this class was exposed by mistake?

CC @RandomShaper
