### PR TITLE
Unify and streamline connecting to Resource changes

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -147,15 +147,28 @@ bool Resource::editor_can_reload_from_file() {
 	return true; //by default yes
 }
 
+void Resource::connect_changed(const Callable &p_callable, uint32_t p_flags) {
+	if (!is_connected(CoreStringNames::get_singleton()->changed, p_callable) || p_flags & CONNECT_REFERENCE_COUNTED) {
+		connect(CoreStringNames::get_singleton()->changed, p_callable, p_flags);
+	}
+}
+
+void Resource::disconnect_changed(const Callable &p_callable) {
+	if (is_connected(CoreStringNames::get_singleton()->changed, p_callable)) {
+		disconnect(CoreStringNames::get_singleton()->changed, p_callable);
+	}
+}
+
 void Resource::reset_state() {
 }
+
 Error Resource::copy_from(const Ref<Resource> &p_resource) {
 	ERR_FAIL_COND_V(p_resource.is_null(), ERR_INVALID_PARAMETER);
 	if (get_class() != p_resource->get_class()) {
 		return ERR_INVALID_PARAMETER;
 	}
 
-	reset_state(); //may want to reset state
+	reset_state(); // May want to reset state.
 
 	List<PropertyInfo> pi;
 	p_resource->get_property_list(&pi);
@@ -322,23 +335,6 @@ RID Resource::get_rid() const {
 	return RID();
 }
 
-void Resource::register_owner(Object *p_owner) {
-	owners.insert(p_owner->get_instance_id());
-}
-
-void Resource::unregister_owner(Object *p_owner) {
-	owners.erase(p_owner->get_instance_id());
-}
-
-void Resource::notify_change_to_owners() {
-	for (const ObjectID &E : owners) {
-		Object *obj = ObjectDB::get_instance(E);
-		ERR_CONTINUE_MSG(!obj, "Object was deleted, while still owning a resource."); //wtf
-		//TODO store string
-		obj->call("resource_changed", Ref<Resource>(this));
-	}
-}
-
 #ifdef TOOLS_ENABLED
 
 uint32_t Resource::hash_edited_version() const {
@@ -443,6 +439,7 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_local_to_scene"), &Resource::is_local_to_scene);
 	ClassDB::bind_method(D_METHOD("get_local_scene"), &Resource::get_local_scene);
 	ClassDB::bind_method(D_METHOD("setup_local_to_scene"), &Resource::setup_local_to_scene);
+
 	ClassDB::bind_method(D_METHOD("emit_changed"), &Resource::emit_changed);
 
 	ClassDB::bind_method(D_METHOD("duplicate", "subresources"), &Resource::duplicate, DEFVAL(false));
@@ -468,9 +465,6 @@ Resource::~Resource() {
 		ResourceCache::lock.lock();
 		ResourceCache::resources.erase(path_cache);
 		ResourceCache::lock.unlock();
-	}
-	if (owners.size()) {
-		WARN_PRINT("Resource is still owned.");
 	}
 }
 

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -54,8 +54,6 @@ public:
 	virtual String get_base_extension() const { return "res"; }
 
 private:
-	HashSet<ObjectID> owners;
-
 	friend class ResBase;
 	friend class ResourceCache;
 
@@ -76,10 +74,6 @@ private:
 	SelfList<Resource> remapped_list;
 
 protected:
-	void emit_changed();
-
-	void notify_change_to_owners();
-
 	virtual void _resource_path_changed();
 	static void _bind_methods();
 
@@ -96,8 +90,9 @@ public:
 	virtual Error copy_from(const Ref<Resource> &p_resource);
 	virtual void reload_from_file();
 
-	void register_owner(Object *p_owner);
-	void unregister_owner(Object *p_owner);
+	void emit_changed();
+	void connect_changed(const Callable &p_callable, uint32_t p_flags = 0);
+	void disconnect_changed(const Callable &p_callable);
 
 	void set_name(const String &p_name);
 	String get_name() const;

--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -20,11 +20,11 @@
 				Sets the collision shape's shape to the addition of all its convexed [MeshInstance3D] siblings geometry.
 			</description>
 		</method>
-		<method name="resource_changed">
+		<method name="resource_changed" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
-				If this method exists within a script it will be called whenever the shape resource has been modified.
+				[i]Obsoleted.[/i] Use [signal Resource.changed] instead.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -119,11 +119,11 @@
 				Removes a collision exception so the shape does report collisions with the specified [RID].
 			</description>
 		</method>
-		<method name="resource_changed">
+		<method name="resource_changed" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
-				This method is used internally to update the debug gizmo in the editor. Any code placed in this function will be called whenever the [member shape] resource is modified.
+				[i]Obsoleted.[/i] Use [signal Resource.changed] instead.
 			</description>
 		</method>
 		<method name="set_collision_mask_value">

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3297,7 +3297,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 		track_edits[_get_track_selected()]->release_focus();
 	}
 	if (animation.is_valid()) {
-		animation->disconnect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
+		animation->disconnect_changed(callable_mp(this, &AnimationTrackEditor::_animation_changed));
 		_clear_selection();
 	}
 	animation = p_anim;
@@ -3308,7 +3308,7 @@ void AnimationTrackEditor::set_animation(const Ref<Animation> &p_anim, bool p_re
 	_update_tracks();
 
 	if (animation.is_valid()) {
-		animation->connect("changed", callable_mp(this, &AnimationTrackEditor::_animation_changed));
+		animation->connect_changed(callable_mp(this, &AnimationTrackEditor::_animation_changed));
 
 		hscroll->show();
 		edit->set_disabled(read_only);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3192,7 +3192,7 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		if (icon.is_valid()) {
 			tb->set_icon(icon);
 			// Make sure the control is updated if the icon is reimported.
-			icon->connect("changed", callable_mp((Control *)tb, &Control::update_minimum_size));
+			icon->connect_changed(callable_mp((Control *)tb, &Control::update_minimum_size));
 		} else if (singleton->gui_base->has_theme_icon(p_editor->get_name(), SNAME("EditorIcons"))) {
 			tb->set_icon(singleton->gui_base->get_theme_icon(p_editor->get_name(), SNAME("EditorIcons")));
 		}

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -395,7 +395,7 @@ void AudioStreamImportSettings::_seek_to(real_t p_x) {
 
 void AudioStreamImportSettings::edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream) {
 	if (!stream.is_null()) {
-		stream->disconnect("changed", callable_mp(this, &AudioStreamImportSettings::_audio_changed));
+		stream->disconnect_changed(callable_mp(this, &AudioStreamImportSettings::_audio_changed));
 	}
 
 	importer = p_importer;
@@ -408,7 +408,7 @@ void AudioStreamImportSettings::edit(const String &p_path, const String &p_impor
 	_duration_label->set_text(text);
 
 	if (!stream.is_null()) {
-		stream->connect("changed", callable_mp(this, &AudioStreamImportSettings::_audio_changed));
+		stream->connect_changed(callable_mp(this, &AudioStreamImportSettings::_audio_changed));
 		_preview->queue_redraw();
 		_indicator->queue_redraw();
 		color_rect->queue_redraw();

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "audio_stream_editor_plugin.h"
 
-#include "core/core_string_names.h"
 #include "editor/audio_stream_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
@@ -195,7 +194,7 @@ void AudioStreamEditor::_seek_to(real_t p_x) {
 
 void AudioStreamEditor::set_stream(const Ref<AudioStream> &p_stream) {
 	if (stream.is_valid()) {
-		stream->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &AudioStreamEditor::_stream_changed));
+		stream->disconnect_changed(callable_mp(this, &AudioStreamEditor::_stream_changed));
 	}
 
 	stream = p_stream;
@@ -203,7 +202,7 @@ void AudioStreamEditor::set_stream(const Ref<AudioStream> &p_stream) {
 		hide();
 		return;
 	}
-	stream->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &AudioStreamEditor::_stream_changed));
+	stream->connect_changed(callable_mp(this, &AudioStreamEditor::_stream_changed));
 
 	_player->set_stream(stream);
 	_current = 0;

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -31,7 +31,6 @@
 #include "curve_editor_plugin.h"
 
 #include "canvas_item_editor_plugin.h"
-#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
@@ -62,15 +61,15 @@ void CurveEdit::set_curve(Ref<Curve> p_curve) {
 	}
 
 	if (curve.is_valid()) {
-		curve->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveEdit::_curve_changed));
-		curve->disconnect(Curve::SIGNAL_RANGE_CHANGED, callable_mp(this, &CurveEdit::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &CurveEdit::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &CurveEdit::_curve_changed));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveEdit::_curve_changed));
-		curve->connect(Curve::SIGNAL_RANGE_CHANGED, callable_mp(this, &CurveEdit::_curve_changed));
+		curve->connect_changed(callable_mp(this, &CurveEdit::_curve_changed));
+		curve->connect_changed(callable_mp(this, &CurveEdit::_curve_changed));
 	}
 
 	// Note: if you edit a curve, then set another, and try to undo,

