### PR TITLE
Deselect curve point with RMB on the empty space

### DIFF
--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -184,7 +184,9 @@ void CurveEdit::gui_input(const Ref<InputEvent> &p_event) {
 					toggle_linear(selected_index, selected_tangent_index);
 				} else {
 					int point_to_remove = get_point_at(mpos);
-					if (point_to_remove != -1) {
+					if (point_to_remove == -1) {
+						set_selected_index(-1); // Nothing on the place of the click, just deselect the point.
+					} else {
 						if (grabbing == GRAB_ADD) {
 							curve->remove_point(point_to_remove); // Point is temporary, so remove directly from curve.
 							set_selected_index(-1);


### PR DESCRIPTION
One of the annoyances in the new curve editor is that if a point is selected, there's only intrusive ways to deselect it.

![image](https://github.com/godotengine/godot/assets/85438892/84744bcb-0b60-4766-ac90-a1bdf6f3e22e)

^ No neat way to get rid of the blue tint or the tangents, you have to add a point and then delete it.

Now right-clicking the empty space will deselect too.

~(currently not tested, just "should work")~