### PR TITLE
Fill in descriptions for import options in the class reference

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -935,23 +935,26 @@
 			Path to a custom [Font] resource to use as default for all GUI elements of the project.
 		</member>
 		<member name="gui/theme/default_font_antialiasing" type="int" setter="" getter="" default="1">
-			Font anti-aliasing mode. See [member FontFile.antialiasing].
+			Font anti-aliasing mode for the default project font. See [member FontFile.antialiasing].
+			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.antialiasing]).
 		</member>
 		<member name="gui/theme/default_font_generate_mipmaps" type="bool" setter="" getter="" default="false">
 			If set to [code]true[/code], the default font will have mipmaps generated. This prevents text from looking grainy when a [Control] is scaled down, or when a [Label3D] is viewed from a long distance (if [member Label3D.texture_filter] is set to a mode that displays mipmaps).
 			Enabling [member gui/theme/default_font_generate_mipmaps] increases font generation time and memory usage. Only enable this setting if you actually need it.
-			[b]Note:[/b] This setting does not affect custom [Font]s used within the project.
+			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.generate_mipmaps]).
 		</member>
 		<member name="gui/theme/default_font_hinting" type="int" setter="" getter="" default="1">
-			Default font hinting mode. See [member FontFile.hinting].
+			Font hinting mode for the default project font. See [member FontFile.hinting].
+			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.hinting]).
 		</member>
 		<member name="gui/theme/default_font_multichannel_signed_distance_field" type="bool" setter="" getter="" default="false">
 			If set to [code]true[/code], the default font will use multichannel signed distance field (MSDF) for crisp rendering at any size. Since this approach does not rely on rasterizing the font every time its size changes, this allows for resizing the font in real-time without any performance penalty. Text will also not look grainy for [Control]s that are scaled down (or for [Label3D]s viewed from a long distance).
 			MSDF font rendering can be combined with [member gui/theme/default_font_generate_mipmaps] to further improve font rendering quality when scaled down.
-			[b]Note:[/b] This setting does not affect custom [Font]s used within the project.
+			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.multichannel_signed_distance_field]).
 		</member>
 		<member name="gui/theme/default_font_subpixel_positioning" type="int" setter="" getter="" default="1">
-			Default font glyph subpixel positioning mode. See [member FontFile.subpixel_positioning].
+			Font glyph subpixel positioning mode for the default project font. See [member FontFile.subpixel_positioning].
+			[b]Note:[/b] This setting does not affect custom [Font]s used within the project. Use the [b]Import[/b] dock for that instead (see [member ResourceImporterDynamicFont.subpixel_positioning]).
 		</member>
 		<member name="gui/theme/default_theme_scale" type="float" setter="" getter="" default="1.0">
 			The default scale factor for [Control]s, when not overridden by a [Theme].

--- a/doc/classes/ResourceImporterBMFont.xml
+++ b/doc/classes/ResourceImporterBMFont.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterBMFont" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a bitmap font in the BMFont ([code].fnt[/code]) format.
 	</brief_description>
 	<description>
+		The BMFont format is a format created by the [url=https://www.angelcode.com/products/bmfont/]BMFont[/url] program. Many BMFont-compatible programs also exist, like [url=https://www.bmglyph.com/]BMGlyph[/url].
+		Compared to [ResourceImporterImageFont], [ResourceImporterBMFont] supports bitmap fonts with varying glyph widths/heights.
+		See also [ResourceImporterDynamicFont].
 	</description>
 	<tutorials>
+		<link title="Bitmap fonts - Using fonts">$DOCS_URL/tutorials/ui/gui_using_fonts.html#bitmap-fonts</link>
 	</tutorials>
 	<members>
 		<member name="compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses lossless compression for the resulting font.
 		</member>
 		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+			List of font fallbacks to use if a glyph isn't found in this bitmap font. Fonts at the beginning of the array are attempted first.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterBitMap.xml
+++ b/doc/classes/ResourceImporterBitMap.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterBitMap" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a [BitMap] resource (2D array of boolean values).
 	</brief_description>
 	<description>
+		[BitMap] resources are typically used as click masks in [TextureButton] and [TouchScreenButton].
 	</description>
 	<tutorials>
+		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<members>
 		<member name="create_from" type="int" setter="" getter="" default="0">
+			The data source to use for generating the bitmap.
+			[b]Black &amp; White:[/b] Pixels whose HSV value is greater than the [member threshold] will be considered as "enabled" (bit is [code]true[/code]). If the pixel is lower than or equal to the threshold, it will be considered as "disabled" (bit is [code]false[/code]).
+			[b]Alpha:[/b] Pixels whose alpha value is greater than the [member threshold] will be considered as "enabled" (bit is [code]true[/code]). If the pixel is lower than or equal to the threshold, it will be considered as "disabled" (bit is [code]false[/code]).
 		</member>
 		<member name="threshold" type="float" setter="" getter="" default="0.5">
+			The threshold to use to determine which bits should be considered enabled or disabled. See also [member create_from].
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterCSVTranslation.xml
+++ b/doc/classes/ResourceImporterCSVTranslation.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterCSVTranslation" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports comma-separated values
 	</brief_description>
 	<description>
+		Comma-separated values are a plain text table storage format. The format's simplicity makes it easy to edit in any text editor or spreadsheet software. This makes it a common choice for game localization.
+		[b]Example CSV file:[/b]
+		[codeblock]
+		keys,en,es,ja
+		GREET,"Hello, friend!","Hola, amigo!",こんにちは
+		ASK,How are you?,Cómo está?,元気ですか
+		BYE,Goodbye,Adiós,さようなら
+		QUOTE,"""Hello"" said the man.","""Hola"" dijo el hombre.",「こんにちは」男は言いました
+		[/codeblock]
 	</description>
 	<tutorials>
+		<link title="Importing translations">https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_translations.html</link>
 	</tutorials>
 	<members>
 		<member name="compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], creates an [OptimizedTranslation] instead of a [Translation]. This makes the resulting file smaller at the cost of a small CPU overhead.
 		</member>
 		<member name="delimiter" type="int" setter="" getter="" default="0">
+			The delimiter to use in the CSV file. The default value matches the common CSV convention. Tab-separated values are sometimes called TSV files.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterDynamicFont.xml
+++ b/doc/classes/ResourceImporterDynamicFont.xml
@@ -1,43 +1,77 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterDynamicFont" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a TTF, TTC, OTF, OTC, WOFF or WOFF2 font file for font rendering that adapts to any size.
 	</brief_description>
 	<description>
+		Unlike bitmap fonts, dynamic fonts can be resized to any size and still look crisp. Dynamic fonts also optionally support MSDF font rendering, which allows for run-time scale changes with no re-rasterization cost.
+		While WOFF and especially WOFF2 tend to result in smaller file sizes, there is no universally "better" font format. In most situations, it's recommended to use the font format that was shipped on the font developer's website.
+		See also [ResourceImporterBMFont] and [ResourceImporterImageFont].
 	</description>
 	<tutorials>
+		<link title="Dynamic fonts - Using fonts">$DOCS_URL/tutorials/ui/gui_using_fonts.html#dynamic-fonts</link>
 	</tutorials>
 	<members>
 		<member name="allow_system_fallback" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], automatically use system fonts as a fallback if a glyph isn't found in this dynamic font. This makes supporting CJK characters or emoji more straightforward, as you don't need to include a CJK/emoji font in your project. See also [member fallbacks].
