### PR TITLE
Fix documentation for `Mutex.try_lock`

### DIFF
--- a/doc/classes/Mutex.xml
+++ b/doc/classes/Mutex.xml
@@ -27,7 +27,7 @@
 			<return type="bool" />
 			<description>
 				Tries locking this [Mutex], but does not block. Returns [code]true[/code] on success, [code]false[/code] otherwise.
-				[b]Note:[/b] This function returns [constant OK] if the thread already has ownership of the mutex.
+				[b]Note:[/b] This function returns [code]true[/code] if the thread already has ownership of the mutex.
 			</description>
 		</method>
 		<method name="unlock">


### PR DESCRIPTION
Documentation was not updated when return type was changed from `Error` to `bool`

* Fixes: #78686
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
