### PR TITLE
Change property hint range for camera attributes exposure multiplier

### DIFF
--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -122,7 +122,7 @@ void CameraAttributes::_bind_methods() {
 
 	ADD_GROUP("Exposure", "exposure_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "exposure_sensitivity", PROPERTY_HINT_RANGE, "0.1,32000.0,0.1,suffix:ISO"), "set_exposure_sensitivity", "get_exposure_sensitivity");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "exposure_multiplier", PROPERTY_HINT_RANGE, "0.0,2048.0,0.001"), "set_exposure_multiplier", "get_exposure_multiplier");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "exposure_multiplier", PROPERTY_HINT_RANGE, "0.0,8.0,0.001,or_greater"), "set_exposure_multiplier", "get_exposure_multiplier");
 
 	ADD_GROUP("Auto Exposure", "auto_exposure_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_exposure_enabled"), "set_auto_exposure_enabled", "is_auto_exposure_enabled");


### PR DESCRIPTION
The current range hint max of 2048 is ~~just absurd~~ too high. In the default scene, an exposure multiplier of about 50 blows up to a completely white screen. I was watching somebody try out Godot 4.1 on a Discord stream when they changed this value and were surprised that most of the slider was completely useless.

This PR changes the range hint to have a max of 8, but also adds `or_greater` so any value can still be typed in.