+			[b]Note:[/b] The appearance of system fonts varies across platforms. Loading system fonts is only supported on Windows, macOS, Linux, Android and iOS.
 		</member>
 		<member name="antialiasing" type="int" setter="" getter="" default="1">
+			The font antialiasing method to use.
+			[b]Disabled:[/b] Most suited for pixel art fonts, although you do not [i]have[/i] to change the antialiasing from the default [b]Grayscale[/b] if the font file was well-created and the font is used at an integer multiple of its intended size. If pixel art fonts have a bad appearance at their intended size, try setting [member subpixel_positioning] to [b]Disabled[/b] instead.
+			[b]Grayscale:[/b] Use grayscale antialiasing. This is the approach used by the operating system on macOS, Android and iOS.
+			[b]LCD Subpixel:[/b] Use antialiasing with subpixel patterns to make fonts sharper on LCD displays. This is the approach used by the operating system on Windows and most Linux distributions. The downside is that this can introduce "fringing" on edges, especially on display technologies that don't use standard RGB subpixels (such as OLED displays). The LCD subpixel layout is globally controlled by [member ProjectSettings.gui/theme/lcd_subpixel_layout], which also allows falling back to grayscale antialiasing.
 		</member>
 		<member name="compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses lossless compression for the resulting font.
 		</member>
 		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+			List of font fallbacks to use if a glyph isn't found in this dynamic font. Fonts at the beginning of the array are attempted first, but fallback fonts that don't support the glyph's language and script are attempted last (see [member language_support] and [member script_support]). See also [member allow_system_fallback].
 		</member>
 		<member name="force_autohinter" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces generation of hinting data for the font using [url=https://freetype.org/]FreeType[/url]'s autohinter. This will make [member hinting] effective with fonts that don't include hinting data.
 		</member>
 		<member name="generate_mipmaps" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], this font will have mipmaps generated. This prevents text from looking grainy when a [Control] is scaled down, or when a [Label3D] is viewed from a long distance (if [member Label3D.texture_filter] is set to a mode that displays mipmaps).
+			Enabling [member generate_mipmaps] increases font generation time and memory usage. Only enable this setting if you actually need it.
 		</member>
 		<member name="hinting" type="int" setter="" getter="" default="1">
+			The hinting mode to use. This controls how aggressively glyph edges should be snapped to pixels when rasterizing the font. Depending on personal preference, you may prefer using one hinting mode over the other. Hinting modes other than [b]None[/b] are only effective if the font contains hinting data (see [member force_autohinter]).
+			[b]None:[/b] Smoothest appearance, which can make the font look blurry at small sizes.
+			[b]Light:[/b] Sharp result by snapping glyph edges to pixels on the Y axis only.
+			[b]Full:[/b] Sharpest by snapping glyph edges to pixels on both X and Y axes.
 		</member>
 		<member name="language_support" type="Dictionary" setter="" getter="" default="{}">
+			Override the list of languages supported by this font. If left empty, this is supplied by the font metadata. There is usually no need to change this. See also [member script_support].
 		</member>
 		<member name="msdf_pixel_range" type="int" setter="" getter="" default="8">
+			The width of the range around the shape between the minimum and maximum representable signed distance. If using font outlines, [member msdf_pixel_range] must be set to at least [i]twice[/i] the size of the largest font outline. The default [member msdf_pixel_range] value of [code]8[/code] allows outline sizes up to [code]4[/code] to look correct.
 		</member>
 		<member name="msdf_size" type="int" setter="" getter="" default="48">
+			Source font size used to generate MSDF textures. Higher values allow for more precision, but are slower to render and require more memory. Only increase this value if you notice a visible lack of precision in glyph rendering. Only effective if [member multichannel_signed_distance_field] is [code]true[/code].
 		</member>
 		<member name="multichannel_signed_distance_field" type="bool" setter="" getter="" default="false">
+			If set to [code]true[/code], the default font will use multichannel signed distance field (MSDF) for crisp rendering at any size. Since this approach does not rely on rasterizing the font every time its size changes, this allows for resizing the font in real-time without any performance penalty. Text will also not look grainy for [Control]s that are scaled down (or for [Label3D]s viewed from a long distance).
+			MSDF font rendering can be combined with [member generate_mipmaps] to further improve font rendering quality when scaled down.
 		</member>
 		<member name="opentype_features" type="Dictionary" setter="" getter="" default="{}">
+			The OpenType features to enable, disable or set a value for this font. This can be used to enable optional features provided by the font, such as ligatures or alternative glyphs. The list of supported OpenType features varies on a per-font basis.
 		</member>
 		<member name="oversampling" type="float" setter="" getter="" default="0.0">
+			If set to a value greater than [code]0.0[/code], overrides the oversampling factor for the font. This can be used to render the font at a higher or lower resolution than intended without affecting its physical size. In most cases, this should be left at [code]0.0[/code].
 		</member>
 		<member name="preload" type="Array" setter="" getter="" default="[]">
+			The glyph ranges to prerender. This can avoid stuttering during gameplay when new characters need to be rendered, especially if [member subpixel_positioning] is enabled. The downside of using preloading is that initial project load times will increase, as well as memory usage.
 		</member>
 		<member name="script_support" type="Dictionary" setter="" getter="" default="{}">
