### PR TITLE
Add example for `NodePath` to grandparent

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -15,6 +15,7 @@
 		^"." # The current node.
 		^".." # The parent node.
 		^"../C" # A sibling node C.
+		^"../.." # The grandparent node.
 		# A leading slash means it is absolute from the SceneTree.
 		^"/root" # Equivalent to get_tree().get_root().
 		^"/root/Main" # If your main scene's root node were named "Main".


### PR DESCRIPTION
The way to get parent of parent etc. might not be obvious to users, added a clarifying example, to prevent assumptions like `...` from extrapolation

* 3.x version: #78661

* Fixes: #78658

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
