### PR TITLE
Allow multiple `SubViewports` within a `Window` to have a focused `Control`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2555,22 +2555,31 @@ Window *Viewport::get_base_window() const {
 	return w;
 }
 
-void Viewport::_gui_remove_focus_for_window(Node *p_window) {
-	if (get_base_window() == p_window) {
-		gui_release_focus();
-	}
-}
-
 bool Viewport::_gui_control_has_focus(const Control *p_control) {
 	return gui.key_focus == p_control;
 }
 
 void Viewport::_gui_control_grab_focus(Control *p_control) {
-	if (gui.key_focus && gui.key_focus == p_control) {
+	// Release previous focus.
+	if (gui.key_focus && gui.key_focus != p_control) {
+		gui_release_focus();
+	}
+
+	// Ensure chain of SubViewportContainer focus in parent Viewport. Needs to happen, even if control has focus in this Viewport.
+	Viewport *vp = this;
+	if (Object::cast_to<SubViewport>(vp)) {
+		SubViewportContainer *p = Object::cast_to<SubViewportContainer>(get_parent());
+		if (p) {
+			p->grab_focus();
+		}
+	}
+
+	if (gui.key_focus == p_control) {
 		// No need for change.
 		return;
 	}
-	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", (Node *)get_base_window());
+
+	// Perform necessary adjustments for focuschange.
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		emit_signal(SNAME("gui_focus_changed"), p_control);
@@ -4624,8 +4633,6 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
 	ClassDB::bind_method(D_METHOD("is_input_disabled"), &Viewport::is_input_disabled);
-
-	ClassDB::bind_method(D_METHOD("_gui_remove_focus_for_window"), &Viewport::_gui_remove_focus_for_window);
 
 	ClassDB::bind_method(D_METHOD("set_positional_shadow_atlas_size", "size"), &Viewport::set_positional_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("get_positional_shadow_atlas_size"), &Viewport::get_positional_shadow_atlas_size);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -437,7 +437,6 @@ private:
 	void _gui_set_drag_preview(Control *p_base, Control *p_control);
 	Control *_gui_get_drag_preview();
 
-	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_unfocus_control(Control *p_control);
 	bool _gui_control_has_focus(const Control *p_control);
 	void _gui_control_grab_focus(Control *p_control);


### PR DESCRIPTION
This PR lifts the restriction, that only a single `SubViewport` within a `Window` can have a focused `Control`-node (focus-stealing via `Viewport::_gui_remove_focus_for_window`).
Now every `Viewport` tracks its own focused `Control`, allowing multiple focused `Controls` within a single `Window`.

This change makes it necessary to introduce some kind of InputEvent-routing, to ensure, that the event reaches the correct focused Control first. This is done in the following way:
Whenever a `Control` receives focus, automatically all containing `SubViewportContainer`-Nodes also receive focus.
With the priorized InputEvent-propagation from #79248, this ensures, that the focused Control receives the InputEvent first.

- implements parts of https://github.com/godotengine/godot-proposals/issues/385
- implements parts of https://github.com/godotengine/godot-proposals/issues/4295
- alternative to #62421
- superseded by alternative #89772

MRP to showcase the functionality: [FocusGroupTestSVC.zip](https://github.com/godotengine/godot/files/12052882/FocusGroupTestSVC.zip) (it achieves the same as the demo-project in https://github.com/godotengine/godot/pull/62421#issuecomment-1611108452)

Behavior-change: This PR changes a core-functionality (method for focusing Control-nodes)
Since there are so many different use-cases, unfortunately i cannot rule out the possibility of regressions.

Updated 2023-08-04: Adhere to `DEV_ASSERT` conventions and remove `DEV_ASSERT`. Added Code-comments
Updated 2023-08-22: Fix merge conflict
Updated 2024-01-19: Fix merge conflict