### PR TITLE
Windows: Always double-quote path when launching explorer.exe to browse

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1356,18 +1356,13 @@ Error OS_Windows::shell_open(String p_uri) {
 }
 
 Error OS_Windows::shell_show_in_file_manager(String p_path, bool p_open_folder) {
-	p_path = p_path.trim_suffix("file://");
-
 	bool open_folder = false;
 	if (DirAccess::dir_exists_absolute(p_path) && p_open_folder) {
 		open_folder = true;
 	}
 
-	if (p_path.begins_with("\"")) {
-		p_path = String("\"") + p_path;
-	}
-	if (p_path.ends_with("\"")) {
-		p_path = p_path + String("\"");
+	if (!p_path.is_quoted()) {
+		p_path = p_path.quote();
 	}
 	p_path = p_path.replace("/", "\\");
 


### PR DESCRIPTION
Fixes #78949

Code now always double quotes the filename to use as command line argument when calling 'explorer.exe'. In particular, commas in a filename would be interpreted by 'explorer.exe' as separators for commands.

Fixed the logic logic where existing leading or trailing double quotes in the filename were duplicated, instead of adding them when they were missing.

Similarly a `trim_suffix` for "file://" is assumed to be a mistake, this could potentially be a _pre_fix that we want to strip, but never a suffix. 

Judging from [the commit](https://github.com/godotengine/godot/pull/69698) that first introduced the `OS_Windows::shell_show_in_file_manager` function I would guess that stripping "file://" was some intermediate decision that might not be needed in the end, and never even worked. The old code would prefix "file://" at several locations, but this was all moved to the base implementation of shell_show_in_file_manager, and the new windows implementation never prefixes, so there is no need for trimming.

Maybe trimming the prefix could be dropped altogether, but I'm playing safe. I do not know if there are usages of this method that I am unaware of. If this method is exposed to GDScript or plugins use it, that code could still be prefixing "file://", hence we need to strip it for the windows version.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
