### PR TITLE
C#: Add platform name to the exported data directory

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -170,7 +170,7 @@ namespace GodotTools.Export
                 string ridOS = DetermineRuntimeIdentifierOS(platform);
                 string ridArch = DetermineRuntimeIdentifierArch(arch);
                 string runtimeIdentifier = $"{ridOS}-{ridArch}";
-                string projectDataDirName = $"data_{GodotSharpDirs.CSharpProjectName}_{arch}";
+                string projectDataDirName = $"data_{GodotSharpDirs.CSharpProjectName}_{platform}_{arch}";
                 if (platform == OS.Platforms.MacOS)
                 {
                     projectDataDirName = Path.Combine("Contents", "Resources", projectDataDirName);


### PR DESCRIPTION
- Since we publish self-contained assemblies, the contents of the data directory are platform specific so adding the platform name to the data directory.
- Fixes https://github.com/godotengine/godot/issues/78385.