### PR TITLE
Expose getters for the currently focused Window

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -194,6 +194,12 @@
 				[b]Note:[/b] This doesn't affect native dialogs such as the ones spawned by [method DisplayServer.dialog_show].
 			</description>
 		</method>
+		<method name="get_top_popup_or_focused_window" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the [method Object.get_instance_id] of the top [Popup] if available or of the currently focused [Window].
+			</description>
+		</method>
 		<method name="get_window_at_screen_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2i" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -104,6 +104,12 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="get_top_popup_or_focused_window" qualifiers="const">
+			<return type="Window" />
+			<description>
+				Returns the top [Popup] if available or the currently focused [Window].
+			</description>
+		</method>
 		<method name="get_viewport_rid" qualifiers="const">
 			<return type="RID" />
 			<description>

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -365,14 +365,14 @@ bool DisplayServerX11::is_dark_mode() const {
 }
 
 Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) {
-	WindowID window_id = last_focused_window;
+	WindowID window_id = currently_focused_window;
 
 	if (!windows.has(window_id)) {
 		window_id = MAIN_WINDOW_ID;
 	}
 
 	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(last_focused_window, xid, p_title, p_current_directory, p_filename, p_mode, p_filters, p_callback);
+	return portal_desktop->file_dialog_show(currently_focused_window, xid, p_title, p_current_directory, p_filename, p_mode, p_filters, p_callback);
 }
 
 #endif
