### PR TITLE
Ignore directory entries in TPZ

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -465,6 +465,13 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 			break;
 		}
 
+		if (String::utf8(fname).ends_with("/")) {
+			// File is a directory, ignore it.
+			// Directories will be created when extracting each file.
+			ret = unzGoToNextFile(pkg);
+			continue;
+		}
+
 		String file_path(String::utf8(fname).simplify_path());
 
 		String file = file_path.get_file();


### PR DESCRIPTION
Zip files may contain directory entries, they always end with a path separator and zip entries always use forward slashes (`/`) for path separators.

There's no need to create the directories included in the zip file, since they'll already be created when creating the individual files.

- Fixes https://github.com/godotengine/godot/issues/33456.