### PR TITLE
Process AnimationNode by passing `AnimationTree*` instead of `State*`.

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -58,10 +58,11 @@
 		</method>
 		<method name="_process" qualifiers="virtual const">
 			<return type="float" />
-			<param index="0" name="time" type="float" />
-			<param index="1" name="seek" type="bool" />
-			<param index="2" name="is_external_seeking" type="bool" />
-			<param index="3" name="test_only" type="bool" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="time" type="float" />
+			<param index="2" name="seek" type="bool" />
+			<param index="3" name="is_external_seeking" type="bool" />
+			<param index="4" name="test_only" type="bool" />
 			<description>
 				When inheriting from [AnimationRootNode], implement this virtual method to run some code when this animation node is processed. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute.
 				Here, call the [method blend_input], [method blend_node] or [method blend_animation] functions. You can also use [method get_parameter] and [method set_parameter] to modify local memory.
@@ -77,13 +78,14 @@
 		</method>
 		<method name="blend_animation">
 			<return type="void" />
-			<param index="0" name="animation" type="StringName" />
-			<param index="1" name="time" type="float" />
-			<param index="2" name="delta" type="float" />
-			<param index="3" name="seeked" type="bool" />
-			<param index="4" name="is_external_seeking" type="bool" />
-			<param index="5" name="blend" type="float" />
-			<param index="6" name="looped_flag" type="int" enum="Animation.LoopedFlag" default="0" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="animation" type="StringName" />
+			<param index="2" name="time" type="float" />
+			<param index="3" name="delta" type="float" />
+			<param index="4" name="seeked" type="bool" />
+			<param index="5" name="is_external_seeking" type="bool" />
+			<param index="6" name="blend" type="float" />
+			<param index="7" name="looped_flag" type="int" enum="Animation.LoopedFlag" default="0" />
 			<description>
 				Blend an animation by [param blend] amount (name must be valid in the linked [AnimationPlayer]). A [param time] and [param delta] may be passed, as well as whether [param seeked] happened.
 				A [param looped_flag] is used by internal processing immediately after the loop. See also [enum Animation.LoopedFlag].
@@ -91,22 +93,8 @@
 		</method>
 		<method name="blend_input">
 			<return type="float" />
-			<param index="0" name="input_index" type="int" />
-			<param index="1" name="time" type="float" />
-			<param index="2" name="seek" type="bool" />
-			<param index="3" name="is_external_seeking" type="bool" />
-			<param index="4" name="blend" type="float" />
-			<param index="5" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
-			<param index="6" name="sync" type="bool" default="true" />
-			<param index="7" name="test_only" type="bool" default="false" />
-			<description>
-				Blend an input. This is only useful for animation nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
-			</description>
-		</method>
-		<method name="blend_node">
-			<return type="float" />
-			<param index="0" name="name" type="StringName" />
-			<param index="1" name="node" type="AnimationNode" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="input_index" type="int" />
 			<param index="2" name="time" type="float" />
 			<param index="3" name="seek" type="bool" />
 			<param index="4" name="is_external_seeking" type="bool" />
@@ -114,6 +102,22 @@
 			<param index="6" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
 			<param index="7" name="sync" type="bool" default="true" />
 			<param index="8" name="test_only" type="bool" default="false" />
+			<description>
+				Blend an input. This is only useful for animation nodes created for an [AnimationNodeBlendTree]. The [param time] parameter is a relative delta, unless [param seek] is [code]true[/code], in which case it is absolute. A filter mode may be optionally passed (see [enum FilterAction] for options).
+			</description>
+		</method>
+		<method name="blend_node">
+			<return type="float" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="name" type="StringName" />
+			<param index="2" name="node" type="AnimationNode" />
+			<param index="3" name="time" type="float" />
+			<param index="4" name="seek" type="bool" />
+			<param index="5" name="is_external_seeking" type="bool" />
+			<param index="6" name="blend" type="float" />
+			<param index="7" name="filter" type="int" enum="AnimationNode.FilterAction" default="0" />
+			<param index="8" name="sync" type="bool" default="true" />
+			<param index="9" name="test_only" type="bool" default="false" />
 			<description>
 				Blend another animation node (in case this animation node contains children animation nodes). This function is only useful if you inherit from [AnimationRootNode] instead, else editors will not display your animation node for addition.
 			</description>
@@ -140,7 +144,8 @@
 		</method>
 		<method name="get_parameter" qualifiers="const">
 			<return type="Variant" />
-			<param index="0" name="name" type="StringName" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="name" type="StringName" />
 			<description>
 				Gets the value of a parameter. Parameters are custom local memory used for your animation nodes, given a resource can be reused in multiple trees.
 			</description>
@@ -177,8 +182,9 @@
 		</method>
 		<method name="set_parameter">
 			<return type="void" />
-			<param index="0" name="name" type="StringName" />
-			<param index="1" name="value" type="Variant" />
+			<param index="0" name="tree" type="AnimationTree" />
+			<param index="1" name="name" type="StringName" />
+			<param index="2" name="value" type="Variant" />
 			<description>
 				Sets a custom parameter. These are used as local memory, because resources can be reused across the tree or scenes.
 			</description>

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -272,19 +272,19 @@ void AnimationNodeBlendSpace1D::_add_blend_point(int p_index, const Ref<Animatio
 	}
 }
 
