### PR TITLE
Fix delay on tab resizing when (un)hovering tabs

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -881,6 +881,8 @@ void TabBar::_update_hover() {
 		if (hover != -1) {
 			emit_signal(SNAME("tab_hovered"), hover);
 		}
+
+		_update_cache();
 		queue_redraw();
 	}
 
@@ -988,6 +990,7 @@ void TabBar::_on_mouse_exited() {
 	highlight_arrow = -1;
 	dragging_valid_tab = false;
 
+	_update_cache();
 	queue_redraw();
 }
 


### PR DESCRIPTION
Currently, when hovering in and out of a tab with the mouse, the size of the tabs will take a second to properly update in case the hovered style is of a different size than the rest. This PR fixes that.