### PR TITLE
GDScript: Add static analysis error reporting in `GDScriptCache::get_full_script()`

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -294,8 +294,12 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 
 	if (p_update_from_disk) {
 		r_error = script->load_source_code(p_path);
+		if (r_error) {
+			return script;
+		}
 	}
 
+	r_error = script->reload(true);
 	if (r_error) {
 		return script;
 	}
@@ -303,7 +307,6 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 	singleton->full_gdscript_cache[p_path] = script;
 	singleton->shallow_gdscript_cache.erase(p_path);
 
-	script->reload(true);
 	return script;
 }
 


### PR DESCRIPTION
Currently, `GDScriptCache::get_full_script()` emits errors during file opening and parsing, but not during static analysis or compilation. This PR changes it so analysis/compilation errors are emitted.

It is essentially a continuation of what #76954 did for `GDScriptCache::get_shallow_script()`.

:warning: this will cause scripts to fail earlier, possibly causing more cascading errors, which was also a worry I had with #76954 :warning:

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
