### PR TITLE
C#: Add null check before calling `UnregisterGodotObject`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -125,7 +125,10 @@ namespace Godot
                 NativePtr = IntPtr.Zero;
             }
 
-            DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
+            if (_weakReferenceToSelf != null)
+            {
+                DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #79148

Not sure under which condition this can happen, but all calls to `UnregisterDisposable` have this check already (and there are no other calls to `UnregisterGodotObject`)