### PR TITLE
Move cached values into `color_mode.cpp` and apply fixes to OKHSL

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -105,6 +105,17 @@ void ColorModeRGB::slider_draw(int p_which) {
 	slider->draw_polygon(pos, col);
 }
 
+void ColorModeHSV::_value_changed() {
+	Vector<float> values = color_picker->get_active_slider_values();
+
+	if (values[1] > 0 || values[0] != cached_hue) {
+		cached_hue = values[0];
+	}
+	if (values[2] > 0 || values[1] != cached_saturation) {
+		cached_saturation = values[1];
+	}
+}
+
 String ColorModeHSV::get_slider_label(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 3, String(), "Couldn't get slider label.");
 	return labels[idx];
@@ -121,14 +132,14 @@ float ColorModeHSV::get_slider_value(int idx) const {
 			if (color_picker->get_pick_color().get_s() > 0) {
 				return color_picker->get_pick_color().get_h() * 360.0;
 			} else {
-				return color_picker->get_cached_hue();
+				return cached_hue;
 			}
 		}
 		case 1: {
 			if (color_picker->get_pick_color().get_v() > 0) {
 				return color_picker->get_pick_color().get_s() * 100.0;
 			} else {
-				return color_picker->get_cached_saturation();
+				return cached_saturation;
 			}
 		}
 		case 2:
