### PR TITLE
GDScript: Solve `_populate_class_members()` cyclic dependency problem 

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -787,11 +787,11 @@ Error GDScript::reload(bool p_keep_state) {
 	err = compiler.compile(&parser, this, p_keep_state);
 
 	if (err) {
+		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		if (can_run) {
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
-			_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 			reloading = false;
 			return ERR_COMPILATION_FAILED;
 		} else {


### PR DESCRIPTION
Fixes #78146 and fixes #79153 (which is pretty much a duplicate). The issue occurs because `_populate_class_members(descendant_class)` is getting called during a call for `_populate_class_members(ancestor_class)`. Thus class members of ancestors are _not_ available for the descendant class when it is populating its own, resulting the `identifier not found` error of the linked issue when the descendant class gets compiled.

### Issue 🔥 
`GDScriptCompiler::_populate_class_members()` sets up the datastructures so that the compiler knows the addresses of member variables of the class being compiled. For this, it needs to know members its base class, so that those are also addressable. In order to obtain those members, it asks for the fully compiled script of the base class using `GDScriptCache::get_full_script()`.

However in certain configurations of dependencies, the base class of the current class may depend on a descendant class. Let's say `Daughter(D) extends Mother(M) extends Grandmother(GM)`, as in the linked issue. If you start by _compiling_ (not just analyzing) M, that requires GM's class members, so you `get_full_script(GM)`, but if `GM` somehow references `D` in a way that asks for its `get_full_script(D)`, then `D` will run its `_populate_class_members()` without `M` having hers populated from `GM`.

Oof, that's a mouthful.

I don't believe it is possible to replicate the issue within the test framework, as it relies on global class names that exist in different files. Instead, I am attaching 🐛 [MRP.zip](https://github.com/godotengine/godot/files/11992352/MRP.zip) 🐞, which causes the issue when running the scene, before this PR, but works properly after this PR.

The dependency is as follows: `Daughter extends Mother extends Grandmother`, with `Grandmother` referring to (but not extending `Daughter`), and `Mother` being the first file loaded, in this case by being attached to the main scene node.

### Solution ⚕️ 

The solution here was to make it so that `_populate_class_members()` did not require `get_full_script()`, but instead only requires the shallow script (which does resolve any necessary inheritance dependencies), followed by calling its `_populate_class_members()`. This no longer triggers `get_full_script()`, and so descendant classes don't get compiled before their base classes are done populating their members.

### Concerns 😨 
I'm not super well versed in the meta-organization of the GDScript infrastructure, so I wonder whether this is the best solution. This doesn't so much solve cyclic dependencies as it sidesteps them insofar as `_populate_class_members` is concerned. Maybe that's not so bad, since it's such a specific case?

Either way, I'd love to see a refactor of the way scripts are loaded, maybe doing away with `get_shallow/full_script` and using `GDScriptCache/raise_status()` to give us more fine-grained control over what is needed at each point in time, and making `GDScript::reload()`, which `get_full_script()` relies on, a little less monolithic.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
