### PR TITLE
Mono: Improve operators codegen for V2, V3, V4 and Color

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -1012,11 +1012,12 @@ namespace Godot
         /// <returns>The added color.</returns>
         public static Color operator +(Color left, Color right)
         {
-            left.R += right.R;
-            left.G += right.G;
-            left.B += right.B;
-            left.A += right.A;
-            return left;
+            Color v;
+            v.R = left.R + right.R;
+            v.G = left.G + right.G;
+            v.B = left.B + right.B;
+            v.A = left.A + right.A;
+            return v;
         }
 
         /// <summary>
@@ -1028,11 +1029,12 @@ namespace Godot
         /// <returns>The subtracted color.</returns>
         public static Color operator -(Color left, Color right)
         {
-            left.R -= right.R;
-            left.G -= right.G;
-            left.B -= right.B;
-            left.A -= right.A;
-            return left;
+            Color v;
+            v.R = left.R - right.R;
+            v.G = left.G - right.G;
+            v.B = left.B - right.B;
+            v.A = left.A - right.A;
+            return v;
         }
 
         /// <summary>
@@ -1056,11 +1058,12 @@ namespace Godot
         /// <returns>The multiplied color.</returns>
         public static Color operator *(Color color, float scale)
         {
-            color.R *= scale;
-            color.G *= scale;
-            color.B *= scale;
-            color.A *= scale;
-            return color;
+            Color v;
+            v.R = color.R * scale;
+            v.G = color.G * scale;
+            v.B = color.B * scale;
+            v.A = color.A * scale;
+            return v;
         }
 
         /// <summary>
@@ -1072,11 +1075,12 @@ namespace Godot
         /// <returns>The multiplied color.</returns>
         public static Color operator *(float scale, Color color)
         {
-            color.R *= scale;
-            color.G *= scale;
-            color.B *= scale;
-            color.A *= scale;
-            return color;
+            Color v;
+            v.R = color.R * scale;
+            v.G = color.G * scale;
+            v.B = color.B * scale;
+            v.A = color.A * scale;
+            return v;
         }
 
         /// <summary>
@@ -1088,11 +1092,12 @@ namespace Godot
         /// <returns>The multiplied color.</returns>
         public static Color operator *(Color left, Color right)
         {
-            left.R *= right.R;
-            left.G *= right.G;
-            left.B *= right.B;
-            left.A *= right.A;
-            return left;
+            Color v;
+            v.R = left.R * right.R;
+            v.G = left.G * right.G;
+            v.B = left.B * right.B;
+            v.A = left.A * right.A;
+            return v;
         }
 
         /// <summary>
@@ -1104,11 +1109,12 @@ namespace Godot
         /// <returns>The divided color.</returns>
         public static Color operator /(Color color, float scale)
         {
-            color.R /= scale;
-            color.G /= scale;
-            color.B /= scale;
-            color.A /= scale;
-            return color;
+            Color v;
+            v.R = color.R / scale;
+            v.G = color.G / scale;
+            v.B = color.B / scale;
+            v.A = color.A / scale;
+            return v;
         }
 
         /// <summary>
@@ -1120,11 +1126,12 @@ namespace Godot
         /// <returns>The divided color.</returns>
         public static Color operator /(Color left, Color right)
         {
-            left.R /= right.R;
-            left.G /= right.G;
-            left.B /= right.B;
-            left.A /= right.A;
-            return left;
+            Color v;
+            v.R = left.R / right.R;
+            v.G = left.G / right.G;
+            v.B = left.B / right.B;
+            v.A = left.A / right.A;
+            return v;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -689,9 +689,10 @@ namespace Godot
         /// <returns>The added vector.</returns>
         public static Vector2 operator +(Vector2 left, Vector2 right)
         {
-            left.X += right.X;
-            left.Y += right.Y;
-            return left;
+            Vector2 v;
+            v.X = left.X + right.X;
+            v.Y = left.Y + right.Y;
+            return v;
         }
 
         /// <summary>
@@ -703,9 +704,10 @@ namespace Godot
         /// <returns>The subtracted vector.</returns>
         public static Vector2 operator -(Vector2 left, Vector2 right)
         {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            return left;
+            Vector2 v;
+            v.X = left.X - right.X;
+            v.Y = left.Y - right.Y;
+            return v;
         }
 
         /// <summary>
@@ -719,9 +721,10 @@ namespace Godot
         /// <returns>The negated/flipped vector.</returns>
         public static Vector2 operator -(Vector2 vec)
         {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            return vec;
+            Vector2 v;
+            v.X = -vec.X;
+            v.Y = -vec.Y;
+            return v;
         }
 
         /// <summary>
@@ -733,9 +736,10 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 vec, real_t scale)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
+            Vector2 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            return v;
         }
 
         /// <summary>
