### PR TITLE
Convert simple uses of `WorkerThreadPool` to parallel `for_range()`

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -204,6 +204,10 @@ public:
 
 template <typename F>
 static _FORCE_INLINE_ void for_range(int i_begin, int i_end, bool parallel, String name, F f) {
+	if (i_begin >= i_end) {
+		return;
+	}
+
 	if (!parallel) {
 		for (int i = i_begin; i < i_end; i++) {
 			f(i);

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -207,9 +207,6 @@ public:
 private:
 	void compute_single_step(uint32_t index, NavAgent **agent);
 
-	void compute_single_avoidance_step_2d(uint32_t index, NavAgent **agent);
-	void compute_single_avoidance_step_3d(uint32_t index, NavAgent **agent);
-
 	void clip_path(const LocalVector<gd::NavigationPoly> &p_navigation_polys, Vector<Vector3> &path, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly, Vector<int32_t> *r_path_types, TypedArray<RID> *r_path_rids, Vector<int64_t> *r_path_owners) const;
 	void _update_rvo_simulation();
 	void _update_rvo_obstacles_tree_2d();

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -352,7 +352,6 @@ class TextServerAdvanced : public TextServerExtension {
 	_FORCE_INLINE_ bool _ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
 	_FORCE_INLINE_ bool _ensure_cache_for_size(FontAdvanced *p_font_data, const Vector2i &p_size) const;
 	_FORCE_INLINE_ void _font_clear_cache(FontAdvanced *p_font_data);
-	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
 	_FORCE_INLINE_ Vector2i _get_size(const FontAdvanced *p_font_data, int p_size) const {
 		if (p_font_data->msdf) {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -321,13 +321,6 @@ public:
 	}
 };
 
-struct MSDFThreadData {
-	msdfgen::Bitmap<float, 4> *output;
-	msdfgen::Shape *shape;
-	msdfgen::Projection *projection;
-	DistancePixelConversion *distancePixelConversion;
-};
-
 static msdfgen::Point2 ft_point2(const FT_Vector &vector) {
 	return msdfgen::Point2(vector.x / 60.0f, vector.y / 60.0f);
 }
@@ -363,19 +356,6 @@ static int ft_cubic_to(const FT_Vector *control1, const FT_Vector *control2, con
 	context->contour->addEdge(new msdfgen::CubicSegment(context->position, ft_point2(*control1), ft_point2(*control2), ft_point2(*to)));
 	context->position = ft_point2(*to);
 	return 0;
-}
-
-void TextServerFallback::_generateMTSDF_threaded(void *p_td, uint32_t p_y) {
-	MSDFThreadData *td = static_cast<MSDFThreadData *>(p_td);
-
-	msdfgen::ShapeDistanceFinder<msdfgen::OverlappingContourCombiner<msdfgen::MultiAndTrueDistanceSelector>> distanceFinder(*td->shape);
-	int row = td->shape->inverseYAxis ? td->output->height() - p_y - 1 : p_y;
-	for (int col = 0; col < td->output->width(); ++col) {
-		int x = (p_y % 2) ? td->output->width() - col - 1 : col;
-		msdfgen::Point2 p = td->projection->unproject(msdfgen::Point2(x + .5, p_y + .5));
-		msdfgen::MultiAndTrueDistance distance = distanceFinder.distance(p);
-		td->distancePixelConversion->operator()(td->output->operator()(x, row), distance);
-	}
 }
 
 _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *outline, const Vector2 &advance) const {
@@ -436,14 +416,16 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 		msdfgen::Projection projection(msdfgen::Vector2(1.0, 1.0), msdfgen::Vector2(-bounds.l, -bounds.b));
 		msdfgen::MSDFGeneratorConfig config(true, msdfgen::ErrorCorrectionConfig());
 
-		MSDFThreadData td;
-		td.output = &image;
-		td.shape = &shape;
-		td.projection = &projection;
-		td.distancePixelConversion = &distancePixelConversion;
-
-		WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_native_group_task(&TextServerFallback::_generateMTSDF_threaded, &td, h, -1, true, String("TextServerFBRenderMSDF"));
-		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+		for_range(0, h, true, SNAME("TextServerFBRenderMSDF"), [&](const int p_y) {
+			msdfgen::ShapeDistanceFinder<msdfgen::OverlappingContourCombiner<msdfgen::MultiAndTrueDistanceSelector>> distanceFinder(shape);
+			int row = shape.inverseYAxis ? image.height() - p_y - 1 : p_y;
+			for (int col = 0; col < image.width(); ++col) {
+				int x = (p_y % 2) ? image.width() - col - 1 : col;
+				msdfgen::Point2 p = projection.unproject(msdfgen::Point2(x + .5, p_y + .5));
+				msdfgen::MultiAndTrueDistance distance = distanceFinder.distance(p);
+				distancePixelConversion.operator()(image.operator()(x, row), distance);
+			}
+		});
 
 		msdfgen::msdfErrorCorrection(image, shape, projection, p_pixel_range, config);
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -302,7 +302,6 @@ class TextServerFallback : public TextServerExtension {
 	_FORCE_INLINE_ bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph) const;
 	_FORCE_INLINE_ bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size) const;
 	_FORCE_INLINE_ void _font_clear_cache(FontFallback *p_font_data);
-	static void _generateMTSDF_threaded(void *p_td, uint32_t p_y);
 
 	_FORCE_INLINE_ Vector2i _get_size(const FontFallback *p_font_data, int p_size) const {
 		if (p_font_data->msdf) {

--- a/servers/physics_2d/godot_step_2d.h
+++ b/servers/physics_2d/godot_step_2d.h
@@ -46,9 +46,8 @@ class GodotStep2D {
 	LocalVector<GodotConstraint2D *> all_constraints;
 
 	void _populate_island(GodotBody2D *p_body, LocalVector<GodotBody2D *> &p_body_island, LocalVector<GodotConstraint2D *> &p_constraint_island);
-	void _setup_constraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
 	void _pre_solve_island(LocalVector<GodotConstraint2D *> &p_constraint_island) const;
-	void _solve_island(uint32_t p_island_index, void *p_userdata = nullptr) const;
+	void _solve_island(uint32_t p_island_index) const;
 	void _check_suspend(LocalVector<GodotBody2D *> &p_body_island) const;
 
 public:

--- a/servers/physics_3d/godot_step_3d.h
+++ b/servers/physics_3d/godot_step_3d.h
@@ -47,9 +47,8 @@ class GodotStep3D {
 
 	void _populate_island(GodotBody3D *p_body, LocalVector<GodotBody3D *> &p_body_island, LocalVector<GodotConstraint3D *> &p_constraint_island);
 	void _populate_island_soft_body(GodotSoftBody3D *p_soft_body, LocalVector<GodotBody3D *> &p_body_island, LocalVector<GodotConstraint3D *> &p_constraint_island);
-	void _setup_constraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
 	void _pre_solve_island(LocalVector<GodotConstraint3D *> &p_constraint_island) const;
-	void _solve_island(uint32_t p_island_index, void *p_userdata = nullptr);
+	void _solve_island(uint32_t p_island_index);
 	void _check_suspend(const LocalVector<GodotBody3D *> &p_body_island) const;
 
 public:

--- a/tests/core/threads/test_worker_thread_pool.h
+++ b/tests/core/threads/test_worker_thread_pool.h
@@ -109,7 +109,7 @@ TEST_CASE("[WorkerThreadPool] Process elements using group tasks") {
 TEST_CASE("[WorkerThreadPool] Parallel foreach") {
 	const int count_max = 256;
 
-	for (int midpoint = 0; midpoint < count_max; midpoint++) {
+	for (int midpoint = 0; midpoint <= count_max; midpoint++) {
 		LocalVector<int> c;
 		c.resize(count_max);
 


### PR DESCRIPTION
Simplifies threading compared to direct usage of `WorkerThreadPool`, since there is no longer a need for intermediate functions or structs.

`image_compress_cvtt()` may experience performance regressions until #72716 is merged.

This has not been tested. Tread with caution.