### PR TITLE
Added brew option to the list of paths for the dotnet finder

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -20,19 +20,21 @@ namespace GodotTools.Build
 
             if (OS.IsMacOS)
             {
-                if (RuntimeInformation.OSArchitecture == Architecture.X64)
+                String[] pathList = {
+                    "/usr/local/share/dotnet/x64/dotnet", // Look for x64 version, when running under Rosetta 2.
+                    "/usr/local/share/dotnet/dotnet", // Look for native version.
+                    "/opt/homebrew/bin/dotnet" // Look for the homebrew path
+                };
+
+                for (int i = 0; i < pathList.Length; i++)
                 {
-                    string dotnet_x64 = "/usr/local/share/dotnet/x64/dotnet"; // Look for x64 version, when running under Rosetta 2.
-                    if (File.Exists(dotnet_x64))
+                    if(File.Exists(pathList[i]))
                     {
-                        return dotnet_x64;
+                        return pathList[i];
                     }
                 }
-                string dotnet = "/usr/local/share/dotnet/dotnet"; // Look for native version.
-                if (File.Exists(dotnet))
-                {
-                    return dotnet;
-                }
+
+                return null;
             }
 
             return OS.PathWhich("dotnet");


### PR DESCRIPTION
This is an attempt to solve the issue on this: https://github.com/godotengine/godot/issues/75668

This is an update on the logic for locating the `dotnet` on the `macOS` hardware.   
I'm not sure why some of the paths are hardcoded, but I did add a new path and loop over it instead of checking depending on the system. 

If there is any extra logic needed on this, please let me know that I can update this for more use cases.