### PR TITLE
Add `hit_back_faces` property to `RayCast3D`

### DIFF
--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -131,6 +131,9 @@
 		<member name="exclude_parent" type="bool" setter="set_exclude_parent_body" getter="get_exclude_parent_body" default="true">
 			If [code]true[/code], collisions will be ignored for this RayCast3D's immediate parent.
 		</member>
+		<member name="hit_back_faces" type="bool" setter="set_hit_back_faces" getter="is_hit_back_faces_enabled" default="true">
+			If [code]true[/code], the ray will hit back faces with concave polygon shapes with back face enabled or heightmap shapes.
+		</member>
 		<member name="hit_from_inside" type="bool" setter="set_hit_from_inside" getter="is_hit_from_inside_enabled" default="false">
 			If [code]true[/code], the ray will detect a hit when starting inside shapes. In this case the collision normal will be [code]Vector3(0, 0, 0)[/code]. Does not affect shapes with no volume like concave polygon or heightmap.
 		</member>

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -223,6 +223,7 @@ void RayCast3D::_update_raycast_state() {
 	ray_params.collide_with_bodies = collide_with_bodies;
 	ray_params.collide_with_areas = collide_with_areas;
 	ray_params.hit_from_inside = hit_from_inside;
+	ray_params.hit_back_faces = hit_back_faces;
 
 	PhysicsDirectSpaceState3D::RayResult rr;
 	if (dss->intersect_ray(ray_params, rr)) {
@@ -297,6 +298,14 @@ bool RayCast3D::is_hit_from_inside_enabled() const {
 	return hit_from_inside;
 }
 
+void RayCast3D::set_hit_back_faces(bool p_enabled) {
+	hit_back_faces = p_enabled;
+}
+
+bool RayCast3D::is_hit_back_faces_enabled() const {
+	return hit_back_faces;
+}
+
 void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &RayCast3D::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &RayCast3D::is_enabled);
@@ -339,6 +348,9 @@ void RayCast3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hit_from_inside", "enable"), &RayCast3D::set_hit_from_inside);
 	ClassDB::bind_method(D_METHOD("is_hit_from_inside_enabled"), &RayCast3D::is_hit_from_inside_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_hit_back_faces", "enable"), &RayCast3D::set_hit_back_faces);
+	ClassDB::bind_method(D_METHOD("is_hit_back_faces_enabled"), &RayCast3D::is_hit_back_faces_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_debug_shape_custom_color", "debug_shape_custom_color"), &RayCast3D::set_debug_shape_custom_color);
 	ClassDB::bind_method(D_METHOD("get_debug_shape_custom_color"), &RayCast3D::get_debug_shape_custom_color);
 
@@ -350,6 +362,7 @@ void RayCast3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "target_position", PROPERTY_HINT_NONE, "suffix:m"), "set_target_position", "get_target_position");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hit_from_inside"), "set_hit_from_inside", "is_hit_from_inside_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hit_back_faces"), "set_hit_back_faces", "is_hit_back_faces_enabled");
 
 	ADD_GROUP("Collide With", "collide_with");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collide_with_areas", "is_collide_with_areas_enabled");

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -69,6 +69,7 @@ class RayCast3D : public Node3D {
 	bool collide_with_bodies = true;
 
 	bool hit_from_inside = false;
+	bool hit_back_faces = true;
 
 protected:
 	void _notification(int p_what);
@@ -84,6 +85,9 @@ public:
 
 	void set_hit_from_inside(bool p_enabled);
 	bool is_hit_from_inside_enabled() const;
+
+	void set_hit_back_faces(bool p_enabled);
+	bool is_hit_back_faces_enabled() const;
 
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;


### PR DESCRIPTION
This adds the `hit_back_faces` parameter, found in [`PhysicsRayQueryParameters3D`](https://docs.godotengine.org/en/stable/classes/class_physicsrayqueryparameters3d.html#class-physicsrayqueryparameters3d-property-hit-back-faces), as a property to the `RayCast3D` node.

For reasons that are not obvious to me this query parameter was left out of the `RayCast3D` node in #54857, which is causing some friction when using Godot Jolt, as Jolt's notion of back-faces include all shapes, including convex shapes, leading to users having to do their ray-casting manually, using `intersect_ray`, when they run up against this discrepancy and want to disable this parameter.

(The documentation was copied from the equivalent parameter in `PhysicsRayQueryParameters3D`.)