@@ -747,9 +751,10 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(real_t scale, Vector2 vec)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
+            Vector2 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            return v;
         }
 
         /// <summary>
@@ -761,9 +766,10 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector2 operator *(Vector2 left, Vector2 right)
         {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            return left;
+            Vector2 v;
+            v.X = left.X * right.X;
+            v.Y = left.Y * right.Y;
+            return v;
         }
 
         /// <summary>
@@ -775,9 +781,10 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, real_t divisor)
         {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            return vec;
+            Vector2 v;
+            v.X = vec.X / divisor;
+            v.Y = vec.Y / divisor;
+            return v;
         }
 
         /// <summary>
@@ -789,9 +796,10 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector2 operator /(Vector2 vec, Vector2 divisorv)
         {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            return vec;
+            Vector2 v;
+            v.X = vec.X / divisorv.X;
+            v.Y = vec.Y / divisorv.Y;
+            return v;
         }
 
         /// <summary>
@@ -812,9 +820,10 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, real_t divisor)
         {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            return vec;
+            Vector2 v;
+            v.X = vec.X % divisor;
+            v.Y = vec.Y % divisor;
+            return v;
         }
 
         /// <summary>
@@ -835,9 +844,10 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector2 operator %(Vector2 vec, Vector2 divisorv)
         {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            return vec;
+            Vector2 v;
+            v.X = vec.X % divisorv.X;
+            v.Y = vec.Y % divisorv.Y;
+            return v;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -733,10 +733,11 @@ namespace Godot
         /// <returns>The added vector.</returns>
         public static Vector3 operator +(Vector3 left, Vector3 right)
         {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            return left;
+            Vector3 v;
+            v.X = left.X + right.X;
+            v.Y = left.Y + right.Y;
+            v.Z = left.Z + right.Z;
+            return v;
         }
 
         /// <summary>
@@ -748,10 +749,11 @@ namespace Godot
         /// <returns>The subtracted vector.</returns>
         public static Vector3 operator -(Vector3 left, Vector3 right)
         {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            return left;
+            Vector3 v;
+            v.X = left.X - right.X;
+            v.Y = left.Y - right.Y;
+            v.Z = left.Z - right.Z;
+            return v;
         }
 
         /// <summary>
@@ -765,10 +767,11 @@ namespace Godot
         /// <returns>The negated/flipped vector.</returns>
         public static Vector3 operator -(Vector3 vec)
         {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            return vec;
+            Vector3 v;
+            v.X = -vec.X;
+            v.Y = -vec.Y;
+            v.Z = -vec.Z;
+            return v;
         }
 
         /// <summary>
@@ -780,10 +783,11 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 vec, real_t scale)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
+            Vector3 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            v.Z = vec.Z * scale;
+            return v;
         }
 
         /// <summary>
@@ -795,10 +799,11 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(real_t scale, Vector3 vec)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
+            Vector3 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            v.Z = vec.Z * scale;
+            return v;
         }
 
         /// <summary>
@@ -810,10 +815,11 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector3 operator *(Vector3 left, Vector3 right)
         {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            return left;
+            Vector3 v;
+            v.X = left.X * right.X;
+            v.Y = left.Y * right.Y;
+            v.Z = left.Z * right.Z;
+            return v;
         }
 
         /// <summary>
