### PR TITLE
Fix sanitizers reports about octahedral tangents in RenderingServer

### DIFF
--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -647,11 +647,11 @@ SpriteBase3D::SpriteBase3D() {
 
 	// Create basic mesh and store format information.
 	for (int i = 0; i < 4; i++) {
-		mesh_normals.write[i] = Vector3(0.0, 0.0, 0.0);
-		mesh_tangents.write[i * 4 + 0] = 0.0;
+		mesh_normals.write[i] = Vector3(0.0, 0.0, 1.0);
+		mesh_tangents.write[i * 4 + 0] = 1.0;
 		mesh_tangents.write[i * 4 + 1] = 0.0;
 		mesh_tangents.write[i * 4 + 2] = 0.0;
-		mesh_tangents.write[i * 4 + 3] = 0.0;
+		mesh_tangents.write[i * 4 + 3] = 1.0;
 		mesh_colors.write[i] = Color(1.0, 1.0, 1.0, 1.0);
 		mesh_uvs.write[i] = Vector2(0.0, 0.0);
 		mesh_vertices.write[i] = Vector3(0.0, 0.0, 0.0);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -402,9 +402,9 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 				const Vector3 *src = array.ptr();
 				for (int i = 0; i < p_vertex_array_len; i++) {
 					Vector2 res = src[i].octahedron_encode();
-					int16_t vector[2] = {
-						(int16_t)CLAMP(res.x * 65535, 0, 65535),
-						(int16_t)CLAMP(res.y * 65535, 0, 65535),
+					uint16_t vector[2] = {
+						(uint16_t)CLAMP(res.x * 65535, 0, 65535),
+						(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 					};
 
 					memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, 4);
@@ -422,9 +422,9 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 					for (int i = 0; i < p_vertex_array_len; i++) {
 						const Vector3 src(src_ptr[i * 4 + 0], src_ptr[i * 4 + 1], src_ptr[i * 4 + 2]);
 						Vector2 res = src.octahedron_tangent_encode(src_ptr[i * 4 + 3]);
-						int16_t vector[2] = {
-							(int16_t)CLAMP(res.x * 65535, 0, 65535),
-							(int16_t)CLAMP(res.y * 65535, 0, 65535),
+						uint16_t vector[2] = {
+							(uint16_t)CLAMP(res.x * 65535, 0, 65535),
+							(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 						};
 
 						memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, 4);
@@ -437,9 +437,9 @@ Error RenderingServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint
 					for (int i = 0; i < p_vertex_array_len; i++) {
 						const Vector3 src(src_ptr[i * 4 + 0], src_ptr[i * 4 + 1], src_ptr[i * 4 + 2]);
 						Vector2 res = src.octahedron_tangent_encode(src_ptr[i * 4 + 3]);
-						int16_t vector[2] = {
-							(int16_t)CLAMP(res.x * 65535, 0, 65535),
-							(int16_t)CLAMP(res.y * 65535, 0, 65535),
+						uint16_t vector[2] = {
+							(uint16_t)CLAMP(res.x * 65535, 0, 65535),
+							(uint16_t)CLAMP(res.y * 65535, 0, 65535),
 						};
 
 						memcpy(&vw[p_offsets[ai] + i * p_vertex_stride], vector, 4);


### PR DESCRIPTION
I found three places in RenderingServer with wrong type casting from `float` clamped by range `[0..65535]` to `int` to `int16_t[-32768..32767]` instead `uint16_t[0..65535]`.
In rarely situations it leads conversion from big positive number to negative.
In some cases it can break the check [Linux / Editor with doubles and GCC sanitizers](https://github.com/godotengine/godot/actions/runs/4970081774/jobs/8893729737?pr=77047).