### PR TITLE
Fix history mismatch

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1982,6 +1982,9 @@ void EditorNode::_dialog_action(String p_file) {
 
 				if (scene_idx != -1) {
 					_discard_changes();
+				} else {
+					// Update the path of the edited scene to ensure later do/undo action history matches.
+					editor_data.set_scene_path(editor_data.get_edited_scene(), p_file);
 				}
 			}
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2156,7 +2156,7 @@ void TileSetAtlasSourceEditor::_undo_redo_inspector_callback(Object *p_undo_redo
 		Ref<TileSetAtlasSource> atlas_source = atlas_source_proxy->get_edited();
 		ERR_FAIL_COND(!atlas_source.is_valid());
 
-		UndoRedo *internal_undo_redo = undo_redo_man->get_history_for_object(atlas_source.ptr()).undo_redo;
+		UndoRedo *internal_undo_redo = undo_redo_man->get_history_for_object(atlas_source_proxy).undo_redo;
 		internal_undo_redo->start_force_keep_in_merge_ends();
 
 		PackedVector2Array arr;
@@ -2180,7 +2180,7 @@ void TileSetAtlasSourceEditor::_undo_redo_inspector_callback(Object *p_undo_redo
 				String prefix = vformat("%d:%d/", coords.x, coords.y);
 				for (PropertyInfo pi : properties) {
 					if (pi.name.begins_with(prefix)) {
-						ADD_UNDO(atlas_source.ptr(), pi.name);
+						ADD_UNDO(atlas_source_proxy, pi.name);
 					}
 				}
 			}


### PR DESCRIPTION
There are two cases for the error message, see https://github.com/godotengine/godot/issues/73603#issuecomment-1612509646.

Set the properties of the resource's proxy instead of setting the resource's properties directly. (For action "Set ...")

Update the path of the edited scene when saving the scene. (For action "Add atlas source", see https://github.com/godotengine/godot/issues/73603#issuecomment-1625339382)

Before 

https://github.com/godotengine/godot/assets/30386067/b2734e81-90fe-477b-bc2a-12a30bdf2b62

After 


https://github.com/godotengine/godot/assets/30386067/61d73d65-e649-4d55-9c10-a1c1de320936








Fix #73603, fix #74594.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
