### PR TITLE
Add copyright to GLTFState

### DIFF
--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -8,6 +8,7 @@
 		GLTFState can be populated by [GLTFDocument] reading a file or by converting a Godot scene. Then the data can either be used to create a Godot scene or save to a GLTF file. The code that converts to/from a Godot scene can be intercepted at arbitrary points by [GLTFDocumentExtension] classes. This allows for custom data to be stored in the GLTF file or for custom data to be converted to/from Godot nodes.
 	</description>
 	<tutorials>
+		<link title="GLTF asset header schema">https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json"</link>
 	</tutorials>
 	<methods>
 		<method name="add_used_extension">
@@ -268,6 +269,9 @@
 		<member name="base_path" type="String" setter="set_base_path" getter="get_base_path" default="&quot;&quot;">
 		</member>
 		<member name="buffers" type="PackedByteArray[]" setter="set_buffers" getter="get_buffers" default="[]">
+		</member>
+		<member name="copyright" type="String" setter="set_copyright" getter="get_copyright" default="&quot;&quot;">
+			The copyright string in the asset header of the GLTF file. This is set during import if present and export if non-empty. See the GLTF asset header documentation for more information.
 		</member>
 		<member name="create_animations" type="bool" setter="set_create_animations" getter="get_create_animations" default="true">
 		</member>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -205,7 +205,7 @@ Error GLTFDocument::_serialize(Ref<GLTFState> p_state, const String &p_path) {
 	}
 
 	/* STEP SERIALIZE VERSION */
-	err = _serialize_version(p_state);
+	err = _serialize_asset_header(p_state);
 	if (err != OK) {
 		return Error::FAILED;
 	}
@@ -6984,20 +6984,8 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess
 		p_state->json = json.get_data();
 	}
 
-	if (!p_state->json.has("asset")) {
-		return ERR_PARSE_ERROR;
-	}
-
-	Dictionary asset = p_state->json["asset"];
-
-	if (!asset.has("version")) {
-		return ERR_PARSE_ERROR;
-	}
-
-	String version = asset["version"];
-
-	p_state->major_version = version.get_slice(".", 0).to_int();
-	p_state->minor_version = version.get_slice(".", 1).to_int();
+	err = _parse_asset_header(p_state);
+	ERR_FAIL_COND_V(err != OK, err);
 
 	document_extensions.clear();
 	for (Ref<GLTFDocumentExtension> ext : all_document_extensions) {
@@ -7054,13 +7042,15 @@ Dictionary GLTFDocument::_serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_
 	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
 }
 
-Error GLTFDocument::_serialize_version(Ref<GLTFState> p_state) {
+Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 	const String version = "2.0";
 	p_state->major_version = version.get_slice(".", 0).to_int();
 	p_state->minor_version = version.get_slice(".", 1).to_int();
 	Dictionary asset;
 	asset["version"] = version;
-
+	if (!p_state->copyright.is_empty()) {
+		asset["copyright"] = p_state->copyright;
+	}
 	String hash = String(VERSION_HASH);
 	asset["generator"] = String(VERSION_FULL_NAME) + String("@") + (hash.is_empty() ? String("unknown") : hash);
 	p_state->json["asset"] = asset;
@@ -7319,6 +7309,23 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 		ERR_CONTINUE(ext.is_null());
 		err = ext->import_post_parse(p_state);
 		ERR_FAIL_COND_V(err != OK, err);
+	}
+	return OK;
+}
+
+Error GLTFDocument::_parse_asset_header(Ref<GLTFState> p_state) {
+	if (!p_state->json.has("asset")) {
+		return ERR_PARSE_ERROR;
+	}
+	Dictionary asset = p_state->json["asset"];
+	if (!asset.has("version")) {
+		return ERR_PARSE_ERROR;
+	}
+	String version = asset["version"];
+	p_state->major_version = version.get_slice(".", 0).to_int();
+	p_state->minor_version = version.get_slice(".", 1).to_int();
+	if (asset.has("copyright")) {
+		p_state->copyright = asset["copyright"];
 	}
 	return OK;
 }

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -272,7 +272,7 @@ private:
 	PackedByteArray _serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err);
 	Dictionary _serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material);
 	Dictionary _serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material);
