### PR TITLE
Fix shader language float literal precision truncation

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -178,7 +178,7 @@ static String _mkid(const String &p_id) {
 }
 
 static String f2sp0(float p_float) {
-	String num = rtoss(p_float);
+	String num = rtos(p_float);
 	if (!num.contains(".") && !num.contains("e")) {
 		num += ".0";
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77325
Fixes https://github.com/godotengine/godot/issues/78896

Related issue, but not affected by this PR: https://github.com/godotengine/godot/issues/78204

This PR simply replaces `rtoss()` with `rtos()`, which behaves much better with float/double precision and is also much more used in the Godot codebase. After this PR, rtoss() will only be used in one place in `variant_parser.cpp`. This should most likely also replaced with a better behaving version. However, the remaining issue is the underlying `String::num_scientific()`, which can sometimes drop too many decimals from float or double values, as documented in https://github.com/godotengine/godot/issues/78204.

Currently, the float literal conversion between Godot shader language and the final GLSL version can drop the float decimal part accuracy dramatically, which breaks many otherwise valid GLSL tutorials, demos and libraries. 

Original Godot (or GLSL) shader code:

```glsl
float rand(vec2 x) {
    return fract(cos(mod(dot(x, vec2(13.9898, 8.141)), 3.14)) * 43758.5453);
}
```

Raw GLSL code generated from Godot Shader Language (notice the dropped decimals in the 43758.5):

```glsl
float m_rand(vec2 m_x) {
    return fract((cos(mod(dot(m_x, vec2(13.9898,8.141)), 3.14)) * 43758.5));
}
```

Raw GLSL after this PR (notice the improved precision, for example 43758.546875 instead of just 43758.5):

```glsl
float m_rand(vec2 m_x) {
    return fract((cos(mod(dot(m_x, vec2(13.989800453186,8.14099979400635)), 3.14000010490417)) * 43758.546875));
}
```

Precision is very important for many use cases, for example that pretty famous (if not very portable) code snippet uses fract() to extract the float fractional part and preserving as much precision as possible is important here. Many existing GLSL / HLSL demos and tutorials currently suffer from this float literal precision loss when porting them to Godot, sometimes drastically, sometimes more subtly.

In many cases this PR slightly increases the length of each float literal in the final shader code, but the added size and parsing performance impact should still be very minor. If we want to be real resource misers with this, we could maybe try to limit the decimals to a smaller float precision (for example calling `String::num(x, 10)` etc. directly), but I don't think it's necessary. Also assuming that we don't want to support GLSL 4.0 style lf/LF double literals in the future.

This PR should not directly break backwards compatibility. However, this increased precision can change existing user shader code behavior, especially if people have already tweaked their code to work around this precision loss.

Generated noise values before this PR:

![noise_before](https://github.com/godotengine/godot/assets/22456603/05d1e4aa-44d8-4747-b0dc-fa5ec302acd7)

After this PR:

![noise_after](https://github.com/godotengine/godot/assets/22456603/c3b6da49-b106-4630-b134-a3aad8f55318)
