### PR TITLE
Add Shift modifier to create nodes as siblings in Create New Node dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -38,10 +38,12 @@
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"
 
-void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
+void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name, const String &p_search_placeholder) {
 	_fill_type_list();
 
 	icon_fallback = search_options->has_theme_icon(base_type, EditorStringName(EditorIcons)) ? base_type : "Object";
+
+	search_box->set_placeholder(p_search_placeholder);
 
 	if (p_dont_clear) {
 		search_box->select_all();

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -119,7 +119,7 @@ public:
 	void set_type_blocklist(const HashSet<StringName> &p_blocklist) { custom_type_blocklist = p_blocklist; }
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 
-	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");
+	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "", const String &p_search_placeholder = "");
 
 	CreateDialog();
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -614,7 +614,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				}
 			}
 
-			create_dialog->popup_create(true);
+			const bool is_on_macos = OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos");
+			const String placeholder = TTRC(vformat("Hold Shift to create as sibling. Hold %s to create another node afterwards.", is_on_macos ? "Cmd" : "Ctrl"));
+			create_dialog->popup_create(true, false, "", "", placeholder);
 			if (!p_confirm_override) {
 				emit_signal(SNAME("add_node_used"));
 			}
@@ -2902,7 +2904,7 @@ void SceneTreeDock::_selection_changed() {
 	_update_script_button();
 }
 
-Node *SceneTreeDock::_do_create(Node *p_parent) {
+Node *SceneTreeDock::_do_create(Node *p_parent, bool p_create_as_sibling, bool p_create_another) {
 	Variant c = create_dialog->instantiate_selected();
 	Node *child = Object::cast_to<Node>(c);
 	ERR_FAIL_NULL_V(child, nullptr);
@@ -2917,14 +2919,21 @@ Node *SceneTreeDock::_do_create(Node *p_parent) {
 	undo_redo->create_action_for_history(TTR("Create Node"), editor_data->get_current_edited_scene_history_id());
 
 	if (edited_scene) {
-		undo_redo->add_do_method(p_parent, "add_child", child, true);
+		Node *parent;
+		if (p_create_as_sibling && p_parent != edited_scene) {
+			// Only create node as a sibling if it's possible (the root node can't have a sibling).
+			parent = p_parent->get_parent();
+		} else {
+			parent = p_parent;
+		}
+		undo_redo->add_do_method(parent, "add_child", child, true);
 		undo_redo->add_do_method(child, "set_owner", edited_scene);
 		undo_redo->add_do_reference(child);
-		undo_redo->add_undo_method(p_parent, "remove_child", child);
+		undo_redo->add_undo_method(parent, "remove_child", child);
 
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(p_parent), child->get_class(), new_name);
-		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).path_join(new_name)));
+		undo_redo->add_do_method(ed, "live_debug_create_node", edited_scene->get_path_to(parent), child->get_class(), new_name);
+		undo_redo->add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)).path_join(new_name)));
 
 	} else {
 		undo_redo->add_do_method(EditorNode::get_singleton(), "set_edited_scene", child);
@@ -2933,13 +2942,13 @@ Node *SceneTreeDock::_do_create(Node *p_parent) {
 		undo_redo->add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
 	}
 
-	undo_redo->add_do_method(this, "_post_do_create", child);
+	undo_redo->add_do_method(this, "_post_do_create", child, p_create_as_sibling, p_create_another);
 	undo_redo->commit_action();
 
 	return child;
 }
 
-void SceneTreeDock::_post_do_create(Node *p_child) {
+void SceneTreeDock::_post_do_create(Node *p_child, bool p_create_as_sibling, bool p_create_another) {
 	editor_selection->clear();
 	editor_selection->add_node(p_child);
 	_push_item(p_child);
@@ -2961,6 +2970,13 @@ void SceneTreeDock::_post_do_create(Node *p_child) {
 	}
 
 	emit_signal(SNAME("node_created"), p_child);
+
+	if (p_create_another) {
+		// Show the dialog again, so the user can create another node immediately.
+		const bool is_on_macos = OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos");
+		const String placeholder = TTRC(vformat("Hold Shift to create as sibling. Hold %s to create another node afterwards.", is_on_macos ? "Cmd" : "Ctrl"));
+		create_dialog->popup_create(true, false, p_child->get_class(), p_child->get_name(), placeholder);
+	}
 }
 
 void SceneTreeDock::_create() {
@@ -2980,7 +2996,7 @@ void SceneTreeDock::_create() {
 			ERR_FAIL_NULL(parent);
 		}
 
-		_do_create(parent);
+		_do_create(parent, Input::get_singleton()->is_key_pressed(Key::SHIFT), Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL));
 
 	} else if (current_option == TOOL_REPLACE) {
 		List<Node *> selection = editor_selection->get_top_selected_node_list();

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -170,8 +170,8 @@ class SceneTreeDock : public VBoxContainer {
 	bool first_enter = true;
 
 	void _create();
-	Node *_do_create(Node *p_parent);
-	void _post_do_create(Node *p_child);
+	Node *_do_create(Node *p_parent, bool p_create_as_sibling = false, bool p_create_another = false);
+	void _post_do_create(Node *p_child, bool p_create_as_sibling = false, bool p_create_another = false);
 	Node *scene_root = nullptr;
 	Node *edited_scene = nullptr;
 	Node *pending_click_select = nullptr;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/79467.

This also allows chaining the creation of multiple nodes by holding down Ctrl (Cmd on macOS) when confirming the selection. Both modifiers can be used at once.

Together, this greatly speeds up the creation of scene trees without having to touch the mouse at any time.

## TODO

- [ ] Fix modifiers not being accounted for if you hold down the key all the way through when using <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>. This may hint at a Godot bug though (modifier state is cleared when a new window is open).
- [ ] Fix search having no results other than Node after creating a subsequent node when holding down <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>.

![Screenshot_20230714_181249](https://github.com/godotengine/godot/assets/180032/9bad7680-e957-4359-901c-fb3e0934768f)

I have no idea why the second part occurs though.
