### PR TITLE
Add vulkan validation features for debugPrintfEXT, shader source debugging

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -239,6 +239,10 @@ bool Engine::is_validation_layers_enabled() const {
 	return use_validation_layers;
 }
 
+bool Engine::is_gpu_validation_features_enabled() const {
+	return gpu_validation_features;
+}
+
 void Engine::set_print_error_messages(bool p_enabled) {
 	CoreGlobals::print_error_enabled = p_enabled;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -67,6 +67,7 @@ private:
 	double _physics_interpolation_fraction = 0.0f;
 	bool abort_on_gpu_errors = false;
 	bool use_validation_layers = false;
+	bool gpu_validation_features = false;
 	int32_t gpu_idx = -1;
 
 	uint64_t _process_frames = 0;
@@ -156,6 +157,7 @@ public:
 
 	bool is_abort_on_gpu_errors_enabled() const;
 	bool is_validation_layers_enabled() const;
+	bool is_gpu_validation_features_enabled() const;
 	int32_t get_gpu_index() const;
 
 	Engine();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -450,6 +450,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --profiling                       Enable profiling in the script debugger.\n");
 	OS::get_singleton()->print("  --gpu-profile                     Show a GPU profile of the tasks that took the most time during frame rendering.\n");
 	OS::get_singleton()->print("  --gpu-validation                  Enable graphics API validation layers for debugging.\n");
+	OS::get_singleton()->print("  --gpu-validation-features         Enable GPU validation features such as debugPrintf and shader debug information.\n");
 #if DEBUG_ENABLED
 	OS::get_singleton()->print("  --gpu-abort                       Abort on graphics API usage errors (usually validation layer errors). May help see the problem if your system freezes.\n");
 #endif
@@ -996,6 +997,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (I->get() == "--gpu-validation") {
 			Engine::singleton->use_validation_layers = true;
+		} else if (I->get() == "--gpu-validation-features") {
+			Engine::singleton->gpu_validation_features = true;
 #ifdef DEBUG_ENABLED
 		} else if (I->get() == "--gpu-abort") {
 			Engine::singleton->abort_on_gpu_errors = true;

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -64,6 +64,7 @@ _arguments \
   '--profiling[enable profiling in the script debugger]' \
   '--gpu-profile[show a GPU profile of the tasks that took the most time during frame rendering]' \
   '--gpu-validation[enable graphics API validation layers for debugging]' \
+  '--gpu-validation-features[enable GPU validation features such as debugPrintf and shader debug information]' \
   '--gpu-abort[abort on graphics API usage errors (usually validation layer errors)]' \
   '--remote-debug[enable remote debugging]:remote debugger address' \
   '--debug-collisions[show collision shapes when running the scene]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -67,6 +67,7 @@ _complete_godot_options() {
 --profiling
 --gpu-profile
 --gpu-validation
+--gpu-validation-features
 --gpu-abort
 --remote-debug
 --debug-collisions

--- a/modules/glslang/register_types.cpp
+++ b/modules/glslang/register_types.cpp
@@ -130,6 +130,10 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 	const int DefaultVersion = 100;
 	std::string pre_processed_code;
 
+	if (Engine::get_singleton()->is_gpu_validation_features_enabled()) {
+		messages = (EShMessages)(messages | EShMsgDebugInfo);
+	}
+
 	//preprocess
 	if (!shader.preprocess(&DefaultTBuiltInResource, DefaultVersion, ENoProfile, false, false, messages, &pre_processed_code, includer)) {
 		if (r_error) {
@@ -174,6 +178,11 @@ static Vector<uint8_t> _compile_shader_glsl(RenderingDevice::ShaderStage p_stage
 	std::vector<uint32_t> SpirV;
 	spv::SpvBuildLogger logger;
 	glslang::SpvOptions spvOptions;
+	if (Engine::get_singleton()->is_gpu_validation_features_enabled()) {
+		spvOptions.generateDebugInfo = true;
+		spvOptions.emitNonSemanticShaderDebugInfo = true;
+		spvOptions.emitNonSemanticShaderDebugSource = true;
+	}
 	glslang::GlslangToSpv(*program.getIntermediate(stages[p_stage]), SpirV, &logger, &spvOptions);
 
 	ret.resize(SpirV.size() * sizeof(uint32_t));


### PR DESCRIPTION
To debug unusual issues within compute shaders in a project, I had to enable some vulkan features for debugPrintfEXT and shader source debugging in RenderDoc.

This enables you to add this to your shaders:
```glsl
#extension GL_EXT_debug_printf : enable
// ...
void main() {
    debugPrintfEXT("Running shader!");
}
```

output:
```
VALIDATION - Message Id Number: -1841738615 | Message Id Name: UNASSIGNED-DEBUG-PRINTF
        Validation Information: [ UNASSIGNED-DEBUG-PRINTF ] Object 0: handle = 0x145320d9e20, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x92394c89 | Running shader!
        Objects - 1
                Object[0] - VK_OBJECT_TYPE_DEVICE, Handle 1396704124448
```



To enable this feature, use the command line option `--gpu-validation-features` and enable the debug printf preset in Vulkan Configurator.

---

Additionally, this option enables compiling SPIR-V shaders with source strings included for source-level debugging in RenderDoc. (Perhaps this should be a separate option?)

To do this:
1. open project in editor with --gpu-validation-features and make sure shaders are imported
2. put a breakpoint in `Main::setup`
3. launch the project `godot.windows.editor.x86_64.exe --path pathToProj --gpu-validation-features`
4. RenderDoc -> Tools -> Settings -> General -> Enable process injection
5. inject into godot
6. resume from breakpoint and debug shaders

---

- [ ] should probably forward this cli option as per https://github.com/godotengine/godot/blob/46424488edc341b65467ee7fd3ac423e4d49ad34/main/main.cpp#L840C21-L844