### PR TITLE
Add compatibility properties to `TouchScreenButton`

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -369,6 +369,19 @@ bool TouchScreenButton::is_passby_press_enabled() const {
 	return passby_press;
 }
 
+#ifndef DISABLE_DEPRECATED
+bool TouchScreenButton::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == SNAME("normal")) { // Compatibility with Godot 3.x.
+		set_texture_normal(p_value);
+		return true;
+	} else if (p_name == SNAME("pressed")) { // Compatibility with Godot 3.x.
+		set_texture_pressed(p_value);
+		return true;
+	}
+	return false;
+}
+#endif // DISABLE_DEPRECATED
+
 void TouchScreenButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_normal", "texture"), &TouchScreenButton::set_texture_normal);
 	ClassDB::bind_method(D_METHOD("get_texture_normal"), &TouchScreenButton::get_texture_normal);

--- a/scene/2d/touch_screen_button.h
+++ b/scene/2d/touch_screen_button.h
@@ -71,6 +71,9 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif // DISABLE_DEPRECATED
 
 public:
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Added support for `3.x` properties:
* `normal` -> `texture_normal`
* `pressed` -> `texture_pressed`

* Fixes: #78930
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
