### PR TITLE
Change default Save Script shortcut (reverted)

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3911,8 +3911,8 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	_update_recent_scripts();
 
 	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save", TTR("Save"), KeyModifierMask::ALT | KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_SAVE);
-	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save_as", TTR("Save As...")), FILE_SAVE_AS);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save", TTR("Save"), KeyModifierMask::CMD_OR_CTRL | Key::S), FILE_SAVE);
+	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save_as", TTR("Save As..."), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::S), FILE_SAVE_AS);
 	file_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_editor/save_all", TTR("Save All"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::S), FILE_SAVE_ALL);
 	ED_SHORTCUT_OVERRIDE("script_editor/save_all", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::S);
 	file_menu->get_popup()->add_separator();


### PR DESCRIPTION
~~Fixesnot #78672~~ 🤪 EDIT: Unlinked, see comment below.

Why this works:
- when you are outside Script Editor, Ctrl+S will save the scene
- when you are inside Script Editor, Ctrl+S will save the script

Also:
- by default scenes are saved when running the project
- when exiting the editor you will get quit confirmation if a scene is unsaved

Thus there isn't (much?) risk of data loss that could be caused by saving the scene less often.

I tested this solution for a day (by changing my shortcut in editor settings xd) and aside from the fact that I'm used to the old shortcut, it works quite well.
Alternatively we could add a second shortcut for saving scenes (e.g. Ctrl+Shift+S), but I think it's not necessary.