### PR TITLE
Linux: Link libsquish directly when unbundling, .pc file unreliable

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -235,7 +235,8 @@ def configure(env: "Environment"):
         env.ParseConfig("pkg-config libenet --cflags --libs")
 
     if not env["builtin_squish"]:
-        env.ParseConfig("pkg-config libsquish --cflags --libs")
+        # libsquish doesn't reliably install its .pc file, so some distros lack it.
+        env.Append(LIBS=["libsquish"])
 
     if not env["builtin_zstd"]:
         env.ParseConfig("pkg-config libzstd --cflags --libs")


### PR DESCRIPTION
For the record, I have the pkgconfig file installed on Mageia, but I had to fix it and install it manually:
http://svnweb.mageia.org/packages/cauldron/libsquish/current/SPECS/libsquish.spec?view=markup

Fedora doesn't do that so they don't have it: https://src.fedoraproject.org/rpms/libsquish/blob/rawhide/f/libsquish.spec