### PR TITLE
Better support for unicode strings in TTR

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5238,6 +5238,10 @@ String TTR(const String &p_text, const String &p_context) {
 	return p_text;
 }
 
+String TTR(const char *p_text, const String &p_context) {
+	return TTR(String::utf8(p_text), p_context);
+}
+
 /**
  * "Tools TRanslate for N items". Performs string replacement for
  * internationalization within the editor. A translation context can optionally
@@ -5260,6 +5264,10 @@ String TTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 		return p_text;
 	}
 	return p_text_plural;
+}
+
+String TTRN(const char *p_text, const char *p_text_plural, int p_n, const String &p_context) {
+	return TTRN(String::utf8(p_text), String::utf8(p_text_plural), p_n, p_context);
 }
 
 /**
@@ -5327,6 +5335,10 @@ String RTR(const String &p_text, const String &p_context) {
 	return p_text;
 }
 
+String RTR(const char *p_text, const String &p_context) {
+	return RTR(String::utf8(p_text), p_context);
+}
+
 /**
  * "Run-time TRanslate for N items". Performs string replacement for
  * internationalization within a running project. The translation string must be
@@ -5356,4 +5368,8 @@ String RTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 		return p_text;
 	}
 	return p_text_plural;
+}
+
+String RTRN(const char *p_text, const char *p_text_plural, int p_n, const String &p_context) {
+	return RTRN(String::utf8(p_text), String::utf8(p_text_plural), p_n, p_context);
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -528,7 +528,9 @@ _FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
 #ifdef TOOLS_ENABLED
 // Gets parsed.
 String TTR(const String &p_text, const String &p_context = "");
+String TTR(const char *p_text, const String &p_context = "");
 String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String TTRN(const char *p_text, const char *p_text_plural, int p_n, const String &p_context = "");
 String DTR(const String &p_text, const String &p_context = "");
 String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 // Use for C strings.
@@ -553,7 +555,9 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 
 // Runtime translate for the public node API.
 String RTR(const String &p_text, const String &p_context = "");
+String RTR(const char *p_text, const String &p_context = "");
 String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String RTRN(const char *p_text, const char *p_text_plural, int p_n, const String &p_context = "");
 
 bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
 

--- a/editor/plugins/editor_resource_tooltip_plugins.cpp
+++ b/editor/plugins/editor_resource_tooltip_plugins.cpp
@@ -106,7 +106,7 @@ Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resou
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());
-	Label *label = memnew(Label(vformat(TTR(U"Dimensions: %d × %d"), dimensions.x, dimensions.y)));
+	Label *label = memnew(Label(vformat(TTR("Dimensions: %d × %d"), dimensions.x, dimensions.y)));
 	vb->add_child(label);
 
 	TextureRect *tr = memnew(TextureRect);


### PR DESCRIPTION
This string
https://github.com/godotengine/godot/blob/46424488edc341b65467ee7fd3ac423e4d49ad34/editor/plugins/editor_resource_tooltip_plugins.cpp#L109
is not included in translation files, because U breaks the regex. The U is necessary to make the string parsed as unicode, because TTR converts it automatically to String.

I came up with as solution that involves the least changes - I just added an overload for TTR that takes `char *` and automatically interprets it as UTF-8. This probably means that all translated strings will now be parsed as unicode, not sure if brings any drawbacks (maybe it's slower than just making a String, idk).