### PR TITLE
Set default `cell_size` on new TileMap Layer navigation layer maps

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -617,6 +617,8 @@ void TileMapLayer::_navigation_update() {
 			uses_world_navigation_map = true;
 		} else {
 			RID new_layer_map = NavigationServer2D::get_singleton()->map_create();
+			// Set the default NavigationPolygon cell_size on the new map as a mismatch causes an error.
+			NavigationServer2D::get_singleton()->map_set_cell_size(new_layer_map, 1.0);
 			NavigationServer2D::get_singleton()->map_set_active(new_layer_map, true);
 			navigation_map = new_layer_map;
 			uses_world_navigation_map = false;


### PR DESCRIPTION
Sets default cell_size on new TileMap Layer navigation layer maps

Related issue https://github.com/godotengine/godot/issues/79474.

This was also an issue in 4.0 but that version had no error that made users aware of it.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
