### PR TITLE
Fix zero-sized WorkerThreadPool not processing group tasks

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -415,7 +415,7 @@ Error WorkerThreadPool::wait_for_task_completion(TaskID p_task_id) {
 WorkerThreadPool::GroupID WorkerThreadPool::_add_group_task(const Callable &p_callable, void (*p_func)(void *, uint32_t), void *p_userdata, BaseTemplateUserdata *p_template_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description) {
 	ERR_FAIL_COND_V(p_elements < 0, INVALID_TASK_ID);
 	if (p_tasks < 0) {
-		p_tasks = threads.size();
+		p_tasks = MAX(1u, threads.size());
 	}
 
 	task_mutex.lock();


### PR DESCRIPTION
With zero threads, tasks are processed on the calling thread, one at a time. However, for group tasks, the logic needed a little tweak.

Fixes #77131.