### PR TITLE
Rework modifying tile source ID

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -156,7 +156,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 
 		// Common to all type of sources.
 		if (!source->get_name().is_empty()) {
-			item_text = vformat(TTR("%s (ID: %d)"), source->get_name(), source_id);
+			item_text = source->get_name();
 		}
 
 		// Atlas source.
@@ -165,7 +165,7 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 			texture = atlas_source->get_texture();
 			if (item_text.is_empty()) {
 				if (texture.is_valid()) {
-					item_text = vformat(TTR("%s (ID: %d)"), texture->get_path().get_file(), source_id);
+					item_text = texture->get_path().get_file();
 				} else {
 					item_text = vformat(TTR("No Texture Atlas Source (ID: %d)"), source_id);
 				}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2529,6 +2529,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	atlas_source_inspector = memnew(EditorInspector);
 	atlas_source_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	atlas_source_inspector->set_show_categories(true);
+	atlas_source_inspector->add_inspector_plugin(memnew(TileSourceInspectorPlugin));
 	atlas_source_inspector->edit(atlas_source_proxy_object);
 	middle_vbox_container->add_child(atlas_source_inspector);
 

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -38,9 +38,12 @@
 #include "tile_set_atlas_source_editor.h"
 #include "tile_set_scenes_collection_source_editor.h"
 
-class EditorFileDialog;
+class AcceptDialog;
+class SpinBox;
 class HBoxContainer;
 class SplitContainer;
+class EditorFileDialog;
+class EditorInspectorPlugin;
 
 class TileSetEditor : public Control {
 	GDCLASS(TileSetEditor, Control);
@@ -121,6 +124,22 @@ public:
 	void register_split(SplitContainer *p_split);
 
 	TileSetEditor();
+};
+
+class TileSourceInspectorPlugin : public EditorInspectorPlugin {
+	GDCLASS(TileSourceInspectorPlugin, EditorInspectorPlugin);
+
+	AcceptDialog *id_edit_dialog = nullptr;
+	Label *id_label = nullptr;
+	SpinBox *id_input = nullptr;
+	Object *edited_source = nullptr;
+
+	void _show_id_edit_dialog(Object *p_for_source);
+	void _confirm_change_id();
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide = false) override;
 };
 
 #endif // TILE_SET_EDITOR_H

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/tiles/tile_set_editor.h"
 
 #include "scene/gui/button.h"
 #include "scene/gui/item_list.h"
@@ -504,6 +505,7 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 
 	scenes_collection_source_inspector = memnew(EditorInspector);
 	scenes_collection_source_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	scenes_collection_source_inspector->add_inspector_plugin(memnew(TileSourceInspectorPlugin));
 	scenes_collection_source_inspector->edit(scenes_collection_source_proxy_object);
 	middle_vbox_container->add_child(scenes_collection_source_inspector);
 


### PR DESCRIPTION
Part of https://github.com/godotengine/godot-proposals/issues/7177

This PR unexposed atlas/scene source ID property from the inspector:
![image](https://github.com/godotengine/godot/assets/2223172/0c764aaf-457b-4dcf-b483-e8a7ac8e2b9c)

It's an advanced feature and providing it for inexperienced users may, in worst case, cause data loss which might be not easy to recover (see the proposal). Changing ID is still possible via scripting. I wonder if it should be documented 🤔