### PR TITLE
Add tooltip description wrapping in scene tree and plugin settings

### DIFF
--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -101,9 +101,18 @@ void EditorPluginSettings::update_plugins() {
 				String description = cf->get_value("plugin", "description");
 				String scr = cf->get_value("plugin", "script");
 
+				const PackedInt32Array boundaries = TS->string_get_word_breaks(description, "", 80);
+				String wrapped_description;
+
+				for (int j = 0; j < boundaries.size(); j += 2) {
+					const int start = boundaries[j];
+					const int end = boundaries[j + 1];
+					wrapped_description += "\n" + description.substr(start, end - start + 1).rstrip("\n");
+				}
+
 				TreeItem *item = plugin_list->create_item(root);
 				item->set_text(0, name);
-				item->set_tooltip_text(0, TTR("Name:") + " " + name + "\n" + TTR("Path:") + " " + path + "\n" + TTR("Main Script:") + " " + scr + "\n" + TTR("Description:") + " " + description);
+				item->set_tooltip_text(0, TTR("Name:") + " " + name + "\n" + TTR("Path:") + " " + path + "\n" + TTR("Main Script:") + " " + scr + "\n" + TTR("Description:") + " " + wrapped_description);
 				item->set_metadata(0, path);
 				item->set_text(1, version);
 				item->set_metadata(1, scr);

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -374,7 +374,14 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		tooltip += String("\n" + TTR("Type:") + " " + (custom_type != StringName() ? String(custom_type) : p_node->get_class()));
 
 		if (!p_node->get_editor_description().is_empty()) {
-			tooltip += "\n\n" + p_node->get_editor_description();
+			const PackedInt32Array boundaries = TS->string_get_word_breaks(p_node->get_editor_description(), "", 80);
+			tooltip += "\n";
+
+			for (int i = 0; i < boundaries.size(); i += 2) {
+				const int start = boundaries[i];
+				const int end = boundaries[i + 1];
+				tooltip += "\n" + p_node->get_editor_description().substr(start, end - start + 1).rstrip("\n");
+			}
 		}
 
 		item->set_tooltip_text(0, tooltip);


### PR DESCRIPTION
Fixes #78202
![tooltip](https://github.com/godotengine/godot/assets/128654806/82fd9dc9-a28d-4f3d-b4f7-f5d7dd347d9a)
