### PR TITLE
Add option to expand tile polygon editors

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -685,6 +685,14 @@ void GenericTilePolygonEditor::_store_snap_options() {
 	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "tile_snap_subdiv", snap_subdivision->get_value());
 }
 
+void GenericTilePolygonEditor::_toggle_expand(bool p_expand) {
+	if (p_expand) {
+		TileSetEditor::get_singleton()->add_expanded_editor(this);
+	} else {
+		TileSetEditor::get_singleton()->remove_expanded_editor();
+	}
+}
+
 void GenericTilePolygonEditor::set_use_undo_redo(bool p_use_undo_redo) {
 	use_undo_redo = p_use_undo_redo;
 }
@@ -793,8 +801,13 @@ void GenericTilePolygonEditor::set_multiple_polygon_mode(bool p_multiple_polygon
 
 void GenericTilePolygonEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
+			if (!get_meta("reparented", false)) {
+				button_expand->set_pressed_no_signal(false);
+			}
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
+			button_expand->set_icon(get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
 			button_create->set_icon(get_theme_icon(SNAME("CurveCreate"), SNAME("EditorIcons")));
 			button_edit->set_icon(get_theme_icon(SNAME("CurveEdit"), SNAME("EditorIcons")));
 			button_delete->set_icon(get_theme_icon(SNAME("CurveDelete"), SNAME("EditorIcons")));
@@ -830,6 +843,16 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	add_child(toolbar);
 
 	tools_button_group.instantiate();
+
+	button_expand = memnew(Button);
+	button_expand->set_flat(true);
+	button_expand->set_toggle_mode(true);
+	button_expand->set_pressed(false);
+	button_expand->set_tooltip_text(TTR("Expand editor"));
+	button_expand->connect("toggled", callable_mp(this, &GenericTilePolygonEditor::_toggle_expand));
+	toolbar->add_child(button_expand);
+
+	toolbar->add_child(memnew(VSeparator));
 
 	button_create = memnew(Button);
 	button_create->set_flat(true);
@@ -885,7 +908,7 @@ GenericTilePolygonEditor::GenericTilePolygonEditor() {
 	snap_subdivision->set_max(99);
 
 	Control *root = memnew(Control);
-	root->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	root->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	root->set_custom_minimum_size(Size2(0, 200 * EDSCALE));
 	root->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 	add_child(root);

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -36,10 +36,11 @@
 #include "editor/editor_properties.h"
 #include "scene/2d/tile_map.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/panel_container.h"
 
+class Label;
 class MenuButton;
 class SpinBox;
-class Label;
 class EditorUndoRedoManager;
 
 class TileDataEditor : public VBoxContainer {
@@ -117,6 +118,7 @@ private:
 
 	HBoxContainer *toolbar = nullptr;
 	Ref<ButtonGroup> tools_button_group;
+	Button *button_expand = nullptr;
 	Button *button_create = nullptr;
 	Button *button_edit = nullptr;
 	Button *button_delete = nullptr;
@@ -165,6 +167,7 @@ private:
 	void _base_control_gui_input(Ref<InputEvent> p_event);
 	void _set_snap_option(int p_index);
 	void _store_snap_options();
+	void _toggle_expand(bool p_expand);
 
 	void _snap_to_tile_shape(Point2 &r_point, float &r_current_snapped_dist, float p_snap_dist);
 	void _snap_point(Point2 &r_point);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/plugins/tiles/tile_set_editor.h"
 #include "editor/progress_dialog.h"
 
 #include "scene/gui/box_container.h"
@@ -2438,6 +2439,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	set_shortcut_context(this);
 	set_process_shortcut_input(true);
 	set_process_internal(true);
+	TileSetEditor::get_singleton()->register_split(this);
 
 	// Middle panel.
 	VBoxContainer *middle_vbox_container = memnew(VBoxContainer);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -370,13 +370,13 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 
 void TileSetEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			sources_delete_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			sources_add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			source_sort_button->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 			sources_advanced_menu_button->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 			missing_texture_texture = get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
+			expanded_area->add_theme_style_override("panel", get_theme_stylebox("panel", "Tree"));
 			_update_sources_list();
 		} break;
 
@@ -399,6 +399,12 @@ void TileSetEditor::_notification(int p_what) {
 				source_sort_button->set_disabled(read_only);
 
 				tile_set_changed_needs_update = false;
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible_in_tree()) {
+				remove_expanded_editor();
 			}
 		} break;
 	}
@@ -749,10 +755,69 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 	}
 }
 
