### PR TITLE
Add an option to jitter BaseMaterial3D dithering pattern across frames

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -772,10 +772,10 @@
 			Smoothly fades the object out based on each pixel's distance from the camera using the alpha channel.
 		</constant>
 		<constant name="DISTANCE_FADE_PIXEL_DITHER" value="2" enum="DistanceFadeMode">
-			Smoothly fades the object out based on each pixel's distance from the camera using a dithering approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware, this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA].
+			Smoothly fades the object out based on each pixel's distance from the camera using a dithering approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware, this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA]. If [member ProjectSettings.rendering/anti_aliasing/quality/use_taa] is [code]true[/code] when the project starts, the dithering pattern is jittered every frame to improve quality.
 		</constant>
 		<constant name="DISTANCE_FADE_OBJECT_DITHER" value="3" enum="DistanceFadeMode">
-			Smoothly fades the object out based on the object's distance from the camera using a dithering approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware, this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA] and [constant DISTANCE_FADE_PIXEL_DITHER].
+			Smoothly fades the object out based on the object's distance from the camera using a dithering approach. Dithering discards pixels based on a set pattern to smoothly fade without enabling transparency. On certain hardware, this can be faster than [constant DISTANCE_FADE_PIXEL_ALPHA] and [constant DISTANCE_FADE_PIXEL_DITHER]. If [member ProjectSettings.rendering/anti_aliasing/quality/use_taa] is [code]true[/code] when the project starts, the dithering pattern is jittered every frame to improve quality.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2371,7 +2371,7 @@
 			[b]Note:[/b] This property is only read when the project starts. To set debanding at run-time, set [member Viewport.use_debanding] on the root [Viewport] instead.
 		</member>
 		<member name="rendering/anti_aliasing/quality/use_taa" type="bool" setter="" getter="" default="false">
-			Enables Temporal Anti-Aliasing for the default screen [Viewport]. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion. Enabling TAA can make the image blurrier, which is partially counteracted by automatically using a negative mipmap LOD bias (see [member rendering/textures/default_filters/texture_mipmap_bias]). Consider also enabling [member rendering/shading/base_material_3d/dithering_use_jitter] when TAA is enabled.
+			Enables Temporal Anti-Aliasing for the default screen [Viewport]. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion. Enabling TAA can make the image blurrier, which is partially counteracted by automatically using a negative mipmap LOD bias (see [member rendering/textures/default_filters/texture_mipmap_bias]). If TAA is enabled when the project starts, the dithering pattern for the [constant BaseMaterial3D.DISTANCE_FADE_PIXEL_DITHER] and [constant BaseMaterial3D.DISTANCE_FADE_OBJECT_DITHER] distance fade modes is jittered every frame to improve quality.
 			[b]Note:[/b] The implementation is not complete yet. Some visual instances such as particles and skinned meshes may show ghosting artifacts in motion.
 			[b]Note:[/b] TAA is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 		</member>
@@ -2814,13 +2814,6 @@
 		<member name="rendering/shader_compiler/shader_cache/strip_debug.release" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="rendering/shader_compiler/shader_cache/use_zstd_compression" type="bool" setter="" getter="" default="true">
