### PR TITLE
C#: Improve binding generator checks/passes

### DIFF
--- a/modules/mono/editor/bindings_generator.h
+++ b/modules/mono/editor/bindings_generator.h
@@ -60,6 +60,7 @@ class BindingsGenerator {
 
 	struct EnumInterface {
 		StringName cname;
+		String proxy_name;
 		List<ConstantInterface> constants;
 		bool is_flags = false;
 
@@ -69,8 +70,10 @@ class BindingsGenerator {
 
 		EnumInterface() {}
 
-		EnumInterface(const StringName &p_cname) {
+		EnumInterface(const StringName &p_cname, const String &p_proxy_name, bool p_is_flags) {
 			cname = p_cname;
+			proxy_name = p_proxy_name;
+			is_flags = p_is_flags;
 		}
 	};
 
@@ -164,6 +167,11 @@ class BindingsGenerator {
 		 * Methods that are not meant to be exposed are those that begin with underscore and are not virtual.
 		 */
 		bool is_internal = false;
+
+		/**
+		 * Determines if the method hides a System.Object name & requires the "new" keyword.
+		 */
+		bool hides_object = false;
 
 		List<ArgumentInterface> arguments;
 
@@ -740,7 +748,7 @@ class BindingsGenerator {
 		return p_type->name;
 	}
 
-	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype);
+	String bbcode_to_xml(const String &p_bbcode, const TypeInterface *p_itype, bool p_is_signal = false);
 
 	void _append_xml_method(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
 	void _append_xml_member(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts);
@@ -785,6 +793,7 @@ class BindingsGenerator {
 	Error _save_file(const String &p_path, const StringBuilder &p_content);
 
 	void _log(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
+	void _log_warn(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
 
 	void _initialize();
 


### PR DESCRIPTION
This is in a similar vein to my other PR, #79351, but it's more involved as it directly changes codeblocks within `bindings_generator.cpp` so it warrants seperation imo. The main changes are
* ~~Enum types will now properly utilize pascal case when referenced in the documentation~~
  * Migrated to #80628
* ~~`paramref` now properly tagged in documentation, unless they're part of a signal~~
  * Migrated to #80630
* Implemented basic docstrings for public auto-generated methods/values
* ~~Fixed delegate docstring logic so it doesn't cause double-summaries~~
  * Migrated to #80631
* ~~Generated methods now include their argument types, preventing ambiguous references with `Compat.cs`~~
  * Migrated to #80629
* ~~Fixed core documentation attempting to reference editor api~~
  * Migrated to #80632
* Properly append "new" to methods hiding inherited names
* Implement warning logs