### PR TITLE
Improve autocompletion by analyzing incomplete fragments from the parser

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -624,6 +624,8 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 	bad_type.kind = GDScriptParser::DataType::VARIANT;
 	bad_type.type_source = GDScriptParser::DataType::INFERRED;
 
+	resolve_incomplete(p_type);
+
 	if (p_type == nullptr) {
 		return bad_type;
 	}
@@ -1462,6 +1464,8 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 		resolve_pending_lambda_bodies();
 	}
 
+	resolve_incomplete(p_class);
+
 	parser->current_class = previous_class;
 }
 
@@ -1620,6 +1624,7 @@ void GDScriptAnalyzer::resolve_annotation(GDScriptParser::AnnotationNode *p_anno
 
 		p_annotation->resolved_arguments.push_back(value);
 	}
+	resolve_incomplete(p_annotation);
 }
 
 void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *p_function, const GDScriptParser::Node *p_source, bool p_is_lambda) {
@@ -1894,6 +1899,7 @@ void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite) {
 		resolve_pending_lambda_bodies();
 		decide_suite_type(p_suite, stmt);
 	}
+	resolve_incomplete(p_suite);
 }
 
 void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assignable, const char *p_kind) {
@@ -2043,6 +2049,7 @@ void GDScriptAnalyzer::resolve_variable(GDScriptParser::VariableNode *p_variable
 	}
 	is_shadowing(p_variable->identifier, kind, p_is_local);
 #endif
+	resolve_incomplete(p_variable);
 }
 
 void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local) {
@@ -2057,11 +2064,13 @@ void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant
 	}
 	is_shadowing(p_constant->identifier, kind, p_is_local);
 #endif
+	resolve_incomplete(p_constant);
 }
 
 void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parameter) {
 	static constexpr const char *kind = "parameter";
 	resolve_assignable(p_parameter, kind);
+	resolve_incomplete(p_parameter);
 }
 
 void GDScriptAnalyzer::resolve_if(GDScriptParser::IfNode *p_if) {
@@ -2074,6 +2083,7 @@ void GDScriptAnalyzer::resolve_if(GDScriptParser::IfNode *p_if) {
 		resolve_suite(p_if->false_block);
 		decide_suite_type(p_if, p_if->false_block);
 	}
+	resolve_incomplete(p_if);
 }
 
 void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
@@ -2155,6 +2165,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 				}
 			}
 		}
+		resolve_incomplete(p_for);
 	}
 
 	GDScriptParser::DataType variable_type;
@@ -2260,6 +2271,8 @@ void GDScriptAnalyzer::resolve_while(GDScriptParser::WhileNode *p_while) {
 
 	resolve_suite(p_while->loop);
 	p_while->set_datatype(p_while->loop->get_datatype());
+
+	resolve_incomplete(p_while);
 }
 
 void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
@@ -2282,6 +2295,7 @@ void GDScriptAnalyzer::resolve_assert(GDScriptParser::AssertNode *p_assert) {
 		}
 	}
 #endif
+	resolve_incomplete(p_assert);
 }
 
 void GDScriptAnalyzer::resolve_match(GDScriptParser::MatchNode *p_match) {
@@ -2292,6 +2306,7 @@ void GDScriptAnalyzer::resolve_match(GDScriptParser::MatchNode *p_match) {
 
 		decide_suite_type(p_match, p_match->branches[i]);
 	}
+	resolve_incomplete(p_match);
 }
 
 void GDScriptAnalyzer::resolve_match_branch(GDScriptParser::MatchBranchNode *p_match_branch, GDScriptParser::ExpressionNode *p_match_test) {
@@ -2312,6 +2327,8 @@ void GDScriptAnalyzer::resolve_match_branch(GDScriptParser::MatchBranchNode *p_m
 	resolve_suite(p_match_branch->block);
 
 	decide_suite_type(p_match_branch, p_match_branch->block);
+
+	resolve_incomplete(p_match_branch);
 }
 
 void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_match_pattern, GDScriptParser::ExpressionNode *p_match_test) {
@@ -2392,6 +2409,8 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 	}
 
 	p_match_pattern->set_datatype(result);
