### PR TITLE
Prevent GDExtensions from trying to remove editor plugins at shutdown

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8119,6 +8119,9 @@ EditorNode::~EditorNode() {
 	memdelete(progress_hb);
 
 	EditorSettings::destroy();
+
+	GDExtensionEditorPlugins::editor_node_add_plugin = nullptr;
+	GDExtensionEditorPlugins::editor_node_remove_plugin = nullptr;
 }
 
 /*


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1178

