### PR TITLE
Have `core_bind.h` Thread type syntax match `core_bind.cpp`

### DIFF
--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -230,8 +230,8 @@ public:
 	String get_cache_dir() const;
 
 	Error set_thread_name(const String &p_name);
-	Thread::ID get_thread_caller_id() const;
-	Thread::ID get_main_thread_id() const;
+	::Thread::ID get_thread_caller_id() const;
+	::Thread::ID get_main_thread_id() const;
 
 	bool has_feature(const String &p_feature) const;
 


### PR DESCRIPTION
Changes two instances of `Thread::ID` to `::Thread::ID`. This is functionally identical to prior implementation, but removes misattributed errors in VSCode intellisense