### PR TITLE
Fix incorrect documentation for `Engine.get_architecture_name()`

### DIFF
--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -12,20 +12,20 @@
 		<method name="get_architecture_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the CPU architecture the Godot binary was built for. Possible return values are [code]x86_64[/code], [code]x86_32[/code], [code]arm64[/code], [code]armv7[/code], [code]rv64[/code], [code]riscv[/code], [code]ppc64[/code], [code]ppc[/code], [code]wasm64[/code] and [code]wasm32[/code].
+				Returns the name of the CPU architecture the Godot binary was built for. Possible return values are [code]x86_64[/code], [code]x86_32[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]riscv[/code], [code]ppc64[/code], [code]ppc[/code], [code]wasm64[/code] and [code]wasm32[/code].
 				To detect whether the current CPU architecture is 64-bit, you can use the fact that all 64-bit architecture names have [code]64[/code] in their name:
 				[codeblocks]
 				[gdscript]
 				if "64" in Engine.get_architecture_name():
-				    print("Running on 64-bit CPU.")
+				    print("Running a 64-bit build of Godot.")
 				else:
-				    print("Running on 32-bit CPU.")
+				    print("Running a 32-bit build of Godot.")
 				[/gdscript]
 				[csharp]
 				if (Engine.GetArchitectureName().Contains("64"))
-				    GD.Print("Running on 64-bit CPU.");
+				    GD.Print("Running a 64-bit build of Godot.");
 				else
-				    GD.Print("Running on 32-bit CPU.");
+				    GD.Print("Running a 32-bit build of Godot.");
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] [method get_architecture_name] does [i]not[/i] return the name of the host CPU architecture. For example, if running an x86_32 Godot binary on a x86_64 system, the returned value will be [code]x86_32[/code].


### PR DESCRIPTION
The documentation is incorrect as of Godot 4.0, the value returned on 32-bit Arm builds is `arm32`.

Also updated the example code to be clearer. Technically checking for the absence of `"64"` in the name doesn't guarantee 32-bit since rv128 exists, but Godot doesn't compile for that yet, so it's correct for now.