### PR TITLE
Fix NavigationObstacle2D debug position

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -79,7 +79,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 			previous_transform = get_global_transform();
 			// need to trigger map controlled agent assignment somehow for the fake_agent since obstacles use no callback like regular agents
 			NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
-			_update_position(get_global_transform().get_origin());
+			_update_position(get_global_position());
 			set_physics_process_internal(true);
 		} break;
 
@@ -112,7 +112,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (is_inside_tree()) {
-				_update_position(get_global_transform().get_origin());
+				_update_position(get_global_position());
 
 				if (velocity_submitted) {
 					velocity_submitted = false;
@@ -164,9 +164,9 @@ NavigationObstacle2D::~NavigationObstacle2D() {
 void NavigationObstacle2D::set_vertices(const Vector<Vector2> &p_vertices) {
 	vertices = p_vertices;
 	NavigationServer2D::get_singleton()->obstacle_set_vertices(obstacle, vertices);
-	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())) {
-		queue_redraw();
-	}
+#ifdef DEBUG_ENABLED
+	queue_redraw();
+#endif // DEBUG_ENABLED
 }
 
 void NavigationObstacle2D::set_navigation_map(RID p_navigation_map) {
@@ -195,9 +195,9 @@ void NavigationObstacle2D::set_radius(real_t p_radius) {
 	radius = p_radius;
 
 	NavigationServer2D::get_singleton()->obstacle_set_radius(obstacle, radius);
-	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())) {
-		queue_redraw();
-	}
+#ifdef DEBUG_ENABLED
+	queue_redraw();
+#endif // DEBUG_ENABLED
 }
 
 void NavigationObstacle2D::set_avoidance_layers(uint32_t p_layers) {
@@ -237,6 +237,9 @@ void NavigationObstacle2D::set_avoidance_enabled(bool p_enabled) {
 
 	avoidance_enabled = p_enabled;
 	NavigationServer2D::get_singleton()->obstacle_set_avoidance_enabled(obstacle, avoidance_enabled);
+#ifdef DEBUG_ENABLED
+	queue_redraw();
+#endif // DEBUG_ENABLED
 }
 
 bool NavigationObstacle2D::get_avoidance_enabled() const {
@@ -255,13 +258,16 @@ void NavigationObstacle2D::_update_map(RID p_map) {
 
 void NavigationObstacle2D::_update_position(const Vector2 p_position) {
 	NavigationServer2D::get_singleton()->obstacle_set_position(obstacle, p_position);
+#ifdef DEBUG_ENABLED
+	queue_redraw();
+#endif // DEBUG_ENABLED
 }
 
 #ifdef DEBUG_ENABLED
 void NavigationObstacle2D::_update_fake_agent_radius_debug() {
 	if (radius > 0.0 && NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_radius()) {
 		Color debug_radius_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_color();
-		draw_circle(get_global_transform().get_origin(), radius, debug_radius_color);
+		RS::get_singleton()->canvas_item_add_circle(get_canvas_item(), Vector2(), radius, debug_radius_color);
 	}
 }
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Fixes NavigationObstacle2D debug position.

Fixes https://github.com/godotengine/godot/issues/79389.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
