### PR TITLE
Streamline creating tile atlas sources

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2250,6 +2250,7 @@ void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource 
 }
 
 void TileSetAtlasSourceEditor::init_source() {
+	tool_setup_atlas_source_button->set_pressed(true);
 	confirm_auto_create_tiles->popup_centered();
 }
 

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -39,6 +39,8 @@
 #include "tile_set_atlas_source_editor.h"
 #include "tile_set_scenes_collection_source_editor.h"
 
+class EditorFileDialog;
+
 class TileSetEditor : public VBoxContainer {
 	GDCLASS(TileSetEditor, VBoxContainer);
 
@@ -72,12 +74,14 @@ private:
 	MenuButton *sources_advanced_menu_button = nullptr;
 	ItemList *sources_list = nullptr;
 	Ref<Texture2D> missing_texture_texture;
+	void _texture_file_selected(const String &p_path);
 	void _source_selected(int p_source_index);
 	void _source_delete_pressed();
 	void _source_add_id_pressed(int p_id_pressed);
 	void _sources_advanced_menu_id_pressed(int p_id_pressed);
 	void _set_source_sort(int p_sort);
 
+	EditorFileDialog *texture_file_dialog = nullptr;
 	AtlasMergingDialog *atlas_merging_dialog = nullptr;
 	TileProxiesManagerDialog *tile_proxies_manager_dialog = nullptr;
 


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/7177

- open file dialog when creating atlas source
- automatically change to Setup tab when new source is created

https://github.com/godotengine/godot/assets/2223172/25daa7a0-b518-4291-9890-00d9d5cda2c7

As a side-effect, creating empty (no texture) atlas sources is no longer possible.