+			Override the list of language scripts supported by this font. If left empty, this is supplied by the font metadata. There is usually no need to change this. See also [member language_support].
 		</member>
 		<member name="subpixel_positioning" type="int" setter="" getter="" default="1">
+			Subpixel positioning improves font rendering appearance, especially at smaller font sizes. The downside is that it takes more time to initially render the font, which can cause stuttering during gameplay, especially if used with large font sizes. This should be set to [b]Disabled[/b] for fonts with a pixel art appearance.
+			[b]Disabled:[/b] No subpixel positioning. Lowest quality, fastest rendering.
+			[b]Auto:[/b] Use subpixel positioning at small font sizes (the chosen quality varies depending on font size). Large fonts will not use subpixel positioning. This is a good tradeoff between performance and quality.
+			[b]One Half of a Pixel:[/b] Always perform intermediate subpixel positioning regardless of font size. High quality, slow rendering.
+			[b]One Quarter of a Pixel:[/b] Always perform precise subpixel positioning regardless of font size. Highest quality, slowest rendering.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterImage.xml
+++ b/doc/classes/ResourceImporterImage.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterImage" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a image for use in scripting, with no rendering capabilities.
 	</brief_description>
 	<description>
+		This importer imports [Image] resources, as opposed to [CompressedTexture2D]. If you need to render the image in 2D or 3D, use [ResourceImporterTexture] instead.
 	</description>
 	<tutorials>
+		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 </class>

--- a/doc/classes/ResourceImporterImageFont.xml
+++ b/doc/classes/ResourceImporterImageFont.xml
@@ -1,25 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterImageFont" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a fixed-width bitmap font where all glyphs have the same width and height.
 	</brief_description>
 	<description>
+		This image-based workflow can be easier to use than [ResourceImporterBMFont], but it requires all glyphs to have the same width and height. This makes [ResourceImporterImageFont] most suited to fixed-width fonts.
+		See also [ResourceImporterDynamicFont].
 	</description>
 	<tutorials>
+		<link title="Bitmap fonts - Using fonts">$DOCS_URL/tutorials/ui/gui_using_fonts.html#bitmap-fonts</link>
 	</tutorials>
 	<members>
 		<member name="character_margin" type="Rect2i" setter="" getter="" default="Rect2i(0, 0, 0, 0)">
+			Margin applied around every imported glyph. If your font image contains guides (in the form of lines between glyphs) or if spacing between characters appears incorrect, try adjusting [member character_margin].
 		</member>
 		<member name="character_ranges" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			The character ranges to import from the font image. This is an array that maps each position on the image (in tile coordinates, not pixels). The font atlas is traversed from left to right and top to bottom. Characters can be specified with decimal numbers (127), hexadecimal numbers ([code]0x007f[/code]) or between single quotes ([code]'~'[/code]). Ranges can be specified with a hyphen between characters.
+			For instance, [code]0-127[/code] (or [code]0x0000-0x007f[/code]) denotes the full ASCII range. As another example, [code]' '-'~'[/code] is equivalent to [code]32-127[/code] and denotes the range of printable (visible) ASCII characters.
+			Make sure [member character_ranges] doesn't exceed the number of [member columns] * [member rows] defined. Otherwise, the font will fail to import.
 		</member>
 		<member name="columns" type="int" setter="" getter="" default="1">
+			Number of columns in the font image. See also [member rows].
 		</member>
 		<member name="compress" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], uses lossless compression for the resulting font.
 		</member>
 		<member name="fallbacks" type="Array" setter="" getter="" default="[]">
+			List of font fallbacks to use if a glyph isn't found in this bitmap font. Fonts at the beginning of the array are attempted first.
 		</member>
 		<member name="image_margin" type="Rect2i" setter="" getter="" default="Rect2i(0, 0, 0, 0)">
+			Margin to cut on the sides of the entire image. This can be used to cut parts of the image that contain attribution information or similar.
 		</member>
 		<member name="rows" type="int" setter="" getter="" default="1">
+			Number of rows in the font image. See also [member columns].
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -1,27 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterLayeredTexture" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a 3-dimensional texture ([Texture3D]), a [Texture2DArray], a [Cubemap] or a [CubemapArray].
 	</brief_description>
 	<description>
+		This imports a 3-dimensional texture, which can then be used in custom shaders, as a [FogMaterial] density map or as a [GPUParticlesAttractorVectorField3D]. See also [ResourceImporterTexture] and [ResourceImporterTextureAtlas].
 	</description>
 	<tutorials>
+		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<members>
 		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
+			Controls how color channels should be used in the imported texture.
+			[b]sRGB Friendly:[/b], prevents the RG color format from being used, as it does not support sRGB color.
+			[b]Optimized:[/b], allows the RG color format to be used if the texture does not use the blue channel. This reduces memory usage if the texture's blue channel can be discarded (all pixels must have a blue value of [code]0[/code]).
+			[b]Normal Map (RG Channels):[/b] This forces all layers from the texture to be imported with the RG color format to reduce memory usage, with only the red and green channels preserved. This only has an effect on textures with the VRAM Compressed or Basis Universal compression modes. This mode is only available in layered textures ([Cubemap], [CubemapArray], [Texture2DArray] and [Texture3D]).
 		</member>
 		<member name="compress/hdr_compression" type="int" setter="" getter="" default="1">
+			Controls how VRAM compression should be performed for HDR images.
+			[b]Disabled:[/b] Never use VRAM compression for HDR textures, regardless of whether they're opaque or transparent. Instead, the texture is converted to RGBE9995 (9-bits per channel + 5-bit exponent = 32 bits per pixel) to reduce memory usage compared to a half-float or single-precision float image format.
+			[b]Opaque Only:[/b] Only uses VRAM compression for opaque HDR textures. This is due to a limitation of HDR formats, as there is no VRAM-compressed HDR format that supports transparency at the same time.
+			[b]Always:[/b] Force VRAM compression even for HDR textures with an alpha channel. To perform this, the alpha channel is discarded on import.
+			[b]Note:[/b] Only effective on Radiance HDR ([code].hdr[/code]) and OpenEXR ([code].exr[/code]) images.
 		</member>
 		<member name="compress/high_quality" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], uses BPTC compression on desktop platforms and ASTC compression on mobile platforms. When using BPTC, BC7 is used for SDR textures and BC6H is used for HDR textures.
