### PR TITLE
Fix `doc_status.py` trying to get removed `version` tag from XML

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Documentation checks
         run: |
+          doc/tools/doc_status.py doc/classes modules/*/doc_classes platform/*/doc_classes
           doc/tools/make_rst.py --dry-run --color doc/classes modules platform
 
       - name: Style checks via clang-format (clang_format.sh)

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -383,12 +383,6 @@ for file in input_file_list:
     tree = ET.parse(file)
     doc = tree.getroot()
 
-    if "version" not in doc.attrib:
-        print('Version missing from "doc"')
-        sys.exit(255)
-
-    version = doc.attrib["version"]
-
     if doc.attrib["name"] in class_names:
         continue
     class_names.append(doc.attrib["name"])


### PR DESCRIPTION
This also runs `doc_status.py` on CI to catch potential future regressions.

- This fixes a regression from https://github.com/godotengine/godot/pull/79092.