### PR TITLE
Make editor inspector follow focus

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -22,6 +22,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" overrides="ScrollContainer" default="true" />
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4189,6 +4189,7 @@ EditorInspector::EditorInspector() {
 	main_vbox->add_theme_constant_override("separation", 0);
 	add_child(main_vbox);
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
+	set_follow_focus(true);
 
 	changing = 0;
 	search_box = nullptr;


### PR DESCRIPTION
No idea if this could have any negative implications. :thinking:

Fixes #78954 (`EditorSettingsDialog` uses `SectionedInspector` which uses `EditorInspector`).
![OyeUr5dpyO](https://github.com/godotengine/godot/assets/9283098/227d8ccd-f744-4b40-9017-1ab6ce055b59)
