### PR TITLE
Fix "reparent to new node" not remembering index

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -179,7 +179,8 @@ class SceneTreeDock : public VBoxContainer {
 	bool first_enter = true;
 
 	void _create();
-	void _do_create(Node *p_parent);
+	Node *_do_create(Node *p_parent);
+	void _post_do_create(Node *p_child);
 	Node *scene_root = nullptr;
 	Node *edited_scene = nullptr;
 	Node *pending_click_select = nullptr;


### PR DESCRIPTION
Supersedes #42730
Fixes https://github.com/godotengine/godot-proposals/issues/1652, fixes https://github.com/godotengine/godot-proposals/issues/5427

https://github.com/godotengine/godot/assets/5117197/e2526753-5571-4d63-9056-9b5f620f0fb5

Also merges the operation into a single undo step.