### PR TITLE
Fix AspectRatioContainer not changing its minimum size based on ratio…

### DIFF
--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -40,6 +40,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 	virtual Size2 get_minimum_size() const override;
+	Size2 calc_child_size(const Size2 &p_child_minsize, const Size2 &p_size) const;
 
 public:
 	enum StretchMode {


### PR DESCRIPTION
… and stretch mode

This change enables proper use of `AspectRatioContainer`s inside another containers. Stretch mode and aspect ratio respected by container's minimum size, so parent container can pick the size right.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