--- a/editor/plugins/gradient_editor.cpp
+++ b/editor/plugins/gradient_editor.cpp
@@ -39,7 +39,7 @@
 void GradientEditor::set_gradient(const Ref<Gradient> &p_gradient) {
 	gradient = p_gradient;
 	connect("ramp_changed", callable_mp(this, &GradientEditor::_ramp_changed));
-	gradient->connect("changed", callable_mp(this, &GradientEditor::_gradient_changed));
+	gradient->connect_changed(callable_mp(this, &GradientEditor::_gradient_changed));
 	set_points(gradient->get_points());
 	set_interpolation_mode(gradient->get_interpolation_mode());
 	set_interpolation_color_space(gradient->get_interpolation_color_space());

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -133,7 +133,7 @@ void GradientTexture2DEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 void GradientTexture2DEdit::set_texture(Ref<GradientTexture2D> &p_texture) {
 	texture = p_texture;
-	texture->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+	texture->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 }
 
 void GradientTexture2DEdit::set_snap_enabled(bool p_snap_enabled) {

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -77,7 +77,7 @@ void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
 
 	input_event = p_event;
 	_event_changed();
-	input_event->connect("changed", callable_mp(this, &InputEventConfigContainer::_event_changed));
+	input_event->connect_changed(callable_mp(this, &InputEventConfigContainer::_event_changed));
 }
 
 InputEventConfigContainer::InputEventConfigContainer() {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4929,7 +4929,7 @@ void Node3DEditorViewport::register_shortcut_action(const String &p_path, const 
 	Ref<Shortcut> sc = ED_SHORTCUT(p_path, p_name, p_keycode, p_physical);
 	shortcut_changed_callback(sc, p_path);
 	// Connect to the change event on the shortcut so the input binding can be updated.
-	sc->connect("changed", callable_mp(this, &Node3DEditorViewport::shortcut_changed_callback).bind(sc, p_path));
+	sc->connect_changed(callable_mp(this, &Node3DEditorViewport::shortcut_changed_callback).bind(sc, p_path));
 }
 
 // Update the action in the InputMap to the provided shortcut events.

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "polygon_3d_editor_plugin.h"
 
-#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/math/geometry_2d.h"
@@ -497,7 +496,7 @@ void Polygon3DEditor::edit(Node *p_node) {
 		node_resource = node->call("_get_editable_3d_polygon_resource");
 
 		if (node_resource.is_valid()) {
-			node_resource->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Polygon3DEditor::_polygon_draw));
+			node_resource->connect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
 		}
 		//Enable the pencil tool if the polygon is empty
 		if (_get_polygon().is_empty()) {
@@ -518,7 +517,7 @@ void Polygon3DEditor::edit(Node *p_node) {
 	} else {
 		node = nullptr;
 		if (node_resource.is_valid()) {
-			node_resource->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Polygon3DEditor::_polygon_draw));
+			node_resource->disconnect_changed(callable_mp(this, &Polygon3DEditor::_polygon_draw));
 		}
 		node_resource.unref();
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -222,7 +222,7 @@ void ShaderFileEditor::_bind_methods() {
 void ShaderFileEditor::edit(const Ref<RDShaderFile> &p_shader) {
 	if (p_shader.is_null()) {
 		if (shader_file.is_valid()) {
-			shader_file->disconnect("changed", callable_mp(this, &ShaderFileEditor::_shader_changed));
+			shader_file->disconnect_changed(callable_mp(this, &ShaderFileEditor::_shader_changed));
 		}
 		return;
 	}
@@ -234,7 +234,7 @@ void ShaderFileEditor::edit(const Ref<RDShaderFile> &p_shader) {
 	shader_file = p_shader;
 
 	if (shader_file.is_valid()) {
-		shader_file->connect("changed", callable_mp(this, &ShaderFileEditor::_shader_changed));
+		shader_file->connect_changed(callable_mp(this, &ShaderFileEditor::_shader_changed));
 	}
 
 	_update_options();

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -43,11 +43,11 @@ void StyleBoxPreview::_grid_preview_toggled(bool p_active) {
 
 void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 	if (stylebox.is_valid()) {
-		stylebox->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		stylebox->disconnect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	stylebox = p_stylebox;
 	if (stylebox.is_valid()) {
-		stylebox->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		stylebox->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	Ref<StyleBoxTexture> sbt = stylebox;
 	grid_preview->set_visible(sbt.is_valid());

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -122,7 +122,7 @@ void ShaderTextEditor::set_edited_shader(const Ref<Shader> &p_shader, const Stri
 		return;
 	}
 	if (shader.is_valid()) {
-		shader->disconnect(SNAME("changed"), callable_mp(this, &ShaderTextEditor::_shader_changed));
+		shader->disconnect_changed(callable_mp(this, &ShaderTextEditor::_shader_changed));
 	}
 	shader = p_shader;
 	shader_inc = Ref<ShaderInclude>();
@@ -130,7 +130,7 @@ void ShaderTextEditor::set_edited_shader(const Ref<Shader> &p_shader, const Stri
 	set_edited_code(p_code);
 
 	if (shader.is_valid()) {
-		shader->connect(SNAME("changed"), callable_mp(this, &ShaderTextEditor::_shader_changed));
+		shader->connect_changed(callable_mp(this, &ShaderTextEditor::_shader_changed));
 	}
 }
 
@@ -152,7 +152,7 @@ void ShaderTextEditor::set_edited_shader_include(const Ref<ShaderInclude> &p_sha
 		return;
 	}
 	if (shader_inc.is_valid()) {
-		shader_inc->disconnect(SNAME("changed"), callable_mp(this, &ShaderTextEditor::_shader_changed));
+		shader_inc->disconnect_changed(callable_mp(this, &ShaderTextEditor::_shader_changed));
 	}
 	shader_inc = p_shader_inc;
 	shader = Ref<Shader>();
@@ -160,7 +160,7 @@ void ShaderTextEditor::set_edited_shader_include(const Ref<ShaderInclude> &p_sha
 	set_edited_code(p_code);
 
 	if (shader_inc.is_valid()) {
-		shader_inc->connect(SNAME("changed"), callable_mp(this, &ShaderTextEditor::_shader_changed));
+		shader_inc->connect_changed(callable_mp(this, &ShaderTextEditor::_shader_changed));
 	}
 }
 

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -115,7 +115,7 @@ void Texture3DEditor::_texture_rect_update_area() {
 
 void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
 	if (!texture.is_null()) {
-		texture->disconnect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 
 	texture = p_texture;
@@ -125,7 +125,7 @@ void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
 			_make_shaders();
 		}
 
-		texture->connect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
+		texture->connect_changed(callable_mp(this, &Texture3DEditor::_texture_changed));
 		queue_redraw();
 		texture_rect->set_material(material);
 		setting = true;
@@ -176,7 +176,7 @@ Texture3DEditor::Texture3DEditor() {
 
 Texture3DEditor::~Texture3DEditor() {
 	if (!texture.is_null()) {
-		texture->disconnect("changed", callable_mp(this, &Texture3DEditor::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 }
 

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -140,7 +140,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		metadata_label = memnew(Label);
 
 		_update_metadata_label_text();
-		p_texture->connect("changed", callable_mp(this, &TexturePreview::_update_metadata_label_text));
+		p_texture->connect_changed(callable_mp(this, &TexturePreview::_update_metadata_label_text));
 
 		// It's okay that these colors are static since the grid color is static too.
 		metadata_label->add_theme_color_override("font_color", Color::named("white"));

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -181,7 +181,7 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 
 void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 	if (!texture.is_null()) {
-		texture->disconnect("changed", callable_mp(this, &TextureLayeredEditor::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &TextureLayeredEditor::_texture_changed));
 	}
 
 	texture = p_texture;
@@ -191,7 +191,7 @@ void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
 			_make_shaders();
 		}
 
-		texture->connect("changed", callable_mp(this, &TextureLayeredEditor::_texture_changed));
+		texture->connect_changed(callable_mp(this, &TextureLayeredEditor::_texture_changed));
 		queue_redraw();
 		texture_rect->set_material(materials[texture->get_layered_type()]);
 		setting = true;

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "texture_region_editor_plugin.h"
 
-#include "core/core_string_names.h"
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
@@ -433,7 +432,7 @@ void TextureRegionEditor::_region_input(const Ref<InputEvent> &p_input) {
 					} else if (obj_styleBox.is_valid()) {
 						undo_redo->add_do_method(obj_styleBox.ptr(), "set_texture_margin", side[edited_margin], obj_styleBox->get_texture_margin(side[edited_margin]));
 						undo_redo->add_undo_method(obj_styleBox.ptr(), "set_texture_margin", side[edited_margin], prev_margin);
-						obj_styleBox->emit_signal(CoreStringNames::get_singleton()->changed);
+						obj_styleBox->emit_changed();
 					}
 					edited_margin = -1;
 				} else {
@@ -913,10 +912,10 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		node_ninepatch->disconnect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (obj_styleBox.is_valid()) {
-		obj_styleBox->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		obj_styleBox->disconnect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 	if (atlas_tex.is_valid()) {
-		atlas_tex->disconnect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+		atlas_tex->disconnect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
 	}
 
 	node_sprite_2d = nullptr;
@@ -941,7 +940,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		}
 
 		if (is_resource) {
-			p_obj->connect("changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
+			Object::cast_to<Resource>(p_obj)->connect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
 		} else {
 			p_obj->connect("texture_changed", callable_mp(this, &TextureRegionEditor::_texture_changed));
 		}

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3151,7 +3151,7 @@ void ThemeTypeEditor::_stylebox_item_changed(Ref<StyleBox> p_value, String p_ite
 void ThemeTypeEditor::_change_pinned_stylebox() {
 	if (leading_stylebox.pinned) {
 		if (leading_stylebox.stylebox.is_valid()) {
-			leading_stylebox.stylebox->disconnect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+			leading_stylebox.stylebox->disconnect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 		}
 
 		Ref<StyleBox> new_stylebox = edited_theme->get_stylebox(leading_stylebox.item_name, edited_type);
@@ -3159,10 +3159,10 @@ void ThemeTypeEditor::_change_pinned_stylebox() {
 		leading_stylebox.ref_stylebox = (new_stylebox.is_valid() ? new_stylebox->duplicate() : Ref<Resource>());
 
 		if (leading_stylebox.stylebox.is_valid()) {
-			new_stylebox->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+			new_stylebox->connect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 		}
 	} else if (leading_stylebox.stylebox.is_valid()) {
-		leading_stylebox.stylebox->disconnect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+		leading_stylebox.stylebox->disconnect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 	}
 }
 
@@ -3187,7 +3187,7 @@ void ThemeTypeEditor::_on_pin_leader_button_pressed(Control *p_editor, String p_
 
 void ThemeTypeEditor::_pin_leading_stylebox(String p_item_name, Ref<StyleBox> p_stylebox) {
 	if (leading_stylebox.stylebox.is_valid()) {
-		leading_stylebox.stylebox->disconnect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+		leading_stylebox.stylebox->disconnect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 	}
 
 	LeadingStylebox leader;
@@ -3198,7 +3198,7 @@ void ThemeTypeEditor::_pin_leading_stylebox(String p_item_name, Ref<StyleBox> p_
 
 	leading_stylebox = leader;
 	if (p_stylebox.is_valid()) {
-		p_stylebox->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+		p_stylebox->connect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 	}
 
 	_update_type_items();
@@ -3214,7 +3214,7 @@ void ThemeTypeEditor::_on_unpin_leader_button_pressed() {
 
 void ThemeTypeEditor::_unpin_leading_stylebox() {
 	if (leading_stylebox.stylebox.is_valid()) {
-		leading_stylebox.stylebox->disconnect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
+		leading_stylebox.stylebox->disconnect_changed(callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
 	}
 
 	LeadingStylebox leader;
@@ -3337,12 +3337,12 @@ void ThemeTypeEditor::_bind_methods() {
 
 void ThemeTypeEditor::set_edited_theme(const Ref<Theme> &p_theme) {
 	if (edited_theme.is_valid()) {
-		edited_theme->disconnect("changed", callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
+		edited_theme->disconnect_changed(callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
 	}
 
 	edited_theme = p_theme;
 	if (edited_theme.is_valid()) {
-		edited_theme->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
+		edited_theme->connect_changed(callable_mp(this, &ThemeTypeEditor::_update_type_list_debounced));
 		_update_type_list();
 	}
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -88,11 +88,11 @@ void TileDataEditor::_bind_methods() {
 
 void TileDataEditor::set_tile_set(Ref<TileSet> p_tile_set) {
 	if (tile_set.is_valid()) {
-		tile_set->disconnect("changed", callable_mp(this, &TileDataEditor::_tile_set_changed_plan_update));
+		tile_set->disconnect_changed(callable_mp(this, &TileDataEditor::_tile_set_changed_plan_update));
 	}
 	tile_set = p_tile_set;
 	if (tile_set.is_valid()) {
-		tile_set->connect("changed", callable_mp(this, &TileDataEditor::_tile_set_changed_plan_update));
+		tile_set->connect_changed(callable_mp(this, &TileDataEditor::_tile_set_changed_plan_update));
 	}
 	_tile_set_changed_plan_update();
 }

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2104,7 +2104,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw() {
 void TileSetAtlasSourceEditor::_tile_set_changed() {
 	if (tile_set->get_source_count() == 0) {
 		// No sources, so nothing to do here anymore.
-		tile_set->disconnect("changed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
+		tile_set->disconnect_changed(callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
 		tile_set = Ref<TileSet>();
 		return;
 	}
@@ -2218,7 +2218,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 
 	// Remove listener for old objects.
 	if (tile_set.is_valid()) {
-		tile_set->disconnect("changed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
+		tile_set->disconnect_changed(callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
 	}
 
 	// Clear the selection.
@@ -2233,7 +2233,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 	read_only = new_read_only_state;
 
 	if (tile_set.is_valid()) {
-		tile_set->connect("changed", callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
+		tile_set->connect_changed(callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
 	}
 
 	if (read_only && tools_button_group->get_pressed_button() == tool_paint_button) {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -723,7 +723,7 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 
 	// Remove listener.
 	if (tile_set.is_valid()) {
-		tile_set->disconnect("changed", callable_mp(this, &TileSetEditor::_tile_set_changed));
+		tile_set->disconnect_changed(callable_mp(this, &TileSetEditor::_tile_set_changed));
 	}
 
 	// Change the edited object.
@@ -738,7 +738,7 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 		sources_advanced_menu_button->set_disabled(read_only);
 		source_sort_button->set_disabled(read_only);
 
-		tile_set->connect("changed", callable_mp(this, &TileSetEditor::_tile_set_changed));
+		tile_set->connect_changed(callable_mp(this, &TileSetEditor::_tile_set_changed));
 		if (first_edit) {
 			first_edit = false;
 			_set_source_sort(EditorSettings::get_singleton()->get_project_metadata("editor_metadata", "tile_source_sort", 0));

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -384,7 +384,7 @@ void TileSetScenesCollectionSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetS
 
 	// Remove listener for old objects.
 	if (tile_set_scenes_collection_source) {
-		tile_set_scenes_collection_source->disconnect("changed", callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
+		tile_set_scenes_collection_source->disconnect_changed(callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
 	}
 
 	// Change the edited object.
@@ -404,7 +404,7 @@ void TileSetScenesCollectionSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetS
 
 	// Add the listener again.
 	if (tile_set_scenes_collection_source) {
-		tile_set_scenes_collection_source->connect("changed", callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
+		tile_set_scenes_collection_source->connect_changed(callable_mp(this, &TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_changed));
 	}
 
 	// Update everything.

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -953,12 +953,12 @@ void CSGMesh3D::set_mesh(const Ref<Mesh> &p_mesh) {
 		return;
 	}
 	if (mesh.is_valid()) {
-		mesh->disconnect("changed", callable_mp(this, &CSGMesh3D::_mesh_changed));
+		mesh->disconnect_changed(callable_mp(this, &CSGMesh3D::_mesh_changed));
 	}
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
-		mesh->connect("changed", callable_mp(this, &CSGMesh3D::_mesh_changed));
+		mesh->connect_changed(callable_mp(this, &CSGMesh3D::_mesh_changed));
 	}
 
 	_mesh_changed();

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -138,11 +138,11 @@
 				Returns the position of a grid cell in the GridMap's local coordinate space. To convert the returned value into global coordinates, use [method Node3D.to_global]. See also [method map_to_local].
 			</description>
 		</method>
-		<method name="resource_changed">
+		<method name="resource_changed" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="resource" type="Resource" />
 			<description>
-				Notifies the [GridMap] about changed resource and recreates octant data.
+				[i]Obsoleted.[/i] Use [signal Resource.changed] instead.
 			</description>
 		</method>
 		<method name="set_cell_item">

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -203,7 +203,9 @@ class GridMap : public Node3D {
 	void _queue_octants_dirty();
 	void _update_octants_callback();
 
+#ifndef DISABLE_DEPRECATED
 	void resource_changed(const Ref<Resource> &p_res);
+#endif
 
 	void _clear_internal();
 

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -32,8 +32,6 @@
 
 #include "noise.h"
 
-#include "core/core_string_names.h"
-
 NoiseTexture2D::NoiseTexture2D() {
 	noise = Ref<Noise>();
 
@@ -223,11 +221,11 @@ void NoiseTexture2D::set_noise(Ref<Noise> p_noise) {
 		return;
 	}
 	if (noise.is_valid()) {
-		noise->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture2D::_queue_update));
+		noise->disconnect_changed(callable_mp(this, &NoiseTexture2D::_queue_update));
 	}
 	noise = p_noise;
 	if (noise.is_valid()) {
-		noise->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture2D::_queue_update));
+		noise->connect_changed(callable_mp(this, &NoiseTexture2D::_queue_update));
 	}
 	_queue_update();
 }
@@ -347,11 +345,11 @@ void NoiseTexture2D::set_color_ramp(const Ref<Gradient> &p_gradient) {
 		return;
 	}
 	if (color_ramp.is_valid()) {
-		color_ramp->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture2D::_queue_update));
+		color_ramp->disconnect_changed(callable_mp(this, &NoiseTexture2D::_queue_update));
 	}
 	color_ramp = p_gradient;
 	if (color_ramp.is_valid()) {
-		color_ramp->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture2D::_queue_update));
+		color_ramp->connect_changed(callable_mp(this, &NoiseTexture2D::_queue_update));
 	}
 	_queue_update();
 }

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -32,8 +32,6 @@
 
 #include "noise.h"
 
-#include "core/core_string_names.h"
-
 NoiseTexture3D::NoiseTexture3D() {
 	noise = Ref<Noise>();
 
@@ -214,11 +212,11 @@ void NoiseTexture3D::set_noise(Ref<Noise> p_noise) {
 		return;
 	}
 	if (noise.is_valid()) {
-		noise->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture3D::_queue_update));
+		noise->disconnect_changed(callable_mp(this, &NoiseTexture3D::_queue_update));
 	}
 	noise = p_noise;
 	if (noise.is_valid()) {
-		noise->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture3D::_queue_update));
+		noise->connect_changed(callable_mp(this, &NoiseTexture3D::_queue_update));
 	}
 	_queue_update();
 }
@@ -297,11 +295,11 @@ void NoiseTexture3D::set_color_ramp(const Ref<Gradient> &p_gradient) {
 		return;
 	}
 	if (color_ramp.is_valid()) {
-		color_ramp->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture3D::_queue_update));
+		color_ramp->disconnect_changed(callable_mp(this, &NoiseTexture3D::_queue_update));
 	}
 	color_ramp = p_gradient;
 	if (color_ramp.is_valid()) {
-		color_ramp->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NoiseTexture3D::_queue_update));
+		color_ramp->connect_changed(callable_mp(this, &NoiseTexture3D::_queue_update));
 	}
 	_queue_update();
 }

--- a/modules/noise/tests/test_noise_texture_2d.h
+++ b/modules/noise/tests/test_noise_texture_2d.h
@@ -210,7 +210,7 @@ TEST_CASE("[NoiseTexture2D][SceneTree] Generating a basic noise texture with mip
 	noise_texture->set_generate_mipmaps(true);
 
 	Ref<NoiseTextureTester> tester = memnew(NoiseTextureTester(noise_texture.ptr()));
-	noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTextureTester::check_mip_and_color_ramp));
+	noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTextureTester::check_mip_and_color_ramp));
 	MessageQueue::get_singleton()->flush();
 }
 
@@ -227,7 +227,7 @@ TEST_CASE("[NoiseTexture2D][SceneTree] Generating a normal map without mipmaps")
 	noise_texture->set_generate_mipmaps(false);
 
 	Ref<NoiseTextureTester> tester = memnew(NoiseTextureTester(noise_texture.ptr()));
-	noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTextureTester::check_normal_map));
+	noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTextureTester::check_normal_map));
 	MessageQueue::get_singleton()->flush();
 }
 
@@ -245,7 +245,7 @@ TEST_CASE("[NoiseTexture2D][SceneTree] Generating a seamless noise texture") {
 
 	SUBCASE("Grayscale(L8) 16x16, with seamless blend skirt of 0.05") {
 		noise_texture->set_seamless_blend_skirt(0.05);
-		noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTextureTester::check_seamless_texture_grayscale));
+		noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTextureTester::check_seamless_texture_grayscale));
 		MessageQueue::get_singleton()->flush();
 	}
 
@@ -257,7 +257,7 @@ TEST_CASE("[NoiseTexture2D][SceneTree] Generating a seamless noise texture") {
 		gradient->set_points(points);
 		noise_texture->set_color_ramp(gradient);
 		noise_texture->set_seamless_blend_skirt(1.0);
-		noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTextureTester::check_seamless_texture_rgba));
+		noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTextureTester::check_seamless_texture_rgba));
 		MessageQueue::get_singleton()->flush();
 	}
 }

--- a/modules/noise/tests/test_noise_texture_3d.h
+++ b/modules/noise/tests/test_noise_texture_3d.h
@@ -194,7 +194,7 @@ TEST_CASE("[NoiseTexture3D][SceneTree] Generating a basic noise texture with mip
 	noise_texture->set_depth(16);
 
 	Ref<NoiseTexture3DTester> tester = memnew(NoiseTexture3DTester(noise_texture.ptr()));
-	noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTexture3DTester::check_mip_and_color_ramp));
+	noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTexture3DTester::check_mip_and_color_ramp));
 	MessageQueue::get_singleton()->flush();
 }
 
