### PR TITLE
Remove GraphNode's comment property and related functionality

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -236,9 +236,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="comment" type="bool" setter="set_comment" getter="is_comment" default="false">
-			If [code]true[/code], the GraphNode is a comment node.
-		</member>
 		<member name="draggable" type="bool" setter="set_draggable" getter="is_draggable" default="true">
 			If [code]true[/code], the user can drag the GraphNode.
 		</member>
@@ -372,12 +369,6 @@
 		</theme_item>
 		<theme_item name="breakpoint" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
-		</theme_item>
-		<theme_item name="comment" data_type="style" type="StyleBox">
-			The [StyleBox] used when [member comment] is enabled.
-		</theme_item>
-		<theme_item name="comment_focus" data_type="style" type="StyleBox">
-			The [StyleBox] used when [member comment] is enabled and the [GraphNode] is focused.
 		</theme_item>
 		<theme_item name="frame" data_type="style" type="StyleBox">
 			The default background for [GraphNode].

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1887,8 +1887,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_stylebox("frame", "GraphNode", graphsb);
 	theme->set_stylebox("selected_frame", "GraphNode", graphsbselected);
-	theme->set_stylebox("comment", "GraphNode", graphsbcomment);
-	theme->set_stylebox("comment_focus", "GraphNode", graphsbcommentselected);
 	theme->set_stylebox("breakpoint", "GraphNode", graphsbbreakpoint);
 	theme->set_stylebox("position", "GraphNode", graphsbposition);
 	theme->set_stylebox("slot", "GraphNode", graphsbslot);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -426,7 +426,8 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 	Ref<VisualShaderNodeGroupBase> group_node = Object::cast_to<VisualShaderNodeGroupBase>(vsnode.ptr());
 	bool is_group = !group_node.is_null();
 
-	bool is_comment = false;
+	Ref<VisualShaderNodeComment> comment_node = Object::cast_to<VisualShaderNodeComment>(vsnode.ptr());
+	bool is_comment = comment_node.is_valid();
 
 	Ref<VisualShaderNodeExpression> expression_node = Object::cast_to<VisualShaderNodeExpression>(group_node.ptr());
 	bool is_expression = !expression_node.is_null();
@@ -465,6 +466,10 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 		expression = expression_node->get_expression();
 	}
 
+	if (is_comment) {
+		node->set_visible(false);
+	}
+
 	node->set_position_offset(visual_shader->get_node_position(p_type, p_id));
 	node->set_title(vsnode->get_caption());
 	node->set_name(itos(p_id));
@@ -488,17 +493,6 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 	}
 
 	if (is_resizable) {
-		Ref<VisualShaderNodeComment> comment_node = Object::cast_to<VisualShaderNodeComment>(vsnode.ptr());
-		if (comment_node.is_valid()) {
-			is_comment = true;
-			node->set_comment(true);
-
-			Label *comment_label = memnew(Label);
-			node->add_child(comment_label);
-			comment_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-			comment_label->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-			comment_label->set_text(comment_node->get_description());
-		}
 		editor->call_deferred(SNAME("_set_node_size"), (int)p_type, p_id, size);
 	}
 
@@ -6120,7 +6114,6 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	// SPECIAL
 
