### PR TITLE
Make shader preprocessor keyword colors consistent

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -238,7 +238,7 @@ void ShaderTextEditor::_load_theme_settings() {
 	ShaderPreprocessor::get_keyword_list(&pp_keywords, false);
 
 	for (const String &E : pp_keywords) {
-		syntax_highlighter->add_keyword_color(E, keyword_color);
+		syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
 	}
 
 	// Colorize built-ins like `COLOR` differently to make them easier


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78799

Currently some shader preprocessor keyword colors (like #if and #else) conflict with normal shader keywords, causing some inconsistencies. The easiest way to fix these is to simply make all preprocessor keywords into control flow keywords (which most of them actually are anyway), this way all preprocessor keyword colors are consistent. Of the two imperfect color choices, this should be the better one.

The best solution would be to improve the syntax highlighter to support more comples keywords that can have symbols (like #) in them or create a custom highlighter, but that's a lot of effort for little gain.

Colors, before and after this PR. With default colors the difference was not too bad, but if you customize your keyword colors it can become confusing fast.

Before:

![before](https://github.com/godotengine/godot/assets/22456603/0959ce64-c7af-4135-b4a6-1d9ade3ed914)

After:

![after](https://github.com/godotengine/godot/assets/22456603/fff8fe7c-caff-450a-90f4-d8d54bb4695a)
