### PR TITLE
[TextServer] Remove excessive Dictionary checks.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2383,10 +2383,8 @@ void TextServerAdvanced::_font_set_variation_coordinates(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	if (fd->variation_coordinates != p_variation_coordinates) {
-		_font_clear_cache(fd);
-		fd->variation_coordinates = p_variation_coordinates;
-	}
+	_font_clear_cache(fd);
+	fd->variation_coordinates = p_variation_coordinates;
 }
 
 Dictionary TextServerAdvanced::_font_get_variation_coordinates(const RID &p_font_rid) const {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1376,10 +1376,8 @@ void TextServerFallback::_font_set_variation_coordinates(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	if (fd->variation_coordinates != p_variation_coordinates) {
-		_font_clear_cache(fd);
-		fd->variation_coordinates = p_variation_coordinates;
-	}
+	_font_clear_cache(fd);
+	fd->variation_coordinates = p_variation_coordinates;
 }
 
 Dictionary TextServerFallback::_font_get_variation_coordinates(const RID &p_font_rid) const {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2833,10 +2833,8 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 }
 
 void FontVariation::set_variation_opentype(const Dictionary &p_coords) {
-	if (variation.opentype != p_coords) {
-		variation.opentype = p_coords;
-		_invalidate_rids();
-	}
+	variation.opentype = p_coords;
+	_invalidate_rids();
 }
 
 Dictionary FontVariation::get_variation_opentype() const {
@@ -2877,10 +2875,8 @@ int FontVariation::get_variation_face_index() const {
 }
 
 void FontVariation::set_opentype_features(const Dictionary &p_features) {
-	if (opentype_features != p_features) {
-		opentype_features = p_features;
-		_invalidate_rids();
-	}
+	opentype_features = p_features;
+	_invalidate_rids();
 }
 
 Dictionary FontVariation::get_opentype_features() const {


### PR DESCRIPTION
Remove dictionary equality check to allow reusing variation dictionary without make a copy:

Allows code like this:
```gdscript
var coords = font.variation_opentype # currently works only with .duplicate()
coords["weight"] = 1000
font.variation_opentype = coords
```

I'm not sure if there's a way to track dictionary element change to do it like:

```gdscript
font.variation_opentype["weight"] = 1000 # won't work
```