### PR TITLE
Generate errors for getters that return no value

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1281,6 +1281,10 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 					member.variable->getter->set_datatype(member.variable->datatype);
 
 					resolve_function_body(member.variable->getter);
+
+					if (!member.variable->getter->body->has_return) {
+						push_error(R"(Not all code paths in the getter function return a value.)", member.variable);
+					}
 				}
 				if (member.variable->setter != nullptr) {
 					resolve_function_signature(member.variable->setter);
@@ -1333,6 +1337,10 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 						if (getter_function->return_type != nullptr) {
 							return_datatype = getter_function->return_type->datatype;
 							return_datatype.is_meta_type = false;
+						}
+
+						if (!getter_function->body->has_return) {
+							push_error(R"(Not all code paths in the getter function return a value.)", member.variable);
 						}
 
 						if (getter_function->parameters.size() != 0 || return_datatype.has_no_type()) {

--- a/modules/gdscript/tests/scripts/analyzer/errors/inline_getter_no_return.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/inline_getter_no_return.gd
@@ -1,0 +1,6 @@
+var x:
+	get:
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/inline_getter_no_return.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/inline_getter_no_return.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Not all code paths in the getter function return a value.

--- a/modules/gdscript/tests/scripts/analyzer/errors/separated_getter_no_return.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/separated_getter_no_return.gd
@@ -1,0 +1,8 @@
+var x:
+	get = get_prop
+
+func get_prop():
+	pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/separated_getter_no_return.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/separated_getter_no_return.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Not all code paths in the getter function return a value.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Replaced #63541
Fixes #63393
Getters now must return a value.