### PR TITLE
Add missing `useModelFront` parameter to GodotSharp Basis and Transform

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace Godot
 {
@@ -623,21 +624,31 @@ namespace Godot
         /// </summary>
         /// <param name="target">The position to look at.</param>
         /// <param name="up">The relative up direction.</param>
+        /// <param name="useModelFront">
+        /// If true, then the model is oriented in reverse,
+        /// towards the model front axis (+Z, Vector3.ModelFront),
+        /// which is more useful for orienting 3D models.
+        /// </param>
         /// <returns>The resulting basis matrix.</returns>
-        public static Basis LookingAt(Vector3 target, Vector3 up)
+        public static Basis LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
         {
+            up ??= Vector3.Up;
 #if DEBUG
             if (target.IsZeroApprox())
             {
                 throw new ArgumentException("The vector can't be zero.", nameof(target));
             }
-            if (up.IsZeroApprox())
+            if (up.Value.IsZeroApprox())
             {
                 throw new ArgumentException("The vector can't be zero.", nameof(up));
             }
 #endif
-            Vector3 column2 = -target.Normalized();
-            Vector3 column0 = up.Cross(column2);
+            Vector3 column2 = target.Normalized();
+            if (!useModelFront)
+            {
+                column2 = -column2;
+            }
+            Vector3 column0 = up.Value.Cross(column2);
 #if DEBUG
             if (column0.IsZeroApprox())
             {
@@ -647,6 +658,13 @@ namespace Godot
             column0.Normalize();
             Vector3 column1 = column2.Cross(column0);
             return new Basis(column0, column1, column2);
+        }
+
+        /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Basis LookingAt(Vector3 target, Vector3 up)
+        {
+            return LookingAt(target, up, false);
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace Godot
 {
@@ -175,12 +176,24 @@ namespace Godot
         /// </summary>
         /// <param name="target">The object to look at.</param>
         /// <param name="up">The relative up direction.</param>
+        /// <param name="useModelFront">
+        /// If true, then the model is oriented in reverse,
+        /// towards the model front axis (+Z, Vector3.ModelFront),
+        /// which is more useful for orienting 3D models.
+        /// </param>
         /// <returns>The resulting transform.</returns>
-        public readonly Transform3D LookingAt(Vector3 target, Vector3 up)
+        public readonly Transform3D LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
         {
             Transform3D t = this;
-            t.SetLookAt(Origin, target, up);
+            t.SetLookAt(Origin, target, up ?? Vector3.Up, useModelFront);
             return t;
+        }
+
+        /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public readonly Transform3D LookingAt(Vector3 target, Vector3 up)
+        {
+            return LookingAt(target, up, false);
         }
 
         /// <summary>
@@ -247,9 +260,9 @@ namespace Godot
             return new Transform3D(Basis * tmpBasis, Origin);
         }
 
-        private void SetLookAt(Vector3 eye, Vector3 target, Vector3 up)
+        private void SetLookAt(Vector3 eye, Vector3 target, Vector3 up, bool useModelFront = false)
         {
-            Basis = Basis.LookingAt(target - eye, up);
+            Basis = Basis.LookingAt(target - eye, up, useModelFront);
             Origin = eye;
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -660,6 +660,13 @@ namespace Godot
         private static readonly Vector3 _forward = new Vector3(0, 0, -1);
         private static readonly Vector3 _back = new Vector3(0, 0, 1);
 
+        private static readonly Vector3 _modelLeft = new Vector3(1, 0, 0);
+        private static readonly Vector3 _modelRight = new Vector3(-1, 0, 0);
+        private static readonly Vector3 _modelTop = new Vector3(0, 1, 0);
+        private static readonly Vector3 _modelBottom = new Vector3(0, -1, 0);
+        private static readonly Vector3 _modelFront = new Vector3(0, 0, 1);
+        private static readonly Vector3 _modelRear = new Vector3(0, 0, -1);
+
         /// <summary>
         /// Zero vector, a vector with all components set to <c>0</c>.
         /// </summary>
@@ -710,6 +717,31 @@ namespace Godot
         /// </summary>
         /// <value>Equivalent to <c>new Vector3(0, 0, 1)</c>.</value>
         public static Vector3 Back { get { return _back; } }
+
+        /// <summary>
+        /// Unit vector pointing towards the left side of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelLeft { get { return _modelLeft; } }
+        /// <summary>
+        /// Unit vector pointing towards the right side of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelRight { get { return _modelRight; } }
+        /// <summary>
+        /// Unit vector pointing towards the top side (up) of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelTop { get { return _modelTop; } }
+        /// <summary>
+        /// Unit vector pointing towards the bottom side (down) of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelBottom { get { return _modelBottom; } }
+        /// <summary>
+        /// Unit vector pointing towards the front side (facing forward) of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelFront { get { return _modelFront; } }
+        /// <summary>
+        /// Unit vector pointing towards the rear side (back) of imported 3D assets.
+        /// </summary>
+        public static Vector3 ModelRear { get { return _modelRear; } }
 
         /// <summary>
         /// Constructs a new <see cref="Vector3"/> with the given components.


### PR DESCRIPTION
On LookAt methods.
Also adds Vector3 Model constants.

These were not added after #76082 was merged.
