### PR TITLE
Fix invalid minimum size for translated messages in option button

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -451,7 +451,7 @@ void OptionButton::_refresh_size_cache() {
 
 	_cached_size = Vector2();
 	for (int i = 0; i < get_item_count(); i++) {
-		_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(get_item_text(i), get_item_icon(i)));
+		_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(popup->get_item_xl_text(i), get_item_icon(i)));
 	}
 	update_minimum_size();
 }

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1471,6 +1471,11 @@ String PopupMenu::get_item_text(int p_idx) const {
 	return items[p_idx].text;
 }
 
+String PopupMenu::get_item_xl_text(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), "");
+	return items[p_idx].xl_text;
+}
+
 Control::TextDirection PopupMenu::get_item_text_direction(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), Control::TEXT_DIRECTION_INHERITED);
 	return items[p_idx].text_direction;

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -250,6 +250,7 @@ public:
 	void toggle_item_checked(int p_idx);
 
 	String get_item_text(int p_idx) const;
+	String get_item_xl_text(int p_idx) const;
 	Control::TextDirection get_item_text_direction(int p_idx) const;
 	String get_item_language(int p_idx) const;
 	int get_item_idx_from_text(const String &text) const;


### PR DESCRIPTION
Followup from #78752

@KoBeWi I'm not sure if this is what you had in mind.