-double AnimationNodeBlendSpace1D::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+double AnimationNodeBlendSpace1D::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	if (blend_points_used == 0) {
 		return 0.0;
 	}
 
 	if (blend_points_used == 1) {
 		// only one point available, just play that animation
-		return blend_node(blend_points[0].name, blend_points[0].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		return blend_node(p_tree, blend_points[0].name, blend_points[0].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	}
 
-	double blend_pos = get_parameter(blend_position);
-	int cur_closest = get_parameter(closest);
-	double cur_length_internal = get_parameter(length_internal);
+	double blend_pos = get_parameter(p_tree, blend_position);
+	int cur_closest = get_parameter(p_tree, closest);
+	double cur_length_internal = get_parameter(p_tree, length_internal);
 	double max_time_remaining = 0.0;
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {
@@ -341,10 +341,10 @@ double AnimationNodeBlendSpace1D::_process(double p_time, bool p_seek, bool p_is
 
 		for (int i = 0; i < blend_points_used; i++) {
 			if (i == point_lower || i == point_higher) {
-				double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, weights[i], FILTER_IGNORE, true, p_test_only);
+				double remaining = blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, weights[i], FILTER_IGNORE, true, p_test_only);
 				max_time_remaining = MAX(max_time_remaining, remaining);
 			} else if (sync) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
+				blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -369,29 +369,29 @@ double AnimationNodeBlendSpace1D::_process(double p_time, bool p_seek, bool p_is
 					na_n->set_backward(na_c->is_backward());
 				}
 				//see how much animation remains
-				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
+				from = cur_length_internal - blend_node(p_tree, blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
 			}
 
-			max_time_remaining = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+			max_time_remaining = blend_node(p_tree, blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 			cur_length_internal = from + max_time_remaining;
 
 			cur_closest = new_closest;
 
 		} else {
-			max_time_remaining = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+			max_time_remaining = blend_node(p_tree, blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
+					blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}
 	}
 
-	set_parameter(this->closest, cur_closest);
-	set_parameter(this->length_internal, cur_length_internal);
+	set_parameter(p_tree, this->closest, cur_closest);
+	set_parameter(p_tree, this->length_internal, cur_length_internal);
 	return max_time_remaining;
 }
 

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -114,7 +114,7 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	String get_caption() const override;
 
 	Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -442,12 +442,12 @@ void AnimationNodeBlendSpace2D::_blend_triangle(const Vector2 &p_pos, const Vect
 	r_weights[2] = w;
 }
 
-double AnimationNodeBlendSpace2D::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+double AnimationNodeBlendSpace2D::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	_update_triangles();
 
-	Vector2 blend_pos = get_parameter(blend_position);
-	int cur_closest = get_parameter(closest);
-	double cur_length_internal = get_parameter(length_internal);
+	Vector2 blend_pos = get_parameter(p_tree, blend_position);
+	int cur_closest = get_parameter(p_tree, closest);
+	double cur_length_internal = get_parameter(p_tree, length_internal);
 	double mind = 0.0; //time of min distance point
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {
@@ -512,7 +512,7 @@ double AnimationNodeBlendSpace2D::_process(double p_time, bool p_seek, bool p_is
 			for (int j = 0; j < 3; j++) {
 				if (i == triangle_points[j]) {
 					//blend with the given weight
-					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, blend_weights[j], FILTER_IGNORE, true, p_test_only);
+					double t = blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, blend_weights[j], FILTER_IGNORE, true, p_test_only);
 					if (first || t < mind) {
 						mind = t;
 						first = false;
@@ -523,7 +523,7 @@ double AnimationNodeBlendSpace2D::_process(double p_time, bool p_seek, bool p_is
 			}
 
 			if (sync && !found) {
-				blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
+				blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	} else {
@@ -548,29 +548,29 @@ double AnimationNodeBlendSpace2D::_process(double p_time, bool p_seek, bool p_is
 					na_n->set_backward(na_c->is_backward());
 				}
 				//see how much animation remains
-				from = cur_length_internal - blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
+				from = cur_length_internal - blend_node(p_tree, blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, false, p_is_external_seeking, 0.0, FILTER_IGNORE, true, p_test_only);
 			}
 
-			mind = blend_node(blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_tree, blend_points[new_closest].name, blend_points[new_closest].node, from, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 			cur_length_internal = from + mind;
 
 			cur_closest = new_closest;
 
 		} else {
-			mind = blend_node(blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+			mind = blend_node(p_tree, blend_points[cur_closest].name, blend_points[cur_closest].node, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 		}
 
 		if (sync) {
 			for (int i = 0; i < blend_points_used; i++) {
 				if (i != cur_closest) {
-					blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
+					blend_node(p_tree, blend_points[i].name, blend_points[i].node, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 				}
 			}
 		}
 	}
 
-	set_parameter(this->closest, cur_closest);
-	set_parameter(this->length_internal, cur_length_internal);
+	set_parameter(p_tree, this->closest, cur_closest);
+	set_parameter(p_tree, this->length_internal, cur_length_internal);
 	return mind;
 }
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -129,7 +129,7 @@ public:
 	void set_y_label(const String &p_label);
 	String get_y_label() const;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	Vector2 get_closest_point(const Vector2 &p_point);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -64,20 +64,21 @@ void AnimationNodeAnimation::_validate_property(PropertyInfo &p_property) const 
 	}
 }
 
-double AnimationNodeAnimation::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	AnimationPlayer *ap = state->player;
+double AnimationNodeAnimation::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	ERR_FAIL_NULL_V(p_tree, 0);
+	AnimationPlayer *ap = get_state(p_tree)->player;
 	ERR_FAIL_NULL_V(ap, 0);
 
-	double cur_time = get_parameter(time);
+	double cur_time = get_parameter(p_tree, time);
 
 	if (!ap->has_animation(animation)) {
-		AnimationNodeBlendTree *tree = Object::cast_to<AnimationNodeBlendTree>(parent);
-		if (tree) {
-			String node_name = tree->get_node_name(Ref<AnimationNodeAnimation>(this));
-			make_invalid(vformat(RTR("On BlendTree node '%s', animation not found: '%s'"), node_name, animation));
+		AnimationNodeBlendTree *blend_tree = Object::cast_to<AnimationNodeBlendTree>(parent);
+		if (blend_tree) {
+			String node_name = blend_tree->get_node_name(Ref<AnimationNodeAnimation>(this));
+			make_invalid(p_tree, vformat(RTR("On BlendTree node '%s', animation not found: '%s'"), node_name, animation));
 
 		} else {
-			make_invalid(vformat(RTR("Animation not found: '%s'"), animation));
+			make_invalid(p_tree, vformat(RTR("Animation not found: '%s'"), animation));
 		}
 
 		return 0;
@@ -150,26 +151,26 @@ double AnimationNodeAnimation::_process(double p_time, bool p_seek, bool p_is_ex
 
 		// Emit start & finish signal. Internally, the detections are the same for backward.
 		// We should use call_deferred since the track keys are still being prosessed.
-		if (state->tree) {
+		if (p_tree) {
 			// AnimationTree uses seek to 0 "internally" to process the first key of the animation, which is used as the start detection.
 			if (p_seek && !p_is_external_seeking && cur_time == 0) {
-				state->tree->call_deferred(SNAME("emit_signal"), "animation_started", animation);
+				p_tree->call_deferred(SNAME("emit_signal"), "animation_started", animation);
 			}
 			// Finished.
 			if (prev_time < anim_size && cur_time >= anim_size) {
-				state->tree->call_deferred(SNAME("emit_signal"), "animation_finished", animation);
+				p_tree->call_deferred(SNAME("emit_signal"), "animation_finished", animation);
 			}
 		}
 	}
 
 	if (!p_test_only) {
 		if (play_mode == PLAY_MODE_FORWARD) {
-			blend_animation(animation, cur_time, step, p_seek, p_is_external_seeking, 1.0, looped_flag);
+			blend_animation(p_tree, animation, cur_time, step, p_seek, p_is_external_seeking, 1.0, looped_flag);
 		} else {
-			blend_animation(animation, anim_size - cur_time, -step, p_seek, p_is_external_seeking, 1.0, looped_flag);
+			blend_animation(p_tree, animation, anim_size - cur_time, -step, p_seek, p_is_external_seeking, 1.0, looped_flag);
 		}
 	}
-	set_parameter(time, cur_time);
+	set_parameter(p_tree, time, cur_time);
 
 	return is_looping ? HUGE_LENGTH : anim_size - cur_time;
 }
@@ -333,16 +334,16 @@ bool AnimationNodeOneShot::has_filter() const {
 	return true;
 }
 
-double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	OneShotRequest cur_request = static_cast<OneShotRequest>((int)get_parameter(request));
-	bool cur_active = get_parameter(active);
-	bool cur_internal_active = get_parameter(internal_active);
-	double cur_time = get_parameter(time);
-	double cur_remaining = get_parameter(remaining);
-	double cur_fade_out_remaining = get_parameter(fade_out_remaining);
-	double cur_time_to_restart = get_parameter(time_to_restart);
+double AnimationNodeOneShot::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	OneShotRequest cur_request = static_cast<OneShotRequest>((int)get_parameter(p_tree, request));
+	bool cur_active = get_parameter(p_tree, active);
+	bool cur_internal_active = get_parameter(p_tree, internal_active);
+	double cur_time = get_parameter(p_tree, time);
+	double cur_remaining = get_parameter(p_tree, remaining);
+	double cur_fade_out_remaining = get_parameter(p_tree, fade_out_remaining);
+	double cur_time_to_restart = get_parameter(p_tree, time_to_restart);
 
-	set_parameter(request, ONE_SHOT_REQUEST_NONE);
+	set_parameter(p_tree, request, ONE_SHOT_REQUEST_NONE);
 
 	bool is_shooting = true;
 	bool clear_remaining_fade = false;
@@ -354,9 +355,9 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 
 	bool do_start = cur_request == ONE_SHOT_REQUEST_FIRE;
 	if (cur_request == ONE_SHOT_REQUEST_ABORT) {
-		set_parameter(internal_active, false);
-		set_parameter(active, false);
-		set_parameter(time_to_restart, -1);
+		set_parameter(p_tree, internal_active, false);
+		set_parameter(p_tree, active, false);
+		set_parameter(p_tree, time_to_restart, -1);
 		is_shooting = false;
 	} else if (cur_request == ONE_SHOT_REQUEST_FADE_OUT && !is_fading_out) { // If fading, keep current fade.
 		if (cur_active) {
@@ -367,15 +368,15 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 			// Shot is ended, do nothing.
 			is_shooting = false;
 		}
-		set_parameter(internal_active, false);
-		set_parameter(time_to_restart, -1);
+		set_parameter(p_tree, internal_active, false);
+		set_parameter(p_tree, time_to_restart, -1);
 	} else if (!do_start && !cur_active) {
 		if (cur_time_to_restart >= 0.0 && !p_seek) {
 			cur_time_to_restart -= p_time;
 			if (cur_time_to_restart < 0) {
 				do_start = true; // Restart.
 			}
-			set_parameter(time_to_restart, cur_time_to_restart);
+			set_parameter(p_tree, time_to_restart, cur_time_to_restart);
 		}
 		if (!do_start) {
 			is_shooting = false;
@@ -387,24 +388,24 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 	if (clear_remaining_fade) {
 		os_seek = false;
 		cur_fade_out_remaining = 0;
-		set_parameter(fade_out_remaining, 0);
+		set_parameter(p_tree, fade_out_remaining, 0);
 		if (is_fading_out) {
 			is_fading_out = false;
-			set_parameter(internal_active, false);
-			set_parameter(active, false);
+			set_parameter(p_tree, internal_active, false);
+			set_parameter(p_tree, active, false);
 		}
 	}
 
 	if (!is_shooting) {
-		return blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+		return blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
 	}
 
 	if (do_start) {
 		cur_time = 0;
 		os_seek = true;
-		set_parameter(request, ONE_SHOT_REQUEST_NONE);
-		set_parameter(internal_active, true);
-		set_parameter(active, true);
+		set_parameter(p_tree, request, ONE_SHOT_REQUEST_NONE);
+		set_parameter(p_tree, internal_active, true);
+		set_parameter(p_tree, active, true);
 	}
 
 	real_t blend = 1.0;
@@ -422,7 +423,7 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 	} else if (!do_start && !is_fading_out && cur_remaining <= fade_out) {
 		is_fading_out = true;
 		cur_fade_out_remaining = cur_remaining;
-		set_parameter(internal_active, false);
+		set_parameter(p_tree, internal_active, false);
 	}
 
 	if (is_fading_out) {
@@ -439,11 +440,11 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 
 	double main_rem = 0.0;
 	if (mix == MIX_MODE_ADD) {
-		main_rem = blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+		main_rem = blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
 	} else {
-		main_rem = blend_input(0, p_time, use_blend && p_seek, p_is_external_seeking, 1.0 - blend, FILTER_BLEND, sync, p_test_only); // Unlike below, processing this edge is a corner case.
+		main_rem = blend_input(p_tree, 0, p_time, use_blend && p_seek, p_is_external_seeking, 1.0 - blend, FILTER_BLEND, sync, p_test_only); // Unlike below, processing this edge is a corner case.
 	}
-	double os_rem = blend_input(1, os_seek ? cur_time : p_time, os_seek, p_is_external_seeking, Math::is_zero_approx(blend) ? CMP_EPSILON : blend, FILTER_PASS, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	double os_rem = blend_input(p_tree, 1, os_seek ? cur_time : p_time, os_seek, p_is_external_seeking, Math::is_zero_approx(blend) ? CMP_EPSILON : blend, FILTER_PASS, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 	if (do_start) {
 		cur_remaining = os_rem;
@@ -456,18 +457,18 @@ double AnimationNodeOneShot::_process(double p_time, bool p_seek, bool p_is_exte
 		cur_remaining = os_rem;
 		cur_fade_out_remaining -= p_time;
 		if (cur_remaining <= 0 || (is_fading_out && cur_fade_out_remaining <= 0)) {
-			set_parameter(internal_active, false);
-			set_parameter(active, false);
+			set_parameter(p_tree, internal_active, false);
+			set_parameter(p_tree, active, false);
 			if (auto_restart) {
 				double restart_sec = auto_restart_delay + Math::randd() * auto_restart_random_delay;
-				set_parameter(time_to_restart, restart_sec);
+				set_parameter(p_tree, time_to_restart, restart_sec);
 			}
 		}
 	}
 
-	set_parameter(time, cur_time);
-	set_parameter(remaining, cur_remaining);
-	set_parameter(fade_out_remaining, cur_fade_out_remaining);
+	set_parameter(p_tree, time, cur_time);
+	set_parameter(p_tree, remaining, cur_remaining);
+	set_parameter(p_tree, fade_out_remaining, cur_fade_out_remaining);
 
 	return MAX(main_rem, cur_remaining);
 }
@@ -542,10 +543,10 @@ bool AnimationNodeAdd2::has_filter() const {
 	return true;
 }
 
-double AnimationNodeAdd2::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double amount = get_parameter(add_amount);
-	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
-	blend_input(1, p_time, p_seek, p_is_external_seeking, amount, FILTER_PASS, sync, p_test_only);
+double AnimationNodeAdd2::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(p_tree, add_amount);
+	double rem0 = blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+	blend_input(p_tree, 1, p_time, p_seek, p_is_external_seeking, amount, FILTER_PASS, sync, p_test_only);
 
 	return rem0;
 }
@@ -576,11 +577,11 @@ bool AnimationNodeAdd3::has_filter() const {
 	return true;
 }
 
-double AnimationNodeAdd3::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double amount = get_parameter(add_amount);
-	blend_input(0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_PASS, sync, p_test_only);
-	double rem0 = blend_input(1, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
-	blend_input(2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_PASS, sync, p_test_only);
+double AnimationNodeAdd3::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(p_tree, add_amount);
+	blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_PASS, sync, p_test_only);
+	double rem0 = blend_input(p_tree, 1, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+	blend_input(p_tree, 2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_PASS, sync, p_test_only);
 
 	return rem0;
 }
@@ -608,11 +609,11 @@ String AnimationNodeBlend2::get_caption() const {
 	return "Blend2";
 }
 
-double AnimationNodeBlend2::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double amount = get_parameter(blend_amount);
+double AnimationNodeBlend2::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(p_tree, blend_amount);
 
-	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0 - amount, FILTER_BLEND, sync, p_test_only);
-	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, amount, FILTER_PASS, sync, p_test_only);
+	double rem0 = blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0 - amount, FILTER_BLEND, sync, p_test_only);
+	double rem1 = blend_input(p_tree, 1, p_time, p_seek, p_is_external_seeking, amount, FILTER_PASS, sync, p_test_only);
 
 	return amount > 0.5 ? rem1 : rem0; // Hacky but good enough.
 }
@@ -643,11 +644,11 @@ String AnimationNodeBlend3::get_caption() const {
 	return "Blend3";
 }
 
-double AnimationNodeBlend3::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double amount = get_parameter(blend_amount);
-	double rem0 = blend_input(0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_IGNORE, sync, p_test_only);
-	double rem1 = blend_input(1, p_time, p_seek, p_is_external_seeking, 1.0 - ABS(amount), FILTER_IGNORE, sync, p_test_only);
-	double rem2 = blend_input(2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_IGNORE, sync, p_test_only);
+double AnimationNodeBlend3::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(p_tree, blend_amount);
+	double rem0 = blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, MAX(0, -amount), FILTER_IGNORE, sync, p_test_only);
+	double rem1 = blend_input(p_tree, 1, p_time, p_seek, p_is_external_seeking, 1.0 - ABS(amount), FILTER_IGNORE, sync, p_test_only);
+	double rem2 = blend_input(p_tree, 2, p_time, p_seek, p_is_external_seeking, MAX(0, amount), FILTER_IGNORE, sync, p_test_only);
 
 	return amount > 0.5 ? rem2 : (amount < -0.5 ? rem0 : rem1); // Hacky but good enough.
 }
@@ -679,11 +680,11 @@ bool AnimationNodeSub2::has_filter() const {
 	return true;
 }
 
-double AnimationNodeSub2::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double amount = get_parameter(sub_amount);
+double AnimationNodeSub2::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double amount = get_parameter(p_tree, sub_amount);
 	// Out = Sub.Transform3D^(-1) * In.Transform3D
-	blend_input(1, p_time, p_seek, p_is_external_seeking, -amount, FILTER_PASS, sync, p_test_only);
-	return blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
+	blend_input(p_tree, 1, p_time, p_seek, p_is_external_seeking, -amount, FILTER_PASS, sync, p_test_only);
+	return blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, sync, p_test_only);
 }
 
 void AnimationNodeSub2::_bind_methods() {
@@ -708,12 +709,12 @@ String AnimationNodeTimeScale::get_caption() const {
 	return "TimeScale";
 }
 
-double AnimationNodeTimeScale::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double cur_scale = get_parameter(scale);
+double AnimationNodeTimeScale::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double cur_scale = get_parameter(p_tree, scale);
 	if (p_seek) {
-		return blend_input(0, p_time, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		return blend_input(p_tree, 0, p_time, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	} else {
-		return blend_input(0, p_time * cur_scale, false, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		return blend_input(p_tree, 0, p_time * cur_scale, false, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	}
 }
 
@@ -738,16 +739,16 @@ String AnimationNodeTimeSeek::get_caption() const {
 	return "TimeSeek";
 }
 
-double AnimationNodeTimeSeek::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double cur_seek_pos = get_parameter(seek_pos_request);
+double AnimationNodeTimeSeek::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double cur_seek_pos = get_parameter(p_tree, seek_pos_request);
 	if (p_seek) {
-		return blend_input(0, p_time, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		return blend_input(p_tree, 0, p_time, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	} else if (cur_seek_pos >= 0) {
-		double ret = blend_input(0, cur_seek_pos, true, true, 1.0, FILTER_IGNORE, true, p_test_only);
-		set_parameter(seek_pos_request, -1.0); // Reset.
+		double ret = blend_input(p_tree, 0, cur_seek_pos, true, true, 1.0, FILTER_IGNORE, true, p_test_only);
+		set_parameter(p_tree, seek_pos_request, -1.0); // Reset.
 		return ret;
 	} else {
-		return blend_input(0, p_time, false, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		return blend_input(p_tree, 0, p_time, false, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	}
 }
 
@@ -931,13 +932,13 @@ bool AnimationNodeTransition::is_allow_transition_to_self() const {
 	return allow_transition_to_self;
 }
 
-double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	String cur_transition_request = get_parameter(transition_request);
-	int cur_current_index = get_parameter(current_index);
-	int cur_prev_index = get_parameter(prev_index);
+double AnimationNodeTransition::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	String cur_transition_request = get_parameter(p_tree, transition_request);
+	int cur_current_index = get_parameter(p_tree, current_index);
+	int cur_prev_index = get_parameter(p_tree, prev_index);
 
-	double cur_time = get_parameter(time);
-	double cur_prev_xfading = get_parameter(prev_xfading);
+	double cur_time = get_parameter(p_tree, time);
+	double cur_prev_xfading = get_parameter(p_tree, prev_xfading);
 
 	bool switched = false;
 	bool restart = false;
@@ -945,16 +946,16 @@ double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_e
 
 	if (pending_update) {
 		if (cur_current_index < 0 || cur_current_index >= get_input_count()) {
-			set_parameter(prev_index, -1);
+			set_parameter(p_tree, prev_index, -1);
 			if (get_input_count() > 0) {
-				set_parameter(current_index, 0);
-				set_parameter(current_state, get_input_name(0));
+				set_parameter(p_tree, current_index, 0);
+				set_parameter(p_tree, current_state, get_input_name(0));
 			} else {
-				set_parameter(current_index, -1);
-				set_parameter(current_state, StringName());
+				set_parameter(p_tree, current_index, -1);
+				set_parameter(p_tree, current_state, StringName());
 			}
 		} else {
-			set_parameter(current_state, get_input_name(cur_current_index));
+			set_parameter(p_tree, current_state, get_input_name(cur_current_index));
 		}
 		pending_update = false;
 	}
@@ -975,29 +976,29 @@ double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_e
 			} else {
 				switched = true;
 				cur_prev_index = cur_current_index;
-				set_parameter(prev_index, cur_current_index);
+				set_parameter(p_tree, prev_index, cur_current_index);
 				cur_current_index = new_idx;
-				set_parameter(current_index, cur_current_index);
-				set_parameter(current_state, cur_transition_request);
+				set_parameter(p_tree, current_index, cur_current_index);
+				set_parameter(p_tree, current_state, cur_transition_request);
 			}
 		} else {
 			ERR_PRINT("No such input: '" + cur_transition_request + "'");
 		}
 		cur_transition_request = String();
-		set_parameter(transition_request, cur_transition_request);
+		set_parameter(p_tree, transition_request, cur_transition_request);
 	}
 
 	if (clear_remaining_fade) {
 		cur_prev_xfading = 0;
-		set_parameter(prev_xfading, 0);
+		set_parameter(p_tree, prev_xfading, 0);
 		cur_prev_index = -1;
-		set_parameter(prev_index, -1);
+		set_parameter(p_tree, prev_index, -1);
 	}
 
 	// Special case for restart.
 	if (restart) {
-		set_parameter(time, 0);
-		return blend_input(cur_current_index, 0, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		set_parameter(p_tree, time, 0);
+		return blend_input(p_tree, cur_current_index, 0, true, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 	}
 
 	if (switched) {
@@ -1014,14 +1015,14 @@ double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_e
 	if (sync) {
 		for (int i = 0; i < get_input_count(); i++) {
 			if (i != cur_current_index && i != cur_prev_index) {
-				blend_input(i, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
+				blend_input(p_tree, i, p_time, p_seek, p_is_external_seeking, 0, FILTER_IGNORE, true, p_test_only);
 			}
 		}
 	}
 
 	if (cur_prev_index < 0) { // Process current animation, check for transition.
 
-		rem = blend_input(cur_current_index, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+		rem = blend_input(p_tree, cur_current_index, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 
 		if (p_seek) {
 			cur_time = p_time;
@@ -1030,7 +1031,7 @@ double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_e
 		}
 
 		if (input_data[cur_current_index].auto_advance && rem <= xfade_time) {
-			set_parameter(transition_request, get_input_name((cur_current_index + 1) % get_input_count()));
+			set_parameter(p_tree, transition_request, get_input_name((cur_current_index + 1) % get_input_count()));
 		}
 
 	} else { // Cross-fading from prev to current.
@@ -1051,25 +1052,25 @@ double AnimationNodeTransition::_process(double p_time, bool p_seek, bool p_is_e
 
 		// Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 		if (input_data[cur_current_index].reset && !p_seek && switched) { // Just switched, seek to start of current.
-			rem = blend_input(cur_current_index, 0, true, p_is_external_seeking, blend_inv, FILTER_IGNORE, true, p_test_only);
+			rem = blend_input(p_tree, cur_current_index, 0, true, p_is_external_seeking, blend_inv, FILTER_IGNORE, true, p_test_only);
 		} else {
-			rem = blend_input(cur_current_index, p_time, p_seek, p_is_external_seeking, blend_inv, FILTER_IGNORE, true, p_test_only);
+			rem = blend_input(p_tree, cur_current_index, p_time, p_seek, p_is_external_seeking, blend_inv, FILTER_IGNORE, true, p_test_only);
 		}
 
-		blend_input(cur_prev_index, p_time, use_blend && p_seek, p_is_external_seeking, blend, FILTER_IGNORE, true, p_test_only);
+		blend_input(p_tree, cur_prev_index, p_time, use_blend && p_seek, p_is_external_seeking, blend, FILTER_IGNORE, true, p_test_only);
 		if (p_seek) {
 			cur_time = p_time;
 		} else {
 			cur_time += p_time;
 			cur_prev_xfading -= p_time;
 			if (cur_prev_xfading < 0) {
-				set_parameter(prev_index, -1);
+				set_parameter(p_tree, prev_index, -1);
 			}
 		}
 	}
 
-	set_parameter(time, cur_time);
-	set_parameter(prev_xfading, cur_prev_xfading);
+	set_parameter(p_tree, time, cur_time);
+	set_parameter(p_tree, prev_xfading, cur_prev_xfading);
 
 	return rem;
 }
@@ -1115,8 +1116,8 @@ String AnimationNodeOutput::get_caption() const {
 	return "Output";
 }
 
-double AnimationNodeOutput::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	return blend_input(0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
+double AnimationNodeOutput::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	return blend_input(p_tree, 0, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, p_test_only);
 }
 
 AnimationNodeOutput::AnimationNodeOutput() {
@@ -1334,9 +1335,9 @@ String AnimationNodeBlendTree::get_caption() const {
 	return "BlendTree";
 }
 
-double AnimationNodeBlendTree::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+double AnimationNodeBlendTree::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	Ref<AnimationNodeOutput> output = nodes[SceneStringNames::get_singleton()->output].node;
-	return _blend_node("output", nodes[SceneStringNames::get_singleton()->output].connections, this, output, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, nullptr, p_test_only);
+	return _blend_node(p_tree, SNAME("output"), nodes[SceneStringNames::get_singleton()->output].connections, this, output, p_time, p_seek, p_is_external_seeking, 1.0, FILTER_IGNORE, true, nullptr, p_test_only);
 }
 
 void AnimationNodeBlendTree::get_node_list(List<StringName> *r_list) {

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -53,7 +53,7 @@ public:
 	static Vector<String> (*get_editable_animation_list)();
 
 	virtual String get_caption() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
@@ -161,7 +161,7 @@ public:
 	MixMode get_mix_mode() const;
 
 	virtual bool has_filter() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeOneShot();
 };
@@ -184,7 +184,7 @@ public:
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeAdd2();
 };
@@ -204,7 +204,7 @@ public:
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeAdd3();
 };
@@ -222,7 +222,7 @@ public:
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
@@ -242,7 +242,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	AnimationNodeBlend3();
 };
 
@@ -261,7 +261,7 @@ public:
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeSub2();
 };
@@ -280,7 +280,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTimeScale();
 };
@@ -299,7 +299,7 @@ public:
 
 	virtual String get_caption() const override;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTimeSeek();
 };
@@ -363,7 +363,7 @@ public:
 	void set_allow_transition_to_self(bool p_enable);
 	bool is_allow_transition_to_self() const;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	AnimationNodeTransition();
 };
@@ -373,7 +373,7 @@ class AnimationNodeOutput : public AnimationNode {
 
 public:
 	virtual String get_caption() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	AnimationNodeOutput();
 };
 
@@ -445,7 +445,7 @@ public:
 	void get_node_connections(List<NodeConnection> *r_connections) const;
 
 	virtual String get_caption() const override;
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 
 	void get_node_list(List<StringName> *r_list);
 

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -665,8 +665,8 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 	}
 }
 
-double AnimationNodeStateMachinePlayback::process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	double rem = _process(p_base_path, p_state_machine, p_time, p_seek, p_is_external_seeking, p_test_only);
+double AnimationNodeStateMachinePlayback::process(AnimationTree *p_tree, const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	double rem = _process(p_tree, p_base_path, p_state_machine, p_time, p_seek, p_is_external_seeking, p_test_only);
 	start_request = StringName();
 	next_request = false;
 	stop_request = false;
@@ -674,10 +674,8 @@ double AnimationNodeStateMachinePlayback::process(const String &p_base_path, Ani
 	return rem;
 }
 
-double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+double AnimationNodeStateMachinePlayback::_process(AnimationTree *p_tree, const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
 	_set_base_path(p_base_path);
-
-	AnimationTree *tree = p_state_machine->state->tree;
 
 	// Check seek to 0 (means reset) by parent AnimationNode.
 	if (p_time == 0 && p_seek && !p_is_external_seeking) {
@@ -685,7 +683,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 			// Restart state machine.
 			if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 				path.clear();
-				_clear_path_children(tree, p_state_machine, p_test_only);
+				_clear_path_children(p_tree, p_state_machine, p_test_only);
 			}
 			reset_request = true;
 			_start(p_state_machine);
@@ -711,7 +709,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 	// Process start/travel request.
 	if (start_request != StringName() || travel_request != StringName()) {
 		if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
-			_clear_path_children(tree, p_state_machine, p_test_only);
+			_clear_path_children(p_tree, p_state_machine, p_test_only);
 		}
 	}
 
@@ -721,7 +719,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 		Vector<String> start_path = String(start_target).split("/");
 		start_request = start_path[0];
 		if (start_path.size()) {
-			_start_children(tree, p_state_machine, start_target, p_test_only);
+			_start_children(p_tree, p_state_machine, start_target, p_test_only);
 		}
 		// Teleport to start.
 		if (p_state_machine->states.has(start_request)) {
@@ -740,12 +738,12 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 		StringName temp_travel_request = travel_request; // For the case that can't travel.
 		// Process children.
 		Vector<StringName> new_path;
-		bool can_travel = _make_travel_path(tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
+		bool can_travel = _make_travel_path(p_tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
 		if (travel_path.size()) {
 			if (can_travel) {
-				can_travel = _travel_children(tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
+				can_travel = _travel_children(p_tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
 			} else {
-				_start_children(tree, p_state_machine, travel_target, p_test_only);
+				_start_children(p_tree, p_state_machine, travel_target, p_test_only);
 			}
 		}
 
@@ -774,9 +772,9 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 		fading_pos = 0;
 		// Init current length.
 		pos_current = 0; // Overwritten suddenly in main process.
-		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true);
+		len_current = p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true);
 		// Don't process first node if not necessary, insteads process next node.
-		_transition_to_next_recursive(tree, p_state_machine, p_test_only);
+		_transition_to_next_recursive(p_tree, p_state_machine, p_test_only);
 	}
 
 	// Check current node existence.
@@ -820,10 +818,10 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 	double rem = 0.0;
 	if (reset_request) {
 		reset_request = false;
-		len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only);
+		len_current = p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, 0, true, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only);
 		rem = len_current;
 	} else {
-		rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, p_time, p_seek, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		rem = p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, p_time, p_seek, p_is_external_seeking, fade_blend, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 	}
 
 	// Cross-fade process.
@@ -839,9 +837,9 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 		float fading_from_rem = 0.0;
 		if (_reset_request_for_fading_from) {
 			_reset_request_for_fading_from = false;
-			fading_from_rem = p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, 0, true, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+			fading_from_rem = p_state_machine->blend_node(p_tree, fading_from, p_state_machine->states[fading_from].node, 0, true, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 		} else {
-			fading_from_rem = p_state_machine->blend_node(fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+			fading_from_rem = p_state_machine->blend_node(p_tree, fading_from, p_state_machine->states[fading_from].node, p_time, p_seek, p_is_external_seeking, fade_blend_inv, AnimationNode::FILTER_IGNORE, true); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 		}
 
 		// Guess playback position.
@@ -862,7 +860,7 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 	pos_current = len_current - rem;
 
 	// Find next and see when to transition.
-	_transition_to_next_recursive(tree, p_state_machine, p_test_only);
+	_transition_to_next_recursive(p_tree, p_state_machine, p_test_only);
 
 	// Predict remaining time.
 	double remain = rem; // If we can't predict the end of state machine, the time remaining must be INFINITY.
@@ -924,7 +922,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		} else {
 			if (reset_request) {
 				// There is no possibility of processing doubly. Now we can apply reset actually in here.
-				p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, p_test_only);
+				p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, p_test_only);
 			}
 			fading_from = StringName();
 			fading_time = 0;
@@ -947,16 +945,16 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		len_fade_from = len_current;
 
 		if (next.switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_SYNC) {
-			p_state_machine->blend_node(current, p_state_machine->states[current].node, MIN(pos_current, len_current), true, false, 0, AnimationNode::FILTER_IGNORE, true);
+			p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, MIN(pos_current, len_current), true, false, 0, AnimationNode::FILTER_IGNORE, true);
 		}
 
 		// Just get length to find next recursive.
 		double rem = 0.0;
 		if (next.is_reset) {
-			len_current = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+			len_current = p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, 0, true, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
 			rem = len_current;
 		} else {
-			rem = p_state_machine->blend_node(current, p_state_machine->states[current].node, 0, false, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+			rem = p_state_machine->blend_node(p_tree, current, p_state_machine->states[current].node, 0, false, false, 0, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
 		}
 
 		// Guess playback position.
@@ -1062,7 +1060,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 			if (ref_transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
-			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(anodesm, ref_transition) || bypass)) {
+			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(p_tree, anodesm, ref_transition) || bypass)) {
 				if (ref_transition->get_priority() <= priority_best) {
 					priority_best = ref_transition->get_priority();
 					auto_advance_to = i;
@@ -1085,23 +1083,20 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 	return next;
 }
 
-bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
+bool AnimationNodeStateMachinePlayback::_check_advance_condition(AnimationTree *p_tree, const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
 	if (transition->get_advance_mode() != AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO) {
 		return false;
 	}
 
 	StringName advance_condition_name = transition->get_advance_condition_name();
 
-	if (advance_condition_name != StringName() && !bool(state_machine->get_parameter(advance_condition_name))) {
+	if (advance_condition_name != StringName() && !bool(state_machine->get_parameter(p_tree, advance_condition_name))) {
 		return false;
 	}
 
 	if (transition->expression.is_valid()) {
-		AnimationTree *tree_base = state_machine->get_animation_tree();
-		ERR_FAIL_COND_V(tree_base == nullptr, false);
-
-		NodePath advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
-		Node *expression_base = tree_base->get_node_or_null(advance_expression_base_node_path);
+		NodePath advance_expression_base_node_path = p_tree->get_advance_expression_base_node();
+		Node *expression_base = p_tree->get_node_or_null(advance_expression_base_node_path);
 
 		if (expression_base) {
 			Ref<Expression> exp = transition->expression;
@@ -1588,14 +1583,14 @@ Vector2 AnimationNodeStateMachine::get_graph_offset() const {
 	return graph_offset;
 }
 
-double AnimationNodeStateMachine::_process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
-	Ref<AnimationNodeStateMachinePlayback> playback_new = get_parameter(playback);
+double AnimationNodeStateMachine::_process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only) {
+	Ref<AnimationNodeStateMachinePlayback> playback_new = get_parameter(p_tree, playback);
 	ERR_FAIL_COND_V(playback_new.is_null(), 0.0);
 	playback_new->_set_grouped(state_machine_type == STATE_MACHINE_TYPE_GROUPED);
 	if (p_test_only) {
 		playback_new = playback_new->duplicate(); // Don't process original when testing.
 	}
-	return playback_new->process(base_path, this, p_time, p_seek, p_is_external_seeking, p_test_only);
+	return playback_new->process(p_tree, base_path, this, p_time, p_seek, p_is_external_seeking, p_test_only);
 }
 
 String AnimationNodeStateMachine::get_caption() const {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -210,7 +210,7 @@ public:
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual double _process(double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
+	virtual double _process(AnimationTree *p_tree, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
@@ -297,10 +297,10 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	bool _travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
 	void _start_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_test_only);
 
-	double process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
-	double _process(const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
+	double process(AnimationTree *p_tree, const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
+	double _process(AnimationTree *p_tree, const String &p_base_path, AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek, bool p_is_external_seeking, bool p_test_only);
 
-	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
+	bool _check_advance_condition(AnimationTree *p_tree, const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
 	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
 	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
 	Ref<AnimationNodeStateMachineTransition> _check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Will close [#6966](https://github.com/godotengine/godot-proposals/issues/6966).

Works in this pr:
1. Move `AnimationNode::State` and `AnimationNode::AnimationState` to `AnimationTree::State` and `AnimationTree::AnimationState`.
2. Process animation node by passing `AnimationTree *` instead of `State *`.
3. Any methods of `AnimationNode` which relate about process should pass `AnimationTree*`, too.
4. `AnimationNode` no longer holds anything about `AnimationTree` ( both `AnimationTree` and `State`).
5. Remove some unused `friend class ` declare to improve robustness.
6. Wrap logics about "input_activity/connection_activity" in `TOOLS_ENABLED` macro, because "activity" only used in editor plugins.

-------------------------------------------------------------

Something I need to explain:
1. Why I move `State` and `AnimationState` from `AnimationNode` to `AnimationTree`?
2. Why I change the declare order in `animation_tree.h`?

The main reason is `GDVIRTUAL5RC(double, _process, AnimationTree *, double, bool, bool, bool)` in `animation_tree.h`, it require  that `AnimationTree` should be declared first.
And if I move `AnimationTree` in front of `AnimationNode`, It will require `AnimationNode::State` and `AnimationNode::AnimationState` are declared first, too.
So I move them from `AnimationNode` to `AnimationTree`.

Of course,  declare order issue can be avoided by changing `GDVIRTUAL5RC(double, _process, AnimationTree *, double, bool, bool, bool)` to `GDVIRTUAL5RC(double, _process, Node*, double, bool, bool, bool)`.
However, in this pr, `AnimationNode` no longer holds `State`, it should be accessed by `p_tree->state`.
In my opinion, it means that `State` is not belong to `AnimationNode` but `AnimaionTree`, so this change is reasonable.

