### PR TITLE
C#: Compare symbol names without null flow state

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -37,7 +37,7 @@ namespace Godot.SourceGenerators
             while (symbol != null)
             {
                 if (symbol.ContainingAssembly?.Name == assemblyName &&
-                    symbol.ToString() == typeFullName)
+                    symbol.FullQualifiedNameOmitGlobal() == typeFullName)
                 {
                     return true;
                 }
@@ -230,22 +230,22 @@ namespace Godot.SourceGenerators
                 .Replace(">", ")");
 
         public static bool IsGodotExportAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.ExportAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportAttr;
 
         public static bool IsGodotSignalAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.SignalAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SignalAttr;
 
         public static bool IsGodotMustBeVariantAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.MustBeVariantAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.MustBeVariantAttr;
 
         public static bool IsGodotClassNameAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.GodotClassNameAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.GodotClassNameAttr;
 
         public static bool IsGodotGlobalClassAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.GlobalClassAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.GlobalClassAttr;
 
         public static bool IsSystemFlagsAttribute(this INamedTypeSymbol symbol)
-            => symbol.ToString() == GodotClasses.SystemFlagsAttr;
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SystemFlagsAttr;
 
         public static GodotMethodData? HasGodotCompatibleSignature(
             this IMethodSymbol method,

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -362,7 +362,7 @@ namespace Godot.SourceGenerators
         {
             foreach (var attr in memberSymbol.GetAttributes())
             {
-                PropertyUsageFlags? propertyUsage = attr.AttributeClass?.ToString() switch
+                PropertyUsageFlags? propertyUsage = attr.AttributeClass?.FullQualifiedNameOmitGlobal() switch
                 {
                     GodotClasses.ExportCategoryAttr => PropertyUsageFlags.Category,
                     GodotClasses.ExportGroupAttr => PropertyUsageFlags.Group,

--- a/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
+++ b/modules/mono/glue/GodotSharp/Godot.SourceGenerators.Internal/ExtensionMethods.cs
@@ -38,7 +38,7 @@ internal static class ExtensionMethods
     }
 
     private static bool IsGenerateUnmanagedCallbacksAttribute(this INamedTypeSymbol symbol)
-        => symbol.ToString() == GeneratorClasses.GenerateUnmanagedCallbacksAttr;
+        => symbol.FullQualifiedNameOmitGlobal() == GeneratorClasses.GenerateUnmanagedCallbacksAttr;
 
     public static IEnumerable<(ClassDeclarationSyntax cds, INamedTypeSymbol symbol)> SelectUnmanagedCallbacksClasses(
         this IEnumerable<ClassDeclarationSyntax> source,


### PR DESCRIPTION
- `Symbol.ToString()` is equivalent to `Symbol.ToDisplayString()` which includes null flow state. This means the string would include `?` for reference types when the may be null and the strings would not be equal.
- Fixes https://github.com/godotengine/godot/issues/79071.