### PR TITLE
Make onready variables created from dropping nodes include custom types

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1726,9 +1726,17 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 
 				String variable_name = String(node->get_name()).to_snake_case().validate_identifier();
 				if (use_type) {
-					text_to_drop += vformat("@onready var %s: %s = %s%s\n", variable_name, node->get_class_name(), is_unique ? "%" : "$", path);
+					StringName class_name = node->get_class_name();
+					Ref<Script> node_script = node->get_script();
+					if (node_script.is_valid()) {
+						StringName global_node_script_name = node_script->get_global_name();
+						if (global_node_script_name != StringName()) {
+							class_name = global_node_script_name;
+						}
+					}
+					text_to_drop += vformat("@onready var %s: %s = %c%s\n", variable_name, class_name, is_unique ? '%' : '$', path);
 				} else {
-					text_to_drop += vformat("@onready var %s = %s%s\n", variable_name, is_unique ? "%" : "$", path);
+					text_to_drop += vformat("@onready var %s = %c%s\n", variable_name, is_unique ? '%' : '$', path);
 				}
 			}
 		} else {


### PR DESCRIPTION
This pull request makes dropping a node into the script editor while holding Ctrl generate code of the form <strike>"@onready var name := $Path as Custom"</strike> "@onready var name:Custom = $Path"

Closes https://github.com/godotengine/godot-proposals/issues/7239