### PR TITLE
[RTL] Add `pop_all`, `push_context` and `pop_context` methods, and use it for `print_rich` to avoid unclosed tags.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -266,6 +266,18 @@
 				Terminates the current tag. Use after [code]push_*[/code] methods to close BBCodes manually. Does not need to follow [code]add_*[/code] methods.
 			</description>
 		</method>
+		<method name="pop_all">
+			<return type="void" />
+			<description>
+				Terminates all tags opened by [code]push_*[/code] methods.
+			</description>
+		</method>
+		<method name="pop_context">
+			<return type="void" />
+			<description>
+				Terminates tags opened after the last [method push_context] call (including context marker), or all tags if there's no context marker on the stack.
+			</description>
+		</method>
 		<method name="push_bgcolor">
 			<return type="void" />
 			<param index="0" name="bgcolor" type="Color" />
@@ -296,6 +308,12 @@
 			<param index="0" name="color" type="Color" />
 			<description>
 				Adds a [code][color][/code] tag to the tag stack.
+			</description>
+		</method>
+		<method name="push_context">
+			<return type="void" />
+			<description>
+				Adds a context marker to the tag stack. See [method pop_context].
 			</description>
 		</method>
 		<method name="push_customfx">

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -338,13 +338,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	} else {
 		log->add_text(p_message.text);
 	}
-
-	// Need to use pop() to exit out of the RichTextLabels current "push" stack.
-	// We only "push" in the above switch when message type != STD and RICH, so only pop when that is the case.
-	if (p_message.type != MSG_TYPE_STD && p_message.type != MSG_TYPE_STD_RICH) {
-		log->pop();
-	}
-
+	log->pop_all(); // Pop all unclosed tags.
 	log->add_newline();
 
 	if (p_replace_previous) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -75,7 +75,8 @@ public:
 		ITEM_META,
 		ITEM_HINT,
 		ITEM_DROPCAP,
-		ITEM_CUSTOMFX
+		ITEM_CUSTOMFX,
+		ITEM_CONTEXT
 	};
 
 	enum MenuItems {
@@ -370,6 +371,10 @@ private:
 		}
 	};
 
+	struct ItemContext : public Item {
+		ItemContext() { type = ITEM_CONTEXT; }
+	};
+
 	ItemFrame *main = nullptr;
 	Item *current = nullptr;
 	ItemFrame *current_frame = nullptr;
@@ -614,6 +619,7 @@ public:
 	void push_bgcolor(const Color &p_color);
 	void push_fgcolor(const Color &p_color);
 	void push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionary p_environment);
+	void push_context();
 	void set_table_column_expand(int p_column, bool p_expand, int p_ratio = 1);
 	void set_cell_row_background_color(const Color &p_odd_row_bg, const Color &p_even_row_bg);
 	void set_cell_border_color(const Color &p_color);
@@ -622,6 +628,8 @@ public:
 	int get_current_table_column() const;
 	void push_cell();
 	void pop();
+	void pop_context();
+	void pop_all();
 
 	void clear();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78520

| Before | After |
| -- | -- |
| <img width="777" alt="Screenshot 2023-07-04 at 09 50 44" src="https://github.com/godotengine/godot/assets/7645683/d0201997-118f-4947-8ef7-169bd4cf9279"> | <img width="777" alt="Screenshot 2023-07-04 at 09 51 06" src="https://github.com/godotengine/godot/assets/7645683/81d67d32-4df6-471f-91a4-7f79d04856a3"> |