### PR TITLE
Linux: Fix build with `use_sowrap=no` and various warnings/errors

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -98,19 +98,20 @@ static bool detect_sandbox() {
 
 JoypadLinux::JoypadLinux(Input *in) {
 #ifdef UDEV_ENABLED
-#ifdef SOWRAP_ENABLED
-#ifdef DEBUG_ENABLED
-	int dylibloader_verbose = 1;
-#else
-	int dylibloader_verbose = 0;
-#endif
 	if (detect_sandbox()) {
 		// Linux binaries in sandboxes / containers need special handling because
 		// libudev doesn't work there. So we need to fallback to manual parsing
 		// of /dev/input in such case.
 		use_udev = false;
 		print_verbose("JoypadLinux: udev enabled, but detected incompatible sandboxed mode. Falling back to /dev/input to detect joypads.");
-	} else {
+	}
+#ifdef SOWRAP_ENABLED
+	else {
+#ifdef DEBUG_ENABLED
+		int dylibloader_verbose = 1;
+#else
+		int dylibloader_verbose = 0;
+#endif
 		use_udev = initialize_libudev(dylibloader_verbose) == 0;
 		if (use_udev) {
 			if (!udev_new || !udev_unref || !udev_enumerate_new || !udev_enumerate_add_match_subsystem || !udev_enumerate_scan_devices || !udev_enumerate_get_list_entry || !udev_list_entry_get_next || !udev_list_entry_get_name || !udev_device_new_from_syspath || !udev_device_get_devnode || !udev_device_get_action || !udev_device_unref || !udev_enumerate_unref || !udev_monitor_new_from_netlink || !udev_monitor_filter_add_match_subsystem_devtype || !udev_monitor_enable_receiving || !udev_monitor_get_fd || !udev_monitor_receive_device || !udev_monitor_unref) {
@@ -124,10 +125,11 @@ JoypadLinux::JoypadLinux(Input *in) {
 			print_verbose("JoypadLinux: udev enabled, but couldn't be loaded. Falling back to /dev/input to detect joypads.");
 		}
 	}
-#endif
+#endif // SOWRAP_ENABLED
 #else
 	print_verbose("JoypadLinux: udev disabled, parsing /dev/input to detect joypads.");
-#endif
+#endif // UDEV_ENABLED
+
 	input = in;
 	monitor_joypads_thread.start(monitor_joypads_thread_func, this);
 	joypad_events_thread.start(joypad_events_thread_func, this);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5449,7 +5449,9 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 #else
 #ifdef XKB_ENABLED
-	xkb_loaded = true;
+	bool xkb_loaded = true;
+	xkb_loaded_v05p = true;
+	xkb_loaded_v08p = true;
 #endif
 #endif
 
@@ -5476,6 +5478,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	r_error = OK;
 
+#ifdef SOWRAP_ENABLED
 	{
 		if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
 			// There's no API to check version, check if functions are available instead.
@@ -5484,6 +5487,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 			return;
 		}
 	}
+#endif
 
 	for (int i = 0; i < CURSOR_MAX; i++) {
 		cursors[i] = None;


### PR DESCRIPTION
Follow-up to #74978 and #76961.
Still testing it, some more changes might be needed.

Fixes this error and these warnings:
```
platform/linuxbsd/x11/display_server_x11.cpp: In constructor 'DisplayServerX11::DisplayServerX11(const String&, DisplayServer::WindowMode, DisplayServer::VSyncMode, uint32_t, const Vector2i*, const Vector2i&, int, Error&)':
platform/linuxbsd/x11/display_server_x11.cpp:5452:9: error: 'xkb_loaded' was not declared in this scope
 5452 |         xkb_loaded = true;
      |         ^~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:22: warning: the address of 'XcursorImage* XcursorImageCreate(int, int)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                      ^~~~~~~~~~~~~~~~~~
In file included from platform/linuxbsd/x11/display_server_x11.h:91,
                 from platform/linuxbsd/x11/display_server_x11.cpp:31:
/usr/include/X11/Xcursor/Xcursor.h:237:1: note: 'XcursorImage* XcursorImageCreate(int, int)' declared here
  237 | XcursorImageCreate (int width, int height);
      | ^~~~~~~~~~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:45: warning: the address of 'Cursor XcursorImageLoadCursor(Display*, const XcursorImage*)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                                             ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/X11/Xcursor/Xcursor.h:386:1: note: 'Cursor XcursorImageLoadCursor(Display*, const XcursorImage*)' declared here
  386 | XcursorImageLoadCursor (Display *dpy, const XcursorImage *image);
      | ^~~~~~~~~~~~~~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:72: warning: the address of 'void XcursorImageDestroy(XcursorImage*)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                                                                        ^~~~~~~~~~~~~~~~~~~
/usr/include/X11/Xcursor/Xcursor.h:240:1: note: 'void XcursorImageDestroy(XcursorImage*)' declared here
  240 | XcursorImageDestroy (XcursorImage *image);
      | ^~~~~~~~~~~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:96: warning: the address of 'int XcursorGetDefaultSize(Display*)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                                                                                                ^~~~~~~~~~~~~~~~~~~~~
/usr/include/X11/Xcursor/Xcursor.h:485:1: note: 'int XcursorGetDefaultSize(Display*)' declared here
  485 | XcursorGetDefaultSize (Display *dpy);
      | ^~~~~~~~~~~~~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:122: warning: the address of 'char* XcursorGetTheme(Display*)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                                                                                                                          ^~~~~~~~~~~~~~~
/usr/include/X11/Xcursor/Xcursor.h:491:1: note: 'char* XcursorGetTheme(Display*)' declared here
  491 | XcursorGetTheme (Display *dpy);
      | ^~~~~~~~~~~~~~~
platform/linuxbsd/x11/display_server_x11.cpp:5480:142: warning: the address of 'XcursorImage* XcursorLibraryLoadImage(const char*, const char*, int)' will never be NULL [-Waddress]
 5480 |                 if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
      |                                                                                                                                              ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/X11/Xcursor/Xcursor.h:366:1: note: 'XcursorImage* XcursorLibraryLoadImage(const char*, const char*, int)' declared here
  366 | XcursorLibraryLoadImage (const char *library, const char *theme, int size);
      | ^~~~~~~~~~~~~~~~~~~~~~~
Compiling thirdparty/astcenc/astcenc_c
```

And this warning which exposed a logic bug:
```
platform/linuxbsd/joypad_linux.cpp:80:13: warning: 'bool detect_sandbox()' defined but not used [-Wunused-function]
   80 | static bool detect_sandbox() {
      |             ^~~~~~~~~~~~~~
```