### PR TITLE
Fix issue with accessing hand tracking without timing info

### DIFF
--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -134,6 +134,10 @@ void OpenXRHandTrackingExtension::on_process() {
 
 	// process our hands
 	const XrTime time = OpenXRAPI::get_singleton()->get_next_frame_time(); // This data will be used for the next frame we render
+	if (time == 0) {
+		// we don't have timing info yet, or we're skipping a frame...
+		return;
+	}
 
 	XrResult result;
 


### PR DESCRIPTION
There was a situation reported where there is no tracking info (xrWaitFrame returns a failure). This does an earlier exit if timing returns 0.