### PR TITLE
Lossy WebP: Enable sharp RGB to YUV conversion

### DIFF
--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -84,6 +84,7 @@ Vector<uint8_t> _webp_packer(const Ref<Image> &p_image, float p_quality, bool p_
 	}
 	config.method = compression_method;
 	config.quality = p_quality;
+	config.use_sharp_yuv = 1;
 	pic.use_argb = 1;
 	pic.width = s.width;
 	pic.height = s.height;


### PR DESCRIPTION
Drastically increases lossy WebP quality by performing a sharp RGB to YUV conversion. This has minimal impact on size and some additional time to encode.

[This article](https://www.ctrl.blog/entry/webp-sharp-yuv.html) explains well how this works.

Here's a preview linked from it:
![Sharp example](https://www.ctrl.blog/media/hero/adobe-webp-q50-vs-sharpyuv.688x387.webp)

I wanted to make a new check option on the import tab to enable/disable. There is a **High Quality** import option that could be used, but it's designed with changing VRAM compressed formats in mind and can't be passed to WebPCommon. Both alternatives can't be done without making major changes to the ResourceSaver that will only benefit lossy WebP.

In the end, I decided that leaving it enabled was better, as the size increase is minimal.