### PR TITLE
Don't use doubles on the mac.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2523,14 +2523,22 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		//pipelines
 		Vector<RD::VertexAttribute> vf;
 		RD::VertexAttribute vd;
+#ifdef MACOS_ENABLED
+		vd.format = RD::DATA_FORMAT_R32G32B32_SFLOAT;
+#else
 		vd.format = sizeof(real_t) == sizeof(float) ? RD::DATA_FORMAT_R32G32B32_SFLOAT : RD::DATA_FORMAT_R64G64B64_SFLOAT;
+#endif
 		vd.location = 0;
 		vd.offset = 0;
 		vd.stride = sizeof(real_t) * 3;
 		vf.push_back(vd);
 		shadow_render.vertex_format = RD::get_singleton()->vertex_format_create(vf);
 
+#ifdef MACOS_ENABLED
+		vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
+#else
 		vd.format = sizeof(real_t) == sizeof(float) ? RD::DATA_FORMAT_R32G32_SFLOAT : RD::DATA_FORMAT_R64G64_SFLOAT;
+#endif
 		vd.stride = sizeof(real_t) * 2;
 
 		vf.write[0] = vd;


### PR DESCRIPTION
This avoid errors in the log about the wrong type on the mac.

What is the proper policy? Should doubles for the gpu be banned across the platforms? This pr only changes it for the mac. I am also unsure if it's correct.

vd.stride is also incorrect.

> Don't use doubles on the mac. · V-Sekai/godot@0783409
> What's the policy on GPU doubles? I thought it was no for any reason
> clayjohn — Today at 17:27
> Metal doesn't support doubles, so they can't be used on the GPU on macs
> A lot of Intel chips don't support them either