### PR TITLE
Fix `PackedScene::get_last_modified_time()` always returns `0`

### DIFF
--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -255,6 +255,7 @@ public:
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 #ifdef TOOLS_ENABLED
 	virtual void set_last_modified_time(uint64_t p_time) override {
+		Resource::set_last_modified_time(p_time);
 		state->set_last_modified_time(p_time);
 	}
 


### PR DESCRIPTION
Previously, the variables operated by `PackedScene::set_last_modified_time()` and `PackedScene::get_last_modified_time()` are different.

Fix #79227.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
