### PR TITLE
Fix autocompletion for enums in incomplete dictionaries

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3282,6 +3282,16 @@ void GDScriptAnalyzer::reduce_dictionary(GDScriptParser::DictionaryNode *p_dicti
 		}
 	}
 
+	if (parser->for_completion && parser->completion_context.node != nullptr) {
+		int cursor_line = parser->tokenizer.get_cursor_line();
+		int cursor_column = parser->tokenizer.get_cursor_column();
+		if (p_dictionary->start_line <= cursor_line && p_dictionary->end_line >= cursor_line && (p_dictionary->start_line != cursor_line || p_dictionary->start_column <= cursor_column) && (p_dictionary->end_line != cursor_line || p_dictionary->end_column >= cursor_column)) {
+			if (parser->completion_context.node->is_expression() && !static_cast<GDScriptParser::ExpressionNode *>(parser->completion_context.node)->reduced) {
+				reduce_expression(static_cast<GDScriptParser::ExpressionNode *>(parser->completion_context.node));
+			}
+		}
+	}
+
 	// It's dictionary in any case.
 	GDScriptParser::DataType dict_type;
 	dict_type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;


### PR DESCRIPTION
Edit: superseded by https://github.com/godotengine/godot/pull/79424

Fixes #78602

As long as there is no colon after the key value the dictionary entry is not complete. The parser will ignore it and it will not be added to the dictionary node. For the autocompletion the type from the analyzer is needed but since the node from the completion context is not part of the dictionary node the analyzer will never try to reduce it.
Notice: the same reason could apply for #72328.

This PR fixes this by comparing the cursor position with the position of the diationary node. If they match and the parser has is for auto completion it will get the node from the completion context and try to reduce it anyway.

Edit:
#72328 is indeed very similar. I opened a PR for it as well (#79343). If you have reviews for this PR they propably apply there as well.