### PR TITLE
Fix missing translation in SceneCreateDialog

### DIFF
--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -126,7 +126,7 @@ void SceneCreateDialog::update_dialog() {
 		node_type_other->set_icon(nullptr);
 	}
 
-	update_error(node_error_label, MSG_OK, "Root node valid.");
+	update_error(node_error_label, MSG_OK, TTR("Root node valid."));
 
 	root_name = root_name_edit->get_text().strip_edges();
 	if (root_name.is_empty()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
