### PR TITLE
Improve script icon cache

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1114,7 +1114,9 @@ Ref<Texture2D> EditorData::_load_script_icon(const String &p_path) const {
 
 Ref<Texture2D> EditorData::get_script_icon(const Ref<Script> &p_script) {
 	// Take from the local cache, if available.
-	if (_script_icon_cache.has(p_script) && _script_icon_cache[p_script].is_valid()) {
+	if (_script_icon_cache.has(p_script)) {
+		// Can be an empty value if we can't resolve any icon for this script.
+		// An empty value is still cached to avoid unnecessary attempts at resolving it again.
 		return _script_icon_cache[p_script];
 	}
 
@@ -1139,6 +1141,27 @@ Ref<Texture2D> EditorData::get_script_icon(const Ref<Script> &p_script) {
 
 		// Move to the base class.
 		base_scr = base_scr->get_base_script();
+	}
+
+	// No custom icon was found in the inheritance chain, so check the base
+	// class of the script instead.
+	String base_type;
+	p_script->get_language()->get_global_class_name(p_script->get_path(), &base_type);
+
+	// Check if the base type is an extension-defined type.
+	Ref<Texture2D> ext_icon = extension_class_get_icon(base_type);
+	if (ext_icon.is_valid()) {
+		_script_icon_cache[p_script] = ext_icon;
+		return ext_icon;
+	}
+
+	// Look for the base type in the editor theme.
+	// This is only relevant for built-in classes.
+	const Control *gui_base = EditorNode::get_singleton()->get_gui_base();
+	if (gui_base && gui_base->has_theme_icon(base_type, SNAME("EditorIcons"))) {
+		Ref<Texture2D> theme_icon = gui_base->get_theme_icon(base_type, SNAME("EditorIcons"));
+		_script_icon_cache[p_script] = theme_icon;
+		return theme_icon;
 	}
 
 	// If no icon found, cache it as null.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3408,6 +3408,7 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 
 void EditorNode::_remove_scene(int index, bool p_change_tab) {
 	// Clear icon cache in case some scripts are no longer needed.
+	// FIXME: Perfectly the cache should never be cleared and only updated on per-script basis, when an icon changes.
 	editor_data.clear_script_icon_cache();
 
 	if (editor_data.get_edited_scene() == index) {
@@ -4242,23 +4243,6 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 		Ref<Texture2D> script_icon = ed.get_script_icon(p_script);
 		if (script_icon.is_valid()) {
 			return script_icon;
-		}
-
-		// No custom icon was found in the inheritance chain, so check the base
-		// class of the script instead.
-		String base_type;
-		p_script->get_language()->get_global_class_name(p_script->get_path(), &base_type);
-
-		// Check if the base type is an extension-defined type.
-		Ref<Texture2D> ext_icon = ed.extension_class_get_icon(base_type);
-		if (ext_icon.is_valid()) {
-			return ext_icon;
-		}
-
-		// Look for the base type in the editor theme.
-		// This is only relevant for built-in classes.
-		if (gui_base && gui_base->has_theme_icon(base_type, "EditorIcons")) {
-			return gui_base->get_theme_icon(base_type, "EditorIcons");
 		}
 	}
 


### PR DESCRIPTION
As noted in https://github.com/godotengine/godot/issues/78295#issuecomment-1606067045, the editor wasn't using null icon cache correctly. This PR makes the `get_script_icon()` return null early if the cache contains null and also moves some script-related logic to this method, so more code is cached.

Fixes #78295
It's noticeably faster, but still quite slow. I only tested debug build though.