### PR TITLE
Fix `Animation::subtract_variant` for affine transforms

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5554,10 +5554,10 @@ Variant Animation::subtract_variant(const Variant &a, const Variant &b) {
 			return (b.operator Quaternion()).inverse() * (a.operator Quaternion());
 		}
 		case Variant::TRANSFORM2D: {
-			return (b.operator Transform2D()).inverse() * (a.operator Transform2D());
+			return (b.operator Transform2D()).affine_inverse() * (a.operator Transform2D());
 		}
 		case Variant::TRANSFORM3D: {
-			return (b.operator Transform3D()).inverse() * (a.operator Transform3D());
+			return (b.operator Transform3D()).affine_inverse() * (a.operator Transform3D());
 		}
 		default: {
 			return Variant::evaluate(Variant::OP_SUBTRACT, a, b);


### PR DESCRIPTION
`Transform2D::inverse`/`Transform3D::inverse` which were used in `Animation::subtract_variant` work only for rotation + translation, don't work for scale, skew, etc.

This resulted in e.g. `PropertyTweener` incorrectly calculating the delta for affine transforms:
https://github.com/godotengine/godot/blob/b8ed596769d2114797015833ce86f86ee872ecfa/scene/animation/tween.cpp#L557

Fixes #79242.