@@ -213,7 +213,7 @@ TEST_CASE("[NoiseTexture3D][SceneTree] Generating a seamless noise texture") {
 
 	SUBCASE("Grayscale(L8) 16x16x16, with seamless blend skirt of 0.05") {
 		noise_texture->set_seamless_blend_skirt(0.05);
-		noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTexture3DTester::check_seamless_texture_grayscale));
+		noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTexture3DTester::check_seamless_texture_grayscale));
 		MessageQueue::get_singleton()->flush();
 	}
 
@@ -225,7 +225,7 @@ TEST_CASE("[NoiseTexture3D][SceneTree] Generating a seamless noise texture") {
 		gradient->set_points(points);
 		noise_texture->set_color_ramp(gradient);
 		noise_texture->set_seamless_blend_skirt(1.0);
-		noise_texture->connect("changed", callable_mp(tester.ptr(), &NoiseTexture3DTester::check_seamless_texture_rgba));
+		noise_texture->connect_changed(callable_mp(tester.ptr(), &NoiseTexture3DTester::check_seamless_texture_rgba));
 		MessageQueue::get_singleton()->flush();
 	}
 }

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -142,7 +142,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 		return;
 	}
 	if (shape.is_valid()) {
-		shape->disconnect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
+		shape->disconnect_changed(callable_mp(this, &CollisionShape2D::_shape_changed));
 	}
 	shape = p_shape;
 	queue_redraw();
@@ -155,7 +155,7 @@ void CollisionShape2D::set_shape(const Ref<Shape2D> &p_shape) {
 	}
 
 	if (shape.is_valid()) {
-		shape->connect("changed", callable_mp(this, &CollisionShape2D::_shape_changed));
+		shape->connect_changed(callable_mp(this, &CollisionShape2D::_shape_changed));
 	}
 
 	update_configuration_warnings();

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "cpu_particles_2d.h"
 
-#include "core/core_string_names.h"
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/curve_texture.h"
@@ -207,13 +206,13 @@ void CPUParticles2D::set_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CPUParticles2D::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &CPUParticles2D::_texture_changed));
 	}
 
 	texture = p_texture;
 
 	if (texture.is_valid()) {
-		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CPUParticles2D::_texture_changed));
+		texture->connect_changed(callable_mp(this, &CPUParticles2D::_texture_changed));
 	}
 
 	queue_redraw();

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "gpu_particles_2d.h"
 
-#include "core/core_string_names.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/particle_process_material.h"
 #include "scene/scene_string_names.h"
@@ -357,13 +356,13 @@ Rect2 GPUParticles2D::capture_rect() const {
 
 void GPUParticles2D::set_texture(const Ref<Texture2D> &p_texture) {
 	if (texture.is_valid()) {
-		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GPUParticles2D::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &GPUParticles2D::_texture_changed));
 	}
 
 	texture = p_texture;
 
 	if (texture.is_valid()) {
-		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GPUParticles2D::_texture_changed));
+		texture->connect_changed(callable_mp(this, &GPUParticles2D::_texture_changed));
 	}
 	_update_collision_size();
 	queue_redraw();

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -215,7 +215,7 @@ bool LightOccluder2D::_edit_is_selected_on_click(const Point2 &p_point, double p
 void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polygon) {
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid()) {
-		occluder_polygon->disconnect("changed", callable_mp(this, &LightOccluder2D::_poly_changed));
+		occluder_polygon->disconnect_changed(callable_mp(this, &LightOccluder2D::_poly_changed));
 	}
 #endif
 	occluder_polygon = p_polygon;
@@ -228,7 +228,7 @@ void LightOccluder2D::set_occluder_polygon(const Ref<OccluderPolygon2D> &p_polyg
 
 #ifdef DEBUG_ENABLED
 	if (occluder_polygon.is_valid()) {
-		occluder_polygon->connect("changed", callable_mp(this, &LightOccluder2D::_poly_changed));
+		occluder_polygon->connect_changed(callable_mp(this, &LightOccluder2D::_poly_changed));
 	}
 	queue_redraw();
 #endif

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "line_2d.h"
 
-#include "core/core_string_names.h"
 #include "core/math/geometry_2d.h"
 #include "line_builder.h"
 
@@ -89,14 +88,14 @@ float Line2D::get_width() const {
 void Line2D::set_curve(const Ref<Curve> &p_curve) {
 	// Cleanup previous connection if any
 	if (_curve.is_valid()) {
-		_curve->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_curve_changed));
+		_curve->disconnect_changed(callable_mp(this, &Line2D::_curve_changed));
 	}
 
 	_curve = p_curve;
 
 	// Connect to the curve so the line will update when it is changed
 	if (_curve.is_valid()) {
-		_curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_curve_changed));
+		_curve->connect_changed(callable_mp(this, &Line2D::_curve_changed));
 	}
 
 	queue_redraw();
@@ -159,14 +158,14 @@ Color Line2D::get_default_color() const {
 void Line2D::set_gradient(const Ref<Gradient> &p_gradient) {
 	// Cleanup previous connection if any
 	if (_gradient.is_valid()) {
-		_gradient->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
+		_gradient->disconnect_changed(callable_mp(this, &Line2D::_gradient_changed));
 	}
 
 	_gradient = p_gradient;
 
 	// Connect to the gradient so the line will update when the Gradient is changed
 	if (_gradient.is_valid()) {
-		_gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Line2D::_gradient_changed));
+		_gradient->connect_changed(callable_mp(this, &Line2D::_gradient_changed));
 	}
 
 	queue_redraw();

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "multimesh_instance_2d.h"
 
