### PR TITLE
C#: Fix command line exporting

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1635,6 +1635,7 @@ void EditorFileSystem::_queue_update_script_class(const String &p_path) {
 }
 
 void EditorFileSystem::update_file(const String &p_file) {
+	ERR_FAIL_COND(p_file.is_empty());
 	EditorFileSystemDirectory *fs = nullptr;
 	int cpos = -1;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2272,7 +2272,7 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 	// If the EditorFileSystem singleton is available, update the file;
 	// otherwise, the file will be updated when the singleton becomes available.
 	EditorFileSystem *efs = EditorFileSystem::get_singleton();
-	if (efs) {
+	if (efs && !p_script->get_path().is_empty()) {
 		efs->update_file(p_script->get_path());
 	}
 #endif


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/79159

During the export `reload_registered_script` is called a few times with scripts that have no path assigned and then when `update_file` is called with an empty string, things break.
I didn't track down exactly what happens and just added an error to prevent future problems like this (I can remove it again if someone thinks there is a valid use for it tho)