### PR TITLE
Hide unusable ColorPickerButton properties.

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2101,6 +2101,12 @@ ColorPickerButton::ColorPickerButton(const String &p_text) :
 	set_toggle_mode(true);
 }
 
+void ColorPickerButton::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "text" || p_property.name == "icon" || p_property.name == "alignment" || p_property.name == "text_overrun_behavior" || p_property.name == "clip_text" || p_property.name == "icon_alignment" || p_property.name == "vertical_icon_alignment" || p_property.name == "expand_icon" || p_property.name == "text_direction" || p_property.name == "language") {
+		p_property.usage &= ~PROPERTY_USAGE_EDITOR;
+	}
+}
+
 /////////////////
 
 void ColorPresetButton::_notification(int p_what) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -400,6 +400,7 @@ protected:
 
 	void _notification(int);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 public:
 	void set_pick_color(const Color &p_color);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/79030
