### PR TITLE
Fix first assignment to `_min/max_value` in `Curve` bypassing `min < max` check

### DIFF
--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -105,6 +105,9 @@ public:
 	real_t get_max_value() const { return _max_value; }
 	void set_max_value(real_t p_max);
 
+	Array get_limits() const;
+	void set_limits(Array input);
+
 	real_t get_range() const { return _max_value - _min_value; }
 
 	real_t sample(real_t p_offset) const;
@@ -156,7 +159,6 @@ private:
 	int _bake_resolution = 100;
 	real_t _min_value = 0.0;
 	real_t _max_value = 1.0;
-	int _minmax_set_once = 0b00; // Encodes whether min and max have been set a first time, first bit for min and second for max.
 };
 
 VARIANT_ENUM_CAST(Curve::TangentMode)


### PR DESCRIPTION
Currently, the very first time one assigns to either `_min_value` or `_max_value` in `Curve`, it bypasses the `min < max` condition:

![image](https://github.com/godotengine/godot/assets/1133892/a60c5f1b-24ad-419c-9d97-08764d268302)

This PR implements "bulk load" for curve limits by adding a "fake" property called `_limits`, which loads an array containing all the values. These are assigned to the proper variables without checking for `min < value`, as it should be during deserialization. The `min < max` condition is still ensured by the `set` methods for the `min/max` values, so that we always serialize `min < max` values.

This solution was taken from https://github.com/godotengine/godot/pull/29959#issuecomment-504783824, and extracted from #67857 as a first step towards reviving it. It also sets the stage for other limits to be added (such as the domain ones) without having to replicate the current, buggy solution.

### Long-winded explanation of the problem to serve as reference in the future:

The reason for the current behavior is that the `min < max` check is disabled the _first time_ each property is written to. The idea is that this happens during deserialization, so that the checks don't conflict with the default values of 0 and 1. Suppose serialized values are `min=5, max=10`. When deserializing `min` first, and trying to set it, the condition that `min < max(default)` is `5 < 1`, which fails.

However, if the `Curve` has default min/max values, those properties aren't serialized in the first place, and, therefore no _first time_ assignment happens deserialization. This makes it so the first time the _user_ attempts to assign to these limits, the checks are not guaranteed.

### Downsides of approach

GDScript recognizes the properties tagged as `PROPERTY_USAGE_INTERNAL` & related methods, which perhaps it shouldn't. In this case, it is unintended since these properties are "fake" and mean to be used just for de/serialization. On the other hand, there might be some GDScript code out there that makes use of internal properties. I can imagine some addons, through GDExtension or GDScript, would do it. See https://github.com/godotengine/godot/issues/25651 for discussion on whether `PROPERTY_USAGE_INTERNAL` properties should be exposed to GDScript.

_Warning_: This contains a minor compatibility break in that `_min/max_value` are no longer serialized. However, they are still deserialized because the resource loaders don't check that the property they are reading must have the `PROPERTY_USAGE_STORAGE` flag. 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