+			If [code]false[/code], uses the faster but lower-quality S3TC compression on desktop platforms and ETC2 on mobile/web platforms. When using S3TC, DXT1 (BC1) is used for opaque textures and DXT5 (BC3) is used for transparent or normal map (RGTC) textures.
+			BPTC and ASTC support VRAM compression for HDR textures, but S3TC and ETC2 do not (see [member compress/hdr_compression]).
 		</member>
 		<member name="compress/lossy_quality" type="float" setter="" getter="" default="0.7">
+			The quality to use when using the [b]Lossy[/b] compression mode. Higher values result in better quality, at the cost of larger file sizes. Lossy quality does not affect memory usage of the imported texture, only its file size on disk.
 		</member>
 		<member name="compress/mode" type="int" setter="" getter="" default="1">
+			The compression mode to use. Each compression mode provides a different tradeoff:
+			[b]Lossless[/b]: Original quality, high memory usage, high size on disk, fast import.
+			[b]Lossy:[/b] Reduced quality, high memory usage, low size on disk, fast import.
+			[b]VRAM Compressed:[/b] Reduced quality, low memory usage, low size on disk, slowest import. Only use for textures in 3D scenes, not for 2D elements.
+			[b]VRAM Uncompressed:[/b] Original quality, high memory usage, highest size on disk, fastest import.
+			[b]Basis Universal:[/b] Reduced quality, low memory usage, lowest size on disk, slow import. Only use for textures in 3D scenes, not for 2D elements.
+			See [url=https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_images.html#compress-mode]Compress mode[/url] in the manual for more details.
 		</member>
 		<member name="mipmaps/generate" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], smaller versions of the texture are generated on import. For example, a 64×64 texture will generate 6 mipmaps (32×32, 16×16, 8×8, 4×4, 2×2, 1×1). This has several benefits:
+			- Textures will not become grainy in the distance (in 3D), or if scaled down due to [Camera2D] zoom or [CanvasItem] scale (in 2D).
+			- Performance will improve if the texture is displayed in the distance, since sampling smaller versions of the original texture is faster and requires less memory bandwidth.
+			The downside of mipmaps is that they increase memory usage by roughly 33% (for [Texture2DArray], [Cubemap] and [CubemapArray]) or 14% (for [Texture3D]).
+			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
+			Unimplemented. This currently has no effect when changed.
 		</member>
 		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
+			Controls how the cubemap's texture is internally laid out. When using high-resolution cubemaps, [b]2×3[/b] and [b]3×2[/b] are less prone to exceeding hardware texture size limits compared to [b]1×6[/b] and [b]6×1[/b].
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterOBJ.xml
+++ b/doc/classes/ResourceImporterOBJ.xml
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterOBJ" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports an OBJ 3D model as a standalone [Mesh] or scene.
 	</brief_description>
 	<description>
+		Unlike [ResourceImporterScene], [ResourceImporterOBJ] will import a single [Mesh] resource by default instead of importing a [PackedScene]. This makes it easier to use the [Mesh] resource in nodes that expect direct [Mesh] resources, such as [GridMap], [GPUParticles3D] or [CPUParticles3D]. Note that it is still possible to save mesh resources from 3D scenes using the [b]Advanced Import Settings[/b] dialog, regardless of the source format.
+		See also [ResourceImporterScene], which is used for more advanced 3D formats such as glTF.
 	</description>
 	<tutorials>
+		<link title="Importing 3D scenes">$DOCS_URL/tutorials/assets_pipeline/importing_scenes.html</link>
 	</tutorials>
 	<members>
 		<member name="generate_tangents" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], generate vertex tangents using [url=http://www.mikktspace.com/]Mikktspace[/url] if the source mesh doesn't have tangent data. When possible, it's recommended to let the 3D modeling software generate tangents on export instead on relying on this option. Tangents are required for correct display of normal and height maps, along with any material/shader features that require tangents.
+			If you don't need material features that require tangents, disabling this can reduce output file size and speed up importing if the source 3D file doesn't contain tangents.
 		</member>
 		<member name="offset_mesh" type="Vector3" setter="" getter="" default="Vector3(0, 0, 0)">
+			Offsets the mesh's data by the specified value. This can be used to work around misaligned meshes without having to modify the source file.
 		</member>
 		<member name="optimize_mesh" type="bool" setter="" getter="" default="true">
+			Unused parameter. This currently has no effect.
 		</member>
 		<member name="scale_mesh" type="Vector3" setter="" getter="" default="Vector3(1, 1, 1)">
+			Scales the mesh's data by the specified value. This can be used to work around misscaled meshes without having to modify the source file.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -1,43 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterScene" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a glTF, FBX, Collada or Blender 3D scene.
 	</brief_description>
 	<description>
+		See also [ResourceImporterOBJ], which is used for OBJ models that can be imported as a standalone [Mesh] or a scene.
+		Additional options (such as extracting individual meshes or materials to files) are available in the [b]Advanced Import Settings[/b] dialog. This dialog can be accessed by double-clicking a 3D scene in the FileSystem dock or by selecting a 3D scene in the FileSystem dock, going to the Import dock and choosing [b]Advanced[/b].
+		[b]Note:[/b] [ResourceImporterScene] is [i]not[/i] used for [PackedScene]s, such as [code].tscn[/code] and [code].scn[/code] files.
 	</description>
 	<tutorials>
+		<link title="Importing 3D scenes">$DOCS_URL/tutorials/assets_pipeline/importing_scenes.html</link>
 	</tutorials>
 	<members>
 		<member name="_subresources" type="Dictionary" setter="" getter="" default="{}">
+			Contains properties for the scene's subresources. This is an internal option which is not visible in the Import dock.
 		</member>
 		<member name="animation/fps" type="float" setter="" getter="" default="30">
+			The number of frames per second to use for baking animation curves to a series of points with linear interpolation. It's recommended to configure this value to match the value you're using as a baseline in your 3D modeling software. Higher values result in more precise animation with fast movement changes, at the cost of higher file sizes and memory usage. Thanks to interpolation, there is usually not much benefit in going above 30 FPS (as the animation will still appear smooth at higher rendering framerates).
 		</member>
 		<member name="animation/import" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], import animations from the 3D scene.
 		</member>
 		<member name="animation/remove_immutable_tracks" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], remove animation tracks that only contain default values. This can reduce output file size and memory usage with certain 3D scenes, depending on the contents of their animation tracks.
 		</member>
 		<member name="animation/trimming" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], trim the beginning and end of animations if there are no keyframe changes. This can reduce output file size and memory usage with certain 3D scenes, depending on the contents of their animation tracks.
 		</member>
 		<member name="import_script/path" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to an import script, which can run code after the import process has completed for custom processing. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_scenes.html#doc-importing-3d-scenes-import-script]Using import scripts for automation[/url] for more information.
 		</member>
 		<member name="meshes/create_shadow_meshes" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables the generation of shadow meshes on import. This optimizes shadow rendering without reducing quality by welding vertices together when possible. This in turn reduces the memory bandwidth required to render shadows. Shadow mesh generation currently doesn't support using a lower detail level than the source mesh (but shadow rendering will make use of LODs when relevant).
 		</member>
 		<member name="meshes/ensure_tangents" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], generate vertex tangents using [url=http://www.mikktspace.com/]Mikktspace[/url] if the input meshes don't have tangent data. When possible, it's recommended to let the 3D modeling software generate tangents on export instead on relying on this option. Tangents are required for correct display of normal and height maps, along with any material/shader features that require tangents.
+			If you don't need material features that require tangents, disabling this can reduce output file size and speed up importing if the source 3D file doesn't contain tangents.
 		</member>
 		<member name="meshes/generate_lods" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], generates lower detail variants of the mesh which will be displayed in the distance to improve rendering performance. Not all meshes benefit from LOD, especially if they are never rendered from far away. Disabling this can reduce output file size and speed up importing. See [url=$DOCS_URL/tutorials/3d/mesh_lod.html#doc-mesh-lod]Mesh level of detail (LOD)[/url] for more information.
 		</member>
 		<member name="meshes/light_baking" type="int" setter="" getter="" default="1">
+			Configures the meshes' [member GeometryInstance3D.gi_mode] in the 3D scene. If set to [b]Static Lightmaps[/b], sets the meshes' GI mode to Static and generates UV2 on import for [LightmapGI] baking.
 		</member>
 		<member name="meshes/lightmap_texel_size" type="float" setter="" getter="" default="0.2">
+			Controls the size of each texel on the baked lightmap. A smaller value results in more precise lightmaps, at the cost of larger lightmap sizes and longer bake times.
+			[b]Note:[/b] Only effective if [member meshes/light_baking] is set to [b]Static Lightmaps[/b].
 		</member>
 		<member name="nodes/apply_root_scale" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], [member nodes/root_scale] will be applied on the meshes and animations directly, while keeping the root node's scale to the default [code](1, 1, 1)[/code]. This means that if you add a child node later on within the imported scene, it won't be scaled. If disabled, [member nodes/root_scale] will multiply the scale of the root node instead.
 		</member>
 		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;Scene Root&quot;">
