### PR TITLE
Improve user-friendliness of project version mismatch message

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -166,7 +166,7 @@ public:
 	void set_project_path(const String &p_path);
 	void set_tags(const PackedStringArray &p_tags, ProjectList *p_parent_list);
 	void set_project_icon(const Ref<Texture2D> &p_icon);
-	void set_unsupported_features(const PackedStringArray &p_features);
+	void set_unsupported_features(PackedStringArray p_features);
 
 	bool should_load_project_icon() const;
 	void set_selected(bool p_selected);


### PR DESCRIPTION
Fixes #79095. EDIT: Updated the text to say "last edited" instead of "built", too lazy to re-take the screenshot.

![Screenshot 2023-07-06 at 11 32 22 AM](https://github.com/godotengine/godot/assets/1646875/6936ea62-00ce-4368-bf06-cc8ba52f2e30)

Should be cherry-picked to 4.1, but it might be good to wait for translations to catch up?

Do not cherry-pick to 4.0, this code has changed between 4.0 and 4.1 to make space in the UI for labels.