-#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
@@ -59,13 +58,13 @@ void MultiMeshInstance2D::_bind_methods() {
 void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	// Cleanup previous connection if any.
 	if (multimesh.is_valid()) {
-		multimesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		multimesh->disconnect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	multimesh = p_multimesh;
 
 	// Connect to the multimesh so the AABB can update when instance transforms are changed.
 	if (multimesh.is_valid()) {
-		multimesh->connect(CoreStringNames::get_singleton()->changed, callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		multimesh->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	queue_redraw();
 }

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "navigation_region_2d.h"
 
-#include "core/core_string_names.h"
 #include "core/math/geometry_2d.h"
 #include "scene/2d/navigation_obstacle_2d.h"
 #include "scene/resources/world_2d.h"
@@ -193,14 +192,14 @@ void NavigationRegion2D::set_navigation_polygon(const Ref<NavigationPolygon> &p_
 	}
 
 	if (navigation_polygon.is_valid()) {
-		navigation_polygon->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationRegion2D::_navigation_polygon_changed));
+		navigation_polygon->disconnect_changed(callable_mp(this, &NavigationRegion2D::_navigation_polygon_changed));
 	}
 
 	navigation_polygon = p_navigation_polygon;
 	NavigationServer2D::get_singleton()->region_set_navigation_polygon(region, p_navigation_polygon);
 
 	if (navigation_polygon.is_valid()) {
-		navigation_polygon->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationRegion2D::_navigation_polygon_changed));
+		navigation_polygon->connect_changed(callable_mp(this, &NavigationRegion2D::_navigation_polygon_changed));
 	}
 	_navigation_polygon_changed();
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -182,13 +182,13 @@ void Path2D::_curve_changed() {
 
 void Path2D::set_curve(const Ref<Curve2D> &p_curve) {
 	if (curve.is_valid()) {
-		curve->disconnect("changed", callable_mp(this, &Path2D::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &Path2D::_curve_changed));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect("changed", callable_mp(this, &Path2D::_curve_changed));
+		curve->connect_changed(callable_mp(this, &Path2D::_curve_changed));
 	}
 
 	_curve_changed();

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "physics_body_2d.h"
 
-#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
 void PhysicsBody2D::_bind_methods() {
@@ -195,15 +194,13 @@ real_t StaticBody2D::get_constant_angular_velocity() const {
 
 void StaticBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics))) {
-			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
-		}
+		physics_material_override->disconnect_changed(callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
+		physics_material_override->connect_changed(callable_mp(this, &StaticBody2D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -651,15 +648,13 @@ const Vector2 &RigidBody2D::get_center_of_mass() const {
 
 void RigidBody2D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics))) {
-			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
-		}
+		physics_material_override->disconnect_changed(callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
+		physics_material_override->connect_changed(callable_mp(this, &RigidBody2D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -31,7 +31,6 @@
 #include "shape_cast_2d.h"
 
 #include "core/config/engine.h"
-#include "core/core_string_names.h"
 #include "scene/2d/collision_object_2d.h"
 #include "scene/2d/physics_body_2d.h"
 #include "scene/resources/circle_shape_2d.h"
@@ -155,11 +154,11 @@ void ShapeCast2D::set_shape(const Ref<Shape2D> &p_shape) {
 		return;
 	}
 	if (shape.is_valid()) {
-		shape->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast2D::_shape_changed));
+		shape->disconnect_changed(callable_mp(this, &ShapeCast2D::_shape_changed));
 	}
 	shape = p_shape;
 	if (shape.is_valid()) {
-		shape->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast2D::_shape_changed));
+		shape->connect_changed(callable_mp(this, &ShapeCast2D::_shape_changed));
 		shape_rid = shape->get_rid();
 	}
 

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -30,7 +30,6 @@
 
 #include "sprite_2d.h"
 
-#include "core/core_string_names.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"
 
@@ -137,13 +136,13 @@ void Sprite2D::set_texture(const Ref<Texture2D> &p_texture) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite2D::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &Sprite2D::_texture_changed));
 	}
 
 	texture = p_texture;
 
 	if (texture.is_valid()) {
-		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Sprite2D::_texture_changed));
+		texture->connect_changed(callable_mp(this, &Sprite2D::_texture_changed));
 	}
 
 	queue_redraw();

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -524,7 +524,7 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 
 	// Set the tileset, registering to its changes.
 	if (tile_set.is_valid()) {
-		tile_set->disconnect("changed", callable_mp(this, &TileMap::_tile_set_changed));
+		tile_set->disconnect_changed(callable_mp(this, &TileMap::_tile_set_changed));
 	}
 
 	if (!p_tileset.is_valid()) {
@@ -534,7 +534,7 @@ void TileMap::set_tileset(const Ref<TileSet> &p_tileset) {
 	tile_set = p_tileset;
 
 	if (tile_set.is_valid()) {
-		tile_set->connect("changed", callable_mp(this, &TileMap::_tile_set_changed));
+		tile_set->connect_changed(callable_mp(this, &TileMap::_tile_set_changed));
 		_clear_internals();
 		_recreate_internals();
 	}
@@ -4250,7 +4250,7 @@ TileMap::TileMap() {
 
 TileMap::~TileMap() {
 	if (tile_set.is_valid()) {
-		tile_set->disconnect("changed", callable_mp(this, &TileMap::_tile_set_changed));
+		tile_set->disconnect_changed(callable_mp(this, &TileMap::_tile_set_changed));
 	}
 
 	_clear_internals();

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -82,11 +82,11 @@ void TouchScreenButton::set_shape(const Ref<Shape2D> &p_shape) {
 		return;
 	}
 	if (shape.is_valid()) {
-		shape->disconnect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		shape->disconnect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	shape = p_shape;
 	if (shape.is_valid()) {
-		shape->connect("changed", callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		shape->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 	queue_redraw();
 }

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -31,7 +31,6 @@
 #include "camera_3d.h"
 
 #include "collision_object_3d.h"
-#include "core/core_string_names.h"
 #include "core/math/projection.h"
 #include "scene/main/viewport.h"
 
@@ -430,7 +429,7 @@ void Camera3D::set_attributes(const Ref<CameraAttributes> &p_attributes) {
 	if (attributes.is_valid()) {
 		CameraAttributesPhysical *physical_attributes = Object::cast_to<CameraAttributesPhysical>(attributes.ptr());
 		if (physical_attributes) {
-			attributes->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Camera3D::_attributes_changed));
+			attributes->disconnect_changed(callable_mp(this, &Camera3D::_attributes_changed));
 		}
 	}
 
@@ -439,7 +438,7 @@ void Camera3D::set_attributes(const Ref<CameraAttributes> &p_attributes) {
 	if (attributes.is_valid()) {
 		CameraAttributesPhysical *physical_attributes = Object::cast_to<CameraAttributesPhysical>(attributes.ptr());
 		if (physical_attributes) {
-			attributes->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Camera3D::_attributes_changed));
+			attributes->connect_changed(callable_mp(this, &Camera3D::_attributes_changed));
 			_attributes_changed();
 		}
 

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -394,11 +394,7 @@ void CollisionObject3D::_update_debug_shapes() {
 				if (s.debug_shape.is_null()) {
 					s.debug_shape = RS::get_singleton()->instance_create();
 					RS::get_singleton()->instance_set_scenario(s.debug_shape, get_world_3d()->get_scenario());
-
-					if (!s.shape->is_connected("changed", callable_mp(this, &CollisionObject3D::_shape_changed))) {
-						s.shape->connect("changed", callable_mp(this, &CollisionObject3D::_shape_changed).bind(s.shape), CONNECT_DEFERRED);
-					}
-
+					s.shape->connect_changed(callable_mp(this, &CollisionObject3D::_shape_changed).bind(s.shape), CONNECT_DEFERRED);
 					++debug_shapes_count;
 				}
 
@@ -422,8 +418,8 @@ void CollisionObject3D::_clear_debug_shapes() {
 			if (s.debug_shape.is_valid()) {
 				RS::get_singleton()->free(s.debug_shape);
 				s.debug_shape = RID();
-				if (s.shape.is_valid() && s.shape->is_connected("changed", callable_mp(this, &CollisionObject3D::_update_shape_data))) {
-					s.shape->disconnect("changed", callable_mp(this, &CollisionObject3D::_update_shape_data));
+				if (s.shape.is_valid()) {
+					s.shape->disconnect_changed(callable_mp(this, &CollisionObject3D::_update_shape_data));
 				}
 			}
 		}
@@ -663,8 +659,8 @@ void CollisionObject3D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 
 	if (s.debug_shape.is_valid()) {
 		RS::get_singleton()->free(s.debug_shape);
-		if (s.shape.is_valid() && s.shape->is_connected("changed", callable_mp(this, &CollisionObject3D::_shape_changed))) {
-			s.shape->disconnect("changed", callable_mp(this, &CollisionObject3D::_shape_changed));
+		if (s.shape.is_valid()) {
+			s.shape->disconnect_changed(callable_mp(this, &CollisionObject3D::_shape_changed));
 		}
 		--debug_shapes_count;
 	}

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -112,9 +112,10 @@ void CollisionShape3D::_notification(int p_what) {
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
 void CollisionShape3D::resource_changed(Ref<Resource> res) {
-	update_gizmos();
 }
+#endif
 
 PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
@@ -145,8 +146,9 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 }
 
 void CollisionShape3D::_bind_methods() {
-	//not sure if this should do anything
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &CollisionShape3D::resource_changed);
+#endif
 	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &CollisionShape3D::set_shape);
 	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape3D::get_shape);
 	ClassDB::bind_method(D_METHOD("set_disabled", "enable"), &CollisionShape3D::set_disabled);
@@ -162,12 +164,12 @@ void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
 	if (p_shape == shape) {
 		return;
 	}
-	if (!shape.is_null()) {
-		shape->unregister_owner(this);
+	if (shape.is_valid()) {
+		shape->disconnect_changed(callable_mp((Node3D *)this, &Node3D::update_gizmos));
 	}
 	shape = p_shape;
-	if (!shape.is_null()) {
-		shape->register_owner(this);
+	if (shape.is_valid()) {
+		shape->connect_changed(callable_mp((Node3D *)this, &Node3D::update_gizmos));
 	}
 	update_gizmos();
 	if (collision_object) {
@@ -206,8 +208,5 @@ CollisionShape3D::CollisionShape3D() {
 }
 
 CollisionShape3D::~CollisionShape3D() {
-	if (!shape.is_null()) {
-		shape->unregister_owner(this);
-	}
 	//RenderingServer::get_singleton()->free(indicator);
 }

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -43,7 +43,9 @@ class CollisionShape3D : public Node3D {
 	uint32_t owner_id = 0;
 	CollisionObject3D *collision_object = nullptr;
 
+#ifndef DISABLE_DEPRECATED
 	void resource_changed(Ref<Resource> res);
+#endif
 	bool disabled = false;
 
 protected:

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -234,13 +234,13 @@ void GPUParticles3D::set_draw_pass_mesh(int p_pass, const Ref<Mesh> &p_mesh) {
 	ERR_FAIL_INDEX(p_pass, draw_passes.size());
 
 	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
-		draw_passes.write[p_pass]->disconnect("changed", callable_mp((Node *)this, &Node::update_configuration_warnings));
+		draw_passes.write[p_pass]->disconnect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings));
 	}
 
 	draw_passes.write[p_pass] = p_mesh;
 
 	if (Engine::get_singleton()->is_editor_hint() && draw_passes.write[p_pass].is_valid()) {
-		draw_passes.write[p_pass]->connect("changed", callable_mp((Node *)this, &Node::update_configuration_warnings), CONNECT_DEFERRED);
+		draw_passes.write[p_pass]->connect_changed(callable_mp((Node *)this, &Node::update_configuration_warnings), CONNECT_DEFERRED);
 	}
 
 	RID mesh_rid;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -30,7 +30,6 @@
 
 #include "label_3d.h"
 
-#include "core/core_string_names.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/theme.h"
 #include "scene/scene_string_names.h"
@@ -762,12 +761,12 @@ void Label3D::_font_changed() {
 void Label3D::set_font(const Ref<Font> &p_font) {
 	if (font_override != p_font) {
 		if (font_override.is_valid()) {
-			font_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Label3D::_font_changed));
+			font_override->disconnect_changed(callable_mp(this, &Label3D::_font_changed));
 		}
 		font_override = p_font;
 		dirty_font = true;
 		if (font_override.is_valid()) {
-			font_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Label3D::_font_changed));
+			font_override->connect_changed(callable_mp(this, &Label3D::_font_changed));
 		}
 		_queue_update();
 	}
@@ -779,7 +778,7 @@ Ref<Font> Label3D::get_font() const {
 
 Ref<Font> Label3D::_get_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
+		theme_font->disconnect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
 		theme_font.unref();
 	}
 
@@ -797,7 +796,7 @@ Ref<Font> Label3D::_get_font_or_default() const {
 				Ref<Font> f = ThemeDB::get_singleton()->get_project_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
+					theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
 				}
 				return f;
 			}
@@ -814,7 +813,7 @@ Ref<Font> Label3D::_get_font_or_default() const {
 				Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
+					theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
 				}
 				return f;
 			}
@@ -825,7 +824,7 @@ Ref<Font> Label3D::_get_font_or_default() const {
 	Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
 	if (f.is_valid()) {
 		theme_font = f;
-		theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
+		theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
 	}
 	return f;
 }

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -31,7 +31,6 @@
 #include "mesh_instance_3d.h"
 
 #include "collision_shape_3d.h"
-#include "core/core_string_names.h"
 #include "physics_body_3d.h"
 #include "scene/resources/concave_polygon_shape_3d.h"
 #include "scene/resources/convex_polygon_shape_3d.h"
@@ -111,7 +110,7 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 	}
 
 	if (mesh.is_valid()) {
-		mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
+		mesh->disconnect_changed(callable_mp(this, &MeshInstance3D::_mesh_changed));
 	}
 
 	mesh = p_mesh;
@@ -120,7 +119,7 @@ void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 		// If mesh is a PrimitiveMesh, calling get_rid on it can trigger a changed callback
 		// so do this before connecting _mesh_changed.
 		set_base(mesh->get_rid());
-		mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &MeshInstance3D::_mesh_changed));
+		mesh->connect_changed(callable_mp(this, &MeshInstance3D::_mesh_changed));
 		_mesh_changed();
 	} else {
 		blend_shape_tracks.clear();

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -30,7 +30,6 @@
 
 #include "navigation_region_3d.h"
 
-#include "core/core_string_names.h"
 #include "scene/resources/navigation_mesh_source_geometry_data_3d.h"
 #include "servers/navigation_server_3d.h"
 
@@ -193,13 +192,13 @@ void NavigationRegion3D::set_navigation_mesh(const Ref<NavigationMesh> &p_naviga
 	}
 
 	if (navigation_mesh.is_valid()) {
-		navigation_mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
+		navigation_mesh->disconnect_changed(callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
 	}
 
 	navigation_mesh = p_navigation_mesh;
 
 	if (navigation_mesh.is_valid()) {
-		navigation_mesh->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
+		navigation_mesh->connect_changed(callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
 	}
 
 	NavigationServer3D::get_singleton()->region_set_navigation_mesh(region, p_navigation_mesh);
@@ -462,7 +461,7 @@ NavigationRegion3D::~NavigationRegion3D() {
 	}
 
 	if (navigation_mesh.is_valid()) {
-		navigation_mesh->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
+		navigation_mesh->disconnect_changed(callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
 	}
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 	NavigationServer3D::get_singleton()->free(region);

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -31,7 +31,6 @@
 #include "occluder_instance_3d.h"
 
 #include "core/config/project_settings.h"
-#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/math/triangulate.h"
@@ -441,14 +440,14 @@ void OccluderInstance3D::set_occluder(const Ref<Occluder3D> &p_occluder) {
 	}
 
 	if (occluder.is_valid()) {
-		occluder->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &OccluderInstance3D::_occluder_changed));
+		occluder->disconnect_changed(callable_mp(this, &OccluderInstance3D::_occluder_changed));
 	}
 
 	occluder = p_occluder;
 
 	if (occluder.is_valid()) {
 		set_base(occluder->get_rid());
-		occluder->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &OccluderInstance3D::_occluder_changed));
+		occluder->connect_changed(callable_mp(this, &OccluderInstance3D::_occluder_changed));
 	} else {
 		set_base(RID());
 	}

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -144,13 +144,13 @@ void Path3D::_curve_changed() {
 
 void Path3D::set_curve(const Ref<Curve3D> &p_curve) {
 	if (curve.is_valid()) {
-		curve->disconnect("changed", callable_mp(this, &Path3D::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &Path3D::_curve_changed));
 	}
 
 	curve = p_curve;
 
 	if (curve.is_valid()) {
-		curve->connect("changed", callable_mp(this, &Path3D::_curve_changed));
+		curve->connect_changed(callable_mp(this, &Path3D::_curve_changed));
 	}
 	_curve_changed();
 }

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -30,7 +30,6 @@
 
 #include "physics_body_3d.h"
 
-#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 
 void PhysicsBody3D::_bind_methods() {
@@ -214,15 +213,13 @@ real_t PhysicsBody3D::get_inverse_mass() const {
 
 void StaticBody3D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody3D::_reload_physics_characteristics))) {
-			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody3D::_reload_physics_characteristics));
-		}
+		physics_material_override->disconnect_changed(callable_mp(this, &StaticBody3D::_reload_physics_characteristics));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &StaticBody3D::_reload_physics_characteristics));
+		physics_material_override->connect_changed(callable_mp(this, &StaticBody3D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }
@@ -726,15 +723,13 @@ const Vector3 &RigidBody3D::get_center_of_mass() const {
 
 void RigidBody3D::set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override) {
 	if (physics_material_override.is_valid()) {
-		if (physics_material_override->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody3D::_reload_physics_characteristics))) {
-			physics_material_override->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody3D::_reload_physics_characteristics));
-		}
+		physics_material_override->disconnect_changed(callable_mp(this, &RigidBody3D::_reload_physics_characteristics));
 	}
 
 	physics_material_override = p_physics_material_override;
 
 	if (physics_material_override.is_valid()) {
-		physics_material_override->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &RigidBody3D::_reload_physics_characteristics));
+		physics_material_override->connect_changed(callable_mp(this, &RigidBody3D::_reload_physics_characteristics));
 	}
 	_reload_physics_characteristics();
 }

