### PR TITLE
Add `get_half` and `put_half` on `StreamPeer`

### DIFF
--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -178,6 +178,18 @@ void StreamPeer::put_64(int64_t p_val) {
 	put_data(buf, 8);
 }
 
+void StreamPeer::put_half(float p_val) {
+	uint8_t buf[2];
+
+	uint16_t *p16 = (uint16_t *)buf;
+	*p16 = Math::make_half_float(p_val);
+	if (big_endian) {
+		*p16 = BSWAP16(*p16);
+	}
+
+	put_data(buf, 2);
+}
+
 void StreamPeer::put_float(float p_val) {
 	uint8_t buf[4];
 
@@ -294,6 +306,18 @@ int64_t StreamPeer::get_64() {
 	return r;
 }
 
+float StreamPeer::get_half() {
+	uint8_t buf[2];
+	get_data(buf, 2);
+
+	uint16_t *p16 = (uint16_t *)buf;
+	if (big_endian) {
+		*p16 = BSWAP16(*p16);
+	}
+
+	return Math::half_to_float(*p16);
+}
+
 float StreamPeer::get_float() {
 	uint8_t buf[4];
 	get_data(buf, 4);
@@ -385,6 +409,7 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("put_u32", "value"), &StreamPeer::put_u32);
 	ClassDB::bind_method(D_METHOD("put_64", "value"), &StreamPeer::put_64);
 	ClassDB::bind_method(D_METHOD("put_u64", "value"), &StreamPeer::put_u64);
+	ClassDB::bind_method(D_METHOD("put_half", "value"), &StreamPeer::put_half);
 	ClassDB::bind_method(D_METHOD("put_float", "value"), &StreamPeer::put_float);
 	ClassDB::bind_method(D_METHOD("put_double", "value"), &StreamPeer::put_double);
 	ClassDB::bind_method(D_METHOD("put_string", "value"), &StreamPeer::put_string);
@@ -399,6 +424,7 @@ void StreamPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_u32"), &StreamPeer::get_u32);
 	ClassDB::bind_method(D_METHOD("get_64"), &StreamPeer::get_64);
 	ClassDB::bind_method(D_METHOD("get_u64"), &StreamPeer::get_u64);
+	ClassDB::bind_method(D_METHOD("get_half"), &StreamPeer::get_half);
 	ClassDB::bind_method(D_METHOD("get_float"), &StreamPeer::get_float);
 	ClassDB::bind_method(D_METHOD("get_double"), &StreamPeer::get_double);
 	ClassDB::bind_method(D_METHOD("get_string", "bytes"), &StreamPeer::get_string, DEFVAL(-1));

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -74,6 +74,7 @@ public:
 	void put_u32(uint32_t p_val);
 	void put_64(int64_t p_val);
 	void put_u64(uint64_t p_val);
+	void put_half(float p_val);
 	void put_float(float p_val);
 	void put_double(double p_val);
 	void put_string(const String &p_string);
@@ -88,6 +89,7 @@ public:
 	int32_t get_32();
 	uint64_t get_u64();
 	int64_t get_64();
+	float get_half();
 	float get_float();
 	double get_double();
 	String get_string(int p_bytes = -1);

--- a/doc/classes/StreamPeer.xml
+++ b/doc/classes/StreamPeer.xml
@@ -59,6 +59,12 @@
 				Gets a single-precision float from the stream.
 			</description>
 		</method>
+		<method name="get_half">
+			<return type="float" />
+			<description>
+				Gets a half-precision float from the stream.
+			</description>
+		</method>
 		<method name="get_partial_data">
 			<return type="Array" />
 			<param index="0" name="bytes" type="int" />
@@ -160,6 +166,13 @@
 			<param index="0" name="value" type="float" />
 			<description>
 				Puts a single-precision float into the stream.
+			</description>
+		</method>
+		<method name="put_half">
+			<return type="void" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Puts a half-precision float into the stream.
 			</description>
 		</method>
 		<method name="put_partial_data">


### PR DESCRIPTION
This pull request implements [`get_half` and `put_half`](https://github.com/godotengine/godot-proposals/discussions/5983#discussioncomment-4489279), closes https://github.com/godotengine/godot-proposals/discussions/5983

The code is using `Math::half_to_float` and `Math::make_half_float`.

Using them results - as expected - in lose of precision.

This is an example script that uses them:

```
	var peer := StreamPeerBuffer.new()
	var input_value := 15.1234
	var expected_value := 15.1171875
	prints(peer.get_size() == 0)
	peer.put_half(input_value)
	prints(peer.get_size() == 2)
	peer.seek(0)
	prints(peer.get_half() == expected_value)
```

The output should be:

```
true
true
true
```