### PR TITLE
Unify error condition for particles trail lifetime

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -149,7 +149,7 @@ void GPUParticles2D::set_trail_enabled(bool p_enabled) {
 }
 
 void GPUParticles2D::set_trail_lifetime(double p_seconds) {
-	ERR_FAIL_COND(p_seconds < 0.001);
+	ERR_FAIL_COND(p_seconds < 0.01);
 	trail_lifetime = p_seconds;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_lifetime);
 	queue_redraw();

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -181,7 +181,7 @@ void GPUParticles3D::set_trail_enabled(bool p_enabled) {
 }
 
 void GPUParticles3D::set_trail_lifetime(double p_seconds) {
-	ERR_FAIL_COND(p_seconds < 0.001);
+	ERR_FAIL_COND(p_seconds < 0.01);
 	trail_lifetime = p_seconds;
 	RS::get_singleton()->particles_set_trails(particles, trail_enabled, trail_lifetime);
 }

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -430,7 +430,7 @@ void ParticlesStorage::particles_set_fractional_delta(RID p_particles, bool p_en
 void ParticlesStorage::particles_set_trails(RID p_particles, bool p_enable, double p_length) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_COND(!particles);
-	ERR_FAIL_COND(p_length < 0.1);
+	ERR_FAIL_COND(p_length < 0.01);
 	p_length = MIN(10.0, p_length);
 
 	particles->trails_enabled = p_enable;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/79091

The error condition was 0.01 in the high-level nodes, 0.1, in the server, but the property only allows setting it as small as 0.01 with a granularity of 0.01. Accordingly, unify all places to use 0.01. I tested locally and while a value of 0.01 results in a very tiny trail, it still works fine. 

This inconsistency appears to date back to when trails were first implemented https://github.com/godotengine/godot/commit/90056460ad8e22d9166523dcb2defebb0581f95c

Property bindings for reference:

https://github.com/godotengine/godot/blob/9d089fe6e501e4818fed1b0688631c4d65d1ba35/scene/3d/gpu_particles_3d.cpp#L597

https://github.com/godotengine/godot/blob/9d089fe6e501e4818fed1b0688631c4d65d1ba35/scene/2d/gpu_particles_2d.cpp#L665