### PR TITLE
Add a default theme for unfocused Windows

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -903,5 +903,8 @@
 			The background style used when the [Window] is embedded. Note that this is drawn only under the window's content, excluding the title. For proper borders and title bar style, you can use [code]expand_margin_*[/code] properties of [StyleBoxFlat].
 			[b]Note:[/b] The content background will not be visible unless [member transparent] is enabled.
 		</theme_item>
+		<theme_item name="embedded_unfocused_border" data_type="style" type="StyleBox">
+			The background style used when the [Window] is embedded and unfocused.
+		</theme_item>
 	</theme_items>
 </class>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1605,6 +1605,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_window->set_border_width(SIDE_TOP, 24 * EDSCALE);
 	style_window->set_expand_margin(SIDE_TOP, 24 * EDSCALE);
 	theme->set_stylebox("embedded_border", "Window", style_window);
+	theme->set_stylebox("embedded_unfocused_border", "Window", style_window);
 
 	theme->set_color("title_color", "Window", font_color);
 	theme->set_icon("close", "Window", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -315,7 +315,7 @@ void Viewport::_sub_window_update(Window *p_window) {
 	Rect2i r = Rect2i(p_window->get_position(), sw.window->get_size());
 
 	if (!p_window->get_flag(Window::FLAG_BORDERLESS)) {
-		Ref<StyleBox> panel = p_window->get_theme_stylebox(SNAME("embedded_border"));
+		Ref<StyleBox> panel = p_window->get_theme_stylebox(gui.subwindow_focused == p_window ? SNAME("embedded_border") : SNAME("embedded_unfocused_border"));
 		panel->draw(sw.canvas_item, r);
 
 		// Draw the title bar text.

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -595,6 +595,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// Window
 
 	theme->set_stylebox("embedded_border", "Window", sb_expand(make_flat_stylebox(style_popup_color, 10, 28, 10, 8), 8, 32, 8, 6));
+	theme->set_stylebox("embedded_unfocused_border", "Window", sb_expand(make_flat_stylebox(style_popup_hover_color, 10, 28, 10, 8), 8, 32, 8, 6));
 
 	theme->set_font("title_font", "Window", Ref<Font>());
 	theme->set_font_size("title_font_size", "Window", -1);


### PR DESCRIPTION
At the moment it is impossible to distinguish between focused and unfocused embedded Windows.
Add a new `theme_item` that is used for coloring the border of unfocused Windows.

I'm not aware of any window-manager, that displays focused and unfocused Windows in the same way. So Godot should do the same.

Let me know, if a different color would be more fitting.
![grafik](https://github.com/godotengine/godot/assets/6299227/6ab6ae61-ea6e-4cdf-b746-a2e6e4dd9172)