--- a/scene/3d/shape_cast_3d.cpp
+++ b/scene/3d/shape_cast_3d.cpp
@@ -30,7 +30,6 @@
 
 #include "shape_cast_3d.h"
 
-#include "core/core_string_names.h"
 #include "scene/3d/collision_object_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/resources/concave_polygon_shape_3d.h"
@@ -93,7 +92,9 @@ void ShapeCast3D::_notification(int p_what) {
 }
 
 void ShapeCast3D::_bind_methods() {
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("resource_changed", "resource"), &ShapeCast3D::resource_changed);
+#endif
 
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &ShapeCast3D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &ShapeCast3D::is_enabled);
@@ -312,12 +313,10 @@ real_t ShapeCast3D::get_closest_collision_unsafe_fraction() const {
 	return collision_unsafe_fraction;
 }
 
+#ifndef DISABLE_DEPRECATED
 void ShapeCast3D::resource_changed(Ref<Resource> p_res) {
-	if (is_inside_tree() && get_tree()->is_debugging_collisions_hint()) {
-		_update_debug_shape();
-	}
-	update_gizmos();
 }
+#endif
 
 void ShapeCast3D::_shape_changed() {
 	update_gizmos();
@@ -332,13 +331,11 @@ void ShapeCast3D::set_shape(const Ref<Shape3D> &p_shape) {
 		return;
 	}
 	if (shape.is_valid()) {
-		shape->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast3D::_shape_changed));
-		shape->unregister_owner(this);
+		shape->disconnect_changed(callable_mp(this, &ShapeCast3D::_shape_changed));
 	}
 	shape = p_shape;
 	if (shape.is_valid()) {
-		shape->register_owner(this);
-		shape->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &ShapeCast3D::_shape_changed));
+		shape->connect_changed(callable_mp(this, &ShapeCast3D::_shape_changed));
 		shape_rid = shape->get_rid();
 	}
 
@@ -632,10 +629,4 @@ void ShapeCast3D::_clear_debug_shape() {
 	}
 
 	debug_shape = nullptr;
-}
-
-ShapeCast3D::~ShapeCast3D() {
-	if (!shape.is_null()) {
-		shape->unregister_owner(this);
-	}
 }

--- a/scene/3d/shape_cast_3d.h
+++ b/scene/3d/shape_cast_3d.h
@@ -40,7 +40,9 @@ class ShapeCast3D : public Node3D {
 	GDCLASS(ShapeCast3D, Node3D);
 
 	bool enabled = true;
+#ifndef DISABLE_DEPRECATED
 	void resource_changed(Ref<Resource> p_res);
+#endif
 
 	Ref<Shape3D> shape;
 	RID shape_rid;
@@ -73,8 +75,6 @@ class ShapeCast3D : public Node3D {
 	real_t collision_unsafe_fraction = 1.0;
 
 	Array _get_collision_result() const;
-
-	~ShapeCast3D();
 
 protected:
 	void _notification(int p_what);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -887,7 +887,7 @@ Ref<SkinReference> Skeleton3D::register_skin(const Ref<Skin> &p_skin) {
 
 	skin_bindings.insert(skin_ref.operator->());
 
-	skin_ref->skin->connect("changed", callable_mp(skin_ref.operator->(), &SkinReference::_skin_changed));
+	skin_ref->skin->connect_changed(callable_mp(skin_ref.operator->(), &SkinReference::_skin_changed));
 
 	_make_dirty(); // Skin needs to be updated, so update skeleton.
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1142,7 +1142,7 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	p_node->connect("tree_changed", callable_mp(this, &AnimationNodeBlendTree::_tree_changed), CONNECT_REFERENCE_COUNTED);
 	p_node->connect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendTree::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
 	p_node->connect("animation_node_removed", callable_mp(this, &AnimationNodeBlendTree::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
-	p_node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_name), CONNECT_REFERENCE_COUNTED);
+	p_node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_name), CONNECT_REFERENCE_COUNTED);
 }
 
 Ref<AnimationNode> AnimationNodeBlendTree::get_node(const StringName &p_name) const {
@@ -1206,7 +1206,7 @@ void AnimationNodeBlendTree::remove_node(const StringName &p_name) {
 		node->disconnect("tree_changed", callable_mp(this, &AnimationNodeBlendTree::_tree_changed));
 		node->disconnect("animation_node_renamed", callable_mp(this, &AnimationNodeBlendTree::_animation_node_renamed));
 		node->disconnect("animation_node_removed", callable_mp(this, &AnimationNodeBlendTree::_animation_node_removed));
-		node->disconnect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed));
+		node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 	}
 
 	nodes.erase(p_name);
@@ -1231,7 +1231,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	ERR_FAIL_COND(p_name == SceneStringNames::get_singleton()->output);
 	ERR_FAIL_COND(p_new_name == SceneStringNames::get_singleton()->output);
 
-	nodes[p_name].node->disconnect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed));
+	nodes[p_name].node->disconnect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 
 	nodes[p_new_name] = nodes[p_name];
 	nodes.erase(p_name);
@@ -1245,7 +1245,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 		}
 	}
 	// Connection must be done with new name.
-	nodes[p_new_name].node->connect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_new_name), CONNECT_REFERENCE_COUNTED);
+	nodes[p_new_name].node->connect_changed(callable_mp(this, &AnimationNodeBlendTree::_node_changed).bind(p_new_name), CONNECT_REFERENCE_COUNTED);
 
 	emit_signal(SNAME("animation_node_renamed"), get_instance_id(), p_name, p_new_name);
 	emit_signal(SNAME("tree_changed"));

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -30,7 +30,6 @@
 
 #include "button.h"
 
-#include "core/core_string_names.h"
 #include "core/string/translation.h"
 #include "servers/rendering_server.h"
 
@@ -540,13 +539,13 @@ void Button::set_icon(const Ref<Texture2D> &p_icon) {
 	}
 
 	if (icon.is_valid()) {
-		icon->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Button::_texture_changed));
+		icon->disconnect_changed(callable_mp(this, &Button::_texture_changed));
 	}
 
 	icon = p_icon;
 
 	if (icon.is_valid()) {
-		icon->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Button::_texture_changed));
+		icon->connect_changed(callable_mp(this, &Button::_texture_changed));
 	}
 
 	queue_redraw();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -271,21 +271,21 @@ bool Control::_set(const StringName &p_name, const Variant &p_value) {
 		if (name.begins_with("theme_override_icons/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.theme_icon_override.has(dname)) {
-				data.theme_icon_override[dname]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+				data.theme_icon_override[dname]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 			}
 			data.theme_icon_override.erase(dname);
 			_notify_theme_override_changed();
 		} else if (name.begins_with("theme_override_styles/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.theme_style_override.has(dname)) {
-				data.theme_style_override[dname]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+				data.theme_style_override[dname]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 			}
 			data.theme_style_override.erase(dname);
 			_notify_theme_override_changed();
 		} else if (name.begins_with("theme_override_fonts/")) {
 			String dname = name.get_slicec('/', 1);
 			if (data.theme_font_override.has(dname)) {
-				data.theme_font_override[dname]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+				data.theme_font_override[dname]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 			}
 			data.theme_font_override.erase(dname);
 			_notify_theme_override_changed();
@@ -2468,13 +2468,13 @@ void Control::set_theme(const Ref<Theme> &p_theme) {
 	}
 
 	if (data.theme.is_valid()) {
-		data.theme->disconnect("changed", callable_mp(this, &Control::_theme_changed));
+		data.theme->disconnect_changed(callable_mp(this, &Control::_theme_changed));
 	}
 
 	data.theme = p_theme;
 	if (data.theme.is_valid()) {
 		data.theme_owner->propagate_theme_changed(this, this, is_inside_tree(), true);
-		data.theme->connect("changed", callable_mp(this, &Control::_theme_changed), CONNECT_DEFERRED);
+		data.theme->connect_changed(callable_mp(this, &Control::_theme_changed), CONNECT_DEFERRED);
 		return;
 	}
 
@@ -2769,11 +2769,11 @@ void Control::add_theme_icon_override(const StringName &p_name, const Ref<Textur
 	ERR_FAIL_COND(!p_icon.is_valid());
 
 	if (data.theme_icon_override.has(p_name)) {
-		data.theme_icon_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_icon_override[p_name] = p_icon;
-	data.theme_icon_override[p_name]->connect("changed", callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	data.theme_icon_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2782,11 +2782,11 @@ void Control::add_theme_style_override(const StringName &p_name, const Ref<Style
 	ERR_FAIL_COND(!p_style.is_valid());
 
 	if (data.theme_style_override.has(p_name)) {
-		data.theme_style_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_style_override[p_name] = p_style;
-	data.theme_style_override[p_name]->connect("changed", callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	data.theme_style_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2795,11 +2795,11 @@ void Control::add_theme_font_override(const StringName &p_name, const Ref<Font> 
 	ERR_FAIL_COND(!p_font.is_valid());
 
 	if (data.theme_font_override.has(p_name)) {
-		data.theme_font_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_font_override[p_name] = p_font;
-	data.theme_font_override[p_name]->connect("changed", callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	data.theme_font_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2824,7 +2824,7 @@ void Control::add_theme_constant_override(const StringName &p_name, int p_consta
 void Control::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme_icon_override.has(p_name)) {
-		data.theme_icon_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_icon_override.erase(p_name);
@@ -2834,7 +2834,7 @@ void Control::remove_theme_icon_override(const StringName &p_name) {
 void Control::remove_theme_style_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme_style_override.has(p_name)) {
-		data.theme_style_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_style_override.erase(p_name);
@@ -2844,7 +2844,7 @@ void Control::remove_theme_style_override(const StringName &p_name) {
 void Control::remove_theme_font_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme_font_override.has(p_name)) {
-		data.theme_font_override[p_name]->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		data.theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	data.theme_font_override.erase(p_name);
@@ -3630,13 +3630,13 @@ Control::~Control() {
 
 	// Resources need to be disconnected.
 	for (KeyValue<StringName, Ref<Texture2D>> &E : data.theme_icon_override) {
-		E.value->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 	for (KeyValue<StringName, Ref<StyleBox>> &E : data.theme_style_override) {
-		E.value->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 	for (KeyValue<StringName, Ref<Font>> &E : data.theme_font_override) {
-		E.value->disconnect("changed", callable_mp(this, &Control::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
 	// Then override maps can be simply cleared.

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -31,7 +31,6 @@
 #include "label.h"
 
 #include "core/config/project_settings.h"
-#include "core/core_string_names.h"
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
 
@@ -784,11 +783,11 @@ void Label::_invalidate() {
 void Label::set_label_settings(const Ref<LabelSettings> &p_settings) {
 	if (settings != p_settings) {
 		if (settings.is_valid()) {
-			settings->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Label::_invalidate));
+			settings->disconnect_changed(callable_mp(this, &Label::_invalidate));
 		}
 		settings = p_settings;
 		if (settings.is_valid()) {
-			settings->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Label::_invalidate), CONNECT_REFERENCE_COUNTED);
+			settings->connect_changed(callable_mp(this, &Label::_invalidate), CONNECT_REFERENCE_COUNTED);
 		}
 		_invalidate();
 	}

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -30,7 +30,6 @@
 
 #include "nine_patch_rect.h"
 
-#include "core/core_string_names.h"
 #include "scene/scene_string_names.h"
 #include "servers/rendering_server.h"
 
@@ -101,13 +100,13 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NinePatchRect::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &NinePatchRect::_texture_changed));
 	}
 
 	texture = p_tex;
 
 	if (texture.is_valid()) {
-		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &NinePatchRect::_texture_changed));
+		texture->connect_changed(callable_mp(this, &NinePatchRect::_texture_changed));
 	}
 
 	queue_redraw();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1968,7 +1968,7 @@ void PopupMenu::clear() {
 void PopupMenu::_ref_shortcut(Ref<Shortcut> p_sc) {
 	if (!shortcut_refcount.has(p_sc)) {
 		shortcut_refcount[p_sc] = 1;
-		p_sc->connect("changed", callable_mp(this, &PopupMenu::_shortcut_changed));
+		p_sc->connect_changed(callable_mp(this, &PopupMenu::_shortcut_changed));
 	} else {
 		shortcut_refcount[p_sc] += 1;
 	}
@@ -1978,7 +1978,7 @@ void PopupMenu::_unref_shortcut(Ref<Shortcut> p_sc) {
 	ERR_FAIL_COND(!shortcut_refcount.has(p_sc));
 	shortcut_refcount[p_sc]--;
 	if (shortcut_refcount[p_sc] == 0) {
-		p_sc->disconnect("changed", callable_mp(this, &PopupMenu::_shortcut_changed));
+		p_sc->disconnect_changed(callable_mp(this, &PopupMenu::_shortcut_changed));
 		shortcut_refcount.erase(p_sc);
 	}
 }

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -30,7 +30,6 @@
 
 #include "texture_button.h"
 
-#include "core/core_string_names.h"
 #include "core/typedefs.h"
 
 #include <stdlib.h>
@@ -353,12 +352,12 @@ void TextureButton::_set_texture(Ref<Texture2D> *p_destination, const Ref<Textur
 		return;
 	}
 	if (destination.is_valid()) {
-		destination->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureButton::_texture_changed));
+		destination->disconnect_changed(callable_mp(this, &TextureButton::_texture_changed));
 	}
 	destination = p_texture;
 	if (destination.is_valid()) {
 		// Pass `CONNECT_REFERENCE_COUNTED` to avoid early disconnect in case the same texture is assigned to different "slots".
-		destination->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureButton::_texture_changed), CONNECT_REFERENCE_COUNTED);
+		destination->connect_changed(callable_mp(this, &TextureButton::_texture_changed), CONNECT_REFERENCE_COUNTED);
 	}
 	_texture_changed();
 }

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -31,7 +31,6 @@
 #include "texture_progress_bar.h"
 
 #include "core/config/engine.h"
-#include "core/core_string_names.h"
 #include "scene/resources/atlas_texture.h"
 
 void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
@@ -162,12 +161,12 @@ void TextureProgressBar::_set_texture(Ref<Texture2D> *p_destination, const Ref<T
 		return;
 	}
 	if (destination.is_valid()) {
-		destination->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureProgressBar::_texture_changed));
+		destination->disconnect_changed(callable_mp(this, &TextureProgressBar::_texture_changed));
 	}
 	destination = p_texture;
 	if (destination.is_valid()) {
 		// Pass `CONNECT_REFERENCE_COUNTED` to avoid early disconnect in case the same texture is assigned to different "slots".
-		destination->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureProgressBar::_texture_changed), CONNECT_REFERENCE_COUNTED);
+		destination->connect_changed(callable_mp(this, &TextureProgressBar::_texture_changed), CONNECT_REFERENCE_COUNTED);
 	}
 	_texture_changed();
 }

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -30,7 +30,6 @@
 
 #include "texture_rect.h"
 
-#include "core/core_string_names.h"
 #include "scene/resources/atlas_texture.h"
 #include "servers/rendering_server.h"
 
@@ -202,13 +201,13 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	if (texture.is_valid()) {
-		texture->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureRect::_texture_changed));
+		texture->disconnect_changed(callable_mp(this, &TextureRect::_texture_changed));
 	}
 
 	texture = p_tex;
 
 	if (texture.is_valid()) {
-		texture->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TextureRect::_texture_changed));
+		texture->connect_changed(callable_mp(this, &TextureRect::_texture_changed));
 	}
 
 	queue_redraw();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -31,7 +31,6 @@
 #include "viewport.h"
 
 #include "core/config/project_settings.h"
-#include "core/core_string_names.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/object/message_queue.h"
 #include "core/string/translation.h"
@@ -3864,7 +3863,7 @@ void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
 	}
 
 	if (own_world_3d.is_valid() && world_3d.is_valid()) {
-		world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+		world_3d->disconnect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
 	}
 
 	world_3d = p_world_3d;
