### PR TITLE
[MP] Add "synchronizining" signals to MultiplayerSynchronizer.

### DIFF
--- a/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
+++ b/modules/multiplayer/doc_classes/MultiplayerSynchronizer.xml
@@ -78,9 +78,19 @@
 				Emitted when a new delta synchronization state is received by this synchronizer after the properties have been updated.
 			</description>
 		</signal>
+		<signal name="delta_synchronizing">
+			<description>
+				Emitted when a new delta synchronization state is received by this synchronizer before updating the properties.
+			</description>
+		</signal>
 		<signal name="synchronized">
 			<description>
 				Emitted when a new synchronization state is received by this synchronizer after the properties have been updated.
+			</description>
+		</signal>
+		<signal name="synchronizing">
+			<description>
+				Emitted when a new synchronization state is received by this synchronizer before updating the properties.
 			</description>
 		</signal>
 		<signal name="visibility_changed">

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -273,7 +273,9 @@ void MultiplayerSynchronizer::_bind_methods() {
 	BIND_ENUM_CONSTANT(VISIBILITY_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(VISIBILITY_PROCESS_NONE);
 
+	ADD_SIGNAL(MethodInfo("synchronizing"));
 	ADD_SIGNAL(MethodInfo("synchronized"));
+	ADD_SIGNAL(MethodInfo("delta_synchronizing"));
 	ADD_SIGNAL(MethodInfo("delta_synchronized"));
 	ADD_SIGNAL(MethodInfo("visibility_changed", PropertyInfo(Variant::INT, "for_peer")));
 }

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -782,10 +782,11 @@ Error SceneReplicationInterface::on_delta_receive(int p_from, const uint8_t *p_b
 		Error err = MultiplayerAPI::decode_and_decompress_variants(vars, p_buffer + ofs, size, consumed);
 		ERR_FAIL_COND_V(err != OK, err);
 		ERR_FAIL_COND_V(uint32_t(consumed) != size, ERR_INVALID_DATA);
+		sync->emit_signal(SNAME("delta_synchronizing"));
 		err = MultiplayerSynchronizer::set_state(props, node, vars);
+		sync->emit_signal(SNAME("delta_synchronized"));
 		ERR_FAIL_COND_V(err != OK, err);
 		ofs += size;
-		sync->emit_signal(SNAME("delta_synchronized"));
 #ifdef DEBUG_ENABLED
 		_profile_node_data("delta_in", sync->get_instance_id(), size);
 #endif
@@ -883,10 +884,11 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		int consumed;
 		Error err = MultiplayerAPI::decode_and_decompress_variants(vars, &p_buffer[ofs], size, consumed);
 		ERR_FAIL_COND_V(err, err);
+		sync->emit_signal(SNAME("synchronizing"));
 		err = MultiplayerSynchronizer::set_state(props, node, vars);
+		sync->emit_signal(SNAME("synchronized"));
 		ERR_FAIL_COND_V(err, err);
 		ofs += size;
-		sync->emit_signal(SNAME("synchronized"));
 #ifdef DEBUG_ENABLED
 		_profile_node_data("sync_in", sync->get_instance_id(), size);
 #endif


### PR DESCRIPTION
Fired before the synchronization happens.

This come up in a discussion in the contributor chat, but I'm not 100% sold to its usefulness, so leaving it here in draft for discussion.