### PR TITLE
Fix node processing order

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -933,9 +933,11 @@ void Node::set_process_thread_group_order(int p_order) {
 	if (data.process_thread_group_order == p_order) {
 		return;
 	}
-	// Make sure we are in SceneTree and an actual process owner
+
+	data.process_thread_group_order = p_order;
+
+	// Not yet in the tree (or not a group owner, in whose case this is pointless but harmless); trivial update.
 	if (!is_inside_tree() || data.process_thread_group_owner != this) {
-		data.process_thread_group_order = p_order;
 		return;
 	}
 
@@ -951,8 +953,8 @@ void Node::set_process_priority(int p_priority) {
 	if (data.process_priority == p_priority) {
 		return;
 	}
-	// Make sure we are in SceneTree and an actual process owner
 	if (!is_inside_tree()) {
+		// Not yet in the tree; trivial update.
 		data.process_priority = p_priority;
 		return;
 	}
@@ -973,8 +975,8 @@ void Node::set_physics_process_priority(int p_priority) {
 	if (data.physics_process_priority == p_priority) {
 		return;
 	}
-	// Make sure we are in SceneTree and an actual physics_process owner
 	if (!is_inside_tree()) {
+		// Not yet in the tree; trivial update.
 		data.physics_process_priority = p_priority;
 		return;
 	}
@@ -997,11 +999,11 @@ void Node::set_process_thread_group(ProcessThreadGroup p_mode) {
 	}
 
 	if (!is_inside_tree()) {
+		// Not yet in the tree; trivial update.
 		data.process_thread_group = p_mode;
 		return;
 	}
 
-	// Mode changed, must update everything.
 	_remove_tree_from_process_thread_group();
 	if (data.process_thread_group != PROCESS_THREAD_GROUP_INHERIT) {
 		_remove_process_group();
@@ -1031,7 +1033,7 @@ Node::ProcessThreadGroup Node::get_process_thread_group() const {
 
 void Node::set_process_thread_messages(BitField<ProcessThreadMessages> p_flags) {
 	ERR_THREAD_GUARD
-	if (data.process_thread_group_order == p_flags) {
+	if (data.process_thread_messages == p_flags) {
 		return;
 	}
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -932,18 +932,18 @@ void SceneTree::_process_group(ProcessGroup *p_group, bool p_physics) {
 		}
 
 		if (p_physics) {
-			if (n->is_physics_processing()) {
-				n->notification(Node::NOTIFICATION_PHYSICS_PROCESS);
-			}
 			if (n->is_physics_processing_internal()) {
 				n->notification(Node::NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 			}
-		} else {
-			if (n->is_processing()) {
-				n->notification(Node::NOTIFICATION_PROCESS);
+			if (n->is_physics_processing()) {
+				n->notification(Node::NOTIFICATION_PHYSICS_PROCESS);
 			}
+		} else {
 			if (n->is_processing_internal()) {
 				n->notification(Node::NOTIFICATION_INTERNAL_PROCESS);
+			}
+			if (n->is_processing()) {
+				n->notification(Node::NOTIFICATION_PROCESS);
 			}
 		}
 	}


### PR DESCRIPTION
Node processing used to work like this (disclaimer: pseudocode):
```
FOR-EACH (Physics, Idle):
	FOR-EACH node:
		node.internal_process()
	FOR-EACH node:
		node.process()
```

After #75901 it changed to (note changed nesting of internal/external and node iterations, as well as the relative order of internal/external):
```
FOR-EACH (Physics, Idle):
	FOR-EACH group:
		group.message_queue.flush()
		FOR-EACH node in group:
			node.process()
			node.internal_process()
		group.message_queue.flush()
```

This PR changes the processing so it looks much closer to what it was like. Specifically, while still supporting group processing, it makes internal happen first and changes the nesting of internal/external and node iterations:
```
FOR-EACH (Physics, Idle):
	FOR-EACH group:
		group.message_queue.flush()
		FOR-EACH node in group:
			node.internal_process()
	FOR-EACH group:
		FOR-EACH node in group:
			node.process()
		group.message_queue.flush()
```

**UPDATE:** See https://github.com/godotengine/godot/pull/78745#issuecomment-1609935022.

Bonus: _Fix issues in group-processing related setters_.

**WARNING:** While this fixes a relevant compat breakage, it's very likely that we have edge cases here and there. Moreover, this would need to be smoke and non-smoke tested to be sure the remedy is not worse than the illness.

Fixes #77548.