-	Error _serialize_version(Ref<GLTFState> p_state);
+	Error _serialize_asset_header(Ref<GLTFState> p_state);
 	Error _serialize_file(Ref<GLTFState> p_state, const String p_path);
 	Error _serialize_gltf_extensions(Ref<GLTFState> p_state) const;
 
@@ -304,6 +304,7 @@ public:
 
 public:
 	Error _parse_gltf_state(Ref<GLTFState> p_state, const String &p_search_path);
+	Error _parse_asset_header(Ref<GLTFState> p_state);
 	Error _parse_gltf_extensions(Ref<GLTFState> p_state);
 	void _process_mesh_instances(Ref<GLTFState> p_state, Node *p_scene_root);
 	void _generate_scene_node(Ref<GLTFState> p_state, Node *p_scene_parent,

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -40,6 +40,8 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_major_version", "major_version"), &GLTFState::set_major_version);
 	ClassDB::bind_method(D_METHOD("get_minor_version"), &GLTFState::get_minor_version);
 	ClassDB::bind_method(D_METHOD("set_minor_version", "minor_version"), &GLTFState::set_minor_version);
+	ClassDB::bind_method(D_METHOD("get_copyright"), &GLTFState::get_copyright);
+	ClassDB::bind_method(D_METHOD("set_copyright", "copyright"), &GLTFState::set_copyright);
 	ClassDB::bind_method(D_METHOD("get_glb_data"), &GLTFState::get_glb_data);
 	ClassDB::bind_method(D_METHOD("set_glb_data", "glb_data"), &GLTFState::set_glb_data);
 	ClassDB::bind_method(D_METHOD("get_use_named_skin_binds"), &GLTFState::get_use_named_skin_binds);
@@ -96,6 +98,7 @@ void GLTFState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "json"), "set_json", "get_json"); // Dictionary
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "major_version"), "set_major_version", "get_major_version"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "minor_version"), "set_minor_version", "get_minor_version"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "copyright"), "set_copyright", "get_copyright"); // String
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "glb_data"), "set_glb_data", "get_glb_data"); // Vector<uint8_t>
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_named_skin_binds"), "set_use_named_skin_binds", "get_use_named_skin_binds"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_nodes", "get_nodes"); // Vector<Ref<GLTFNode>>
@@ -159,6 +162,14 @@ int GLTFState::get_minor_version() {
 
 void GLTFState::set_minor_version(int p_minor_version) {
 	minor_version = p_minor_version;
+}
+
+String GLTFState::get_copyright() {
+	return copyright;
+}
+
+void GLTFState::set_copyright(String p_copyright) {
+	copyright = p_copyright;
 }
 
 Vector<uint8_t> GLTFState::get_glb_data() {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -52,6 +52,7 @@ class GLTFState : public Resource {
 	Dictionary json;
 	int major_version = 0;
 	int minor_version = 0;
+	String copyright;
 	Vector<uint8_t> glb_data;
 
 	bool use_named_skin_binds = false;
@@ -124,6 +125,9 @@ public:
 
 	int get_minor_version();
 	void set_minor_version(int p_minor_version);
+
+	String get_copyright();
+	void set_copyright(String p_copyright);
 
 	Vector<uint8_t> get_glb_data();
 	void set_glb_data(Vector<uint8_t> p_glb_data);


### PR DESCRIPTION
This PR adds a copyright property to GLTFState which can be used to set the GLTF copyright string in the asset header (`asset.copyright`). https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json

I also organized the asset header code, adding a new method `_parse_asset_header` and renaming `_serialize_version` to `_serialize_asset_header`.

For example, during export this can be done:

```gdscript
gltf_state.copyright = "2014 Godette"
```

Which results in the GLTF containing this text:

```gltf
"asset": {
	"copyright": "2014 Godette",
	"version": "2.0"
},
```

And it can be read back at import time:

```gdscript
print("Copyright " + gltf_state.copyright) # Copyright 2014 Godette
```