### PR TITLE
Add layer, shadow and visibility range options to the Scene importer

### DIFF
--- a/doc/classes/ImporterMeshInstance3D.xml
+++ b/doc/classes/ImporterMeshInstance3D.xml
@@ -7,11 +7,25 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
+		</member>
+		<member name="layer_mask" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
+		</member>
 		<member name="mesh" type="ImporterMesh" setter="set_mesh" getter="get_mesh">
 		</member>
 		<member name="skeleton_path" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;&quot;)">
 		</member>
 		<member name="skin" type="Skin" setter="set_skin" getter="get_skin">
+		</member>
+		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin" default="0.0">
+		</member>
+		<member name="visibility_range_begin_margin" type="float" setter="set_visibility_range_begin_margin" getter="get_visibility_range_begin_margin" default="0.0">
+		</member>
+		<member name="visibility_range_end" type="float" setter="set_visibility_range_end" getter="get_visibility_range_end" default="0.0">
+		</member>
+		<member name="visibility_range_end_margin" type="float" setter="set_visibility_range_end_margin" getter="get_visibility_range_end_margin" default="0.0">
+		</member>
+		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode" default="0">
 		</member>
 	</members>
 </class>

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1356,6 +1356,40 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 		}
 	}
 
+	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
+		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
+
+		if (node_settings.has("mesh_instance/layers")) {
+			mi->set_layer_mask(node_settings["mesh_instance/layers"]);
+		}
+
+		if (node_settings.has("mesh_instance/visibility_range_begin")) {
+			mi->set_visibility_range_begin(node_settings["mesh_instance/visibility_range_begin"]);
+		}
+
+		if (node_settings.has("mesh_instance/visibility_range_begin_margin")) {
+			mi->set_visibility_range_begin_margin(node_settings["mesh_instance/visibility_range_begin_margin"]);
+		}
+
+		if (node_settings.has("mesh_instance/visibility_range_end")) {
+			mi->set_visibility_range_end(node_settings["mesh_instance/visibility_range_end"]);
+		}
+
+		if (node_settings.has("mesh_instance/visibility_range_end_margin")) {
+			mi->set_visibility_range_end_margin(node_settings["mesh_instance/visibility_range_end_margin"]);
+		}
+
+		if (node_settings.has("mesh_instance/visibility_range_fade_mode")) {
+			const GeometryInstance3D::VisibilityRangeFadeMode range_fade_mode = (GeometryInstance3D::VisibilityRangeFadeMode)node_settings["mesh_instance/visibility_range_fade_mode"].operator int();
+			mi->set_visibility_range_fade_mode(range_fade_mode);
+		}
+
+		if (node_settings.has("mesh_instance/cast_shadow")) {
+			const GeometryInstance3D::ShadowCastingSetting cast_shadows = (GeometryInstance3D::ShadowCastingSetting)node_settings["mesh_instance/cast_shadow"].operator int();
+			mi->set_cast_shadows_setting(cast_shadows);
+		}
+	}
+
 	if (Object::cast_to<AnimationPlayer>(p_node)) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
@@ -1603,6 +1637,14 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/navmesh", PROPERTY_HINT_ENUM, "Disabled,Mesh + NavMesh,NavMesh Only"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "physics/body_type", PROPERTY_HINT_ENUM, "Static,Dynamic,Area"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "physics/shape_type", PROPERTY_HINT_ENUM, "Decompose Convex,Simple Convex,Trimesh,Box,Sphere,Cylinder,Capsule", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 0));
+
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mesh_instance/layers", PROPERTY_HINT_LAYERS_3D_RENDER), 1));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mesh_instance/visibility_range_begin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), 0.0f));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mesh_instance/visibility_range_begin_margin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), 0.0f));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mesh_instance/visibility_range_end", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), 0.0f));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mesh_instance/visibility_range_end_margin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), 0.0f));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mesh_instance/visibility_range_fade_mode", PROPERTY_HINT_ENUM, "Disabled,Self,Dependencies"), GeometryInstance3D::VISIBILITY_RANGE_FADE_DISABLED));
+			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mesh_instance/cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), GeometryInstance3D::SHADOW_CASTING_SETTING_ON));
 
 			// Decomposition
 			Ref<MeshConvexDecompositionSettings> decomposition_default = Ref<MeshConvexDecompositionSettings>();
@@ -2098,6 +2140,14 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_STATIC);
 			} break;
 		}
