### PR TITLE
Standardize dialog input validation as a new class

### DIFF
--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -33,10 +33,10 @@
 #include "core/io/dir_access.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/gui/editor_validation_panel.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/panel_container.h"
 
 static String sanitize_input(const String &p_path) {
 	String path = p_path.strip_edges();
@@ -73,24 +73,17 @@ String DirectoryCreateDialog::_validate_path(const String &p_path) const {
 	return String();
 }
 
-void DirectoryCreateDialog::_on_dir_path_changed(const String &p_text) {
-	const String path = sanitize_input(p_text);
+void DirectoryCreateDialog::_on_dir_path_changed() {
+	const String path = sanitize_input(dir_path->get_text());
 	const String error = _validate_path(path);
 
 	if (error.is_empty()) {
-		status_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
-
 		if (path.contains("/")) {
-			status_label->set_text(TTR("Using slashes in folder names will create subfolders recursively."));
-		} else {
-			status_label->set_text(TTR("Folder name is valid."));
+			validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Using slashes in folder names will create subfolders recursively."), EditorValidationPanel::MSG_OK);
 		}
 	} else {
-		status_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-		status_label->set_text(error);
+		validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, error, EditorValidationPanel::MSG_ERROR);
 	}
-
-	get_ok_button()->set_disabled(!error.is_empty());
 }
 
 void DirectoryCreateDialog::ok_pressed() {
@@ -127,19 +120,11 @@ void DirectoryCreateDialog::config(const String &p_base_dir) {
 	label->set_text(vformat(TTR("Create new folder in %s:"), base_dir));
 	dir_path->set_text("new folder");
 	dir_path->select_all();
-	_on_dir_path_changed(dir_path->get_text());
+	validation_panel->update();
 }
 
 void DirectoryCreateDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("dir_created"));
-}
-
-void DirectoryCreateDialog::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
-		} break;
-	}
 }
 
 DirectoryCreateDialog::DirectoryCreateDialog() {
@@ -154,7 +139,6 @@ DirectoryCreateDialog::DirectoryCreateDialog() {
 	vb->add_child(label);
 
 	dir_path = memnew(LineEdit);
-	dir_path->connect("text_changed", callable_mp(this, &DirectoryCreateDialog::_on_dir_path_changed));
 	vb->add_child(dir_path);
 	register_text_enter(dir_path);
 
@@ -162,11 +146,11 @@ DirectoryCreateDialog::DirectoryCreateDialog() {
 	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
 	vb->add_child(spacing);
 
-	status_panel = memnew(PanelContainer);
-	status_panel->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	vb->add_child(status_panel);
+	validation_panel = memnew(EditorValidationPanel);
+	vb->add_child(validation_panel);
+	validation_panel->add_line(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Folder name is valid."));
+	validation_panel->set_update_callback(callable_mp(this, &DirectoryCreateDialog::_on_dir_path_changed));
+	validation_panel->set_accept_button(get_ok_button());
 
-	status_label = memnew(Label);
-	status_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	status_panel->add_child(status_label);
+	dir_path->connect("text_changed", callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -39,6 +39,7 @@ class AcceptDialog;
 class Button;
 class ConfirmationDialog;
 class EditorInspector;
+class EditorValidationPanel;
 class LineEdit;
 class OptionButton;
 class PanelContainer;
@@ -543,12 +544,11 @@ class EditorInspector : public ScrollContainer {
 	ConfirmationDialog *add_meta_dialog = nullptr;
 	LineEdit *add_meta_name = nullptr;
 	OptionButton *add_meta_type = nullptr;
-	PanelContainer *add_meta_error_panel = nullptr;
-	Label *add_meta_error = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();
-	void _check_meta_name(const String &p_name);
+	void _check_meta_name();
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1280,6 +1280,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	}
 
 	theme->set_stylebox("panel", "Tree", style_tree_bg);
+	theme->set_stylebox("panel", "EditorValidationPanel", style_tree_bg);
 
 	// Tree
 	theme->set_icon("checked", "Tree", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));

--- a/editor/gui/editor_validation_panel.cpp
+++ b/editor/gui/editor_validation_panel.cpp
@@ -1,0 +1,134 @@
+/**************************************************************************/
+/*  editor_validation_panel.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_validation_panel.h"
+
+#include "editor/editor_scale.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/label.h"
+
+void EditorValidationPanel::_update() {
+	for (const KeyValue<int, String> &E : valid_messages) {
+		set_message(E.key, E.value, MSG_OK);
+	}
+
+	valid = true;
+	update_callback.callv(Array());
+
+	if (accept_button) {
+		accept_button->set_disabled(!valid);
+	}
+	pending_update = false;
+}
+
+void EditorValidationPanel::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			theme_cache.valid_color = get_theme_color(SNAME("success_color"), SNAME("Editor"));
+			theme_cache.warning_color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
+			theme_cache.error_color = get_theme_color(SNAME("error_color"), SNAME("Editor"));
+		} break;
+	}
+}
+
+void EditorValidationPanel::add_line(int p_id, const String &p_valid_message) {
+	ERR_FAIL_COND(valid_messages.has(p_id));
+
+	Label *label = memnew(Label);
+	message_container->add_child(label);
+	label->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+	label->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+
+	valid_messages[p_id] = p_valid_message;
+	labels[p_id] = label;
+}
+
+void EditorValidationPanel::set_accept_button(Button *p_button) {
+	accept_button = p_button;
+}
+
+void EditorValidationPanel::set_update_callback(const Callable &p_callback) {
+	update_callback = p_callback;
+}
+
+void EditorValidationPanel::update() {
+	ERR_FAIL_COND(update_callback.is_null());
+
+	if (pending_update) {
+		return;
+	}
+	pending_update = true;
+	callable_mp(this, &EditorValidationPanel::_update).call_deferred();
+}
+
+void EditorValidationPanel::set_message(int p_id, const String &p_text, MessageType p_type, bool p_auto_prefix) {
+	ERR_FAIL_COND(!valid_messages.has(p_id));
+
+	Label *label = labels[p_id];
+	if (p_text.is_empty()) {
+		label->hide();
+		return;
+	}
+	label->show();
+
+	if (p_auto_prefix) {
+		label->set_text(String(U"•  ") + p_text);
+	} else {
+		label->set_text(p_text);
+	}
+
+	switch (p_type) {
+		case MSG_OK:
+			label->add_theme_color_override(SNAME("font_color"), theme_cache.valid_color);
+			break;
+		case MSG_WARNING:
+			label->add_theme_color_override(SNAME("font_color"), theme_cache.warning_color);
+			break;
+		case MSG_ERROR:
+			label->add_theme_color_override(SNAME("font_color"), theme_cache.error_color);
+			valid = false;
+			break;
+		case MSG_INFO:
+			label->remove_theme_color_override(SNAME("font_color"));
+			break;
+	}
+}
+
+bool EditorValidationPanel::is_valid() const {
+	return valid;
+}
+
+EditorValidationPanel::EditorValidationPanel() {
+	set_v_size_flags(SIZE_EXPAND_FILL);
+
+	message_container = memnew(VBoxContainer);
+	add_child(message_container);
+}

--- a/editor/gui/editor_validation_panel.h
+++ b/editor/gui/editor_validation_panel.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  directory_create_dialog.h                                             */
+/*  editor_validation_panel.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,37 +28,61 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef DIRECTORY_CREATE_DIALOG_H
-#define DIRECTORY_CREATE_DIALOG_H
+#ifndef EDITOR_VALIDATION_PANEL_H
+#define EDITOR_VALIDATION_PANEL_H
 
-#include "scene/gui/dialogs.h"
+#include "scene/gui/panel_container.h"
 
-class EditorValidationPanel;
+class Button;
 class Label;
-class LineEdit;
+class VBoxContainer;
 
-class DirectoryCreateDialog : public ConfirmationDialog {
-	GDCLASS(DirectoryCreateDialog, ConfirmationDialog);
-
-	String base_dir;
-
-	Label *label = nullptr;
-	LineEdit *dir_path = nullptr;
-	EditorValidationPanel *validation_panel = nullptr;
-
-	String _validate_path(const String &p_path) const;
-	void _on_dir_path_changed();
-
-protected:
-	static void _bind_methods();
-
-	virtual void ok_pressed() override;
-	virtual void _post_popup() override;
+class EditorValidationPanel : public PanelContainer {
+	GDCLASS(EditorValidationPanel, PanelContainer);
 
 public:
-	void config(const String &p_base_dir);
+	enum MessageType {
+		MSG_OK,
+		MSG_WARNING,
+		MSG_ERROR,
+		MSG_INFO,
+	};
 
-	DirectoryCreateDialog();
+	static const int MSG_ID_DEFAULT = 0; // Avoids hard-coding ID in dialogs with single-line validation.
+
+private:
+	VBoxContainer *message_container = nullptr;
+
+	HashMap<int, String> valid_messages;
+	HashMap<int, Label *> labels;
+
+	bool valid = false;
+	bool pending_update = false;
+
+	struct ThemeCache {
+		Color valid_color;
+		Color warning_color;
+		Color error_color;
+	} theme_cache;
+
+	void _update();
+
+	Callable update_callback;
+	Button *accept_button = nullptr;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void add_line(int p_id, const String &p_valid_message = "");
+	void set_accept_button(Button *p_button);
+	void set_update_callback(const Callable &p_callback);
+
+	void update();
+	void set_message(int p_id, const String &p_text, MessageType p_type, bool p_auto_prefix = true);
+	bool is_valid() const;
+
+	EditorValidationPanel();
 };
 
-#endif // DIRECTORY_CREATE_DIALOG_H
+#endif // EDITOR_VALIDATION_PANEL_H

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -34,6 +34,7 @@
 #include "editor/create_dialog.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/gui/editor_validation_panel.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/gui/box_container.h"
@@ -41,7 +42,6 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
-#include "scene/gui/panel_container.h"
 #include "scene/resources/packed_scene.h"
 
 void SceneCreateDialog::_notification(int p_what) {
@@ -53,7 +53,6 @@ void SceneCreateDialog::_notification(int p_what) {
 			node_type_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
 			node_type_gui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));
 			node_type_other->add_theme_icon_override(SNAME("icon"), get_theme_icon(SNAME("Node"), SNAME("EditorIcons")));
-			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));
 		} break;
 	}
 }
@@ -63,7 +62,7 @@ void SceneCreateDialog::config(const String &p_dir) {
 	root_name_edit->set_text("");
 	scene_name_edit->set_text("");
 	scene_name_edit->call_deferred(SNAME("grab_focus"));
-	update_dialog();
+	validation_panel->update();
 }
 
 void SceneCreateDialog::accept_create() {
@@ -82,40 +81,35 @@ void SceneCreateDialog::browse_types() {
 void SceneCreateDialog::on_type_picked() {
 	other_type_display->set_text(select_node_dialog->get_selected_type().get_slice(" ", 0));
 	if (node_type_other->is_pressed()) {
-		update_dialog();
+		validation_panel->update();
 	} else {
-		node_type_other->set_pressed(true); // Calls update_dialog() via group.
+		node_type_other->set_pressed(true); // Calls validation_panel->update() via group.
 	}
 }
 
 void SceneCreateDialog::update_dialog() {
 	scene_name = scene_name_edit->get_text().strip_edges();
-	update_error(file_error_label, MSG_OK, TTR("Scene name is valid."));
 
-	bool is_valid = true;
 	if (scene_name.is_empty()) {
-		update_error(file_error_label, MSG_ERROR, TTR("Scene name is empty."));
-		is_valid = false;
+		validation_panel->set_message(MSG_ID_PATH, TTR("Scene name is empty."), EditorValidationPanel::MSG_ERROR);
 	}
 
-	if (is_valid) {
+	if (validation_panel->is_valid()) {
 		if (!scene_name.ends_with(".")) {
 			scene_name += ".";
 		}
 		scene_name += scene_extension_picker->get_selected_metadata().operator String();
 	}
 
-	if (is_valid && !scene_name.is_valid_filename()) {
-		update_error(file_error_label, MSG_ERROR, TTR("File name invalid."));
-		is_valid = false;
+	if (validation_panel->is_valid() && !scene_name.is_valid_filename()) {
+		validation_panel->set_message(MSG_ID_PATH, TTR("File name invalid."), EditorValidationPanel::MSG_ERROR);
 	}
 
-	if (is_valid) {
+	if (validation_panel->is_valid()) {
 		scene_name = directory.path_join(scene_name);
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->file_exists(scene_name)) {
-			update_error(file_error_label, MSG_ERROR, TTR("File already exists."));
-			is_valid = false;
+			validation_panel->set_message(MSG_ID_PATH, TTR("File already exists."), EditorValidationPanel::MSG_ERROR);
 		}
 	}
 
@@ -126,8 +120,6 @@ void SceneCreateDialog::update_dialog() {
 		node_type_other->set_icon(nullptr);
 	}
 
-	update_error(node_error_label, MSG_OK, TTR("Root node valid."));
-
 	root_name = root_name_edit->get_text().strip_edges();
 	if (root_name.is_empty()) {
 		root_name = scene_name_edit->get_text().strip_edges();
@@ -135,39 +127,16 @@ void SceneCreateDialog::update_dialog() {
 		if (root_name.is_empty()) {
 			root_name_edit->set_placeholder(TTR("Leave empty to derive from scene name"));
 		} else {
-			// Respect the desired root node casing from ProjectSettings and ensure it's a valid node name.
-			String adjusted_root_name = Node::adjust_name_casing(root_name);
-			root_name = adjusted_root_name.validate_node_name();
-
-			bool has_invalid_characters = root_name != adjusted_root_name;
-			if (has_invalid_characters) {
-				update_error(node_error_label, MSG_WARNING, TTR("Invalid root node name characters have been replaced."));
-			}
-
-			root_name_edit->set_placeholder(root_name);
+			// Respect the desired root node casing from ProjectSettings.
+			root_name = Node::adjust_name_casing(root_name);
+			root_name_edit->set_placeholder(root_name.validate_node_name());
 		}
 	}
 
-	if (root_name.is_empty() || root_name.validate_node_name() != root_name) {
-		update_error(node_error_label, MSG_ERROR, TTR("Invalid root node name."));
-		is_valid = false;
-	}
-
-	get_ok_button()->set_disabled(!is_valid);
-}
-
-void SceneCreateDialog::update_error(Label *p_label, MsgType p_type, const String &p_msg) {
-	p_label->set_text(String::utf8("•  ") + p_msg);
-	switch (p_type) {
-		case MSG_OK:
-			p_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
-			break;
-		case MSG_ERROR:
-			p_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			break;
-		case MSG_WARNING:
-			p_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-			break;
+	if (root_name.is_empty()) {
+		validation_panel->set_message(MSG_ID_ROOT, TTR("Invalid root node name."), EditorValidationPanel::MSG_ERROR);
+	} else if (root_name != root_name.validate_node_name()) {
+		validation_panel->set_message(MSG_ID_ROOT, TTR("Invalid root node name characters have been replaced."), EditorValidationPanel::MSG_WARNING);
 	}
 }
 
@@ -268,8 +237,6 @@ SceneCreateDialog::SceneCreateDialog() {
 		select_node_button = memnew(Button);
 		hb->add_child(select_node_button);
 		select_node_button->connect("pressed", callable_mp(this, &SceneCreateDialog::browse_types));
-
-		node_type_group->connect("pressed", callable_mp(this, &SceneCreateDialog::update_dialog).unbind(1));
 	}
 
 	{
@@ -282,7 +249,6 @@ SceneCreateDialog::SceneCreateDialog() {
 		scene_name_edit = memnew(LineEdit);
 		hb->add_child(scene_name_edit);
 		scene_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		scene_name_edit->connect("text_changed", callable_mp(this, &SceneCreateDialog::update_dialog).unbind(1));
 		scene_name_edit->connect("text_submitted", callable_mp(this, &SceneCreateDialog::accept_create).unbind(1));
 
 		List<String> extensions;
@@ -305,7 +271,6 @@ SceneCreateDialog::SceneCreateDialog() {
 		gc->add_child(root_name_edit);
 		root_name_edit->set_tooltip_text(TTR("When empty, the root node name is derived from the scene name based on the \"editor/naming/node_name_casing\" project setting."));
 		root_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		root_name_edit->connect("text_changed", callable_mp(this, &SceneCreateDialog::update_dialog).unbind(1));
 		root_name_edit->connect("text_submitted", callable_mp(this, &SceneCreateDialog::accept_create).unbind(1));
 	}
 
@@ -313,19 +278,16 @@ SceneCreateDialog::SceneCreateDialog() {
 	main_vb->add_child(spacing);
 	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
 
-	status_panel = memnew(PanelContainer);
-	main_vb->add_child(status_panel);
-	status_panel->set_h_size_flags(Control::SIZE_FILL);
-	status_panel->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	validation_panel = memnew(EditorValidationPanel);
+	main_vb->add_child(validation_panel);
+	validation_panel->add_line(MSG_ID_PATH, TTR("Scene name is valid."));
+	validation_panel->add_line(MSG_ID_ROOT, TTR("Root node valid."));
+	validation_panel->set_update_callback(callable_mp(this, &SceneCreateDialog::update_dialog));
+	validation_panel->set_accept_button(get_ok_button());
 
-	VBoxContainer *status_vb = memnew(VBoxContainer);
-	status_panel->add_child(status_vb);
-
-	file_error_label = memnew(Label);
-	status_vb->add_child(file_error_label);
-
-	node_error_label = memnew(Label);
-	status_vb->add_child(node_error_label);
+	node_type_group->connect("pressed", callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	scene_name_edit->connect("text_changed", callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	root_name_edit->connect("text_changed", callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
 
 	set_title(TTR("Create New Scene"));
 	set_min_size(Size2i(400 * EDSCALE, 0));

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -37,18 +37,17 @@ class ButtonGroup;
 class CheckBox;
 class CreateDialog;
 class EditorFileDialog;
+class EditorValidationPanel;
 class Label;
 class LineEdit;
 class OptionButton;
-class PanelContainer;
 
 class SceneCreateDialog : public ConfirmationDialog {
 	GDCLASS(SceneCreateDialog, ConfirmationDialog);
 
-	enum MsgType {
-		MSG_OK,
-		MSG_ERROR,
-		MSG_WARNING,
+	enum {
+		MSG_ID_PATH,
+		MSG_ID_ROOT,
 	};
 
 	const StringName type_meta = StringName("type");
@@ -80,15 +79,12 @@ private:
 	OptionButton *scene_extension_picker = nullptr;
 	LineEdit *root_name_edit = nullptr;
 
-	PanelContainer *status_panel = nullptr;
-	Label *file_error_label = nullptr;
-	Label *node_error_label = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 
 	void accept_create();
 	void browse_types();
 	void on_type_picked();
 	void update_dialog();
-	void update_error(Label *p_label, MsgType p_type, const String &p_msg);
 
 protected:
 	void _notification(int p_what);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -41,17 +41,20 @@
 
 class CreateDialog;
 class EditorFileDialog;
+class EditorValidationPanel;
 
 class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
 
+	enum {
+		MSG_ID_SCRIPT,
+		MSG_ID_PATH,
+		MSG_ID_BUILT_IN,
+		MSG_ID_TEMPLATE,
+	};
+
 	LineEdit *class_name = nullptr;
-	Label *error_label = nullptr;
-	Label *path_error_label = nullptr;
-	Label *builtin_warning_label = nullptr;
-	Label *script_name_warning_label = nullptr;
-	Label *template_info_label = nullptr;
-	PanelContainer *status_panel = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 	LineEdit *parent_name = nullptr;
 	Button *parent_browse_button = nullptr;
 	Button *parent_search_button = nullptr;
@@ -67,6 +70,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	AcceptDialog *alert = nullptr;
 	CreateDialog *select_class = nullptr;
 	bool is_browsing_parent = false;
+	String path_error;
 	String template_inactive_message;
 	String initial_bp;
 	bool is_new_script_created = true;
@@ -113,8 +117,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	virtual void ok_pressed() override;
 	void _create_new();
 	void _load_exist();
-	void _msg_script_valid(bool valid, const String &p_msg = String());
-	void _msg_path_valid(bool valid, const String &p_msg = String());
 	void _update_template_menu();
 	void _update_dialog();
 	ScriptLanguage::ScriptTemplate _get_current_template() const;

--- a/editor/shader_create_dialog.h
+++ b/editor/shader_create_dialog.h
@@ -40,9 +40,16 @@
 #include "scene/gui/panel_container.h"
 
 class EditorFileDialog;
+class EditorValidationPanel;
 
 class ShaderCreateDialog : public ConfirmationDialog {
 	GDCLASS(ShaderCreateDialog, ConfirmationDialog);
+
+	enum {
+		MSG_ID_SHADER,
+		MSG_ID_PATH,
+		MSG_ID_BUILT_IN,
+	};
 
 	struct ShaderTypeData {
 		List<String> extensions;
@@ -53,10 +60,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	List<ShaderTypeData> type_data;
 
 	GridContainer *gc = nullptr;
-	Label *error_label = nullptr;
-	Label *path_error_label = nullptr;
-	Label *builtin_warning_label = nullptr;
-	PanelContainer *status_panel = nullptr;
+	EditorValidationPanel *validation_panel = nullptr;
 	OptionButton *type_menu = nullptr;
 	OptionButton *mode_menu = nullptr;
 	OptionButton *template_menu = nullptr;
@@ -67,6 +71,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	AcceptDialog *alert = nullptr;
 
 	String initial_base_path;
+	String path_error;
 	bool is_new_shader_created = true;
 	bool is_path_valid = false;
 	bool is_built_in = false;
@@ -93,8 +98,6 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	virtual void ok_pressed() override;
 	void _create_new();
 	void _load_exist();
-	void _msg_script_valid(bool valid, const String &p_msg = String());
-	void _msg_path_valid(bool valid, const String &p_msg = String());
 	void _update_dialog();
 
 protected:


### PR DESCRIPTION
Since some time we have an established way to validate input in various dialogs. We use a panel with error messages, like this one:
![](https://user-images.githubusercontent.com/2223172/235779087-7db4a899-dd41-40c7-8cb3-b295a42eec5e.png)
However every dialog implemented it separately, with led to duplicate code and even some inconsistencies (like missing panel style or using wrong listing character).

This PR adds EditorValidationPanel. It serves 2 purposes:
- displays provided messages, styling them depending on message type (ok/warning/error/info)
- reduces boilerplate code by doing some error management automatically

EditorValidationPanel's constructor expects a vector of strings. They will serve as default "valid" messages (i.e. no errors); size of the vector determines number of labels. After panel is created, use `EditorValidationPanel.update()` to *queue* an update method. This method will first setup labels to their default state (so the status is "valid" by default and you don't need to set it each time), then a designated update callback is called. In this callback the user is supposed to use `set_message()` method to set the texts of the labels. The `set_message()` takes label index, message text and message type (ok/warning/error/info). EditorValidationPanel will automatically prefix the messages with •, assign them colors based on type and disable or enable the dialog's OK button if it was registered.

I replaced all custom validations with EditorValidationPanel, in some cases making them more consistent (although I tried to preserve the previous appearance, notably the notes without bullet points in script create dialog). This also exposed some messages that previously weren't previously used due to faulty logic. I noticed that AnimationBlendSpaceEditor also uses some similar panel with errors, but it behaves a bit differently and is not a dialog, so I left it for now (although the validation panel is capable of handling it).

EDIT:
After latest changes the messages are no longer part of the constructor. Instead you need to define them with explicit ID.

EDIT2:
Fixes #80218