-	add_options.push_back(AddOption("Comment", "Special", "VisualShaderNodeComment", TTR("A rectangular area with a description string for better graph organization.")));
 	add_options.push_back(AddOption("Expression", "Special", "VisualShaderNodeExpression", TTR("Custom Godot Shader Language expression, with custom amount of input and output ports. This is a direct injection of code into the vertex/fragment/light function, do not use it to write the function declarations inside.")));
 	add_options.push_back(AddOption("GlobalExpression", "Special", "VisualShaderNodeGlobalExpression", TTR("Custom Godot Shader Language expression, which is placed on top of the resulted shader. You can place various function definitions inside and call it later in the Expressions. You can also declare varyings, parameters and constants.")));
 	add_options.push_back(AddOption("ParameterRef", "Special", "VisualShaderNodeParameterRef", TTR("A reference to an existing parameter.")));

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -373,11 +373,8 @@ void GraphEdit::_update_scroll() {
 void GraphEdit::_graph_node_raised(Node *p_gn) {
 	GraphNode *gn = Object::cast_to<GraphNode>(p_gn);
 	ERR_FAIL_NULL(gn);
-	if (gn->is_comment()) {
-		move_child(gn, 0);
-	} else {
-		gn->move_to_front();
-	}
+
+	gn->move_to_front();
 }
 
 void GraphEdit::_graph_node_selected(Node *p_gn) {
@@ -545,44 +542,6 @@ void GraphEdit::_notification(int p_what) {
 			top_layer->queue_redraw();
 			minimap->queue_redraw();
 		} break;
-	}
-}
-
-void GraphEdit::_update_comment_enclosed_nodes_list(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes) {
-	Rect2 comment_node_rect = p_node->get_rect();
-
-	Vector<GraphNode *> enclosed_nodes;
-	for (int i = 0; i < get_child_count(); i++) {
-		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
-		if (!gn || gn->is_selected()) {
-			continue;
-		}
-
-		Rect2 node_rect = gn->get_rect();
-
-		bool included = comment_node_rect.encloses(node_rect);
-		if (included) {
-			enclosed_nodes.push_back(gn);
-		}
-	}
-
-	p_comment_enclosed_nodes.insert(p_node->get_name(), enclosed_nodes);
-}
-
-void GraphEdit::_set_drag_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, bool p_drag) {
-	for (int i = 0; i < p_comment_enclosed_nodes[p_node->get_name()].size(); i++) {
-		p_comment_enclosed_nodes[p_node->get_name()][i]->set_drag(p_drag);
-	}
-}
-
-void GraphEdit::_set_position_of_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, Vector2 p_drag_accum) {
-	for (int i = 0; i < p_comment_enclosed_nodes[p_node->get_name()].size(); i++) {
-		Vector2 pos = (p_comment_enclosed_nodes[p_node->get_name()][i]->get_drag_from() * zoom + drag_accum) / zoom;
-		if (is_using_snap() ^ Input::get_singleton()->is_key_pressed(Key::CTRL)) {
-			const int snap = get_snap();
-			pos = pos.snapped(Vector2(snap, snap));
-		}
-		p_comment_enclosed_nodes[p_node->get_name()][i]->set_position_offset(pos);
 	}
 }
 
@@ -1039,33 +998,10 @@ void GraphEdit::_minimap_draw() {
 	Vector2 graph_offset = minimap->_get_graph_offset();
 	Vector2 minimap_offset = minimap->minimap_offset;
 
-	// Draw comment graph nodes.
-	for (int i = get_child_count() - 1; i >= 0; i--) {
-		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
-		if (!gn || !gn->is_comment()) {
-			continue;
-		}
-
-		Vector2 node_position = minimap->_convert_from_graph_position(gn->get_position_offset() * zoom - graph_offset) + minimap_offset;
-		Vector2 node_size = minimap->_convert_from_graph_position(gn->get_size() * zoom);
-		Rect2 node_rect = Rect2(node_position, node_size);
-
-		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox(SNAME("node"))->duplicate();
-
-		// Override default values with colors provided by the GraphNode's stylebox, if possible.
-		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "comment_focus" : "comment");
-		if (sbf.is_valid()) {
-			Color node_color = sbf->get_bg_color();
-			sb_minimap->set_bg_color(node_color);
-		}
-
-		minimap->draw_style_box(sb_minimap, node_rect);
-	}
-
 	// Draw regular graph nodes.
 	for (int i = get_child_count() - 1; i >= 0; i--) {
 		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
-		if (!gn || gn->is_comment()) {
+		if (!gn) {
 			continue;
 		}
 
@@ -1164,9 +1100,6 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 				}
 
 				gn->set_position_offset(pos);
-				if (gn->is_comment()) {
-					_set_position_of_comment_enclosed_nodes(gn, comment_enclosed_nodes, drag_accum);
-				}
 			}
 		}
 	}
@@ -1240,9 +1173,6 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 					GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 					if (gn && gn->is_selected()) {
 						gn->set_drag(false);
-						if (gn->is_comment()) {
-							_set_drag_comment_enclosed_nodes(gn, comment_enclosed_nodes, false);
-						}
 					}
 				}
 			}
@@ -1309,10 +1239,6 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 					}
 					if (o_gn->is_selected()) {
 						o_gn->set_drag(true);
-						if (o_gn->is_comment()) {
-							_update_comment_enclosed_nodes_list(o_gn, comment_enclosed_nodes);
-							_set_drag_comment_enclosed_nodes(o_gn, comment_enclosed_nodes, true);
-						}
 					}
 				}
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -241,11 +241,6 @@ private:
 	HashSet<int> valid_left_disconnect_types;
 	HashSet<int> valid_right_disconnect_types;
 
-	HashMap<StringName, Vector<GraphNode *>> comment_enclosed_nodes;
-	void _update_comment_enclosed_nodes_list(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes);
-	void _set_drag_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, bool p_drag);
-	void _set_position_of_comment_enclosed_nodes(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes, Vector2 p_pos);
-
 	HBoxContainer *zoom_hb = nullptr;
 
 	friend class GraphEditFilter;

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -286,37 +286,12 @@ void GraphNode::_resort() {
 	connpos_dirty = true;
 }
 
