### PR TITLE
C#: Generate instance types for singletons

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -72,7 +72,7 @@
 
 // Types that will be skipped over (in favor of their base types) when setting up instance bindings.
 // This must be a superset of `ignored_types` in bindings_generator.cpp.
-const Vector<String> ignored_types = { "PhysicsServer2DExtension", "PhysicsServer3DExtension" };
+const Vector<String> ignored_types = {};
 
 #ifdef TOOLS_ENABLED
 static bool _create_project_solution_if_needed() {

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -231,6 +231,14 @@ class BindingsGenerator {
 		bool is_ref_counted = false;
 
 		/**
+		 * Class is a singleton, but can't be declared as a static class as that would
+		 * break backwards compatibility. As such, instead of going with a static class,
+		 * we use the actual singleton pattern (private constructor with instance property),
+		 * which doesn't break compatibility.
+		 */
+		bool is_compat_singleton = false;
+
+		/**
 		 * Determines whether the native return value of this type must be disposed
 		 * by the generated internal call (think of `godot_string`, whose destructor
 		 * must be called). Some structs that are disposable may still disable this
@@ -615,8 +623,10 @@ class BindingsGenerator {
 	HashMap<const MethodInterface *, const InternalCall *> method_icalls_map;
 
 	HashMap<StringName, List<StringName>> blacklisted_methods;
+	HashSet<StringName> compat_singletons;
 
 	void _initialize_blacklisted_methods();
+	void _initialize_compat_singletons();
 
 	struct NameCache {
 		StringName type_void = StaticCString::create("void");

--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -227,6 +227,7 @@ class BindingsGenerator {
 		bool is_enum = false;
 		bool is_object_type = false;
 		bool is_singleton = false;
+		bool is_singleton_instance = false;
 		bool is_ref_counted = false;
 
 		/**
@@ -756,6 +757,7 @@ class BindingsGenerator {
 	Error _populate_method_icalls_table(const TypeInterface &p_itype);
 
 	const TypeInterface *_get_type_or_null(const TypeReference &p_typeref);
+	const TypeInterface *_get_type_or_singleton_or_null(const TypeReference &p_typeref);
 
 	const String _get_generic_type_parameters(const TypeInterface &p_itype, const List<TypeReference> &p_generic_type_parameters);
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -276,8 +276,13 @@ namespace Godot.Bridge
 
             if (wrapperType != null && IsStatic(wrapperType))
             {
-                // A static class means this is a Godot singleton class. If an instance is needed we use GodotObject.
-                return typeof(GodotObject);
+                // A static class means this is a Godot singleton class. Try to get the Instance proxy type.
+                wrapperType = TypeGetProxyClass($"{nativeTypeNameStr}Instance");
+                if (wrapperType == null)
+                {
+                    // Otherwise, fallback to GodotObject.
+                    return typeof(GodotObject);
+                }
             }
 
             return wrapperType;


### PR DESCRIPTION
Singleton classes in C# are currently exposed as static classes. In some cases these classes are inherited (e.g.: `PhysicsServer2DExtension` derives from the singleton class `PhysicsServer2D`).

We currently ignore these classes and don't generate them, because C# doesn't allow inheriting static classes. In order to fix this, with this PR C# now generates additional _Instance_ classes for every singleton. E.g.:

```csharp
// Good old static singleton class. Still generated.
public static class PhysicsServer2D { ... }

// New singleton instance class.
public class PhysicsServer2DInstance { ... }

// Now we can generate PhysicsServer2DExtension, deriving from the instance class.
public class PhysicsServer2DExtension : PhysicsServer2DInstance { ... }
```

- Constants and enums remain in the static singleton class (e.g.: `Input.MouseModeEnum`).
- Paves the way to eventually remove the static singleton classes[^1].
	- Previous attempt: https://github.com/godotengine/godot/pull/59208
- Considerably simplifies the implementation of https://github.com/godotengine/godot/pull/73730 for the singleton classes, since it can reuse the existing system used by instance classes to raise the events.

[^1]: This would break compatibility and won't happen in 4.x, but in 5.0 we could remove the static classes, rename the instance classes to remove the _Instance_ suffix and create a `Singletons` static class that can be used with `global using`. Similar to how singletons are exposed in GDScript using `@GlobalScope`. See https://github.com/godotengine/godot/pull/59208#issuecomment-1069583895.
