### PR TITLE
[Terminal Output] Reset text properties after `print_rich`.

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -164,6 +164,8 @@ void __print_line_rich(String p_string) {
 		p_string_ansi = p_string_ansi.replace("[/fgcolor]", "\u001b[39;49m");
 	}
 
+	p_string_ansi += "\u001b[0m"; // Reset.
+
 	OS::get_singleton()->print_rich("%s\n", p_string_ansi.utf8().get_data());
 
 	_global_lock();


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/79011, but for terminal output.

```gdscript
func _ready():
	print_rich("[color=red]red [b]text")
	print_rich("[color=blue]blue [i]text")
	print_rich("white text")
```

| Before | After |
|--|--|
| <img width="497" alt="Screenshot 2023-07-04 141539" src="https://github.com/godotengine/godot/assets/7645683/0374c91d-9834-4a6c-98d4-21d6b433ed7f"> | <img width="497" alt="Screenshot 2023-07-04 141539" src="https://github.com/godotengine/godot/assets/7645683/645f69c4-2eef-4949-91c1-ebb81135451a"> |