### PR TITLE
[3.x] GDScript: Prevent native class shadowing

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3758,7 +3758,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 					return;
 				}
 
-				if (ClassDB::class_exists(p_class->name)) {
+				if (ClassDB::class_exists(p_class->name) || ClassDB::class_exists("_" + p_class->name.operator String())) {
 					_set_error("The class \"" + p_class->name + "\" shadows a native class.");
 					return;
 				}
@@ -4922,6 +4922,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				member.usages = 0;
 				member.rpc_mode = rpc_mode;
 
+				// GH-57496
+				if (ClassDB::class_exists(member.identifier) || ClassDB::class_exists("_" + member.identifier.operator String())) {
+					_set_error("Variable \"" + String(member.identifier) + "\" shadows a native class.");
+					return;
+				}
+
 				if (current_class->constant_expressions.has(member.identifier)) {
 					_set_error("A constant named \"" + String(member.identifier) + "\" already exists in this class (at line: " +
 							itos(current_class->constant_expressions[member.identifier].expression->line) + ").");
@@ -5180,6 +5186,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				StringName const_id = tokenizer->get_token_literal();
 				int line = tokenizer->get_token_line();
 
+				// GH-57496
+				if (ClassDB::class_exists(const_id) || ClassDB::class_exists("_" + const_id.operator String())) {
+					_set_error("Constant \"" + String(const_id) + "\" shadows a native class.");
+					return;
+				}
+
 				if (current_class->constant_expressions.has(const_id)) {
 					_set_error("Constant \"" + String(const_id) + "\" already exists in this class (at line " +
 							itos(current_class->constant_expressions[const_id].expression->line) + ").");
@@ -5255,6 +5267,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				tokenizer->advance();
 				if (tokenizer->is_token_literal(0, true)) {
 					enum_name = tokenizer->get_token_literal();
+
+					// GH-57496
+					if (ClassDB::class_exists(enum_name) || ClassDB::class_exists("_" + enum_name)) {
+						_set_error("Enumeration \"" + enum_name + "\" shadows a native class.");
+						return;
+					}
 
 					if (current_class->constant_expressions.has(enum_name)) {
 						_set_error("A constant named \"" + String(enum_name) + "\" already exists in this class (at line " +
@@ -5348,6 +5366,12 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 						if (enum_name != "") {
 							enum_dict[const_id] = enum_value_expr->value;
 						} else {
+							// GH-57496
+							if (ClassDB::class_exists(const_id) || ClassDB::class_exists("_" + const_id.operator String())) {
+								_set_error("Constant \"" + String(const_id) + "\" shadows a native class.");
+								return;
+							}
+
 							if (current_class->constant_expressions.has(const_id)) {
 								_set_error("A constant named \"" + String(const_id) + "\" already exists in this class (at line " +
 										itos(current_class->constant_expressions[const_id].expression->line) + ").");


### PR DESCRIPTION
* Fixes #57496.

In 4.x, an attempt to define a member that shadows a native class results in an error. In 3.x, this is done for nested classes, but not for constants, which can also be used as type hints.

Proper implementation of shadowing is too difficult and risky for the LTS branch, especially since it's not implemented even in 4.x. Showing error is the easiest option. Let me know if you think a warning is better here.