### PR TITLE
Make automatic root node naming in "create new scene" dialog follow naming settings

### DIFF
--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -130,7 +130,7 @@ void SceneCreateDialog::update_dialog() {
 
 	root_name = root_name_edit->get_text().strip_edges();
 	if (root_name.is_empty()) {
-		root_name = scene_name.get_file().get_basename();
+		root_name = adjust_name_casing(scene_name.get_file().get_basename());
 	}
 
 	if (root_name.is_empty() || root_name.validate_node_name().size() != root_name.size()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Resolves #78946.

In the "Create New Scene" dialog, if the root name is left empty and we set it to the scene filename, then also adjust the case depending on the editor settings for naming cases.