### PR TITLE
Improve physics body/shape scale warnings, check shear/global, add to 2D

### DIFF
--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -609,6 +609,10 @@ PackedStringArray CollisionObject2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionObject2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change the size in child collision shapes instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -610,6 +610,10 @@ PackedStringArray CollisionObject2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionObject2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change the size in child collision shapes instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -256,6 +256,10 @@ PackedStringArray CollisionPolygon2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("The One Way Collision property will be ignored when the collision object is an Area2D."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionPolygon2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change its polygon's vertices instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -261,6 +261,10 @@ PackedStringArray CollisionPolygon2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("The One Way Collision property will be ignored when the collision object is an Area2D."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionPolygon2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change its polygon's vertices instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -194,6 +194,10 @@ PackedStringArray CollisionShape2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("The CollisionShape2D node has limited editing options for polygon-based shapes. Consider using a CollisionPolygon2D node instead."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionShape2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change the size of its shape resource instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -198,6 +198,10 @@ PackedStringArray CollisionShape2D::get_configuration_warnings() const {
 		warnings.push_back(RTR("The CollisionShape2D node has limited editing options for polygon-based shapes. Consider using a CollisionPolygon2D node instead."));
 	}
 
+	if (!get_transform().is_conformal() || !get_global_transform().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionShape2D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on both axes), and change the size of its shape resource instead."));
+	}
+
 	return warnings;
 }
 

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -744,9 +744,8 @@ PackedStringArray CollisionObject3D::get_configuration_warnings() const {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));
 	}
 
-	Vector3 scale = get_transform().get_basis().get_scale();
-	if (!(Math::is_zero_approx(scale.x - scale.y) && Math::is_zero_approx(scale.y - scale.z))) {
-		warnings.push_back(RTR("With a non-uniform scale this node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change the size in children collision shapes instead."));
+	if (!get_transform().get_basis().is_conformal() || !get_global_transform().get_basis().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionObject3D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change the size in child collision shapes instead."));
 	}
 
 	return warnings;

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -756,9 +756,8 @@ PackedStringArray CollisionObject3D::get_configuration_warnings() const {
 		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));
 	}
 
-	Vector3 scale = get_transform().get_basis().get_scale();
-	if (!(Math::is_zero_approx(scale.x - scale.y) && Math::is_zero_approx(scale.y - scale.z))) {
-		warnings.push_back(RTR("With a non-uniform scale this node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change the size in children collision shapes instead."));
+	if (!get_transform().get_basis().is_conformal() || !get_global_transform().get_basis().is_conformal()) {
+		warnings.push_back(RTR("A non-uniformly scaled CollisionObject3D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change the size in child collision shapes instead."));
 	}
 
 	return warnings;

--- a/scene/3d/physics/collision_polygon_3d.cpp
+++ b/scene/3d/physics/collision_polygon_3d.cpp
@@ -245,8 +245,7 @@ PackedStringArray CollisionPolygon3D::get_configuration_warnings() const {
 		warnings.push_back(RTR("An empty CollisionPolygon3D has no effect on collision."));
 	}
 
-	Vector3 scale = get_transform().get_basis().get_scale();
-	if (!(Math::is_zero_approx(scale.x - scale.y) && Math::is_zero_approx(scale.y - scale.z))) {
+	if (!get_transform().get_basis().is_conformal() || !get_global_transform().get_basis().is_conformal()) {
 		warnings.push_back(RTR("A non-uniformly scaled CollisionPolygon3D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change its polygon's vertices instead."));
 	}
 

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -153,8 +153,7 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 		}
 	}
 
-	Vector3 scale = get_transform().get_basis().get_scale();
-	if (!(Math::is_zero_approx(scale.x - scale.y) && Math::is_zero_approx(scale.y - scale.z))) {
+	if (!get_transform().get_basis().is_conformal() || !get_global_transform().get_basis().is_conformal()) {
 		warnings.push_back(RTR("A non-uniformly scaled CollisionShape3D node will probably not function as expected.\nPlease make its scale uniform (i.e. the same on all axes), and change the size of its shape resource instead."));
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88415, fixes https://github.com/godotengine/godot/issues/92205

Previously, the body/shape scale warning code did not handle these cases:

* If an ancestor node had a non-uniform scale.
* If the node or an ancestor had a shear/skew.

This PR changes the code to check if the Basis is conformal, which handles all these cases. It actually does this twice, another time for the global transform, to ensure that there is no invalid transform inherited from ancestors (we also want the node's local transform to be validated in addition to global).

Also, this PR adds the same checks to 2D, since it was missing before.

Note: Negative scale is allowed in master and still allowed in this PR.

Note: Zero scale is invalid but is not validated in master or in this PR. I don't know if that's worth checking for since it's kinda obvious that it's invalid because most things in 3D are considered invalid if they have an zero scale.