### PR TITLE
Unify some EditorData usage

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1283,20 +1283,20 @@ void ScriptEditorDebugger::_live_edit_set() {
 
 	NodePath np = path;
 
-	EditorNode::get_singleton()->get_editor_data().set_edited_scene_live_edit_root(np);
+	EditorNode::get_editor_data().set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::_live_edit_clear() {
 	NodePath np = NodePath("/root");
-	EditorNode::get_singleton()->get_editor_data().set_edited_scene_live_edit_root(np);
+	EditorNode::get_editor_data().set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::update_live_edit_root() {
-	NodePath np = EditorNode::get_singleton()->get_editor_data().get_edited_scene_live_edit_root();
+	NodePath np = EditorNode::get_editor_data().get_edited_scene_live_edit_root();
 
 	Array msg;
 	msg.push_back(np);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -878,8 +878,8 @@ void EditorProperty::_update_pin_flags() {
 		// Avoid errors down the road by ignoring nodes which are not part of a scene
 		if (!node->get_owner()) {
 			bool is_scene_root = false;
-			for (int i = 0; i < EditorNode::get_singleton()->get_editor_data().get_edited_scene_count(); ++i) {
-				if (EditorNode::get_singleton()->get_editor_data().get_edited_scene_root(i) == node) {
+			for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); ++i) {
+				if (EditorNode::get_editor_data().get_edited_scene_root(i) == node) {
 					is_scene_root = true;
 					break;
 				}
@@ -1717,7 +1717,7 @@ void EditorInspectorArray::_move_element(int p_element_index, int p_to_pos) {
 	undo_redo->create_action(action_name);
 	if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 		// Call the function.
-		Callable move_function = EditorNode::get_singleton()->get_editor_data().get_move_array_element_function(object->get_class_name());
+		Callable move_function = EditorNode::get_editor_data().get_move_array_element_function(object->get_class_name());
 		if (move_function.is_valid()) {
 			Variant args[] = { undo_redo, object, array_element_prefix, p_element_index, p_to_pos };
 			const Variant *args_p[] = { &args[0], &args[1], &args[2], &args[3], &args[4] };
@@ -1862,7 +1862,7 @@ void EditorInspectorArray::_clear_array() {
 	if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 		for (int i = count - 1; i >= 0; i--) {
 			// Call the function.
-			Callable move_function = EditorNode::get_singleton()->get_editor_data().get_move_array_element_function(object->get_class_name());
+			Callable move_function = EditorNode::get_editor_data().get_move_array_element_function(object->get_class_name());
 			if (move_function.is_valid()) {
 				Variant args[] = { undo_redo, object, array_element_prefix, i, -1 };
 				const Variant *args_p[] = { &args[0], &args[1], &args[2], &args[3], &args[4] };
@@ -1916,7 +1916,7 @@ void EditorInspectorArray::_resize_array(int p_size) {
 		if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 			for (int i = count; i < p_size; i++) {
 				// Call the function.
-				Callable move_function = EditorNode::get_singleton()->get_editor_data().get_move_array_element_function(object->get_class_name());
+				Callable move_function = EditorNode::get_editor_data().get_move_array_element_function(object->get_class_name());
 				if (move_function.is_valid()) {
 					Variant args[] = { undo_redo, object, array_element_prefix, -1, -1 };
 					const Variant *args_p[] = { &args[0], &args[1], &args[2], &args[3], &args[4] };
@@ -1935,7 +1935,7 @@ void EditorInspectorArray::_resize_array(int p_size) {
 		if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 			for (int i = count - 1; i > p_size - 1; i--) {
 				// Call the function.
-				Callable move_function = EditorNode::get_singleton()->get_editor_data().get_move_array_element_function(object->get_class_name());
+				Callable move_function = EditorNode::get_editor_data().get_move_array_element_function(object->get_class_name());
 				if (move_function.is_valid()) {
 					Variant args[] = { undo_redo, object, array_element_prefix, i, -1 };
 					const Variant *args_p[] = { &args[0], &args[1], &args[2], &args[3], &args[4] };
@@ -3690,7 +3690,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		Variant v_undo_redo = undo_redo;
 		Variant v_object = object;
 		Variant v_name = p_name;
-		const Vector<Callable> &callbacks = EditorNode::get_singleton()->get_editor_data().get_undo_redo_inspector_hook_callback();
+		const Vector<Callable> &callbacks = EditorNode::get_editor_data().get_undo_redo_inspector_hook_callback();
 		for (int i = 0; i < callbacks.size(); i++) {
 			const Callable &callback = callbacks[i];
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7618,8 +7618,8 @@ EditorNode::EditorNode() {
 
 	// Instantiate and place editor docks.
 
-	memnew(SceneTreeDock(scene_root, editor_selection, editor_data));
-	memnew(InspectorDock(editor_data));
+	memnew(SceneTreeDock);
+	memnew(InspectorDock);
 	memnew(ImportDock);
 	memnew(NodeDock);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -364,11 +364,11 @@ bool EditorPlugin::get_remove_list(List<Node *> *p_list) {
 }
 
 void EditorPlugin::add_undo_redo_inspector_hook_callback(Callable p_callable) {
-	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(p_callable);
+	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(p_callable);
 }
 
 void EditorPlugin::remove_undo_redo_inspector_hook_callback(Callable p_callable) {
-	EditorNode::get_singleton()->get_editor_data().remove_undo_redo_inspector_hook_callback(p_callable);
+	EditorNode::get_editor_data().remove_undo_redo_inspector_hook_callback(p_callable);
 }
 
 void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -70,7 +70,7 @@ int EditorUndoRedoManager::get_history_id_for_object(Object *p_object) const {
 		Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 
 		if (edited_scene && (node == edited_scene || edited_scene->is_ancestor_of(node))) {
-			int idx = EditorNode::get_singleton()->get_editor_data().get_current_edited_scene_history_id();
+			int idx = EditorNode::get_editor_data().get_current_edited_scene_history_id();
 			if (idx > 0) {
 				history_id = idx;
 			}
@@ -80,12 +80,12 @@ int EditorUndoRedoManager::get_history_id_for_object(Object *p_object) const {
 	if (Resource *res = Object::cast_to<Resource>(p_object)) {
 		if (res->is_built_in()) {
 			if (res->get_path().is_empty()) {
-				int idx = EditorNode::get_singleton()->get_editor_data().get_current_edited_scene_history_id();
+				int idx = EditorNode::get_editor_data().get_current_edited_scene_history_id();
 				if (idx > 0) {
 					history_id = idx;
 				}
 			} else {
-				int idx = EditorNode::get_singleton()->get_editor_data().get_scene_history_id_from_path(res->get_path().get_slice("::", 0));
+				int idx = EditorNode::get_editor_data().get_scene_history_id_from_path(res->get_path().get_slice("::", 0));
 				if (idx > 0) {
 					history_id = idx;
 				}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1361,7 +1361,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);
 			if (ResourceLoader::get_resource_type(new_item_path) == "PackedScene" && EditorNode::get_singleton()->is_scene_open(file_changed_paths[i])) {
-				EditorData *ed = &EditorNode::get_singleton()->get_editor_data();
+				EditorData *ed = &EditorNode::get_editor_data();
 				for (int j = 0; j < ed->get_edited_scene_count(); j++) {
 					if (ed->get_scene_path(j) == file_changed_paths[i]) {
 						ed->get_edited_scene_root(j)->set_scene_file_path(new_item_path);
@@ -1629,7 +1629,7 @@ void FileSystemDock::_make_scene_confirm() {
 	const String scene_path = make_scene_dialog->get_scene_path();
 
 	int idx = EditorNode::get_singleton()->new_scene();
-	EditorNode::get_singleton()->get_editor_data().set_scene_path(idx, scene_path);
+	EditorNode::get_editor_data().set_scene_path(idx, scene_path);
 	EditorNode::get_singleton()->set_edited_scene(make_scene_dialog->create_scene_root());
 	EditorNode::get_singleton()->save_scene_list({ scene_path });
 }

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -102,16 +102,16 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 
 		case OBJECT_COPY_PARAMS: {
-			editor_data->apply_changes_in_editors();
+			EditorNode::get_editor_data().apply_changes_in_editors();
 			if (current) {
-				editor_data->copy_object_params(current);
+				EditorNode::get_editor_data().copy_object_params(current);
 			}
 		} break;
 
 		case OBJECT_PASTE_PARAMS: {
-			editor_data->apply_changes_in_editors();
+			EditorNode::get_editor_data().apply_changes_in_editors();
 			if (current) {
-				editor_data->paste_object_params(current);
+				EditorNode::get_editor_data().paste_object_params(current);
 			}
 		} break;
 
@@ -157,7 +157,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 					unique_resources_confirmation->popup_centered();
 				}
 			} else {
-				editor_data->apply_changes_in_editors();
+				EditorNode::get_editor_data().apply_changes_in_editors();
 
 				if (current) {
 					List<PropertyInfo> props;
@@ -619,11 +619,9 @@ void InspectorDock::apply_script_properties(Object *p_object) {
 	stored_properties.clear();
 }
 
-InspectorDock::InspectorDock(EditorData &p_editor_data) {
+InspectorDock::InspectorDock() {
 	singleton = this;
 	set_name("Inspector");
-
-	editor_data = &p_editor_data;
 
 	property_name_style = EditorPropertyNameProcessor::get_default_inspector_style();
 

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -159,7 +159,7 @@ public:
 	void store_script_properties(Object *p_object);
 	void apply_script_properties(Object *p_object);
 
-	InspectorDock(EditorData &p_editor_data);
+	InspectorDock();
 	~InspectorDock();
 };
 

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -116,7 +116,7 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 }
 
 AudioStreamRandomizerEditorPlugin::AudioStreamRandomizerEditorPlugin() {
-	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("AudioStreamRandomizer"), callable_mp(this, &AudioStreamRandomizerEditorPlugin::_move_stream_array_element));
+	EditorNode::get_editor_data().add_move_array_element_function(SNAME("AudioStreamRandomizer"), callable_mp(this, &AudioStreamRandomizerEditorPlugin::_move_stream_array_element));
 }
 
 AudioStreamRandomizerEditorPlugin::~AudioStreamRandomizerEditorPlugin() {}

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -350,7 +350,7 @@ EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
 	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
 	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
 
-	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
+	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
 }
 
 MaterialEditorPlugin::MaterialEditorPlugin() {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2703,7 +2703,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 			_update_navigation_controls_visibility();
 			_update_freelook(delta);
 
-			Node *scene_root = SceneTreeDock::get_singleton()->get_editor_data()->get_edited_scene_root();
+			Node *scene_root = EditorNode::get_editor_data().get_edited_scene_root();
 			if (previewing_cinema && scene_root != nullptr) {
 				Camera3D *cam = scene_root->get_viewport()->get_camera_3d();
 				if (cam != nullptr && cam != previewing) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3610,7 +3610,7 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 		Ref<Resource> res = ResourceLoader::load(fpath);
 
 		if (fpath.get_extension() == "gdshader") {
-			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_editor_data().get_editor("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);
 			shader_editor->get_shader_editor(res)->goto_line_selection(line_number - 1, begin, end);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3487,6 +3487,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 ///////////////////////
 
 void ThemeEditor::edit(const Ref<Theme> &p_theme) {
+	print_line(p_theme);
 	if (theme == p_theme) {
 		return;
 	}

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -4089,7 +4089,7 @@ TileMapEditor::TileMapEditor() {
 	_tab_changed(0);
 
 	// Registers UndoRedo inspector callback.
-	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("TileMap"), callable_mp(this, &TileMapEditor::_move_tile_map_array_element));
+	EditorNode::get_editor_data().add_move_array_element_function(SNAME("TileMap"), callable_mp(this, &TileMapEditor::_move_tile_map_array_element));
 }
 
 TileMapEditor::~TileMapEditor() {

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2626,7 +2626,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_atlas_view->add_control_over_alternative_tiles(alternative_tiles_control_unscaled, false);
 	alternative_tiles_control_unscaled->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 
-	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &TileSetAtlasSourceEditor::_undo_redo_inspector_callback));
+	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &TileSetAtlasSourceEditor::_undo_redo_inspector_callback));
 
 	// -- Dialogs --
 	confirm_auto_create_tiles = memnew(AcceptDialog);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -865,6 +865,6 @@ TileSetEditor::TileSetEditor() {
 	patterns_item_list->add_child(patterns_help_label);
 
 	// Registers UndoRedo inspector callback.
-	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("TileSet"), callable_mp(this, &TileSetEditor::_move_tile_set_array_element));
-	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &TileSetEditor::_undo_redo_inspector_callback));
+	EditorNode::get_editor_data().add_move_array_element_function(SNAME("TileSet"), callable_mp(this, &TileSetEditor::_move_tile_set_array_element));
+	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &TileSetEditor::_undo_redo_inspector_callback));
 }

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -458,7 +458,7 @@ void VersionControlEditorPlugin::_force_push() {
 }
 
 void VersionControlEditorPlugin::_update_opened_tabs() {
-	Vector<EditorData::EditedScene> open_scenes = EditorNode::get_singleton()->get_editor_data().get_edited_scenes();
+	Vector<EditorData::EditedScene> open_scenes = EditorNode::get_editor_data().get_edited_scenes();
 	for (int i = 0; i < open_scenes.size(); i++) {
 		if (open_scenes[i].root == NULL) {
 			continue;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6538,7 +6538,7 @@ void EditorPropertyVisualShaderMode::_option_selected(int p_which) {
 		return;
 	}
 
-	ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
+	ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_editor_data().get_editor("Shader"));
 	if (!shader_editor) {
 		return;
 	}

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -444,11 +444,11 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 		result = result.replace("${TYPE}", node->get_class());
 	}
 
-	int current = EditorNode::get_singleton()->get_editor_data().get_edited_scene();
+	int current = EditorNode::get_editor_data().get_edited_scene();
 	// Always request the scene title with the extension stripped.
 	// Otherwise, the result could vary depending on whether a scene with the same name
 	// (but different extension) is currently open.
-	result = result.replace("${SCENE}", EditorNode::get_singleton()->get_editor_data().get_scene_title(current, true));
+	result = result.replace("${SCENE}", EditorNode::get_editor_data().get_scene_title(current, true));
 
 	Node *root_node = SceneTree::get_singleton()->get_edited_scene_root();
 	if (root_node) {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -37,8 +37,6 @@
 #include "scene/resources/animation.h"
 
 class CheckBox;
-class EditorData;
-class EditorSelection;
 class EditorQuickOpen;
 class MenuButton;
 class ReparentDialog;
@@ -138,9 +136,6 @@ class SceneTreeDock : public VBoxContainer {
 	String resource_drop_path;
 	void _perform_property_drop(Node *p_node, String p_property, Ref<Resource> p_res);
 
-	EditorData *editor_data = nullptr;
-	EditorSelection *editor_selection = nullptr;
-
 	List<Node *> node_clipboard;
 	String clipboard_source_scene;
 	HashMap<String, HashMap<Ref<Resource>, Ref<Resource>>> clipboard_resource_remap;
@@ -176,7 +171,6 @@ class SceneTreeDock : public VBoxContainer {
 
 	void _create();
 	void _do_create(Node *p_parent);
-	Node *scene_root = nullptr;
 	Node *edited_scene = nullptr;
 	Node *pending_click_select = nullptr;
 	bool tree_clicked = false;
@@ -308,7 +302,6 @@ public:
 	void fill_path_renames(Node *p_node, Node *p_new_parent, HashMap<Node *, NodePath> *p_renames);
 	void perform_node_renames(Node *p_base, HashMap<Node *, NodePath> *p_renames, HashMap<Ref<Animation>, HashSet<int>> *r_rem_anims = nullptr);
 	SceneTreeEditor *get_tree_editor() { return scene_tree; }
-	EditorData *get_editor_data() { return editor_data; }
 
 	void add_remote_tree_editor(Control *p_remote);
 	void show_remote_tree();
@@ -334,7 +327,7 @@ public:
 		return script_create_dialog;
 	}
 
-	SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
+	SceneTreeDock();
 	~SceneTreeDock();
 };
 


### PR DESCRIPTION
Another cleanup of legacy stuff.
- replace usages of `EditorNode::get_singleton()->get_editor_data()` with `EditorNode::get_editor_data()`
- remove local EditorData pointers from SceneTreeDock and InspectorDock
- remove local EditorSelection and scene root pointers from SceneTreeDock