### PR TITLE
Support `uid://` paths from external PCK files

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -94,6 +94,13 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 			cd->files.insert(filename);
 		}
 	}
+
+	// Handle special files
+	if (simplified_path == ResourceUID::get_cache_file()) {
+		// UID cache file
+		Ref<FileAccessPack> f = memnew(FileAccessPack(p_pkg_path, pf));
+		ResourceUID::get_singleton()->load_from_file(f);
+	}
 }
 
 void PackedData::add_pack_source(PackSource *p_source) {

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
-#include "core/io/file_access.h"
 
 static constexpr uint32_t char_count = ('z' - 'a');
 static constexpr uint32_t base = char_count + ('9' - '0');
@@ -169,22 +168,27 @@ Error ResourceUID::save_to_cache() {
 
 Error ResourceUID::load_from_cache() {
 	Ref<FileAccess> f = FileAccess::open(get_cache_file(), FileAccess::READ);
-	if (f.is_null()) {
+	unique_ids.clear();
+
+	return load_from_file(f);
+}
+
+Error ResourceUID::load_from_file(const Ref<FileAccess> &p_file) {
+	if (p_file.is_null()) {
 		return ERR_CANT_OPEN;
 	}
 
 	MutexLock l(mutex);
-	unique_ids.clear();
 
-	uint32_t entry_count = f->get_32();
+	uint32_t entry_count = p_file->get_32();
 	for (uint32_t i = 0; i < entry_count; i++) {
-		int64_t id = f->get_64();
-		int32_t len = f->get_32();
+		int64_t id = p_file->get_64();
+		int32_t len = p_file->get_32();
 		Cache c;
 		c.cs.resize(len + 1);
 		ERR_FAIL_COND_V(c.cs.size() != len + 1, ERR_FILE_CORRUPT); // out of memory
 		c.cs[len] = 0;
-		int32_t rl = f->get_buffer((uint8_t *)c.cs.ptrw(), len);
+		int32_t rl = p_file->get_buffer((uint8_t *)c.cs.ptrw(), len);
 		ERR_FAIL_COND_V(rl != len, ERR_FILE_CORRUPT);
 
 		c.saved_to_cache = true;

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -31,6 +31,7 @@
 #ifndef RESOURCE_UID_H
 #define RESOURCE_UID_H
 
+#include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
 #include "core/templates/hash_map.h"
@@ -74,6 +75,7 @@ public:
 	void remove_id(ID p_id);
 
 	Error load_from_cache();
+	Error load_from_file(const Ref<FileAccess> &p_file);
 	Error save_to_cache();
 	Error update_cache();
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7181

Because Godot now uses UIDs whenever possible, if these don't exist, warnings are generated. External scenes from PCK files can reference external UIDs not on the original project.

Since the `uid_cache.bin` is being force-exported anyways, this takes advantage of that fact by appending that information to the UID map.

https://github.com/godotengine/godot/blob/46424488edc341b65467ee7fd3ac423e4d49ad34/editor/export/editor_export_platform.cpp#L842-L845
