### PR TITLE
Remove spaces from input of HTML color in color picker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -564,7 +564,7 @@ void ColorPicker::_html_submitted(const String &p_html) {
 	}
 
 	const Color previous_color = color;
-	color = Color::from_string(p_html, previous_color);
+	color = Color::from_string(p_html.strip_edges(), previous_color);
 
 	if (!is_editing_alpha()) {
 		color.a = previous_color.a;


### PR DESCRIPTION
The color picker is now much more liberal about the user input, and simply removes the spaces before passing the string for further processing.
This is especially useful when copy-pasting HTML color codes from color palettes, as there is always the chance of accidentally copying some spaces as well. Having to remove them manually is quite tedious and not as intuitive as it could be.

Accepting valid HTML color codes with spaces is also the default behavior of programs with similar color picker functionality such as Affinity Designer, Blender, or Gimp.

* *Bugsquad edit, fixes: #79338*