### PR TITLE
CI: Allow skipping our GHA workflows with `DISABLE_GODOT_CI` variable

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -9,37 +9,44 @@ jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 
   # Second stage: Run all the builds and some of the tests.
 
   android-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🤖 Android
     needs: static-checks
     uses: ./.github/workflows/android_builds.yml
 
   ios-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🍏 iOS
     needs: static-checks
     uses: ./.github/workflows/ios_builds.yml
 
   linux-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🐧 Linux
     needs: static-checks
     uses: ./.github/workflows/linux_builds.yml
 
   macos-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🍎 macOS
     needs: static-checks
     uses: ./.github/workflows/macos_builds.yml
 
   windows-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🏁 Windows
     needs: static-checks
     uses: ./.github/workflows/windows_builds.yml
 
   web-build:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🌐 Web
     needs: static-checks
     uses: ./.github/workflows/web_builds.yml
@@ -49,6 +56,7 @@ jobs:
   # Can be turned off for PRs that intentionally break compat with godot-cpp,
   # until both the upstream PR and the matching godot-cpp changes are merged.
   godot-cpp-test:
+    if: ${{ vars.DISABLE_GODOT_CI == '' }}
     name: 🪲 Godot CPP
     # This can be changed to depend on another platform, if we decide to use it for
     # godot-cpp instead. Make sure to move the .github/actions/godot-api-dump step


### PR DESCRIPTION
Useful for custom forks of Godot which don't want to run our CI for any reason.
Uses the (currently in beta) GitHub Actions configuration variables: https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context

This is configured in `settings/variables/actions` for the repository, setting it to any value aside from an empty string will skip all jobs.

Here's how it looks like on my fork:
![image](https://github.com/godotengine/godot/assets/4701338/f8f94a5c-80d0-4681-b520-f5bb4e68c04b)

And the corresponding GitHub Actions run for this PR's branch on my fork:
https://github.com/akien-mga/godot/actions/runs/5517696597

Ideally I'd prefer a system that would outright disable the whole workflow, so no GH Actions step runs at all, instead of reporting it as successful with 5 skipped jobs. If anyone wants to look further into how to do this better, I'm open to suggestion, this is a quick proof of concept, but which should already be useful enough as is.

CC @shana 