### PR TITLE
Fix VoxelGI saving VoxelGIData as a built-in file, despite being prompted to save it to an external file

### DIFF
--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -166,8 +166,13 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 	probe_file->hide();
 	if (voxel_gi) {
 		voxel_gi->bake();
-		ERR_FAIL_COND(voxel_gi->get_probe_data().is_null());
-		ResourceSaver::save(voxel_gi->get_probe_data(), p_path, ResourceSaver::FLAG_CHANGE_PATH);
+		// Ensure the VoxelGIData is always saved to an external resource.
+		// This avoids bloating the scene file with large binary data,
+		// which would be serialized as Base64 if the scene is a `.tscn` file.
+		Ref<VoxelGIData> voxel_gi_data = voxel_gi->get_probe_data();
+		ERR_FAIL_COND(voxel_gi_data.is_null());
+		voxel_gi_data->set_path(p_path);
+		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH);
 	}
 }
 


### PR DESCRIPTION
This fixes #50029.

It seems like the resource saver will change the VoxelGIData resource path to the external file, save the resource and the revert it to what it was previously (an empty string), essentially creating two resources, one built-in to the scene (which has the actual data) and the external file. I do not know why the resource saver works this way, but the `ScriptCreateDialog` does the same thing:
```cpp
String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
scr->set_path(lpath);
Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
if (err != OK) {
	alert->set_text(TTR("Error - Could not create script in filesystem."));
	alert->popup_centered();
	return;
}
``` 
so I copied that.