### PR TITLE
Enable `InputEvent`-filtering in `SubViewportContainer`

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -10,6 +10,15 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="_propagate_input_event" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="event" type="InputEvent" />
+			<description>
+				Virtual method to be implemented by the user. If it returns [code]true[/code], the [param event] is propagated to [SubViewport] children. Propagation doesn't happen if it returns [code]false[/code]. If the function is not implemented, all events are propagated to SubViewports.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="1" />
 		<member name="stretch" type="bool" setter="set_stretch" getter="is_stretch_enabled" default="false">

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -190,6 +190,13 @@ void SubViewportContainer::_propagate_nonpositional_event(const Ref<InputEvent> 
 		return;
 	}
 
+	bool send;
+	if (GDVIRTUAL_CALL(_propagate_input_event, p_event, send)) {
+		if (!send) {
+			return;
+		}
+	}
+
 	_send_event_to_viewports(p_event);
 }
 
@@ -202,6 +209,13 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (!_is_propagated_in_gui_input(p_event)) {
 		return;
+	}
+
+	bool send;
+	if (GDVIRTUAL_CALL(_propagate_input_event, p_event, send)) {
+		if (!send) {
+			return;
+		}
 	}
 
 	if (stretch && shrink > 1) {
@@ -275,6 +289,8 @@ void SubViewportContainer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink"), "set_stretch_shrink", "get_stretch_shrink");
+
+	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }
 
 SubViewportContainer::SubViewportContainer() {

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -50,6 +50,8 @@ protected:
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 
+	GDVIRTUAL1RC(bool, _propagate_input_event, Ref<InputEvent>);
+
 public:
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;


### PR DESCRIPTION
Introduce an user overridable function `_propagate_input_event`, that allows filtering, if an `InputEvent` should be sent to `SubViewport` children.

implements https://github.com/godotengine/godot/pull/78759#issue-1777295419
alternative to #78759
implements a more generic approach than the one in godotengine/godot-proposals#1249
related to #62421

MRP to showcase the new functionality: [SvcInputEventFilter78762.zip](https://github.com/godotengine/godot/files/12255380/SvcInputEventFilter78762.zip)

Updated 2023-08-03: rename `_send_input_event` to `_propagate_input_event` in order to adhere to the usual nomenclature. improve docstring. Rebase for CI-changes.