### PR TITLE
Allow using floating-point bone sizes and outline widths in the 2D editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -232,14 +232,16 @@
 		<member name="editors/2d/bone_outline_color" type="Color" setter="" getter="">
 			The outline color to use for non-selected bones in the 2D skeleton editor. See also [member editors/2d/bone_selected_color].
 		</member>
-		<member name="editors/2d/bone_outline_size" type="int" setter="" getter="">
+		<member name="editors/2d/bone_outline_size" type="float" setter="" getter="">
 			The outline size in the 2D skeleton editor (in pixels). See also [member editors/2d/bone_width].
+			[b]Note:[/b] Changes to this value only apply after modifying a [Bone2D] node in any way, or closing and reopening the scene.
 		</member>
 		<member name="editors/2d/bone_selected_color" type="Color" setter="" getter="">
 			The color to use for selected bones in the 2D skeleton editor. See also [member editors/2d/bone_outline_color].
 		</member>
-		<member name="editors/2d/bone_width" type="int" setter="" getter="">
+		<member name="editors/2d/bone_width" type="float" setter="" getter="">
 			The bone width in the 2D skeleton editor (in pixels). See also [member editors/2d/bone_outline_size].
+			[b]Note:[/b] Changes to this value only apply after modifying a [Bone2D] node in any way, or closing and reopening the scene.
 		</member>
 		<member name="editors/2d/grid_color" type="Color" setter="" getter="">
 			The grid color to use in the 2D editor.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -680,13 +680,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07));
 	_initial_set("editors/2d/guides_color", Color(0.6, 0.0, 0.8));
 	_initial_set("editors/2d/smart_snapping_line_color", Color(0.9, 0.1, 0.1));
-	_initial_set("editors/2d/bone_width", 5);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/bone_width", 5.0, "0.01,20,0.01,or_greater")
 	_initial_set("editors/2d/bone_color1", Color(1.0, 1.0, 1.0, 0.7));
 	_initial_set("editors/2d/bone_color2", Color(0.6, 0.6, 0.6, 0.7));
 	_initial_set("editors/2d/bone_selected_color", Color(0.9, 0.45, 0.45, 0.7));
 	_initial_set("editors/2d/bone_ik_color", Color(0.9, 0.9, 0.45, 0.7));
 	_initial_set("editors/2d/bone_outline_color", Color(0.35, 0.35, 0.35, 0.5));
-	_initial_set("editors/2d/bone_outline_size", 2);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/2d/bone_outline_size", 2.0, "0.01,8,0.01,or_greater")
 	_initial_set("editors/2d/viewport_border_color", Color(0.4, 0.4, 1.0, 0.4));
 	_initial_set("editors/2d/use_integer_zoom_by_default", false);
 

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -309,8 +309,8 @@ void Bone2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p_outline_shape, Bone2D *p_other_bone) {
-	int bone_width = EDITOR_GET("editors/2d/bone_width");
-	int bone_outline_width = EDITOR_GET("editors/2d/bone_outline_size");
+	float bone_width = EDITOR_GET("editors/2d/bone_width");
+	float bone_outline_width = EDITOR_GET("editors/2d/bone_outline_size");
 
 	if (!is_inside_tree()) {
 		return false; //may have been removed


### PR DESCRIPTION
This is useful when animating pixel art sprites in the 2D editor, as a value of `1` is often too large when zoomed in.

I've tested this change locally and can confirm that sizes as low as `0.01` work without any errors (and with visible output, at high zoom levels).

- This closes https://github.com/godotengine/godot-proposals/issues/6176.
