### PR TITLE
Check `FLAG_POPUP` to close an AcceptDialog when parent is focused

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -626,7 +626,6 @@
 		</member>
 		<member name="popup_window" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] will be considered a popup. Popups are sub-windows that don't show as separate windows in system's window manager's window list and will send close request when anything is clicked outside of them (unless [member exclusive] is enabled).
-			[b]Note:[/b] This property only works with native windows.
 		</member>
 		<member name="position" type="Vector2i" setter="set_position" getter="get_position" default="Vector2i(0, 0)">
 			The window's position in pixels.

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -45,7 +45,7 @@ void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
 }
 
 void AcceptDialog::_parent_focused() {
-	if (close_on_escape && !is_exclusive()) {
+	if (!is_exclusive() && get_flag(FLAG_POPUP)) {
 		_cancel_pressed();
 	}
 }


### PR DESCRIPTION
Fix #79150 

The `close_on_escape` property was used to be able to close an AcceptDialog by pressing the `Esc` key, but it was also checked to close when the parent was focused, meaning it had lost the focus. 

With this pull request instead of checking if `close_on_escape` is `true` to close automatically when the parent is focused (For example clicking outside of the dialog), it will check if `popup_window` is `true`.

Now `dialogue_close_on_escape`  only affects if pressing the `Esc` key will close the dialog.

Here is a video showing the change:

https://github.com/godotengine/godot/assets/109873547/afef6078-7c84-40d9-b76a-1e77f827b2e6

***Note:** When using `popup_window` you will need that `exclusive` is `false` so that it works. `exclusive` as `true` blocks all input that is outside the dialog.*
***Note 2:** When only using `dialog_close_on_escape` clicking outside will make the dialog's focus be lost and so using `Esc` won't work until the dialog has the focus again.*
