### PR TITLE
GDScript: Optimize `match`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -496,6 +496,8 @@
 		<member name="debug/gdscript/warnings/redundant_await" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function that is not a coroutine is called with await.
 		</member>
+		<member name="debug/gdscript/warnings/redundant_pattern" type="int" setter="" getter="" default="1">
+		</member>
 		<member name="debug/gdscript/warnings/redundant_static_unload" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@static_unload[/code] annotation is used in a script without any static variables.
 		</member>

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -70,6 +70,7 @@ public:
 	virtual uint32_t add_local(const StringName &p_name, const GDScriptDataType &p_type) = 0;
 	virtual uint32_t add_local_constant(const StringName &p_name, const Variant &p_constant) = 0;
 	virtual uint32_t add_or_get_constant(const Variant &p_constant) = 0;
+	virtual uint32_t add_or_get_variant_vector_constant(const Vector<Variant> &p_constant) = 0;
 	virtual uint32_t add_or_get_name(const StringName &p_name) = 0;
 	virtual uint32_t add_temporary(const GDScriptDataType &p_type) = 0;
 	virtual void pop_temporary() = 0;
@@ -144,6 +145,11 @@ public:
 	virtual void write_endif() = 0;
 	virtual void write_jump_if_shared(const Address &p_value) = 0;
 	virtual void write_end_jump_if_shared() = 0;
+	virtual void write_jump_table_range(const Address &p_value, int p_offset, int p_size, int p_branch_count) = 0;
+	virtual void write_jump_table_bsearch(const Address &p_value, const Vector<Variant> &p_array, int p_branch_count) = 0;
+	virtual void write_jump_table_branch() = 0;
+	virtual void write_jump_table_set_case_branch(int p_case, int p_branch) = 0;
+	virtual void write_end_jump_table() = 0;
 	virtual void start_for(const GDScriptDataType &p_iterator_type, const GDScriptDataType &p_list_type) = 0;
 	virtual void write_for_assignment(const Address &p_list) = 0;
 	virtual void write_for(const Address &p_variable, bool p_use_conversion) = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1379,439 +1379,235 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 	}
 }
 
-GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested) {
-	switch (p_pattern->pattern_type) {
-		case GDScriptParser::PatternNode::PT_LITERAL: {
-			if (p_is_nested) {
-				codegen.generator->write_and_left_operand(p_previous_test);
-			} else if (!p_is_first) {
-				codegen.generator->write_or_left_operand(p_previous_test);
-			}
-
-			// Get literal type into constant map.
-			Variant::Type literal_type = p_pattern->literal->value.get_type();
-			GDScriptCodeGenerator::Address literal_type_addr = codegen.add_constant(literal_type);
-
-			// Equality is always a boolean.
-			GDScriptDataType equality_type;
-			equality_type.has_type = true;
-			equality_type.kind = GDScriptDataType::BUILTIN;
-			equality_type.builtin_type = Variant::BOOL;
-
-			// Check type equality.
-			GDScriptCodeGenerator::Address type_equality_addr = codegen.add_temporary(equality_type);
-			codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_EQUAL, p_type_addr, literal_type_addr);
-
-			if (literal_type == Variant::STRING) {
-				GDScriptCodeGenerator::Address type_stringname_addr = codegen.add_constant(Variant::STRING_NAME);
-
-				// Check StringName <-> String type equality.
-				GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
-
-				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
-				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
-
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
-			} else if (literal_type == Variant::STRING_NAME) {
-				GDScriptCodeGenerator::Address type_string_addr = codegen.add_constant(Variant::STRING);
-
-				// Check String <-> StringName type equality.
-				GDScriptCodeGenerator::Address tmp_comp_addr = codegen.add_temporary(equality_type);
-
-				codegen.generator->write_binary_operator(tmp_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
-				codegen.generator->write_binary_operator(type_equality_addr, Variant::OP_OR, type_equality_addr, tmp_comp_addr);
-
-				codegen.generator->pop_temporary(); // Remove tmp_comp_addr from stack.
-			}
-
-			codegen.generator->write_and_left_operand(type_equality_addr);
-
-			// Get literal.
-			GDScriptCodeGenerator::Address literal_addr = _parse_expression(codegen, r_error, p_pattern->literal);
-			if (r_error) {
-				return GDScriptCodeGenerator::Address();
-			}
-
-			// Check value equality.
-			GDScriptCodeGenerator::Address equality_addr = codegen.add_temporary(equality_type);
-			codegen.generator->write_binary_operator(equality_addr, Variant::OP_EQUAL, p_value_addr, literal_addr);
-			codegen.generator->write_and_right_operand(equality_addr);
-
-			// AND both together (reuse temporary location).
-			codegen.generator->write_end_and(type_equality_addr);
-
-			codegen.generator->pop_temporary(); // Remove equality_addr from stack.
-
-			if (literal_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				codegen.generator->pop_temporary();
-			}
-
-			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
-			if (p_is_nested) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_and_right_operand(type_equality_addr);
-				codegen.generator->write_end_and(p_previous_test);
-			} else if (!p_is_first) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_or_right_operand(type_equality_addr);
-				codegen.generator->write_end_or(p_previous_test);
-			} else {
-				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign(p_previous_test, type_equality_addr);
-			}
-			codegen.generator->pop_temporary(); // Remove type_equality_addr.
-
-			return p_previous_test;
-		} break;
-		case GDScriptParser::PatternNode::PT_EXPRESSION: {
-			if (p_is_nested) {
-				codegen.generator->write_and_left_operand(p_previous_test);
-			} else if (!p_is_first) {
-				codegen.generator->write_or_left_operand(p_previous_test);
-			}
-
-			GDScriptCodeGenerator::Address type_string_addr = codegen.add_constant(Variant::STRING);
-			GDScriptCodeGenerator::Address type_stringname_addr = codegen.add_constant(Variant::STRING_NAME);
-
-			// Equality is always a boolean.
-			GDScriptDataType equality_type;
-			equality_type.has_type = true;
-			equality_type.kind = GDScriptDataType::BUILTIN;
-			equality_type.builtin_type = Variant::BOOL;
-
-			// Create the result temps first since it's the last to go away.
-			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address equality_test_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address stringy_comp_addr = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address stringy_comp_addr_2 = codegen.add_temporary(equality_type);
-			GDScriptCodeGenerator::Address expr_type_addr = codegen.add_temporary();
-
-			// Evaluate expression.
-			GDScriptCodeGenerator::Address expr_addr;
-			expr_addr = _parse_expression(codegen, r_error, p_pattern->expression);
-			if (r_error) {
-				return GDScriptCodeGenerator::Address();
-			}
-
-			// Evaluate expression type.
-			Vector<GDScriptCodeGenerator::Address> typeof_args;
-			typeof_args.push_back(expr_addr);
-			codegen.generator->write_call_utility(expr_type_addr, "typeof", typeof_args);
-
-			// Check type equality.
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, expr_type_addr);
-
-			// Check for String <-> StringName comparison.
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_string_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_stringname_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
-
-			// Check for StringName <-> String comparison.
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_EQUAL, p_type_addr, type_stringname_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr_2, Variant::OP_EQUAL, expr_type_addr, type_string_addr);
-			codegen.generator->write_binary_operator(stringy_comp_addr, Variant::OP_AND, stringy_comp_addr, stringy_comp_addr_2);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_OR, result_addr, stringy_comp_addr);
-
-			codegen.generator->pop_temporary(); // Remove expr_type_addr from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr_2 from stack.
-			codegen.generator->pop_temporary(); // Remove stringy_comp_addr from stack.
-
-			codegen.generator->write_and_left_operand(result_addr);
-
-			// Check value equality.
-			codegen.generator->write_binary_operator(equality_test_addr, Variant::OP_EQUAL, p_value_addr, expr_addr);
-			codegen.generator->write_and_right_operand(equality_test_addr);
-
-			// AND both type and value equality.
-			codegen.generator->write_end_and(result_addr);
-
-			// We don't need the expression temporary anymore.
-			if (expr_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-				codegen.generator->pop_temporary();
-			}
-			codegen.generator->pop_temporary(); // Remove equality_test_addr from stack.
-
-			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
-			if (p_is_nested) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_and_right_operand(result_addr);
-				codegen.generator->write_end_and(p_previous_test);
-			} else if (!p_is_first) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_or_right_operand(result_addr);
-				codegen.generator->write_end_or(p_previous_test);
-			} else {
-				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign(p_previous_test, result_addr);
-			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
-
-			return p_previous_test;
-		} break;
-		case GDScriptParser::PatternNode::PT_ARRAY: {
-			if (p_is_nested) {
-				codegen.generator->write_and_left_operand(p_previous_test);
-			} else if (!p_is_first) {
-				codegen.generator->write_or_left_operand(p_previous_test);
-			}
-			// Get array type into constant map.
-			GDScriptCodeGenerator::Address array_type_addr = codegen.add_constant((int)Variant::ARRAY);
-
-			// Equality is always a boolean.
-			GDScriptDataType temp_type;
-			temp_type.has_type = true;
-			temp_type.kind = GDScriptDataType::BUILTIN;
-			temp_type.builtin_type = Variant::BOOL;
-
-			// Check type equality.
-			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, array_type_addr);
-			codegen.generator->write_and_left_operand(result_addr);
-
-			// Store pattern length in constant map.
-			GDScriptCodeGenerator::Address array_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->array.size() - 1 : p_pattern->array.size());
-
-			// Get value length.
-			temp_type.builtin_type = Variant::INT;
-			GDScriptCodeGenerator::Address value_length_addr = codegen.add_temporary(temp_type);
-			Vector<GDScriptCodeGenerator::Address> len_args;
-			len_args.push_back(p_value_addr);
-			codegen.generator->write_call_gdscript_utility(value_length_addr, "len", len_args);
-
-			// Test length compatibility.
-			temp_type.builtin_type = Variant::BOOL;
-			GDScriptCodeGenerator::Address length_compat_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(length_compat_addr, p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL, value_length_addr, array_length_addr);
-			codegen.generator->write_and_right_operand(length_compat_addr);
-
-			// AND type and length check.
-			codegen.generator->write_end_and(result_addr);
-
-			// Remove length temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
-
-			// Create temporaries outside the loop so they can be reused.
-			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
-			GDScriptCodeGenerator::Address element_type_addr = codegen.add_temporary();
-
-			// Evaluate element by element.
-			for (int i = 0; i < p_pattern->array.size(); i++) {
-				if (p_pattern->array[i]->pattern_type == GDScriptParser::PatternNode::PT_REST) {
-					// Don't want to access an extra element of the user array.
-					break;
-				}
-
-				// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
-				codegen.generator->write_and_left_operand(result_addr);
-
-				// Add index to constant map.
-				GDScriptCodeGenerator::Address index_addr = codegen.add_constant(i);
-
-				// Get the actual element from the user-sent array.
-				codegen.generator->write_get(element_addr, index_addr, p_value_addr);
-
-				// Also get type of element.
-				Vector<GDScriptCodeGenerator::Address> typeof_args;
-				typeof_args.push_back(element_addr);
-				codegen.generator->write_call_utility(element_type_addr, "typeof", typeof_args);
-
-				// Try the pattern inside the element.
-				result_addr = _parse_match_pattern(codegen, r_error, p_pattern->array[i], element_addr, element_type_addr, result_addr, false, true);
-				if (r_error != OK) {
-					return GDScriptCodeGenerator::Address();
-				}
-
-				codegen.generator->write_and_right_operand(result_addr);
-				codegen.generator->write_end_and(result_addr);
-			}
-			// Remove element temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
-
-			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
-			if (p_is_nested) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_and_right_operand(result_addr);
-				codegen.generator->write_end_and(p_previous_test);
-			} else if (!p_is_first) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_or_right_operand(result_addr);
-				codegen.generator->write_end_or(p_previous_test);
-			} else {
-				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign(p_previous_test, result_addr);
-			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
-
-			return p_previous_test;
-		} break;
-		case GDScriptParser::PatternNode::PT_DICTIONARY: {
-			if (p_is_nested) {
-				codegen.generator->write_and_left_operand(p_previous_test);
-			} else if (!p_is_first) {
-				codegen.generator->write_or_left_operand(p_previous_test);
-			}
-			// Get dictionary type into constant map.
-			GDScriptCodeGenerator::Address dict_type_addr = codegen.add_constant((int)Variant::DICTIONARY);
-
-			// Equality is always a boolean.
-			GDScriptDataType temp_type;
-			temp_type.has_type = true;
-			temp_type.kind = GDScriptDataType::BUILTIN;
-			temp_type.builtin_type = Variant::BOOL;
-
-			// Check type equality.
-			GDScriptCodeGenerator::Address result_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(result_addr, Variant::OP_EQUAL, p_type_addr, dict_type_addr);
-			codegen.generator->write_and_left_operand(result_addr);
-
-			// Store pattern length in constant map.
-			GDScriptCodeGenerator::Address dict_length_addr = codegen.add_constant(p_pattern->rest_used ? p_pattern->dictionary.size() - 1 : p_pattern->dictionary.size());
-
-			// Get user's dictionary length.
-			temp_type.builtin_type = Variant::INT;
-			GDScriptCodeGenerator::Address value_length_addr = codegen.add_temporary(temp_type);
-			Vector<GDScriptCodeGenerator::Address> func_args;
-			func_args.push_back(p_value_addr);
-			codegen.generator->write_call_gdscript_utility(value_length_addr, "len", func_args);
-
-			// Test length compatibility.
-			temp_type.builtin_type = Variant::BOOL;
-			GDScriptCodeGenerator::Address length_compat_addr = codegen.add_temporary(temp_type);
-			codegen.generator->write_binary_operator(length_compat_addr, p_pattern->rest_used ? Variant::OP_GREATER_EQUAL : Variant::OP_EQUAL, value_length_addr, dict_length_addr);
-			codegen.generator->write_and_right_operand(length_compat_addr);
-
-			// AND type and length check.
-			codegen.generator->write_end_and(result_addr);
-
-			// Remove length temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
-
-			// Create temporaries outside the loop so they can be reused.
-			GDScriptCodeGenerator::Address element_addr = codegen.add_temporary();
-			GDScriptCodeGenerator::Address element_type_addr = codegen.add_temporary();
-
-			// Evaluate element by element.
-			for (int i = 0; i < p_pattern->dictionary.size(); i++) {
-				const GDScriptParser::PatternNode::Pair &element = p_pattern->dictionary[i];
-				if (element.value_pattern && element.value_pattern->pattern_type == GDScriptParser::PatternNode::PT_REST) {
-					// Ignore rest pattern.
-					break;
-				}
-
-				// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
-				codegen.generator->write_and_left_operand(result_addr);
-
-				// Get the pattern key.
-				GDScriptCodeGenerator::Address pattern_key_addr = _parse_expression(codegen, r_error, element.key);
-				if (r_error) {
-					return GDScriptCodeGenerator::Address();
-				}
-
-				// Check if pattern key exists in user's dictionary. This will be AND-ed with next result.
-				func_args.clear();
-				func_args.push_back(pattern_key_addr);
-				codegen.generator->write_call(result_addr, p_value_addr, "has", func_args);
-
-				if (element.value_pattern != nullptr) {
-					// Use AND here too, as we don't want to be checking elements if previous test failed (which means this might be an invalid get).
-					codegen.generator->write_and_left_operand(result_addr);
-
-					// Get actual value from user dictionary.
-					codegen.generator->write_get(element_addr, pattern_key_addr, p_value_addr);
-
-					// Also get type of value.
-					func_args.clear();
-					func_args.push_back(element_addr);
-					codegen.generator->write_call_utility(element_type_addr, "typeof", func_args);
-
-					// Try the pattern inside the value.
-					result_addr = _parse_match_pattern(codegen, r_error, element.value_pattern, element_addr, element_type_addr, result_addr, false, true);
-					if (r_error != OK) {
-						return GDScriptCodeGenerator::Address();
-					}
-					codegen.generator->write_and_right_operand(result_addr);
-					codegen.generator->write_end_and(result_addr);
-				}
-
-				codegen.generator->write_and_right_operand(result_addr);
-				codegen.generator->write_end_and(result_addr);
-
-				// Remove pattern key temporary.
-				if (pattern_key_addr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
-				}
-			}
-
-			// Remove element temporaries.
-			codegen.generator->pop_temporary();
-			codegen.generator->pop_temporary();
-
-			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
-			if (p_is_nested) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_and_right_operand(result_addr);
-				codegen.generator->write_end_and(p_previous_test);
-			} else if (!p_is_first) {
-				// Use the previous value as target, since we only need one temporary variable.
-				codegen.generator->write_or_right_operand(result_addr);
-				codegen.generator->write_end_or(p_previous_test);
-			} else {
-				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign(p_previous_test, result_addr);
-			}
-			codegen.generator->pop_temporary(); // Remove temp result addr.
-
-			return p_previous_test;
-		} break;
-		case GDScriptParser::PatternNode::PT_REST:
-			// Do nothing.
-			return p_previous_test;
-			break;
-		case GDScriptParser::PatternNode::PT_BIND: {
-			if (p_is_nested) {
-				codegen.generator->write_and_left_operand(p_previous_test);
-			} else if (!p_is_first) {
-				codegen.generator->write_or_left_operand(p_previous_test);
-			}
-			// Get the bind address.
-			GDScriptCodeGenerator::Address bind = codegen.locals[p_pattern->bind->name];
-
-			// Assign value to bound variable.
-			codegen.generator->write_assign(bind, p_value_addr);
-		}
-			[[fallthrough]]; // Act like matching anything too.
-		case GDScriptParser::PatternNode::PT_WILDCARD:
-			// If this is a fall through we don't want to do this again.
-			if (p_pattern->pattern_type != GDScriptParser::PatternNode::PT_BIND) {
-				if (p_is_nested) {
-					codegen.generator->write_and_left_operand(p_previous_test);
-				} else if (!p_is_first) {
-					codegen.generator->write_or_left_operand(p_previous_test);
-				}
-			}
-			// This matches anything so just do the same as `if(true)`.
-			// If this isn't the first, we need to OR with the previous pattern. If it's nested, we use AND instead.
-			if (p_is_nested) {
-				// Use the operator with the `true` constant so it works as always matching.
-				GDScriptCodeGenerator::Address constant = codegen.add_constant(true);
-				codegen.generator->write_and_right_operand(constant);
-				codegen.generator->write_end_and(p_previous_test);
-			} else if (!p_is_first) {
-				// Use the operator with the `true` constant so it works as always matching.
-				GDScriptCodeGenerator::Address constant = codegen.add_constant(true);
-				codegen.generator->write_or_right_operand(constant);
-				codegen.generator->write_end_or(p_previous_test);
-			} else {
-				// Just assign this value to the accumulator temporary.
-				codegen.generator->write_assign_true(p_previous_test);
-			}
-			return p_previous_test;
+Error GDScriptCompiler::_parse_match(CodeGen &codegen, const GDScriptParser::MatchNode *p_match) {
+	Error err = OK;
+	GDScriptCodeGenerator *gen = codegen.generator;
+
+	codegen.start_block();
+
+	// Evaluate the match expression.
+	GDScriptDataType value_type = _gdtype_from_datatype(p_match->test->get_datatype(), codegen.script);
+	GDScriptCodeGenerator::Address value = codegen.add_local("@match_value", value_type);
+	GDScriptCodeGenerator::Address value_expr = _parse_expression(codegen, err, p_match->test);
+	if (err) {
+		return err;
 	}
-	ERR_FAIL_V_MSG(p_previous_test, "Reaching the end of pattern compilation without matching a pattern.");
+
+	// Assign to local.
+	// TODO: This can be improved by passing the target to parse_expression().
+	gen->write_assign(value, value_expr);
+	if (value_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+		gen->pop_temporary();
+	}
+
+	// Check the type if needed.
+	GDScriptDataType typeof_type;
+	typeof_type.has_type = true;
+	typeof_type.kind = GDScriptDataType::BUILTIN;
+	typeof_type.builtin_type = Variant::INT;
+	GDScriptCodeGenerator::Address type;
+	if (!value_type.has_type) {
+		type = codegen.add_local("@match_type", typeof_type);
+
+		Vector<GDScriptCodeGenerator::Address> typeof_args;
+		typeof_args.push_back(value);
+		gen->write_call_utility(type, "typeof", typeof_args);
+	}
+
+	// Collect constant case branches to write the group using a jump table.
+	// Variable and destructuring patterns break `match` into several groups.
+	List<MatchBranch> branches;
+	HashSet<Variant, VariantHasher, VariantComparator> handled_const_cases;
+	for (int i = 0; i < p_match->branches.size(); i++) {
+		const GDScriptParser::MatchBranchNode *branch_node = p_match->branches[i];
+		MatchBranch branch(branch_node);
+
+		if (branch_node->has_wildcard) {
+			branches.push_back(branch);
+			break;
+		}
+
+		bool all_constant = true;
+		for (int j = 0; j < branch_node->patterns.size(); j++) {
+			const GDScriptParser::PatternNode *pattern_node = branch_node->patterns[j];
+			bool is_constant = false;
+			Variant pt_value;
+
+			switch (pattern_node->pattern_type) {
+				case GDScriptParser::PatternNode::PT_LITERAL:
+					is_constant = true;
+					pt_value = pattern_node->literal->value;
+					break;
+				case GDScriptParser::PatternNode::PT_EXPRESSION:
+					if (pattern_node->expression->is_constant) {
+						is_constant = true;
+						pt_value = pattern_node->expression->reduced_value;
+					} else {
+						all_constant = false;
+					}
+					break;
+				case GDScriptParser::PatternNode::PT_ARRAY:
+				case GDScriptParser::PatternNode::PT_DICTIONARY:
+					all_constant = false;
+					break;
+				case GDScriptParser::PatternNode::PT_BIND:
+				case GDScriptParser::PatternNode::PT_REST:
+				case GDScriptParser::PatternNode::PT_WILDCARD:
+					return ERR_BUG; // This shouldn't happen.
+			}
+
+			if (is_constant && !handled_const_cases.has(pt_value)) {
+				handled_const_cases.insert(pt_value);
+				branch.cases.push_back(pt_value);
+			}
+		}
+
+		if (all_constant) {
+			if (!branch.cases.is_empty()) {
+				branches.push_back(branch);
+			}
+		} else {
+			// The constant patterns **before the first variable/destructuring pattern**
+			// can be included in the jump table (and the jump addresses patched later).
+			// But this is a rare case, so let's skip the optimization.
+			if (!branches.is_empty()) {
+				err = _parse_match_branch_group(codegen, value, branches);
+				if (err) {
+					return err;
+				}
+				branches.clear();
+			}
+			/*err = _parse_match_branch(codegen, value, branch);
+			if (err) {
+				return err;
+			}*/
+			all_constant = true; // Resume.
+		}
+	}
+
+	if (!branches.is_empty()) {
+		err = _parse_match_branch_group(codegen, value, branches);
+		if (err) {
+			return err;
+		}
+	}
+
+	codegen.end_block();
+
+	return OK;
+}
+
+// TODO
+Error GDScriptCompiler::_parse_match_branch_group(CodeGen &codegen, const GDScriptCodeGenerator::Address &p_value, const List<MatchBranch> &p_branches) {
+	Error err = OK;
+	GDScriptCodeGenerator *gen = codegen.generator;
+
+	constexpr int RANGE_TABLE_MAX_SIZE = 256;
+
+	int branch_index = 0;
+	int min_int = 0;
+	int max_int = 0;
+	bool use_bsearch = false;
+	HashMap<Variant, int, VariantHasher, VariantComparator> case_to_branch_index;
+	Vector<Variant> array;
+
+	// TODO: Use `if` if there are few cases.
+	// TODO: always use bsearch if value is not hard int (enum).
+	// TODO: default branch
+	// TODO: make correct Variant comparator for sort and bsearch!
+	// For example, if types are different, first compare their Variant::Type.
+	// NB: String vs StringName.
+
+	for (const List<MatchBranch>::Element *E = p_branches.front(); E; E = E->next()) {
+		const MatchBranch &branch = E->get();
+		for (const List<Variant>::Element *F = branch.cases.front(); F; F = F->next()) {
+			const Variant &_case = F->get();
+			if (_case.get_type() == Variant::INT) {
+				int value = _case;
+				if (array.is_empty()) {
+					min_int = value;
+					max_int = value;
+				} else if (value > max_int) {
+					max_int = value;
+				} else if (value < min_int) {
+					min_int = value;
+				}
+			} else {
+				use_bsearch = true;
+			}
+			case_to_branch_index[_case] = branch_index;
+			array.push_back(_case);
+		}
+		branch_index++;
+	}
+
+	if (max_int - min_int > RANGE_TABLE_MAX_SIZE) {
+		use_bsearch = true;
+	}
+
+	int default_case_index = 0;
+	if (use_bsearch) {
+		default_case_index = array.size();
+		array.sort_custom<GDScriptFunction::SafeVariantSort>();
+		gen->write_jump_table_bsearch(p_value, array, p_branches.size());
+	} else {
+		default_case_index = max_int - min_int + 1;
+		gen->write_jump_table_range(p_value, min_int, max_int - min_int + 1, p_branches.size());
+	}
+
+	for (const List<MatchBranch>::Element *E = p_branches.front(); E; E = E->next()) {
+		const MatchBranch &branch = E->get();
+		gen->write_jump_table_branch();
+
+		codegen.start_block(); // Create an extra block around for binds.
+
+		// Add locals in block before patterns, so temporaries don't use the stack address for binds.
+		List<GDScriptCodeGenerator::Address> branch_locals = _add_locals_in_block(codegen, branch.branch->block);
+
+#ifdef DEBUG_ENABLED
+		// Add a newline before each branch, since the debugger needs those.
+		gen->write_newline(branch.branch->start_line);
+#endif
+
+		err = _parse_block(codegen, branch.branch->block, false); // Don't add locals again.
+		if (err) {
+			return err;
+		}
+
+		_clear_addresses(codegen, branch_locals);
+
+		codegen.end_block(); // Get out of extra block.
+	}
+
+	if (use_bsearch) {
+		for (int i = 0; i < array.size(); i++) {
+			HashMap<Variant, int, VariantHasher, VariantComparator>::ConstIterator E = case_to_branch_index.find(array[i]);
+			if (E) {
+				gen->write_jump_table_set_case_branch(i, E->value);
+			}
+		}
+	} else {
+		for (int i = min_int; i <= max_int; i++) {
+			HashMap<Variant, int, VariantHasher, VariantComparator>::ConstIterator E = case_to_branch_index.find(i);
+			if (E) {
+				gen->write_jump_table_set_case_branch(i - min_int, E->value);
+			}
+		}
+	}
+
+	const MatchBranch &last_branch = p_branches.back()->get();
+	if (last_branch.branch->has_wildcard) {
+		// Set default case to default branch.
+		gen->write_jump_table_set_case_branch(default_case_index, p_branches.size() - 1);
+	}
+
+	gen->write_end_jump_table();
+
+	return OK;
+}
+
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested) {
+	// TODO
 }
 
 List<GDScriptCodeGenerator::Address> GDScriptCompiler::_add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block) {
@@ -1859,84 +1655,9 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 
 		switch (s->type) {
 			case GDScriptParser::Node::MATCH: {
-				const GDScriptParser::MatchNode *match = static_cast<const GDScriptParser::MatchNode *>(s);
-
-				codegen.start_block();
-
-				// Evaluate the match expression.
-				GDScriptCodeGenerator::Address value = codegen.add_local("@match_value", _gdtype_from_datatype(match->test->get_datatype(), codegen.script));
-				GDScriptCodeGenerator::Address value_expr = _parse_expression(codegen, err, match->test);
-				if (err) {
+				err = _parse_match(codegen, static_cast<const GDScriptParser::MatchNode *>(s));
+				if (err != OK) {
 					return err;
-				}
-
-				// Assign to local.
-				// TODO: This can be improved by passing the target to parse_expression().
-				gen->write_assign(value, value_expr);
-
-				if (value_expr.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
-					codegen.generator->pop_temporary();
-				}
-
-				// Then, let's save the type of the value in the stack too, so we can reuse for later comparisons.
-				GDScriptDataType typeof_type;
-				typeof_type.has_type = true;
-				typeof_type.kind = GDScriptDataType::BUILTIN;
-				typeof_type.builtin_type = Variant::INT;
-				GDScriptCodeGenerator::Address type = codegen.add_local("@match_type", typeof_type);
-
-				Vector<GDScriptCodeGenerator::Address> typeof_args;
-				typeof_args.push_back(value);
-				gen->write_call_utility(type, "typeof", typeof_args);
-
-				// Now we can actually start testing.
-				// For each branch.
-				for (int j = 0; j < match->branches.size(); j++) {
-					if (j > 0) {
-						// Use `else` to not check the next branch after matching.
-						gen->write_else();
-					}
-
-					const GDScriptParser::MatchBranchNode *branch = match->branches[j];
-
-					codegen.start_block(); // Create an extra block around for binds.
-
-					// Add locals in block before patterns, so temporaries don't use the stack address for binds.
-					List<GDScriptCodeGenerator::Address> branch_locals = _add_locals_in_block(codegen, branch->block);
-
-#ifdef DEBUG_ENABLED
-					// Add a newline before each branch, since the debugger needs those.
-					gen->write_newline(branch->start_line);
-#endif
-					// For each pattern in branch.
-					GDScriptCodeGenerator::Address pattern_result = codegen.add_temporary();
-					for (int k = 0; k < branch->patterns.size(); k++) {
-						pattern_result = _parse_match_pattern(codegen, err, branch->patterns[k], value, type, pattern_result, k == 0, false);
-						if (err != OK) {
-							return err;
-						}
-					}
-
-					// Check if pattern did match.
-					gen->write_if(pattern_result);
-
-					// Remove the result from stack.
-					gen->pop_temporary();
-
-					// Parse the branch block.
-					err = _parse_block(codegen, branch->block, false); // Don't add locals again.
-					if (err) {
-						return err;
-					}
-
-					_clear_addresses(codegen, branch_locals);
-
-					codegen.end_block(); // Get out of extra block.
-				}
-
-				// End all nested `if`s.
-				for (int j = 0; j < match->branches.size(); j++) {
-					gen->write_endif();
 				}
 			} break;
 			case GDScriptParser::Node::IF: {

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -115,6 +115,17 @@ class GDScriptCompiler {
 		}
 	};
 
+	struct MatchBranch {
+		const GDScriptParser::MatchBranchNode *branch = nullptr;
+		// Constant cases that are possible for the branch (duplicates excluded).
+		List<Variant> cases;
+
+		MatchBranch() {}
+		MatchBranch(const GDScriptParser::MatchBranchNode *p_branch) {
+			branch = p_branch;
+		}
+	};
+
 	bool _is_class_member_property(CodeGen &codegen, const StringName &p_name);
 	bool _is_class_member_property(GDScript *owner, const StringName &p_name);
 	bool _is_local_or_parameter(CodeGen &codegen, const StringName &p_name);
@@ -128,6 +139,8 @@ class GDScriptCompiler {
 
 	GDScriptCodeGenerator::Address _parse_assign_right_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::AssignmentNode *p_assignmentint, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
 	GDScriptCodeGenerator::Address _parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root = false, bool p_initializer = false, const GDScriptCodeGenerator::Address &p_index_addr = GDScriptCodeGenerator::Address());
+	Error _parse_match(CodeGen &codegen, const GDScriptParser::MatchNode *p_match);
+	Error _parse_match_branch_group(CodeGen &codegen, const GDScriptCodeGenerator::Address &p_value, const List<MatchBranch> &p_branches);
 	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested);
 	List<GDScriptCodeGenerator::Address> _add_locals_in_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
 	void _clear_addresses(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_addresses);

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -947,6 +947,55 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 				incr = 3;
 			} break;
+			case OPCODE_JUMP_TABLE_RANGE: {
+				text += "jump-table-range ";
+				text += DADDR(1);
+				text += "\n";
+
+				int offset = _code_ptr[ip + 2];
+				int size = _code_ptr[ip + 3];
+
+				String indent = String(" ").repeat(7 + itos(ip).length());
+
+				for (int i = 0; i < size; i++) {
+					text += indent;
+					text += "case ";
+					text += itos(offset + i);
+					text += " to ";
+					text += itos(_code_ptr[ip + 4 + i]);
+					text += "\n";
+				}
+
+				text += indent;
+				text += "default to ";
+				text += itos(_code_ptr[ip + 4 + size]);
+
+				incr = 4 + size + 1;
+			} break;
+			case OPCODE_JUMP_TABLE_BSEARCH: {
+				text += "jump-table-bsearch ";
+				text += DADDR(1);
+				text += "\n";
+
+				Vector<Variant> array = get_variant_vector_constant(_code_ptr[ip + 2] & ADDR_MASK);
+
+				String indent = String(" ").repeat(7 + itos(ip).length());
+
+				for (int i = 0; i < array.size(); i++) {
+					text += indent;
+					text += "case ";
+					text += _get_variant_string(array[i]);
+					text += " to ";
+					text += itos(_code_ptr[ip + 3 + i]);
+					text += "\n";
+				}
+
+				text += indent;
+				text += "default to ";
+				text += itos(_code_ptr[ip + 3 + array.size()]);
+
+				incr = 3 + array.size() + 1;
+			} break;
 			case OPCODE_RETURN: {
 				text += "return ";
 				text += DADDR(1);

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -37,6 +37,11 @@ Variant GDScriptFunction::get_constant(int p_idx) const {
 	return constants[p_idx];
 }
 
+Vector<Variant> GDScriptFunction::get_variant_vector_constant(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, variant_vector_constants.size(), Vector<Variant>());
+	return variant_vector_constants[p_idx];
+}
+
 StringName GDScriptFunction::get_global_name(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, global_names.size(), "<errgname>");
 	return global_names[p_idx];

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1959,10 +1959,10 @@ GDScriptParser::IfNode *GDScriptParser::parse_if(const String &p_token) {
 }
 
 GDScriptParser::MatchNode *GDScriptParser::parse_match() {
-	MatchNode *match = alloc_node<MatchNode>();
+	MatchNode *match_node = alloc_node<MatchNode>();
 
-	match->test = parse_expression(false);
-	if (match->test == nullptr) {
+	match_node->test = parse_expression(false);
+	if (match_node->test == nullptr) {
 		push_error(R"(Expected expression to test after "match".)");
 	}
 
@@ -1970,14 +1970,19 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	consume(GDScriptTokenizer::Token::NEWLINE, R"(Expected a newline after "match" statement.)");
 
 	if (!consume(GDScriptTokenizer::Token::INDENT, R"(Expected an indented block after "match" statement.)")) {
-		complete_extents(match);
-		return match;
+		complete_extents(match_node);
+		return match_node;
 	}
 
 	bool all_have_return = true;
 	bool have_wildcard = false;
 
 	while (!check(GDScriptTokenizer::Token::DEDENT) && !is_at_end()) {
+		if (match(GDScriptTokenizer::Token::PASS)) {
+			consume(GDScriptTokenizer::Token::NEWLINE, R"(Expected newline after "pass".)");
+			continue;
+		}
+
 		MatchBranchNode *branch = parse_match_branch();
 		if (branch == nullptr) {
 			advance();
@@ -1992,9 +1997,9 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 
 		have_wildcard = have_wildcard || branch->has_wildcard;
 		all_have_return = all_have_return && branch->block->has_return;
-		match->branches.push_back(branch);
+		match_node->branches.push_back(branch);
 	}
-	complete_extents(match);
+	complete_extents(match_node);
 
 	consume(GDScriptTokenizer::Token::DEDENT, R"(Expected an indented block after "match" statement.)");
 
@@ -2002,7 +2007,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 		current_suite->has_return = true;
 	}
 
-	return match;
+	return match_node;
 }
 
 GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
@@ -2019,8 +2024,14 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 		if (pattern->binds.size() > 0) {
 			has_bind = true;
 		}
-		if (branch->patterns.size() > 0 && has_bind) {
-			push_error(R"(Cannot use a variable bind with multiple patterns.)");
+		if (branch->patterns.size() > 0) {
+			if (has_bind) {
+				push_error(R"(Cannot use a variable bind with multiple patterns.)");
+#ifdef DEBUG_ENABLED
+			} else if (branch->has_wildcard || pattern->pattern_type == PatternNode::PT_BIND || pattern->pattern_type == PatternNode::PT_WILDCARD) {
+				push_warning(branch->has_wildcard ? pattern : branch->patterns[0], GDScriptWarning::REDUNDANT_PATTERN);
+#endif
+			}
 		}
 		if (pattern->pattern_type == PatternNode::PT_REST) {
 			push_error(R"(Rest pattern can only be used inside array and dictionary patterns.)");

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -283,6 +283,8 @@ void (*type_init_function_table[])(Variant *) = {
 		&&OPCODE_JUMP_IF_NOT,                        \
 		&&OPCODE_JUMP_TO_DEF_ARGUMENT,               \
 		&&OPCODE_JUMP_IF_SHARED,                     \
+		&&OPCODE_JUMP_TABLE_RANGE,                   \
+		&&OPCODE_JUMP_TABLE_BSEARCH,                 \
 		&&OPCODE_RETURN,                             \
 		&&OPCODE_RETURN_TYPED_BUILTIN,               \
 		&&OPCODE_RETURN_TYPED_ARRAY,                 \
@@ -2587,6 +2589,44 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				} else {
 					ip += 3;
 				}
+			}
+			DISPATCH_OPCODE;
+
+			OPCODE(OPCODE_JUMP_TABLE_RANGE) {
+				CHECK_SPACE(4);
+
+				GET_VARIANT_PTR(val, 0);
+				GD_ERR_BREAK(val->get_type() != Variant::INT);
+
+				int value = *val;
+				int offset = _code_ptr[ip + 2];
+				int size = _code_ptr[ip + 3];
+
+				CHECK_SPACE(4 + size + 1);
+
+				int index = value - offset;
+				ip = (index >= 0 && index < size) ? _code_ptr[ip + 4 + index] : _code_ptr[ip + 4 + size];
+				GD_ERR_BREAK(ip < 0 || ip >= _code_size);
+			}
+			DISPATCH_OPCODE;
+
+			OPCODE(OPCODE_JUMP_TABLE_BSEARCH) {
+				CHECK_SPACE(3);
+
+				GET_VARIANT_PTR(val, 0);
+				int arr_idx = _code_ptr[ip + 2];
+				GD_ERR_BREAK(arr_idx < 0 || arr_idx >= variant_vector_constants.size());
+
+				Variant value = *val;
+				Vector<Variant> array = variant_vector_constants[arr_idx];
+
+				CHECK_SPACE(3 + array.size() + 1);
+
+				SearchArray<Variant, SafeVariantSort> sa;
+				int index = sa.bisect(array.ptr(), array.size(), value, true);
+				bool found = index < array.size() && array[index].get_type() == value.get_type() && array[index] == value;
+				ip = found ? _code_ptr[ip + 3 + index] : _code_ptr[ip + 3 + array.size()];
+				GD_ERR_BREAK(ip < 0 || ip >= _code_size);
 			}
 			DISPATCH_OPCODE;
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -119,6 +119,8 @@ String GDScriptWarning::get_message() const {
 			return R"(The "@static_unload" annotation is redundant because the file does not have a class with static variables.)";
 		case REDUNDANT_AWAIT:
 			return R"("await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.)";
+		case REDUNDANT_PATTERN:
+			return R"(There is no point to use multiple patterns with a wildcard pattern.)";
 		case ASSERT_ALWAYS_TRUE:
 			return "Assert statement is redundant because the expression is always true.";
 		case ASSERT_ALWAYS_FALSE:
@@ -216,6 +218,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"STATIC_CALLED_ON_INSTANCE",
 		"REDUNDANT_STATIC_UNLOAD",
 		"REDUNDANT_AWAIT",
+		"REDUNDANT_PATTERN",
 		"ASSERT_ALWAYS_TRUE",
 		"ASSERT_ALWAYS_FALSE",
 		"INTEGER_DIVISION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -74,6 +74,7 @@ public:
 		STATIC_CALLED_ON_INSTANCE, // A static method was called on an instance of a class instead of on the class itself.
 		REDUNDANT_STATIC_UNLOAD, // The `@static_unload` annotation is used but the class does not have static data.
 		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
+		REDUNDANT_PATTERN, // Pattern in a match statement with a wildcard pattern.
 		ASSERT_ALWAYS_TRUE, // Expression for assert argument is always true.
 		ASSERT_ALWAYS_FALSE, // Expression for assert argument is always false.
 		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
@@ -122,6 +123,7 @@ public:
 		WARN, // STATIC_CALLED_ON_INSTANCE
 		WARN, // REDUNDANT_STATIC_UNLOAD
 		WARN, // REDUNDANT_AWAIT
+		WARN, // REDUNDANT_PATTERN
 		WARN, // ASSERT_ALWAYS_TRUE
 		WARN, // ASSERT_ALWAYS_FALSE
 		WARN, // INTEGER_DIVISION


### PR DESCRIPTION
* Closes #63719. 
* Closes #75682.

Optimize `match` with jump tables whenever possible. I want to use two kinds of tables:

1. `OPCODE_JUMP_TABLE_RANGE`. Can be used for continuous (or with a little sparsity) ranges of integers (such as enums). For example, from 0 to 10, or from 2 to 12. Instead of doing N comparisons (in the worst case), the jump address is calculated using the value, offset, and size.
2. `OPCODE_JUMP_TABLE_BSEARCH`. Can be used to binary search in a constant array sorted at compilation. Suitable when the value is not an integer or the range is very sparse.

When using variable patterns, destructuring (and match guards in the future), the old bytecode will be preserved (or the branches will be divided into subgroups in which optimizations can be performed).

#### TODO

##### Parser

- [x] (Bonus) Allow `pass` in `match`.
- [x] Add warning `REDUNDANT_PATTERN` (multiple patterns with a wildcard pattern).
- [ ] Add the ability to ignore warnings in `match`.

##### Analyzer

- [x] Add error on type mismatch for typed variables. Reduces the impact of the non-obvious comparison difference from `==` operator described in #74462.
- [ ] Add warning `DUPLICATE_PATTERN`.

##### Codegen, VM, disassembler

- [x] Add opcodes `OPCODE_JUMP_TABLE_RANGE` and `OPCODE_JUMP_TABLE_BSEARCH`.

##### Compiler

- [ ] Do not perform unnecessary operations if the type is known.
- [ ] Optimize `match` with jump tables.
- [ ] Remove unreachable branches?

##### Miscellaneous

- [ ] Add tests.
- [ ] Make benchmarks: PR vs master vs `if`-`elif`-`else`.