### PR TITLE
Mark Node as ready after sending notification

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -226,9 +226,9 @@ void Node::_propagate_ready() {
 	notification(NOTIFICATION_POST_ENTER_TREE);
 
 	if (data.ready_first) {
-		data.ready_first = false;
 		notification(NOTIFICATION_READY);
 		emit_signal(SceneStringNames::get_singleton()->ready);
+		data.ready_first = false;
 	}
 }
 


### PR DESCRIPTION
Ensures the `Node::is_node_ready` method returns true only after `NOTIFICATION_READY` has been sent (and therefore after the script's `_ready` method has been called).