+			The name of the root node in the imported scene. This is generally not noticeable when instancing the scene in the editor (or drag-and-dropping from the FileSystem dock), as the root node is renamed to match the filename in this case.
 		</member>
 		<member name="nodes/root_scale" type="float" setter="" getter="" default="1.0">
+			The scale of meshes and animations (if [member nodes/apply_root_scale] is [code]true[/code]), or the scale of the root node in the imported scene (if [member nodes/apply_root_scale] is [code]false[/code]).
 		</member>
 		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;Node3D&quot;">
+			The node type to use as a root node. Using node types that inherit from [Node3D] is recommended. Otherwise, you'll lose the ability to position the node directly in the 3D editor.
 		</member>
 		<member name="skins/use_named_skins" type="bool" setter="" getter="" default="true">
+			If checked, use named [Skin]s for animation. The [MeshInstance3D] node contains 3 properties of relevance here: a skeleton [NodePath] pointing to the [Skeleton3D] node (usually [code]..[/code]), a mesh, and a skin:
+			- The [Skeleton3D] node contains a list of bones with names, their pose and rest, a name and a parent bone.
+			- The mesh is all of the raw vertex data needed to display a mesh. In terms of the mesh, it knows how vertices are weight-painted and uses some internal numbering often imported from 3D modeling software.
+			- The skin contains the information necessary to bind this mesh onto this Skeleton3D. For every one of the internal bone IDs chosen by the 3D modeling software, it contains two things. Firstly, a matrix known as the Bind Pose Matrix, Inverse Bind Matrix, or IBM for short. Secondly, the [Skin] contains each bone's name (if [member skins/use_named_skins] is [code]true[/code]), or the bone's index within the [Skeleton3D] list (if [member skins/use_named_skins] is [code]false[/code]).
+			Together, this information is enough to tell Godot how to use the bone poses in the [Skeleton3D] node to render the mesh from each [MeshInstance3D]. Note that each [MeshInstance3D] may share binds, as is common in models exported from Blender, or each [MeshInstance3D] may use a separate [Skin] object, as is common in models exported from other tools such as Maya.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterShaderFile.xml
+++ b/doc/classes/ResourceImporterShaderFile.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterShaderFile" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports native GLSL shaders (not Godot shaders) as a [RDShaderFile].
 	</brief_description>
 	<description>
+		This imports native GLSL shaders as [RDShaderFile] resources, for use with low-level [RenderingDevice] operations. This importer does [i]not[/i] handle [code].gdshader[/code] files.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -1,51 +1,106 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterTexture" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports an image for use in 2D or 3D rendering.
 	</brief_description>
 	<description>
+		This importer imports [CompressedTexture2D] resources. If you need to process the image in scripts in a more convenient way, use [ResourceImporterImage] instead. See also [ResourceImporterLayeredTexture].
 	</description>
 	<tutorials>
+		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<members>
 		<member name="compress/channel_pack" type="int" setter="" getter="" default="0">
+			Controls how color channels should be used in the imported texture.
+			[b]sRGB Friendly:[/b] Prevents the RG color format from being used, as it does not support sRGB color.
+			[b]Optimized:[/b] Allows the RG color format to be used if the texture does not use the blue channel. This reduces memory usage if the texture's blue channel can be discarded (all pixels must have a blue value of [code]0[/code]).
 		</member>
 		<member name="compress/hdr_compression" type="int" setter="" getter="" default="1">
