### PR TITLE
C#: Fix deserialization of delegates that are 0-parameter overloads

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -500,24 +500,17 @@ namespace Godot
             Type? returnType = hasReturn ? DeserializeType(reader) : typeof(void);
 
             int parametersCount = reader.ReadInt32();
+            var parameterTypes = parametersCount == 0 ? Type.EmptyTypes : new Type[parametersCount];
 
-            if (parametersCount > 0)
+            for (int i = 0; i < parametersCount; i++)
             {
-                var parameterTypes = new Type[parametersCount];
-
-                for (int i = 0; i < parametersCount; i++)
-                {
-                    Type? parameterType = DeserializeType(reader);
-                    if (parameterType == null)
-                        return false;
-                    parameterTypes[i] = parameterType;
-                }
-
-                methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
-                return methodInfo != null && methodInfo.ReturnType == returnType;
+                Type? parameterType = DeserializeType(reader);
+                if (parameterType == null)
+                    return false;
+                parameterTypes[i] = parameterType;
             }
 
-            methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags);
+            methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
             return methodInfo != null && methodInfo.ReturnType == returnType;
         }
 


### PR DESCRIPTION
`TryDeserializeSingleDelegate` causes `GetMethod` to throw when deserializing a method with a 0-parameter overload.

`GetMethod` without a `types` argument matches all methods with the given `name`, whereas a 0-length `types` argument explicitly matches methods with 0 parameters.

E.g.
```
private void OnValueChanged(float _) {
    OnValueChanged();
}

private void OnValueChanged() {
   //...
}

//...
{
    _mySlider.ValueChanged += OnValueChanged;
}
```

* Bugsquad edit, closes: #78886