### PR TITLE
Fix comments and indentation in `.gdshaderinc` files

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -646,13 +646,13 @@ void TextShaderEditor::_menu_option(int p_option) {
 			shader_editor->move_lines_down();
 		} break;
 		case EDIT_INDENT: {
-			if (shader.is_null()) {
+			if (shader.is_null() && shader_inc.is_null()) {
 				return;
 			}
 			shader_editor->get_text_editor()->indent_lines();
 		} break;
 		case EDIT_UNINDENT: {
-			if (shader.is_null()) {
+			if (shader.is_null() && shader_inc.is_null()) {
 				return;
 			}
 			shader_editor->get_text_editor()->unindent_lines();
@@ -668,12 +668,10 @@ void TextShaderEditor::_menu_option(int p_option) {
 			shader_editor->get_text_editor()->set_line_wrapping_mode(wrap == TextEdit::LINE_WRAPPING_BOUNDARY ? TextEdit::LINE_WRAPPING_NONE : TextEdit::LINE_WRAPPING_BOUNDARY);
 		} break;
 		case EDIT_TOGGLE_COMMENT: {
-			if (shader.is_null()) {
+			if (shader.is_null() && shader_inc.is_null()) {
 				return;
 			}
-
 			shader_editor->toggle_inline_comment("//");
-
 		} break;
 		case EDIT_COMPLETE: {
 			shader_editor->get_text_editor()->request_code_completion();


### PR DESCRIPTION
Fixes [#78205](https://github.com/godotengine/godot/issues/78205)

The handling of comments and indentation in the shader editor wasn't considering shader include files.
It was using a `shader.is_null()` call to check if a shader file was empty before doing the comments/indentation, but, when using a shader include file, the `shader` property will be `null` even when the file isn't empty, and that would cause an early exit from the comments/indentation handling.

### Testing:
![shaderincludes_bug](https://github.com/godotengine/godot/assets/38991758/0ceca4db-17b2-4c9d-8e3f-e0c6f92399b7)
