### PR TITLE
Add 3.x compatibility for animation loop mode

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -427,6 +427,11 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else {
 			return false;
 		}
+#ifndef DISABLE_DEPRECATED
+	} else if (prop_name == "loop" && p_value.operator bool()) { // Compatibility with Godot 3.x.
+		loop_mode = Animation::LoopMode::LOOP_LINEAR;
+		return true;
+#endif // DISABLE_DEPRECATED
 	} else {
 		return false;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Bugfix for #57779 Conversion from 3.x to 4.x stops looping animations.

* *Bugsquad edit, fixes: #57779*