### PR TITLE
Correctly set mass for a rigid body with custom inertia and center of mass

### DIFF
--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -35,7 +35,7 @@
 #include "godot_space_2d.h"
 
 void GodotBody2D::_mass_properties_changed() {
-	if (get_space() && !mass_properties_update_list.in_list() && (calculate_inertia || calculate_center_of_mass)) {
+	if (get_space() && !mass_properties_update_list.in_list()) {
 		get_space()->body_add_to_mass_properties_update_list(&mass_properties_update_list);
 	}
 }

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -35,7 +35,7 @@
 #include "godot_space_3d.h"
 
 void GodotBody3D::_mass_properties_changed() {
-	if (get_space() && !mass_properties_update_list.in_list() && (calculate_inertia || calculate_center_of_mass)) {
+	if (get_space() && !mass_properties_update_list.in_list()) {
 		get_space()->body_add_to_mass_properties_update_list(&mass_properties_update_list);
 	}
 }


### PR DESCRIPTION
See #78750 for issue description.

Removed erroneous check, which caused ```_inv_mass``` not to be calculated when **RigidBody2D** or **RigidBody3D** used both custom center of mass and custom inertia.

The only purpose of the check for ```(calculate_inertia || calculate_center_of_mass)``` appears to be to prevent adding bodies to the godot_space's ```mass_properties_update_list``` . On elements of this list ```GodotBody3D::update_mass_properties()``` is then executed.
At the first glance it appears that if ```calculate_inertia == false``` and ```calculate_center_of_mass == false``` function ```GodotBody3D::update_mass_properties()``` would do nothing and this check in ```GodotBody3D::_mass_properties_changed()``` is valid.
This is not entirely true. ```GodotBody3D::update_mass_properties()``` is also used to calculate ```_inv_mass```, which would be left at default value if the body was omitted from mass property update and cause incorrect physics behavior as described in #78750.

By removing the check for ```(calculate_inertia || calculate_center_of_mass)``` it can be ensured that ```_inv_mass``` is always calculated. At the same time ```GodotBody3D::update_mass_properties()``` already contains checks for the above parameters, meaning that if ```calculate_inertia == false``` or ```calculate_center_of_mass == false``` no unnecessary calculations will be executed. Checking for these parameters twice is not needed.

* Bugsquad edit, fixes: #78750