### PR TITLE
[DRAFT] Add Android-related functions to gdextension_interface.h

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2297,6 +2297,46 @@ typedef void (*GDExtensionInterfaceEditorAddPlugin)(GDExtensionConstStringNamePt
  */
 typedef void (*GDExtensionInterfaceEditorRemovePlugin)(GDExtensionConstStringNamePtr p_class_name);
 
+/**
+ * @name android_get_env
+ * @since 4.2
+ *
+ * Gets the Android JNIEnv (when running on Android).
+ *
+ * @return The JNIEnv cast to a void pointer when running on Android; otherwise NULL.
+ */
+typedef void *(*GDExtensionInterfaceAndroidGetEnv)();
+
+/**
+ * @name android_get_activity
+ * @since 4.2
+ *
+ * Gets the Android activity jobject (when running on Android).
+ *
+ * @return The jobject cast to a void pointer when running on Android; otherwise NULL.
+ */
+typedef void *(*GDExtensionInterfaceAndroidGetActivity)();
+
+/**
+ * @name android_get_surface
+ * @since 4.2
+ *
+ * Gets the Android surface jobject (when running on Android).
+ *
+ * @return The jobject cast to a void pointer when running on Android; otherwise NULL.
+ */
+typedef void *(*GDExtensionInterfaceAndroidGetSurface)();
+
+/**
+ * @name android_is_activity_resumed
+ * @since 4.2
+ *
+ * Returns true if the Android activity is resumed (when running on Android).
+ *
+ * @return true if the Android activity is resumed when running on Android; otherwise, false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceAndroidIsActivityResumed)();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
@paddy-exe asked me to throw this together, so he can try to integrate ARCore as a GDExtension.

I don't know if this is necessarily the right way to do this. @m4gr3d mentioned that he had an idea to allow integrating ARCore entirely on the Android side?

Anyway, posting this here as a draft for now, to start the discussion and allow @paddy-exe to move forward. It compiles (both on Android and not) but I haven't tested it and have no idea if it actually works :-)

Here's a companion godot-cpp PR https://github.com/godotengine/godot-cpp/pull/1156
