### PR TITLE
Fix missing GDExtension in-editor API reference

### DIFF
--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -374,11 +374,6 @@ void DocTools::generate(bool p_basic_types) {
 				classes.pop_front();
 				continue;
 			}
-			if (ClassDB::get_api_type(name) != ClassDB::API_CORE && ClassDB::get_api_type(name) != ClassDB::API_EDITOR) {
-				print_verbose(vformat("Class '%s' belongs neither to core nor editor, skipping.", name));
-				classes.pop_front();
-				continue;
-			}
 
 			String cname = name;
 			// Property setters and getters do not get exposed as individual methods.


### PR DESCRIPTION
~This commit partially reverts e1ce0340b78875a864d449a5e3e38e4535e9a800 (#76431), keeping the core changes which should still be safe.~
~It also reverts 67e8c57f0371d952a5d6623e2fbfb1400e05b84f (#77578) which depends on e1ce0340b.~

This commit partially reverts a change in e1ce0340b78875a864d449a5e3e38e4535e9a800 (#76431) which would prevent from generating API reference for GDExtension APIs.

Fixes #78829.

Another option could be to revert all changes related to the docs cache and revisit it for 4.2, as it's current disabled anyway, and those changes had bigger implications as seen here. But this surgical revert might be enough.