### PR TITLE
Implement `LoopModeOverride` to `AnimationNodeAnimation` to properly manage the loop state for each `AnimationTree`

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -660,6 +660,9 @@
 		<constant name="LOOP_PINGPONG" value="2" enum="LoopMode">
 			Repeats playback and reverse playback at both ends of the animation.
 		</constant>
+		<constant name="LOOP_NO_OVERRIDE" value="3" enum="LoopMode">
+			Disables overriding loop mode if the overriding can be caused in the other class which uses animation.
+		</constant>
 		<constant name="LOOPED_FLAG_NONE" value="0" enum="LoopedFlag">
 			This flag indicates that the animation proceeds without any looping.
 		</constant>

--- a/doc/classes/AnimationNodeAnimation.xml
+++ b/doc/classes/AnimationNodeAnimation.xml
@@ -5,6 +5,27 @@
 	</brief_description>
 	<description>
 		A resource to add to an [AnimationNodeBlendTree]. Only has one output port using the [member animation] property. Used as an input for [AnimationNode]s that blend animations together.
+		The [AnimationNodeAnimation] has [code]loop_mode_override[/code] parameter to manage the looping state of each [AnimationNodeAnimation] for each [AnimationTree] as a node. See also [enum Animation.LoopMode].
+		[codeblocks]
+		[gdscript]
+		# Set loop mode override.
+		animation_tree.set("parameters/Animation/loop_mode_override", Animation.LOOP_LINEAR)
+		# Alternative syntax (same result as above).
+		animation_tree["parameters/Animation/loop_mode_override"] = Animation.LOOP_LINEAR
+
+		# Get loop mode override.
+		animation_tree.get("parameters/Animation/loop_mode_override")
+		# Alternative syntax (same result as above).
+		animation_tree["parameters/Animation/loop_mode_override"]
+		[/gdscript]
+		[csharp]
+		// Set loop mode override.
+		animationTree.Set("parameters/Animation/loop_mode_override", (int)Animation.LoopMode.Linear);
+
+		// Get loop mode override.
+		animationTree.Get("parameters/Animation/loop_mode_override");
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -36,19 +36,23 @@
 class AnimationNodeAnimation : public AnimationRootNode {
 	GDCLASS(AnimationNodeAnimation, AnimationRootNode);
 
-	StringName animation;
-	StringName time = "time";
-
-	uint64_t last_version = 0;
-	bool skip = false;
-
 public:
 	enum PlayMode {
 		PLAY_MODE_FORWARD,
 		PLAY_MODE_BACKWARD
 	};
 
+private:
+	StringName animation;
+	StringName time = "time";
+	StringName loop_mode_override = "loop_mode_override";
+
+	uint64_t last_version = 0;
+	bool skip = false;
+
+public:
 	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	static Vector<String> (*get_editable_animation_list)();
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3123,6 +3123,8 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 				from_time += CMP_EPSILON;
 			}
 		} break;
+		default: {
+		} break;
 	}
 	switch (t->type) {
 		case TYPE_POSITION_3D: {
@@ -3938,6 +3940,7 @@ void Animation::_bind_methods() {
 	BIND_ENUM_CONSTANT(LOOP_NONE);
 	BIND_ENUM_CONSTANT(LOOP_LINEAR);
 	BIND_ENUM_CONSTANT(LOOP_PINGPONG);
+	BIND_ENUM_CONSTANT(LOOP_NO_OVERRIDE);
 
 	BIND_ENUM_CONSTANT(LOOPED_FLAG_NONE);
 	BIND_ENUM_CONSTANT(LOOPED_FLAG_END);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -71,6 +71,7 @@ public:
 		LOOP_NONE,
 		LOOP_LINEAR,
 		LOOP_PINGPONG,
+		LOOP_NO_OVERRIDE,
 	};
 
 	enum LoopedFlag {


### PR DESCRIPTION
Closes #79208.

Implement the LoopModeOverride parameter to the AnimationNodeAnimation.

Context: https://github.com/godotengine/godot/issues/79208#issuecomment-1633283541

AutoAdvance should not be executed for looping animations, since it is undecided where the animation will end. However, there are cases where AutoAdvance is executed at the appropriate time after looping several times.

The straightforward way to solve this is to disable the Animation's Loop at any intended timing. However, changing the Loop property of an Animation resource will affect all the multiple AnimationTrees and AnimationPlayers that reference it.

Therefore, by implementing LoopModeOverride as a parameter of AnimationNodeAnimation, the loop state of the animation can be managed for each AnimationTree as a node.

This makes it easy to manage the looping state of animations for multiple characters.

![image](https://github.com/godotengine/godot/assets/61938263/4af8516a-d3e7-4cda-9974-705c04a2425c)

