### PR TITLE
Fix infinite loop state check in `AnimationStateMachine`

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -901,18 +901,20 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 	bool is_state_changed = false;
 
 	NextInfo next;
-	StringName transition_start = current;
+	Vector<StringName> transition_path;
+	transition_path.push_back(current);
 	while (true) {
 		next = _find_next(p_tree, p_state_machine);
-		if (next.node == transition_start) {
-			is_state_changed = false;
-			break; // Maybe infinity loop, do noting more.
+		if (transition_path.has(next.node)) {
+			WARN_PRINT_ONCE_ED("AnimationNodeStateMachinePlayback: " + base_path + "playback aborts the transition by detecting one or more looped transitions in the same frame to prevent to infinity loop. You may need to check the transition settings.");
+			break; // Maybe infinity loop, do nothing more.
 		}
 
 		if (!_can_transition_to_next(p_tree, p_state_machine, next, p_test_only)) {
 			break; // Finish transition.
 		}
 
+		transition_path.push_back(next.node);
 		is_state_changed = true;
 
 		// Setting for fading.


### PR DESCRIPTION
Fixes #79012.

If only the first pass is stored and compared, the loop detection will fail if an infinite loop starts in the middle of the path. So, all transition paths must be stored and compared. Also, remove `is_state_changed = false` as it was actually wrong (state change occurs just before the try infinite loop).