### PR TITLE
Fix the fallback logic of `OS::shell_show_in_file_manager`.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -295,12 +295,14 @@ Error OS::shell_open(String p_uri) {
 }
 
 Error OS::shell_show_in_file_manager(String p_path, bool p_open_folder) {
-	if (!p_path.begins_with("file://")) {
-		p_path = String("file://") + p_path;
-	}
-	if (!p_path.ends_with("/")) {
+	p_path = p_path.trim_prefix("file://");
+
+	if (!DirAccess::dir_exists_absolute(p_path)) {
 		p_path = p_path.get_base_dir();
 	}
+
+	p_path = String("file://") + p_path;
+
 	return shell_open(p_path);
 }
 // implement these with the canvas?

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -657,7 +657,7 @@
 				Requests the OS to open the file manager, then navigate to the given [param file_or_dir_path] and select the target file or folder.
 				If [param file_or_dir_path] is a valid directory path, and [param open_folder] is [code]true[/code], the method will open the file manager and enter the target folder without selecting anything.
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] path into a system path for use with this method.
-				[b]Note:[/b] Currently this method is only implemented on Windows. On other platforms, it will fallback to [method shell_open] with a directory path for [param file_or_dir_path].
+				[b]Note:[/b] Currently this method is only implemented on Windows and macOS. On other platforms, it will fallback to [method shell_open] with a directory path of [param file_or_dir_path] with prefix [code]file://[/code].
 			</description>
 		</method>
 		<method name="unset_environment" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix [#79044](https://github.com/godotengine/godot/issues/79044) and update document.

Still need someone to implements `OS::shell_show_in_file_manager` on other platiforms.