### PR TITLE
Fix `Camera2D.rotating` not being converted and reversed properly

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -2241,9 +2241,10 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 
 	// rotating = true  ->   ignore_rotation = false # reversed "rotating" for Camera2D
 	if (contains_function_call(line, "rotating")) {
-		int start = line.find("rotating");
+		String function_name = "rotating";
+		int start = line.find(function_name);
 		bool foundNextEqual = false;
-		String line_to_check = line.substr(start + String("rotating").length());
+		String line_to_check = line.substr(start + function_name.length());
 		String assigned_value;
 		for (int current_index = 0; line_to_check.length() > current_index; current_index++) {
 			char32_t chr = line_to_check.get(current_index);
@@ -2251,14 +2252,14 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 				continue;
 			} else if (chr == '=') {
 				foundNextEqual = true;
-				assigned_value = line.right(current_index).strip_edges();
+				assigned_value = line.substr(start + function_name.length() + current_index + 1).strip_edges();
 				assigned_value = assigned_value == "true" ? "false" : "true";
 			} else {
 				break;
 			}
 		}
 		if (foundNextEqual) {
-			line = line.substr(0, start) + "ignore_rotation =" + assigned_value + " # reversed \"rotating\" for Camera2D";
+			line = line.substr(0, start) + "ignore_rotation = " + assigned_value + " # reversed \"rotating\" for Camera2D";
 		}
 	}
 


### PR DESCRIPTION
Godot 3's Camera2D `rotating = true` and `rotating = false` are supposed to be converted and reversed to Godot 4's `ignore_rotation = false` and `ignore_rotation = true` respectively. This wasn't the case before this PR, as the project converter was failing to properly read the `true` and `false` strings, thus resulting in `ignore_rotation = true` in all cases.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