+void TileSetEditor::add_expanded_editor(Control *p_editor) {
+	expanded_editor = p_editor;
+	expanded_editor_parent = p_editor->get_parent()->get_instance_id();
+
+	// Find the scrollable control this node belongs to.
+	Node *check_parent = expanded_editor->get_parent();
+	Control *parent_container = nullptr;
+	while (check_parent) {
+		parent_container = Object::cast_to<EditorInspector>(check_parent);
+		if (parent_container) {
+			break;
+		}
+		parent_container = Object::cast_to<ScrollContainer>(check_parent);
+		if (parent_container) {
+			break;
+		}
+		check_parent = check_parent->get_parent();
+	}
+	ERR_FAIL_NULL(parent_container);
+
+	expanded_editor->set_meta("reparented", true);
+	expanded_editor->reparent(expanded_area);
+	expanded_area->show();
+	expanded_area->set_size(Vector2(parent_container->get_global_rect().get_end().x - expanded_area->get_global_position().x, expanded_area->get_size().y));
+
+	for (SplitContainer *split : disable_on_expand) {
+		split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
+	}
+}
+
+void TileSetEditor::remove_expanded_editor() {
+	if (!expanded_editor) {
+		return;
+	}
+
+	Node *original_parent = Object::cast_to<Node>(ObjectDB::get_instance(expanded_editor_parent));
+	if (original_parent) {
+		expanded_editor->remove_meta("reparented");
+		expanded_editor->reparent(original_parent);
+	} else {
+		expanded_editor->queue_free();
+	}
+	expanded_editor = nullptr;
+	expanded_editor_parent = ObjectID();
+	expanded_area->hide();
+
+	for (SplitContainer *split : disable_on_expand) {
+		split->set_dragger_visibility(SplitContainer::DRAGGER_VISIBLE);
+	}
+}
+
+void TileSetEditor::register_split(SplitContainer *p_split) {
+	disable_on_expand.push_back(p_split);
+}
+
 TileSetEditor::TileSetEditor() {
 	singleton = this;
 
 	set_process_internal(true);
+
+	VBoxContainer *main_vb = memnew(VBoxContainer);
+	add_child(main_vb);
+	main_vb->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 
 	// TabBar.
 	tabs_bar = memnew(TabBar);
@@ -765,7 +830,7 @@ TileSetEditor::TileSetEditor() {
 	tile_set_toolbar = memnew(HBoxContainer);
 	tile_set_toolbar->set_h_size_flags(SIZE_EXPAND_FILL);
 	tile_set_toolbar->add_child(tabs_bar);
-	add_child(tile_set_toolbar);
+	main_vb->add_child(tile_set_toolbar);
 
 	//// Tiles ////
 	// Split container.
@@ -773,7 +838,7 @@ TileSetEditor::TileSetEditor() {
 	split_container->set_name(TTR("Tiles"));
 	split_container->set_h_size_flags(SIZE_EXPAND_FILL);
 	split_container->set_v_size_flags(SIZE_EXPAND_FILL);
-	add_child(split_container);
+	main_vb->add_child(split_container);
 
 	// Sources list.
 	VBoxContainer *split_container_left_side = memnew(VBoxContainer);
@@ -880,7 +945,7 @@ TileSetEditor::TileSetEditor() {
 	patterns_item_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 	patterns_item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	patterns_item_list->connect("gui_input", callable_mp(this, &TileSetEditor::_patterns_item_list_gui_input));
-	add_child(patterns_item_list);
+	main_vb->add_child(patterns_item_list);
 	patterns_item_list->hide();
 
 	patterns_help_label = memnew(Label);
@@ -888,6 +953,12 @@ TileSetEditor::TileSetEditor() {
 	patterns_help_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	patterns_help_label->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
 	patterns_item_list->add_child(patterns_help_label);
+
+	// Expanded editor
+	expanded_area = memnew(PanelContainer);
+	add_child(expanded_area);
+	expanded_area->set_anchors_and_offsets_preset(PRESET_LEFT_WIDE);
+	expanded_area->hide();
 
 	// Registers UndoRedo inspector callback.
 	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("TileSet"), callable_mp(this, &TileSetEditor::_move_tile_set_array_element));

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -32,7 +32,6 @@
 #define TILE_SET_EDITOR_H
 
 #include "atlas_merging_dialog.h"
-#include "scene/gui/box_container.h"
 #include "scene/gui/tab_bar.h"
 #include "scene/resources/tile_set.h"
 #include "tile_proxies_manager_dialog.h"
@@ -40,9 +39,11 @@
 #include "tile_set_scenes_collection_source_editor.h"
 
 class EditorFileDialog;
+class HBoxContainer;
+class SplitContainer;
 
-class TileSetEditor : public VBoxContainer {
-	GDCLASS(TileSetEditor, VBoxContainer);
+class TileSetEditor : public Control {
+	GDCLASS(TileSetEditor, Control);
 
 	static TileSetEditor *singleton;
 
@@ -95,6 +96,12 @@ private:
 	bool select_last_pattern = false;
 	void _update_patterns_list();
 
+	// Expanded editor.
+	PanelContainer *expanded_area = nullptr;
+	Control *expanded_editor = nullptr;
+	ObjectID expanded_editor_parent;
+	LocalVector<SplitContainer *> disable_on_expand;
+
 	void _tile_set_changed();
 	void _tab_changed(int p_tab_changed);
 
@@ -108,6 +115,10 @@ public:
 	_FORCE_INLINE_ static TileSetEditor *get_singleton() { return singleton; }
 
 	void edit(Ref<TileSet> p_tile_set);
+
+	void add_expanded_editor(Control *p_editor);
+	void remove_expanded_editor();
+	void register_split(SplitContainer *p_split);
 
 	TileSetEditor();
 };


### PR DESCRIPTION
This PR adds an expand button to tile polygon editor so you no longer need to draw shapes in a tiny area.

https://github.com/godotengine/godot/assets/2223172/cfd41bbc-b2ca-4bfb-8b4e-1a0a246ac09e

For simplicity, the split dragger is disabled while the editor is expanded (I had to use a few hacks to make it appear on that position).