### PR TITLE
Make NavigationRegion3D baking NavMesh on the main thread not finish deferred

### DIFF
--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -262,11 +262,19 @@ void _bake_navigation_mesh(void *p_user_data) {
 		Ref<NavigationMeshSourceGeometryData3D> source_geometry_data = args->source_geometry_data;
 
 		NavigationServer3D::get_singleton()->bake_from_source_geometry_data(nav_mesh, source_geometry_data);
-		args->nav_region->call_deferred(SNAME("_bake_finished"), nav_mesh);
+		if (!Thread::is_main_thread()) {
+			args->nav_region->call_deferred(SNAME("_bake_finished"), nav_mesh);
+		} else {
+			args->nav_region->_bake_finished(nav_mesh);
+		}
 		memdelete(args);
 	} else {
 		ERR_PRINT("Can't bake the navigation mesh if the `NavigationMesh` resource doesn't exist");
-		args->nav_region->call_deferred(SNAME("_bake_finished"), Ref<NavigationMesh>());
+		if (!Thread::is_main_thread()) {
+			args->nav_region->call_deferred(SNAME("_bake_finished"), Ref<NavigationMesh>());
+		} else {
+			args->nav_region->_bake_finished(Ref<NavigationMesh>());
+		}
 		memdelete(args);
 	}
 }


### PR DESCRIPTION
Makes NavigationRegion3D baking NavMesh on the main thread not finish deferred.

Closes https://github.com/godotengine/godot/issues/77801

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
