### PR TITLE
GLES3: always make gl calls when setting filter and repeat on texture

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -247,16 +247,12 @@ struct Texture {
 
 	// texture state
 	void gl_set_filter(RS::CanvasItemTextureFilter p_filter) {
-		if (p_filter == state_filter) {
-			return;
-		}
 		Config *config = Config::get_singleton();
-		state_filter = p_filter;
 		GLenum pmin = GL_NEAREST; // param min
 		GLenum pmag = GL_NEAREST; // param mag
 		GLint max_lod = 1000;
-		bool use_anisotropy = false;
-		switch (state_filter) {
+		float anisotropy = 1.0f;
+		switch (p_filter) {
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
 				pmin = GL_NEAREST;
 				pmag = GL_NEAREST;
@@ -268,7 +264,7 @@ struct Texture {
 				max_lod = 0;
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
-				use_anisotropy = true;
+				anisotropy = config->anisotropic_level;
 			};
 				[[fallthrough]];
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
@@ -283,7 +279,7 @@ struct Texture {
 				}
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
-				use_anisotropy = true;
+				anisotropy = config->anisotropic_level;
 			};
 				[[fallthrough]];
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
@@ -304,17 +300,13 @@ struct Texture {
 		glTexParameteri(target, GL_TEXTURE_MAG_FILTER, pmag);
 		glTexParameteri(target, GL_TEXTURE_BASE_LEVEL, 0);
 		glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, max_lod);
-		if (config->support_anisotropic_filter && use_anisotropy) {
-			glTexParameterf(target, _GL_TEXTURE_MAX_ANISOTROPY_EXT, config->anisotropic_level);
+		if (config->support_anisotropic_filter) {
+			glTexParameterf(target, _GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
 		}
 	}
 	void gl_set_repeat(RS::CanvasItemTextureRepeat p_repeat) {
-		if (p_repeat == state_repeat) {
-			return;
-		}
-		state_repeat = p_repeat;
 		GLenum prep = GL_CLAMP_TO_EDGE; // parameter repeat
-		switch (state_repeat) {
+		switch (p_repeat) {
 			case RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
 				prep = GL_REPEAT;
 			} break;
@@ -328,10 +320,6 @@ struct Texture {
 		glTexParameteri(target, GL_TEXTURE_WRAP_R, prep);
 		glTexParameteri(target, GL_TEXTURE_WRAP_S, prep);
 	}
-
-private:
-	RS::CanvasItemTextureFilter state_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
-	RS::CanvasItemTextureRepeat state_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
 };
 
 struct RenderTarget {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This is intended as a fix for #79315. Sometimes the repeat property of a texture doesn't get updated, usually when the texture has been seen recently. While looking through the source code, I noticed that it avoids calling `glTexParameteri` if it thinks it's redundant, and figured this is likely a culprit. Changing this so it always updates the texture parameters resolves the issue from my testing. While I was at it, I also made the change for updating the filtering mode (including anisotropic filtering), since it uses the same caching system, and could have similar issues with it. This isn't an *elegant* solution, as it doesn't directly address the original cause of the stale state, but it's a viable one.

As to why the bug exists in the first place, I'm assuming it's down to something related to the re-use of data and/or IDs in `TextureStorage`. How exactly it happens, I didn't test. One option is that the values for `state_filter` and `state_repeat` are leftovers from an unrelated texture, so the engine thinks it's already set the parameters for the current texture when it hasn't. (If this is the case, then the bug should also apply to the filtering mode, though I didn't really test that). Another option is that some of the texture parameters are reset when certain actions are performed on an existing texture (such as changing the pixel data).

This PR should be safe to cherry-pick for a 4.1.x release. I will also understand if you'd rather take a different approach to resolving this issue, since this is a bit of a blunt solution.

* *Bugsquad edit, fixes: #79315*