### PR TITLE
Mention Xbox menu button by name in Start button description

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1192,7 +1192,7 @@ static const char *_joy_button_descriptions[(size_t)JoyButton::SDL_MAX] = {
 	TTRC("Top Action, Sony Triangle, Xbox Y, Nintendo X"),
 	TTRC("Back, Sony Select, Xbox Back, Nintendo -"),
 	TTRC("Guide, Sony PS, Xbox Home"),
-	TTRC("Start, Nintendo +"),
+	TTRC("Start, Xbox Menu, Nintendo +"),
 	TTRC("Left Stick, Sony L3, Xbox L/LS"),
 	TTRC("Right Stick, Sony R3, Xbox R/RS"),
 	TTRC("Left Shoulder, Sony L1, Xbox LB"),


### PR DESCRIPTION
Microsoft officially calls it the Menu button: https://support.xbox.com/en-US/help/hardware-network/controller/get-to-know-your-xbox-series-x-s-controller

- This closes https://github.com/godotengine/godot/issues/78674.

## Preview

![image](https://github.com/godotengine/godot/assets/180032/f71864e0-fd9c-4312-b240-03e92564455d)