### PR TITLE
Fix invalid shader compilation when using `hint_normal_roughness_texture` in mobile backend

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8800,8 +8800,8 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									new_hint = ShaderNode::Uniform::HINT_NORMAL_ROUGHNESS_TEXTURE;
 									--texture_uniforms;
 									--texture_binding;
-									if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
-										_set_error(RTR("'hint_normal_roughness_texture' is not supported in gl_compatibility shaders."));
+									if (OS::get_singleton()->get_current_rendering_method() != "forward_plus") {
+										_set_error(RTR("'hint_normal_roughness_texture' is only available when using the Forward+ backend."));
 										return ERR_PARSE_ERROR;
 									}
 									if (String(shader_type_identifier) != "spatial") {


### PR DESCRIPTION
Fixes #78411

Returns shader parse error when using `hint_normal_roughness_texture` and not using the Forward+ backend. 

Previously this error was returned only when using the GL compatibility renderer, but the hint is also unsupported on the mobile backend, and using it allowed shader compilation to continue and consequently generate invalid shader code.