### PR TITLE
Expose `Image::get_mipmap_count()` and add `GLTFState::get_source_images()`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3393,6 +3393,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Image::get_height);
 	ClassDB::bind_method(D_METHOD("get_size"), &Image::get_size);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Image::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &Image::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_format"), &Image::get_format);
 	ClassDB::bind_method(D_METHOD("get_data"), &Image::get_data);
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -222,6 +222,12 @@
 				Returns the image's height.
 			</description>
 		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the image's number of mipmaps.
+			</description>
+		</method>
 		<method name="get_mipmap_offset" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="mipmap" type="int" />

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -124,6 +124,12 @@
 				Returns an array of all [GLTFSkin]s in the GLTF file. These are the skins that the [member GLTFNode.skin] index refers to.
 			</description>
 		</method>
+		<method name="get_source_images">
+			<return type="Image[]" />
+			<description>
+				Gets the source images of the GLTF file as an array of [Image]s. These are the images that the [member GLTFTexture.src_image] index refers to.
+			</description>
+		</method>
 		<method name="get_texture_samplers">
 			<return type="GLTFTextureSampler[]" />
 			<description>

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -70,6 +70,7 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_samplers", "texture_samplers"), &GLTFState::set_texture_samplers);
 	ClassDB::bind_method(D_METHOD("get_images"), &GLTFState::get_images);
 	ClassDB::bind_method(D_METHOD("set_images", "images"), &GLTFState::set_images);
+	ClassDB::bind_method(D_METHOD("get_source_images"), &GLTFState::get_source_images);
 	ClassDB::bind_method(D_METHOD("get_skins"), &GLTFState::get_skins);
 	ClassDB::bind_method(D_METHOD("set_skins", "skins"), &GLTFState::set_skins);
 	ClassDB::bind_method(D_METHOD("get_cameras"), &GLTFState::get_cameras);
@@ -259,6 +260,10 @@ void GLTFState::set_texture_samplers(TypedArray<GLTFTextureSampler> p_texture_sa
 
 TypedArray<Texture2D> GLTFState::get_images() {
 	return GLTFTemplateConvert::to_array(images);
+}
+
+TypedArray<Image> GLTFState::get_source_images() {
+	return GLTFTemplateConvert::to_array(source_images);
 }
 
 void GLTFState::set_images(TypedArray<Texture2D> p_images) {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -179,6 +179,8 @@ public:
 	TypedArray<Texture2D> get_images();
 	void set_images(TypedArray<Texture2D> p_images);
 
+	TypedArray<Image> get_source_images();
+
 	TypedArray<GLTFSkin> get_skins();
 	void set_skins(TypedArray<GLTFSkin> p_skins);
 


### PR DESCRIPTION
I noticed that`Image::get_mipmap_count()` and `GLTFState::source_images` were not exposed to GDScript. First one can be quite useful for plugins that are displaying Image information etc. Second one is performance related and allows to access GLTF source images without the need of copying it from an ImageTexture.  Very useful for batch tasks on GLTF files (e.g conversions) 