### PR TITLE
Fix Extra Cull Margin triggers worst LOD

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -963,6 +963,12 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 					distance = -distance_max;
 				}
 
+				if (inst->transformed_aabb.has_point(p_render_data->scene_data->cam_transform.origin)) {
+					Vector3 cam_to_center = inst->transformed_aabb.get_center() - p_render_data->scene_data->cam_transform.origin;
+					float scale_factor = cam_to_center.length() / inst->transformed_aabb.get_size().length();
+					distance *= scale_factor;
+				}
+
 				if (p_render_data->scene_data->cam_orthogonal) {
 					distance = 1.0;
 				}


### PR DESCRIPTION
DRAFT PR.

It introduces a new condition that checks if the transformed AABB (Axis-Aligned Bounding Box) contains the camera's origin point. If it does, it calculates a scale factor based on the distance between the camera and the center of the AABB, and applies this factor to adjust the distance value.

Fixes: https://github.com/godotengine/godot/issues/67890