### PR TITLE
Correct description of `ParticleProcessMaterial.lifetime_randomness`

### DIFF
--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -209,7 +209,7 @@
 			Minimum equivalent of [member initial_velocity_max].
 		</member>
 		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
-			Particle lifetime randomness ratio. The lifetime will be multiplied by a value interpolated between [code]1.0[/code] and a random number less than one. For example a random ratio of [code]0.4[/code] would scale the original lifetime between [code]0.4-1.0[/code] of its original value.
+			Particle lifetime randomness ratio. The equation for the lifetime of a particle is [code]lifetime * (1.0 - randf() * lifetime_randomness)[/code]. For example, a [member lifetime_randomness] of [code]0.4[/code] scales the lifetime between [code]0.6[/code] to [code]1.0[/code] of its original value.
 		</member>
 		<member name="linear_accel_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's linear acceleration will vary along this [CurveTexture].


### PR DESCRIPTION
The current description fails to correctly explain the equation which calculates a particle's lifetime.

The new description explains the equation properly.

Fixes [godot/godot-docs/#7559](https://github.com/godotengine/godot-docs/issues/7559#issue-1773652586)