@@ -176,7 +187,7 @@ void ColorModeHSV::slider_draw(int p_which) {
 		s_col.set_hsv(color.get_h(), 0, color.get_v());
 		left_color = (p_which == 1) ? s_col : Color(0, 0, 0);
 
-		float s_col_hue = (color.get_s() == 0.0) ? color_picker->get_cached_hue() / 360.0 : color.get_h();
+		float s_col_hue = (Math::is_zero_approx(color.get_s())) ? cached_hue / 360.0 : color.get_h();
 		s_col.set_hsv(s_col_hue, 1, color.get_v());
 		v_col.set_hsv(color.get_h(), color.get_s(), 1);
 		right_color = (p_which == 1) ? s_col : v_col;
@@ -262,6 +273,17 @@ bool ColorModeRAW::apply_theme() const {
 	return true;
 }
 
+void ColorModeOKHSL::_value_changed() {
+	Vector<float> values = color_picker->get_active_slider_values();
+
+	if (values[1] > 0 || values[0] != cached_hue) {
+		cached_hue = values[0];
+	}
+	if (values[2] > 0 || values[1] != cached_saturation) {
+		cached_saturation = values[1];
+	}
+}
+
 String ColorModeOKHSL::get_slider_label(int idx) const {
 	ERR_FAIL_INDEX_V_MSG(idx, 3, String(), "Couldn't get slider label.");
 	return labels[idx];
@@ -274,10 +296,20 @@ float ColorModeOKHSL::get_slider_max(int idx) const {
 
 float ColorModeOKHSL::get_slider_value(int idx) const {
 	switch (idx) {
-		case 0:
-			return color_picker->get_pick_color().get_ok_hsl_h() * 360.0;
-		case 1:
-			return color_picker->get_pick_color().get_ok_hsl_s() * 100.0;
+		case 0: {
+			if (color_picker->get_pick_color().get_ok_hsl_s() > 0) {
+				return color_picker->get_pick_color().get_ok_hsl_h() * 360.0;
+			} else {
+				return cached_hue;
+			}
+		}
+		case 1: {
+			if (color_picker->get_pick_color().get_ok_hsl_l() > 0) {
+				return color_picker->get_pick_color().get_ok_hsl_s() * 100.0;
+			} else {
+				return cached_saturation;
+			}
+		}
 		case 2:
 			return color_picker->get_pick_color().get_ok_hsl_l() * 100.0;
 		case 3:
@@ -316,8 +348,11 @@ void ColorModeOKHSL::slider_draw(int p_which) {
 		col.resize(6);
 		left_color = Color(0, 0, 0);
 		Color middle_color;
-		middle_color.set_ok_hsl(color.get_ok_hsl_h(), color.get_ok_hsl_s(), 0.5);
-		right_color.set_ok_hsl(color.get_ok_hsl_h(), color.get_ok_hsl_s(), 1);
+		float slider_hue = (Math::is_zero_approx(color.get_ok_hsl_s())) ? cached_hue / 360.0 : color.get_ok_hsl_h();
+		float slider_sat = (Math::is_zero_approx(color.get_ok_hsl_l())) ? cached_saturation / 100.0 : color.get_ok_hsl_s();
+
+		middle_color.set_ok_hsl(slider_hue, slider_sat, 0.5);
+		right_color.set_ok_hsl(slider_hue, slider_sat, 1);
 
 		col.set(0, left_color);
 		col.set(1, middle_color);
@@ -344,7 +379,8 @@ void ColorModeOKHSL::slider_draw(int p_which) {
 			right_color.a = 1;
 		} else {
 			left_color.set_ok_hsl(color.get_ok_hsl_h(), 0, color.get_ok_hsl_l());
-			right_color.set_ok_hsl(color.get_ok_hsl_h(), 1, color.get_ok_hsl_l());
+			float s_col_hue = (Math::is_zero_approx(color.get_ok_hsl_s())) ? cached_hue / 360.0 : color.get_ok_hsl_h();
+			right_color.set_ok_hsl(s_col_hue, 1, color.get_ok_hsl_l());
 		}
 
 		col.set(0, left_color);

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -49,6 +49,8 @@ public:
 
 	virtual Color get_color() const = 0;
 
+	virtual void _value_changed(){};
+
 	virtual void slider_draw(int p_which) = 0;
 	virtual bool apply_theme() const { return false; }
 	virtual ColorPicker::PickerShapeType get_shape_override() const { return ColorPicker::SHAPE_MAX; }
@@ -61,6 +63,8 @@ class ColorModeHSV : public ColorMode {
 public:
 	String labels[3] = { "H", "S", "V" };
 	float slider_max[4] = { 359, 100, 100, 255 };
+	float cached_hue = 0.0;
+	float cached_saturation = 0.0;
 
 	virtual String get_name() const override { return "HSV"; }
 
@@ -70,6 +74,8 @@ public:
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
+
+	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
 
@@ -121,6 +127,8 @@ class ColorModeOKHSL : public ColorMode {
 public:
 	String labels[3] = { "H", "S", "L" };
 	float slider_max[4] = { 359, 100, 100, 255 };
+	float cached_hue = 0.0;
+	float cached_saturation = 0.0;
 
 	virtual String get_name() const override { return "OKHSL"; }
 
@@ -130,6 +138,8 @@ public:
 	virtual float get_slider_value(int idx) const override;
 
 	virtual Color get_color() const override;
+
+	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
 	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -375,15 +375,7 @@ void ColorPicker::_value_changed(double) {
 	}
 
 	color = modes[current_mode]->get_color();
-
-	if (current_mode == MODE_HSV) {
-		if (sliders[1]->get_value() > 0 || sliders[0]->get_value() != cached_hue) {
-			cached_hue = sliders[0]->get_value();
-		}
-		if (sliders[2]->get_value() > 0 || sliders[1]->get_value() != cached_saturation) {
-			cached_saturation = sliders[1]->get_value();
-		}
-	}
+	modes[current_mode]->_value_changed();
 
 	if (current_mode == MODE_HSV || current_mode == MODE_OKHSL) {
 		h = sliders[0]->get_value() / 360.0;

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -204,8 +204,6 @@ private:
 	float h = 0.0;
 	float s = 0.0;
 	float v = 0.0;
-	float cached_hue = 0.0;
-	float cached_saturation = 0.0;
 	Color last_color;
 
 	struct ThemeCache {
@@ -296,9 +294,6 @@ public:
 #ifdef TOOLS_ENABLED
 	void set_editor_settings(Object *p_editor_settings);
 #endif
-	float get_cached_hue() { return cached_hue; };
-	float get_cached_saturation() { return cached_saturation; };
-
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();
 


### PR DESCRIPTION
I'm following up a quote by @KoBeWi  on #78486 and #77863. I have moved the caching logic into the color_mode.
https://github.com/godotengine/godot/pull/78486#discussion_r1237779159

However, I am debating whether to move out the `h`, `s`, `v`, and `last_color` values as well. For `h`, `s`, and `v`, I see that they are used by other functions such as `_w_input` and `_uv_input`. It seems these are part of the picker shape.. For `last_color`,  I believe this is a part of the last_color shown in the picker. Thus, I did not move this logic into color_mode. 

In addition, I applied the same logic to OKHSL, it seems I overlooked the issue a while back. This logic is put in `color_mode.cpp`