@@ -3872,7 +3871,7 @@ void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
 	if (own_world_3d.is_valid()) {
 		if (world_3d.is_valid()) {
 			own_world_3d = world_3d->duplicate();
-			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+			world_3d->connect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
 		} else {
 			own_world_3d = Ref<World3D>(memnew(World3D));
 		}
@@ -3923,14 +3922,14 @@ void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
 	if (p_use_own_world_3d) {
 		if (world_3d.is_valid()) {
 			own_world_3d = world_3d->duplicate();
-			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+			world_3d->connect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
 		} else {
 			own_world_3d = Ref<World3D>(memnew(World3D));
 		}
 	} else {
 		own_world_3d = Ref<World3D>();
 		if (world_3d.is_valid()) {
-			world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
+			world_3d->disconnect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
 		}
 	}
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -54,21 +54,21 @@ bool Window::_set(const StringName &p_name, const Variant &p_value) {
 		if (name.begins_with("theme_override_icons/")) {
 			String dname = name.get_slicec('/', 1);
 			if (theme_icon_override.has(dname)) {
-				theme_icon_override[dname]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+				theme_icon_override[dname]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 			}
 			theme_icon_override.erase(dname);
 			_notify_theme_override_changed();
 		} else if (name.begins_with("theme_override_styles/")) {
 			String dname = name.get_slicec('/', 1);
 			if (theme_style_override.has(dname)) {
-				theme_style_override[dname]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+				theme_style_override[dname]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 			}
 			theme_style_override.erase(dname);
 			_notify_theme_override_changed();
 		} else if (name.begins_with("theme_override_fonts/")) {
 			String dname = name.get_slicec('/', 1);
 			if (theme_font_override.has(dname)) {
-				theme_font_override[dname]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+				theme_font_override[dname]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 			}
 			theme_font_override.erase(dname);
 			_notify_theme_override_changed();
@@ -1823,13 +1823,13 @@ void Window::set_theme(const Ref<Theme> &p_theme) {
 	}
 
 	if (theme.is_valid()) {
-		theme->disconnect("changed", callable_mp(this, &Window::_theme_changed));
+		theme->disconnect_changed(callable_mp(this, &Window::_theme_changed));
 	}
 
 	theme = p_theme;
 	if (theme.is_valid()) {
 		theme_owner->propagate_theme_changed(this, this, is_inside_tree(), true);
-		theme->connect("changed", callable_mp(this, &Window::_theme_changed), CONNECT_DEFERRED);
+		theme->connect_changed(callable_mp(this, &Window::_theme_changed), CONNECT_DEFERRED);
 		return;
 	}
 
@@ -2165,11 +2165,11 @@ void Window::add_theme_icon_override(const StringName &p_name, const Ref<Texture
 	ERR_FAIL_COND(!p_icon.is_valid());
 
 	if (theme_icon_override.has(p_name)) {
-		theme_icon_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_icon_override[p_name] = p_icon;
-	theme_icon_override[p_name]->connect("changed", callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	theme_icon_override[p_name]->connect_changed(callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2178,11 +2178,11 @@ void Window::add_theme_style_override(const StringName &p_name, const Ref<StyleB
 	ERR_FAIL_COND(!p_style.is_valid());
 
 	if (theme_style_override.has(p_name)) {
-		theme_style_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_style_override[p_name] = p_style;
-	theme_style_override[p_name]->connect("changed", callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	theme_style_override[p_name]->connect_changed(callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2191,11 +2191,11 @@ void Window::add_theme_font_override(const StringName &p_name, const Ref<Font> &
 	ERR_FAIL_COND(!p_font.is_valid());
 
 	if (theme_font_override.has(p_name)) {
-		theme_font_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_font_override[p_name] = p_font;
-	theme_font_override[p_name]->connect("changed", callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
+	theme_font_override[p_name]->connect_changed(callable_mp(this, &Window::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
@@ -2220,7 +2220,7 @@ void Window::add_theme_constant_override(const StringName &p_name, int p_constan
 void Window::remove_theme_icon_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (theme_icon_override.has(p_name)) {
-		theme_icon_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_icon_override.erase(p_name);
@@ -2230,7 +2230,7 @@ void Window::remove_theme_icon_override(const StringName &p_name) {
 void Window::remove_theme_style_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (theme_style_override.has(p_name)) {
-		theme_style_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_style_override.erase(p_name);
@@ -2240,7 +2240,7 @@ void Window::remove_theme_style_override(const StringName &p_name) {
 void Window::remove_theme_font_override(const StringName &p_name) {
 	ERR_MAIN_THREAD_GUARD;
 	if (theme_font_override.has(p_name)) {
-		theme_font_override[p_name]->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	theme_font_override.erase(p_name);
@@ -2768,13 +2768,13 @@ Window::~Window() {
 
 	// Resources need to be disconnected.
 	for (KeyValue<StringName, Ref<Texture2D>> &E : theme_icon_override) {
-		E.value->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 	for (KeyValue<StringName, Ref<StyleBox>> &E : theme_style_override) {
-		E.value->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 	for (KeyValue<StringName, Ref<Font>> &E : theme_font_override) {
-		E.value->disconnect("changed", callable_mp(this, &Window::_notify_theme_override_changed));
+		E.value->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
 	}
 
 	// Then override maps can be simply cleared.

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -52,13 +52,13 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
-		animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
+		animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
 		animations.erase(p_name);
 		emit_signal(SNAME("animation_removed"), p_name);
 	}
 
 	animations.insert(p_name, p_animation);
-	animations.get(p_name)->connect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
+	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
 	emit_signal(SNAME("animation_added"), p_name);
 	notify_property_list_changed();
 	return OK;
@@ -67,7 +67,7 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 void AnimationLibrary::remove_animation(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 
-	animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_removed"), p_name);
 	notify_property_list_changed();
@@ -78,8 +78,8 @@ void AnimationLibrary::rename_animation(const StringName &p_name, const StringNa
 	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND_MSG(animations.has(p_new_name), vformat("Animation name \"%s\" already exists in library.", p_new_name));
 
-	animations.get(p_name)->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
-	animations.get(p_name)->connect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
+	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
 	animations.insert(p_new_name, animations[p_name]);
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_renamed"), p_name, p_new_name);
@@ -125,7 +125,7 @@ void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const 
 
 void AnimationLibrary::_set_data(const Dictionary &p_data) {
 	for (KeyValue<StringName, Ref<Animation>> &K : animations) {
-		K.value->disconnect(SNAME("changed"), callable_mp(this, &AnimationLibrary::_animation_changed));
+		K.value->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
 	}
 	animations.clear();
 	List<Variant> keys;

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -77,11 +77,11 @@ void AtlasTexture::set_atlas(const Ref<Texture2D> &p_atlas) {
 	}
 	// Support recursive AtlasTextures.
 	if (Ref<AtlasTexture>(atlas).is_valid()) {
-		atlas->disconnect(CoreStringNames::get_singleton()->changed, callable_mp((Resource *)this, &AtlasTexture::emit_changed));
+		atlas->disconnect_changed(callable_mp((Resource *)this, &AtlasTexture::emit_changed));
 	}
 	atlas = p_atlas;
 	if (Ref<AtlasTexture>(atlas).is_valid()) {
-		atlas->connect(CoreStringNames::get_singleton()->changed, callable_mp((Resource *)this, &AtlasTexture::emit_changed));
+		atlas->connect_changed(callable_mp((Resource *)this, &AtlasTexture::emit_changed));
 	}
 
 	emit_changed();

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -80,7 +80,7 @@ void BoxShape3D::set_size(const Vector3 &p_size) {
 	ERR_FAIL_COND_MSG(p_size.x < 0 || p_size.y < 0 || p_size.z < 0, "BoxShape3D size cannot be negative.");
 	size = p_size;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 Vector3 BoxShape3D::get_size() const {

--- a/scene/resources/capsule_shape_3d.cpp
+++ b/scene/resources/capsule_shape_3d.cpp
@@ -86,7 +86,7 @@ void CapsuleShape3D::set_radius(float p_radius) {
 		height = radius * 2.0;
 	}
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float CapsuleShape3D::get_radius() const {
@@ -100,7 +100,7 @@ void CapsuleShape3D::set_height(float p_height) {
 		radius = height * 0.5;
 	}
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float CapsuleShape3D::get_height() const {

--- a/scene/resources/concave_polygon_shape_3d.cpp
+++ b/scene/resources/concave_polygon_shape_3d.cpp
@@ -81,7 +81,7 @@ void ConcavePolygonShape3D::_update_shape() {
 void ConcavePolygonShape3D::set_faces(const Vector<Vector3> &p_faces) {
 	faces = p_faces;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 Vector<Vector3> ConcavePolygonShape3D::get_faces() const {
@@ -93,7 +93,7 @@ void ConcavePolygonShape3D::set_backface_collision_enabled(bool p_enabled) {
 
 	if (!faces.is_empty()) {
 		_update_shape();
-		notify_change_to_owners();
+		emit_changed();
 	}
 }
 

--- a/scene/resources/convex_polygon_shape_3d.cpp
+++ b/scene/resources/convex_polygon_shape_3d.cpp
@@ -71,7 +71,7 @@ void ConvexPolygonShape3D::_update_shape() {
 void ConvexPolygonShape3D::set_points(const Vector<Vector3> &p_points) {
 	points = p_points;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 Vector<Vector3> ConvexPolygonShape3D::get_points() const {

--- a/scene/resources/curve_texture.cpp
+++ b/scene/resources/curve_texture.cpp
@@ -81,11 +81,11 @@ void CurveTexture::ensure_default_setup(float p_min, float p_max) {
 void CurveTexture::set_curve(Ref<Curve> p_curve) {
 	if (_curve != p_curve) {
 		if (_curve.is_valid()) {
-			_curve->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveTexture::_update));
+			_curve->disconnect_changed(callable_mp(this, &CurveTexture::_update));
 		}
 		_curve = p_curve;
 		if (_curve.is_valid()) {
-			_curve->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveTexture::_update));
+			_curve->connect_changed(callable_mp(this, &CurveTexture::_update));
 		}
 		_update();
 	}
@@ -245,11 +245,11 @@ void CurveXYZTexture::ensure_default_setup(float p_min, float p_max) {
 void CurveXYZTexture::set_curve_x(Ref<Curve> p_curve) {
 	if (_curve_x != p_curve) {
 		if (_curve_x.is_valid()) {
-			_curve_x->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
+			_curve_x->disconnect_changed(callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_x = p_curve;
 		if (_curve_x.is_valid()) {
-			_curve_x->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
+			_curve_x->connect_changed(callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}
@@ -258,11 +258,11 @@ void CurveXYZTexture::set_curve_x(Ref<Curve> p_curve) {
 void CurveXYZTexture::set_curve_y(Ref<Curve> p_curve) {
 	if (_curve_y != p_curve) {
 		if (_curve_y.is_valid()) {
-			_curve_y->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
+			_curve_y->disconnect_changed(callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_y = p_curve;
 		if (_curve_y.is_valid()) {
-			_curve_y->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
+			_curve_y->connect_changed(callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}
@@ -271,11 +271,11 @@ void CurveXYZTexture::set_curve_y(Ref<Curve> p_curve) {
 void CurveXYZTexture::set_curve_z(Ref<Curve> p_curve) {
 	if (_curve_z != p_curve) {
 		if (_curve_z.is_valid()) {
-			_curve_z->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update));
+			_curve_z->disconnect_changed(callable_mp(this, &CurveXYZTexture::_update));
 		}
 		_curve_z = p_curve;
 		if (_curve_z.is_valid()) {
-			_curve_z->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
+			_curve_z->connect_changed(callable_mp(this, &CurveXYZTexture::_update), CONNECT_REFERENCE_COUNTED);
 		}
 		_update();
 	}

--- a/scene/resources/cylinder_shape_3d.cpp
+++ b/scene/resources/cylinder_shape_3d.cpp
@@ -76,7 +76,7 @@ void CylinderShape3D::set_radius(float p_radius) {
 	ERR_FAIL_COND_MSG(p_radius < 0, "CylinderShape3D radius cannot be negative.");
 	radius = p_radius;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float CylinderShape3D::get_radius() const {
@@ -87,7 +87,7 @@ void CylinderShape3D::set_height(float p_height) {
 	ERR_FAIL_COND_MSG(p_height < 0, "CylinderShape3D height cannot be negative.");
 	height = p_height;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float CylinderShape3D::get_height() const {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -31,7 +31,6 @@
 #include "environment.h"
 
 #include "core/config/project_settings.h"
-#include "core/core_string_names.h"
 #include "scene/resources/gradient_texture.h"
 #include "servers/rendering_server.h"
 
@@ -1004,9 +1003,7 @@ void Environment::set_adjustment_color_correction(Ref<Texture> p_color_correctio
 	adjustment_color_correction = p_color_correction;
 	Ref<GradientTexture1D> grad_tex = p_color_correction;
 	if (grad_tex.is_valid()) {
-		if (!grad_tex->is_connected(CoreStringNames::get_singleton()->changed, callable_mp(this, &Environment::_update_adjustment))) {
-			grad_tex->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Environment::_update_adjustment));
-		}
+		grad_tex->connect_changed(callable_mp(this, &Environment::_update_adjustment));
 	}
 	Ref<Texture2D> adjustment_texture_2d = adjustment_color_correction;
 	if (adjustment_texture_2d.is_valid()) {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -30,7 +30,6 @@
 
 #include "font.h"
 
-#include "core/core_string_names.h"
 #include "core/io/image_loader.h"
 #include "core/io/resource_loader.h"
 #include "core/string/translation.h"
@@ -160,14 +159,14 @@ void Font::set_fallbacks(const TypedArray<Font> &p_fallbacks) {
 	for (int i = 0; i < fallbacks.size(); i++) {
 		Ref<Font> f = fallbacks[i];
 		if (f.is_valid()) {
-			f->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Font::_invalidate_rids));
+			f->disconnect_changed(callable_mp(this, &Font::_invalidate_rids));
 		}
 	}
 	fallbacks = p_fallbacks;
 	for (int i = 0; i < fallbacks.size(); i++) {
 		Ref<Font> f = fallbacks[i];
 		if (f.is_valid()) {
-			f->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			f->connect_changed(callable_mp(this, &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 	}
 	_invalidate_rids();
@@ -2675,12 +2674,12 @@ void FontVariation::_update_rids() const {
 
 void FontVariation::reset_state() {
 	if (base_font.is_valid()) {
-		base_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+		base_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		base_font.unref();
 	}
 
 	if (theme_font.is_valid()) {
-		theme_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -2697,11 +2696,11 @@ void FontVariation::reset_state() {
 void FontVariation::set_base_font(const Ref<Font> &p_font) {
 	if (base_font != p_font) {
 		if (base_font.is_valid()) {
-			base_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+			base_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		}
 		base_font = p_font;
 		if (base_font.is_valid()) {
-			base_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			base_font->connect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 		_invalidate_rids();
 		notify_property_list_changed();
@@ -2714,7 +2713,7 @@ Ref<Font> FontVariation::get_base_font() const {
 
 Ref<Font> FontVariation::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -2735,7 +2734,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 				}
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 				}
 				return f;
 			}
@@ -2755,7 +2754,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 				}
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 				}
 				return f;
 			}
@@ -2766,7 +2765,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 		if (f != this) {
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
@@ -2950,7 +2949,7 @@ void SystemFont::_update_rids() const {
 
 void SystemFont::_update_base_font() {
 	if (base_font.is_valid()) {
-		base_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+		base_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		base_font.unref();
 	}
 
@@ -3031,7 +3030,7 @@ void SystemFont::_update_base_font() {
 	}
 
 	if (base_font.is_valid()) {
-		base_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+		base_font->connect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_invalidate_rids();
@@ -3040,12 +3039,12 @@ void SystemFont::_update_base_font() {
 
 void SystemFont::reset_state() {
 	if (base_font.is_valid()) {
-		base_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+		base_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		base_font.unref();
 	}
 
 	if (theme_font.is_valid()) {
-		theme_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(this), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -3071,7 +3070,7 @@ void SystemFont::reset_state() {
 
 Ref<Font> SystemFont::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -3092,7 +3091,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 				}
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 				}
 				return f;
 			}
@@ -3112,7 +3111,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 				}
 				if (f.is_valid()) {
 					theme_font = f;
-					theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 				}
 				return f;
 			}
@@ -3123,7 +3122,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 		if (f != this) {
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect(CoreStringNames::get_singleton()->changed, callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -66,11 +66,11 @@ void GradientTexture1D::set_gradient(Ref<Gradient> p_gradient) {
 		return;
 	}
 	if (gradient.is_valid()) {
-		gradient->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture1D::_update));
+		gradient->disconnect_changed(callable_mp(this, &GradientTexture1D::_update));
 	}
 	gradient = p_gradient;
 	if (gradient.is_valid()) {
-		gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture1D::_update));
+		gradient->connect_changed(callable_mp(this, &GradientTexture1D::_update));
 	}
 	_update();
 	emit_changed();
@@ -192,11 +192,11 @@ void GradientTexture2D::set_gradient(Ref<Gradient> p_gradient) {
 		return;
 	}
 	if (gradient.is_valid()) {
-		gradient->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture2D::_queue_update));
+		gradient->disconnect_changed(callable_mp(this, &GradientTexture2D::_queue_update));
 	}
 	gradient = p_gradient;
 	if (gradient.is_valid()) {
-		gradient->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &GradientTexture2D::_queue_update));
+		gradient->connect_changed(callable_mp(this, &GradientTexture2D::_queue_update));
 	}
 	_update();
 	emit_changed();

--- a/scene/resources/height_map_shape_3d.cpp
+++ b/scene/resources/height_map_shape_3d.cpp
@@ -112,7 +112,7 @@ void HeightMapShape3D::set_map_width(int p_new) {
 		}
 
 		_update_shape();
-		notify_change_to_owners();
+		emit_changed();
 	}
 }
 
@@ -136,7 +136,7 @@ void HeightMapShape3D::set_map_depth(int p_new) {
 		}
 
 		_update_shape();
-		notify_change_to_owners();
+		emit_changed();
 	}
 }
 
@@ -172,7 +172,7 @@ void HeightMapShape3D::set_map_data(Vector<real_t> p_new) {
 	}
 
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 Vector<real_t> HeightMapShape3D::get_map_data() const {

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -30,8 +30,6 @@
 
 #include "label_settings.h"
 
-#include "core/core_string_names.h"
-
 void LabelSettings::_font_changed() {
 	emit_changed();
 }
@@ -95,11 +93,11 @@ real_t LabelSettings::get_line_spacing() const {
 void LabelSettings::set_font(const Ref<Font> &p_font) {
 	if (font != p_font) {
 		if (font.is_valid()) {
-			font->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &LabelSettings::_font_changed));
+			font->disconnect_changed(callable_mp(this, &LabelSettings::_font_changed));
 		}
 		font = p_font;
 		if (font.is_valid()) {
-			font->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &LabelSettings::_font_changed), CONNECT_REFERENCE_COUNTED);
+			font->connect_changed(callable_mp(this, &LabelSettings::_font_changed), CONNECT_REFERENCE_COUNTED);
 		}
 		emit_changed();
 	}

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -385,7 +385,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 	// This can be a slow operation, and `notify_property_list_changed()` (which is called by `_shader_changed()`)
 	// does nothing in non-editor builds anyway. See GH-34741 for details.
 	if (shader.is_valid() && Engine::get_singleton()->is_editor_hint()) {
-		shader->disconnect("changed", callable_mp(this, &ShaderMaterial::_shader_changed));
+		shader->disconnect_changed(callable_mp(this, &ShaderMaterial::_shader_changed));
 	}
 
 	shader = p_shader;
@@ -395,7 +395,7 @@ void ShaderMaterial::set_shader(const Ref<Shader> &p_shader) {
 		rid = shader->get_rid();
 
 		if (Engine::get_singleton()->is_editor_hint()) {
-			shader->connect("changed", callable_mp(this, &ShaderMaterial::_shader_changed));
+			shader->connect_changed(callable_mp(this, &ShaderMaterial::_shader_changed));
 		}
 	}
 

--- a/scene/resources/mesh_library.cpp
+++ b/scene/resources/mesh_library.cpp
@@ -144,7 +144,6 @@ void MeshLibrary::set_item_name(int p_item, const String &p_name) {
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].mesh = p_mesh;
-	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }
@@ -152,7 +151,6 @@ void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
 void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_transform) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].mesh_transform = p_transform;
-	notify_change_to_owners();
 	emit_changed();
 }
 
@@ -160,7 +158,6 @@ void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes)
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].shapes = p_shapes;
 	notify_property_list_changed();
-	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }
@@ -169,7 +166,6 @@ void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh>
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navigation_mesh = p_navigation_mesh;
 	notify_property_list_changed();
-	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }
@@ -177,7 +173,6 @@ void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh>
 void MeshLibrary::set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navigation_mesh_transform = p_transform;
-	notify_change_to_owners();
 	emit_changed();
 	notify_property_list_changed();
 }
@@ -186,7 +181,6 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navigation_layers = p_navigation_layers;
 	notify_property_list_changed();
-	notify_change_to_owners();
 	emit_changed();
 }
 
@@ -244,14 +238,12 @@ bool MeshLibrary::has_item(int p_item) const {
 void MeshLibrary::remove_item(int p_item) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map.erase(p_item);
-	notify_change_to_owners();
 	notify_property_list_changed();
 	emit_changed();
 }
 
 void MeshLibrary::clear() {
 	item_map.clear();
-	notify_change_to_owners();
 	notify_property_list_changed();
 	emit_changed();
 }

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -31,7 +31,6 @@
 #include "primitive_meshes.h"
 
 #include "core/config/project_settings.h"
-#include "core/core_string_names.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering_server.h"
@@ -2194,11 +2193,11 @@ void TubeTrailMesh::set_curve(const Ref<Curve> &p_curve) {
 		return;
 	}
 	if (curve.is_valid()) {
-		curve->disconnect("changed", callable_mp(this, &TubeTrailMesh::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &TubeTrailMesh::_curve_changed));
 	}
 	curve = p_curve;
 	if (curve.is_valid()) {
-		curve->connect("changed", callable_mp(this, &TubeTrailMesh::_curve_changed));
+		curve->connect_changed(callable_mp(this, &TubeTrailMesh::_curve_changed));
 	}
 	_request_update();
 }
@@ -2533,11 +2532,11 @@ void RibbonTrailMesh::set_curve(const Ref<Curve> &p_curve) {
 		return;
 	}
 	if (curve.is_valid()) {
-		curve->disconnect("changed", callable_mp(this, &RibbonTrailMesh::_curve_changed));
+		curve->disconnect_changed(callable_mp(this, &RibbonTrailMesh::_curve_changed));
 	}
 	curve = p_curve;
 	if (curve.is_valid()) {
-		curve->connect("changed", callable_mp(this, &RibbonTrailMesh::_curve_changed));
+		curve->connect_changed(callable_mp(this, &RibbonTrailMesh::_curve_changed));
 	}
 	_request_update();
 }
@@ -3446,13 +3445,13 @@ void TextMesh::_font_changed() {
 void TextMesh::set_font(const Ref<Font> &p_font) {
 	if (font_override != p_font) {
 		if (font_override.is_valid()) {
-			font_override->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_font_changed"));
+			font_override->disconnect_changed(Callable(this, "_font_changed"));
 		}
 		font_override = p_font;
 		dirty_font = true;
 		dirty_cache = true;
 		if (font_override.is_valid()) {
-			font_override->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_font_changed"));
+			font_override->connect_changed(Callable(this, "_font_changed"));
 		}
 		_request_update();
 	}

--- a/scene/resources/separation_ray_shape_3d.cpp
+++ b/scene/resources/separation_ray_shape_3d.cpp
@@ -56,7 +56,7 @@ void SeparationRayShape3D::_update_shape() {
 void SeparationRayShape3D::set_length(float p_length) {
 	length = p_length;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float SeparationRayShape3D::get_length() const {
@@ -66,7 +66,7 @@ float SeparationRayShape3D::get_length() const {
 void SeparationRayShape3D::set_slide_on_slope(bool p_active) {
 	slide_on_slope = p_active;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 bool SeparationRayShape3D::get_slide_on_slope() const {
@@ -88,5 +88,5 @@ SeparationRayShape3D::SeparationRayShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_SEPARATION_RAY)) {
 	/* Code copied from setters to prevent the use of uninitialized variables */
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -63,7 +63,7 @@ void Shader::set_include_path(const String &p_path) {
 
 void Shader::set_code(const String &p_code) {
 	for (const Ref<ShaderInclude> &E : include_dependencies) {
-		E->disconnect(SNAME("changed"), callable_mp(this, &Shader::_dependency_changed));
+		E->disconnect_changed(callable_mp(this, &Shader::_dependency_changed));
 	}
 
 	code = p_code;
@@ -102,7 +102,7 @@ void Shader::set_code(const String &p_code) {
 	}
 
 	for (const Ref<ShaderInclude> &E : include_dependencies) {
-		E->connect(SNAME("changed"), callable_mp(this, &Shader::_dependency_changed));
+		E->connect_changed(callable_mp(this, &Shader::_dependency_changed));
 	}
 
 	RenderingServer::get_singleton()->shader_set_code(shader, pp_code);

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -40,7 +40,7 @@ void ShaderInclude::set_code(const String &p_code) {
 	code = p_code;
 
 	for (const Ref<ShaderInclude> &E : dependencies) {
-		E->disconnect(SNAME("changed"), callable_mp(this, &ShaderInclude::_dependency_changed));
+		E->disconnect_changed(callable_mp(this, &ShaderInclude::_dependency_changed));
 	}
 
 	{
@@ -60,7 +60,7 @@ void ShaderInclude::set_code(const String &p_code) {
 	}
 
 	for (const Ref<ShaderInclude> &E : dependencies) {
-		E->connect(SNAME("changed"), callable_mp(this, &ShaderInclude::_dependency_changed));
+		E->connect_changed(callable_mp(this, &ShaderInclude::_dependency_changed));
 	}
 
 	emit_changed();

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -67,7 +67,7 @@ void SphereShape3D::set_radius(float p_radius) {
 	ERR_FAIL_COND_MSG(p_radius < 0, "SphereShape3D radius cannot be negative.");
 	radius = p_radius;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 float SphereShape3D::get_radius() const {

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -222,13 +222,13 @@ void Theme::set_default_font(const Ref<Font> &p_default_font) {
 	}
 
 	if (default_font.is_valid()) {
-		default_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		default_font->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	default_font = p_default_font;
 
 	if (default_font.is_valid()) {
-		default_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
+		default_font->connect_changed(callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed();
@@ -268,13 +268,13 @@ void Theme::set_icon(const StringName &p_name, const StringName &p_theme_type, c
 	bool existing = false;
 	if (icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
 		existing = true;
-		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		icon_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	icon_map[p_theme_type][p_name] = p_icon;
 
 	if (p_icon.is_valid()) {
-		icon_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
+		icon_map[p_theme_type][p_name]->connect_changed(callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);
@@ -314,7 +314,7 @@ void Theme::clear_icon(const StringName &p_name, const StringName &p_theme_type)
 	ERR_FAIL_COND_MSG(!icon_map[p_theme_type].has(p_name), "Cannot clear the icon '" + String(p_name) + "' because it does not exist.");
 
 	if (icon_map[p_theme_type][p_name].is_valid()) {
-		icon_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		icon_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	icon_map[p_theme_type].erase(p_name);
@@ -353,7 +353,7 @@ void Theme::remove_icon_type(const StringName &p_theme_type) {
 	for (const KeyValue<StringName, Ref<Texture2D>> &E : icon_map[p_theme_type]) {
 		Ref<Texture2D> icon = E.value;
 		if (icon.is_valid()) {
-			icon->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+			icon->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 		}
 	}
 
@@ -378,13 +378,13 @@ void Theme::set_stylebox(const StringName &p_name, const StringName &p_theme_typ
 	bool existing = false;
 	if (style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
 		existing = true;
-		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		style_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	style_map[p_theme_type][p_name] = p_style;
 
 	if (p_style.is_valid()) {
-		style_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
+		style_map[p_theme_type][p_name]->connect_changed(callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);
@@ -424,7 +424,7 @@ void Theme::clear_stylebox(const StringName &p_name, const StringName &p_theme_t
 	ERR_FAIL_COND_MSG(!style_map[p_theme_type].has(p_name), "Cannot clear the stylebox '" + String(p_name) + "' because it does not exist.");
 
 	if (style_map[p_theme_type][p_name].is_valid()) {
-		style_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		style_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	style_map[p_theme_type].erase(p_name);
@@ -463,7 +463,7 @@ void Theme::remove_stylebox_type(const StringName &p_theme_type) {
 	for (const KeyValue<StringName, Ref<StyleBox>> &E : style_map[p_theme_type]) {
 		Ref<StyleBox> style = E.value;
 		if (style.is_valid()) {
-			style->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+			style->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 		}
 	}
 
@@ -488,13 +488,13 @@ void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, c
 	bool existing = false;
 	if (font_map[p_theme_type][p_name].is_valid()) {
 		existing = true;
-		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		font_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	font_map[p_theme_type][p_name] = p_font;
 
 	if (p_font.is_valid()) {
-		font_map[p_theme_type][p_name]->connect("changed", callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
+		font_map[p_theme_type][p_name]->connect_changed(callable_mp(this, &Theme::_emit_theme_changed).bind(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed(!existing);
@@ -536,7 +536,7 @@ void Theme::clear_font(const StringName &p_name, const StringName &p_theme_type)
 	ERR_FAIL_COND_MSG(!font_map[p_theme_type].has(p_name), "Cannot clear the font '" + String(p_name) + "' because it does not exist.");
 
 	if (font_map[p_theme_type][p_name].is_valid()) {
-		font_map[p_theme_type][p_name]->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+		font_map[p_theme_type][p_name]->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
 	font_map[p_theme_type].erase(p_name);
@@ -575,7 +575,7 @@ void Theme::remove_font_type(const StringName &p_theme_type) {
 	for (const KeyValue<StringName, Ref<Font>> &E : font_map[p_theme_type]) {
 		Ref<Font> font = E.value;
 		if (font.is_valid()) {
-			font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+			font->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 		}
 	}
 
@@ -1622,7 +1622,7 @@ void Theme::clear() {
 			for (const KeyValue<StringName, Ref<Texture2D>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<Texture2D> icon = F.value;
-					icon->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+					icon->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}
@@ -1633,7 +1633,7 @@ void Theme::clear() {
 			for (const KeyValue<StringName, Ref<StyleBox>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<StyleBox> style = F.value;
-					style->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+					style->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}
@@ -1644,7 +1644,7 @@ void Theme::clear() {
 			for (const KeyValue<StringName, Ref<Font>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<Font> font = F.value;
-					font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+					font->disconnect_changed(callable_mp(this, &Theme::_emit_theme_changed));
 				}
 			}
 		}

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -30,7 +30,6 @@
 
 #include "tile_set.h"
 
-#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/templates/local_vector.h"
@@ -488,7 +487,7 @@ int TileSet::add_source(Ref<TileSetSource> p_tile_set_source, int p_atlas_source
 	p_tile_set_source->set_tile_set(this);
 	_compute_next_source_id();
 
-	sources[new_source_id]->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TileSet::_source_changed));
+	sources[new_source_id]->connect_changed(callable_mp(this, &TileSet::_source_changed));
 
 	terrains_cache_dirty = true;
 	emit_changed();
@@ -499,7 +498,7 @@ int TileSet::add_source(Ref<TileSetSource> p_tile_set_source, int p_atlas_source
 void TileSet::remove_source(int p_source_id) {
 	ERR_FAIL_COND_MSG(!sources.has(p_source_id), vformat("Cannot remove TileSet atlas source. No tileset atlas source with id %d.", p_source_id));
 
-	sources[p_source_id]->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &TileSet::_source_changed));
+	sources[p_source_id]->disconnect_changed(callable_mp(this, &TileSet::_source_changed));
 
 	sources[p_source_id]->set_tile_set(nullptr);
 	sources.erase(p_source_id);
@@ -3815,13 +3814,13 @@ void TileSetAtlasSource::reset_state() {
 
 void TileSetAtlasSource::set_texture(Ref<Texture2D> p_texture) {
 	if (texture.is_valid()) {
-		texture->disconnect(SNAME("changed"), callable_mp(this, &TileSetAtlasSource::_queue_update_padded_texture));
+		texture->disconnect_changed(callable_mp(this, &TileSetAtlasSource::_queue_update_padded_texture));
 	}
 
 	texture = p_texture;
 
 	if (texture.is_valid()) {
-		texture->connect(SNAME("changed"), callable_mp(this, &TileSetAtlasSource::_queue_update_padded_texture));
+		texture->connect_changed(callable_mp(this, &TileSetAtlasSource::_queue_update_padded_texture));
 	}
 
 	_clear_tiles_outside_texture();

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -767,7 +767,7 @@ void VisualShader::add_node(Type p_type, const Ref<VisualShaderNode> &p_node, co
 		input->shader_type = p_type;
 	}
 
-	n.node->connect("changed", callable_mp(this, &VisualShader::_queue_update));
+	n.node->connect_changed(callable_mp(this, &VisualShader::_queue_update));
 
 	Ref<VisualShaderNodeCustom> custom = n.node;
 	if (custom.is_valid()) {
@@ -834,7 +834,7 @@ void VisualShader::remove_node(Type p_type, int p_id) {
 	Graph *g = &graph[p_type];
 	ERR_FAIL_COND(!g->nodes.has(p_id));
 
-	g->nodes[p_id].node->disconnect("changed", callable_mp(this, &VisualShader::_queue_update));
+	g->nodes[p_id].node->disconnect_changed(callable_mp(this, &VisualShader::_queue_update));
 
 	g->nodes.erase(p_id);
 
@@ -907,7 +907,7 @@ void VisualShader::replace_node(Type p_type, int p_id, const StringName &p_new_c
 		}
 	}
 
-	vsn->connect("changed", callable_mp(this, &VisualShader::_queue_update));
+	vsn->connect_changed(callable_mp(this, &VisualShader::_queue_update));
 	g->nodes[p_id].node = Ref<VisualShaderNode>(vsn);
 
 	_queue_update();

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -30,7 +30,6 @@
 
 #include "visual_shader_particle_nodes.h"
 
-#include "core/core_string_names.h"
 #include "scene/resources/image_texture.h"
 
 // VisualShaderNodeParticleEmitter
@@ -638,21 +637,13 @@ void VisualShaderNodeParticleMeshEmitter::set_mesh(Ref<Mesh> p_mesh) {
 	}
 
 	if (mesh.is_valid()) {
-		Callable callable = callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures);
-
-		if (mesh->is_connected(CoreStringNames::get_singleton()->changed, callable)) {
-			mesh->disconnect(CoreStringNames::get_singleton()->changed, callable);
-		}
+		mesh->disconnect_changed(callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures));
 	}
 
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
-		Callable callable = callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures);
-
-		if (!mesh->is_connected(CoreStringNames::get_singleton()->changed, callable)) {
-			mesh->connect(CoreStringNames::get_singleton()->changed, callable);
-		}
+		mesh->connect_changed(callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures));
 	}
 
 	emit_changed();
@@ -733,7 +724,7 @@ void VisualShaderNodeParticleMeshEmitter::_bind_methods() {
 }
 
 VisualShaderNodeParticleMeshEmitter::VisualShaderNodeParticleMeshEmitter() {
-	connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures));
+	connect_changed(callable_mp(this, &VisualShaderNodeParticleMeshEmitter::_update_textures));
 
 	position_texture.instantiate();
 	normal_texture.instantiate();

--- a/scene/resources/world_boundary_shape_3d.cpp
+++ b/scene/resources/world_boundary_shape_3d.cpp
@@ -69,7 +69,7 @@ void WorldBoundaryShape3D::_update_shape() {
 void WorldBoundaryShape3D::set_plane(const Plane &p_plane) {
 	plane = p_plane;
 	_update_shape();
-	notify_change_to_owners();
+	emit_changed();
 }
 
 const Plane &WorldBoundaryShape3D::get_plane() const {


### PR DESCRIPTION
Resource's `changed` signal is one of the most used signals in the codebase. So far there was no standard way to use it, editors and nodes just connected them however they pleased:
- using `connect(CoreStringNames::get_singleton()->changed`
- using `connect(SNAME("changed"`
- using `connect("changed"`

There was also a weird and underused concept of "resource owners". The idea is that you do `register_owner(this)` and then Resource calls `notify_change_to_owners()` and you get notified. The problem is that you need to manually register **and** deregister the resource. Also the callback is a hard-coded `"resource_changed"` method. On top of that, this mechanism was used in a few 3D-related classes. Some used it instead the `changed` signal, which made it impossible to listen to changes normally (the resource_changed thing is not exposed). Some classes used both the signal and notify. And then there is `ShapeCast3D`, which both connected to signal and to the notify, which means that it reacted twice to each change, running the same code in 2 separate methods xd

Another thing is that it's often good practice to use `is_connected()` before connecting the signal, to avoid errors. This resulted in code like
```C++
Callable c= callable_mp()
if (!is_connected(c)) {
    connect(c)
}
```
or in worse cases the callable was just repeated twice ¯\\\_( •\_•)\_\/¯

This PR resolves all aforementioned issues by:
- adding `connect_changed()` and `disconnect_changed()` methods to Resource, which always connect with CoreStringNames
- both methods first check if the signal is (isn't) already connected, also respecting the CONNECT_REFERENCE_COUNTED flag
- I changed all code to use these methods, which in some cases reduced 4 lines of boilerplate into one
- this also allowed to remove `core_string_names` include in some files
- resource owners are removed and replaced with the usage of `connect_changed()` and `emit_changed()`
- `emit_changed()` is now public, so it can be called outside the resource (just like in GDScript xdd)

The new methods are not exposed (yet?).