### PR TITLE
Make `OptionButton` resize when disabling "Fit to Longest Item"

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -445,13 +445,11 @@ void OptionButton::_select_int(int p_which) {
 void OptionButton::_refresh_size_cache() {
 	cache_refresh_pending = false;
 
-	if (!fit_to_longest_item) {
-		return;
-	}
-
-	_cached_size = Vector2();
-	for (int i = 0; i < get_item_count(); i++) {
-		_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(popup->get_item_xl_text(i), get_item_icon(i)));
+	if (fit_to_longest_item) {
+		_cached_size = Vector2();
+		for (int i = 0; i < get_item_count(); i++) {
+			_cached_size = _cached_size.max(get_minimum_size_for_text_and_icon(popup->get_item_xl_text(i), get_item_icon(i)));
+		}
 	}
 	update_minimum_size();
 }


### PR DESCRIPTION
Minimum size update was skipped when setting "Fit to Longest Item" to false.