### PR TITLE
Add Rose Pine themes to the editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -457,7 +457,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/float_drag_speed", 5.0, "0.1,100,0.01")
 
 	// Theme
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Rose Pine,Rose Pine Dawn,Solarized (Dark),Solarized (Light),Black (OLED),Custom")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/icon_and_font_color", 0, "Auto,Dark,Light")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.2, 0.23, 0.31), "")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/accent_color", Color(0.41, 0.61, 0.91), "")

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -465,6 +465,15 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		preset_base_color = Color(0.9, 0.9, 0.9);
 		// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
 		preset_contrast = -0.08;
+	} else if (preset == "Rose Pine") {
+		preset_accent_color = Color(0.19, 0.45, 0.56);
+		preset_base_color = Color(0.15, 0.14, 0.23);
+		preset_contrast = 0.23;
+	} else if (preset == "Rose Pine Dawn") {
+		preset_accent_color = Color(0.16, 0.41, 0.51);
+		preset_base_color = Color(0.98, 0.96, 0.93);
+		// A negative contrast rate looks better for light themes, since it better follows the natural order of UI "elevation".
+		preset_contrast = -0.01;
 	} else if (preset == "Solarized (Dark)") {
 		preset_accent_color = Color(0.15, 0.55, 0.82);
 		preset_base_color = Color(0.04, 0.23, 0.27);


### PR DESCRIPTION
This PR adds the [Rose Pine](https://rosepinetheme.com/palette/ingredients/) light and dark theme variants to interface/theme/preset. There is a decent variety of themes there already but I find that there is no good middle ground between OLED Black and the other, much lighter dark themes (also it's just a really nice theme :P). Godot already has the solarized themes, so third party themes aren't entirely out of the question I think.

The Rose Pine theme is MIT licensed, and I've replicated it to the best of my abilities using the contrast value, so there should be no issues merging, unless of course this is a really unwanted change. 
[I will make a proposal for this tomorrow, I wasn't quite sure of the process for something like this evidently, sorry for any annoyance]

Screenshot examples:
![image](https://github.com/godotengine/godot/assets/69182455/f5396013-f8b0-448f-90f0-d6edcd1158b3)
![image](https://github.com/godotengine/godot/assets/69182455/cf70f299-7050-4b97-a080-ef65ac66cd2d)
