### PR TITLE
Add a `fill_region` method to the `AStarGrid2D`

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -194,6 +194,38 @@ real_t AStarGrid2D::get_point_weight_scale(const Vector2i &p_id) const {
 	return GET_POINT_UNCHECKED(p_id).weight_scale;
 }
 
+void AStarGrid2D::fill_solid_region(const Rect2i &p_region, bool p_solid) {
+	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
+
+	Rect2i safe_region = p_region.intersection(region);
+	int from_x = safe_region.get_position().x;
+	int from_y = safe_region.get_position().y;
+	int end_x = safe_region.get_end().x;
+	int end_y = safe_region.get_end().y;
+
+	for (int x = from_x; x < end_x; x++) {
+		for (int y = from_y; y < end_y; y++) {
+			GET_POINT_UNCHECKED(Vector2i(x, y)).solid = p_solid;
+		}
+	}
+}
+
+void AStarGrid2D::fill_weight_scale_region(const Rect2i &p_region, real_t p_weight_scale) {
+	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
+
+	Rect2i safe_region = p_region.intersection(region);
+	int from_x = safe_region.get_position().x;
+	int from_y = safe_region.get_position().y;
+	int end_x = safe_region.get_end().x;
+	int end_y = safe_region.get_end().y;
+	for (int x = from_x; x < end_x; x++) {
+		for (int y = from_y; y < end_y; y++) {
+			GET_POINT_UNCHECKED(Vector2i(x, y)).weight_scale = p_weight_scale;
+		}
+	}
+}
+
 AStarGrid2D::Point *AStarGrid2D::_jump(Point *p_from, Point *p_to) {
 	if (!p_to || p_to->solid) {
 		return nullptr;
@@ -606,6 +638,8 @@ void AStarGrid2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_point_solid", "id"), &AStarGrid2D::is_point_solid);
 	ClassDB::bind_method(D_METHOD("set_point_weight_scale", "id", "weight_scale"), &AStarGrid2D::set_point_weight_scale);
 	ClassDB::bind_method(D_METHOD("get_point_weight_scale", "id"), &AStarGrid2D::get_point_weight_scale);
+	ClassDB::bind_method(D_METHOD("fill_solid_region", "region", "solid"), &AStarGrid2D::fill_solid_region, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("fill_weight_scale_region", "region", "weight_scale"), &AStarGrid2D::fill_weight_scale_region);
 	ClassDB::bind_method(D_METHOD("clear"), &AStarGrid2D::clear);
 
 	ClassDB::bind_method(D_METHOD("get_point_position", "id"), &AStarGrid2D::get_point_position);

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -177,6 +177,9 @@ public:
 	void set_point_weight_scale(const Vector2i &p_id, real_t p_weight_scale);
 	real_t get_point_weight_scale(const Vector2i &p_id) const;
 
+	void fill_solid_region(const Rect2i &p_region, bool p_solid = true);
+	void fill_weight_scale_region(const Rect2i &p_region, real_t p_weight_scale);
+
 	void clear();
 
 	Vector2 get_point_position(const Vector2i &p_id) const;

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -53,6 +53,24 @@
 				Clears the grid and sets the [member region] to [code]Rect2i(0, 0, 0, 0)[/code].
 			</description>
 		</method>
+		<method name="fill_solid_region">
+			<return type="void" />
+			<param index="0" name="region" type="Rect2i" />
+			<param index="1" name="solid" type="bool" default="true" />
+			<description>
+				Fills the given [param region] on the grid with the specified value for the solid flag.
+				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
+			</description>
+		</method>
+		<method name="fill_weight_scale_region">
+			<return type="void" />
+			<param index="0" name="region" type="Rect2i" />
+			<param index="1" name="weight_scale" type="float" />
+			<description>
+				Fills the given [param region] on the grid with the specified value for the weight scale.
+				[b]Note:[/b] Calling [method update] is not needed after the call of this function.
+			</description>
+		</method>
 		<method name="get_id_path">
 			<return type="Vector2i[]" />
 			<param index="0" name="from_id" type="Vector2i" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7276 ~by adding a property `default_solid_enabled` to the `AStarGrid2D` - after the user set it to <b>true</b>, the next call of `update` method will make all points solid.~ Adds the `fill_region` method to assign the solid flag and weight_scale to the specified region on the gird.
