### PR TITLE
Don't grab theme icons for scripts

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1154,15 +1154,6 @@ Ref<Texture2D> EditorData::get_script_icon(const Ref<Script> &p_script) {
 		return ext_icon;
 	}
 
-	// Look for the base type in the editor theme.
-	// This is only relevant for built-in classes.
-	const Control *gui_base = EditorNode::get_singleton()->get_gui_base();
-	if (gui_base && gui_base->has_theme_icon(base_type, SNAME("EditorIcons"))) {
-		Ref<Texture2D> theme_icon = gui_base->get_theme_icon(base_type, SNAME("EditorIcons"));
-		_script_icon_cache[p_script] = theme_icon;
-		return theme_icon;
-	}
-
 	// If no icon found, cache it as null.
 	_script_icon_cache[p_script] = Ref<Texture>();
 	return nullptr;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4277,7 +4277,7 @@ void EditorNode::_pick_main_scene_custom_action(const String &p_custom_action_na
 	}
 }
 
-Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, const Ref<Script> &p_script, const String &p_fallback) {
+Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, const Ref<Script> &p_script, const String &p_fallback, bool p_fallback_script_to_theme) {
 	ERR_FAIL_COND_V_MSG(p_class.is_empty(), nullptr, "Class name cannot be empty.");
 	EditorData &ed = EditorNode::get_editor_data();
 
@@ -4286,6 +4286,16 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 		Ref<Texture2D> script_icon = ed.get_script_icon(p_script);
 		if (script_icon.is_valid()) {
 			return script_icon;
+		}
+
+		if (p_fallback_script_to_theme) {
+			// Look for the base type in the editor theme.
+			// This is only relevant for built-in classes.
+			String base_type;
+			p_script->get_language()->get_global_class_name(p_script->get_path(), &base_type);
+			if (gui_base && gui_base->has_theme_icon(base_type, SNAME("EditorIcons"))) {
+				return gui_base->get_theme_icon(base_type, SNAME("EditorIcons"));
+			}
 		}
 	}
 
@@ -4339,7 +4349,7 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 		scr = EditorNode::get_editor_data().script_class_load_script(p_class);
 	}
 
-	return _get_class_or_script_icon(p_class, scr, p_fallback);
+	return _get_class_or_script_icon(p_class, scr, p_fallback, true);
 }
 
 bool EditorNode::is_object_of_custom_type(const Object *p_object, const StringName &p_class) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -688,7 +688,7 @@ private:
 	void _feature_profile_changed();
 	bool _is_class_editor_disabled_by_feature_profile(const StringName &p_class);
 
-	Ref<Texture2D> _get_class_or_script_icon(const String &p_class, const Ref<Script> &p_script, const String &p_fallback = "Object");
+	Ref<Texture2D> _get_class_or_script_icon(const String &p_class, const Ref<Script> &p_script, const String &p_fallback = "Object", bool p_fallback_script_to_theme = false);
 
 	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 


### PR DESCRIPTION
When a node is extending a different class from it's actual type, the scene tree dock will show the script class instead. Extending a different class is a common use-case, e.g. you might have a Container-based node, but make the script extend Control to avoid problems with changing type etc. Scene tree displaying script type means that you don't know what Container type this node represents unless you hover it and check the tooltip. It's confusing and annoying.

This PR gets rid of this behavior. Custom types are unaffected.

Before
![image](https://github.com/godotengine/godot/assets/2223172/94020d4e-34a7-4294-8314-69ecf16e048d)

After
![image](https://github.com/godotengine/godot/assets/2223172/96ade140-f744-496e-898d-666358ae4a25)

EDIT:
Fixes #76983