### PR TITLE
Fix documentation for consistency

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -85,7 +85,7 @@
 			Attenuation factor used if listener is outside of [member emission_angle_degrees] and [member emission_angle_enabled] is set, in decibels.
 		</member>
 		<member name="max_db" type="float" setter="set_max_db" getter="get_max_db" default="3.0">
-			Sets the absolute maximum of the soundlevel, in decibels.
+			Sets the absolute maximum of the sound level, in decibels.
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
 			The distance past which the sound can no longer be heard at all. Only has an effect if set to a value greater than [code]0.0[/code]. [member max_distance] works in tandem with [member unit_size]. However, unlike [member unit_size] whose behavior depends on the [member attenuation_model], [member max_distance] always works in a linear fashion. This can be used to prevent the [AudioStreamPlayer3D] from requiring audio mixing when the listener is far away, which saves CPU resources.

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -757,7 +757,7 @@
 		<method name="is_touchscreen_available" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if touch events are available (Android or iOS), the capability is detected on the Webplatform or if [member ProjectSettings.input_devices/pointing/emulate_touch_from_mouse] is [code]true[/code].
+				Returns [code]true[/code] if touch events are available (Android or iOS), the capability is detected on the Web platform or if [member ProjectSettings.input_devices/pointing/emulate_touch_from_mouse] is [code]true[/code].
 			</description>
 		</method>
 		<method name="keyboard_get_current_layout" qualifiers="const">

--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -81,7 +81,7 @@
 			<return type="Array" />
 			<description>
 				Returns an array of [EditorDebuggerSession] currently available to this debugger plugin.
-				Note: Not sessions in the array may be inactive, check their state via [method EditorDebuggerSession.is_active]
+				[b]Note:[/b] Not sessions in the array may be inactive, check their state via [method EditorDebuggerSession.is_active]
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1146,7 +1146,7 @@
 			A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
 		</constant>
 		<constant name="SLIDER_JOINT_LINEAR_LIMIT_RESTITUTION" value="3" enum="SliderJointParam">
-			The amount of restitution once the limits are surpassed. The lower, the more velocityenergy gets lost.
+			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
 		</constant>
 		<constant name="SLIDER_JOINT_LINEAR_LIMIT_DAMPING" value="4" enum="SliderJointParam">
 			The amount of damping once the slider limits are surpassed.

--- a/doc/classes/SliderJoint3D.xml
+++ b/doc/classes/SliderJoint3D.xml
@@ -105,7 +105,7 @@
 			A factor applied to the movement across the slider axis once the limits get surpassed. The lower, the slower the movement.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_RESTITUTION" value="3" enum="Param">
-			The amount of restitution once the limits are surpassed. The lower, the more velocityenergy gets lost.
+			The amount of restitution once the limits are surpassed. The lower, the more velocity-energy gets lost.
 		</constant>
 		<constant name="PARAM_LINEAR_LIMIT_DAMPING" value="4" enum="Param">
 			The amount of damping once the slider limits are surpassed.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1234,7 +1234,7 @@
 			<param index="1" name="to_line" type="int" />
 			<description>
 				Emitted immediately when the text changes.
-				When text is added [param from_line] will be less then [param to_line]. On a remove [param to_line] will be less then [param from_line].
+				When text is added [param from_line] will be less than [param to_line]. On a remove [param to_line] will be less than [param from_line].
 			</description>
 		</signal>
 		<signal name="text_changed">

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -76,7 +76,7 @@ void ENetPacketPeer::throttle_configure(int p_interval, int p_acceleration, int 
 
 void ENetPacketPeer::set_timeout(int p_timeout, int p_timeout_min, int p_timeout_max) {
 	ERR_FAIL_COND_MSG(peer == nullptr, "Peer not connected");
-	ERR_FAIL_COND_MSG(p_timeout > p_timeout_min || p_timeout_min > p_timeout_max, "Timeout limit must be less than minimum timeout, which itself must be less then maximum timeout");
+	ERR_FAIL_COND_MSG(p_timeout > p_timeout_min || p_timeout_min > p_timeout_max, "Timeout limit must be less than minimum timeout, which itself must be less than maximum timeout");
 	enet_peer_timeout(peer, p_timeout, p_timeout_min, p_timeout_max);
 }
 


### PR DESCRIPTION
To match with the rest of the codebase: 
- `soundlevel` to `sound level`
- `Webplatform` to `Web platform`
- `velocityenergy` to `velocity-energy`
- `less then` to `less than`
- Added bold tag on non-bold Note