### PR TITLE
Clear the previously set state when configuring for a new scene root node

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -239,6 +239,7 @@ void Resource::configure_for_local_scene(Node *p_for_scene, HashMap<Ref<Resource
 	List<PropertyInfo> plist;
 	get_property_list(&plist);
 
+	reset_local_to_scene();
 	local_scene = p_for_scene;
 
 	for (const PropertyInfo &E : plist) {
@@ -380,6 +381,10 @@ Node *Resource::get_local_scene() const {
 void Resource::setup_local_to_scene() {
 	// Can't use GDVIRTUAL in Resource, so this will have to be done with a signal
 	emit_signal(SNAME("setup_local_to_scene_requested"));
+}
+
+void Resource::reset_local_to_scene() {
+	// Restores the state as if setup_local_to_scene() hadn't been called.
 }
 
 Node *(*Resource::_get_local_scene_func)() = nullptr;

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -80,6 +80,8 @@ protected:
 	void _set_path(const String &p_path);
 	void _take_over_path(const String &p_path);
 
+	virtual void reset_local_to_scene();
+
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor
 	static void (*_update_configuration_warning)(); //used by editor

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -87,12 +87,7 @@ void ViewportTexture::setup_local_to_scene() {
 	}
 }
 
-void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
-	if (path == p_path) {
-		return;
-	}
-
-	path = p_path;
+void ViewportTexture::reset_local_to_scene() {
 	vp_changed = true;
 
 	if (vp) {
@@ -104,6 +99,16 @@ void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
 		proxy_ph = RS::get_singleton()->texture_2d_placeholder_create();
 		RS::get_singleton()->texture_proxy_update(proxy, proxy_ph);
 	}
+}
+
+void ViewportTexture::set_viewport_path_in_scene(const NodePath &p_path) {
+	if (path == p_path) {
+		return;
+	}
+
+	path = p_path;
+
+	reset_local_to_scene();
 
 	if (get_local_scene() && !path.is_empty()) {
 		setup_local_to_scene();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -70,6 +70,8 @@ class ViewportTexture : public Texture2D {
 protected:
 	static void _bind_methods();
 
+	virtual void reset_local_to_scene() override;
+
 public:
 	void set_viewport_path_in_scene(const NodePath &p_path);
 	NodePath get_viewport_path_in_scene() const;


### PR DESCRIPTION
Saving a subscene (or other reasons) causes the main scene to be re-instantiated. And the resource instance in the main scene will be reused when the main scene is re-instantiated. So for resources with `resource_local_to_scene` enabled, resetting state may be necessary (at least for `ViewportTexture`).

Fix #69469, fix #79176, fix #77981, fix #74080, fix #80417.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
