### PR TITLE
Extend minimum/maximum zoom level of TextureRegion editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -2178,7 +2178,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	min_thumbnail_zoom = 0.1f * MAX(1.0f, EDSCALE);
 	// Default the zoom to match the editor scale, but don't dezoom on editor scales below 100% to prevent pixel art from looking bad.
 	sheet_zoom = MAX(1.0f, EDSCALE);
-	max_sheet_zoom = 16.0f * MAX(1.0f, EDSCALE);
+	max_sheet_zoom = 128.0f * MAX(1.0f, EDSCALE);
 	min_sheet_zoom = 0.01f * MAX(1.0f, EDSCALE);
 	_zoom_reset();
 

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -698,7 +698,7 @@ void TextureRegionEditor::_set_snap_sep_y(float p_val) {
 }
 
 void TextureRegionEditor::_zoom_on_position(float p_zoom, Point2 p_position) {
-	if (p_zoom < 0.25 || p_zoom > 8) {
+	if (p_zoom < min_draw_zoom || p_zoom > max_draw_zoom) {
 		return;
 	}
 
@@ -1165,6 +1165,11 @@ TextureRegionEditor::TextureRegionEditor() {
 	hb_grid->add_child(sb_sep_y);
 
 	hb_grid->hide();
+
+	// Default the zoom to match the editor scale, but don't dezoom on editor scales below 100% to prevent pixel art from looking bad.
+	draw_zoom = MAX(1.0f, EDSCALE);
+	max_draw_zoom = 128.0f * MAX(1.0f, EDSCALE);
+	min_draw_zoom = 0.01f * MAX(1.0f, EDSCALE);
 
 	texture_preview = memnew(PanelContainer);
 	vb->add_child(texture_preview);

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -76,6 +76,8 @@ class TextureRegionEditor : public AcceptDialog {
 
 	Vector2 draw_ofs;
 	float draw_zoom = 1.0;
+	float min_draw_zoom = 1.0;
+	float max_draw_zoom = 1.0;
 	bool updating_scroll = false;
 
 	SnapMode snap_mode = SNAP_NONE;


### PR DESCRIPTION
This also applies a similar change to the SpriteFrames editor.

- This partially addresses https://github.com/godotengine/godot-proposals/issues/6330.