+			Controls how VRAM compression should be performed for HDR images.
+			[b]Disabled:[/b] Never use VRAM compression for HDR textures, regardless of whether they're opaque or transparent. Instead, the texture is converted to RGBE9995 (9-bits per channel + 5-bit exponent = 32 bits per pixel) to reduce memory usage compared to a half-float or single-precision float image format.
+			[b]Opaque Only:[/b] Only uses VRAM compression for opaque HDR textures. This is due to a limitation of HDR formats, as there is no VRAM-compressed HDR format that supports transparency at the same time.
+			[b]Always:[/b] Force VRAM compression even for HDR textures with an alpha channel. To perform this, the alpha channel is discarded on import.
+			[b]Note:[/b] Only effective on Radiance HDR ([code].hdr[/code]) and OpenEXR ([code].exr[/code]) images.
 		</member>
 		<member name="compress/high_quality" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], uses BPTC compression on desktop platforms and ASTC compression on mobile platforms. When using BPTC, BC7 is used for SDR textures and BC6H is used for HDR textures.
+			If [code]false[/code], uses the faster but lower-quality S3TC compression on desktop platforms and ETC2 on mobile/web platforms. When using S3TC, DXT1 (BC1) is used for opaque textures and DXT5 (BC3) is used for transparent or normal map (RGTC) textures.
+			BPTC and ASTC support VRAM compression for HDR textures, but S3TC and ETC2 do not (see [member compress/hdr_compression]).
 		</member>
 		<member name="compress/lossy_quality" type="float" setter="" getter="" default="0.7">
+			The quality to use when using the [b]Lossy[/b] compression mode. Higher values result in better quality, at the cost of larger file sizes. Lossy quality does not affect memory usage of the imported texture, only its file size on disk.
 		</member>
 		<member name="compress/mode" type="int" setter="" getter="" default="0">
+			The compression mode to use. Each compression mode provides a different tradeoff:
+			[b]Lossless[/b]: Original quality, high memory usage, high size on disk, fast import.
+			[b]Lossy:[/b] Reduced quality, high memory usage, low size on disk, fast import.
+			[b]VRAM Compressed:[/b] Reduced quality, low memory usage, low size on disk, slowest import. Only use for textures in 3D scenes, not for 2D elements.
+			[b]VRAM Uncompressed:[/b] Original quality, high memory usage, highest size on disk, fastest import.
+			[b]Basis Universal:[/b] Reduced quality, low memory usage, lowest size on disk, slow import. Only use for textures in 3D scenes, not for 2D elements.
+			See [url=https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_images.html#compress-mode]Compress mode[/url] in the manual for more details.
 		</member>
 		<member name="compress/normal_map" type="int" setter="" getter="" default="0">
+			When using a texture as normal map, only the red and green channels are required. Given regular texture compression algorithms produce artifacts that don't look that nice in normal maps, the RGTC compression format is the best fit for this data. Forcing this option to Enable will make Godot import the image as RGTC compressed. By default, it's set to Detect. This means that if the texture is ever detected to be used as a normal map, it will be changed to Enable and reimported automatically.
+			Note that RGTC compression affects the resulting normal map image. You will have to adjust custom shaders that use the normal map's blue channel to take this into account. Built-in material shaders already ignore the blue channel in a normal map (regardless of the actual normal map's contents).
 		</member>
 		<member name="detect_3d/compress_to" type="int" setter="" getter="" default="1">
+			This changes the [member compress/mode] option that is used when a texture is detected as being used in 3D.
+			Changing this import option only has an effect if a texture is detected as being used in 3D. Changing this to [b]Disabled[/b] then reimporting will not change the existing compress mode on a texture (if it's detected to be used in 3D), but choosing [b]VRAM Compressed[/b] or [b]Basis Universal[/b] will.
 		</member>
 		<member name="editor/convert_colors_with_editor_theme" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], converts the imported image's colors to match [member EditorSettings.interface/theme/icon_and_font_color]. This assumes the image uses the exact same colors as [url=$DOCS_URL/contributing/development/editor/creating_icons.html]Godot's own color palette for editor icons[/url], with the source file designed for a dark editor theme. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
+			[b]Note:[/b] Only available for SVG images.
 		</member>
 		<member name="editor/scale_with_editor_scale" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], scales the imported image to match [member EditorSettings.interface/editor/custom_display_scale]. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
+			[b]Note:[/b] Only available for SVG images.
 		</member>
 		<member name="mipmaps/generate" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], smaller versions of the texture are generated on import. For example, a 64×64 texture will generate 6 mipmaps (32×32, 16×16, 8×8, 4×4, 2×2, 1×1). This has several benefits:
+			- Textures will not become grainy in the distance (in 3D), or if scaled down due to [Camera2D] zoom or [CanvasItem] scale (in 2D).
+			- Performance will improve if the texture is displayed in the distance, since sampling smaller versions of the original texture is faster and requires less memory bandwidth.
+			The downside of mipmaps is that they increase memory usage by roughly 33%.
+			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
+			Unimplemented. This currently has no effect when changed.
 		</member>
 		<member name="process/fix_alpha_border" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], puts pixels of the same surrounding color in transition from transparent to opaque areas. For textures displayed with bilinear filtering, this helps mitigate the outline effect when exporting images from an image editor.
+			It's recommended to leave this enabled (as it is by default), unless this causes issues for a particular image.
 		</member>
 		<member name="process/hdr_as_srgb" type="bool" setter="" getter="" default="false">
+			Some HDR images you can find online may be broken and contain sRGB color data (instead of linear color data). It is advised not to use those files. If you absolutely have to, enabling [member process/hdr_as_srgb] will make them look correct.
+			[b]Warning:[/b] Enabling [member process/hdr_as_srgb] on well-formatted HDR images will cause the resulting image to look too dark, so leave this on [code]false[/code] if unsure.
 		</member>
 		<member name="process/hdr_clamp_exposure" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], clamps exposure in the imported high dynamic range images using a smart clamping formula (without introducing [i]visible[/i] clipping).
+			Some HDR panorama images you can find online may contain extremely bright pixels, due to being taken from real life sources without any clipping.
+			While these HDR panorama images are accurate to real life, this can cause the radiance map generated by Godot to contain sparkles when used as a background sky. This can be seen in material reflections (even on rough materials in extreme cases). Enabling [member process/hdr_clamp_exposure] can resolve this.
 		</member>
 		<member name="process/normal_map_invert_y" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], convert the normal map from Y- (DirectX-style) to Y+ (OpenGL-style) by inverting its green color channel. This is the normal map convention expected by Godot.
