### PR TITLE
Attach script dialog now respects user case choice

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -171,7 +171,12 @@ void ScriptCreateDialog::config(const String &p_base_name, const String &p_base_
 	internal_name->set_text("");
 
 	if (!p_base_path.is_empty()) {
-		initial_bp = p_base_path.get_basename();
+		String file_name_no_ext = p_base_path.get_file().trim_suffix("." + p_base_path.get_extension());
+		String base_dir = p_base_path.get_base_dir();
+		if (!base_dir.ends_with("/")) {
+			base_dir = base_dir + "/";
+		}
+		initial_bp = base_dir + EditorNode::adjust_scene_name_casing(file_name_no_ext);
 		file_path->set_text(initial_bp + "." + ScriptServer::get_language(language_menu->get_selected())->get_extension());
 		current_language = language_menu->get_selected();
 	} else {


### PR DESCRIPTION
In the "Attach Node Script" dialog, the suggested file name will now respect user choice of case, as per the scene_name_casing setting.

This makes the naming behaviour consistent even when attaching a script to a new scene that wasn't already saved to any file path.

Resolves #39441 ?