### PR TITLE
C#: Suppress NU5128 warning

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- Do not include the generator as a lib dependency -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />


### PR DESCRIPTION
Suppress dependencies of SourceGenerators package to fix NU5128.

For more context see https://github.com/godotengine/godot/pull/65532#discussion_r967467489. As per the [NU5128](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) documentation:

> If your package does not contain any `lib/` or `ref/` files and is not a meta-package, it likely does not have any dependencies that the package consumer needs. If you are packing with NuGet's MSBuild Pack target, you can set `<SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>` in any `PropertyGroup` in your project file. If you are using a custom `nuspec` file, remove the `<dependencies>` element.

This seems to be a well-known false positive in analyzer projects:
- https://github.com/NuGet/Home/issues/11354.