### PR TITLE
Fix property hint class name type string restriction and replace mode

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -621,7 +621,7 @@ void EditorPropertyClassName::update_property() {
 }
 
 void EditorPropertyClassName::_property_selected() {
-	dialog->popup_create(true);
+	dialog->popup_create(true, true, get_edited_property_value(), get_edited_property());
 }
 
 void EditorPropertyClassName::_dialog_created() {
@@ -3622,7 +3622,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_TYPE_STRING) {
 				EditorPropertyClassName *editor = memnew(EditorPropertyClassName);
-				editor->setup("Object", p_hint_text);
+				editor->setup(p_hint_text, p_hint_text);
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_LOCALE_ID) {
 				EditorPropertyLocale *editor = memnew(EditorPropertyLocale);


### PR DESCRIPTION
Before, the type restriction hint (like "Node") was ignored, and the dialog was set up for creation, not replacing:

<img width="1045" alt="Screenshot 2023-07-06 at 11 09 11 PM" src="https://github.com/godotengine/godot/assets/1646875/7c5cb361-f3ea-4d10-b342-32702f26a86d">


After, it will respect the type restriction hint, and the dialog will be set up for replacement:

<img width="1045" alt="Screenshot 2023-07-06 at 11 05 52 PM" src="https://github.com/godotengine/godot/assets/1646875/a1121e37-1fcd-4107-86c7-d12ab2f8a2ef">

I added the import label to this PR because this property type is currently only used in one place, scene import.