### PR TITLE
Fix button shortcut with `ACTION_MODE_BUTTON_RELEASE`

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -362,7 +362,8 @@ void BaseButton::_shortcut_feedback_timeout() {
 void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!is_disabled() && p_event->is_pressed() && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
+	bool action_mode_press = get_action_mode() == ACTION_MODE_BUTTON_PRESS;
+	if (!is_disabled() && p_event->is_pressed() == action_mode_press && is_visible_in_tree() && !p_event->is_echo() && shortcut.is_valid() && shortcut->matches_event(p_event)) {
 		if (toggle_mode) {
 			status.pressed = !status.pressed;
 


### PR DESCRIPTION
A button with `ACTION_MODE_BUTTON_RELEASE` should not react to pressed, but to unpressed shortcuts.
resolve part of #75318

This doesn't try to fix the other issue, that when the button has focus, `enter-press+release` triggers the button twice, which would require a bigger change: `InputEvent` gets set to handled, when a button is successfully pressed.