### PR TITLE
Revert "Fix focusloss of non-exclusive `AcceptDialog` with `close_on_escape`"

### DIFF
--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -44,6 +44,8 @@ class LineEdit;
 class AcceptDialog : public Window {
 	GDCLASS(AcceptDialog, Window);
 
+	Window *parent_visible = nullptr;
+
 	Panel *bg_panel = nullptr;
 	Label *message_label = nullptr;
 	HBoxContainer *buttons_hbox = nullptr;
@@ -63,6 +65,7 @@ class AcceptDialog : public Window {
 	static bool swap_cancel_ok;
 
 	void _input_from_window(const Ref<InputEvent> &p_event);
+	void _parent_focused();
 
 protected:
 	virtual Size2 _get_contents_minimum_size() const override;


### PR DESCRIPTION
This reverts commit 7f547fcf09e7af0e2443356fe7a003c3c8335cd6 (#78363)

resolve #79052

The introduced bug seems more severe that the original resolved bug.
And solving the new problem would require large changes to the popup-focus method.