### PR TITLE
[MP] Use `get/set_indexed` in MultiplayerSynchronizer

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -157,7 +157,7 @@ Error MultiplayerSynchronizer::get_state(const List<NodePath> &p_properties, Obj
 		bool valid = false;
 		const Object *obj = _get_prop_target(p_obj, prop);
 		ERR_FAIL_COND_V(!obj, FAILED);
-		r_variant.write[i] = obj->get(prop.get_concatenated_subnames(), &valid);
+		r_variant.write[i] = obj->get_indexed(prop.get_subnames(), &valid);
 		r_variant_ptrs.write[i] = &r_variant[i];
 		ERR_FAIL_COND_V_MSG(!valid, ERR_INVALID_DATA, vformat("Property '%s' not found.", prop));
 		i++;
@@ -171,7 +171,7 @@ Error MultiplayerSynchronizer::set_state(const List<NodePath> &p_properties, Obj
 	for (const NodePath &prop : p_properties) {
 		Object *obj = _get_prop_target(p_obj, prop);
 		ERR_FAIL_COND_V(!obj, FAILED);
-		obj->set(prop.get_concatenated_subnames(), p_state[i]);
+		obj->set_indexed(prop.get_subnames(), p_state[i]);
 		i += 1;
 	}
 	return OK;


### PR DESCRIPTION
Allows synchronizing (sub-)resource properties, transform components, etc. by using subnames.

As an example, `.:transform.x` will only synchronize the `x` component of the root transform instead of the whole transform.

This can also be used to synchronize a resource own properties, as long as they are synchronizable (i.e. the property itself is not an Object, RID, or Callable).