### PR TITLE
Rename `button_pressed` default signal binding to avoid shadowing

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -17,7 +17,7 @@
 		</method>
 		<method name="_toggled" qualifiers="virtual">
 			<return type="void" />
-			<param index="0" name="button_pressed" type="bool" />
+			<param index="0" name="toggled_on" type="bool" />
 			<description>
 				Called when the button is toggled (only if [member toggle_mode] is active).
 			</description>
@@ -98,9 +98,9 @@
 			</description>
 		</signal>
 		<signal name="toggled">
-			<param index="0" name="button_pressed" type="bool" />
+			<param index="0" name="toggled_on" type="bool" />
 			<description>
-				Emitted when the button was just toggled between pressed and normal states (only if [member toggle_mode] is active). The new state is contained in the [param button_pressed] argument.
+				Emitted when the button was just toggled between pressed and normal states (only if [member toggle_mode] is active). The new state is contained in the [param toggled_on] argument.
 			</description>
 		</signal>
 	</signals>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -468,12 +468,12 @@ void BaseButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_button_group"), &BaseButton::get_button_group);
 
 	GDVIRTUAL_BIND(_pressed);
-	GDVIRTUAL_BIND(_toggled, "button_pressed");
+	GDVIRTUAL_BIND(_toggled, "toggled_on");
 
 	ADD_SIGNAL(MethodInfo("pressed"));
 	ADD_SIGNAL(MethodInfo("button_up"));
 	ADD_SIGNAL(MethodInfo("button_down"));
-	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "button_pressed")));
+	ADD_SIGNAL(MethodInfo("toggled", PropertyInfo(Variant::BOOL, "toggled_on")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");


### PR DESCRIPTION
Title says it all :3 