### PR TITLE
Fix `tween_property` on `Basis` to properly update its value

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5508,6 +5508,9 @@ Variant Animation::add_variant(const Variant &a, const Variant &b) {
 			const ::AABB ab = b.operator ::AABB();
 			return ::AABB(aa.position + ab.position, aa.size + ab.size);
 		}
+		case Variant::BASIS: {
+			return (a.operator Basis()) * (b.operator Basis());
+		}
 		case Variant::QUATERNION: {
 			return (a.operator Quaternion()) * (b.operator Quaternion());
 		}
@@ -5554,6 +5557,9 @@ Variant Animation::subtract_variant(const Variant &a, const Variant &b) {
 			const ::AABB aa = a.operator ::AABB();
 			const ::AABB ab = b.operator ::AABB();
 			return ::AABB(aa.position - ab.position, aa.size - ab.size);
+		}
+		case Variant::BASIS: {
+			return (b.operator Basis()).inverse() * (a.operator Basis());
 		}
 		case Variant::QUATERNION: {
 			return (b.operator Quaternion()).inverse() * (a.operator Quaternion());


### PR DESCRIPTION
Fix #79372 
```gdscript
extends Node

@onready var lbl1 : Label = $Label
@onready var lbl2 : Label = $Label2

var vector3 = Vector3.ONE
var target_vector3 = Vector3(-1,-1,-1)

var basis = Basis(Vector3.RIGHT, Vector3.UP, Vector3.BACK)
var target_basis = Basis(Vector3.LEFT, Vector3.DOWN, Vector3.FORWARD)

func _ready() -> void:
	create_tween().tween_property(self, "basis", target_basis, 5.0)
	create_tween().tween_property(self, "vector3", target_vector3, 5.0)

func _process(delta):
	lbl2.text = "Tweening Vector3: " + str(vector3)
	lbl1.text = "Tweening Basis: " + str(basis)
```

Before

https://github.com/godotengine/godot/assets/13846022/320c94d7-1ccc-472b-b607-c3a2fdea9832



After


https://github.com/godotengine/godot/assets/13846022/1cb08a3d-bb30-4469-944c-b37e811759d5