-		</member>
-		<member name="rendering/shading/base_material_3d/dithering_use_jitter" type="int" setter="" getter="" default="0">
-			If set to [b]Auto[/b], jitters the [BaseMaterial3D]'s [constant BaseMaterial3D.DISTANCE_FADE_PIXEL_DITHER] and [constant BaseMaterial3D.DISTANCE_FADE_OBJECT_DITHER] transparency modes' pattern every frame if [member rendering/anti_aliasing/quality/use_taa] is [code]true[/code]. This improves dithering quality significantly by making the noisy pattern mostly invisible.
-			If set to [b]Always[/b], jitters the [BaseMaterial3D]'s dithered transparency modes' pattern every frame even if TAA is disabled. This improves [i]perceptual[/i] dither quality by letting the display's response time smooth out the different patterns together. The effect works best on high refresh rate monitors (&gt; 80 Hz) and at high framerates (&gt; 80 FPS). When TAA is disabled, given its reliance on monitor response times not being instant, the effect is not visible on screenshots. At lower framerates, dither jittering can still be useful to prevent the dither pattern from "following" the camera as it moves and rotates.
-			Enabling dither jittering doesn't have any performance cost.
-			[b]Note:[/b] The dither jittering pattern is only updated every time a frame is rendered. Since the editor only redraws when needed by default, the dither will not change in the editor unless the camera moves or rotates. This also applies when [member application/run/low_processor_mode] is [code]true[/code]. To preview dither jittering in the editor, enable [b]Update Continuously[/b] in the Editor Settings (then disable it once you don't need to preview the jittering anymore).
-			[b]Note:[/b] This property is only read when the project starts (including the status of [b]Auto[/b] with regards to TAA being enabled or not). There is currently no way to change this setting at run-time.
 		</member>
 		<member name="rendering/shading/overrides/force_lambert_over_burley" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses faster but lower-quality Lambert material lighting model instead of Burley.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2371,7 +2371,7 @@
 			[b]Note:[/b] This property is only read when the project starts. To set debanding at run-time, set [member Viewport.use_debanding] on the root [Viewport] instead.
 		</member>
 		<member name="rendering/anti_aliasing/quality/use_taa" type="bool" setter="" getter="" default="false">
-			Enables Temporal Anti-Aliasing for the default screen [Viewport]. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion. Enabling TAA can make the image blurrier, which is partially counteracted by automatically using a negative mipmap LOD bias (see [member rendering/textures/default_filters/texture_mipmap_bias]).
+			Enables Temporal Anti-Aliasing for the default screen [Viewport]. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion. Enabling TAA can make the image blurrier, which is partially counteracted by automatically using a negative mipmap LOD bias (see [member rendering/textures/default_filters/texture_mipmap_bias]). Consider also enabling [member rendering/shading/base_material_3d/dithering_use_jitter] when TAA is enabled.
 			[b]Note:[/b] The implementation is not complete yet. Some visual instances such as particles and skinned meshes may show ghosting artifacts in motion.
 			[b]Note:[/b] TAA is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 		</member>
@@ -2814,6 +2814,13 @@
 		<member name="rendering/shader_compiler/shader_cache/strip_debug.release" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="rendering/shader_compiler/shader_cache/use_zstd_compression" type="bool" setter="" getter="" default="true">
+		</member>
+		<member name="rendering/shading/base_material_3d/dithering_use_jitter" type="int" setter="" getter="" default="0">
+			If set to [b]Auto[/b], jitters the [BaseMaterial3D]'s [constant BaseMaterial3D.DISTANCE_FADE_PIXEL_DITHER] and [constant BaseMaterial3D.DISTANCE_FADE_OBJECT_DITHER] transparency modes' pattern every frame if [member rendering/anti_aliasing/quality/use_taa] is [code]true[/code]. This improves dithering quality significantly by making the noisy pattern mostly invisible.
+			If set to [b]Always[/b], jitters the [BaseMaterial3D]'s dithered transparency modes' pattern every frame even if TAA is disabled. This improves [i]perceptual[/i] dither quality by letting the display's response time smooth out the different patterns together. The effect works best on high refresh rate monitors (&gt; 80 Hz) and at high framerates (&gt; 80 FPS). When TAA is disabled, given its reliance on monitor response times not being instant, the effect is not visible on screenshots. At lower framerates, dither jittering can still be useful to prevent the dither pattern from "following" the camera as it moves and rotates.
+			Enabling dither jittering doesn't have any performance cost.
+			[b]Note:[/b] The dither jittering pattern is only updated every time a frame is rendered. Since the editor only redraws when needed by default, the dither will not change in the editor unless the camera moves or rotates. This also applies when [member application/run/low_processor_mode] is [code]true[/code]. To preview dither jittering in the editor, enable [b]Update Continuously[/b] in the Editor Settings (then disable it once you don't need to preview the jittering anymore).
+			[b]Note:[/b] This property is only read when the project starts (including the status of [b]Auto[/b] with regards to TAA being enabled or not). There is currently no way to change this setting at run-time.
 		</member>
 		<member name="rendering/shading/overrides/force_lambert_over_burley" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], uses faster but lower-quality Lambert material lighting model instead of Burley.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4293,6 +4293,15 @@
 		<constant name="MATERIAL_RENDER_PRIORITY_MAX" value="127">
 			The maximum renderpriority of all materials.
 		</constant>
+		<constant name="BASE_MATERIAL_3D_DITHERING_JITTER_AUTO" value="0" enum="BaseMaterial3DDitheringJitter">
+			Jitter the [BaseMaterial3D] dithered transparency modes' pattern if temporal antialiasing (TAA) is enabled.
+		</constant>
+		<constant name="BASE_MATERIAL_3D_DITHERING_JITTER_NEVER" value="1" enum="BaseMaterial3DDitheringJitter">
+			Never jitter the [BaseMaterial3D] dithered transparency modes' pattern, even if temporal antialiasing (TAA) is enabled.
+		</constant>
+		<constant name="BASE_MATERIAL_3D_DITHERING_JITTER_ALWAYS" value="2" enum="BaseMaterial3DDitheringJitter">
+			Always jitter the [BaseMaterial3D] dithered transparency modes' pattern, even if temporal antialiasing (TAA) is disabled.
+		</constant>
 		<constant name="ARRAY_VERTEX" value="0" enum="ArrayType">
 			Array is a vertex position array.
 		</constant>

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3568,7 +3568,6 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading.mobile", true);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley.mobile", true);
-	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/shading/base_material_3d/dithering_use_jitter", PROPERTY_HINT_ENUM, "Auto (Jitter when TAA Enabled),Never,Always"), 0);
 
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/enable", true);
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2308,6 +2308,10 @@ void RenderingServer::_bind_methods() {
 	BIND_CONSTANT(MATERIAL_RENDER_PRIORITY_MIN);
 	BIND_CONSTANT(MATERIAL_RENDER_PRIORITY_MAX);
 
+	BIND_ENUM_CONSTANT(BASE_MATERIAL_3D_DITHERING_JITTER_AUTO);
+	BIND_ENUM_CONSTANT(BASE_MATERIAL_3D_DITHERING_JITTER_NEVER);
+	BIND_ENUM_CONSTANT(BASE_MATERIAL_3D_DITHERING_JITTER_ALWAYS);
+
 	/* MESH API */
 
 	ClassDB::bind_method(D_METHOD("mesh_create_from_surfaces", "surfaces", "blend_shape_count"), &RenderingServer::_mesh_create_from_surfaces, DEFVAL(0));
@@ -3564,6 +3568,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading.mobile", true);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley.mobile", true);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/shading/base_material_3d/dithering_use_jitter", PROPERTY_HINT_ENUM, "Auto (Jitter when TAA Enabled),Never,Always"), 0);
 
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/enable", true);
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -231,6 +231,12 @@ public:
 		MATERIAL_RENDER_PRIORITY_MAX = 127,
 	};
 
