### PR TITLE
Assume root when dropping node to unassigned script

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/gui/editor_toaster.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 
@@ -1759,10 +1760,14 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			return;
 		}
 
+		if (!ClassDB::is_parent_class(script->get_instance_base_type(), "Node")) {
+			EditorToaster::get_singleton()->popup_str(vformat(TTR("Can't drop nodes because script '%s' does not inherit Node."), get_name()), EditorToaster::SEVERITY_WARNING);
+			return;
+		}
+
 		Node *sn = _find_script_node(scene_root, scene_root, script);
 		if (!sn) {
-			EditorNode::get_singleton()->show_warning(vformat(TTR("Can't drop nodes because script '%s' is not used in this scene."), get_name()));
-			return;
+			sn = scene_root;
 		}
 
 		Array nodes = d["nodes"];


### PR DESCRIPTION
When dropping a node to Script Editor, you will sometimes get the arbitrary error that the script is nowhere in the scene:

https://github.com/godotengine/godot/assets/2223172/356f5efb-7211-4350-9bd1-c982041dd5a7

The error may appear in valid scenarios, e.g. when dropping node into parent script. In any case, I think it's less relevant now that we have scene unique names, as the hierarchy does not matter that much.

With this PR, if a script is not found in the scene, the editor will assume that the node is relative to scene's root (which, again, is irrelevant if the node has unique name). Here's me casually dropping a node into random EditorScript:

https://github.com/godotengine/godot/assets/2223172/51300850-ba34-4f5b-aebf-c00d0cb3770f