+
+		mesh_node->set_layer_mask(src_mesh_node->get_layer_mask());
+		mesh_node->set_cast_shadows_setting(src_mesh_node->get_cast_shadows_setting());
+		mesh_node->set_visibility_range_begin(src_mesh_node->get_visibility_range_begin());
+		mesh_node->set_visibility_range_begin_margin(src_mesh_node->get_visibility_range_begin_margin());
+		mesh_node->set_visibility_range_end(src_mesh_node->get_visibility_range_end());
+		mesh_node->set_visibility_range_end_margin(src_mesh_node->get_visibility_range_end_margin());
+		mesh_node->set_visibility_range_fade_mode(src_mesh_node->get_visibility_range_fade_mode());
 
 		p_node->replace_by(mesh_node);
 		p_node->set_owner(nullptr);

--- a/scene/3d/importer_mesh_instance_3d.cpp
+++ b/scene/3d/importer_mesh_instance_3d.cpp
@@ -69,6 +69,67 @@ NodePath ImporterMeshInstance3D::get_skeleton_path() const {
 	return skeleton_path;
 }
 
+uint32_t ImporterMeshInstance3D::get_layer_mask() const {
+	return layer_mask;
+}
+
+void ImporterMeshInstance3D::set_layer_mask(const uint32_t p_layer_mask) {
+	layer_mask = p_layer_mask;
+}
+
+void ImporterMeshInstance3D::set_cast_shadows_setting(GeometryInstance3D::ShadowCastingSetting p_shadow_casting_setting) {
+	shadow_casting_setting = p_shadow_casting_setting;
+}
+
+GeometryInstance3D::ShadowCastingSetting ImporterMeshInstance3D::get_cast_shadows_setting() const {
+	return shadow_casting_setting;
+}
+
+void ImporterMeshInstance3D::set_visibility_range_begin(float p_dist) {
+	visibility_range_begin = p_dist;
+	update_configuration_warnings();
+}
+
+float ImporterMeshInstance3D::get_visibility_range_begin() const {
+	return visibility_range_begin;
+}
+
+void ImporterMeshInstance3D::set_visibility_range_end(float p_dist) {
+	visibility_range_end = p_dist;
+	update_configuration_warnings();
+}
+
+float ImporterMeshInstance3D::get_visibility_range_end() const {
+	return visibility_range_end;
+}
+
+void ImporterMeshInstance3D::set_visibility_range_begin_margin(float p_dist) {
+	visibility_range_begin_margin = p_dist;
+	update_configuration_warnings();
+}
+
+float ImporterMeshInstance3D::get_visibility_range_begin_margin() const {
+	return visibility_range_begin_margin;
+}
+
+void ImporterMeshInstance3D::set_visibility_range_end_margin(float p_dist) {
+	visibility_range_end_margin = p_dist;
+	update_configuration_warnings();
+}
+
+float ImporterMeshInstance3D::get_visibility_range_end_margin() const {
+	return visibility_range_end_margin;
+}
+
+void ImporterMeshInstance3D::set_visibility_range_fade_mode(GeometryInstance3D::VisibilityRangeFadeMode p_mode) {
+	visibility_range_fade_mode = p_mode;
+	update_configuration_warnings();
+}
+
+GeometryInstance3D::VisibilityRangeFadeMode ImporterMeshInstance3D::get_visibility_range_fade_mode() const {
+	return visibility_range_fade_mode;
+}
+
 void ImporterMeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &ImporterMeshInstance3D::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &ImporterMeshInstance3D::get_mesh);
@@ -79,7 +140,38 @@ void ImporterMeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skeleton_path", "skeleton_path"), &ImporterMeshInstance3D::set_skeleton_path);
 	ClassDB::bind_method(D_METHOD("get_skeleton_path"), &ImporterMeshInstance3D::get_skeleton_path);
 
