### PR TITLE
Support loading of translations on threads

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -82,6 +82,15 @@ void Translation::_set_messages(const Dictionary &p_messages) {
 void Translation::set_locale(const String &p_locale) {
 	locale = TranslationServer::get_singleton()->standardize_locale(p_locale);
 
+	if (Thread::is_main_thread()) {
+		_notify_translation_changed_if_applies();
+	} else {
+		// Avoid calling non-thread-safe functions here.
+		callable_mp(this, &Translation::_notify_translation_changed_if_applies).call_deferred();
+	}
+}
+
+void Translation::_notify_translation_changed_if_applies() {
 	if (OS::get_singleton()->get_main_loop() && TranslationServer::get_singleton()->get_loaded_locales().has(get_locale())) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
 	}

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -47,6 +47,8 @@ class Translation : public Resource {
 	virtual Dictionary _get_messages() const;
 	virtual void _set_messages(const Dictionary &p_messages);
 
+	void _notify_translation_changed_if_applies();
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
Resources can safely do deferred calls from threads in the context of resource loading. The `ResourceLoader` has a mechanism in place to make them eventually run on the main thread, safely. With this PR, the patched call can benefit from it.

That said, ideally we would have a safety net in some other layer of the engine. We are patching this call because we know that its current implementation leads to thread-unsafe calls along the call chain. In other words, this fix is a bit flimsy as it relies too much on implementation details of other classes. **UPDATE:** Implementation changed to move the threading concern to the resource class instead of the translation loader; I'm a bit happier with this, but none should be having to care about that, to be honest.

Fixes #78689 (but testing is needed to confirm; can anyone check?).