### PR TITLE
Add `clear` function to NavigationMesh / NavigationPolygon

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -18,6 +18,12 @@
 				Adds a polygon using the indices of the vertices you get when calling [method get_vertices].
 			</description>
 		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				Clears the internal arrays for vertices and polygon indices.
+			</description>
+		</method>
 		<method name="clear_polygons">
 			<return type="void" />
 			<description>

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -69,6 +69,12 @@
 				Adds a polygon using the indices of the vertices you get when calling [method get_vertices].
 			</description>
 		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				Clears the internal arrays for vertices and polygon indices.
+			</description>
+		</method>
 		<method name="clear_outlines">
 			<return type="void" />
 			<description>

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -341,6 +341,11 @@ void NavigationMesh::clear_polygons() {
 	polygons.clear();
 }
 
+void NavigationMesh::clear() {
+	polygons.clear();
+	vertices.clear();
+}
+
 #ifdef DEBUG_ENABLED
 Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 	if (debug_mesh.is_valid()) {
@@ -517,6 +522,8 @@ void NavigationMesh::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_polygons", "polygons"), &NavigationMesh::_set_polygons);
 	ClassDB::bind_method(D_METHOD("_get_polygons"), &NavigationMesh::_get_polygons);
+
+	ClassDB::bind_method(D_METHOD("clear"), &NavigationMesh::clear);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR3_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -202,6 +202,8 @@ public:
 	Vector<int> get_polygon(int p_idx);
 	void clear_polygons();
 
+	void clear();
+
 #ifdef DEBUG_ENABLED
 	Ref<ArrayMesh> get_debug_mesh();
 #endif // DEBUG_ENABLED

--- a/scene/resources/navigation_polygon.cpp
+++ b/scene/resources/navigation_polygon.cpp
@@ -162,6 +162,15 @@ void NavigationPolygon::clear_polygons() {
 	}
 }
 
+void NavigationPolygon::clear() {
+	polygons.clear();
+	vertices.clear();
+	{
+		MutexLock lock(navigation_mesh_generation);
+		navigation_mesh.unref();
+	}
+}
+
 Ref<NavigationMesh> NavigationPolygon::get_navigation_mesh() {
 	MutexLock lock(navigation_mesh_generation);
 
@@ -359,6 +368,8 @@ void NavigationPolygon::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_cell_size", "cell_size"), &NavigationPolygon::set_cell_size);
 	ClassDB::bind_method(D_METHOD("get_cell_size"), &NavigationPolygon::get_cell_size);
+
+	ClassDB::bind_method(D_METHOD("clear"), &NavigationPolygon::clear);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "vertices", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_vertices", "get_vertices");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "polygons", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_polygons", "_get_polygons");

--- a/scene/resources/navigation_polygon.h
+++ b/scene/resources/navigation_polygon.h
@@ -92,6 +92,8 @@ public:
 	void set_cell_size(real_t p_cell_size);
 	real_t get_cell_size() const;
 
+	void clear();
+
 	NavigationPolygon() {}
 	~NavigationPolygon() {}
 };


### PR DESCRIPTION
Adds `clear()` function to NavigationMesh / NavigationPolygon.

Previously the `NavigationMeshGenerator` had the only convenient `clear()` function that did reset the arrays of polygon indices and vertices for the NavigationMesh resource in the navigation mesh baking process.

The resources only had this awkward way of clearing the internal arrays by calling the `clear_polygons()` function and calling a `set_vertices()` with an empty array.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