+			More information about normal maps (including a coordinate order table for popular engines) can be found [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details]here[/url].
 		</member>
 		<member name="process/premult_alpha" type="bool" setter="" getter="" default="false">
+			An alternative to fixing darkened borders with [member process/fix_alpha_border] is to use premultiplied alpha. By enabling this option, the texture will be converted to this format. A premultiplied alpha texture requires specific materials to be displayed correctly:
+			- In 2D, a [CanvasItemMaterial] will need to be created and configured to use the [constant CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA] blend mode on [CanvasItem]s that use this texture.
+			- In 3D, there is no support for premultiplied alpha blend mode yet, so this option is only suited for 2D.
 		</member>
 		<member name="process/size_limit" type="int" setter="" getter="" default="0">
+			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using cubic interpolation.
+			This can be used to reduce memory usage without affecting the source images, or avoid issues with textures not displaying on mobile/web platforms (as these usually can't display textures larger than 4096×4096).
 		</member>
 		<member name="roughness/mode" type="int" setter="" getter="" default="0">
+			The color channel to consider as a roughness map in this texture. Only effective if Roughness &gt; Src Normal is not empty.
 		</member>
 		<member name="roughness/src_normal" type="String" setter="" getter="" default="&quot;&quot;">
+			The path to the texture to consider as a normal map for roughness filtering on import. Specifying this can help decrease specular aliasing slightly in 3D.
+			Roughness filtering on import is only used in 3D rendering, not 2D.
 		</member>
 		<member name="svg/scale" type="float" setter="" getter="" default="1.0">
+			The scale the SVG should be rendered at, with [code]1.0[/code] being the original design size. Higher values result in a larger image. Note that unlike font oversampling, this affects the size the SVG is rendered at in 2D. See also [member editor/scale_with_editor_scale].
+			[b]Note:[/b] Only available for SVG images.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterTextureAtlas.xml
+++ b/doc/classes/ResourceImporterTextureAtlas.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterTextureAtlas" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a collection of textures from a PNG image into an optimized [AtlasTexture] for 2D rendering.
 	</brief_description>
 	<description>
+		This imports a collection of textures from a PNG image into an [AtlasTexture] or 2D [ArrayMesh]. This can be used to save memory when importing 2D animations from spritesheets. Texture atlases are only supported in 2D rendering, not 3D. See also [ResourceImporterTexture] and [ResourceImporterLayeredTexture].
+		[b]Note:[/b] [ResourceImporterTextureAtlas] does not handle importing [TileSetAtlasSource], which is created using the [TileSet] editor instead.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="atlas_file" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the atlas spritesheet. This [i]must[/i] be set to valid path to a PNG image. Otherwise, the atlas will fail to import.
 		</member>
 		<member name="crop_to_region" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], discards empty areas from the atlas. This only affects final sprite positioning, not storage. See also [member trim_alpha_border_from_region].
+			[b]Note:[/b] Only effective if [member import_mode] is [b]Region[/b].
 		</member>
 		<member name="import_mode" type="int" setter="" getter="" default="0">
+			[b]Region:[/b] Imports the atlas in an [AtlasTexture] resource, which is rendered as a rectangle. This is fast to render, but transparent areas still have to be rendered if they can't be trimmed effectively by [member trim_alpha_border_from_region]. This can reduce performance when rendering large sprites on screen.
+			[b]Mesh:[/b] Imports the atlas as an [ArrayMesh] resource, keeping the original bitmap visible (but rendered as a polygon). This can be used to reduce fill rate when rendering large transparent sprites, at the cost of slower rendering if there are little to no transparent areas in the sprite.
 		</member>
 		<member name="trim_alpha_border_from_region" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], trims the region to exclude fully transparent pixels using a clipping rectangle (which is never rotated). This can be used to save memory. See also [member trim_alpha_border_from_region].
+			[b]Note:[/b] Only effective if [member import_mode] is [b]Region[/b].
 		</member>
 	</members>
 </class>

--- a/doc/classes/ResourceImporterWAV.xml
+++ b/doc/classes/ResourceImporterWAV.xml
@@ -1,31 +1,53 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterWAV" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		Imports a WAV audio file for playback.
 	</brief_description>
 	<description>
+		WAV is an uncompressed format, which can provide higher quality compared to Ogg Vorbis and MP3. It also has the lowest CPU cost to decode. This means high numbers of WAV sounds can be played at the same time, even on low-end deviceS.
 	</description>
 	<tutorials>
+		<link title="Importing audio samples">$DOCS_URL/tutorials/assets_pipeline/importing_audio_samples.html</link>
 	</tutorials>
 	<members>
 		<member name="compress/mode" type="int" setter="" getter="" default="0">
+			The compression mode to use on import.
+			[b]Disabled:[/b] Imports audio data without any compression. This results in the highest possible quality.
+			[b]RAM (Ima-ADPCM):[/b] Performs fast lossy compression on import. Low CPU cost, but quality is noticeably decreased compared to Ogg Vorbis or even MP3.
 		</member>
 		<member name="edit/loop_begin" type="int" setter="" getter="" default="0">
+			The begin loop point to use when [member edit/loop_mode] is [b]Forward[/b], [b]Ping-Pong[/b] or [b]Backward[/b]. This is set in seconds after the beginning of the audio file.
 		</member>
 		<member name="edit/loop_end" type="int" setter="" getter="" default="-1">
+			The end loop point to use when [member edit/loop_mode] is [b]Forward[/b], [b]Ping-Pong[/b] or [b]Backward[/b]. This is set in seconds after the beginning of the audio file. A value of [code]-1[/code] uses the end of the audio file as the end loop point.
 		</member>
 		<member name="edit/loop_mode" type="int" setter="" getter="" default="0">
