### PR TITLE
Expose `compute_convex_mesh_points` function to GDScript

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -919,6 +919,17 @@ Geometry3D *Geometry3D::get_singleton() {
 	return singleton;
 }
 
+Vector<Vector3> Geometry3D::compute_convex_mesh_points(const TypedArray<Plane> &p_planes) {
+	Vector<Plane> planes_vec;
+	int size = p_planes.size();
+	planes_vec.resize(size);
+	for (int i = 0; i < size; ++i) {
+		planes_vec.set(i, p_planes[i]);
+	}
+	Variant ret = ::Geometry3D::compute_convex_mesh_points(planes_vec.ptr(), size);
+	return ret;
+}
+
 TypedArray<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {
 	Variant ret = ::Geometry3D::build_box_planes(p_extents);
 	return ret;
@@ -1014,6 +1025,7 @@ Vector<Vector3> Geometry3D::clip_polygon(const Vector<Vector3> &p_points, const 
 }
 
 void Geometry3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("compute_convex_mesh_points", "planes"), &Geometry3D::compute_convex_mesh_points);
 	ClassDB::bind_method(D_METHOD("build_box_planes", "extents"), &Geometry3D::build_box_planes);
 	ClassDB::bind_method(D_METHOD("build_cylinder_planes", "radius", "height", "sides", "axis"), &Geometry3D::build_cylinder_planes, DEFVAL(Vector3::AXIS_Z));
 	ClassDB::bind_method(D_METHOD("build_capsule_planes", "radius", "height", "sides", "lats", "axis"), &Geometry3D::build_capsule_planes, DEFVAL(Vector3::AXIS_Z));

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -318,6 +318,7 @@ protected:
 
 public:
 	static Geometry3D *get_singleton();
+	Vector<Vector3> compute_convex_mesh_points(const TypedArray<Plane> &p_planes);
 	TypedArray<Plane> build_box_planes(const Vector3 &p_extents);
 	TypedArray<Plane> build_cylinder_planes(float p_radius, float p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	TypedArray<Plane> build_capsule_planes(float p_radius, float p_height, int p_sides, int p_lats, Vector3::Axis p_axis = Vector3::AXIS_Z);

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -45,6 +45,13 @@
 				Clips the polygon defined by the points in [param points] against the [param plane] and returns the points of the clipped polygon.
 			</description>
 		</method>
+		<method name="compute_convex_mesh_points">
+			<return type="PackedVector3Array" />
+			<param index="0" name="planes" type="Plane[]" />
+			<description>
+				Calculates and returns all the vertex points of a convex shape defined by an array of [param planes].
+			</description>
+		</method>
 		<method name="get_closest_point_to_segment">
 			<return type="Vector3" />
 			<param index="0" name="point" type="Vector3" />


### PR DESCRIPTION
A useful function that was only available in C++ before.  Addresses request: https://github.com/godotengine/godot-proposals/issues/6695

* Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/6695