### PR TITLE
Prevent crash when processing line caches in `RichTextLabel`

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2802,7 +2802,7 @@ _FORCE_INLINE_ float RichTextLabel::_update_scroll_exceeds(float p_total_height,
 
 		total_height = 0;
 		for (int j = 0; j <= p_idx; j++) {
-			total_height = _resize_line(main, j, theme_cache.normal_font, theme_cache.normal_font_size, p_width, total_height);
+			total_height = _resize_line(main, j, theme_cache.normal_font, theme_cache.normal_font_size, p_width - scroll_w, total_height);
 
 			main->first_resized_line.store(j);
 		}
@@ -2852,7 +2852,7 @@ bool RichTextLabel::_validate_line_caches() {
 		float total_height = (fi == 0) ? 0 : _calculate_line_vertical_offset(main->lines[fi - 1]);
 		for (int i = fi; i < (int)main->lines.size(); i++) {
 			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, text_rect.get_size().width - scroll_w, total_height);
-			total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width - scroll_w, i, old_scroll, text_rect.size.height);
+			total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width, i, old_scroll, text_rect.size.height);
 			main->first_resized_line.store(i);
 		}
 
@@ -2918,7 +2918,7 @@ void RichTextLabel::_process_line_caches() {
 
 		for (int i = sr; i < fi; i++) {
 			total_height = _resize_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, text_rect.get_size().width - scroll_w, total_height);
-			total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width - scroll_w, i, old_scroll, text_rect.size.height);
+			total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width, i, old_scroll, text_rect.size.height);
 
 			main->first_resized_line.store(i);
 
@@ -2930,7 +2930,7 @@ void RichTextLabel::_process_line_caches() {
 
 	for (int i = fi; i < (int)main->lines.size(); i++) {
 		total_height = _shape_line(main, i, theme_cache.normal_font, theme_cache.normal_font_size, text_rect.get_size().width - scroll_w, total_height, &total_chars);
-		total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width - scroll_w, i, old_scroll, text_rect.size.height);
+		total_height = _update_scroll_exceeds(total_height, ctrl_height, text_rect.get_size().width, i, old_scroll, text_rect.size.height);
 
 		main->first_invalid_line.store(i);
 		main->first_resized_line.store(i);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78912.
Fixes https://github.com/godotengine/godot/issues/78849.
Fixes https://github.com/godotengine/godot/issues/78932.
Supersedes https://github.com/godotengine/godot/pull/78916 as a solution (though sizing changes may be welcome at some point).

I investigated https://github.com/godotengine/godot/pull/78241 which introduced this regression and noticed a small logical difference in what appeared to be a simple act of refactoring. We used the old value of `scroll_w`, valid only at the time of the function call, while in the process the value of `scroll_w` was updated. This broke pre-existing logic from before the refactoring resulting in the crash.

I admit, I don't really understand the entirety of what's going on, but this doesn't seem intentional and does seem to be the source of the issue.

-----

PS. There is also another difference in that refactoring which I haven't touched because it has nothing to do with the crash. But when we do `_process_line_caches` we used to call `main->first_invalid_line.store` and `main->first_invalid_font_line.store` while iterating. In the factored out code of `_update_scroll_exceeds` this no longer happens, and only `main->first_resized_line.store` is called. Might be something to look into.