### PR TITLE
Fix Button clipping when internal margins exist

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -327,17 +327,18 @@ void Button::_notification(int p_what) {
 			if (align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER && icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
 				icon_ofs.x = 0.0;
 			}
+
 			int text_clip = size.width - style->get_minimum_size().width - icon_ofs.width;
-			text_buf->set_width((clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? text_clip : -1);
-
-			int text_width = MAX(1, (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
-
 			if (_internal_margin[SIDE_LEFT] > 0) {
 				text_clip -= _internal_margin[SIDE_LEFT] + theme_cache.h_separation;
 			}
 			if (_internal_margin[SIDE_RIGHT] > 0) {
 				text_clip -= _internal_margin[SIDE_RIGHT] + theme_cache.h_separation;
 			}
+
+			text_buf->set_width((clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? text_clip : -1);
+
+			int text_width = MAX(1, (clip_text || overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
 


### PR DESCRIPTION
Button text clipping width did not take internal margins into account.

<table>
<tr><th scope="col"></th><th>Before</th><th>After</th></tr>
<tr><th scope="col">CheckBoxes<br>w/ & w/o ellipses</th>
<th>

![demo-before](https://github.com/godotengine/godot/assets/372476/b18f24ea-7327-415f-ac40-78f757024b5b)
</th>
<th>

![demo-after](https://github.com/godotengine/godot/assets/372476/1577de60-511e-44c3-8afb-1871727e788a)
</th>
</tr>
<tr><th scope="col">Inspector Flags</th>
<th>

![inspector-before](https://github.com/godotengine/godot/assets/372476/a6632c9e-8c75-4471-8a4d-b91972e3461f)
</th>
<th>

![inspector-after](https://github.com/godotengine/godot/assets/372476/3a27e440-a66c-47b0-b684-4bd1847a43e3)
</th>
</tr>
</table>

The two `if`s in the current code updates clip width _after_ the width is used, thus the problem.

Closes #78868