### PR TITLE
Change GDScript tests to use InstancePlaceholder as the example abstract class

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.gd
@@ -1,2 +1,2 @@
 func test():
-	CanvasItem.new()
+	InstancePlaceholder.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_class_instantiate.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Native class "CanvasItem" cannot be constructed as it is abstract.
+Native class "InstancePlaceholder" cannot be constructed as it is abstract.

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.gd
@@ -1,4 +1,4 @@
-class A extends CanvasItem:
+class A extends InstancePlaceholder:
 	func _init():
 		print('no')
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_script_instantiate.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
-Class "abstract_script_instantiate.gd::B" cannot be constructed as it is based on abstract native class "CanvasItem".
+Class "abstract_script_instantiate.gd::B" cannot be constructed as it is based on abstract native class "InstancePlaceholder".

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -170,6 +170,7 @@ protected:
 	_FORCE_INLINE_ void set_hide_clip_children(bool p_value) { hide_clip_children = p_value; }
 
 	GDVIRTUAL0(_draw)
+
 public:
 	enum {
 		NOTIFICATION_TRANSFORM_CHANGED = SceneTree::NOTIFICATION_TRANSFORM_CHANGED, //unique
@@ -179,7 +180,6 @@ public:
 		NOTIFICATION_EXIT_CANVAS = 33,
 		NOTIFICATION_LOCAL_TRANSFORM_CHANGED = 35,
 		NOTIFICATION_WORLD_2D_CHANGED = 36,
-
 	};
 
 	/* EDITOR */
@@ -189,7 +189,7 @@ public:
 
 	// Save and restore a CanvasItem state
 	virtual void _edit_set_state(const Dictionary &p_state) {}
-	virtual Dictionary _edit_get_state() const { return Dictionary(); };
+	virtual Dictionary _edit_get_state() const { return Dictionary(); }
 
 	// Used to move the node
 	virtual void _edit_set_position(const Point2 &p_position) = 0;


### PR DESCRIPTION
This PR is split off from #67510 for easy reviewing.

It changes the GDScript tests to use InstancePlaceholder as the example abstract class instead of CanvasItem, since I want to allow extending CanvasItem. Why InstancePlaceholder: somewhat arbitrary, out of the current abstract classes this seems like a class that nobody would ever want to extend.

Also, this PR includes some formatting fixes in `canvas_item.h`.