### PR TITLE
Fix that `ViewportTexture` cannot be setup again after failed setup

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -170,6 +170,9 @@ Ref<Image> ViewportTexture::get_image() const {
 }
 
 void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
+	// Always reset this, even if this call fails with an error.
+	vp_pending = false;
+
 	Node *vpn = p_loc_scene->get_node_or_null(path);
 	ERR_FAIL_NULL_MSG(vpn, "Path to node is invalid: '" + path + "'.");
 	vp = Object::cast_to<Viewport>(vpn);
@@ -186,7 +189,6 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 		ERR_FAIL_COND(proxy.is_valid()); // Should be invalid.
 		proxy = RS::get_singleton()->texture_proxy_create(vp->texture_rid);
 	}
-	vp_pending = false;
 	vp_changed = false;
 
 	emit_changed();


### PR DESCRIPTION
`vp_pending` is a flag indicating to wait for `ViewportTexture::_setup_local_to_scene` to be called. Once this method is called, no matter whether the setup will fail or not, it needs to be reset to `false`.

Fix #77678.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
