### PR TITLE
C#: Fix line in OpenInExternalEditor

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -280,7 +280,7 @@ void EditorInterface::edit_node(Node *p_node) {
 }
 
 void EditorInterface::edit_script(const Ref<Script> &p_script, int p_line, int p_col, bool p_grab_focus) {
-	ScriptEditor::get_singleton()->edit(p_script, p_line, p_col, p_grab_focus);
+	ScriptEditor::get_singleton()->edit(p_script, p_line - 1, p_col - 1, p_grab_focus);
 }
 
 void EditorInterface::open_scene_from_path(const String &scene_path) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2331,7 +2331,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 				}
 
 				if (p_line > 0) {
-					se->goto_line(p_line - 1);
+					se->goto_line(p_line);
 				}
 			}
 			_update_script_names();
@@ -2426,8 +2426,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	_test_script_times_on_disk(p_resource);
 	_update_modified_scripts_for_external_editor(p_resource);
 
-	if (p_line > 0) {
-		se->goto_line(p_line - 1);
+	if (p_line >= 0) {
+		se->goto_line(p_line);
 	}
 
 	notify_script_changed(p_resource);

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -138,7 +138,8 @@ namespace GodotTools.Build
             {
                 var script = (Script)ResourceLoader.Load(file, typeHint: Internal.CSharpLanguageType);
 
-                if (script != null && Internal.ScriptEditorEdit(script, issue.Line, issue.Column))
+                // Godot's ScriptEditor.Edit is 0-based but the issue lines are 1-based.
+                if (script != null && Internal.ScriptEditorEdit(script, issue.Line - 1, issue.Column - 1))
                     Internal.EditorNodeShowScriptScreen();
             }
         }


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/41816.
- :warning: Only tested this with VSCode, I hope I didn't break other IDEs :warning:
- ~**Note for 3.x cherrypick**: Requires also cherry-picking https://github.com/godotengine/godot/pull/73584~.