### PR TITLE
Make sure the shortcut key respects the context in `TileSetAtlasSourceEditor`

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1693,7 +1693,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 	}
 }
 
-void TileSetAtlasSourceEditor::_unhandled_key_input(const Ref<InputEvent> &p_event) {
+void TileSetAtlasSourceEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	// Check for shortcuts.
 	if (ED_IS_SHORTCUT("tiles_editor/delete_tile", p_event)) {
 		if (tools_button_group->get_pressed_button() == tool_select_button && !selection.is_empty()) {
@@ -2418,14 +2418,14 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 }
 
 void TileSetAtlasSourceEditor::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_unhandled_key_input"), &TileSetAtlasSourceEditor::_unhandled_key_input);
 	ClassDB::bind_method(D_METHOD("_set_selection_from_array"), &TileSetAtlasSourceEditor::_set_selection_from_array);
 
 	ADD_SIGNAL(MethodInfo("source_id_changed", PropertyInfo(Variant::INT, "source_id")));
 }
 
 TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
-	set_process_unhandled_key_input(true);
+	set_shortcut_context(this);
+	set_process_shortcut_input(true);
 	set_process_internal(true);
 
 	// Middle panel.

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -257,9 +257,6 @@ private:
 	void _update_atlas_view();
 	void _update_toolbar();
 
-	// -- input events --
-	void _unhandled_key_input(const Ref<InputEvent> &p_event);
-
 	// -- Misc --
 	void _auto_create_tiles();
 	void _auto_remove_tiles();
@@ -274,6 +271,9 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+
+	// -- input events --
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_source, int p_source_id);


### PR DESCRIPTION
Fix #74061.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