+
+	resolve_incomplete(p_match_pattern);
 }
 
 void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
@@ -2465,6 +2484,18 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 	}
 
 	p_return->set_datatype(result);
+
+	resolve_incomplete(p_return);
+}
+
+inline void GDScriptAnalyzer::resolve_incomplete(GDScriptParser::Node *p_node) {
+#ifdef TOOLS_ENABLED
+	if (p_node != nullptr) {
+		for (GDScriptParser::Node *E : p_node->incomplete_fragments) {
+			resolve_node(E);
+		}
+	}
+#endif
 }
 
 void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expression, bool p_is_root) {
@@ -2567,6 +2598,8 @@ void GDScriptAnalyzer::reduce_expression(GDScriptParser::ExpressionNode *p_expre
 		dummy.kind = GDScriptParser::DataType::VARIANT;
 		p_expression->set_datatype(dummy);
 	}
+
+	resolve_incomplete(p_expression);
 }
 
 void GDScriptAnalyzer::reduce_array(GDScriptParser::ArrayNode *p_array) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -96,6 +96,7 @@ class GDScriptAnalyzer {
 	void resolve_match_branch(GDScriptParser::MatchBranchNode *p_match_branch, GDScriptParser::ExpressionNode *p_match_test);
 	void resolve_match_pattern(GDScriptParser::PatternNode *p_match_pattern, GDScriptParser::ExpressionNode *p_match_test);
 	void resolve_return(GDScriptParser::ReturnNode *p_return);
+	inline void resolve_incomplete(GDScriptParser::Node *p_node);
 
 	// Reduction functions.
 	void reduce_expression(GDScriptParser::ExpressionNode *p_expression, bool p_is_root = false);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -338,7 +338,9 @@ public:
 		int leftmost_column = 0, rightmost_column = 0;
 		Node *next = nullptr;
 		List<AnnotationNode *> annotations;
-
+#ifdef TOOLS_ENABLED
+		Vector<Node *> incomplete_fragments;
+#endif
 		DataType datatype;
 
 		virtual DataType get_datatype() const { return datatype; }
@@ -1354,6 +1356,9 @@ private:
 	HashSet<int> warning_ignored_lines[GDScriptWarning::WARNING_MAX];
 	HashSet<int> unsafe_lines;
 #endif
+#ifdef TOOLS_ENABLED
+	Vector<GDScriptParser::Node *> incomplete_fragments;
+#endif
 
 	GDScriptTokenizer *tokenizer = nullptr;
 	GDScriptTokenizer::Token previous;
@@ -1455,6 +1460,8 @@ private:
 	}
 	void apply_pending_warnings();
 #endif
