### PR TITLE
Fix management of safe-for-nodes flag in ResourceLoader and WorkerThreadPool

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -309,6 +309,10 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	}
 	// --
 
+	if (!Thread::is_main_thread()) {
+		set_current_thread_safe_for_nodes(true);
+	}
+
 	Ref<Resource> res = _load(load_task.remapped_path, load_task.remapped_path != load_task.local_path ? load_task.local_path : String(), load_task.type_hint, load_task.cache_mode, &load_task.error, load_task.use_sub_threads, &load_task.progress);
 	if (mq_override) {
 		mq_override->flush();


### PR DESCRIPTION
Fixes the issue explained in https://github.com/godotengine/godot/issues/78734#issuecomment-1614547344.