### PR TITLE
Allow implementing `get_class_category` in GDExtension

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1213,6 +1213,7 @@ static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDE
 	info_2->get_func = p_info->get_func;
 	info_2->get_property_list_func = p_info->get_property_list_func;
 	info_2->free_property_list_func = p_info->free_property_list_func;
+	info_2->get_class_category_func = nullptr;
 	info_2->property_can_revert_func = p_info->property_can_revert_func;
 	info_2->property_get_revert_func = p_info->property_get_revert_func;
 	info_2->get_owner_func = p_info->get_owner_func;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -430,6 +430,8 @@ typedef GDExtensionBool (*GDExtensionScriptInstanceSet)(GDExtensionScriptInstanc
 typedef GDExtensionBool (*GDExtensionScriptInstanceGet)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
 typedef const GDExtensionPropertyInfo *(*GDExtensionScriptInstanceGetPropertyList)(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDExtensionScriptInstanceFreePropertyList)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo *p_list);
+typedef GDExtensionBool (*GDExtensionScriptInstanceGetClassCategory)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_class_category);
+
 typedef GDExtensionVariantType (*GDExtensionScriptInstanceGetPropertyType)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid);
 typedef GDExtensionBool (*GDExtensionScriptInstanceValidateProperty)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_property);
 
@@ -508,6 +510,7 @@ typedef struct {
 	GDExtensionScriptInstanceGet get_func;
 	GDExtensionScriptInstanceGetPropertyList get_property_list_func;
 	GDExtensionScriptInstanceFreePropertyList free_property_list_func;
+	GDExtensionScriptInstanceGetClassCategory get_class_category_func;
 
 	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
 	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -670,9 +670,20 @@ public:
 			const GDExtensionPropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
 
 #ifdef TOOLS_ENABLED
-			Ref<Script> script = get_script();
-			if (script.is_valid() && pcount > 0) {
-				p_list->push_back(script->get_class_category());
+			if (pcount > 0) {
+				if (native_info->get_class_category_func) {
+					GDExtensionPropertyInfo gdext_class_category;
+					if (native_info->get_class_category_func(instance, &gdext_class_category)) {
+						p_list->push_back(PropertyInfo(gdext_class_category));
+					}
+#ifndef DISABLE_DEPRECATED
+				} else {
+					Ref<Script> script = get_script();
+					if (script.is_valid()) {
+						p_list->push_back(script->get_class_category());
+					}
+#endif // DISABLE_DEPRECATED
+				}
 			}
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
Change GetClassCategory so it is handled in native directly.

After #78392 I tried extending `MyScriptExtension` to include `get_class_category` while I was probably doing something wrong it seemed more consistent to also `get_class_category `true as a native function and let the extension handle it the way they want.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

CC @dsnopek 