### PR TITLE
Sort project tags before saving

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2504,6 +2504,7 @@ void ProjectManager::_apply_project_tags() {
 		callable_mp((Window *)tag_manage_dialog, &Window::show).call_deferred(); // Make sure the dialog does not disappear.
 		return;
 	} else {
+		tags.sort();
 		cfg.set_value("application", "config/tags", tags);
 		err = cfg.save(project_godot);
 		if (err != OK) {


### PR DESCRIPTION
As noted [here](https://github.com/godotengine/godot-demo-projects/pull/926), having the tags not be in a consistent order is quite annoying.

The fix is simple, sort before saving. This is in a similar vain to #76964, and similar to how features are sorted.