### PR TITLE
Add option to center image when loading particle emission mask

### DIFF
--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -217,11 +217,16 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 	}
 
 	{
+		Vector2 offset;
+		if (emission_mask_centered->is_pressed()) {
+			offset = Vector2(-s.width * 0.5, -s.height * 0.5);
+		}
+
 		PackedVector2Array points;
 		points.resize(valid_positions.size());
 		Vector2 *pointsw = points.ptrw();
 		for (int i = 0; i < valid_positions.size(); i += 1) {
-			pointsw[i] = valid_positions[i];
+			pointsw[i] = valid_positions[i] + offset;
 		}
 		particles->set_emission_points(points);
 	}
@@ -281,9 +286,14 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	emission_mask_mode->add_item(TTR("Solid Pixels"), EMISSION_MODE_SOLID);
 	emission_mask_mode->add_item(TTR("Border Pixels"), EMISSION_MODE_BORDER);
 	emission_mask_mode->add_item(TTR("Directed Border Pixels"), EMISSION_MODE_BORDER_DIRECTED);
+	VBoxContainer *optionsvb = memnew(VBoxContainer);
+	emvb->add_margin_child(TTR("Options"), optionsvb);
+	emission_mask_centered = memnew(CheckBox);
+	emission_mask_centered->set_text(TTR("Centered"));
+	optionsvb->add_child(emission_mask_centered);
 	emission_colors = memnew(CheckBox);
-	emission_colors->set_text(TTR("Capture from Pixel"));
-	emvb->add_margin_child(TTR("Emission Colors"), emission_colors);
+	emission_colors->set_text(TTR("Capture Colors from Pixel"));
+	optionsvb->add_child(emission_colors);
 
 	toolbar->add_child(emission_mask);
 

--- a/editor/plugins/cpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.h
@@ -69,6 +69,7 @@ class CPUParticles2DEditorPlugin : public EditorPlugin {
 
 	ConfirmationDialog *emission_mask = nullptr;
 	OptionButton *emission_mask_mode = nullptr;
+	CheckBox *emission_mask_centered = nullptr;
 	CheckBox *emission_colors = nullptr;
 
 	String source_emission_file;

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -292,11 +292,16 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 	texdata.resize(w * h * 2 * sizeof(float));
 
 	{
+		Vector2 offset;
+		if (emission_mask_centered->is_pressed()) {
+			offset = Vector2(-s.width * 0.5, -s.height * 0.5);
+		}
+
 		uint8_t *tw = texdata.ptrw();
 		float *twf = reinterpret_cast<float *>(tw);
 		for (int i = 0; i < vpc; i++) {
-			twf[i * 2 + 0] = valid_positions[i].x;
-			twf[i * 2 + 1] = valid_positions[i].y;
+			twf[i * 2 + 0] = valid_positions[i].x + offset.x;
+			twf[i * 2 + 1] = valid_positions[i].y + offset.y;
 		}
 	}
 
@@ -417,9 +422,14 @@ GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	emission_mask_mode->add_item(TTR("Solid Pixels"), EMISSION_MODE_SOLID);
 	emission_mask_mode->add_item(TTR("Border Pixels"), EMISSION_MODE_BORDER);
 	emission_mask_mode->add_item(TTR("Directed Border Pixels"), EMISSION_MODE_BORDER_DIRECTED);
+	VBoxContainer *optionsvb = memnew(VBoxContainer);
+	emvb->add_margin_child(TTR("Options"), optionsvb);
+	emission_mask_centered = memnew(CheckBox);
+	emission_mask_centered->set_text(TTR("Centered"));
+	optionsvb->add_child(emission_mask_centered);
 	emission_colors = memnew(CheckBox);
-	emission_colors->set_text(TTR("Capture from Pixel"));
-	emvb->add_margin_child(TTR("Emission Colors"), emission_colors);
+	emission_colors->set_text(TTR("Capture Colors from Pixel"));
+	optionsvb->add_child(emission_colors);
 
 	toolbar->add_child(emission_mask);
 

--- a/editor/plugins/gpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.h
@@ -75,6 +75,7 @@ class GPUParticles2DEditorPlugin : public EditorPlugin {
 
 	ConfirmationDialog *emission_mask = nullptr;
 	OptionButton *emission_mask_mode = nullptr;
+	CheckBox *emission_mask_centered = nullptr;
 	CheckBox *emission_colors = nullptr;
 
 	String source_emission_file;


### PR DESCRIPTION
I messed up pull request [78583](https://github.com/godotengine/godot/pull/78583) by working on master and some rebasing/resetting and force pushing. This is a recreation of that pull request with [a change as commented](https://github.com/godotengine/godot/pull/78583#issuecomment-1610018172) by @KoBeWi

The dialog now looks like:
![Screenshot 2023-07-02 121740](https://github.com/godotengine/godot/assets/1334501/a4140e00-7315-4710-8acd-c2d445e3f89f)

Recap: when loading an image to use as a particle emission mask, the option to center the image is now available. The centering is applied when generating the mask, so no extra runtime cost is involved.

Fixes https://github.com/godotengine/godot/issues/16411

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