+	inline void push_incomplete(GDScriptParser::Node *p_incomplete);
+	inline void apply_incomplete(GDScriptParser::Node *p_apply_to);
 	// Setting p_force to false will prevent the completion context from being update if a context was already set before.
 	// This should only be done when we push context before we consumed any tokens for the corresponding structure.
 	// See parse_precedence for an example.

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_dictionary.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_dictionary.cfg
@@ -1,0 +1,10 @@
+[output]
+include=[
+    {"display": "CLIP_CHILDREN_DISABLED"},
+    {"display": "CLIP_CHILDREN_ONLY"},
+    {"display": "CLIP_CHILDREN_AND_DRAW"},
+    {"display": "CLIP_CHILDREN_MAX"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_dictionary.gd
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_dictionary.gd
@@ -1,0 +1,5 @@
+extends Node2D
+
+var test_var = {
+    ClipChildrenMode.➡
+}

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_match.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_match.cfg
@@ -1,0 +1,10 @@
+[output]
+include=[
+    {"display": "CLIP_CHILDREN_DISABLED"},
+    {"display": "CLIP_CHILDREN_ONLY"},
+    {"display": "CLIP_CHILDREN_AND_DRAW"},
+    {"display": "CLIP_CHILDREN_MAX"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_match.gd
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_match.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+var test_var := ClipChildrenMode.CLIP_CHILDREN_ONLY
+
+func _init():
+    match test_var:
+        ClipChildrenMode.➡

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_ternary.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_ternary.cfg
@@ -1,0 +1,10 @@
+[output]
+include=[
+    {"display": "CLIP_CHILDREN_DISABLED"},
+    {"display": "CLIP_CHILDREN_ONLY"},
+    {"display": "CLIP_CHILDREN_AND_DRAW"},
+    {"display": "CLIP_CHILDREN_MAX"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_ternary.gd
+++ b/modules/gdscript/tests/scripts/completion/common/builtin_enum_in_unfinished_ternary.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _init():
+    var test_var = 1 if ClipChildrenMode.➡

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_dictionary.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_dictionary.cfg
@@ -1,0 +1,9 @@
+[output]
+include=[
+    {"display": "OPT1"},
+    {"display": "OPT2"},
+    {"display": "OPT3"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_dictionary.gd
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_dictionary.gd
@@ -1,0 +1,9 @@
+enum TestEnum {
+    OPT1,
+    OPT2,
+    OPT3,
+}
+
+var test_var = {
+    TestEnum.➡
+}

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_match.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_match.cfg
@@ -1,0 +1,9 @@
+[output]
+include=[
+    {"display": "OPT1"},
+    {"display": "OPT2"},
+    {"display": "OPT3"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_match.gd
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_match.gd
@@ -1,0 +1,11 @@
+enum TestEnum {
+    OPT1,
+    OPT2,
+    OPT3,
+}
+
+var test_var := TestEnum.OPT1
+
+func _init():
+    match test_var:
+        TestEnum.➡

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_ternary.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_ternary.cfg
@@ -1,0 +1,9 @@
+[output]
+include=[
+    {"display": "OPT1"},
+    {"display": "OPT2"},
+    {"display": "OPT3"},
+]
+exclude=[
+    {"display": "test_var"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_ternary.gd
+++ b/modules/gdscript/tests/scripts/completion/common/custom_enum_in_unfinished_ternary.gd
@@ -1,0 +1,8 @@
+enum TestEnum {
+    OPT1,
+    OPT2,
+    OPT3,
+}
+
+func _init():
+    var test_var = 1 if TestEnum.➡

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
@@ -1,4 +1,3 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
@@ -1,4 +1,3 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
@@ -1,4 +1,3 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node

--- a/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
@@ -1,4 +1,3 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 exclude=[
     ; Node

--- a/modules/gdscript/tests/scripts/completion/common/self.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/self.cfg
@@ -1,4 +1,3 @@
-scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node


### PR DESCRIPTION
Fixes #72328, fixes #78602, fixes #96157

Fixes or moves #37061 to the 3.x milestone

Supersedes: #79340, #79343

There are cases in the parser were succesfully parsed nodes don't end up in the final parse tree because they are part of an faulty structure. Because those nodes do not end up in the parse tree they are never examined by the analyzer. This is usually fine because it is assumed that scripts don't contain errors. However when providing code completion a structure might be invalid because the user is currently typing it in. In this case we still want to provide the best autocompletion for the valid subparts. And indeed this subparts end up in the `CompletionContext`. But since the analyzer never resolved their types the autocompletion can be worse at some points.

This PR tries to resolve this by letting the parser save such completed fragments with the nearest valid Node if parsing fails somewhere. The analyzer does now also analyse all fragments for a node and can therefore add type information e.g. for identifiers.

I had two other PR's which fixed two type completion problems resulting from this, individually in the analyzer, they were however a little bit hacky. In this PR I tried to find a unified solution for this kind of problem which can easily expanded to new Nodes in the future. (Also found some other cases were parsed nodes would be discarded)

Edit: Now also with completion tests