### PR TITLE
Fixed GPUParticles2D preprocessing bug 

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -519,6 +519,7 @@ bool SceneTree::process(double p_time) {
 
 	process_tweens(p_time, false);
 
+	MessageQueue::get_singleton()->flush(); //small little hack
 	flush_transform_notifications(); //additional transforms after timers update
 
 	_call_idle_callbacks();


### PR DESCRIPTION
When awaiting on timer before switching to a scene containing the particles, GPUParticles2D is first preprocessed with an initial position, and then updated to the set position on the next frame. Details of the fix in my comment on the bug page.

Fixes #75723 