### PR TITLE
C#: Improve `GD.PushError` and `GD.PushWarning`

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -526,8 +526,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		error->set_custom_color(1, color);
 
 		String error_title;
-		if (oe.callstack.size() > 0) {
-			// If available, use the script's stack in the error title.
+		if (!oe.source_func.is_empty() && source_is_project_file) {
+			// If source function is inside the project file.
+			error_title += oe.source_func + ": ";
+		} else if (oe.callstack.size() > 0) {
+			// Otherwise, if available, use the script's stack in the error title.
 			error_title = _format_frame_text(&oe.callstack[0]) + ": ";
 		} else if (!oe.source_func.is_empty()) {
 			// Otherwise try to use the C++ source function.
@@ -602,7 +605,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 			if (i == 0) {
 				stack_trace->set_text(0, "<" + TTR("Stack Trace") + ">");
 				stack_trace->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
-				error->set_metadata(0, meta);
+				if (!source_is_project_file) {
+					// Only override metadata if the source is not inside the project.
+					error->set_metadata(0, meta);
+				}
 				tooltip += TTR("Stack Trace:") + "\n";
 			}
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -95,7 +95,7 @@ namespace Godot.NativeInterop
                 }
 
                 NativeFuncs.godotsharp_internal_script_debugger_send_error(nFunc, nFile, line,
-                    nErrorMsg, nExcMsg, p_warning: godot_bool.False, stackInfoVector);
+                    nErrorMsg, nExcMsg, godot_error_handler_type.ERR_HANDLER_ERROR, stackInfoVector);
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -1133,4 +1133,13 @@ namespace Godot.NativeInterop
             get => _ptr != null ? *((int*)_ptr - 1) : 0;
         }
     }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public enum godot_error_handler_type
+    {
+        ERR_HANDLER_ERROR = 0,
+        ERR_HANDLER_WARNING,
+        ERR_HANDLER_SCRIPT,
+        ERR_HANDLER_SHADER,
+    }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -58,7 +58,7 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_internal_script_debugger_send_error(in godot_string p_func,
             in godot_string p_file, int p_line, in godot_string p_err, in godot_string p_descr,
-            godot_bool p_warning, in DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
+            godot_error_handler_type p_type, in DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
 
         internal static partial godot_bool godotsharp_internal_script_debugger_is_active();
 
@@ -540,9 +540,7 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
 
-        internal static partial void godotsharp_pusherror(in godot_string p_str);
-
-        internal static partial void godotsharp_pushwarning(in godot_string p_str);
+        internal static partial void godotsharp_err_print_error(in godot_string p_function, in godot_string p_file, int p_line, in godot_string p_error, in godot_string p_message = default, godot_bool p_editor_notify = godot_bool.False, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
 
         // Object
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -92,10 +92,10 @@ void godotsharp_stack_info_vector_destroy(
 
 void godotsharp_internal_script_debugger_send_error(const String *p_func,
 		const String *p_file, int32_t p_line, const String *p_err, const String *p_descr,
-		bool p_warning, const Vector<ScriptLanguage::StackInfo> *p_stack_info_vector) {
+		ErrorHandlerType p_type, const Vector<ScriptLanguage::StackInfo> *p_stack_info_vector) {
 	const String file = ProjectSettings::get_singleton()->localize_path(p_file->simplify_path());
 	EngineDebugger::get_script_debugger()->send_error(*p_func, file, p_line, *p_err, *p_descr,
-			true, p_warning ? ERR_HANDLER_WARNING : ERR_HANDLER_ERROR, *p_stack_info_vector);
+			true, p_type, *p_stack_info_vector);
 }
 
 bool godotsharp_internal_script_debugger_is_active() {
@@ -1320,12 +1320,14 @@ void godotsharp_printraw(const godot_string *p_what) {
 	OS::get_singleton()->print("%s", reinterpret_cast<const String *>(p_what)->utf8().get_data());
 }
 
-void godotsharp_pusherror(const godot_string *p_str) {
-	ERR_PRINT(*reinterpret_cast<const String *>(p_str));
-}
-
-void godotsharp_pushwarning(const godot_string *p_str) {
-	WARN_PRINT(*reinterpret_cast<const String *>(p_str));
+void godotsharp_err_print_error(const godot_string *p_function, const godot_string *p_file, int32_t p_line, const godot_string *p_error, const godot_string *p_message, bool p_editor_notify, ErrorHandlerType p_type) {
+	_err_print_error(
+			reinterpret_cast<const String *>(p_function)->utf8().get_data(),
+			reinterpret_cast<const String *>(p_file)->utf8().get_data(),
+			p_line,
+			reinterpret_cast<const String *>(p_error)->utf8().get_data(),
+			reinterpret_cast<const String *>(p_message)->utf8().get_data(),
+			p_editor_notify, p_type);
 }
 
 void godotsharp_var_to_str(const godot_variant *p_var, godot_string *r_ret) {
@@ -1611,8 +1613,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_str_to_var,
 	(void *)godotsharp_var_to_bytes,
 	(void *)godotsharp_var_to_str,
-	(void *)godotsharp_pusherror,
-	(void *)godotsharp_pushwarning,
+	(void *)godotsharp_err_print_error,
 	(void *)godotsharp_object_to_string,
 };
 


### PR DESCRIPTION
- Use the name, file path and line number of the caller that invokes `GD.PushError` and `GD.PushWarning` instead of the location in the C++ `runtime_interop.cpp` file.
	- See https://github.com/godotengine/godot/pull/71943#issuecomment-1415809223.
- ~Deprecate `GD.PushError` and `GD.PushWarning` overloads that take a `params` parameter, since those can't be used with [Caller] attributes and the reported error location will be the `GD.cs` file.~
- ~Remove `GD.PushError` and `GD.PushWarning` overloads that take a single string parameter. This breaks compatibility but otherwise overload resolution will prefer them over the new overloads, which defeats the purpose of this PR.~
	- ~Interestingly, I'm the one that added those overloads as performance optimization in https://github.com/godotengine/godot/pull/71946.~
	- ~This breaks binary compatibility but not source compatibility, meaning that it only breaks for users that are calling these methods from a library that was built for 4.0 - 4.1. Users calling these methods directly in their game code will be unaffected.~
- Improvements to getting the C# stack trace.
  - Use C# type keywords for built-in types in method declarations.
  - Remove extra space before each parameter in method declarations.
  - Skip one more frame to avoid `NativeInterop.NativeFuncs`.
	  - Fixes https://github.com/godotengine/godot/issues/79449.
  - Skip methods annotated with the `[StackTraceHidden]` attribute.
- Improvements to `ScriptEditorDebugger` when source is in project.
  - Avoid overriding error metadata when the source is inside the project file.
    - Fixes https://github.com/godotengine/godot/issues/72662.
    - May fix https://github.com/godotengine/godot/issues/76415.
  - Use the source function in the title when the source is inside the project file.

Users that use these methods would expect the reported location printed by these methods to correspond to a location in their project source files. Specifically, they'd expect to see the file path and line number at which they call these methods, and not the location of the C++ code (which is always the same). Now, these methods are a lot more useful since users can know which line in their source code printed the error/warning.

4.1.stable | This PR
-|-
![error4.1](https://github.com/godotengine/godot/assets/3903059/4239c8f3-ba9e-4a2f-990f-e2e541495ba1) | ![error4.2](https://github.com/godotengine/godot/assets/3903059/f113a243-e0f9-4aca-9c40-9aac1adbfbf9)
