### PR TITLE
C#: Fix reloading of non-tool scripts

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -781,7 +781,8 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		MutexLock lock(script_instances_mutex);
 
 		for (SelfList<CSharpScript> *elem = script_list.first(); elem; elem = elem->next()) {
-			bool is_reloadable = false;
+			// Do not reload scripts with only non-collectible instances to avoid disrupting event subscriptions and such.
+			bool is_reloadable = elem->self()->instances.size() == 0;
 			for (Object *obj : elem->self()->instances) {
 				ERR_CONTINUE(!obj->get_script_instance());
 				CSharpInstance *csi = static_cast<CSharpInstance *>(obj->get_script_instance());


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/78765

I forgot about non-tool scripts, which do not have any instances.

Always reload scripts without any instances, as there are no instances to cause issues for, and thus this really just updates their metadata.