+	ClassDB::bind_method(D_METHOD("set_layer_mask", "layer_mask"), &ImporterMeshInstance3D::set_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_layer_mask"), &ImporterMeshInstance3D::get_layer_mask);
+
+	ClassDB::bind_method(D_METHOD("set_cast_shadows_setting", "shadow_casting_setting"), &ImporterMeshInstance3D::set_cast_shadows_setting);
+	ClassDB::bind_method(D_METHOD("get_cast_shadows_setting"), &ImporterMeshInstance3D::get_cast_shadows_setting);
+
+	ClassDB::bind_method(D_METHOD("set_visibility_range_end_margin", "distance"), &ImporterMeshInstance3D::set_visibility_range_end_margin);
+	ClassDB::bind_method(D_METHOD("get_visibility_range_end_margin"), &ImporterMeshInstance3D::get_visibility_range_end_margin);
+
+	ClassDB::bind_method(D_METHOD("set_visibility_range_end", "distance"), &ImporterMeshInstance3D::set_visibility_range_end);
+	ClassDB::bind_method(D_METHOD("get_visibility_range_end"), &ImporterMeshInstance3D::get_visibility_range_end);
+
+	ClassDB::bind_method(D_METHOD("set_visibility_range_begin_margin", "distance"), &ImporterMeshInstance3D::set_visibility_range_begin_margin);
+	ClassDB::bind_method(D_METHOD("get_visibility_range_begin_margin"), &ImporterMeshInstance3D::get_visibility_range_begin_margin);
+
+	ClassDB::bind_method(D_METHOD("set_visibility_range_begin", "distance"), &ImporterMeshInstance3D::set_visibility_range_begin);
+	ClassDB::bind_method(D_METHOD("get_visibility_range_begin"), &ImporterMeshInstance3D::get_visibility_range_begin);
+
+	ClassDB::bind_method(D_METHOD("set_visibility_range_fade_mode", "mode"), &ImporterMeshInstance3D::set_visibility_range_fade_mode);
+	ClassDB::bind_method(D_METHOD("get_visibility_range_fade_mode"), &ImporterMeshInstance3D::get_visibility_range_fade_mode);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "ImporterMesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, "Skin"), "set_skin", "get_skin");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton"), "set_skeleton_path", "get_skeleton_path");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows_setting", "get_cast_shadows_setting");
+
+	ADD_GROUP("Visibility Range", "visibility_range_");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visibility_range_begin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), "set_visibility_range_begin", "get_visibility_range_begin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visibility_range_begin_margin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), "set_visibility_range_begin_margin", "get_visibility_range_begin_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visibility_range_end", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), "set_visibility_range_end", "get_visibility_range_end");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "visibility_range_end_margin", PROPERTY_HINT_RANGE, "0.0,4096.0,0.01,or_greater,suffix:m"), "set_visibility_range_end_margin", "get_visibility_range_end_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_range_fade_mode", PROPERTY_HINT_ENUM, "Disabled,Self,Dependencies"), "set_visibility_range_fade_mode", "get_visibility_range_fade_mode");
 }

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -32,6 +32,7 @@
 #define IMPORTER_MESH_INSTANCE_3D_H
 
 #include "scene/3d/node_3d.h"
+#include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/immediate_mesh.h"
 #include "scene/resources/skin.h"
 
@@ -44,6 +45,13 @@ class ImporterMeshInstance3D : public Node3D {
 	Ref<Skin> skin;
 	NodePath skeleton_path;
 	Vector<Ref<Material>> surface_materials;
+	uint32_t layer_mask = 1;
+	GeometryInstance3D::ShadowCastingSetting shadow_casting_setting = GeometryInstance3D::SHADOW_CASTING_SETTING_ON;
+	float visibility_range_begin = 0.0;
+	float visibility_range_end = 0.0;
+	float visibility_range_begin_margin = 0.0;
+	float visibility_range_end_margin = 0.0;
+	GeometryInstance3D::VisibilityRangeFadeMode visibility_range_fade_mode = GeometryInstance3D::VISIBILITY_RANGE_FADE_DISABLED;
 
 protected:
 	static void _bind_methods();
@@ -60,6 +68,27 @@ public:
 
 	void set_skeleton_path(const NodePath &p_path);
 	NodePath get_skeleton_path() const;
+
+	void set_layer_mask(const uint32_t p_layer_mask);
+	uint32_t get_layer_mask() const;
+
+	void set_cast_shadows_setting(GeometryInstance3D::ShadowCastingSetting p_shadow_casting_setting);
+	GeometryInstance3D::ShadowCastingSetting get_cast_shadows_setting() const;
+
+	void set_visibility_range_begin(float p_dist);
+	float get_visibility_range_begin() const;
+
+	void set_visibility_range_end(float p_dist);
+	float get_visibility_range_end() const;
+
+	void set_visibility_range_begin_margin(float p_dist);
+	float get_visibility_range_begin_margin() const;
+
+	void set_visibility_range_end_margin(float p_dist);
+	float get_visibility_range_end_margin() const;
+
+	void set_visibility_range_fade_mode(GeometryInstance3D::VisibilityRangeFadeMode p_mode);
+	GeometryInstance3D::VisibilityRangeFadeMode get_visibility_range_fade_mode() const;
 };
 
 #endif // IMPORTER_MESH_INSTANCE_3D_H


### PR DESCRIPTION
Sister PR to #77533.

![image](https://github.com/godotengine/godot/assets/20043270/87f431be-c770-445e-b6ba-cf77d83047db)

Adds additional importy options for MeshInstance3Ds.
- Render Layers
- VisibilityRange
- Shadow Casting

Has been discussed with @Calinou and is a desired feature.
EDIT(lyuma): Linking to proposal: godotengine/godot-proposals#7173
~~EDIT(lyuma): Please write a specific proposal to cover this PR and link it here.~~
EDIT(EMBYRDEV): I am specifically trying to address the proposal that lyuma initially linked.