### PR TITLE
Add `KHR_materials_emissive_strength` extension support for exporting GLTFs

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3769,6 +3769,12 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			extensions["KHR_materials_unlit"] = mat_unlit;
 			p_state->add_used_extension("KHR_materials_unlit");
 		}
+		if (base_material->get_feature(BaseMaterial3D::FEATURE_EMISSION) && !Math::is_equal_approx(base_material->get_emission_energy_multiplier(), 1.0f)) {
+			Dictionary mat_emissive_strength;
+			mat_emissive_strength["emissiveStrength"] = base_material->get_emission_energy_multiplier();
+			extensions["KHR_materials_emissive_strength"] = mat_emissive_strength;
+			p_state->add_used_extension("KHR_materials_emissive_strength");
+		}
 		d["extensions"] = extensions;
 
 		materials.push_back(d);


### PR DESCRIPTION
As we added support for importing gltf files with KHR_materials_emissive_strength extension in this PR: https://github.com/godotengine/godot/pull/78621 it would be good to also have an ability to export it. 