### PR TITLE
Convert shader compilation and occlusion buffer to use parallel `for_range()`

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -50,22 +50,6 @@ public:
 	private:
 		Size2i tile_grid_size;
 
-		struct CameraRayThreadData {
-			int thread_count;
-			float z_near;
-			float z_far;
-			Vector3 camera_dir;
-			Vector3 camera_pos;
-			Vector3 pixel_corner;
-			Vector3 pixel_u_interp;
-			Vector3 pixel_v_interp;
-			bool camera_orthogonal;
-			Size2i buffer_size;
-		};
-
-		void _camera_rays_threaded(uint32_t p_thread, const CameraRayThreadData *p_data);
-		void _generate_camera_rays(const CameraRayThreadData *p_data, int p_from, int p_to);
-
 	public:
 		unsigned int camera_rays_tile_count = 0;
 		uint8_t *camera_rays_unaligned_buffer = nullptr;
@@ -116,11 +100,6 @@ private:
 	};
 
 	struct Scenario {
-		struct RaycastThreadData {
-			CameraRayTile *rays = nullptr;
-			const uint32_t *masks;
-		};
-
 		Thread *commit_thread = nullptr;
 		bool commit_done = true;
 		bool dirty = false;
@@ -139,7 +118,6 @@ private:
 		static void _commit_scene(void *p_ud);
 		bool update();
 
-		void _raycast(uint32_t p_thread, const RaycastThreadData *p_raycast_data) const;
 		void raycast(CameraRayTile *r_rays, const uint32_t *p_valid_masks, uint32_t p_tile_count) const;
 	};
 

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -480,16 +480,9 @@ void ShaderRD::_compile_version(Version *p_version) {
 		}
 	}
 
-#if 1
-
-	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &ShaderRD::_compile_variant, p_version, variant_defines.size(), -1, true, SNAME("ShaderCompilation"));
-	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
-
-#else
-	for (int i = 0; i < variant_defines.size(); i++) {
+	for_range(0, variant_defines.size(), true, SNAME("ShaderCompilation"), [&](const int i) {
 		_compile_variant(i, p_version);
-	}
-#endif
+	});
 
 	bool all_valid = true;
 	for (int i = 0; i < variant_defines.size(); i++) {


### PR DESCRIPTION
Simplifies threading compared to direct usage of `WorkerThreadPool`, since there is no longer a need for intermediate functions or structs.

Some instances of `WorkerThreadPool` have been omitted from this PR to avoid conflicting with #72687

`RaycastOcclusionCull::RaycastHZBuffer::update_camera_rays()` may experience performance regressions until #72716 is merged.

This PR passes the regression test here: https://github.com/godotengine/godot-benchmarks/issues/34
This PR has not been tested on https://github.com/Calinou/godot-rendering-tests