### PR TITLE
Classref: Don't say that reference types are passed by reference

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -38,7 +38,7 @@
 		GD.Print(array1 + array2); // Prints [One, 2, 3, Four]
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Arrays are always passed by reference. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
 		[b]Note:[/b] Erasing elements while iterating over arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -133,7 +133,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Dictionaries are always passed by reference. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
+		[b]Note:[/b] Dictionary is a reference type. This means that changing the entries of a dictionary will be reflected in other references to that dictionary. To get a copy of a dictionary which can be modified independently of the original dictionary, use [method duplicate].
 		[b]Note:[/b] Erasing elements while iterating over dictionaries is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -4,8 +4,10 @@
 		A packed array of bytes.
 	</brief_description>
 	<description>
-		An array specifically designed to hold bytes. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold bytes. It packs data tightly, so it saves memory for large array sizes.
 		[PackedByteArray] also provides methods to encode/decode various types to/from bytes. The way values are encoded is an implementation detail and shouldn't be relied upon when interacting with external apps.
+		[b]Note:[/b] PackedByteArray is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedByteArrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -4,7 +4,9 @@
 		A packed array of [Color]s.
 	</brief_description>
 	<description>
-		An array specifically designed to hold [Color]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Color]. It packs data tightly, so it saves memory for large array sizes.
+		[b]Note:[/b] PackedColorArray is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedColorArrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -4,8 +4,10 @@
 		A packed array of 32-bit floating-point values.
 	</brief_description>
 	<description>
-		An array specifically designed to hold 32-bit floating-point values (float). Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 32-bit floating-point values (float). It packs data tightly, so it saves memory for large array sizes.
 		If you need to pack 64-bit floats tightly, see [PackedFloat64Array].
+		[b]Note:[/b] PackedFloat32Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedFloat32Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -4,8 +4,10 @@
 		A packed array of 64-bit floating-point values.
 	</brief_description>
 	<description>
-		An array specifically designed to hold 64-bit floating-point values (double). Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 64-bit floating-point values (double). It packs data tightly, so it saves memory for large array sizes.
 		If you only need to pack 32-bit floats tightly, see [PackedFloat32Array] for a more memory-friendly alternative.
+		[b]Note:[/b] PackedFloat64Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedFloat64Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -4,8 +4,10 @@
 		A packed array of 32-bit integers.
 	</brief_description>
 	<description>
-		An array specifically designed to hold 32-bit integer values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 32-bit integer values. It packs data tightly, so it saves memory for large array sizes.
 		[b]Note:[/b] This type stores signed 32-bit integers, which means it can take values in the interval [code][-2^31, 2^31 - 1][/code], i.e. [code][-2147483648, 2147483647][/code]. Exceeding those bounds will wrap around. In comparison, [int] uses signed 64-bit integers which can hold much larger values. If you need to pack 64-bit integers tightly, see [PackedInt64Array].
+		[b]Note:[/b] PackedInt32Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedInt32Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -4,8 +4,10 @@
 		A packed array of 64-bit integers.
 	</brief_description>
 	<description>
-		An array specifically designed to hold 64-bit integer values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 64-bit integer values. It packs data tightly, so it saves memory for large array sizes.
 		[b]Note:[/b] This type stores signed 64-bit integers, which means it can take values in the interval [code][-2^63, 2^63 - 1][/code], i.e. [code][-9223372036854775808, 9223372036854775807][/code]. Exceeding those bounds will wrap around. If you only need to pack 32-bit integers tightly, see [PackedInt32Array] for a more memory-friendly alternative.
+		[b]Note:[/b] PackedInt64Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedInt64Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -4,13 +4,15 @@
 		A packed array of [String]s.
 	</brief_description>
 	<description>
-		An array specifically designed to hold [String]s. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [String]s. It packs data tightly, so it saves memory for large array sizes.
 		If you want to join the strings in the array, use [method String.join].
 		[codeblock]
 		var string_array = PackedStringArray(["hello", "world"])
 		var string = " ".join(string_array)
 		print(string) # "hello world"
 		[/codeblock]
+		[b]Note:[/b] PackedStringArray is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedStringArrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -4,7 +4,9 @@
 		A packed array of [Vector2]s.
 	</brief_description>
 	<description>
-		An array specifically designed to hold [Vector2]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Vector2]. It packs data tightly, so it saves memory for large array sizes.
+		[b]Note:[/b] PackedVector2Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedVector2Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 		<link title="2D Navigation Astar Demo">https://godotengine.org/asset-library/asset/519</link>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -4,7 +4,9 @@
 		A packed array of [Vector3]s.
 	</brief_description>
 	<description>
-		An array specifically designed to hold [Vector3]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Vector3]. It packs data tightly, so it saves memory for large array sizes.
+		[b]Note:[/b] PackedVector3Array is a reference type. This means that changing the elements of an array will be reflected in other references to that array. To get a copy of an array that can be modified independently of the original array, use [method duplicate].
+		[b]Note:[/b] Erasing elements while iterating over PackedVector3Arrays is [b]not[/b] supported and will result in unpredictable behavior.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
GDScript does not have pass by reference variables, only pass by value. **However**, some values are references.
The difference is best explained with an example:
```gdscript
func _ready() -> void:
	var array := ["A", "B", "C"]
	pointers_demonstration(array)
	print(array)

func pointers_demonstration(array: Array) -> void:
	array = [1, 2, 3]
```
The above example prints `["A", "B", "C"]`. If GDScript's arrays were actually pass by reference, it would instead print `[1, 2, 3]`.

The descriptions of Array and Dictionary stated that they were pass by reference. I have corrected them, and also copied this information and the note below it about deleting while iterating to the Packed*Array types.