### PR TITLE
Fix `GDVIRTUAL_NATIVE_PTR` by adding missing `VariantInternalAccessor` specializations

### DIFF
--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -53,36 +53,46 @@ struct GDExtensionPtr {
 	operator Variant() const { return uint64_t(data); }
 };
 
-#define GDVIRTUAL_NATIVE_PTR(m_type)                                                                 \
-	template <>                                                                                      \
-	struct GDExtensionConstPtr<const m_type> {                                                       \
-		const m_type *data = nullptr;                                                                \
-		GDExtensionConstPtr() {}                                                                     \
-		GDExtensionConstPtr(const m_type *p_assign) { data = p_assign; }                             \
-		static const char *get_name() { return "const " #m_type; }                                   \
-		operator const m_type *() const { return data; }                                             \
-		operator Variant() const { return uint64_t(data); }                                          \
-	};                                                                                               \
-	template <>                                                                                      \
-	struct VariantCaster<GDExtensionConstPtr<const m_type>> {                                        \
-		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) {     \
-			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t()); \
-		}                                                                                            \
-	};                                                                                               \
-	template <>                                                                                      \
-	struct GDExtensionPtr<m_type> {                                                                  \
-		m_type *data = nullptr;                                                                      \
-		GDExtensionPtr() {}                                                                          \
-		GDExtensionPtr(m_type *p_assign) { data = p_assign; }                                        \
-		static const char *get_name() { return #m_type; }                                            \
-		operator m_type *() const { return data; }                                                   \
-		operator Variant() const { return uint64_t(data); }                                          \
-	};                                                                                               \
-	template <>                                                                                      \
-	struct VariantCaster<GDExtensionPtr<m_type>> {                                                   \
-		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) {                \
-			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t());                  \
-		}                                                                                            \
+#define GDVIRTUAL_NATIVE_PTR(m_type)                                                                                                                                                               \
+	template <>                                                                                                                                                                                    \
+	struct GDExtensionConstPtr<const m_type> {                                                                                                                                                     \
+		const m_type *data = nullptr;                                                                                                                                                              \
+		GDExtensionConstPtr() {}                                                                                                                                                                   \
+		GDExtensionConstPtr(const m_type *p_assign) { data = p_assign; }                                                                                                                           \
+		static const char *get_name() { return "const " #m_type; }                                                                                                                                 \
+		operator const m_type *() const { return data; }                                                                                                                                           \
+		operator Variant() const { return uint64_t(data); }                                                                                                                                        \
+	};                                                                                                                                                                                             \
+	template <>                                                                                                                                                                                    \
+	struct VariantCaster<GDExtensionConstPtr<const m_type>> {                                                                                                                                      \
+		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) {                                                                                                   \
+			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t());                                                                                               \
+		}                                                                                                                                                                                          \
+	};                                                                                                                                                                                             \
+	template <>                                                                                                                                                                                    \
+	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> {                                                                                                                            \
+		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) { return *reinterpret_cast<const GDExtensionConstPtr<const m_type> *>(VariantInternal::get_int(v)); } \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) { *VariantInternal::get_int(v) = uint64_t(p_value.data); }                                    \
+	};                                                                                                                                                                                             \
+	template <>                                                                                                                                                                                    \
+	struct GDExtensionPtr<m_type> {                                                                                                                                                                \
+		m_type *data = nullptr;                                                                                                                                                                    \
+		GDExtensionPtr() {}                                                                                                                                                                        \
+		GDExtensionPtr(m_type *p_assign) { data = p_assign; }                                                                                                                                      \
+		static const char *get_name() { return #m_type; }                                                                                                                                          \
+		operator m_type *() const { return data; }                                                                                                                                                 \
+		operator Variant() const { return uint64_t(data); }                                                                                                                                        \
+	};                                                                                                                                                                                             \
+	template <>                                                                                                                                                                                    \
+	struct VariantCaster<GDExtensionPtr<m_type>> {                                                                                                                                                 \
+		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) {                                                                                                              \
+			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t());                                                                                                                \
+		}                                                                                                                                                                                          \
+	};                                                                                                                                                                                             \
+	template <>                                                                                                                                                                                    \
+	struct VariantInternalAccessor<GDExtensionPtr<m_type>> {                                                                                                                                       \
+		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) { return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v)); }                       \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) { *VariantInternal::get_int(v) = uint64_t(p_value.data); }                                               \
 	};
 
 template <class T>


### PR DESCRIPTION
This commit fixes the usage of GDExtensionPtr and GDExtensionConstPtr in GDExtension by introducing the required VariantInternalAccessor specializations. Without this fix using the GDVIRTUAL_NATIVE_PTR() macro results in a compilation error.

Sponsored by Migeran (https://migeran.com)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
