### PR TITLE
Initialize particles instance buffer in case it is used before being updated

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -820,12 +820,11 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 		particles->num_attrib_arrays_cache = 5 + userdata_count + (xform_size - 2);
 		particles->process_buffer_stride_cache = sizeof(float) * 4 * particles->num_attrib_arrays_cache;
 
-		int process_data_amount = 4 * particles->num_attrib_arrays_cache * total_amount;
-		float *data = memnew_arr(float, process_data_amount);
+		PackedByteArray data;
+		data.resize_zeroed(particles->process_buffer_stride_cache * total_amount);
 
-		for (int i = 0; i < process_data_amount; i++) {
-			data[i] = 0;
-		}
+		PackedByteArray instance_data;
+		instance_data.resize_zeroed(particles->instance_buffer_size_cache);
 
 		{
 			glGenVertexArrays(1, &particles->front_vertex_array);
@@ -834,7 +833,7 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 			glGenBuffers(1, &particles->front_instance_buffer);
 
 			glBindBuffer(GL_ARRAY_BUFFER, particles->front_process_buffer);
-			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->front_process_buffer, particles->process_buffer_stride_cache * total_amount, data, GL_DYNAMIC_COPY, "Particles front process buffer");
+			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->front_process_buffer, particles->process_buffer_stride_cache * total_amount, data.ptr(), GL_DYNAMIC_COPY, "Particles front process buffer");
 
 			for (uint32_t j = 0; j < particles->num_attrib_arrays_cache; j++) {
 				glEnableVertexAttribArray(j);
@@ -843,7 +842,7 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 			glBindVertexArray(0);
 
 			glBindBuffer(GL_ARRAY_BUFFER, particles->front_instance_buffer);
-			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->front_instance_buffer, particles->instance_buffer_size_cache, nullptr, GL_DYNAMIC_COPY, "Particles front instance buffer");
+			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->front_instance_buffer, particles->instance_buffer_size_cache, instance_data.ptr(), GL_DYNAMIC_COPY, "Particles front instance buffer");
 		}
 
 		{
@@ -853,7 +852,7 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 			glGenBuffers(1, &particles->back_instance_buffer);
 
 			glBindBuffer(GL_ARRAY_BUFFER, particles->back_process_buffer);
-			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->back_process_buffer, particles->process_buffer_stride_cache * total_amount, data, GL_DYNAMIC_COPY, "Particles back process buffer");
+			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->back_process_buffer, particles->process_buffer_stride_cache * total_amount, data.ptr(), GL_DYNAMIC_COPY, "Particles back process buffer");
 
 			for (uint32_t j = 0; j < particles->num_attrib_arrays_cache; j++) {
 				glEnableVertexAttribArray(j);
@@ -862,11 +861,9 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 			glBindVertexArray(0);
 
 			glBindBuffer(GL_ARRAY_BUFFER, particles->back_instance_buffer);
-			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->back_instance_buffer, particles->instance_buffer_size_cache, nullptr, GL_DYNAMIC_COPY, "Particles back instance buffer");
+			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, particles->back_instance_buffer, particles->instance_buffer_size_cache, instance_data.ptr(), GL_DYNAMIC_COPY, "Particles back instance buffer");
 		}
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-		memdelete_arr(data);
 	}
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1288,7 +1288,10 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 
 		particles->userdata_count = userdata_count;
 
-		particles->particle_instance_buffer = RD::get_singleton()->storage_buffer_create(sizeof(float) * 4 * (xform_size + 1 + 1) * total_amount);
+		PackedByteArray data;
+		data.resize_zeroed(sizeof(float) * 4 * (xform_size + 1 + 1) * total_amount);
+
+		particles->particle_instance_buffer = RD::get_singleton()->storage_buffer_create(sizeof(float) * 4 * (xform_size + 1 + 1) * total_amount, data);
 		//needs to clear it
 
 		{


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/71935

We have two buffers that we use for particles:
1. The particles process buffer (stores full data: Transform, Color, custom, flags, velocity, userdata)
2. The particles instance buffer (stores only data needed for rendering: transposed Transform, color, custom)

The particles instance buffer is usually filled right after rendering the particles, but when using the "view depth' draw order, or when using billboarding the instance buffer is filled during the scene culling stage (so the camera is known).

This causes problems as particles can get updated late in the frame that they were just allocated (which is the problem that https://github.com/godotengine/godot/pull/70418 solved, but only partially). 

The bug here comes from relying on unitialized memory (i.e. instance buffer gets created but isn't filled), so the solution is simply to initialize the memory to 0. This way the particles won't draw until ready. Alternative solutions that are less robust are:
1. try to run fill the instance buffer late (bad solution as camera won't always be known and can cause hiccups in rendering if done too late due to compute->raster dependency)
2. Track whether the instance buffer has been filled and skip rendering if not (this could be good, but would require significant refactoring on the rendering side as the renderer caches needed particle information.)