@@ -825,10 +831,11 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, real_t divisor)
         {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            return vec;
+            Vector3 v;
+            v.X = vec.X / divisor;
+            v.Y = vec.Y / divisor;
+            v.Z = vec.Z / divisor;
+            return v;
         }
 
         /// <summary>
@@ -840,10 +847,11 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector3 operator /(Vector3 vec, Vector3 divisorv)
         {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            return vec;
+            Vector3 v;
+            v.X = vec.X / divisorv.X;
+            v.Y = vec.Y / divisorv.Y;
+            v.Z = vec.Z / divisorv.Z;
+            return v;
         }
 
         /// <summary>
@@ -864,10 +872,11 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, real_t divisor)
         {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            return vec;
+            Vector3 v;
+            v.X = vec.X % divisor;
+            v.Y = vec.Y % divisor;
+            v.Z = vec.Z % divisor;
+            return v;
         }
 
         /// <summary>
@@ -888,10 +897,11 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector3 operator %(Vector3 vec, Vector3 divisorv)
         {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            return vec;
+            Vector3 v;
+            v.X = vec.X % divisorv.X;
+            v.Y = vec.Y % divisorv.Y;
+            v.Z = vec.Z % divisorv.Z;
+            return v;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -521,11 +521,12 @@ namespace Godot
         /// <returns>The added vector.</returns>
         public static Vector4 operator +(Vector4 left, Vector4 right)
         {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            left.W += right.W;
-            return left;
+            Vector4 v;
+            v.X = left.X + right.X;
+            v.Y = left.Y + right.Y;
+            v.Z = left.Z + right.Z;
+            v.W = left.W + right.W;
+            return v;
         }
 
         /// <summary>
@@ -537,11 +538,12 @@ namespace Godot
         /// <returns>The subtracted vector.</returns>
         public static Vector4 operator -(Vector4 left, Vector4 right)
         {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            left.W -= right.W;
-            return left;
+            Vector4 v;
+            v.X = left.X - right.X;
+            v.Y = left.Y - right.Y;
+            v.Z = left.Z - right.Z;
+            v.W = left.W - right.W;
+            return v;
         }
 
         /// <summary>
@@ -555,11 +557,12 @@ namespace Godot
         /// <returns>The negated/flipped vector.</returns>
         public static Vector4 operator -(Vector4 vec)
         {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            vec.W = -vec.W;
-            return vec;
+            Vector4 v;
+            v.X = -vec.X;
+            v.Y = -vec.Y;
+            v.Z = -vec.Z;
+            v.W = -vec.W;
+            return v;
         }
 
         /// <summary>
@@ -571,11 +574,12 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector4 operator *(Vector4 vec, real_t scale)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
+            Vector4 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            v.Z = vec.Z * scale;
+            v.W = vec.W * scale;
+            return v;
         }
 
         /// <summary>
@@ -587,11 +591,12 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector4 operator *(real_t scale, Vector4 vec)
         {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
+            Vector4 v;
+            v.X = vec.X * scale;
+            v.Y = vec.Y * scale;
+            v.Z = vec.Z * scale;
+            v.W = vec.W * scale;
+            return v;
         }
 
         /// <summary>
@@ -603,11 +608,12 @@ namespace Godot
         /// <returns>The multiplied vector.</returns>
         public static Vector4 operator *(Vector4 left, Vector4 right)
         {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            left.W *= right.W;
-            return left;
+            Vector4 v;
+            v.X = left.X * right.X;
+            v.Y = left.Y * right.Y;
+            v.Z = left.Z * right.Z;
+            v.W = left.W * right.W;
+            return v;
         }
 
         /// <summary>
