### PR TITLE
Fix export options of scripted `EditorExportPlugin`s

### DIFF
--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -45,6 +45,7 @@ class EditorExport : public Node {
 
 	Timer *save_timer = nullptr;
 	bool block_save = false;
+	bool should_update_presets = false;
 
 	static EditorExport *singleton;
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -329,9 +329,10 @@ Ref<EditorExportPreset> EditorExportPlatform::create_preset() {
 	}
 
 	for (const ExportOption &E : options) {
-		preset->properties.push_back(E.option);
-		preset->values[E.option.name] = E.default_value;
-		preset->update_visibility[E.option.name] = E.update_visibility;
+		StringName option_name = E.option.name;
+		preset->properties[option_name] = E.option;
+		preset->values[option_name] = E.default_value;
+		preset->update_visibility[option_name] = E.update_visibility;
 	}
 
 	return preset;

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -31,9 +31,9 @@
 #include "editor_export.h"
 
 bool EditorExportPreset::_set(const StringName &p_name, const Variant &p_value) {
-	if (values.has(p_name)) {
-		values[p_name] = p_value;
-		EditorExport::singleton->save_presets();
+	values[p_name] = p_value;
+	EditorExport::singleton->save_presets();
+	if (update_visibility.has(p_name)) {
 		if (update_visibility[p_name]) {
 			notify_property_list_changed();
 		}
@@ -61,9 +61,9 @@ String EditorExportPreset::_get_property_warning(const StringName &p_name) const
 }
 
 void EditorExportPreset::_get_property_list(List<PropertyInfo> *p_list) const {
-	for (const PropertyInfo &E : properties) {
-		if (platform->get_export_option_visibility(this, E.name)) {
-			p_list->push_back(E);
+	for (const KeyValue<StringName, PropertyInfo> &E : properties) {
+		if (platform->get_export_option_visibility(this, E.key)) {
+			p_list->push_back(E.value);
 		}
 	}
 }

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -70,7 +70,7 @@ private:
 	friend class EditorExport;
 	friend class EditorExportPlatform;
 
-	List<PropertyInfo> properties;
+	HashMap<StringName, PropertyInfo> properties;
 	HashMap<StringName, Variant> values;
 	HashMap<StringName, bool> update_visibility;
 
@@ -154,7 +154,8 @@ public:
 
 	Variant get_or_env(const StringName &p_name, const String &p_env_var, bool *r_valid = nullptr) const;
 
-	const List<PropertyInfo> &get_properties() const { return properties; }
+	const HashMap<StringName, PropertyInfo> &get_properties() const { return properties; }
+	const HashMap<StringName, Variant> &get_values() const { return values; }
 
 	EditorExportPreset();
 };

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -577,8 +577,8 @@ void ProjectExportDialog::_duplicate_preset() {
 	preset->set_exclude_filter(current->get_exclude_filter());
 	preset->set_custom_features(current->get_custom_features());
 
-	for (const PropertyInfo &E : current->get_properties()) {
-		preset->set(E.name, current->get(E.name));
+	for (const KeyValue<StringName, Variant> &E : current->get_values()) {
+		preset->set(E.key, E.value);
 	}
 
 	EditorExport::get_singleton()->add_export_preset(preset);


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/78958#issuecomment-1618994224

Not sure what the issue @m4gr3d has was, in my testing export options that are created by scripted export plugins, didn't work at all, unless the preset was created after enabling the plugin and only until the editor is restarted.

This PR ensures that the presets are updated after enabling/disabling export plugins, so that its options show up in/disappear from existing presets. Additionally this PR preserves the values of all options, even when they no longer exist, so that disabling a plugin doesn't cause its options to be lost. There is one exception to this in secret options, which will be dropped when the option no longer exists, to prefer loosing the secret over leaking it into the normal preset file when next saving the options.