### PR TITLE
Fix documentation error on EditorExportPlugin.xml

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -43,7 +43,7 @@
 			<param index="1" name="path" type="String" />
 			<description>
 				Customize a scene. If changes are made to it, return the same or a new scene. Otherwise, return [code]null[/code]. If a new scene is returned, it is up to you to dispose of the old one.
-				Implementing this method is required if [method _begin_customize_resources] returns [code]true[/code].
+				Implementing this method is required if [method _begin_customize_scenes] returns [code]true[/code].
 			</description>
 		</method>
 		<method name="_end_customize_resources" qualifiers="virtual">


### PR DESCRIPTION
Fixed a possible copy pasta error.
Note: I haven't tested it, because my plugin only modifies resource files. maybe the docs is right.