### PR TITLE
Hide/show `AcceptDialog`'s button spacer on button visibility changed

### DIFF
--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -60,6 +60,7 @@ class AcceptDialog : public Window {
 	} theme_cache;
 
 	void _custom_action(const String &p_action);
+	void _custom_button_visibility_changed(Button *button);
 	void _update_child_rects();
 
 	static bool swap_cancel_ok;


### PR DESCRIPTION
Fixes #79096.

| Before| After |
|--------|--------|
|![0dyPvBDWdQ](https://github.com/godotengine/godot/assets/9283098/ba676a2c-af71-45d2-b520-d40db8381300)|![GitHubDesktop_ZolZrNAUIs](https://github.com/godotengine/godot/assets/9283098/fe0d9eb8-1ad6-458a-ad2d-e8c57eac568b)|