-bool GraphNode::has_point(const Point2 &p_point) const {
-	if (comment) {
-		Ref<StyleBox> comment_sb = get_theme_stylebox(SNAME("comment"));
-		Ref<Texture2D> resizer = get_theme_icon(SNAME("resizer"));
-
-		if (Rect2(get_size() - resizer->get_size(), resizer->get_size()).has_point(p_point)) {
-			return true;
-		}
-
-		if (Rect2(0, 0, get_size().width, comment_sb->get_margin(SIDE_TOP)).has_point(p_point)) {
-			return true;
-		}
-
-		return false;
-
-	} else {
-		return Control::has_point(p_point);
-	}
-}
-
 void GraphNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
 			Ref<StyleBox> sb;
 
-			if (comment) {
-				sb = get_theme_stylebox(selected ? SNAME("comment_focus") : SNAME("comment"));
-
-			} else {
-				sb = get_theme_stylebox(selected ? SNAME("selected_frame") : SNAME("frame"));
-			}
+			sb = get_theme_stylebox(selected ? SNAME("selected_frame") : SNAME("frame"));
 
 			Ref<StyleBox> sb_slot = get_theme_stylebox(SNAME("slot"));
 
@@ -1003,19 +978,6 @@ GraphNode::Overlay GraphNode::get_overlay() const {
 	return overlay;
 }
 
-void GraphNode::set_comment(bool p_enable) {
-	if (comment == p_enable) {
-		return;
-	}
-
-	comment = p_enable;
-	queue_redraw();
-}
-
-bool GraphNode::is_comment() const {
-	return comment;
-}
-
 void GraphNode::set_resizable(bool p_enable) {
 	if (resizable == p_enable) {
 		return;
@@ -1115,9 +1077,6 @@ void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position_offset", "offset"), &GraphNode::set_position_offset);
 	ClassDB::bind_method(D_METHOD("get_position_offset"), &GraphNode::get_position_offset);
 
-	ClassDB::bind_method(D_METHOD("set_comment", "comment"), &GraphNode::set_comment);
-	ClassDB::bind_method(D_METHOD("is_comment"), &GraphNode::is_comment);
-
 	ClassDB::bind_method(D_METHOD("set_resizable", "resizable"), &GraphNode::set_resizable);
 	ClassDB::bind_method(D_METHOD("is_resizable"), &GraphNode::is_resizable);
 
@@ -1157,7 +1116,6 @@ void GraphNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draggable"), "set_draggable", "is_draggable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selectable"), "set_selectable", "is_selectable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selected"), "set_selected", "is_selected");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "comment"), "set_comment", "is_comment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "overlay", PROPERTY_HINT_ENUM, "Disabled,Breakpoint,Position"), "set_overlay", "get_overlay");
 
 	ADD_GROUP("BiDi", "");

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -124,8 +124,6 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:
-	bool has_point(const Point2 &p_point) const override;
-
 	void set_slot(int p_idx, bool p_enable_left, int p_type_left, const Color &p_color_left, bool p_enable_right, int p_type_right, const Color &p_color_right, const Ref<Texture2D> &p_custom_left = Ref<Texture2D>(), const Ref<Texture2D> &p_custom_right = Ref<Texture2D>(), bool p_draw_stylebox = true);
 	void clear_slot(int p_idx);
 	void clear_all_slots();
@@ -188,9 +186,6 @@ public:
 
 	void set_overlay(Overlay p_overlay);
 	Overlay get_overlay() const;
-
-	void set_comment(bool p_enable);
-	bool is_comment() const;
 
 	void set_resizable(bool p_enable);
 	bool is_resizable() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -711,8 +711,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_stylebox("frame", "GraphNode", graphnode_normal);
 	theme->set_stylebox("selected_frame", "GraphNode", graphnode_selected);
-	theme->set_stylebox("comment", "GraphNode", graphnode_comment_normal);
-	theme->set_stylebox("comment_focus", "GraphNode", graphnode_comment_selected);
 	theme->set_stylebox("breakpoint", "GraphNode", graphnode_breakpoint);
 	theme->set_stylebox("position", "GraphNode", graphnode_position);
 	theme->set_stylebox("slot", "GraphNode", graphnode_slot);


### PR DESCRIPTION
(this functionality will be reintroduced in a new and more flexible way)

Part of the graph editor refactoring process.
Comment nodes in the current form aren't really working well, especially with several of them on top of each other.
Improved, special Nodes for organizing the graph will be reintroduced at a later time. 
(There are already some experiments, but a satisfying solution hasn't been found yet)