### PR TITLE
Fix NavigationAgent continues avoidance velocity

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -755,6 +755,11 @@ void NavigationAgent2D::update_navigation() {
 				navigation_path_index -= 1;
 				navigation_finished = true;
 				target_position_submitted = false;
+				if (avoidance_enabled) {
+					NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
+					NavigationServer2D::get_singleton()->agent_set_velocity(agent, Vector2(0.0, 0.0));
+					NavigationServer2D::get_singleton()->agent_set_velocity_forced(agent, Vector2(0.0, 0.0));
+				}
 				emit_signal(SNAME("navigation_finished"));
 				break;
 			}

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -801,6 +801,11 @@ void NavigationAgent3D::update_navigation() {
 				navigation_path_index -= 1;
 				navigation_finished = true;
 				target_position_submitted = false;
+				if (avoidance_enabled) {
+					NavigationServer3D::get_singleton()->agent_set_position(agent, agent_parent->get_global_transform().origin);
+					NavigationServer3D::get_singleton()->agent_set_velocity(agent, Vector3(0.0, 0.0, 0.0));
+					NavigationServer3D::get_singleton()->agent_set_velocity_forced(agent, Vector3(0.0, 0.0, 0.0));
+				}
 				emit_signal(SNAME("navigation_finished"));
 				break;
 			}


### PR DESCRIPTION
Fixes NavigationAgent continues avoidance velocity.

Fixes https://github.com/godotengine/godot/issues/78840.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