+	enum BaseMaterial3DDitheringJitter {
+		BASE_MATERIAL_3D_DITHERING_JITTER_AUTO,
+		BASE_MATERIAL_3D_DITHERING_JITTER_NEVER,
+		BASE_MATERIAL_3D_DITHERING_JITTER_ALWAYS,
+	};
+
 	virtual RID material_create() = 0;
 
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
@@ -1779,6 +1785,7 @@ private:
 VARIANT_ENUM_CAST(RenderingServer::TextureLayeredType);
 VARIANT_ENUM_CAST(RenderingServer::CubeMapLayer);
 VARIANT_ENUM_CAST(RenderingServer::ShaderMode);
+VARIANT_ENUM_CAST(RenderingServer::BaseMaterial3DDitheringJitter);
 VARIANT_ENUM_CAST(RenderingServer::ArrayType);
 VARIANT_BITFIELD_CAST(RenderingServer::ArrayFormat);
 VARIANT_ENUM_CAST(RenderingServer::ArrayCustomFormat);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/61834 (can be merged independently).

This improves the dithering pattern's appearance when TAA is enabled, or at high frame rates when TAA is disabled (thanks to monitor response times not being instant).

See https://github.com/godotengine/godot-proposals/issues/4179 (the rationale is very similar).

- This closes https://github.com/godotengine/godot-proposals/issues/12008.

## Preview

*Click to view at full size (this is required for accurate preview). TAA is enabled on all screenshots.*

Before | After
-|-
![Screenshot_20230716_004902 webp](https://github.com/godotengine/godot/assets/180032/851b675e-6ff9-48f7-919a-e1986a9c3138) | ![Screenshot_20230716_004940 webp](https://github.com/godotengine/godot/assets/180032/11c7d7be-32c4-48d1-a43b-a44cac3ad582)

[Bonus screenshot (6 MB)](https://github.com/godotengine/godot/assets/180032/617e7341-426a-46cb-a7be-3a87adb51699)

## TODO

- [ ] See if we can make the project setting change effective without requiring a restart. https://github.com/godotengine/godot/pull/62038 will likely help here.
- [ ] Apply this change to the **Alpha Hash** transparency mode (could be done in a future PR).