### PR TITLE
Fix crash with failed compatibility tiles

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2609,6 +2609,7 @@ void TileSet::_compatibility_conversion() {
 					compatibility_tilemap_mapping_tile_modes[E.key] = COMPATIBILITY_TILE_MODE_SINGLE_TILE;
 
 					TileData *tile_data = atlas_source->get_tile_data(coords, alternative_tile);
+					ERR_CONTINUE(!tile_data);
 
 					tile_data->set_flip_h(flip_h);
 					tile_data->set_flip_v(flip_v);


### PR DESCRIPTION
Fixes #77673

Opening the project now results in a spam of
```
 Cannot create tile. The tile is outside the texture or tiles are already present in the space the tile would cover.
  The TileSetAtlasSource atlas has no tile at (0, 0).
  C:\godot_source\scene/resources/tile_set.cpp:2612 - Condition "!tile_data" is true. Continuing.
```
Looks like some tile was too big or something, it failed to create, and TileData was null. Maybe there is a way to somehow restore the TileData, but for now this prevents a crash.