@@ -2892,7 +2892,7 @@ void DisplayServerX11::window_move_to_foreground(WindowID p_window) {
 }
 
 DisplayServerX11::WindowID DisplayServerX11::get_focused_window() const {
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 bool DisplayServerX11::window_is_focused(WindowID p_window) const {
@@ -3975,7 +3975,7 @@ DisplayServer::WindowID DisplayServerX11::_get_focused_window_or_popup() const {
 		return E->get();
 	}
 
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 void DisplayServerX11::_dispatch_input_events(const Ref<InputEvent> &p_event) {
@@ -4604,7 +4604,7 @@ void DisplayServerX11::process_events() {
 				}
 
 				WindowData &wd = windows[window_id];
-				last_focused_window = window_id;
+				currently_focused_window = window_id;
 				wd.focused = true;
 
 				// Keep track of focus order for overlapping windows.
@@ -4659,6 +4659,7 @@ void DisplayServerX11::process_events() {
 					im_selection = Vector2i();
 					OS_Unix::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 				}
+				currently_focused_window = INVALID_WINDOW_ID;
 				wd.focused = false;
 
 				Input::get_singleton()->release_pressed_events();

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -230,7 +230,7 @@ class DisplayServerX11 : public DisplayServer {
 	List<WindowID> popup_list;
 
 	WindowID window_mouseover_id = INVALID_WINDOW_ID;
-	WindowID last_focused_window = INVALID_WINDOW_ID;
+	WindowID currently_focused_window = INVALID_WINDOW_ID;
 
 	WindowID window_id_counter = MAIN_WINDOW_ID;
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect);
@@ -353,7 +353,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	Context context = CONTEXT_ENGINE;
 
-	WindowID _get_focused_window_or_popup() const;
+	virtual WindowID _get_focused_window_or_popup() const override;
 	bool _window_focus_check();
 
 	void _send_window_event(const WindowData &wd, WindowEvent p_event);

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -187,7 +187,7 @@ private:
 	bool keyboard_layout_dirty = true;
 
 	WindowID window_mouseover_id = INVALID_WINDOW_ID;
-	WindowID last_focused_window = INVALID_WINDOW_ID;
+	WindowID currently_focused_window = INVALID_WINDOW_ID;
 	WindowID window_id_counter = MAIN_WINDOW_ID;
 	float display_max_scale = 1.f;
 	Point2i origin;
@@ -251,14 +251,14 @@ public:
 	void push_to_key_event_buffer(const KeyEvent &p_event);
 	void pop_last_key_event();
 	void update_im_text(const Point2i &p_selection, const String &p_text);
-	void set_last_focused_window(WindowID p_window);
+	void set_currently_focused_window(WindowID p_window);
 	bool mouse_process_popups(bool p_close = false);
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);
 	void set_is_resizing(bool p_is_resizing);
 	bool get_is_resizing() const;
 	void reparent_check(WindowID p_window);
-	WindowID _get_focused_window_or_popup() const;
+	virtual WindowID _get_focused_window_or_popup() const override;
 	void mouse_enter_window(WindowID p_window);
 	void mouse_exit_window(WindowID p_window);
 	void update_presentation_mode();

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -388,7 +388,7 @@ DisplayServer::WindowID DisplayServerMacOS::_get_focused_window_or_popup() const
 		return E->get();
 	}
 
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 void DisplayServerMacOS::mouse_enter_window(WindowID p_window) {
@@ -768,8 +768,8 @@ void DisplayServerMacOS::update_im_text(const Point2i &p_selection, const String
 	OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 }
 
-void DisplayServerMacOS::set_last_focused_window(WindowID p_window) {
-	last_focused_window = p_window;
+void DisplayServerMacOS::set_currently_focused_window(WindowID p_window) {
+	currently_focused_window = p_window;
 }
 
 void DisplayServerMacOS::set_is_resizing(bool p_is_resizing) {
@@ -2200,7 +2200,7 @@ Error DisplayServerMacOS::file_dialog_show(const String &p_title, const String &
 	NSString *url = [NSString stringWithUTF8String:p_current_directory.utf8().get_data()];
 	FileDialogDropdown *handler = nullptr;
 
-	WindowID prev_focus = last_focused_window;
+	WindowID prev_focus = currently_focused_window;
 
 	Callable callback = p_callback; // Make a copy for async completion handler.
 	if (p_mode == FILE_DIALOG_MODE_SAVE_FILE) {
@@ -3724,7 +3724,7 @@ bool DisplayServerMacOS::window_is_focused(WindowID p_window) const {
 }
 
 DisplayServerMacOS::WindowID DisplayServerMacOS::get_focused_window() const {
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 bool DisplayServerMacOS::window_can_draw(WindowID p_window) const {

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -321,7 +321,7 @@
 	[self windowDidResize:notification]; // Emit resize event, to ensure content is resized if the window was resized while it was hidden.
 
 	wd.focused = true;
-	ds->set_last_focused_window(window_id);
+	ds->set_currently_focused_window(window_id);
 	ds->send_window_event(wd, DisplayServerMacOS::WINDOW_EVENT_FOCUS_IN);
 }
 
@@ -338,6 +338,7 @@
 	}
 
 	wd.focused = false;
+	ds->set_currently_focused_window(DisplayServerMacOS::INVALID_WINDOW_ID);
 	ds->release_pressed_events();
 	ds->send_window_event(wd, DisplayServerMacOS::WINDOW_EVENT_FOCUS_OUT);
 }
@@ -351,6 +352,7 @@
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 
 	wd.focused = false;
+	ds->set_currently_focused_window(DisplayServerMacOS::INVALID_WINDOW_ID);
 	ds->release_pressed_events();
 	ds->send_window_event(wd, DisplayServerMacOS::WINDOW_EVENT_FOCUS_OUT);
 }
@@ -364,7 +366,7 @@
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	if ([wd.window_object isKeyWindow]) {
 		wd.focused = true;
-		ds->set_last_focused_window(window_id);
+		ds->set_currently_focused_window(window_id);
 		ds->send_window_event(wd, DisplayServerMacOS::WINDOW_EVENT_FOCUS_IN);
 	}
 }

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -159,7 +159,7 @@ DisplayServer::WindowID DisplayServerWindows::_get_focused_window_or_popup() con
 		return E->get();
 	}
 
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 void DisplayServerWindows::_register_raw_input_devices(WindowID p_target_window) {
@@ -259,7 +259,7 @@ Error DisplayServerWindows::file_dialog_show(const String &p_title, const String
 		filters.push_back({ (LPCWSTR)filter_names[i].ptr(), (LPCWSTR)filter_exts[i].ptr() });
 	}
 
-	WindowID prev_focus = last_focused_window;
+	WindowID prev_focus = currently_focused_window;
 
 	HRESULT hr = S_OK;
 	IFileDialog *pfd = nullptr;
@@ -514,10 +514,10 @@ String DisplayServerWindows::clipboard_get() const {
 
 Ref<Image> DisplayServerWindows::clipboard_get_image() const {
 	Ref<Image> image;
-	if (!windows.has(last_focused_window)) {
+	if (!windows.has(currently_focused_window)) {
 		return image; // No focused window?
 	}
-	if (!OpenClipboard(windows[last_focused_window].hWnd)) {
+	if (!OpenClipboard(windows[currently_focused_window].hWnd)) {
 		ERR_FAIL_V_MSG(image, "Unable to open clipboard.");
 	}
 	UINT png_format = RegisterClipboardFormatA("PNG");
@@ -1155,8 +1155,8 @@ void DisplayServerWindows::delete_sub_window(WindowID p_window) {
 	DestroyWindow(windows[p_window].hWnd);
 	windows.erase(p_window);
 
-	if (last_focused_window == p_window) {
-		last_focused_window = INVALID_WINDOW_ID;
+	if (currently_focused_window == p_window) {
+		currently_focused_window = INVALID_WINDOW_ID;
 	}
 }
 
@@ -1949,7 +1949,7 @@ bool DisplayServerWindows::window_is_focused(WindowID p_window) const {
 }
 
 DisplayServerWindows::WindowID DisplayServerWindows::get_focused_window() const {
-	return last_focused_window;
+	return currently_focused_window;
 }
 
 bool DisplayServerWindows::window_can_draw(WindowID p_window) const {
@@ -2999,7 +2999,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_SETFOCUS: {
 			windows[window_id].window_has_focus = true;
-			last_focused_window = window_id;
+			currently_focused_window = window_id;
 
 			// Restore mouse mode.
 			_set_mouse_mode_impl(mouse_mode);
@@ -3013,7 +3013,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_KILLFOCUS: {
 			windows[window_id].window_has_focus = false;
-			last_focused_window = window_id;
+			currently_focused_window = INVALID_WINDOW_ID;
 
 			// Release capture unconditionally because it can be set due to dragging, in addition to captured mode.
 			ReleaseCapture();

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -447,7 +447,7 @@ class DisplayServerWindows : public DisplayServer {
 	WindowID window_id_counter = MAIN_WINDOW_ID;
 	RBMap<WindowID, WindowData> windows;
 
-	WindowID last_focused_window = INVALID_WINDOW_ID;
+	WindowID currently_focused_window = INVALID_WINDOW_ID;
 
 	HCURSOR hCursor;
 
@@ -485,7 +485,7 @@ class DisplayServerWindows : public DisplayServer {
 	void _update_real_mouse_position(WindowID p_window);
 
 	void _set_mouse_mode_impl(MouseMode p_mode);
-	WindowID _get_focused_window_or_popup() const;
+	virtual WindowID _get_focused_window_or_popup() const override;
 	void _register_raw_input_devices(WindowID p_target_window);
 
 	void _process_activate_event(WindowID p_window_id, WPARAM wParam, LPARAM lParam);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2555,6 +2555,10 @@ Window *Viewport::get_base_window() const {
 	return w;
 }
 
+Window *Viewport::get_top_popup_or_focused_window() const {
+	return gui.subwindow_focused;
+}
+
 void Viewport::_gui_remove_focus_for_window(Node *p_window) {
 	if (get_base_window() == p_window) {
 		gui_release_focus();
@@ -4657,6 +4661,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_embedding_subwindows", "enable"), &Viewport::set_embedding_subwindows);
 	ClassDB::bind_method(D_METHOD("is_embedding_subwindows"), &Viewport::is_embedding_subwindows);
 	ClassDB::bind_method(D_METHOD("get_embedded_subwindows"), &Viewport::get_embedded_subwindows);
+	ClassDB::bind_method(D_METHOD("get_top_popup_or_focused_window"), &Viewport::get_top_popup_or_focused_window);
 
 	ClassDB::bind_method(D_METHOD("set_canvas_cull_mask", "mask"), &Viewport::set_canvas_cull_mask);
 	ClassDB::bind_method(D_METHOD("get_canvas_cull_mask"), &Viewport::get_canvas_cull_mask);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -669,6 +669,7 @@ public:
 
 	Viewport *get_parent_viewport() const;
 	Window *get_base_window() const;
+	Window *get_top_popup_or_focused_window() const;
 
 	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
 

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -457,6 +457,14 @@ void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }
 
+ObjectID DisplayServer::get_top_popup_or_focused_window() const {
+	WindowID wid = _get_focused_window_or_popup();
+	if (wid == INVALID_WINDOW_ID) {
+		return ObjectID();
+	}
+	return window_get_attached_instance_id(wid);
+}
+
 void DisplayServer::window_set_exclusive(WindowID p_window, bool p_exclusive) {
 	// Do nothing, if not supported.
 }
@@ -721,6 +729,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_window_list"), &DisplayServer::get_window_list);
 	ClassDB::bind_method(D_METHOD("get_window_at_screen_position", "position"), &DisplayServer::get_window_at_screen_position);
+	ClassDB::bind_method(D_METHOD("get_top_popup_or_focused_window"), &DisplayServer::get_top_popup_or_focused_window);
 
 	ClassDB::bind_method(D_METHOD("window_get_native_handle", "handle_type", "window_id"), &DisplayServer::window_get_native_handle, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_active_popup"), &DisplayServer::window_get_active_popup);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -337,6 +337,10 @@ public:
 
 	typedef int WindowID;
 
+private:
+	virtual WindowID _get_focused_window_or_popup() const { return MAIN_WINDOW_ID; };
+
+public:
 	virtual Vector<DisplayServer::WindowID> get_window_list() const = 0;
 
 	enum WindowFlags {
@@ -374,6 +378,7 @@ public:
 	virtual int64_t window_get_native_handle(HandleType p_handle_type, WindowID p_window = MAIN_WINDOW_ID) const;
 
 	virtual WindowID get_window_at_screen_position(const Point2i &p_position) const = 0;
+	ObjectID get_top_popup_or_focused_window() const;
 
 	virtual void window_attach_instance_id(ObjectID p_instance, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window = MAIN_WINDOW_ID) const = 0;


### PR DESCRIPTION
Make it easier to get the focused `Window`-node be exposing `Viewport` and `DisplayServer` functions, that return the focused window.
Currently it is necessary to traverse the scene-tree recursively in order to check every Node, if it is a Window, that has focus.

Here is a MRP to showcase how the exposed functions can be used to find the focused `Control`-node, that receives Key-InputEvents during the GUI-Input-stage.
[GetFocusedControl.zip](https://github.com/godotengine/godot/files/12064483/GetFocusedControl79261.zip) (updated 2023-07-16)

Press `F1` to print the currently focused Control in the console.

resolve godotengine/godot-proposals#7242 by making it easier to find the focused `Control`-node, that receives Key-InputEvents during the GUI-Input-stage

Updated 2023-08-09: Fix merge conflict
Updated 2023-08-12: Fix merge conflict
Updated 2023-08-22: Fix merge conflict
Updated 2024-01-19: Fix merge conflict