### PR TITLE
Allow `push_input()` to work when `gui_disable_input` is enabled on `Viewport`s

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -262,7 +262,7 @@
 			The global canvas transform of the viewport. The canvas transform is relative to this.
 		</member>
 		<member name="gui_disable_input" type="bool" setter="set_disable_input" getter="is_input_disabled" default="false">
-			If [code]true[/code], the viewport will not receive input events.
+			If [code]true[/code], the viewport will not receive input events. Inputs from [method push_input] will still be taken.
 		</member>
 		<member name="gui_embed_subwindows" type="bool" setter="set_embedding_subwindows" getter="is_embedding_subwindows" default="false">
 			If [code]true[/code], sub-windows (popups and dialogs) will be embedded inside application window as control-like nodes. If [code]false[/code], they will appear as separate windows handled by the operating system.

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -315,7 +315,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 
 	if (action != StringName()) {
 		Input::get_singleton()->action_release(action);
-		if (!p_exiting_tree) {
+		if (!p_exiting_tree && !get_viewport()->is_input_disabled()) {
 			Ref<InputEventAction> iea;
 			iea.instantiate();
 			iea->set_action(action);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2937,10 +2937,6 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (disable_input) {
-		return;
-	}
-
 	if (Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_ancestor_of(this)) {
 		return;
 	}
@@ -2997,7 +2993,7 @@ void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local
 
 	local_input_handled = false;
 
-	if (disable_input || !_can_consume_input_events()) {
+	if (!_can_consume_input_events()) {
 		return;
 	}
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -723,6 +723,11 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 
 void Window::update_mouse_cursor_state() {
 	ERR_MAIN_THREAD_GUARD;
+
+	if (is_input_disabled()) {
+		return;
+	}
+
 	// Update states based on mouse cursor position.
 	// This includes updated mouse_enter or mouse_exit signals or the current mouse cursor shape.
 	// These details are set in Viewport::_gui_input_event. To instantly


### PR DESCRIPTION
In 3.*, if a `Viewport` had `gui_disable_input` enabled, it could still receive inputs via the `input()` method. This was handy if you wished to cherry-pick which inputs went into a sub-viewport (which is the case in my game).

In 4.*, however, this is not possible anymore. So this PR brings back the old behavior.