### PR TITLE
Automatically switch the shader editor to the selected Node's shader

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -43,6 +43,7 @@
 #include "editor/gui/editor_zoom_widget.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "editor/plugins/shader_editor_plugin.h"
 #include "editor/scene_tree_dock.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
@@ -3984,6 +3985,18 @@ void CanvasItemEditor::edit(CanvasItem *p_canvas_item) {
 	Array selection = editor_selection->get_selected_nodes();
 	if (selection.size() != 1 || Object::cast_to<Node>(selection[0]) != p_canvas_item) {
 		_reset_drag();
+	}
+
+	// If this CanvasItem's shader is already open in the shader editor, switch to it.
+	ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+	Ref<ShaderMaterial> shader_material = Object::cast_to<ShaderMaterial>(p_canvas_item->call("get_material"));
+	if (shader_material.is_valid()) {
+		Ref<Shader> shader = shader_material->get_shader();
+		if (shader.is_valid()) {
+			if (shader_editor->get_shader_editor(shader.ptr())) {
+				shader_editor->edit(shader.ptr());
+			}
+		}
 	}
 }
 

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
+#include "editor/plugins/shader_editor_plugin.h"
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/navigation_region_3d.h"
 #include "scene/3d/physics_body_3d.h"
@@ -579,6 +580,29 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 
 void MeshInstance3DEditorPlugin::edit(Object *p_object) {
 	mesh_editor->edit(Object::cast_to<MeshInstance3D>(p_object));
+
+	// If either of this MeshInstance3D's shaders are open in the shader editor, switch to them.
+	if (p_object) {
+		ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+		Ref<ShaderMaterial> material_overlay = Object::cast_to<ShaderMaterial>(p_object->call("get_material_overlay"));
+		if (material_overlay.is_valid()) {
+			Ref<Shader> shader = material_overlay->get_shader();
+			if (shader.is_valid()) {
+				if (shader_editor->get_shader_editor(shader.ptr())) {
+					shader_editor->edit(shader.ptr());
+				}
+			}
+		}
+		Ref<ShaderMaterial> material_override = Object::cast_to<ShaderMaterial>(p_object->call("get_material_override"));
+		if (material_override.is_valid()) {
+			Ref<Shader> shader = material_override->get_shader();
+			if (shader.is_valid()) {
+				if (shader_editor->get_shader_editor(shader.ptr())) {
+					shader_editor->edit(shader.ptr());
+				}
+			}
+		}
+	}
 }
 
 bool MeshInstance3DEditorPlugin::handles(Object *p_object) const {


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/78666

### Changes

If a `Node`'s shader is open in one of the tabs in the shader editor, automatically switch to it when the node is selected. The logic to perform this switch has been added to both the `MeshInstance3D` and `CanvasItem` nodes, which, as far as i can see, are the only base classes that can contain shaders.

If a `Node` contains a shader that isn't open in the editor, we don't open it. This was done so that we don't fill the shader editor with shaders we don't intend to be editing, but is something that can be easility changed if anyone disagrees with the decision.
 
`MeshInstance3D` nodes can contains two shaders. In the case both are open in the editor we always switch to the first one, the 
`material_override` shader.

We don't switch to the shader editor if it isn't open. This was done so that we don't switch out of the animation editor during the selection of a Node if we don't explicitly click on the shader editor tab.


### Quick Demo


https://github.com/godotengine/godot/assets/38991758/4e43c5d5-dac5-4d52-8078-285d6fe19384


### Testing

Tested the following test cases:

- Selecting a `MeshInstance3D` Node that contains a `material_override` shader that has already been opened in the editor.
	- We can see the current edited shader switch to the expected shader.
- Selecting a `MeshInstance3D` Node that contains a `material_overlay` shader that has already been opened in the editor.
	- We can see the current edited shader switch to the expected shader.
- Selecting a `MeshInstance3D` Node that contains both a `material_override` and a`material_overlay` shader that were already opened in the editor.
	- We can see the current edited shader switch to the `material_override` shader.
- Selecting a `MeshInstance3D` Node that contains a `material_override` shader that hasn't been opened in the editor.
	- The shader editor doesn't open the shader if it isn't already open.
- Selecting a `CanvasItem` Node that contains a shader that has already been opened in the editor.
	- We can see the current edited shader switch to the expected shader.
- Selecting a `CanvasItem` Node that contains a shader that hasn't been opened in the editor.
	- The shader editor doesn't open the shader if it isn't already open.
- While having the Animation tab open, switching to any of the previous nodes.
	- The animation tab stays opened, the editor doesn't switch to the shader editor.