### PR TITLE
Expose `String.resize()`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1738,6 +1738,7 @@ static void _register_variant_builtin_methods() {
 	bind_string_method(to_utf32_buffer, sarray(), varray());
 	bind_string_method(hex_decode, sarray(), varray());
 	bind_string_method(to_wchar_buffer, sarray(), varray());
+	bind_method(String, resize, sarray("size"), varray());
 
 	bind_static_method(String, num_scientific, sarray("number"), varray());
 	bind_static_method(String, num, sarray("number", "decimals"), varray(-1));

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -720,6 +720,13 @@
 				Replaces all [b]case-insensitive[/b] occurrences of [param what] inside the string with the given [param forwhat].
 			</description>
 		</method>
+		<method name="resize">
+			<return type="int" />
+			<param index="0" name="size" type="int" />
+			<description>
+				Resizes this string to the new size. The size should be one more than desired string length (in order to accommodate the null terminator).
+			</description>
+		</method>
 		<method name="rfind" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="what" type="String" />


### PR DESCRIPTION
This supersedes PR https://github.com/godotengine/godot/pull/79156 (which didn't expose `String.resize()` the normal way, but instead added a function to `gdextension_interface.h` so it wouldn't be exposed to GDScript)

The one thing I'm concerned about (now that this would be exposed to GDScript) is that `resize()` takes the array size of the string (so, including the null terminator character), but `length()` returns the string length (so, without the null terminator aka 1 less than the array length).

Will this be too confusing to users? Would it make sense to also expose `size()` so that `str.resize(str.size() + 2)` clearly makes the string 2 characters longer? Or, will having both `size()` and `length()` just be even more confusing? Or, should the version of `String.resize()` that's exposed be made to work with string length, rather than array length?

Fixes godot-cpp issue https://github.com/godotengine/godot-cpp/issues/1141 which originally came up when trying to compile the text_server_adv module in Godot as a GDExtension. See: https://github.com/godotengine/godot/pull/77532