### PR TITLE
C#: Fix NodePaths completion error for not calling from main thread

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/MessagingServer.cs
@@ -385,9 +385,12 @@ namespace GodotTools.Ides
                 // However, it doesn't fix resource loading if the rest of the path is also case insensitive.
                 string scriptFileLocalized = FsPathUtils.LocalizePathWithCaseChecked(request.ScriptFile);
 
+                // The node API can only be called from the main thread.
+                await Godot.Engine.GetMainLoop().ToSignal(Godot.Engine.GetMainLoop(), "process_frame");
+
                 var response = new CodeCompletionResponse { Kind = request.Kind, ScriptFile = request.ScriptFile };
-                response.Suggestions = await Task.Run(() =>
-                    Internal.CodeCompletionRequest(response.Kind, scriptFileLocalized ?? request.ScriptFile));
+                response.Suggestions = Internal.CodeCompletionRequest(response.Kind,
+                    scriptFileLocalized ?? request.ScriptFile);
                 return response;
             }
         }


### PR DESCRIPTION
The node API we use for code completion changed and no longer allows being called from threads other than the main one.

Fixes #78913

I don't know if awaiting the next frame takes longer with low processor mode. It may be better to implement an awaitable version of `CallDeferred`.
