### PR TITLE
GUI: Fix text overlapping icon in `Tree`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -339,6 +339,13 @@
 				Returns item's text base writing direction.
 			</description>
 		</method>
+		<method name="get_text_overrun_behavior" qualifiers="const">
+			<return type="int" enum="TextServer.OverrunBehavior" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the clipping behavior when the text exceeds the item's bounding rectangle in the given [param column]. By default it is [constant TextServer.OVERRUN_TRIM_ELLIPSIS].
+			</description>
+		</method>
 		<method name="get_tooltip_text" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="column" type="int" />
@@ -726,6 +733,14 @@
 			<param index="1" name="direction" type="int" enum="Control.TextDirection" />
 			<description>
 				Sets item's text base writing direction.
+			</description>
+		</method>
+		<method name="set_text_overrun_behavior">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="overrun_behavior" type="int" enum="TextServer.OverrunBehavior" />
+			<description>
+				Sets the clipping behavior when the text exceeds the item's bounding rectangle in the given [param column].
 			</description>
 		</method>
 		<method name="set_tooltip_text">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -117,6 +117,7 @@ private:
 
 		Cell() {
 			text_buf.instantiate();
+			text_buf->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		}
 
 		Size2 get_icon_size() const;
@@ -230,6 +231,9 @@ public:
 
 	void set_autowrap_mode(int p_column, TextServer::AutowrapMode p_mode);
 	TextServer::AutowrapMode get_autowrap_mode(int p_column) const;
+
+	void set_text_overrun_behavior(int p_column, TextServer::OverrunBehavior p_behavior);
+	TextServer::OverrunBehavior get_text_overrun_behavior(int p_column) const;
 
 	void set_structured_text_bidi_override(int p_column, TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override(int p_column) const;


### PR DESCRIPTION
* Closes #78741.

![](https://github.com/godotengine/godot/assets/47700418/4ff9919a-f99f-48db-be09-6a2910a9a1a4)

1. Fix icon (left) size not being taken into account which causes the button (right) to overlap the text.
2. Restore old default `text_overrun_behavior`. `TextLine` defaults to `OVERRUN_TRIM_ELLIPSIS` and `TextParagraph` defaults to `OVERRUN_NO_TRIMMING`.
3. Make `text_overrun_behavior` customizable.