### PR TITLE
[3.x] MultiRect - Fix flushing in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1653,6 +1653,11 @@ void TextEdit::_notification(int p_what) {
 				line_drawing_cache[line] = cache_entry;
 			}
 
+			// Flush out any text in the drawer BEFORE
+			// drawing the completion box, as we want the completion
+			// box to overwrite the underlying text.
+			drawer.flush();
+
 			bool completion_below = false;
 			if (completion_active && is_cursor_visible && completion_options.size() > 0) {
 				// Completion panel

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -542,15 +542,18 @@ FontDrawer::FontDrawer(const Ref<Font> &p_font, const Color &p_outline_color) :
 		font(p_font),
 		outline_color(p_outline_color) {
 	has_outline = p_font->has_outline();
-	multirect.begin();
 }
 
-FontDrawer::~FontDrawer() {
+void FontDrawer::flush() {
 	for (int i = 0; i < pending_draws.size(); ++i) {
 		const PendingDraw &draw = pending_draws[i];
 		font->draw_char_ex(draw.canvas_item, draw.pos, draw.chr, draw.next, draw.modulate, false, &multirect);
 	}
-	multirect.end();
+	multirect.flush();
+}
+
+FontDrawer::~FontDrawer() {
+	flush();
 }
 
 void BitmapFont::set_fallback(const Ref<BitmapFont> &p_fallback) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -110,6 +110,7 @@ public:
 		return font->draw_char_ex(p_canvas_item, p_pos, p_char, p_next, has_outline ? outline_color : p_modulate, has_outline, &multirect);
 	}
 	MultiRect &get_multirect() { return multirect; }
+	void flush();
 
 	~FontDrawer();
 };

--- a/servers/visual/visual_server_canvas_helper.h
+++ b/servers/visual/visual_server_canvas_helper.h
@@ -97,7 +97,6 @@ private:
 
 public:
 	// Simple API
-	void begin();
 	void add_rect(RID p_canvas_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, RID p_normal_map = RID(), bool p_clip_uv = false);
 
 	// Efficient API
@@ -105,10 +104,12 @@ public:
 	bool add(const Rect2 &p_rect, const Rect2 &p_src_rect, bool p_commit_on_flip_change = true);
 	bool is_empty() const { return rects.is_empty(); }
 	bool is_full() const { return rects.is_full(); }
-	void end();
 
-	MultiRect();
-	~MultiRect();
+	// Always called in destructor, but can be used explicitly
+	// for multiple draws, or to time the flush.
+	void flush();
+
+	~MultiRect() { flush(); }
 };
 
 #endif // VISUAL_SERVER_CANVAS_HELPER_H


### PR DESCRIPTION
The FontDrawer used in TextEdit was previously not being flushed before drawing auto-completion boxes. This was causing rendering artifacts. This PR also increases the backward compatibility of the MultiRect OFF mode, by forcing a flush after each character.

Fixes #77582

## Notes
* Fixes the issue by flushing _before_ the "drawer" object scope is destroyed, which writes the text before the completion box is drawn.
* Simplifies the `MultiRect` API a little to use `flush()` instead of `begin() / end()`.
* Thanks to the flush per character, the legacy mode is now truer to previous behaviour.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
