### PR TITLE
SCons : Add `scu_limit` argument

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -220,6 +220,7 @@ opts.Add(
 )
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
 opts.Add(BoolVariable("scu_build", "Use single compilation unit build", False))
+opts.Add("scu_limit", "Max includes per SCU file when using scu_build (determines RAM use)", "0")
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))
@@ -549,7 +550,16 @@ if selected_platform in platform_list:
 
     # Run SCU file generation script if in a SCU build.
     if env["scu_build"]:
-        methods.set_scu_folders(scu_builders.generate_scu_files(env["verbose"], env_base.dev_build == False))
+        max_includes_per_scu = 8
+        if env_base.dev_build == True:
+            max_includes_per_scu = 1024
+
+        read_scu_limit = int(env["scu_limit"])
+        read_scu_limit = max(0, min(read_scu_limit, 1024))
+        if read_scu_limit != 0:
+            max_includes_per_scu = read_scu_limit
+
+        methods.set_scu_folders(scu_builders.generate_scu_files(env["verbose"], max_includes_per_scu))
 
     # Must happen after the flags' definition, as configure is when most flags
     # are actually handled to change compile options, etc.

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -8,8 +8,8 @@ from os.path import normpath, basename
 base_folder_path = str(Path(__file__).parent) + "/"
 base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
 _verbose = False
-_is_release_build = False
 _scu_folders = set()
+_max_includes_per_scu = 1024
 
 
 def clear_out_existing_files(output_folder, extension):
@@ -197,13 +197,14 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
 
     # adjust number of output files according to whether DEV or release
     num_output_files = 1
-    if _is_release_build:
-        # always have a maximum in release
-        includes_per_scu = 8
-        num_output_files = max(math.ceil(total_lines / float(includes_per_scu)), 1)
+
+    if includes_per_scu == 0:
+        includes_per_scu = _max_includes_per_scu
     else:
-        if includes_per_scu > 0:
-            num_output_files = max(math.ceil(total_lines / float(includes_per_scu)), 1)
+        if includes_per_scu > _max_includes_per_scu:
+            includes_per_scu = _max_includes_per_scu
+
+    num_output_files = max(math.ceil(total_lines / float(includes_per_scu)), 1)
 
     lines_per_file = math.ceil(total_lines / float(num_output_files))
     lines_per_file = max(lines_per_file, 1)
@@ -241,15 +242,15 @@ def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension=
         )
 
 
-def generate_scu_files(verbose, is_release_build):
+def generate_scu_files(verbose, max_includes_per_scu):
     print("=============================")
     print("Single Compilation Unit Build")
     print("=============================")
-    print("Generating SCU build files")
     global _verbose
     _verbose = verbose
-    global _is_release_build
-    _is_release_build = is_release_build
+    global _max_includes_per_scu
+    _max_includes_per_scu = max_includes_per_scu
+    print("Generating SCU build files... (max includes per scu " + str(_max_includes_per_scu) + ")")
 
     curr_folder = os.path.abspath("./")
 


### PR DESCRIPTION
"scu_limit" allows specifying the maximum number of includes in a single SCU file (translation unit). A lower limit (e.g. 8) uses less RAM during compilation, but may be slower to compile.

## Explanation
The max number of includes in a SCU file (which is a single translation unit used by a single compiler instance) determines very roughly the maximum RAM used by the compiler instances. RAM is important to not let get out of hand, particularly in release builds (which use a lot more RAM), so the defaults are for 1024 maximum includes in dev builds (to maximize compilation speed) and 8 in release (to get some acceleration, but limit RAM use to approx 1Gb per compilation instance).

The total RAM used by SCons approximates to:
`number_of_cores * RAM_per_core`
So a more powerful machine with more RAM and cores _may not always_ be able to safely increase `scu_limit` if it has a corresponding large number of cores (e.g. 64Gb machine with 32 cores = 2Gb per core, same as 8Gb with 4 cores).

Although these defaults are fine in most cases, there are a couple of situations where it is nice to be able to manually fine tune the RAM usage:
* On computers with large amounts of RAM, for faster compilation in release
* On CI runs, where cores and total RAM may be limited

Particularly the CI runs RAM may be more limited, so it may be sensible to set `scu_limit` for DEV builds to a value closer to the release default (8 or 16 or so, rather than the default 1024). This may require some testing to get the best value for `scu_limit` to use on a particular system.

## Notes
* As always, happy to change the name of the parameter etc if we can think of something better.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
