### PR TITLE
Fix using uint suffix at the hex number declaration in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -659,7 +659,7 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 							char t = char(i);
 
 							suffix_lut[CASE_ALL][i] = t == '.' || t == 'x' || t == 'e' || t == 'f' || t == 'u' || t == '-' || t == '+';
-							suffix_lut[CASE_HEXA_PERIOD][i] = t == 'e' || t == 'f';
+							suffix_lut[CASE_HEXA_PERIOD][i] = t == 'e' || t == 'f' || t == 'u';
 							suffix_lut[CASE_EXPONENT][i] = t == 'f' || t == '-' || t == '+';
 							suffix_lut[CASE_SIGN_AFTER_EXPONENT][i] = t == 'f';
 							suffix_lut[CASE_NONE][i] = false;
@@ -738,6 +738,13 @@ ShaderLanguage::Token ShaderLanguage::_get_token() {
 					char32_t last_char = str[str.length() - 1];
 
 					if (hexa_found) { // Integer (hex).
+						if (uint_suffix_found) {
+							// Strip the suffix.
+							str = str.left(str.length() - 1);
+
+							// Compensate reading cursor position.
+							char_idx += 1;
+						}
 						if (str.size() > 11 || !str.is_valid_hex_number(true)) { // > 0xFFFFFFFF
 							return _make_token(TK_ERROR, "Invalid (hexadecimal) numeric constant");
 						}


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/78800 by allowing using 'u' suffix with the hex number:

![image](https://github.com/godotengine/godot/assets/3036176/6d33f180-22c2-4a8c-91d5-e8f1a8cb5b72)
