### PR TITLE
Fix crash on removing added sibling in `_ready`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1409,7 +1409,9 @@ void Node::add_sibling(Node *p_sibling, bool p_force_readable_name) {
 
 	data.parent->add_child(p_sibling, p_force_readable_name, data.internal_mode);
 	data.parent->_update_children_cache();
-	data.parent->_move_child(p_sibling, get_index() + 1);
+	if (p_sibling->data.parent == data.parent) { // This check is in case p_sibling was removed/reparent in its _ready function
+		data.parent->_move_child(p_sibling, get_index() + 1);
+	}
 }
 
 void Node::remove_child(Node *p_child) {


### PR DESCRIPTION
If a Node that was added to the tree via `add_sibling()` was removed/reparented in its `_ready()` function, it would cause a crash.

Example:
```gdscript
extends Node

class MyNode extends Node:
	var new_parent = Engine.get_main_loop().current_scene
	func _ready() -> void:
		reparent(new_parent)

func _ready() -> void:
	await get_parent().ready
	for i in 3:
		add_sibling(MyNode.new())
```