### PR TITLE
Fix missing `_THREAD_SAFE_METHOD_` missing from `RenderingDeviceVulkan` `submit` and `sync`

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -7780,6 +7780,8 @@ RenderingDevice::ComputeListID RenderingDeviceVulkan::compute_list_begin(bool p_
 }
 
 void RenderingDeviceVulkan::compute_list_bind_compute_pipeline(ComputeListID p_list, RID p_compute_pipeline) {
+	// Must be called within a compute list, the class mutex is locked during that time
+
 	ERR_FAIL_COND(p_list != ID_TYPE_COMPUTE_LIST);
 	ERR_FAIL_COND(!compute_list);
 
@@ -7844,6 +7846,8 @@ void RenderingDeviceVulkan::compute_list_bind_compute_pipeline(ComputeListID p_l
 }
 
 void RenderingDeviceVulkan::compute_list_bind_uniform_set(ComputeListID p_list, RID p_uniform_set, uint32_t p_index) {
+	// Must be called within a compute list, the class mutex is locked during that time
+
 	ERR_FAIL_COND(p_list != ID_TYPE_COMPUTE_LIST);
 	ERR_FAIL_COND(!compute_list);
 
@@ -8018,6 +8022,8 @@ void RenderingDeviceVulkan::compute_list_set_push_constant(ComputeListID p_list,
 }
 
 void RenderingDeviceVulkan::compute_list_dispatch(ComputeListID p_list, uint32_t p_x_groups, uint32_t p_y_groups, uint32_t p_z_groups) {
+	// Must be called within a compute list, the class mutex is locked during that time
+
 	ERR_FAIL_COND(p_list != ID_TYPE_COMPUTE_LIST);
 	ERR_FAIL_COND(!compute_list);
 
@@ -8161,6 +8167,8 @@ void RenderingDeviceVulkan::compute_list_dispatch_indirect(ComputeListID p_list,
 }
 
 void RenderingDeviceVulkan::compute_list_add_barrier(ComputeListID p_list) {
+	// Must be called within a compute list, the class mutex is locked during that time
+
 	uint32_t barrier_flags = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
 	uint32_t access_flags = VK_ACCESS_SHADER_READ_BIT;
 	_compute_list_add_barrier(BARRIER_MASK_COMPUTE, barrier_flags, access_flags);
@@ -8649,6 +8657,8 @@ void RenderingDeviceVulkan::swap_buffers() {
 }
 
 void RenderingDeviceVulkan::submit() {
+	_THREAD_SAFE_METHOD_
+
 	ERR_FAIL_COND_MSG(local_device.is_null(), "Only local devices can submit and sync.");
 	ERR_FAIL_COND_MSG(local_device_processing, "device already submitted, call sync to wait until done.");
 
@@ -8660,6 +8670,8 @@ void RenderingDeviceVulkan::submit() {
 }
 
 void RenderingDeviceVulkan::sync() {
+	_THREAD_SAFE_METHOD_
+
 	ERR_FAIL_COND_MSG(local_device.is_null(), "Only local devices can submit and sync.");
 	ERR_FAIL_COND_MSG(!local_device_processing, "sync can only be called after a submit");
 


### PR DESCRIPTION
I use `RenderingDeviceVulkan` from multiple threads. While one thread is dedicated to execute compute lists, submit and sync, other threads can create or update resources, and that caused crashes inside the Vulkan driver.

Turns out `submit` and `sync` did not have `_THREAD_SAFE_METHOD_`. Adding them made the crashes go away.

------------

While working on this, I also found out this call to `_buffer_update` has a problem:
https://github.com/godotengine/godot/blob/a7583881af5477cd73110cc859fecf7ceaf39bd7/drivers/vulkan/rendering_device_vulkan.cpp#L5867
The last sent argument is `p_post_barrier`, which is a `BitField<BarrierMask>`, but then the signature of `_buffer_update` is:
https://github.com/godotengine/godot/blob/a7583881af5477cd73110cc859fecf7ceaf39bd7/drivers/vulkan/rendering_device_vulkan.h#L227
So `p_post_barrier` ends up being fed as the `p_use_draw_command_buffer` parameter, which doesn't seem to be the same meaning.
I don't know if there is a bug associated with this, but it doesn't seems right. I don't know what the code should be though.

cc @RandomShaper 