### PR TITLE
Fix NavigationAgent position not always updating

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -258,11 +258,13 @@ void NavigationAgent2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (agent_parent && avoidance_enabled) {
+				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
+			}
 			if (agent_parent && target_position_submitted) {
 				if (velocity_submitted) {
 					velocity_submitted = false;
 					if (avoidance_enabled) {
-						NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
 						NavigationServer2D::get_singleton()->agent_set_velocity(agent, velocity);
 					}
 				}

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -273,11 +273,13 @@ void NavigationAgent3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (agent_parent && avoidance_enabled) {
+				NavigationServer3D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());
+			}
 			if (agent_parent && target_position_submitted) {
 				if (velocity_submitted) {
 					velocity_submitted = false;
 					if (avoidance_enabled) {
-						NavigationServer3D::get_singleton()->agent_set_position(agent, agent_parent->get_global_transform().origin);
 						if (!use_3d_avoidance) {
 							stored_y_velocity = velocity.y;
 							velocity.y = 0.0;


### PR DESCRIPTION
Fixes NavigationAgent position not always updating.

Fixes https://github.com/godotengine/godot/issues/78853.

Tbh this is a brute-force fix but I am also done with those issues where the global_position is returned zero for reasons.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
