### PR TITLE
Fix byte to float color conversion in `DisplayServerWindows::screen_get_pixel`

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -618,7 +618,7 @@ Color DisplayServerWindows::screen_get_pixel(const Point2i &p_position) const {
 		COLORREF col = GetPixel(dc, p.x, p.y);
 		if (col != CLR_INVALID) {
 			ReleaseDC(NULL, dc);
-			return Color(float(col & 0x000000FF) / 256.0, float((col & 0x0000FF00) >> 8) / 256.0, float((col & 0x00FF0000) >> 16) / 256.0, 1.0);
+			return Color(float(col & 0x000000FF) / 255.0f, float((col & 0x0000FF00) >> 8) / 255.0f, float((col & 0x00FF0000) >> 16) / 255.0f, 1.0f);
 		}
 		ReleaseDC(NULL, dc);
 	}


### PR DESCRIPTION
`255` should be mapped to `1.0`, it was mapped to `255.0 / 256.0`.

`byte / 255.0` is how we convert in most places I think (e.g. in `Color` or `Image`).

Fixes #79348.


No incorrect conversion spotted for Linux / MacOS:

https://github.com/godotengine/godot/blob/23318e877890029f35856036b9c4e0bfa09cacc6/platform/linuxbsd/x11/display_server_x11.cpp#L1220-L1220
https://github.com/godotengine/godot/blob/23318e877890029f35856036b9c4e0bfa09cacc6/platform/macos/display_server_macos.mm#L2226-L2228