### PR TITLE
Fix node selection not handled correctly at launch

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -925,7 +925,6 @@ Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, 
 	for (Node *E : es.selection) {
 		p_selection->add_node(E);
 	}
-	p_selection->cancel_update(); // Selection update results in redundant Node edit, so we cancel it.
 	set_editor_plugin_states(es.editor_states);
 
 	return es.custom_state;
@@ -1348,10 +1347,6 @@ void EditorSelection::clear() {
 
 	changed = true;
 	node_list_changed = true;
-}
-
-void EditorSelection::cancel_update() {
-	changed = false;
 }
 
 EditorSelection::EditorSelection() {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -312,7 +312,6 @@ public:
 
 	void update();
 	void clear();
-	void cancel_update();
 
 	// Returns all the selected nodes.
 	TypedArray<Node> get_selected_nodes();


### PR DESCRIPTION
Partially reverts #78125

While these changes fixed a minor issue, it spawned two, more major issues:
- when editor starts and you had a node selected, the editor will restore this selection, but the inspector will always show the scene root
- if the selected node uses an editor, it might cause an empty bottom panel
![](https://chat.godotengine.org/file-upload/knW2fXLBrSgfzwkAz/Clipboard%20-%202%20%D0%B8%D1%8E%D0%BB%D1%8F%202023%20%D0%B3.,%2021:43)

The reverted fix can be revised later; maybe there is a better way to do it. The issues it caused are more important to fix now.