### PR TITLE
C#: Fix MSVC dotnet builds failing if running `dev_mode`

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2228,17 +2228,16 @@ String EditorExportPlatformAndroid::get_apksigner_path(int p_target_sdk, bool p_
 }
 
 bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+#ifdef MODULE_MONO_ENABLED
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error += TTR("Exporting to Android is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Android with C#/Mono instead.") + "\n";
+	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	return false;
+#else
+
 	String err;
 	bool valid = false;
 	const bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
-
-#ifdef MODULE_MONO_ENABLED
-	err += TTR("Exporting to Android is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Android with C#/Mono instead.") + "\n";
-	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error = err;
-	return false;
-#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 
@@ -2369,6 +2368,7 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 	}
 
 	return valid;
+#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1900,16 +1900,15 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 }
 
 bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+#ifdef MODULE_MONO_ENABLED
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error += TTR("Exporting to iOS is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target iOS with C#/Mono instead.") + "\n";
+	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	return false;
+#else
+
 	String err;
 	bool valid = false;
-
-#ifdef MODULE_MONO_ENABLED
-	err += TTR("Exporting to iOS is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target iOS with C#/Mono instead.") + "\n";
-	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error = err;
-	return false;
-#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 
@@ -1937,6 +1936,7 @@ bool EditorExportPlatformIOS::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
+#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformIOS::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -135,7 +135,7 @@ bool EditorExportPlatformUWP::has_valid_export_configuration(const Ref<EditorExp
 	// contributors can still test the pipeline if/when we can build it again.
 	r_error = "The UWP platform is currently not supported in Godot 4.\n";
 	return false;
-#endif
+#else
 
 	String err;
 	bool valid = false;
@@ -175,6 +175,7 @@ bool EditorExportPlatformUWP::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
+#endif // DEV_ENABLED
 }
 
 bool EditorExportPlatformUWP::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {
@@ -184,7 +185,7 @@ bool EditorExportPlatformUWP::has_valid_project_configuration(const Ref<EditorEx
 	// contributors can still test the pipeline if/when we can build it again.
 	r_error = "The UWP platform is currently not supported in Godot 4.\n";
 	return false;
-#endif
+#else
 
 	String err;
 	bool valid = true;
@@ -258,6 +259,7 @@ bool EditorExportPlatformUWP::has_valid_project_configuration(const Ref<EditorEx
 
 	r_error = err;
 	return valid;
+#endif // DEV_ENABLED
 }
 
 Error EditorExportPlatformUWP::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -359,17 +359,16 @@ Ref<Texture2D> EditorExportPlatformWeb::get_logo() const {
 }
 
 bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
+#ifdef MODULE_MONO_ENABLED
+	// Don't check for additional errors, as this particular error cannot be resolved.
+	r_error += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
+	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
+	return false;
+#else
+
 	String err;
 	bool valid = false;
 	bool extensions = (bool)p_preset->get("variant/extensions_support");
-
-#ifdef MODULE_MONO_ENABLED
-	err += TTR("Exporting to Web is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Web with C#/Mono instead.") + "\n";
-	err += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error = err;
-	return false;
-#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 	bool dvalid = exists_export_template(_get_template_name(extensions, true), &err);
@@ -396,6 +395,7 @@ bool EditorExportPlatformWeb::has_valid_export_configuration(const Ref<EditorExp
 	}
 
 	return valid;
+#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformWeb::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {


### PR DESCRIPTION
Added `#else` section to mono `#ifdef` checks in `export_plugin` scripts. This not being in place caused compilation to fail when enabling extended warnings & warnings as errors, as otherwise the latter sections would be detected as "unreachable code"