@@ -619,11 +625,12 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector4 operator /(Vector4 vec, real_t divisor)
         {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            vec.W /= divisor;
-            return vec;
+            Vector4 v;
+            v.X = vec.X / divisor;
+            v.Y = vec.Y / divisor;
+            v.Z = vec.Z / divisor;
+            v.W = vec.W / divisor;
+            return v;
         }
 
         /// <summary>
@@ -635,11 +642,12 @@ namespace Godot
         /// <returns>The divided vector.</returns>
         public static Vector4 operator /(Vector4 vec, Vector4 divisorv)
         {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            vec.W /= divisorv.W;
-            return vec;
+            Vector4 v;
+            v.X = vec.X / divisorv.X;
+            v.Y = vec.Y / divisorv.Y;
+            v.Z = vec.Z / divisorv.Z;
+            v.W = vec.W / divisorv.W;
+            return v;
         }
 
         /// <summary>
@@ -660,11 +668,12 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector4 operator %(Vector4 vec, real_t divisor)
         {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            vec.W %= divisor;
-            return vec;
+            Vector4 v;
+            v.X = vec.X % divisor;
+            v.Y = vec.Y % divisor;
+            v.Z = vec.Z % divisor;
+            v.W = vec.W % divisor;
+            return v;
         }
 
         /// <summary>
@@ -685,11 +694,12 @@ namespace Godot
         /// <returns>The remainder vector.</returns>
         public static Vector4 operator %(Vector4 vec, Vector4 divisorv)
         {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            vec.W %= divisorv.W;
-            return vec;
+            Vector4 v;
+            v.X = vec.X % divisorv.X;
+            v.Y = vec.Y % divisorv.Y;
+            v.Z = vec.Z % divisorv.Z;
+            v.W = vec.W % divisorv.W;
+            return v;
         }
 
         /// <summary>


### PR DESCRIPTION
Codegen can be improved drastically by using a temp variable instead of updating and reusing the values of the left operand.

Take for example v3+v3:

<table>
<tr>
<th>Old</th>
<th>New</th>
</tr>

<tr><td>

```cs
Vector3 operator +(Vector3 left, Vector3 right)
{
    left.X += right.X;
    left.Y += right.Y;
    left.Z += right.Z;
    return left;
}
```
</td><td>

```cs
Vector3 operator +(Vector3 left, Vector3 right)
{
    Vector3 v;
    v.X = left.X + right.X;
    v.Y = left.Y + right.Y;
    v.Z = left.Z + right.Z;
    return v;
}
```
</td>
</tr>
<tr><td>

```asm
L0000: vzeroupper
L0003: vmovss xmm0, [rdx]
L0007: vaddss xmm0, xmm0, [r8]
L000c: vmovss [rdx], xmm0
L0010: lea rax, [rdx+4]
L0014: vmovss xmm0, [rax]
L0018: vaddss xmm0, xmm0, [r8+4]
L001e: vmovss [rax], xmm0
L0022: lea rax, [rdx+8]
L0026: vmovss xmm0, [rax]
L002a: vaddss xmm0, xmm0, [r8+8]
L0030: vmovss [rax], xmm0
L0034: mov rax, [rdx]
L0037: mov [rcx], rax
L003a: mov rax, [rdx+4]
L003e: mov [rcx+4], rax
L0042: mov rax, rcx
L0045: ret
```
</td>
<td>

```asm
L0000: vzeroupper
L0003: vmovss xmm0, [rdx]
L0007: vaddss xmm0, xmm0, [r8]
L000c: vmovss xmm1, [rdx+4]
L0011: vaddss xmm1, xmm1, [r8+4]
L0017: vmovss xmm2, [rdx+8]
L001c: vaddss xmm2, xmm2, [r8+8]
L0022: vmovss [rcx], xmm0
L0026: vmovss [rcx+4], xmm1
L002b: vmovss [rcx+8], xmm2
L0030: mov rax, rcx
L0033: ret
```
</td>
</tr>
</table>

TODO
- [x] Test new impl against old
- [ ] Investigate V4 lack of improvements
- [ ] Bench vectors related types? (quat, basis etc)

