### PR TITLE
Do not change a node unique name to the same name

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1019,11 +1019,18 @@ void SceneTreeEditor::_renamed() {
 		}
 	}
 
-	if (n->is_unique_name_in_owner() && get_tree()->get_edited_scene_root()->get_node_or_null("%" + new_name) != nullptr) {
-		error->set_text(TTR("Another node already uses this unique name in the scene."));
-		error->popup_centered();
-		which->set_text(0, n->get_name());
-		return;
+	if (n->is_unique_name_in_owner()) {
+		Node *existing = get_tree()->get_edited_scene_root()->get_node_or_null("%" + new_name);
+		if (existing == n) {
+			which->set_text(0, n->get_name());
+			return;
+		}
+		if (existing != nullptr) {
+			error->set_text(TTR("Another node already uses this unique name in the scene."));
+			error->popup_centered();
+			which->set_text(0, n->get_name());
+			return;
+		}
 	}
 
 	_rename_node(n, new_name);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78922
Fixes https://github.com/godotengine/godot/issues/79085

The code already attempted to get a node by the new name to check if there was a different existing node with a unique name matching the name. I have added a check to see if the node it finds is the same being renamed, in which case the operation is aborted silently.