### PR TITLE
Keep `GraphNode` port icons crisp at high zoom levels and remove artifacts

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1910,7 +1910,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_icon("close", "GraphNode", theme->get_icon(SNAME("GuiCloseCustomizable"), SNAME("EditorIcons")));
 	theme->set_icon("resizer", "GraphNode", theme->get_icon(SNAME("GuiResizer"), SNAME("EditorIcons")));
-	theme->set_icon("port", "GraphNode", theme->get_icon(SNAME("GuiGraphNodePort"), SNAME("EditorIcons")));
+	Ref<ImageTexture> port_icon = theme->get_icon(SNAME("GuiGraphNodePort"), SNAME("EditorIcons"));
+	// The true size is 24x24 This is necessary for sharp port icons at high zoom levels in GraphEdit (up to ~200%).
+	port_icon->set_size_override(Size2(12, 12));
+	theme->set_icon("port", "GraphNode", port_icon);
 
 	theme->set_font("title_font", "GraphNode", theme->get_font(SNAME("main_bold_msdf"), SNAME("EditorFonts")));
 

--- a/editor/icons/GuiGraphNodePort.svg
+++ b/editor/icons/GuiGraphNodePort.svg
@@ -1,1 +1,1 @@
-<svg height="10" viewBox="0 0 10 10" width="10" xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" fill="#fff" r="5"/></svg>
+<svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" fill="#fff" r="10"/></svg>


### PR DESCRIPTION
With zoom levels up to 207%, the port icons are noticeably stretched. You can also observe interpolation/sampling artifacts because the circle touches all edges of the SVG's viewport. This can be solved with size overrides and adjusting the circle/the image's dimensions.

Before/After:
<img width="326" alt="1QVjFujSBJ" src="https://github.com/godotengine/godot/assets/50084500/0145704e-7e4c-42bc-803b-bcdf6e55f093"> <img width="326" alt="AfgNu6m39j" src="https://github.com/godotengine/godot/assets/50084500/2554ab71-a808-4882-bccc-dd8b5e95e0e3">