+			Controls how audio should loop. This is automatically read from the WAV metadata on import.
+			[b]Disabled:[/b] Don't loop audio, even if metadata indicates the file should be played back looping.
+			[b]Forward:[/b] Standard audio looping.
+			[b]Ping-Pong:[/b] Play audio forward until it's done playing, then play it backward and repeat. This is similar to mirrored texture repeat, but for audio.
+			[b]Backward:[/b] Play audio in reverse and loop back to the end when done playing.
+			[b]Note:[/b] In [AudioStreamPlayer], the [signal AudioStreamPlayer.finished] signal won't be emitted for looping audio when it reaches the end of the audio file, as the audio will keep playing indefinitely.
 		</member>
 		<member name="edit/normalize" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], normalize the audio volume so that its peak volume is equal to 0 dB. When enabled, normalization will make audio sound louder depending on its original peak volume.
 		</member>
 		<member name="edit/trim" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], automatically trim the beginning and end of the audio if it's lower than -50 dB after normalization (see [member edit/normalize]). This prevents having files with silence at the beginning or end, which increases their size unnecessarily and adds latency to the moment they are played back. A fade-in/fade-out period of 500 samples is also used during trimming to avoid audible pops.
 		</member>
 		<member name="force/8_bit" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces the imported audio to use 8-bit quantization if the source file is 16-bit or higher.
+			Enabling this is generally not recommended, as 8-bit quantization decreases audio quality significantly. If you need smaller file sizes, consider using Ogg Vorbis or MP3 audio instead.
 		</member>
 		<member name="force/max_rate" type="bool" setter="" getter="" default="false">
+			If set to a value greater than [code]0[/code], forces the audio's sample rate to be reduced to a value lower than or equal to the value specified in [member force/max_rate_hz].
+			This can decrease file size noticeably on certain sounds, without impacting quality depending on the actual sound's contents. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_audio_samples.html#doc-importing-audio-samples-best-practices]Best practices[/url] for more information.
 		</member>
 		<member name="force/max_rate_hz" type="float" setter="" getter="" default="44100">
+			The frequency to limit the imported audio sample to (in Hz). Only effective if [member force/max_rate] is [code]true[/code].
 		</member>
 		<member name="force/mono" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], forces the imported audio to be mono if the source file is stereo. This decreases the file size by 50% by merging the two channels into one.
 		</member>
 	</members>
 </class>

--- a/modules/minimp3/doc_classes/ResourceImporterMP3.xml
+++ b/modules/minimp3/doc_classes/ResourceImporterMP3.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterMP3" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Imports a MP3 audio file for playback.
 	</brief_description>
 	<description>
+		MP3 is a lossy audio format, with worse audio quality compared to [ResourceImporterOggVorbis] at a given bitrate.
+		In most cases, it's recommended to use Ogg Vorbis over MP3. However, if you're using a MP3 sound source with no higher quality source available, then it's recommended to use the MP3 file directly to avoid double lossy compression.
+		MP3 requires more CPU to decode than [ResourceImporterWAV]. If you need to play a lot of simultaneous sounds, it's recommended to use WAV for those sounds instead, especially if targeting low-end devices.
 	</description>
 	<tutorials>
+		<link title="Importing audio samples">$DOCS_URL/tutorials/assets_pipeline/importing_audio_samples.html</link>
 	</tutorials>
 	<members>
 		<member name="bar_beats" type="int" setter="" getter="" default="4">
+			The number of bars within a single beat in the audio track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member bar_beats] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="beat_count" type="int" setter="" getter="" default="0">
+			The beat count of the audio track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member beat_count] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="bpm" type="float" setter="" getter="" default="0">
+			The Beats Per Minute of the audio track. This should match the BPM measure that was used to compose the track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member bpm] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="loop" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
+			If enabled, the audio will begin playing at the beginning after playback ends by reaching the end of the audio.
+			[b]Note:[/b] In [AudioStreamPlayer], the [signal AudioStreamPlayer.finished] signal won't be emitted for looping audio when it reaches the end of the audio file, as the audio will keep playing indefinitely.
 		</member>
 		<member name="loop_offset" type="float" setter="" getter="" default="0">
+			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in seconds relative to the beginning of the audio. A value of [code]0.0[/code] will loop the entire audio file.
+			Only has an effect if [member loop] is [code]true[/code].
+			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 	</members>
 </class>

--- a/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
+++ b/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
@@ -1,22 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterOggVorbis" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Imports an Ogg Vorbis audio file for playback.
 	</brief_description>
 	<description>
+		Ogg Vorbis is a lossy audio format, with better audio quality compared to [ResourceImporterMP3] at a given bitrate.
+		In most cases, it's recommended to use Ogg Vorbis over MP3. However, if you're using a MP3 sound source with no higher quality source available, then it's recommended to use the MP3 file directly to avoid double lossy compression.
+		Ogg Vorbis requires more CPU to decode than [ResourceImporterWAV]. If you need to play a lot of simultaneous sounds, it's recommended to use WAV for those sounds instead, especially if targeting low-end devices.
 	</description>
 	<tutorials>
+		<link title="Importing audio samples">https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_audio_samples.html</link>
 	</tutorials>
 	<members>
 		<member name="bar_beats" type="int" setter="" getter="" default="4">
+			The number of bars within a single beat in the audio track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member bar_beats] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="beat_count" type="int" setter="" getter="" default="0">
+			The beat count of the audio track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member beat_count] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="bpm" type="float" setter="" getter="" default="0">
+			The Beats Per Minute of the audio track. This should match the BPM measure that was used to compose the track. This is only relevant for music that wishes to make use of interactive music functionality (not implemented yet), not sound effects.
+			A more convenient editor for [member bpm] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="loop" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], the audio will play again from the specified [member loop_offset] once it is done playing. Useful for ambient sounds and background music.
+			If enabled, the audio will begin playing at the beginning after playback ends by reaching the end of the audio.
+			[b]Note:[/b] In [AudioStreamPlayer], the [signal AudioStreamPlayer.finished] signal won't be emitted for looping audio when it reaches the end of the audio file, as the audio will keep playing indefinitely.
 		</member>
 		<member name="loop_offset" type="float" setter="" getter="" default="0">
+			Determines where audio will start to loop after playback reaches the end of the audio. This can be used to only loop a part of the audio file, which is useful for some ambient sounds or music. The value is determined in seconds relative to the beginning of the audio. A value of [code]0.0[/code] will loop the entire audio file.
+			Only has an effect if [member loop] is [code]true[/code].
+			A more convenient editor for [member loop_offset] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/49524.

This fully documents all editor import options currently exposed. (We are missing some options due to how they're registered, such as `slices/amount` in ResourceImporterLayeredTexture and `gltf/embedded_texture_handling` in EditorSceneFormatImporterGLTF.)