### PR TITLE
Fix function signature in `EditorImportPlugin` example

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -30,10 +30,10 @@
 		func _get_preset_count():
 		    return 1
 
-		func _get_preset_name(i):
+		func _get_preset_name(preset_index):
 		    return "Default"
 
-		func _get_import_options(i):
+		func _get_import_options(path, preset_index):
 		    return [{"name": "my_option", "default_value": false}]
 
 		func _import(source_file, save_path, options, platform_variants, gen_files):


### PR DESCRIPTION
A parameter was added to `_get_import_options`, but the signature in GDScript example was not synced.

Also changed `i` to `preset_index`.