### PR TITLE
Fix threading bug in Vulkan rendering device

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7470,6 +7470,7 @@ uint32_t RenderingDeviceVulkan::draw_list_get_current_pass() {
 }
 
 RenderingDevice::DrawListID RenderingDeviceVulkan::draw_list_switch_to_next_pass() {
+	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND_V(draw_list == nullptr, INVALID_ID);
 	ERR_FAIL_COND_V(draw_list_current_subpass >= draw_list_subpass_count - 1, INVALID_FORMAT_ID);
 
@@ -7485,6 +7486,7 @@ RenderingDevice::DrawListID RenderingDeviceVulkan::draw_list_switch_to_next_pass
 	return int64_t(ID_TYPE_DRAW_LIST) << ID_BASE_SHIFT;
 }
 Error RenderingDeviceVulkan::draw_list_switch_to_next_pass_split(uint32_t p_splits, DrawListID *r_split_ids) {
+	_THREAD_SAFE_METHOD_
 	ERR_FAIL_COND_V(draw_list == nullptr, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(draw_list_current_subpass >= draw_list_subpass_count - 1, ERR_INVALID_PARAMETER);
 


### PR DESCRIPTION
This is a fix for the following bug:

https://github.com/godotengine/godot/issues/78786

The bug was that:
`draw_list_switch_to_next_pass` was not holding the lock, and was calling 
`_draw_list_free(&viewport);`
and `draw_list_allocate` with stuff in between, all mid a single multiple pass draw-list.

The free and allocate functions release and acquire the lock. So in between the two calls, other stuff was happening (other draw lists being started and ended), which meant bad things happened because the vulkan state goes bad (segfaults in graphics drivers on my machine).

This is I think a pretty trivial bugfix - deffo for 4.2, would be great for 4.1 if poss? 

* Bugsquad edit, fixes: #78786
