### PR TITLE
Fix CharacterBody3D `get_position_delta()` and `get_real_velocity()`

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1780,7 +1780,7 @@ const Vector3 &CharacterBody3D::get_last_motion() const {
 }
 
 Vector3 CharacterBody3D::get_position_delta() const {
-	return get_transform().origin - previous_position;
+	return get_global_transform().origin - previous_position;
 }
 
 const Vector3 &CharacterBody3D::get_real_velocity() const {


### PR DESCRIPTION
The `previous_position` variable is in global coordinates:

https://github.com/godotengine/godot/blob/3710f069293f2fde8afe33fea898c4b36fa5e943/scene/3d/physics_body_3d.cpp#L1171-L1172

so `get_position_delta()` should subtract this from the current *global* position.

That's also how it is in 2D:

https://github.com/godotengine/godot/blob/1f9e540f14edbf2d496a1421f8d37e5b483c4c53/scene/2d/physics_body_2d.cpp#L1530-L1532

This also fixes `get_real_velocity()` in 3D:

https://github.com/godotengine/godot/blob/3710f069293f2fde8afe33fea898c4b36fa5e943/scene/3d/physics_body_3d.cpp#L1230-L1231

- Fixes https://github.com/godotengine/godot/issues/78690