### PR TITLE
Particle internal refactor and additions for more artistic control

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -50,6 +50,10 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles emitted in one emission cycle.
 		</member>
+		<member name="amount_ratio" type="float" setter="set_amount_ratio" getter="get_amount_ratio" default="1.0">
+			The ratio of particles that should actually be emitted. If set to a value lower than [code]1.0[/code], this will set the amount of emitted particles throughout the lifetime to [code]amount * amount_ratio[/code]. Unlike changing [member amount], changing [member amount_ratio] while emitting does not affect already-emitted particles and doesn't cause the particle system to restart. [member amount_ratio] can be used to create effects that make the number of emitted particles vary over time.
+			[b]Note:[/b] Reducing the [member amount_ratio] has no performance benefit, since resources need to be allocated and processed for the total [member amount] of particles regardless of the [member amount_ratio].
+		</member>
 		<member name="collision_base_size" type="float" setter="set_collision_base_size" getter="get_collision_base_size" default="1.0">
 			Multiplier for particle's collision radius. [code]1.0[/code] corresponds to the size of the sprite.
 		</member>
@@ -67,6 +71,10 @@
 		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
+		</member>
+		<member name="interp_to_end" type="float" setter="set_interp_to_end" getter="get_interp_to_end" default="0.0">
+			Causes all the particles in this node to interpolate towards the end of their lifetime.
+			[b]Note[/b]: This only works when used with a [ParticleProcessMaterial]. It needs to be manually implemented for custom process shaders.
 		</member>
 		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="true">
 			Enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is lower than the screen refresh rate.

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -63,6 +63,10 @@
 		<member name="amount" type="int" setter="set_amount" getter="get_amount" default="8">
 			Number of particles to emit.
 		</member>
+		<member name="amount_ratio" type="float" setter="set_amount_ratio" getter="get_amount_ratio" default="1.0">
+			The ratio of particles that should actually be emitted. If set to a value lower than [code]1.0[/code], this will set the amount of emitted particles throughout the lifetime to [code]amount * amount_ratio[/code]. Unlike changing [member amount], changing [member amount_ratio] while emitting does not affect already-emitted particles and doesn't cause the particle system to restart. [member amount_ratio] can be used to create effects that make the number of emitted particles vary over time.
+			[b]Note:[/b] Reducing the [member amount_ratio] has no performance benefit, since resources need to be allocated and processed for the total [member amount] of particles regardless of the [member amount_ratio].
+		</member>
 		<member name="collision_base_size" type="float" setter="set_collision_base_size" getter="get_collision_base_size" default="0.01">
 		</member>
 		<member name="draw_order" type="int" setter="set_draw_order" getter="get_draw_order" enum="GPUParticles3D.DrawOrder" default="0">
@@ -97,6 +101,10 @@
 		</member>
 		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
+		</member>
+		<member name="interp_to_end" type="float" setter="set_interp_to_end" getter="get_interp_to_end" default="0.0">
+			Causes all the particles in this node to interpolate towards the end of their lifetime.
+			[b]Note[/b]: This only works when used with a [ParticleProcessMaterial]. It needs to be manually implemented for custom process shaders.
 		</member>
 		<member name="interpolate" type="bool" setter="set_interpolate" getter="get_interpolate" default="true">
 			Enables particle interpolation, which makes the particle movement smoother when their [member fixed_fps] is lower than the screen refresh rate.

--- a/doc/classes/ParticleProcessMaterial.xml
+++ b/doc/classes/ParticleProcessMaterial.xml
@@ -71,6 +71,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="alpha_curve" type="Texture2D" setter="set_alpha_curve" getter="get_alpha_curve">
+			The alpha value of each particle's color will be multiplied by this [CurveTexture] over its lifetime.
+		</member>
 		<member name="angle_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's rotation will be animated along this [CurveTexture].
 		</member>
@@ -151,12 +154,28 @@
 		<member name="direction" type="Vector3" setter="set_direction" getter="get_direction" default="Vector3(1, 0, 0)">
 			Unit vector specifying the particles' emission direction.
 		</member>
+		<member name="directional_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
+			A curve that specifies the velocity along each of the axes of the particle system along its lifetime.
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
+		<member name="directional_velocity_max" type="float" setter="set_param_max" getter="get_param_max">
+			Maximum directional velocity value, which is multiplied by [member directional_velocity_curve].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
+		<member name="directional_velocity_min" type="float" setter="set_param_min" getter="get_param_min">
+			Minimum directional velocity value, which is multiplied by [member directional_velocity_curve].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
 		<member name="emission_box_extents" type="Vector3" setter="set_emission_box_extents" getter="get_emission_box_extents">
 			The box's extents if [member emission_shape] is set to [constant EMISSION_SHAPE_BOX].
 		</member>
 		<member name="emission_color_texture" type="Texture2D" setter="set_emission_color_texture" getter="get_emission_color_texture">
 			Particle color will be modulated by color determined by sampling this texture at the same point as the [member emission_point_texture].
 			[b]Note:[/b] [member emission_color_texture] multiplies the particle mesh's vertex colors. To have a visible effect on a [BaseMaterial3D], [member BaseMaterial3D.vertex_color_use_as_albedo] [i]must[/i] be [code]true[/code]. For a [ShaderMaterial], [code]ALBEDO *= COLOR.rgb;[/code] must be inserted in the shader's [code]fragment()[/code] function. Otherwise, [member emission_color_texture] will have no visible effect.
+		</member>
+		<member name="emission_curve" type="Texture2D" setter="set_emission_curve" getter="get_emission_curve">
+			Each particle's color will be multiplied by this [CurveTexture] over its lifetime.
+			[b]Note:[/b] This property won't have a visible effect unless the render material is marked as unshaded.
 		</member>
 		<member name="emission_normal_texture" type="Texture2D" setter="set_emission_normal_texture" getter="get_emission_normal_texture">
 			Particle velocity and rotation will be set by sampling this texture at the same point as the [member emission_point_texture]. Used only in [constant EMISSION_SHAPE_DIRECTED_POINTS]. Can be created automatically from mesh or node by selecting "Create Emission Points from Mesh/Node" under the "Particles" tool in the toolbar.
@@ -182,6 +201,12 @@
 		<member name="emission_shape" type="int" setter="set_emission_shape" getter="get_emission_shape" enum="ParticleProcessMaterial.EmissionShape" default="0">
 			Particles will be emitted inside this region. Use [enum EmissionShape] constants for values.
 		</member>
+		<member name="emission_shape_offset" type="Vector3" setter="set_emission_shape_offset" getter="get_emission_shape_offset" default="Vector3(0, 0, 0)">
+			The offset for the [member emission_shape], in local space.
+		</member>
+		<member name="emission_shape_scale" type="Vector3" setter="set_emission_shape_scale" getter="get_emission_shape_scale" default="Vector3(1, 1, 1)">
+			The scale of the [member emission_shape], in local space.
+		</member>
 		<member name="emission_sphere_radius" type="float" setter="set_emission_sphere_radius" getter="get_emission_sphere_radius">
 			The sphere's radius if [member emission_shape] is set to [constant EMISSION_SHAPE_SPHERE].
 		</member>
@@ -199,6 +224,9 @@
 		</member>
 		<member name="hue_variation_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 			Minimum equivalent of [member hue_variation_max].
+		</member>
+		<member name="inherit_velocity_ratio" type="float" setter="set_inherit_velocity_ratio" getter="get_inherit_velocity_ratio" default="0.0">
+			Percentage of the velocity of the respective [GPUParticles2D] or [GPUParticles3D] inherited by each particle when spawning.
 		</member>
 		<member name="initial_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum initial velocity magnitude for each particle. Direction comes from [member direction] and [member spread].
@@ -220,16 +248,22 @@
 		</member>
 		<member name="orbit_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's orbital velocity will vary along this [CurveTexture].
+			[b]Note:[/b] For 3D orbital velocity, use a [CurveXYZTexture].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
 		</member>
-		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max">
+		<member name="orbit_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
 			Maximum orbital velocity applied to each particle. Makes the particles circle around origin. Specified in number of full rotations around origin per second.
-			Only available when [member particle_flag_disable_z] is [code]true[/code].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
 		</member>
-		<member name="orbit_velocity_min" type="float" setter="set_param_min" getter="get_param_min">
+		<member name="orbit_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 			Minimum equivalent of [member orbit_velocity_max].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
 		</member>
 		<member name="particle_flag_align_y" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			Align Y axis of particle with the direction of its velocity.
+		</member>
+		<member name="particle_flag_damping_as_friction" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
+			Changes the behavior of the damping properties from a linear deceleration to a deceleration based on speed percentage.
 		</member>
 		<member name="particle_flag_disable_z" type="bool" setter="set_particle_flag" getter="get_particle_flag" default="false">
 			If [code]true[/code], particles will not move on the z axis.
@@ -246,6 +280,18 @@
 		<member name="radial_accel_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 			Minimum equivalent of [member radial_accel_max].
 		</member>
+		<member name="radial_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
+			A [CurveTexture] that defines the velocity over the particle's lifetime away (or toward) the [member velocity_pivot].
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
+		<member name="radial_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum radial velocity applied to each particle. Makes particles move away from the [member velocity_pivot], or toward it if negative.
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
+		<member name="radial_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum radial velocity applied to each particle. Makes particles move away from the [member velocity_pivot], or toward it if negative.
+			[b]Note:[/b] Animated velocities will not be affected by damping, use [member velocity_limit_curve] instead.
+		</member>
 		<member name="scale_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's scale will vary along this [CurveTexture]. If a [CurveXYZTexture] is supplied instead, the scale will be separated per-axis.
 		</member>
@@ -254,6 +300,17 @@
 		</member>
 		<member name="scale_min" type="float" setter="set_param_min" getter="get_param_min" default="1.0">
 			Minimum equivalent of [member scale_max].
+		</member>
+		<member name="scale_over_velocity_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
+			Either a [CurveTexture] or a [CurveXYZTexture] that scales each particle based on its velocity.
+		</member>
+		<member name="scale_over_velocity_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
+			Maximum velocity value reference for [member scale_over_velocity_curve].
+			[member scale_over_velocity_curve] will be interpolated between [member scale_over_velocity_min] and [member scale_over_velocity_max].
+		</member>
+		<member name="scale_over_velocity_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
+			Minimum velocity value reference for [member scale_over_velocity_curve].
+			[member scale_over_velocity_curve] will be interpolated between [member scale_over_velocity_min] and [member scale_over_velocity_max].
 		</member>
 		<member name="spread" type="float" setter="set_spread" getter="get_spread" default="45.0">
 			Each particle's initial direction range from [code]+spread[/code] to [code]-spread[/code] degrees.
@@ -317,6 +374,11 @@
 		<member name="turbulence_noise_strength" type="float" setter="set_turbulence_noise_strength" getter="get_turbulence_noise_strength" default="1.0">
 			The turbulence noise strength. Increasing this will result in a stronger, more contrasting, flow pattern.
 		</member>
+		<member name="velocity_limit_curve" type="Texture2D" setter="set_velocity_limit_curve" getter="get_velocity_limit_curve">
+			A [CurveTexture] that defines the maximum velocity of a particle during its lifetime.
+		</member>
+		<member name="velocity_pivot" type="Vector3" setter="set_velocity_pivot" getter="get_velocity_pivot" default="Vector3(0, 0, 0)">
+		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_INITIAL_LINEAR_VELOCITY" value="0" enum="Parameter">
@@ -355,7 +417,16 @@
 		<constant name="PARAM_ANIM_OFFSET" value="11" enum="Parameter">
 			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set animation offset properties.
 		</constant>
-		<constant name="PARAM_MAX" value="15" enum="Parameter">
+		<constant name="PARAM_RADIAL_VELOCITY" value="15" enum="Parameter">
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set radial velocity properties.
+		</constant>
+		<constant name="PARAM_DIRECTIONAL_VELOCITY" value="16" enum="Parameter">
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set directional velocity properties.
+		</constant>
+		<constant name="PARAM_SCALE_OVER_VELOCITY" value="17" enum="Parameter">
+			Use with [method set_param_min], [method set_param_max], and [method set_param_texture] to set scale over velocity properties.
+		</constant>
+		<constant name="PARAM_MAX" value="18" enum="Parameter">
 			Represents the size of the [enum Parameter] enum.
 		</constant>
 		<constant name="PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY" value="0" enum="ParticleFlags">
@@ -367,7 +438,9 @@
 		<constant name="PARTICLE_FLAG_DISABLE_Z" value="2" enum="ParticleFlags">
 			Use with [method set_particle_flag] to set [member particle_flag_disable_z].
 		</constant>
-		<constant name="PARTICLE_FLAG_MAX" value="3" enum="ParticleFlags">
+		<constant name="PARTICLE_FLAG_DAMPING_AS_FRICTION" value="3" enum="ParticleFlags">
+		</constant>
+		<constant name="PARTICLE_FLAG_MAX" value="4" enum="ParticleFlags">
 			Represents the size of the [enum ParticleFlags] enum.
 		</constant>
 		<constant name="EMISSION_SHAPE_POINT" value="0" enum="EmissionShape">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2627,6 +2627,14 @@
 				Sets the number of particles to be drawn and allocates the memory for them. Equivalent to [member GPUParticles3D.amount].
 			</description>
 		</method>
+		<method name="particles_set_amount_ratio">
+			<return type="void" />
+			<param index="0" name="particles" type="RID" />
+			<param index="1" name="ratio" type="float" />
+			<description>
+				Sets the amount ratio for particles to be emitted. Equivalent to [member GPUParticles3D.amount_ratio].
+			</description>
+		</method>
 		<method name="particles_set_collision_base_size">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
@@ -2675,6 +2683,14 @@
 				Sets the [Transform3D] that will be used by the particles when they first emit.
 			</description>
 		</method>
+		<method name="particles_set_emitter_velocity">
+			<return type="void" />
+			<param index="0" name="particles" type="RID" />
+			<param index="1" name="velocity" type="Vector3" />
+			<description>
+				Sets the velocity of a particle node, that will be used by [member ParticleProcessMaterial.inherit_velocity_ratio].
+			</description>
+		</method>
 		<method name="particles_set_emitting">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />
@@ -2705,6 +2721,14 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				If [code]true[/code], uses fractional delta which smooths the movement of the particles. Equivalent to [member GPUParticles3D.fract_delta].
+			</description>
+		</method>
+		<method name="particles_set_interp_to_end">
+			<return type="void" />
+			<param index="0" name="particles" type="RID" />
+			<param index="1" name="factor" type="float" />
+			<description>
+				Sets the value that informs a [ParticleProcessMaterial] to rush all particles towards the end of their lifetime.
 			</description>
 		</method>
 		<method name="particles_set_interpolate">

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -78,7 +78,7 @@ layout(std140) uniform FrameData { //ubo:0
 	float delta;
 
 	float particle_size;
-	float pad0;
+	float amount_ratio;
 	float pad1;
 	float pad2;
 
@@ -88,6 +88,9 @@ layout(std140) uniform FrameData { //ubo:0
 	uint frame;
 
 	mat4 emission_transform;
+
+	vec3 emitter_velocity;
+	float interp_to_end;
 
 	Attractor attractors[MAX_ATTRACTORS];
 	Collider colliders[MAX_COLLIDERS];

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1395,6 +1395,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["DELTA"] = "local_delta";
 		actions.renames["NUMBER"] = "particle_number";
 		actions.renames["INDEX"] = "index";
+		actions.renames["AMOUNT_RATIO"] = "amount_ratio";
 		//actions.renames["GRAVITY"] = "current_gravity";
 		actions.renames["EMISSION_TRANSFORM"] = "emission_transform";
 		actions.renames["RANDOM_SEED"] = "random_seed";
@@ -1407,6 +1408,8 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["COLLISION_NORMAL"] = "collision_normal";
 		actions.renames["COLLISION_DEPTH"] = "collision_depth";
 		actions.renames["ATTRACTOR_FORCE"] = "attractor_force";
+		actions.renames["EMITTER_VELOCITY"] = "emitter_velocity";
+		actions.renames["INTERPOLATE_TO_END"] = "interp_to_end";
 
 		// These are unsupported, but may be used by users. To avoid compile time overhead, we add the stub only when used.
 		actions.renames["FLAG_EMIT_POSITION"] = "uint(1)";

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -190,6 +190,13 @@ void ParticlesStorage::particles_set_amount(RID p_particles, int p_amount) {
 	particles->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_PARTICLES);
 }
 
+void ParticlesStorage::particles_set_amount_ratio(RID p_particles, float p_amount_ratio) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->amount_ratio = p_amount_ratio;
+}
+
 void ParticlesStorage::particles_set_lifetime(RID p_particles, double p_lifetime) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
@@ -431,6 +438,20 @@ void ParticlesStorage::particles_set_emission_transform(RID p_particles, const T
 	particles->emission_transform = p_transform;
 }
 
+void ParticlesStorage::particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->emitter_velocity = p_velocity;
+}
+
+void ParticlesStorage::particles_set_interp_to_end(RID p_particles, float p_interp) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->interp_to_end = p_interp;
+}
+
 int ParticlesStorage::particles_get_draw_passes(RID p_particles) const {
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, 0);
@@ -507,9 +528,13 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 
 	frame_params.cycle = p_particles->cycle_number;
 	frame_params.frame = p_particles->frame_counter++;
-	frame_params.pad0 = 0;
+	frame_params.amount_ratio = p_particles->amount_ratio;
 	frame_params.pad1 = 0;
 	frame_params.pad2 = 0;
+	frame_params.interp_to_end = p_particles->interp_to_end;
+	frame_params.emitter_velocity[0] = p_particles->emitter_velocity.x;
+	frame_params.emitter_velocity[1] = p_particles->emitter_velocity.y;
+	frame_params.emitter_velocity[2] = p_particles->emitter_velocity.z;
 
 	{ //collision and attractors
 

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -128,7 +128,7 @@ private:
 		float delta;
 
 		float particle_size;
-		float pad0;
+		float amount_ratio;
 		float pad1;
 		float pad2;
 
@@ -138,6 +138,8 @@ private:
 		uint32_t frame;
 
 		float emission_transform[16];
+		float emitter_velocity[3];
+		float interp_to_end;
 
 		Attractor attractors[MAX_ATTRACTORS];
 		Collider colliders[MAX_COLLIDERS];
@@ -149,6 +151,7 @@ private:
 		double inactive_time = 0.0;
 		bool emitting = false;
 		bool one_shot = false;
+		float amount_ratio = 1.0;
 		int amount = 0;
 		double lifetime = 1.0;
 		double pre_process_time = 0.0;
@@ -229,6 +232,8 @@ private:
 		bool clear = true;
 
 		Transform3D emission_transform;
+		Vector3 emitter_velocity;
+		float interp_to_end;
 
 		HashSet<RID> collisions;
 
@@ -313,6 +318,7 @@ public:
 	virtual void particles_emit(RID p_particles, const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) override;
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) override;
 	virtual void particles_set_amount(RID p_particles, int p_amount) override;
+	virtual void particles_set_amount_ratio(RID p_particles, float p_amount_ratio) override;
 	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) override;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) override;
 	virtual void particles_set_pre_process_time(RID p_particles, double p_time) override;
@@ -347,6 +353,8 @@ public:
 	virtual AABB particles_get_aabb(RID p_particles) const override;
 
 	virtual void particles_set_emission_transform(RID p_particles, const Transform3D &p_transform) override;
+	virtual void particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) override;
+	virtual void particles_set_interp_to_end(RID p_particles, float p_interp) override;
 
 	virtual bool particles_get_emitting(RID p_particles) override;
 	virtual int particles_get_draw_passes(RID p_particles) const override;

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -287,3 +287,9 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_ge
 Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/commit/arguments/1': meta changed value in new API, from "uint32" to "uint64".
 
 Surface format was increased to 64 bits from 32 bits. Compatibility methods registered. 
+
+GH-79527
+--------
+Validate extension JSON: Error: Field 'classes/ParticleProcessMaterial/properties/orbit_velocity_curve': type changed value in new API, from "CurveTexture" to "CurveTexture,CurveXYZTexture".
+
+Added accepted curve type from only CurveTexture to CurveXYZTexture.

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -192,6 +192,11 @@ void GPUParticles2D::set_trail_section_subdivisions(int p_subdivisions) {
 	queue_redraw();
 }
 
+void GPUParticles2D::set_interp_to_end(float p_interp) {
+	interp_to_end_factor = CLAMP(p_interp, 0.0, 1.0);
+	RS::get_singleton()->particles_set_interp_to_end(particles, interp_to_end_factor);
+}
+
 #ifdef TOOLS_ENABLED
 void GPUParticles2D::set_show_visibility_rect(bool p_show_visibility_rect) {
 	show_visibility_rect = p_show_visibility_rect;
@@ -318,6 +323,10 @@ bool GPUParticles2D::get_interpolate() const {
 	return interpolate;
 }
 
+float GPUParticles2D::get_interp_to_end() const {
+	return interp_to_end_factor;
+}
+
 PackedStringArray GPUParticles2D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
@@ -421,6 +430,15 @@ void GPUParticles2D::set_sub_emitter(const NodePath &p_path) {
 
 NodePath GPUParticles2D::get_sub_emitter() const {
 	return sub_emitter;
+}
+
+void GPUParticles2D::set_amount_ratio(float p_ratio) {
+	amount_ratio = p_ratio;
+	RenderingServer::get_singleton()->particles_set_amount_ratio(particles, p_ratio);
+}
+
+float GPUParticles2D::get_amount_ratio() const {
+	return amount_ratio;
 }
 
 void GPUParticles2D::restart() {
@@ -670,6 +688,8 @@ void GPUParticles2D::_notification(int p_what) {
 			} else {
 				RS::get_singleton()->particles_set_speed_scale(particles, 0);
 			}
+			set_process_internal(true);
+			previous_position = get_global_position();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -692,6 +712,12 @@ void GPUParticles2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
+			RS::get_singleton()->particles_set_emitter_velocity(particles,
+					Vector3((get_global_position() - previous_position).x,
+							(get_global_position() - previous_position).y,
+							0.0) /
+							get_process_delta_time());
+			previous_position = get_global_position();
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
@@ -730,6 +756,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_material", "material"), &GPUParticles2D::set_process_material);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &GPUParticles2D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("set_collision_base_size", "size"), &GPUParticles2D::set_collision_base_size);
+	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles2D::set_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles2D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles2D::get_amount);
@@ -746,6 +773,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_process_material"), &GPUParticles2D::get_process_material);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &GPUParticles2D::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_collision_base_size"), &GPUParticles2D::get_collision_base_size);
+	ClassDB::bind_method(D_METHOD("get_interp_to_end"), &GPUParticles2D::get_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("set_draw_order", "order"), &GPUParticles2D::set_draw_order);
 	ClassDB::bind_method(D_METHOD("get_draw_order"), &GPUParticles2D::get_draw_order);
@@ -776,11 +804,15 @@ void GPUParticles2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &GPUParticles2D::convert_from_particles);
 
+	ClassDB::bind_method(D_METHOD("set_amount_ratio", "ratio"), &GPUParticles2D::set_amount_ratio);
+	ClassDB::bind_method(D_METHOD("get_amount_ratio"), &GPUParticles2D::get_amount_ratio);
+
 	ADD_SIGNAL(MethodInfo("finished"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles2D"), "set_sub_emitter", "get_sub_emitter");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "process_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,ParticleProcessMaterial"), "set_process_material", "get_process_material");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
@@ -794,6 +826,7 @@ void GPUParticles2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps", PROPERTY_HINT_RANGE, "0,1000,1,suffix:FPS"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interpolate"), "set_interpolate", "get_interpolate");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "interp_to_end", PROPERTY_HINT_RANGE, "0.00,1.0,0.001"), "set_interp_to_end", "get_interp_to_end");
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_base_size", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater"), "set_collision_base_size", "get_collision_base_size");
 	ADD_GROUP("Drawing", "");
@@ -829,6 +862,7 @@ GPUParticles2D::GPUParticles2D() {
 	set_emitting(true);
 	set_one_shot(false);
 	set_amount(8);
+	set_amount_ratio(1.0);
 	set_lifetime(1);
 	set_fixed_fps(0);
 	set_fractional_delta(true);

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -52,6 +52,7 @@ private:
 	bool signal_canceled = false;
 	bool one_shot = false;
 	int amount = 0;
+	float amount_ratio = 1.0;
 	double lifetime = 0.0;
 	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
@@ -62,6 +63,8 @@ private:
 	int fixed_fps = 0;
 	bool fractional_delta = false;
 	bool interpolate = true;
+	float interp_to_end_factor = 0;
+	Vector2 previous_position;
 #ifdef TOOLS_ENABLED
 	bool show_visibility_rect = false;
 #endif
@@ -114,6 +117,7 @@ public:
 	void set_trail_lifetime(double p_seconds);
 	void set_trail_sections(int p_sections);
 	void set_trail_section_subdivisions(int p_subdivisions);
+	void set_interp_to_end(float p_interp);
 
 #ifdef TOOLS_ENABLED
 	void set_show_visibility_rect(bool p_show_visibility_rect);
@@ -136,6 +140,7 @@ public:
 	double get_trail_lifetime() const;
 	int get_trail_sections() const;
 	int get_trail_section_subdivisions() const;
+	float get_interp_to_end() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;
@@ -151,6 +156,9 @@ public:
 
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
+
+	void set_amount_ratio(float p_ratio);
+	float get_amount_ratio() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -61,6 +61,8 @@ void GPUParticles3D::set_emitting(bool p_emitting) {
 		} else {
 			set_process_internal(false);
 		}
+	} else {
+		set_process_internal(true);
 	}
 
 	emitting = p_emitting;
@@ -79,19 +81,19 @@ void GPUParticles3D::set_lifetime(double p_lifetime) {
 	RS::get_singleton()->particles_set_lifetime(particles, lifetime);
 }
 
+void GPUParticles3D::set_interp_to_end(float p_interp) {
+	interp_to_end_factor = CLAMP(p_interp, 0.0, 1.0);
+	RS::get_singleton()->particles_set_interp_to_end(particles, interp_to_end_factor);
+}
+
 void GPUParticles3D::set_one_shot(bool p_one_shot) {
 	one_shot = p_one_shot;
 	RS::get_singleton()->particles_set_one_shot(particles, one_shot);
 
 	if (is_emitting()) {
-		set_process_internal(true);
 		if (!one_shot) {
 			RenderingServer::get_singleton()->particles_restart(particles);
 		}
-	}
-
-	if (!one_shot) {
-		set_process_internal(false);
 	}
 }
 
@@ -152,6 +154,10 @@ int GPUParticles3D::get_amount() const {
 
 double GPUParticles3D::get_lifetime() const {
 	return lifetime;
+}
+
+float GPUParticles3D::get_interp_to_end() const {
+	return interp_to_end_factor;
 }
 
 bool GPUParticles3D::get_one_shot() const {
@@ -401,9 +407,7 @@ void GPUParticles3D::restart() {
 	time = 0;
 	emission_time = lifetime * (1 - explosiveness_ratio);
 	active_time = lifetime * (2 - explosiveness_ratio);
-	if (one_shot) {
-		set_process_internal(true);
-	}
+	set_process_internal(true);
 }
 
 AABB GPUParticles3D::capture_aabb() const {
@@ -456,6 +460,9 @@ void GPUParticles3D::_notification(int p_what) {
 		// Use internal process when emitting and one_shot is on so that when
 		// the shot ends the editor can properly update.
 		case NOTIFICATION_INTERNAL_PROCESS: {
+			RS::get_singleton()->particles_set_emitter_velocity(particles, (get_global_position() - previous_position) / get_process_delta_time());
+			previous_position = get_global_position();
+
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
@@ -477,6 +484,7 @@ void GPUParticles3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+			set_process_internal(false);
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
@@ -485,6 +493,8 @@ void GPUParticles3D::_notification(int p_what) {
 			} else {
 				RS::get_singleton()->particles_set_speed_scale(particles, 0);
 			}
+			previous_position = get_global_transform().origin;
+			set_process_internal(true);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -641,6 +651,15 @@ void GPUParticles3D::convert_from_particles(Node *p_particles) {
 #undef CONVERT_PARAM
 }
 
+void GPUParticles3D::set_amount_ratio(float p_ratio) {
+	amount_ratio = p_ratio;
+	RS::get_singleton()->particles_set_amount_ratio(particles, p_ratio);
+}
+
+float GPUParticles3D::get_amount_ratio() const {
+	return amount_ratio;
+}
+
 void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles3D::set_emitting);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles3D::set_amount);
@@ -657,6 +676,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_material", "material"), &GPUParticles3D::set_process_material);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &GPUParticles3D::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("set_collision_base_size", "size"), &GPUParticles3D::set_collision_base_size);
+	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles3D::set_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles3D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles3D::get_amount);
@@ -673,6 +693,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_process_material"), &GPUParticles3D::get_process_material);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &GPUParticles3D::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_collision_base_size"), &GPUParticles3D::get_collision_base_size);
+	ClassDB::bind_method(D_METHOD("get_interp_to_end"), &GPUParticles3D::get_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("set_draw_order", "order"), &GPUParticles3D::set_draw_order);
 
@@ -706,14 +727,19 @@ void GPUParticles3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("convert_from_particles", "particles"), &GPUParticles3D::convert_from_particles);
 
+	ClassDB::bind_method(D_METHOD("set_amount_ratio", "ratio"), &GPUParticles3D::set_amount_ratio);
+	ClassDB::bind_method(D_METHOD("get_amount_ratio"), &GPUParticles3D::get_amount_ratio);
+
 	ADD_SIGNAL(MethodInfo("finished"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles3D"), "set_sub_emitter", "get_sub_emitter");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,exp,suffix:s"), "set_lifetime", "get_lifetime");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "interp_to_end", PROPERTY_HINT_RANGE, "0.00,1.0,0.01"), "set_interp_to_end", "get_interp_to_end");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "get_one_shot");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "preprocess", PROPERTY_HINT_RANGE, "0.00,600.0,0.01,exp,suffix:s"), "set_pre_process_time", "get_pre_process_time");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "0,64,0.01"), "set_speed_scale", "get_speed_scale");
@@ -767,6 +793,7 @@ GPUParticles3D::GPUParticles3D() {
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);
 	set_one_shot(false);
+	set_amount_ratio(1.0);
 	set_amount(8);
 	set_lifetime(1);
 	set_fixed_fps(30);

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -65,6 +65,7 @@ private:
 	bool signal_canceled = false;
 	bool one_shot = false;
 	int amount = 0;
+	float amount_ratio = 1.0;
 	double lifetime = 0.0;
 	double pre_process_time = 0.0;
 	real_t explosiveness_ratio = 0.0;
@@ -93,6 +94,8 @@ private:
 	double time = 0.0;
 	double emission_time = 0.0;
 	double active_time = 0.0;
+	float interp_to_end_factor = 0;
+	Vector3 previous_position;
 
 	void _attach_sub_emitter();
 
@@ -120,9 +123,11 @@ public:
 	void set_collision_base_size(real_t p_ratio);
 	void set_trail_enabled(bool p_enabled);
 	void set_trail_lifetime(double p_seconds);
+	void set_interp_to_end(float p_interp);
 
 	bool is_emitting() const;
 	int get_amount() const;
+
 	double get_lifetime() const;
 	bool get_one_shot() const;
 	double get_pre_process_time() const;
@@ -135,6 +140,10 @@ public:
 	real_t get_collision_base_size() const;
 	bool is_trail_enabled() const;
 	double get_trail_lifetime() const;
+	float get_interp_to_end() const;
+
+	void set_amount_ratio(float p_ratio);
+	float get_amount_ratio() const;
 
 	void set_fixed_fps(int p_count);
 	int get_fixed_fps() const;

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -50,6 +50,7 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->initial_angle_min = "initial_angle_min";
 	shader_names->angular_velocity_min = "angular_velocity_min";
 	shader_names->orbit_velocity_min = "orbit_velocity_min";
+	shader_names->radial_velocity_min = "radial_velocity_min";
 	shader_names->linear_accel_min = "linear_accel_min";
 	shader_names->radial_accel_min = "radial_accel_min";
 	shader_names->tangent_accel_min = "tangent_accel_min";
@@ -58,11 +59,14 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->hue_variation_min = "hue_variation_min";
 	shader_names->anim_speed_min = "anim_speed_min";
 	shader_names->anim_offset_min = "anim_offset_min";
+	shader_names->directional_velocity_min = "directional_velocity_min";
+	shader_names->scale_over_velocity_min = "scale_over_velocity_min";
 
 	shader_names->initial_linear_velocity_max = "initial_linear_velocity_max";
 	shader_names->initial_angle_max = "initial_angle_max";
 	shader_names->angular_velocity_max = "angular_velocity_max";
 	shader_names->orbit_velocity_max = "orbit_velocity_max";
+	shader_names->radial_velocity_max = "radial_velocity_max";
 	shader_names->linear_accel_max = "linear_accel_max";
 	shader_names->radial_accel_max = "radial_accel_max";
 	shader_names->tangent_accel_max = "tangent_accel_max";
@@ -71,22 +75,32 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->hue_variation_max = "hue_variation_max";
 	shader_names->anim_speed_max = "anim_speed_max";
 	shader_names->anim_offset_max = "anim_offset_max";
+	shader_names->directional_velocity_max = "directional_velocity_max";
+	shader_names->scale_over_velocity_max = "scale_over_velocity_max";
 
 	shader_names->angle_texture = "angle_texture";
 	shader_names->angular_velocity_texture = "angular_velocity_texture";
-	shader_names->orbit_velocity_texture = "orbit_velocity_texture";
+	shader_names->orbit_velocity_texture = "orbit_velocity_curve";
+	shader_names->radial_velocity_texture = "radial_velocity_curve";
 	shader_names->linear_accel_texture = "linear_accel_texture";
 	shader_names->radial_accel_texture = "radial_accel_texture";
 	shader_names->tangent_accel_texture = "tangent_accel_texture";
 	shader_names->damping_texture = "damping_texture";
-	shader_names->scale_texture = "scale_texture";
+	shader_names->scale_texture = "scale_curve";
 	shader_names->hue_variation_texture = "hue_variation_texture";
 	shader_names->anim_speed_texture = "anim_speed_texture";
 	shader_names->anim_offset_texture = "anim_offset_texture";
+	shader_names->directional_velocity_texture = "directional_velocity_curve";
+	shader_names->scale_over_velocity_texture = "scale_over_velocity_curve";
 
 	shader_names->color = "color_value";
 	shader_names->color_ramp = "color_ramp";
+	shader_names->alpha_ramp = "alpha_curve";
+	shader_names->emission_ramp = "emission_curve";
 	shader_names->color_initial_ramp = "color_initial_ramp";
+	shader_names->velocity_limit_curve = "velocity_limit_curve";
+	shader_names->inherit_emitter_velocity_ratio = "inherit_emitter_velocity_ratio";
+	shader_names->velocity_pivot = "velocity_pivot";
 
 	shader_names->emission_sphere_radius = "emission_sphere_radius";
 	shader_names->emission_box_extents = "emission_box_extents";
@@ -98,6 +112,8 @@ void ParticleProcessMaterial::init_shaders() {
 	shader_names->emission_ring_height = "emission_ring_height";
 	shader_names->emission_ring_radius = "emission_ring_radius";
 	shader_names->emission_ring_inner_radius = "emission_ring_inner_radius";
+	shader_names->emission_shape_offset = "emission_shape_offset";
+	shader_names->emission_shape_scale = "emission_shape_scale";
 
 	shader_names->turbulence_enabled = "turbulence_enabled";
 	shader_names->turbulence_noise_strength = "turbulence_noise_strength";
@@ -134,7 +150,7 @@ void ParticleProcessMaterial::_update_shader() {
 	dirty_materials->remove(&element);
 
 	MaterialKey mk = _compute_key();
-	if (mk.key == current_key.key) {
+	if (mk == current_key) {
 		return; //no update required in the end
 	}
 
@@ -160,6 +176,7 @@ void ParticleProcessMaterial::_update_shader() {
 	String code = "// NOTE: Shader automatically converted from " VERSION_NAME " " VERSION_FULL_CONFIG "'s ParticleProcessMaterial.\n\n";
 
 	code += "shader_type particles;\n";
+	code += "render_mode disable_velocity;\n";
 
 	if (collision_scale) {
 		code += "render_mode collision_use_scale;\n";
@@ -168,32 +185,61 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "uniform vec3 direction;\n";
 	code += "uniform float spread;\n";
 	code += "uniform float flatness;\n";
-	code += "uniform float initial_linear_velocity_min;\n";
-	code += "uniform float initial_angle_min;\n";
-	code += "uniform float angular_velocity_min;\n";
-	code += "uniform float orbit_velocity_min;\n";
-	code += "uniform float linear_accel_min;\n";
-	code += "uniform float radial_accel_min;\n";
-	code += "uniform float tangent_accel_min;\n";
-	code += "uniform float damping_min;\n";
-	code += "uniform float scale_min;\n";
-	code += "uniform float hue_variation_min;\n";
-	code += "uniform float anim_speed_min;\n";
-	code += "uniform float anim_offset_min;\n";
 
+	code += "uniform float inherit_emitter_velocity_ratio = 0;\n";
+
+	code += "uniform float initial_linear_velocity_min;\n";
 	code += "uniform float initial_linear_velocity_max;\n";
-	code += "uniform float initial_angle_max;\n";
+
+	code += "uniform float directional_velocity_min;\n";
+	code += "uniform float directional_velocity_max;\n";
+
+	code += "uniform float angular_velocity_min;\n";
 	code += "uniform float angular_velocity_max;\n";
+
+	code += "uniform float orbit_velocity_min;\n";
 	code += "uniform float orbit_velocity_max;\n";
+
+	code += "uniform float radial_velocity_min;\n";
+	code += "uniform float radial_velocity_max;\n";
+
+	code += "uniform float linear_accel_min;\n";
 	code += "uniform float linear_accel_max;\n";
+
+	code += "uniform float radial_accel_min;\n";
 	code += "uniform float radial_accel_max;\n";
+
+	code += "uniform float tangent_accel_min;\n";
 	code += "uniform float tangent_accel_max;\n";
+
+	code += "uniform float damping_min;\n";
 	code += "uniform float damping_max;\n";
+
+	code += "uniform float initial_angle_min;\n";
+	code += "uniform float initial_angle_max;\n";
+
+	code += "uniform float scale_min;\n";
 	code += "uniform float scale_max;\n";
+
+	code += "uniform float hue_variation_min;\n";
 	code += "uniform float hue_variation_max;\n";
+
+	code += "uniform float anim_speed_min;\n";
 	code += "uniform float anim_speed_max;\n";
+
+	code += "uniform float anim_offset_min;\n";
 	code += "uniform float anim_offset_max;\n";
+
 	code += "uniform float lifetime_randomness;\n";
+	code += "uniform vec3 emission_shape_offset = vec3(0.);\n";
+	code += "uniform vec3 emission_shape_scale = vec3(1.);\n";
+
+	code += "uniform vec3 velocity_pivot = vec3(0.);\n";
+
+	if (tex_parameters[PARAM_SCALE_OVER_VELOCITY].is_valid()) {
+		code += "uniform float scale_over_velocity_min = 0.0;\n";
+		code += "uniform float scale_over_velocity_max = 5.0;\n";
+	}
 
 	switch (emission_shape) {
 		case EMISSION_SHAPE_POINT: {
@@ -254,12 +300,18 @@ void ParticleProcessMaterial::_update_shader() {
 	if (color_initial_ramp.is_valid()) {
 		code += "uniform sampler2D color_initial_ramp : repeat_disable;\n";
 	}
+	if (alpha_curve.is_valid()) {
+		code += "uniform sampler2D alpha_curve : repeat_disable;\n";
+	}
+	if (emission_curve.is_valid()) {
+		code += "uniform sampler2D emission_curve : repeat_disable;\n";
+	}
 
 	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
 		code += "uniform sampler2D linear_velocity_texture : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
-		code += "uniform sampler2D orbit_velocity_texture : repeat_disable;\n";
+		code += "uniform sampler2D orbit_velocity_curve : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
 		code += "uniform sampler2D angular_velocity_texture : repeat_disable;\n";
@@ -280,16 +332,28 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "uniform sampler2D angle_texture : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_SCALE].is_valid()) {
-		code += "uniform sampler2D scale_texture : repeat_disable;\n";
+		code += "uniform sampler2D scale_curve : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_HUE_VARIATION].is_valid()) {
-		code += "uniform sampler2D hue_variation_texture : repeat_disable;\n";
+		code += "uniform sampler2D hue_rot_curve : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_ANIM_SPEED].is_valid()) {
-		code += "uniform sampler2D anim_speed_texture : repeat_disable;\n";
+		code += "uniform sampler2D animation_speed_curve : repeat_disable;\n";
 	}
 	if (tex_parameters[PARAM_ANIM_OFFSET].is_valid()) {
-		code += "uniform sampler2D anim_offset_texture : repeat_disable;\n";
+		code += "uniform sampler2D animation_offset_curve : repeat_disable;\n";
+	}
+	if (tex_parameters[PARAM_RADIAL_VELOCITY].is_valid()) {
+		code += "uniform sampler2D radial_velocity_curve : repeat_disable;\n";
+	}
+	if (tex_parameters[PARAM_SCALE_OVER_VELOCITY].is_valid()) {
+		code += "uniform sampler2D scale_over_velocity_curve : repeat_disable;\n";
+	}
+	if (tex_parameters[PARAM_DIRECTIONAL_VELOCITY].is_valid()) {
+		code += "uniform sampler2D directional_velocity_curve: repeat_disable;\n";
+	}
+	if (velocity_limit_curve.is_valid()) {
+		code += "uniform sampler2D velocity_limit_curve: repeat_disable;\n";
 	}
 
 	if (collision_mode == COLLISION_RIGID) {
@@ -390,6 +454,23 @@ void ParticleProcessMaterial::_update_shader() {
 		code += "	return noise_direction;\n";
 		code += "}\n";
 	}
+	code += "vec4 rotate_hue(vec4 current_color, float hue_rot_angle){\n";
+	code += "	float hue_rot_c = cos(hue_rot_angle);\n";
+	code += "	float hue_rot_s = sin(hue_rot_angle);\n";
+	code += "	mat4 hue_rot_mat = mat4(vec4(0.299, 0.587, 0.114, 0.0),\n";
+	code += "			vec4(0.299, 0.587, 0.114, 0.0),\n";
+	code += "			vec4(0.299, 0.587, 0.114, 0.0),\n";
+	code += "			vec4(0.000, 0.000, 0.000, 1.0)) +\n";
+	code += "		mat4(vec4(0.701, -0.587, -0.114, 0.0),\n";
+	code += "			vec4(-0.299, 0.413, -0.114, 0.0),\n";
+	code += "			vec4(-0.300, -0.588, 0.886, 0.0),\n";
+	code += "			vec4(0.000, 0.000, 0.000, 0.0)) * hue_rot_c +\n";
+	code += "		mat4(vec4(0.168, 0.330, -0.497, 0.0),\n";
+	code += "			vec4(-0.328, 0.035,  0.292, 0.0),\n";
+	code += "			vec4(1.250, -1.050, -0.203, 0.0),\n";
+	code += "			vec4(0.000, 0.000, 0.000, 0.0)) * hue_rot_s;\n";
+	code += "	return hue_rot_mat * current_color;\n";
+	code += "}\n";
 
 	//need a random function
 	code += "\n\n";
@@ -421,398 +502,528 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "}\n";
 	code += "\n";
 
-	code += "void start() {\n";
-	code += "	uint base_number = NUMBER;\n";
-	code += "	uint alt_seed = hash(base_number + uint(1) + RANDOM_SEED);\n";
-	code += "	float angle_rand = rand_from_seed(alt_seed);\n";
-	code += "	float scale_rand = rand_from_seed(alt_seed);\n";
-	code += "	float hue_rot_rand = rand_from_seed(alt_seed);\n";
-	code += "	float anim_offset_rand = rand_from_seed(alt_seed);\n";
-	if (color_initial_ramp.is_valid()) {
-		code += "	float color_initial_rand = rand_from_seed(alt_seed);\n";
+	code += "struct DisplayParameters{\n";
+	code += "	vec3 scale;\n";
+	code += "	float hue_rotation;\n";
+	code += "	float animation_speed;\n";
+	code += "	float animation_offset;\n";
+	code += "	float lifetime;\n";
+	code += "	vec4 color;\n";
+	code += "};\n";
+	code += "\n";
+	code += "struct DynamicsParameters{\n";
+	code += "	float angle;\n";
+	code += "	float angular_velocity;\n";
+	code += "	float initial_velocity_multiplier;\n";
+	code += "	float directional_velocity;\n";
+	code += "	float radial_velocity;\n";
+	code += "	float orbit_velocity;\n";
+	if (turbulence_enabled) {
+		code += "	float turb_influence;\n";
 	}
+	code += "};\n";
+	code += "struct PhysicalParameters{\n";
+	code += "	float linear_accel;\n";
+	code += "	float radial_accel;\n";
+	code += "	float tangent_accel;\n";
+	code += "	float damping;\n";
+	code += "};\n";
+
+	code += "\n";
+	code += "void calculate_initial_physical_params(inout PhysicalParameters params, inout uint alt_seed){\n";
+	code += "	params.linear_accel = mix(linear_accel_min, linear_accel_min ,rand_from_seed(alt_seed));\n";
+	code += "	params.radial_accel = mix(radial_accel_min, radial_accel_min,rand_from_seed(alt_seed));\n";
+	code += "	params.tangent_accel = mix(tangent_accel_min, tangent_accel_max,rand_from_seed(alt_seed));\n";
+	code += "	params.damping = mix(damping_min, damping_max,rand_from_seed(alt_seed));\n";
+	code += "}\n";
+	code += "\n";
+	code += "void calculate_initial_dynamics_params(inout DynamicsParameters params,inout uint alt_seed){\n";
+	code += "	// -------------------- DO NOT REORDER OPERATIONS, IT BREAKS VISUAL COMPATIBILITY\n";
+	code += "	// -------------------- ADD NEW OPERATIONS AT THE BOTTOM\n";
+	code += "	params.angle = mix(initial_angle_min, initial_angle_max, rand_from_seed(alt_seed));\n";
+	code += "	params.angular_velocity = mix(angular_velocity_min, angular_velocity_max, rand_from_seed(alt_seed));\n";
+	code += "	params.initial_velocity_multiplier = mix(initial_linear_velocity_min, initial_linear_velocity_max,rand_from_seed(alt_seed));\n";
+	code += "	params.directional_velocity = mix(directional_velocity_min, directional_velocity_max,rand_from_seed(alt_seed));\n";
+	code += "	params.radial_velocity = mix(radial_velocity_min, radial_velocity_max,rand_from_seed(alt_seed));\n";
+	code += "	params.orbit_velocity = mix(orbit_velocity_min, orbit_velocity_max,rand_from_seed(alt_seed));\n";
+	if (turbulence_enabled) {
+		code += "   params.turb_influence = mix(turbulence_influence_min,turbulence_influence_max,rand_from_seed(alt_seed));\n";
+	}
+	code += "}\n";
+	code += "void calculate_initial_display_params(inout DisplayParameters params,inout uint alt_seed){\n";
+	code += "	// -------------------- DO NOT REORDER OPERATIONS, IT BREAKS VISUAL COMPATIBILITY\n";
+	code += "	// -------------------- ADD NEW OPERATIONS AT THE BOTTOM\n";
 	code += "	float pi = 3.14159;\n";
 	code += "	float degree_to_rad = pi / 180.0;\n";
-	code += "\n";
 
-	if (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
+	code += "   params.scale = vec3(mix(scale_min, scale_max, rand_from_seed(alt_seed)));\n";
+	code += "   params.scale = sign(params.scale) * max(abs(params.scale), 0.001);\n";
+	code += "	params.hue_rotation =  pi * 2.0 * mix(hue_variation_min, hue_variation_max, rand_from_seed(alt_seed));\n";
+	code += "	params.animation_speed = mix(anim_speed_min, anim_speed_max, rand_from_seed(alt_seed));\n";
+	code += "	params.animation_offset = mix(anim_offset_min, anim_offset_max, rand_from_seed(alt_seed));\n";
+	code += "	params.lifetime = (1.0 - lifetime_randomness * rand_from_seed(alt_seed));\n";
+	code += "	params.color = color_value;\n";
+	if (color_initial_ramp.is_valid()) {
+		code += "	params.color = texture(color_initial_ramp, vec2(rand_from_seed(alt_seed)));\n";
+	}
+	if (emission_color_texture.is_valid() && (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS)) {
 		code += "	int point = min(emission_texture_point_count - 1, int(rand_from_seed(alt_seed) * float(emission_texture_point_count)));\n";
 		code += "	ivec2 emission_tex_size = textureSize(emission_texture_points, 0);\n";
 		code += "	ivec2 emission_tex_ofs = ivec2(point % emission_tex_size.x, point / emission_tex_size.x);\n";
+		code += "	parameters.color *= texelFetch(emission_texture_color, emission_tex_ofs, 0);\n";
 	}
-	if (tex_parameters[PARAM_ANGLE].is_valid()) {
-		code += "	float tex_angle = textureLod(angle_texture, vec2(0.0, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_angle = 1.0;\n";
-	}
+	code += "}\n";
 
+	// process display parameters that are bound solely by lifetime
+	code += "void process_display_param(inout DisplayParameters parameters, float lifetime){\n";
+	code += "	// compile-time add textures\n";
+	if (tex_parameters[PARAM_SCALE].is_valid()) {
+		code += "	parameters.scale *= texture(scale_curve, vec2(lifetime)).rgb;\n";
+	}
+	if (tex_parameters[PARAM_HUE_VARIATION].is_valid()) {
+		code += "	parameters.hue_rotation *= texture(hue_rot_curve, vec2(lifetime)).r;\n";
+	}
 	if (tex_parameters[PARAM_ANIM_OFFSET].is_valid()) {
-		code += "	float tex_anim_offset = textureLod(anim_offset_texture, vec2(0.0, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_anim_offset = 1.0;\n";
+		code += "	parameters.animation_offset += texture(animation_offset_curve, vec2(lifetime)).r;\n";
+	}
+	if (tex_parameters[PARAM_ANIM_SPEED].is_valid()) {
+		code += "	parameters.animation_speed *= texture(animation_speed_curve, vec2(lifetime)).r;\n";
+	}
+	if (color_ramp.is_valid()) {
+		code += "   parameters.color *= texture(color_ramp, vec2(lifetime));\n";
+	}
+	if (alpha_curve.is_valid()) {
+		code += "	parameters.color.a *= texture(alpha_curve, vec2(lifetime)).r;\n";
+	}
+	code += "	parameters.color = rotate_hue(parameters.color, parameters.hue_rotation);\n";
+	if (emission_curve.is_valid()) {
+		code += "	parameters.color.rgb *= 1.0 + texture(emission_curve, vec2(lifetime)).r;\n";
+	}
+	code += "}\n";
+
+	code += "vec3 calculate_initial_position(inout uint alt_seed) {\n";
+	code += "	float pi = 3.14159;\n";
+	code += "	float degree_to_rad = pi / 180.0;\n";
+	code += "	vec3 pos = vec3(0.);\n";
+	if (emission_shape == EMISSION_SHAPE_POINT) {
+		code += "	 pos = vec3(0.);\n";
+	}
+	if (emission_shape == EMISSION_SHAPE_SPHERE) {
+		code += "		float s = rand_from_seed(alt_seed) * 2.0 - 1.0;\n";
+		code += "		float t = rand_from_seed(alt_seed) * 2.0 * pi;\n";
+		code += "		float p = rand_from_seed(alt_seed);\n";
+		code += "		float radius = emission_sphere_radius * sqrt(1.0 - s * s);\n";
+		code += "		pos = mix(vec3(0.0, 0.0, 0.0), vec3(radius * cos(t), radius * sin(t), emission_sphere_radius * s), p);\n";
 	}
 
-	code += "	float spread_rad = spread * degree_to_rad;\n";
-
-	code += "	if (RESTART_VELOCITY) {\n";
-
-	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
-		code += "		float tex_linear_velocity = textureLod(linear_velocity_texture, vec2(0.0, 0.0), 0.0).r;\n";
-	} else {
-		code += "		float tex_linear_velocity = 1.0;\n";
+	if (emission_shape == EMISSION_SHAPE_SPHERE_SURFACE) {
+		code += "		float s = rand_from_seed(alt_seed) * 2.0 - 1.0;\n";
+		code += "		float t = rand_from_seed(alt_seed) * 2.0 * pi;\n";
+		code += "		float radius = emission_sphere_radius * sqrt(1.0 - s * s);\n";
+		code += "		pos = vec3(radius * cos(t), radius * sin(t), emission_sphere_radius * s);\n";
 	}
-
-	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "		{\n";
-		code += "			float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
-		code += "			angle1_rad += direction.x != 0.0 ? atan(direction.y, direction.x) : sign(direction.y) * (pi / 2.0);\n";
-		code += "			vec3 rot = vec3(cos(angle1_rad), sin(angle1_rad), 0.0);\n";
-		code += "			VELOCITY = rot * mix(initial_linear_velocity_min,initial_linear_velocity_max, rand_from_seed(alt_seed));\n";
+	if (emission_shape == EMISSION_SHAPE_BOX) {
+		code += "		pos = vec3(rand_from_seed(alt_seed) * 2.0 - 1.0, rand_from_seed(alt_seed) * 2.0 - 1.0, rand_from_seed(alt_seed) * 2.0 - 1.0) * emission_box_extents;\n";
+	}
+	if (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
+		code += "		int point = min(emission_texture_point_count - 1, int(rand_from_seed(alt_seed) * float(emission_texture_point_count)));\n";
+		code += "		ivec2 emission_tex_size = textureSize(emission_texture_points, 0);\n";
+		code += "		ivec2 emission_tex_ofs = ivec2(point % emission_tex_size.x, point / emission_tex_size.x);\n";
+		code += "		pos = texelFetch(emission_texture_points, emission_tex_ofs, 0).xyz;\n";
+	}
+	if (emission_shape == EMISSION_SHAPE_RING) {
+		code += "		\n";
+		code += "		float ring_spawn_angle = rand_from_seed(alt_seed) * 2.0 * pi;\n";
+		code += "		float ring_random_radius = rand_from_seed(alt_seed) * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;\n";
+		code += "		vec3 axis = normalize(emission_ring_axis);\n";
+		code += "		vec3 ortho_axis = vec3(0.0);\n";
+		code += "		if (axis == vec3(1.0, 0.0, 0.0)) {\n";
+		code += "			ortho_axis = cross(axis, vec3(0.0, 1.0, 0.0));\n";
+		code += "		} else {\n";
+		code += " 			ortho_axis = cross(axis, vec3(1.0, 0.0, 0.0));\n";
 		code += "		}\n";
-
-	} else {
-		//initiate velocity spread in 3D
-		code += "		{\n";
-		code += "			float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
-		code += "			float angle2_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad * (1.0 - flatness);\n";
-		code += "			vec3 direction_xz = vec3(sin(angle1_rad), 0.0, cos(angle1_rad));\n";
-		code += "			vec3 direction_yz = vec3(0.0, sin(angle2_rad), cos(angle2_rad));\n";
-		code += "			direction_yz.z = direction_yz.z / max(0.0001,sqrt(abs(direction_yz.z))); // better uniform distribution\n";
-		code += "			vec3 spread_direction = vec3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);\n";
-		code += "			vec3 direction_nrm = length(direction) > 0.0 ? normalize(direction) : vec3(0.0, 0.0, 1.0);\n";
-		code += "			// rotate spread to direction\n";
-		code += "			vec3 binormal = cross(vec3(0.0, 1.0, 0.0), direction_nrm);\n";
-		code += "			if (length(binormal) < 0.0001) {\n";
-		code += "				// direction is parallel to Y. Choose Z as the binormal.\n";
-		code += "				binormal = vec3(0.0, 0.0, 1.0);\n";
-		code += "			}\n";
-		code += "			binormal = normalize(binormal);\n";
-		code += "			vec3 normal = cross(binormal, direction_nrm);\n";
-		code += "			spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;\n";
-		code += "			VELOCITY = spread_direction * mix(initial_linear_velocity_min, initial_linear_velocity_max,rand_from_seed(alt_seed));\n";
-		code += "		}\n";
+		code += "		ortho_axis = normalize(ortho_axis);\n";
+		code += "		float s = sin(ring_spawn_angle);\n";
+		code += "		float c = cos(ring_spawn_angle);\n";
+		code += "		float oc = 1.0 - c;\n";
+		code += "		ortho_axis = mat3(\n";
+		code += "			vec3(c + axis.x * axis.x * oc, axis.x * axis.y * oc - axis.z * s, axis.x * axis.z *oc + axis.y * s),\n";
+		code += "			vec3(axis.x * axis.y * oc + s * axis.z, c + axis.y * axis.y * oc, axis.y * axis.z * oc - axis.x * s),\n";
+		code += "			vec3(axis.z * axis.x * oc - axis.y * s, axis.z * axis.y * oc + axis.x * s, c + axis.z * axis.z * oc)\n";
+		code += "			) * ortho_axis;\n";
+		code += "		ortho_axis = normalize(ortho_axis);\n";
+		code += "		pos = ortho_axis * ring_random_radius + (rand_from_seed(alt_seed) * emission_ring_height - emission_ring_height / 2.0) * axis;\n";
 	}
+
+	code += "	return pos * emission_shape_scale + emission_shape_offset;\n";
+	code += "}\n";
+	code += "\n";
+	if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid() || particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		code += "vec3 process_orbit_displacement(DynamicsParameters param, float lifetime, inout uint alt_seed, mat4 transform, mat4 emission_transform,float delta, float total_lifetime){\n";
+		// No reason to run all these expensive calculation below if we have no orbit velocity
+		// HOWEVER
+		// May be a bad idea for fps consistency?
+		code += "if(abs(param.orbit_velocity) < 0.01){ return vec3(0.0);}\n";
+		code += "\n";
+		code += "	vec3 displacement = vec3(0.);\n";
+		code += "	float pi = 3.14159;\n";
+		code += "	float degree_to_rad = pi / 180.0;\n";
+		if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+			code += "	float orbit_amount = param.orbit_velocity;\n";
+
+			if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
+				code += "   orbit_amount *= texture(orbit_velocity_curve, vec2(lifetime)).r;\n";
+			}
+			code += "	if (orbit_amount != 0.0) {\n";
+			code += "       vec3 pos = transform[3].xyz;\n";
+			code += "       vec3 org = emission_transform[3].xyz;\n";
+			code += "       vec3 diff = pos - org;\n";
+			code += "	     float ang = orbit_amount * delta * pi * 2.0;\n";
+			code += "	     mat2 rot = mat2(vec2(cos(ang), -sin(ang)), vec2(sin(ang), cos(ang)));\n";
+			code += "	     displacement.xy -= diff.xy;\n";
+			code += "        displacement.xy += rot * diff.xy;\n";
+			code += "	}\n";
+		} else {
+			code += "	vec3 orbit_velocities = vec3(param.orbit_velocity);\n";
+			code += "   orbit_velocities *= texture(orbit_velocity_curve, vec2(lifetime)).rgb;\n";
+
+			code += "	orbit_velocities *= degree_to_rad;\n";
+			code += "	orbit_velocities *= delta/total_lifetime; // we wanna process those by the delta angle\n";
+			code += "	//vec3 local_velocity_pivot = ((emission_transform) * vec4(velocity_pivot,1.0)).xyz;\n";
+			code += "	// X axis\n";
+			code += "	vec3 local_pos = (inverse(emission_transform) * transform[3]).xyz;\n";
+			code += "	local_pos -= velocity_pivot;\n";
+			code += "	local_pos.x = 0.;\n";
+			code += "	mat3 x_rotation_mat = mat3(\n";
+			code += "		vec3(1.0,0.0,0.0),\n";
+			code += "		vec3(0.0, cos(orbit_velocities.x), sin(orbit_velocities.x)),\n";
+			code += "		vec3(0.0, -sin(orbit_velocities.x), cos(orbit_velocities.x))\n";
+			code += "	);\n";
+			code += "	vec3 new_pos = x_rotation_mat * local_pos;\n";
+			code += "	displacement = new_pos - local_pos;\n";
+			code += "\n";
+			code += "	// Y axis\n";
+			code += "	local_pos = (inverse(emission_transform) * transform[3]).xyz;\n";
+			code += "	local_pos -= velocity_pivot;\n";
+			code += "	local_pos.y = 0.;\n";
+			code += "	mat3 y_rotation_mat = mat3(\n";
+			code += "		vec3(cos(orbit_velocities.y), 0.0, -sin(orbit_velocities.y)),\n";
+			code += "		vec3(0.0, 1.0,0.0),\n";
+			code += "		vec3(sin(orbit_velocities.y), 0.0, cos(orbit_velocities.y))\n";
+			code += "	);\n";
+			code += "	new_pos = y_rotation_mat * local_pos;\n";
+			code += "	displacement += new_pos - local_pos;\n";
+			code += "	// z axis\n";
+			code += "\n";
+			code += "	local_pos = (inverse(emission_transform) * transform[3]).xyz;\n";
+			code += "	local_pos -= velocity_pivot;\n";
+			code += "	local_pos.z = 0.;\n";
+			code += "	mat3 z_rotation_mat = mat3(\n";
+			code += "		vec3(cos(orbit_velocities.z),-sin(orbit_velocities.z),0.0),\n";
+			code += "		vec3(-sin(orbit_velocities.z),cos(orbit_velocities.z), 0.0),\n";
+			code += "		vec3(0.0,0.0,1.0)\n";
+			code += "	);\n";
+			code += "	new_pos = z_rotation_mat * local_pos;\n";
+			code += "	displacement += new_pos - local_pos;\n";
+			code += "\n";
+		}
+		code += "	return (emission_transform * vec4(displacement, 0.0)).xyz;\n";
+		code += "}\n";
+		code += "\n";
+		code += "\n";
+	}
+
+	code += "vec3 get_random_direction_from_spread(inout uint alt_seed, float spread_angle){\n";
+	code += "	float pi = 3.14159;\n";
+	code += "	float degree_to_rad = pi / 180.0;\n";
+	code += "	vec3 velocity = vec3(0.);\n";
+	code += "	float spread_rad = spread_angle * degree_to_rad;\n";
+	code += "	float angle1_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad;\n";
+	code += "	float angle2_rad = rand_from_seed_m1_p1(alt_seed) * spread_rad * (1.0 - flatness);\n";
+	code += "	vec3 direction_xz = vec3(sin(angle1_rad), 0.0, cos(angle1_rad));\n";
+	code += "	vec3 direction_yz = vec3(0.0, sin(angle2_rad), cos(angle2_rad));\n";
+	code += "	direction_yz.z = direction_yz.z / max(0.0001,sqrt(abs(direction_yz.z))); // better uniform distribution\n";
+	code += "	vec3 spread_direction = vec3(direction_xz.x * direction_yz.z, direction_yz.y, direction_xz.z * direction_yz.z);\n";
+	code += "	vec3 direction_nrm = length(direction) > 0.0 ? normalize(direction) : vec3(0.0, 0.0, 1.0);\n";
+	code += "	// rotate spread to direction\n";
+	code += "	vec3 binormal = cross(vec3(0.0, 1.0, 0.0), direction_nrm);\n";
+	code += "	if (length(binormal) < 0.0001) {\n";
+	code += "		// direction is parallel to Y. Choose Z as the binormal.\n";
+	code += "		binormal = vec3(0.0, 0.0, 1.0);\n";
 	code += "	}\n";
+	code += "	binormal = normalize(binormal);\n";
+	code += "	vec3 normal = cross(binormal, direction_nrm);\n";
+	code += "	spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;\n";
+	code += "	return spread_direction;\n";
 
-	code += "	float base_angle = (tex_angle) * mix(initial_angle_min, initial_angle_max, angle_rand);\n";
-	code += "	CUSTOM.x = base_angle * degree_to_rad;\n"; // angle
-	code += "	CUSTOM.y = 0.0;\n"; // phase
-	code += "	CUSTOM.w = (1.0 - lifetime_randomness * rand_from_seed(alt_seed));\n";
-	code += "	CUSTOM.z = (tex_anim_offset) * mix(anim_offset_min, anim_offset_max, anim_offset_rand);\n\n"; // animation offset (0-1)
+	code += "}\n";
 
+	code += "vec3 process_radial_displacement(DynamicsParameters param, float lifetime, inout uint alt_seed, mat4 transform, mat4 emission_transform, float delta){\n";
+	code += "	vec3 radial_displacement = vec3(0.0);\n";
+	code += "	float radial_displacement_multiplier = 1.0;\n";
+	if (tex_parameters[PARAM_RADIAL_VELOCITY].is_valid()) {
+		code += "   radial_displacement_multiplier = texture(radial_velocity_curve, vec2(lifetime)).r;\n";
+	}
+	code += "	vec3 global_pivot = (emission_transform * vec4(velocity_pivot, 1.0)).xyz;\n";
+	code += "	if(length(transform[3].xyz - global_pivot) > 0.01){\n";
+	code += "		radial_displacement = normalize(transform[3].xyz - global_pivot) * radial_displacement_multiplier * param.radial_velocity;\n";
+	code += "	}else{radial_displacement = get_random_direction_from_spread(alt_seed, 360.0)* param.radial_velocity;} \n";
+	code += "	if (radial_displacement_multiplier * param.radial_velocity < 0.0){\n // Prevent inwards velocity to flicker once the point is reached.";
+	code += "		if (length(radial_displacement) > 0.01){\n";
+	code += "		radial_displacement = normalize(radial_displacement) * min(abs((radial_displacement_multiplier * param.radial_velocity)), length(transform[3].xyz - global_pivot));\n";
+	code += "		}\n";
+	code += "	\n";
+	code += "	return radial_displacement * delta;\n";
+	code += "}\n";
+	if (tex_parameters[PARAM_DIRECTIONAL_VELOCITY].is_valid()) {
+		code += "vec3 process_directional_displacement(DynamicsParameters param, float lifetime_percent,mat4 transform, mat4 emission_transform, float delta){\n";
+		code += "	vec3 displacement = vec3(0.);\n";
+		if (directional_velocity_global) {
+			code += "		displacement = texture(directional_velocity_curve, vec2(lifetime_percent)).xyz * param.directional_velocity;\n";
+			code += "		displacement = (emission_transform * vec4(displacement, 0.0)).xyz;\n";
+		} else {
+			code += "		displacement = texture(directional_velocity_curve, vec2(lifetime_percent)).xyz * param.directional_velocity;\n";
+		}
+		code += "	return displacement * delta;\n";
+		code += "}\n";
+	}
+
+	code += "\n";
+	code += "void process_physical_parameters(inout PhysicalParameters params, float lifetime_percent){\n";
+	if (tex_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
+		code += "	params.linear_accel *= texture(linear_accel_texture, vec2(lifetime_percent)).r;\n";
+	}
+	if (tex_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
+		code += "	params.radial_accel *= texture(radial_accel_texture, vec2(lifetime_percent)).r;\n";
+	}
+	if (tex_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
+		code += "	params.tangent_accel *= texture(tangent_accel_texture, vec2(lifetime_percent)).r;\n";
+	}
+	if (tex_parameters[PARAM_DAMPING].is_valid()) {
+		code += "	params.damping *= texture(damping_texture, vec2(lifetime_percent)).r;\n";
+	}
+	code += "	\n";
+	code += "}\n";
+	code += "\n";
+
+	code += "void start() {\n";
+	code += "	uint base_number = NUMBER;\n";
+	code += "	uint alt_seed = hash(base_number + uint(1) + RANDOM_SEED);\n";
+	code += "	if (rand_from_seed(alt_seed) > AMOUNT_RATIO) {\n";
+	code += "		ACTIVE = false;\n";
+	code += "	}\n";
+	code += "	DisplayParameters params;\n";
+	code += "	calculate_initial_display_params(params, alt_seed);\n";
+	code += "	// reset alt seed?\n";
+	code += "	// alt_seed = hash(base_number + uint(1) + RANDOM_SEED);\n";
+	code += "	DynamicsParameters dynamic_params;\n";
+	code += "	calculate_initial_dynamics_params(dynamic_params, alt_seed);\n";
+	code += "	PhysicalParameters physics_params;\n";
+	code += "	calculate_initial_physical_params(physics_params, alt_seed);\n";
+	code += "   process_display_param(params, 0.0);\n";
+	code += "	\n";
+	code += "	float pi = 3.14159;\n";
+	code += "	float degree_to_rad = pi / 180.0;\n";
+	code += "	\n";
+	code += "	if (RESTART_CUSTOM){\n";
+	code += "		CUSTOM = vec4(0.);\n";
+	code += "		CUSTOM.w = params.lifetime;\n";
+	code += "		CUSTOM.x = dynamic_params.angle;\n";
+	code += "	}\n";
+	code += "	if (RESTART_COLOR){\n";
+	code += "		COLOR = params.color;\n";
+	code += "	}\n";
 	code += "	if (RESTART_ROT_SCALE) {\n";
 	code += "		TRANSFORM[0].xyz = vec3(1.0, 0.0, 0.0);\n";
 	code += "		TRANSFORM[1].xyz = vec3(0.0, 1.0, 0.0);\n";
 	code += "		TRANSFORM[2].xyz = vec3(0.0, 0.0, 1.0);\n";
-	code += "	}\n\n";
-
-	code += "	if (RESTART_POSITION) {\n";
-
-	switch (emission_shape) {
-		case EMISSION_SHAPE_POINT: {
-			//do none, identity (will later be multiplied by emission transform)
-			code += "		TRANSFORM[3].xyz = vec3(0.0, 0.0, 0.0);\n";
-		} break;
-		case EMISSION_SHAPE_SPHERE: {
-			code += "		float s = rand_from_seed(alt_seed) * 2.0 - 1.0;\n";
-			code += "		float t = rand_from_seed(alt_seed) * 2.0 * pi;\n";
-			code += "		float p = rand_from_seed(alt_seed);\n";
-			code += "		float radius = emission_sphere_radius * sqrt(1.0 - s * s);\n";
-			code += "		TRANSFORM[3].xyz = mix(vec3(0.0, 0.0, 0.0), vec3(radius * cos(t), radius * sin(t), emission_sphere_radius * s), p);\n";
-		} break;
-		case EMISSION_SHAPE_SPHERE_SURFACE: {
-			code += "		float s = rand_from_seed(alt_seed) * 2.0 - 1.0;\n";
-			code += "		float t = rand_from_seed(alt_seed) * 2.0 * pi;\n";
-			code += "		float radius = emission_sphere_radius * sqrt(1.0 - s * s);\n";
-			code += "		TRANSFORM[3].xyz = vec3(radius * cos(t), radius * sin(t), emission_sphere_radius * s);\n";
-		} break;
-		case EMISSION_SHAPE_BOX: {
-			code += "		TRANSFORM[3].xyz = vec3(rand_from_seed(alt_seed) * 2.0 - 1.0, rand_from_seed(alt_seed) * 2.0 - 1.0, rand_from_seed(alt_seed) * 2.0 - 1.0) * emission_box_extents;\n";
-		} break;
-		case EMISSION_SHAPE_POINTS:
-		case EMISSION_SHAPE_DIRECTED_POINTS: {
-			code += "		TRANSFORM[3].xyz = texelFetch(emission_texture_points, emission_tex_ofs, 0).xyz;\n";
-
-			if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
-				if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-					code += "		{\n";
-					code += "			mat2 rotm;";
-					code += "			rotm[0] = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xy;\n";
-					code += "			rotm[1] = rotm[0].yx * vec2(1.0, -1.0);\n";
-					code += "			if (RESTART_VELOCITY) VELOCITY.xy = rotm * VELOCITY.xy;\n";
-					code += "		}\n";
-				} else {
-					code += "		{\n";
-					code += "			vec3 normal = texelFetch(emission_texture_normal, emission_tex_ofs, 0).xyz;\n";
-					code += "			vec3 v0 = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);\n";
-					code += "			vec3 tangent = normalize(cross(v0, normal));\n";
-					code += "			vec3 bitangent = normalize(cross(tangent, normal));\n";
-					code += "			if (RESTART_VELOCITY) VELOCITY = mat3(tangent, bitangent, normal) * VELOCITY;\n";
-					code += "		}\n";
-				}
-			}
-		} break;
-		case EMISSION_SHAPE_RING: {
-			code += "		float ring_spawn_angle = rand_from_seed(alt_seed) * 2.0 * pi;\n";
-			code += "		float ring_random_radius = rand_from_seed(alt_seed) * (emission_ring_radius - emission_ring_inner_radius) + emission_ring_inner_radius;\n";
-			code += "		vec3 axis = normalize(emission_ring_axis);\n";
-			code += "		vec3 ortho_axis = vec3(0.0);\n";
-			code += "		if (axis == vec3(1.0, 0.0, 0.0)) {\n";
-			code += "			ortho_axis = cross(axis, vec3(0.0, 1.0, 0.0));\n";
-			code += "		} else {\n";
-			code += " 			ortho_axis = cross(axis, vec3(1.0, 0.0, 0.0));\n";
-			code += "		}\n";
-			code += "		ortho_axis = normalize(ortho_axis);\n";
-			code += "		float s = sin(ring_spawn_angle);\n";
-			code += "		float c = cos(ring_spawn_angle);\n";
-			code += "		float oc = 1.0 - c;\n";
-			code += "		ortho_axis = mat3(\n";
-			code += "			vec3(c + axis.x * axis.x * oc, axis.x * axis.y * oc - axis.z * s, axis.x * axis.z *oc + axis.y * s),\n";
-			code += "			vec3(axis.x * axis.y * oc + s * axis.z, c + axis.y * axis.y * oc, axis.y * axis.z * oc - axis.x * s),\n";
-			code += "			vec3(axis.z * axis.x * oc - axis.y * s, axis.z * axis.y * oc + axis.x * s, c + axis.z * axis.z * oc)\n";
-			code += "			) * ortho_axis;\n";
-			code += "		ortho_axis = normalize(ortho_axis);\n";
-			code += "		TRANSFORM[3].xyz = ortho_axis * ring_random_radius + (rand_from_seed(alt_seed) * emission_ring_height - emission_ring_height / 2.0) * axis;\n";
-		} break;
-		case EMISSION_SHAPE_MAX: { // Max value for validity check.
-			break;
-		}
-	}
-	code += "	if (RESTART_VELOCITY) VELOCITY = (EMISSION_TRANSFORM * vec4(VELOCITY, 0.0)).xyz;\n";
-	// Apply noise/turbulence: initial displacement.
-	if (turbulence_enabled) {
-		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
-		code += "	float turb_init_displacement = mix(turbulence_initial_displacement_min, turbulence_initial_displacement_max, rand_from_seed(alt_seed));";
-		code += "	TRANSFORM[3].xyz += noise_direction * turb_init_displacement;\n";
-	}
-	code += "	TRANSFORM = EMISSION_TRANSFORM * TRANSFORM;\n";
-	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	VELOCITY.z = 0.0;\n";
-		code += "	TRANSFORM[3].z = 0.0;\n";
-	}
 	code += "	}\n";
-	code += "}\n\n";
+	code += "\n";
+	code += "	if (RESTART_POSITION) {\n";
+	code += "		TRANSFORM[3].xyz = calculate_initial_position(alt_seed);\n";
+	if (turbulence_enabled) {
+		code += "	float initial_turbulence_displacement = mix(turbulence_initial_displacement_min, turbulence_initial_displacement_max, rand_from_seed(alt_seed));\n";
+		code += "			vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
+		code += "			TRANSFORM[3].xyz += noise_direction * initial_turbulence_displacement;\n";
+	}
+	code += "		TRANSFORM = EMISSION_TRANSFORM * TRANSFORM;\n";
+	code += "		}\n";
+	code += "	if (RESTART_VELOCITY) {\n";
+	code += "		VELOCITY = get_random_direction_from_spread(alt_seed, spread) * dynamic_params.initial_velocity_multiplier;\n";
+	code += "		}\n";
+	code += "	process_display_param(params, 0.);\n";
+	code += "//	process_dynamic_parameters(dynamic_params, 0., alt_seed, TRANSFORM, EMISSION_TRANSFORM, DELTA);\n";
+	code += "	VELOCITY = (EMISSION_TRANSFORM * vec4(VELOCITY, 0.0)).xyz;\n";
+	code += "	VELOCITY += EMITTER_VELOCITY * inherit_emitter_velocity_ratio;\n";
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		code += "		VELOCITY.z = 0.;\n";
+		code += "		TRANSFORM[3].z = 0.;\n";
+	}
+	code += "}\n";
+	code += "\n";
 
 	code += "void process() {\n";
 	code += "	uint base_number = NUMBER;\n";
+	// TODO add optional determinism here
+	code += "//	if (repeatable){\n";
+	code += "//		base_number = INDEX;\n";
+	code += "//	}\n";
 	code += "	uint alt_seed = hash(base_number + uint(1) + RANDOM_SEED);\n";
-	code += "	float angle_rand = rand_from_seed(alt_seed);\n";
-	code += "	float scale_rand = rand_from_seed(alt_seed);\n";
-	code += "	float hue_rot_rand = rand_from_seed(alt_seed);\n";
-	code += "	float anim_offset_rand = rand_from_seed(alt_seed);\n";
-	if (color_initial_ramp.is_valid()) {
-		code += "	float color_initial_rand = rand_from_seed(alt_seed);\n";
-	}
+	code += "	DisplayParameters params;\n";
+	code += "	calculate_initial_display_params(params, alt_seed);\n";
+	code += "	DynamicsParameters dynamic_params;\n";
+	code += "	calculate_initial_dynamics_params(dynamic_params, alt_seed);\n";
+	code += "	PhysicalParameters physics_params;\n";
+	code += "	calculate_initial_physical_params(physics_params, alt_seed);\n";
 	code += "	float pi = 3.14159;\n";
 	code += "	float degree_to_rad = pi / 180.0;\n";
 	code += "\n";
-
-	if (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS) {
-		code += "	int point = min(emission_texture_point_count - 1, int(rand_from_seed(alt_seed) * float(emission_texture_point_count)));\n";
-		code += "	ivec2 emission_tex_size = textureSize(emission_texture_points, 0);\n";
-		code += "	ivec2 emission_tex_ofs = ivec2(point % emission_tex_size.x, point / emission_tex_size.x);\n";
-	}
-
 	code += "	CUSTOM.y += DELTA / LIFETIME;\n";
-	code += "	float tv = CUSTOM.y / CUSTOM.w;\n";
-	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
-		code += "	float tex_linear_velocity = textureLod(linear_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_linear_velocity = 1.0;\n";
+	code += "	CUSTOM.y = mix(CUSTOM.y, 1.0, INTERPOLATE_TO_END);\n";
+	code += "	float lifetime_percent = CUSTOM.y/ params.lifetime;\n";
+	code += "	if (CUSTOM.y > CUSTOM.w) {\n";
+	code += "		ACTIVE = false;\n";
+	code += "	}\n";
+	code += "	\n";
+	code += "	\n";
+	code += "	\n";
+	code += "	// will use this later to calculate final displacement and orient the particle.\n";
+	code += "	vec3 starting_position = TRANSFORM[3].xyz;\n";
+	code += "	vec3 controlled_displacement = vec3(0.0);\n";
+	code += "	\n";
+	code += "//	VELOCITY += process_physics_parameters(dynamic_params, lifetime_percent, alt_seed, TRANSFORM, EMISSION_TRANSFORM, DELTA);\n";
+	code += "	\n";
+	if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid() || particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		code += "	controlled_displacement += process_orbit_displacement(dynamic_params, lifetime_percent, alt_seed, TRANSFORM, EMISSION_TRANSFORM, DELTA, params.lifetime * LIFETIME);\n";
 	}
-
-	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		if (tex_parameters[PARAM_ORBIT_VELOCITY].is_valid()) {
-			code += "	float tex_orbit_velocity = textureLod(orbit_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
-		} else {
-			code += "	float tex_orbit_velocity = 1.0;\n";
-		}
-	}
-
-	if (tex_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
-		code += "	float tex_angular_velocity = textureLod(angular_velocity_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_angular_velocity = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_LINEAR_ACCEL].is_valid()) {
-		code += "	float tex_linear_accel = textureLod(linear_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_linear_accel = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_RADIAL_ACCEL].is_valid()) {
-		code += "	float tex_radial_accel = textureLod(radial_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_radial_accel = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_TANGENTIAL_ACCEL].is_valid()) {
-		code += "	float tex_tangent_accel = textureLod(tangent_accel_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_tangent_accel = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_DAMPING].is_valid()) {
-		code += "	float tex_damping = textureLod(damping_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_damping = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_ANGLE].is_valid()) {
-		code += "	float tex_angle = textureLod(angle_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_angle = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_ANIM_SPEED].is_valid()) {
-		code += "	float tex_anim_speed = textureLod(anim_speed_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_anim_speed = 1.0;\n";
-	}
-
-	if (tex_parameters[PARAM_ANIM_OFFSET].is_valid()) {
-		code += "	float tex_anim_offset = textureLod(anim_offset_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_anim_offset = 1.0;\n";
-	}
-
-	code += "	vec3 force = gravity;\n";
-	code += "	vec3 pos = TRANSFORM[3].xyz;\n";
-	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	pos.z = 0.0;\n";
-	}
-	code += "	// apply linear acceleration\n";
-	code += "	float linear_accel_rand = rand_from_seed(alt_seed);\n";
-	code += "	force += length(VELOCITY) > 0.0 ? normalize(VELOCITY) * tex_linear_accel * mix(linear_accel_min, linear_accel_max, linear_accel_rand) : vec3(0.0);\n";
-	code += "	// apply radial acceleration\n";
-	code += "	vec3 org = EMISSION_TRANSFORM[3].xyz;\n";
-	code += "	vec3 diff = pos - org;\n";
-	code += "	float radial_accel_rand = rand_from_seed(alt_seed);\n";
-	code += "	force += length(diff) > 0.0 ? normalize(diff) * tex_radial_accel * mix(radial_accel_min, radial_accel_max, radial_accel_rand) : vec3(0.0);\n";
-	code += "	// apply tangential acceleration;\n";
-	code += "	float tangent_accel_val = tex_tangent_accel * mix(tangent_accel_min, tangent_accel_max, rand_from_seed(alt_seed));\n";
-	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	force += length(diff.yx) > 0.0 ? vec3(normalize(diff.yx * vec2(-1.0, 1.0)), 0.0) * tangent_accel_val : vec3(0.0);\n";
-
-	} else {
-		code += "	vec3 crossDiff = cross(normalize(diff), normalize(gravity));\n";
-		code += "	force += length(crossDiff) > 0.0 ? normalize(crossDiff) * tangent_accel_val : vec3(0.0);\n";
-	}
-	if (attractor_interaction_enabled) {
-		code += "	force += ATTRACTOR_FORCE;\n\n";
-	}
-
-	code += "	// apply attractor forces\n";
-	code += "	VELOCITY += force * DELTA;\n";
-
-	if (tex_parameters[PARAM_INITIAL_LINEAR_VELOCITY].is_valid()) {
-		code += "	VELOCITY = normalize(VELOCITY) * tex_linear_velocity;\n";
-	}
-
-	// Apply noise/turbulence.
-	if (turbulence_enabled) {
-		code += "	// apply turbulence\n";
-		if (tex_parameters[PARAM_TURB_INFLUENCE_OVER_LIFE].is_valid()) {
-			code += "	float turbulence_influence = textureLod(turbulence_influence_over_life, vec2(tv, 0.0), 0.0).r;\n";
-		} else {
-			code += "	const float turbulence_influence = 1.0;\n";
-		}
-		code += "	\n";
-		code += "	vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
-		// If collision happened, turbulence is no longer applied.
-		// We don't need this check when the collision mode is "hide on contact",
-		// as the particle will be hidden anyway.
-		String extra_tab = "";
-		if (collision_mode != COLLISION_RIGID) {
-			code += "	if (!COLLIDED) {\n";
-			extra_tab = "	";
-		}
-		code += extra_tab + "	\n";
-		code += extra_tab + "	float vel_mag = length(VELOCITY);\n";
-		code += extra_tab + "	float vel_infl = clamp(mix(turbulence_influence_min, turbulence_influence_max, rand_from_seed(alt_seed)) * turbulence_influence, 0.0, 1.0);\n";
-		code += extra_tab + "	VELOCITY = mix(VELOCITY, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";
-		if (collision_mode != COLLISION_RIGID) {
-			code += "	}";
-		}
+	code += "	// calculate all velocity\n";
+	code += "	\n";
+	code += "	controlled_displacement += process_radial_displacement(dynamic_params, lifetime_percent, alt_seed, TRANSFORM, EMISSION_TRANSFORM, DELTA);\n";
+	code += "	\n";
+	if (tex_parameters[PARAM_DIRECTIONAL_VELOCITY].is_valid()) {
+		code += "	controlled_displacement += process_directional_displacement(dynamic_params, lifetime_percent, TRANSFORM, EMISSION_TRANSFORM, DELTA);\n";
 	}
 	code += "	\n";
-	code += "	// orbit velocity\n";
+	code += "	process_physical_parameters(physics_params, lifetime_percent);\n";
+	code += "	vec3 force;\n";
+	code += "	{\n";
+	code += "		// copied from previous version\n";
+	code += "		vec3 pos = TRANSFORM[3].xyz;\n";
+	code += "		force = gravity;\n";
+	code += "		// apply linear acceleration\n";
+	code += "		force += length(VELOCITY) > 0.0 ? normalize(VELOCITY) * physics_params.linear_accel : vec3(0.0);\n";
+	code += "		// apply radial acceleration\n";
+	code += "		vec3 org = EMISSION_TRANSFORM[3].xyz;\n";
+	code += "		vec3 diff = pos - org;\n";
+	code += "		force += length(diff) > 0.0 ? normalize(diff) * physics_params.radial_accel : vec3(0.0);\n";
+	code += "		// apply tangential acceleration;\n";
+	code += "		float tangent_accel_val = physics_params.tangent_accel;\n";
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		code += "	float orbit_amount = tex_orbit_velocity * mix(orbit_velocity_min, orbit_velocity_max, rand_from_seed(alt_seed));\n";
-		code += "	if (orbit_amount != 0.0) {\n";
-		code += "	     float ang = orbit_amount * DELTA * pi * 2.0;\n";
-		code += "	     mat2 rot = mat2(vec2(cos(ang), -sin(ang)), vec2(sin(ang), cos(ang)));\n";
-		code += "	     TRANSFORM[3].xy -= diff.xy;\n";
-		code += "	     TRANSFORM[3].xy += rot * diff.xy;\n";
-		code += "	}\n";
-	}
-
-	code += "	float dmp = mix(damping_min, damping_max, rand_from_seed(alt_seed));\n";
-	code += "	if (dmp * tex_damping > 0.0) {\n";
-	code += "		float v = length(VELOCITY);\n";
-	code += "		float damp = tex_damping * dmp;\n";
-	code += "		v -= damp * DELTA;\n";
-	code += "		if (v < 0.0) {\n";
-	code += "			VELOCITY = vec3(0.0);\n";
-	code += "		} else {\n";
-	code += "			VELOCITY = normalize(VELOCITY) * v;\n";
-	code += "		}\n";
-	code += "	}\n";
-	code += "	float base_angle = (tex_angle) * mix(initial_angle_min, initial_angle_max, angle_rand);\n";
-	code += "	base_angle += CUSTOM.y * LIFETIME * (tex_angular_velocity) * mix(angular_velocity_min,angular_velocity_max, rand_from_seed(alt_seed));\n";
-	code += "	CUSTOM.x = base_angle * degree_to_rad;\n"; // angle
-	code += "	CUSTOM.z = (tex_anim_offset) * mix(anim_offset_min, anim_offset_max, anim_offset_rand) + tv * tex_anim_speed * mix(anim_speed_min, anim_speed_max, rand_from_seed(alt_seed));\n"; // angle
-
-	// apply color
-	// apply hue rotation
-	if (tex_parameters[PARAM_SCALE].is_valid()) {
-		code += "	vec3 tex_scale = textureLod(scale_texture, vec2(tv, 0.0), 0.0).rgb;\n";
+		code += "       force += length(diff.yx) > 0.0 ? vec3(normalize(diff.yx * vec2(-1.0, 1.0)), 0.0) * tangent_accel_val : vec3(0.0);\n";
 	} else {
-		code += "	vec3 tex_scale = vec3(1.0);\n";
+		code += "		vec3 crossDiff = cross(normalize(diff), normalize(gravity));\n";
+		code += "		force += length(crossDiff) > 0.0 ? normalize(crossDiff) * tangent_accel_val : vec3(0.0);\n";
 	}
-
-	if (tex_parameters[PARAM_HUE_VARIATION].is_valid()) {
-		code += "	float tex_hue_variation = textureLod(hue_variation_texture, vec2(tv, 0.0), 0.0).r;\n";
-	} else {
-		code += "	float tex_hue_variation = 1.0;\n";
-	}
-
-	code += "	float hue_rot_angle = (tex_hue_variation) * pi * 2.0 * mix(hue_variation_min, hue_variation_max, rand_from_seed(alt_seed));\n";
-	code += "	float hue_rot_c = cos(hue_rot_angle);\n";
-	code += "	float hue_rot_s = sin(hue_rot_angle);\n";
-	code += "	mat4 hue_rot_mat = mat4(vec4(0.299, 0.587, 0.114, 0.0),\n";
-	code += "			vec4(0.299, 0.587, 0.114, 0.0),\n";
-	code += "			vec4(0.299, 0.587, 0.114, 0.0),\n";
-	code += "			vec4(0.000, 0.000, 0.000, 1.0)) +\n";
-	code += "		mat4(vec4(0.701, -0.587, -0.114, 0.0),\n";
-	code += "			vec4(-0.299, 0.413, -0.114, 0.0),\n";
-	code += "			vec4(-0.300, -0.588, 0.886, 0.0),\n";
-	code += "			vec4(0.000, 0.000, 0.000, 0.0)) * hue_rot_c +\n";
-	code += "		mat4(vec4(0.168, 0.330, -0.497, 0.0),\n";
-	code += "			vec4(-0.328, 0.035,  0.292, 0.0),\n";
-	code += "			vec4(1.250, -1.050, -0.203, 0.0),\n";
-	code += "			vec4(0.000, 0.000, 0.000, 0.0)) * hue_rot_s;\n";
-	if (color_ramp.is_valid()) {
-		code += "	COLOR = hue_rot_mat * textureLod(color_ramp, vec2(tv, 0.0), 0.0) * color_value;\n";
-	} else {
-		code += "	COLOR = hue_rot_mat * color_value;\n";
-	}
-
-	if (color_initial_ramp.is_valid()) {
-		code += "	vec4 start_color = textureLod(color_initial_ramp, vec2(color_initial_rand, 0.0), 0.0);\n";
-		code += "	COLOR *= start_color;\n";
-	}
-
-	if (emission_color_texture.is_valid() && (emission_shape == EMISSION_SHAPE_POINTS || emission_shape == EMISSION_SHAPE_DIRECTED_POINTS)) {
-		code += "	COLOR *= texelFetch(emission_texture_color, emission_tex_ofs, 0);\n";
+	if (attractor_interaction_enabled) {
+		code += "		force += ATTRACTOR_FORCE;\n";
 	}
 	code += "\n";
+	code += "		// apply attractor forces\n";
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		code += "			force.z = 0.;\n";
+	}
+	code += "		VELOCITY += force * DELTA;\n";
+	code += "	}\n";
+	code += "	{\n";
+	code += "		// copied from previous version\n";
+	code += "		if (physics_params.damping > 0.0) {\n";
+	if (!particle_flags[PARTICLE_FLAG_DAMPING_AS_FRICTION]) {
+		code += "				float v = length(VELOCITY);\n";
+		code += "				v -= physics_params.damping * DELTA;\n";
+		code += "				if (v < 0.0) {\n";
+		code += "					VELOCITY = vec3(0.0);\n";
+		code += "				} else {\n";
+		code += "					VELOCITY = normalize(VELOCITY) * v;\n";
+		code += "				}\n";
+	} else {
+		code += "				if (length(VELOCITY) > 0.01){\n";
+		code += "					VELOCITY -= normalize(VELOCITY) * length(VELOCITY) * (physics_params.damping) * DELTA;\n";
+		code += "				}\n";
+	}
+	code += "		}\n";
+	code += "		\n";
+	code += "	}\n";
+	code += "	\n";
+	if (collision_mode == COLLISION_RIGID) {
+		code += "	if (COLLIDED) {\n";
+		code += "		if (length(VELOCITY) > 3.0) {\n";
+		code += "			TRANSFORM[3].xyz += COLLISION_NORMAL * COLLISION_DEPTH;\n";
+		code += "			VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce);\n";
+		code += "			VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
+		code += "		} else {\n";
+		code += "			VELOCITY = vec3(0.0);\n";
+		// If turbulence is enabled, set the noise direction to up so the turbulence color is "neutral"
+		if (turbulence_enabled) {
+			code += "			noise_direction = vec3(1.0, 0.0, 0.0);\n";
+		}
+		code += "		}\n";
+		code += "	}\n";
+	} else if (collision_mode == COLLISION_HIDE_ON_CONTACT) {
+		code += "	if (COLLIDED) {\n";
+		code += "		ACTIVE = false;\n";
+		code += "	}\n";
+	}
+	code += "	vec3 final_velocity = controlled_displacement/DELTA + VELOCITY;\n";
+	code += "	\n";
+	code += "	// turbulence before limiting\n";
+	if (turbulence_enabled) {
+		if (tex_parameters[PARAM_TURB_INFLUENCE_OVER_LIFE].is_valid()) {
+			code += "		float turbulence_influence = textureLod(turbulence_influence_over_life, vec2(lifetime_percent, 0.0), 0.0).r;\n";
+		} else {
+			code += "   float turbulence_influence = 1.0;\n";
+		}
+		code += "		\n";
+		code += "		vec3 noise_direction = get_noise_direction(TRANSFORM[3].xyz);\n";
+		code += "		if (!COLLIDED) {\n";
+		code += "			\n";
+		code += "			float vel_mag = length(final_velocity);\n";
+		code += "			float vel_infl = clamp(dynamic_params.turb_influence * turbulence_influence, 0.0,1.0);\n";
+		code += "			final_velocity = mix(final_velocity, normalize(noise_direction) * vel_mag * (1.0 + (1.0 - vel_infl) * 0.2), vel_infl);\n";
+		code += "		}\n";
+	}
+	code += "	\n";
+	code += "	// limit velocity\n";
+	if (velocity_limit_curve.is_valid()) {
+		code += "	if (length(final_velocity) > 0.001){\n";
+		code += "		final_velocity = normalize(final_velocity) * min(abs(length(final_velocity)), abs(texture(velocity_limit_curve, vec2(lifetime_percent)).r));\n";
+		code += "	}\n";
+	}
+	code += "	\n";
+	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
+		code += "		final_velocity.z = 0.;\n";
+	}
+	code += "	TRANSFORM[3].xyz += final_velocity * DELTA;\n";
+	code += "	\n";
+	code += "	\n";
+	code += "	process_display_param(params, lifetime_percent);\n";
+	code += "	\n";
+	code += "	float base_angle = dynamic_params.angle;\n";
+	if (tex_parameters[PARAM_ANGLE].is_valid()) {
+		code += "	base_angle *= texture(angle_texture, vec2(lifetime_percent)).r;\n";
+	}
+	if (tex_parameters[PARAM_ANGULAR_VELOCITY].is_valid()) {
+		code += "	base_angle += CUSTOM.y * LIFETIME * dynamic_params.angular_velocity * texture(angular_velocity_texture, vec2(lifetime_percent)).r;\n";
+
+	} else {
+		code += "	base_angle += CUSTOM.y * LIFETIME * dynamic_params.angular_velocity;\n";
+	}
+	code += "	CUSTOM.x = base_angle * degree_to_rad;\n";
+	code += "   COLOR = params.color;\n";
 
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			code += "	if (length(VELOCITY) > 0.0) {\n";
-			code += "		TRANSFORM[1].xyz = normalize(VELOCITY);\n";
+			code += "	if (length(final_velocity) > 0.0) {\n";
+			code += "		TRANSFORM[1].xyz = normalize(final_velocity);\n";
 			code += "	} else {\n";
 			code += "		TRANSFORM[1].xyz = normalize(TRANSFORM[1].xyz);\n";
 			code += "	}\n";
@@ -827,8 +1038,8 @@ void ParticleProcessMaterial::_update_shader() {
 	} else {
 		// orient particle Y towards velocity
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			code += "	if (length(VELOCITY) > 0.0) {\n";
-			code += "		TRANSFORM[1].xyz = normalize(VELOCITY);\n";
+			code += "	if (length(final_velocity) > 0.0) {\n";
+			code += "		TRANSFORM[1].xyz = normalize(final_velocity);\n";
 			code += "	} else {\n";
 			code += "		TRANSFORM[1].xyz = normalize(TRANSFORM[1].xyz);\n";
 			code += "	}\n";
@@ -855,33 +1066,20 @@ void ParticleProcessMaterial::_update_shader() {
 	if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 		code += "	TRANSFORM[3].z = 0.0;\n";
 	}
-
-	// scale by scale
-	code += "	float base_scale = mix(scale_min, scale_max, scale_rand);\n";
-	code += "	base_scale = sign(base_scale) * max(abs(base_scale), 0.001);\n";
-	code += "	TRANSFORM[0].xyz *= base_scale * sign(tex_scale.r) * max(abs(tex_scale.r), 0.001);\n";
-	code += "	TRANSFORM[1].xyz *= base_scale * sign(tex_scale.g) * max(abs(tex_scale.g), 0.001);\n";
-	code += "	TRANSFORM[2].xyz *= base_scale * sign(tex_scale.b) * max(abs(tex_scale.b), 0.001);\n";
-
-	if (collision_mode == COLLISION_RIGID) {
-		code += "	if (COLLIDED) {\n";
-		code += "		if (length(VELOCITY) > 3.0) {\n";
-		code += "			TRANSFORM[3].xyz += COLLISION_NORMAL * COLLISION_DEPTH;\n";
-		code += "			VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce);\n";
-		code += "			VELOCITY = mix(VELOCITY,vec3(0.0),clamp(collision_friction, 0.0, 1.0));\n";
-		code += "		} else {\n";
-		code += "			VELOCITY = vec3(0.0);\n";
-		// If turbulence is enabled, set the noise direction to up so the turbulence color is "neutral"
-		if (turbulence_enabled) {
-			code += "			noise_direction = vec3(1.0, 0.0, 0.0);\n";
-		}
-		code += "		}\n";
-		code += "	}\n";
-	} else if (collision_mode == COLLISION_HIDE_ON_CONTACT) {
-		code += "	if (COLLIDED) {\n";
-		code += "		ACTIVE = false;\n";
-		code += "	}\n";
+	if (tex_parameters[PARAM_SCALE_OVER_VELOCITY].is_valid()) {
+		code += "	if(length(final_velocity) > 0.001){\n";
+		code += "		params.scale *= texture(scale_over_velocity_curve, vec2(clamp(length(final_velocity)/(scale_over_velocity_max - scale_over_velocity_min), 0.0,1.0), 0.0)).rgb;\n";
+		code += "	} else {params.scale *= texture(scale_over_velocity_curve, vec2(0.0)).rgb;}\n \n";
 	}
+	code += "//	params.scale *= length(final_velocity)/100.0;\n";
+	code += "\n";
+	code += "	TRANSFORM[0].xyz *= sign(params.scale.x) * max(abs(params.scale.x), 0.001);\n";
+	code += "	TRANSFORM[1].xyz *= sign(params.scale.y) * max(abs(params.scale.y), 0.001);\n";
+	code += "	TRANSFORM[2].xyz *= sign(params.scale.z) * max(abs(params.scale.z), 0.001);\n";
+	code += "	\n";
+	code += "	// \n";
+	code += "	CUSTOM.z = params.animation_offset + lifetime_percent * params.animation_speed;\n";
+	code += "	\n";
 
 	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_low_end()) {
 		code += "	int emit_count = 0;\n";
@@ -975,6 +1173,15 @@ float ParticleProcessMaterial::get_flatness() const {
 	return flatness;
 }
 
+void ParticleProcessMaterial::set_velocity_pivot(const Vector3 &p_pivot) {
+	velocity_pivot = p_pivot;
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->velocity_pivot, p_pivot);
+}
+
+Vector3 ParticleProcessMaterial::get_velocity_pivot() {
+	return velocity_pivot;
+}
+
 void ParticleProcessMaterial::set_param_min(Parameter p_param, float p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 
@@ -1028,6 +1235,15 @@ void ParticleProcessMaterial::set_param_min(Parameter p_param, float p_value) {
 		} break;
 		case PARAM_TURB_INFLUENCE_OVER_LIFE: {
 			// Can't happen, but silences warning
+		} break;
+		case PARAM_RADIAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_velocity_min, p_value);
+		} break;
+		case PARAM_SCALE_OVER_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_over_velocity_min, p_value);
+		} break;
+		case PARAM_DIRECTIONAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->directional_velocity_min, p_value);
 		} break;
 		case PARAM_MAX:
 			break; // Can't happen, but silences warning
@@ -1094,6 +1310,15 @@ void ParticleProcessMaterial::set_param_max(Parameter p_param, float p_value) {
 		case PARAM_TURB_INFLUENCE_OVER_LIFE: {
 			// Can't happen, but silences warning
 		} break;
+		case PARAM_RADIAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_velocity_max, p_value);
+		} break;
+		case PARAM_SCALE_OVER_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_over_velocity_max, p_value);
+		} break;
+		case PARAM_DIRECTIONAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->directional_velocity_max, p_value);
+		} break;
 		case PARAM_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -1107,11 +1332,15 @@ float ParticleProcessMaterial::get_param_max(Parameter p_param) const {
 
 static void _adjust_curve_range(const Ref<Texture2D> &p_texture, float p_min, float p_max) {
 	Ref<CurveTexture> curve_tex = p_texture;
-	if (!curve_tex.is_valid()) {
+	if (curve_tex.is_valid()) {
+		curve_tex->ensure_default_setup(p_min, p_max);
 		return;
 	}
-
-	curve_tex->ensure_default_setup(p_min, p_max);
+	Ref<CurveXYZTexture> curve_xyz_tex = p_texture;
+	if (curve_xyz_tex.is_valid()) {
+		curve_xyz_tex->ensure_default_setup(p_min, p_max);
+		return;
+	}
 }
 
 void ParticleProcessMaterial::set_param_texture(Parameter p_param, const Ref<Texture2D> &p_texture) {
@@ -1132,6 +1361,7 @@ void ParticleProcessMaterial::set_param_texture(Parameter p_param, const Ref<Tex
 		case PARAM_ORBIT_VELOCITY: {
 			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->orbit_velocity_texture, tex_rid);
 			_adjust_curve_range(p_texture, -500, 500);
+			notify_property_list_changed();
 		} break;
 		case PARAM_LINEAR_ACCEL: {
 			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->linear_accel_texture, tex_rid);
@@ -1177,6 +1407,18 @@ void ParticleProcessMaterial::set_param_texture(Parameter p_param, const Ref<Tex
 		} break;
 		case PARAM_TURB_INIT_DISPLACEMENT: {
 			// Can't happen, but silences warning
+		} break;
+		case PARAM_RADIAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->radial_velocity_texture, tex_rid);
+		} break;
+		case PARAM_SCALE_OVER_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->scale_over_velocity_texture, tex_rid);
+			_adjust_curve_range(p_texture, 0, 3);
+			notify_property_list_changed();
+		} break;
+		case PARAM_DIRECTIONAL_VELOCITY: {
+			RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->directional_velocity_texture, tex_rid);
+			notify_property_list_changed();
 		} break;
 		case PARAM_MAX:
 			break; // Can't happen, but silences warning
@@ -1231,6 +1473,42 @@ void ParticleProcessMaterial::set_particle_flag(ParticleFlags p_particle_flag, b
 	if (p_particle_flag == PARTICLE_FLAG_DISABLE_Z) {
 		notify_property_list_changed();
 	}
+}
+
+void ParticleProcessMaterial::set_alpha_curve(const Ref<Texture2D> &p_texture) {
+	alpha_curve = p_texture;
+	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->alpha_ramp, tex_rid);
+	_queue_shader_change();
+	notify_property_list_changed();
+}
+
+Ref<Texture2D> ParticleProcessMaterial::get_alpha_curve() const {
+	return alpha_curve;
+}
+
+void ParticleProcessMaterial::set_emission_curve(const Ref<Texture2D> &p_texture) {
+	emission_curve = p_texture;
+	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_ramp, tex_rid);
+	_queue_shader_change();
+	notify_property_list_changed();
+}
+
+Ref<Texture2D> ParticleProcessMaterial::get_emission_curve() const {
+	return emission_curve;
+}
+
+void ParticleProcessMaterial::set_velocity_limit_curve(const Ref<Texture2D> &p_texture) {
+	velocity_limit_curve = p_texture;
+	RID tex_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->velocity_limit_curve, tex_rid);
+	_queue_shader_change();
+	notify_property_list_changed();
+}
+
+Ref<Texture2D> ParticleProcessMaterial::get_velocity_limit_curve() const {
+	return velocity_limit_curve;
 }
 
 bool ParticleProcessMaterial::get_particle_flag(ParticleFlags p_particle_flag) const {
@@ -1299,6 +1577,11 @@ void ParticleProcessMaterial::set_emission_ring_inner_radius(real_t p_radius) {
 	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_ring_inner_radius, p_radius);
 }
 
+void ParticleProcessMaterial::set_inherit_velocity_ratio(double p_ratio) {
+	inherit_emitter_velocity_ratio = p_ratio;
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->inherit_emitter_velocity_ratio, p_ratio);
+}
+
 ParticleProcessMaterial::EmissionShape ParticleProcessMaterial::get_emission_shape() const {
 	return emission_shape;
 }
@@ -1341,6 +1624,28 @@ real_t ParticleProcessMaterial::get_emission_ring_radius() const {
 
 real_t ParticleProcessMaterial::get_emission_ring_inner_radius() const {
 	return emission_ring_inner_radius;
+}
+
+void ParticleProcessMaterial::set_emission_shape_offset(const Vector3 &p_emission_shape_offset) {
+	emission_shape_offset = p_emission_shape_offset;
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_shape_offset, p_emission_shape_offset);
+}
+
+Vector3 ParticleProcessMaterial::get_emission_shape_offset() const {
+	return emission_shape_offset;
+}
+
+void ParticleProcessMaterial::set_emission_shape_scale(const Vector3 &p_emission_shape_scale) {
+	emission_shape_scale = p_emission_shape_scale;
+	RenderingServer::get_singleton()->material_set_param(_get_material(), shader_names->emission_shape_scale, p_emission_shape_scale);
+}
+
+Vector3 ParticleProcessMaterial::get_emission_shape_scale() const {
+	return emission_shape_scale;
+}
+
+double ParticleProcessMaterial::get_inherit_velocity_ratio() {
+	return inherit_emitter_velocity_ratio;
 }
 
 void ParticleProcessMaterial::set_turbulence_enabled(const bool p_turbulence_enabled) {
@@ -1459,10 +1764,6 @@ void ParticleProcessMaterial::_validate_property(PropertyInfo &p_property) const
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if (p_property.name.begins_with("orbit_") && !particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
-		p_property.usage = PROPERTY_USAGE_NONE;
-	}
-
 	if (!turbulence_enabled) {
 		if (p_property.name == "turbulence_noise_strength" ||
 				p_property.name == "turbulence_noise_scale" ||
@@ -1483,6 +1784,15 @@ void ParticleProcessMaterial::_validate_property(PropertyInfo &p_property) const
 
 	if (p_property.name == "collision_bounce" && collision_mode != COLLISION_RIGID) {
 		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	if ((p_property.name == "directional_velocity_min" || p_property.name == "directional_velocity_max") && !tex_parameters[PARAM_DIRECTIONAL_VELOCITY].is_valid()) {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+	if ((p_property.name == "scale_over_velocity_min" || p_property.name == "scale_over_velocity_max") && !tex_parameters[PARAM_SCALE_OVER_VELOCITY].is_valid()) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+	if ((p_property.name == "orbit_velocity_min" || p_property.name == "orbit_velocity_max") && (!tex_parameters[PARAM_ORBIT_VELOCITY].is_valid() && !particle_flags[PARTICLE_FLAG_DISABLE_Z])) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 
@@ -1588,6 +1898,9 @@ void ParticleProcessMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_direction", "degrees"), &ParticleProcessMaterial::set_direction);
 	ClassDB::bind_method(D_METHOD("get_direction"), &ParticleProcessMaterial::get_direction);
 
+	ClassDB::bind_method(D_METHOD("set_inherit_velocity_ratio", "ratio"), &ParticleProcessMaterial::set_inherit_velocity_ratio);
+	ClassDB::bind_method(D_METHOD("get_inherit_velocity_ratio"), &ParticleProcessMaterial::get_inherit_velocity_ratio);
+
 	ClassDB::bind_method(D_METHOD("set_spread", "degrees"), &ParticleProcessMaterial::set_spread);
 	ClassDB::bind_method(D_METHOD("get_spread"), &ParticleProcessMaterial::get_spread);
 
@@ -1608,12 +1921,23 @@ void ParticleProcessMaterial::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_color_ramp", "ramp"), &ParticleProcessMaterial::set_color_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_ramp"), &ParticleProcessMaterial::get_color_ramp);
+	ClassDB::bind_method(D_METHOD("set_alpha_curve", "curve"), &ParticleProcessMaterial::set_alpha_curve);
+	ClassDB::bind_method(D_METHOD("get_alpha_curve"), &ParticleProcessMaterial::get_alpha_curve);
+
+	ClassDB::bind_method(D_METHOD("set_emission_curve", "curve"), &ParticleProcessMaterial::set_emission_curve);
+	ClassDB::bind_method(D_METHOD("get_emission_curve"), &ParticleProcessMaterial::get_emission_curve);
 
 	ClassDB::bind_method(D_METHOD("set_color_initial_ramp", "ramp"), &ParticleProcessMaterial::set_color_initial_ramp);
 	ClassDB::bind_method(D_METHOD("get_color_initial_ramp"), &ParticleProcessMaterial::get_color_initial_ramp);
 
+	ClassDB::bind_method(D_METHOD("set_velocity_limit_curve", "curve"), &ParticleProcessMaterial::set_velocity_limit_curve);
+	ClassDB::bind_method(D_METHOD("get_velocity_limit_curve"), &ParticleProcessMaterial::get_velocity_limit_curve);
+
 	ClassDB::bind_method(D_METHOD("set_particle_flag", "particle_flag", "enable"), &ParticleProcessMaterial::set_particle_flag);
 	ClassDB::bind_method(D_METHOD("get_particle_flag", "particle_flag"), &ParticleProcessMaterial::get_particle_flag);
+
+	ClassDB::bind_method(D_METHOD("set_velocity_pivot", "pivot"), &ParticleProcessMaterial::set_velocity_pivot);
+	ClassDB::bind_method(D_METHOD("get_velocity_pivot"), &ParticleProcessMaterial::get_velocity_pivot);
 
 	ClassDB::bind_method(D_METHOD("set_emission_shape", "shape"), &ParticleProcessMaterial::set_emission_shape);
 	ClassDB::bind_method(D_METHOD("get_emission_shape"), &ParticleProcessMaterial::get_emission_shape);
@@ -1647,6 +1971,12 @@ void ParticleProcessMaterial::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_emission_ring_inner_radius", "inner_radius"), &ParticleProcessMaterial::set_emission_ring_inner_radius);
 	ClassDB::bind_method(D_METHOD("get_emission_ring_inner_radius"), &ParticleProcessMaterial::get_emission_ring_inner_radius);
+
+	ClassDB::bind_method(D_METHOD("set_emission_shape_offset", "emission_shape_offset"), &ParticleProcessMaterial::set_emission_shape_offset);
+	ClassDB::bind_method(D_METHOD("get_emission_shape_offset"), &ParticleProcessMaterial::get_emission_shape_offset);
+
+	ClassDB::bind_method(D_METHOD("set_emission_shape_scale", "emission_shape_scale"), &ParticleProcessMaterial::set_emission_shape_scale);
+	ClassDB::bind_method(D_METHOD("get_emission_shape_scale"), &ParticleProcessMaterial::get_emission_shape_scale);
 
 	ClassDB::bind_method(D_METHOD("get_turbulence_enabled"), &ParticleProcessMaterial::get_turbulence_enabled);
 	ClassDB::bind_method(D_METHOD("set_turbulence_enabled", "turbulence_enabled"), &ParticleProcessMaterial::set_turbulence_enabled);
@@ -1699,10 +2029,16 @@ void ParticleProcessMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_bounce", "bounce"), &ParticleProcessMaterial::set_collision_bounce);
 	ClassDB::bind_method(D_METHOD("get_collision_bounce"), &ParticleProcessMaterial::get_collision_bounce);
 
-	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime_randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_lifetime_randomness", "get_lifetime_randomness");
-
-	ADD_GROUP("Emission Shape", "emission_");
+	ADD_GROUP("Particle Flags", "particle_flag_");
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_align_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_rotate_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ROTATE_Y);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_disable_z"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_DISABLE_Z);
+	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_damping_as_friction"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_DAMPING_AS_FRICTION);
+	ADD_GROUP("Spawn", "");
+	ADD_SUBGROUP("Position", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "emission_shape_offset"), "set_emission_shape_offset", "get_emission_shape_offset");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "emission_shape_scale"), "set_emission_shape_scale", "get_emission_shape_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_shape", PROPERTY_HINT_ENUM, "Point,Sphere,Sphere Surface,Box,Points,Directed Points,Ring"), "set_emission_shape", "get_emission_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_sphere_radius", PROPERTY_HINT_RANGE, "0.01,128,0.01,or_greater"), "set_emission_sphere_radius", "get_emission_sphere_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "emission_box_extents"), "set_emission_box_extents", "get_emission_box_extents");
@@ -1714,60 +2050,87 @@ void ParticleProcessMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_ring_height"), "set_emission_ring_height", "get_emission_ring_height");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_ring_radius"), "set_emission_ring_radius", "get_emission_ring_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_ring_inner_radius"), "set_emission_ring_inner_radius", "get_emission_ring_inner_radius");
-	ADD_GROUP("Particle Flags", "particle_flag_");
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_align_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_rotate_y"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_ROTATE_Y);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "particle_flag_disable_z"), "set_particle_flag", "get_particle_flag", PARTICLE_FLAG_DISABLE_Z);
-	ADD_GROUP("Direction", "");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "direction"), "set_direction", "get_direction");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,180,0.01"), "set_spread", "get_spread");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "flatness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_flatness", "get_flatness");
-	ADD_GROUP("Gravity", "");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "gravity"), "set_gravity", "get_gravity");
-	ADD_GROUP("Initial Velocity", "initial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_INITIAL_LINEAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_INITIAL_LINEAR_VELOCITY);
-	ADD_GROUP("Angular Velocity", "angular_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_min", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ANGULAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_max", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ANGULAR_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angular_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANGULAR_VELOCITY);
-	ADD_GROUP("Orbit Velocity", "orbit_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_min", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ORBIT_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_max", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ORBIT_VELOCITY);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "orbit_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ORBIT_VELOCITY);
-	ADD_GROUP("Linear Accel", "linear_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_LINEAR_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_LINEAR_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "linear_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_LINEAR_ACCEL);
-	ADD_GROUP("Radial Accel", "radial_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_RADIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_RADIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "radial_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_RADIAL_ACCEL);
-	ADD_GROUP("Tangential Accel", "tangential_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_TANGENTIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_TANGENTIAL_ACCEL);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "tangential_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_TANGENTIAL_ACCEL);
-	ADD_GROUP("Damping", "");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_min", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_param_min", "get_param_min", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_max", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_param_max", "get_param_max", PARAM_DAMPING);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "damping_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_DAMPING);
-	ADD_GROUP("Angle", "");
+	ADD_SUBGROUP("Angle", "");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_min", PROPERTY_HINT_RANGE, "-720,720,0.1,or_less,or_greater,degrees"), "set_param_min", "get_param_min", PARAM_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angle_max", PROPERTY_HINT_RANGE, "-720,720,0.1,or_less,or_greater,degrees"), "set_param_max", "get_param_max", PARAM_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angle_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANGLE);
-	ADD_GROUP("Scale", "");
+	ADD_SUBGROUP("Velocity", "");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "inherit_velocity_ratio", PROPERTY_HINT_RANGE, "0.0,1.0,0.001,or_less,or_greater"), "set_inherit_velocity_ratio", "get_inherit_velocity_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "velocity_pivot"), "set_velocity_pivot", "get_velocity_pivot");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "direction"), "set_direction", "get_direction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,180,0.001"), "set_spread", "get_spread");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "flatness", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_flatness", "get_flatness");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "initial_velocity_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_INITIAL_LINEAR_VELOCITY);
+	ADD_GROUP("Animated Velocity", "");
+	ADD_SUBGROUP("Velocity Limit", "");
+	ADD_SUBGROUP("Angular Velocity", "angular_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_min", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "angular_velocity_max", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ANGULAR_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "angular_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANGULAR_VELOCITY);
+	ADD_SUBGROUP("Directional Velocity", "directional_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_velocity_min", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_DIRECTIONAL_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_velocity_max", PROPERTY_HINT_RANGE, "-720,720,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_DIRECTIONAL_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "directional_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_DIRECTIONAL_VELOCITY);
+	ADD_SUBGROUP("Orbit Velocity", "orbit_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_min", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "orbit_velocity_max", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ORBIT_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "orbit_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture,CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_ORBIT_VELOCITY);
+	ADD_SUBGROUP("Radial Velocity", "radial_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_velocity_min", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_RADIAL_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_velocity_max", PROPERTY_HINT_RANGE, "-1000,1000,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_RADIAL_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "radial_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_RADIAL_VELOCITY);
+	ADD_SUBGROUP("Velocity Limit", "");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "velocity_limit_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_velocity_limit_curve", "get_velocity_limit_curve");
+	ADD_GROUP("Accelerations", "");
+	ADD_SUBGROUP("Gravity", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "gravity"), "set_gravity", "get_gravity");
+	ADD_SUBGROUP("Linear Accel", "linear_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "linear_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_LINEAR_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "linear_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_LINEAR_ACCEL);
+	ADD_SUBGROUP("Radial Accel", "radial_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "radial_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_RADIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "radial_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_RADIAL_ACCEL);
+	ADD_SUBGROUP("Tangential Accel", "tangential_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_min", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "tangential_accel_max", PROPERTY_HINT_RANGE, "-100,100,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_TANGENTIAL_ACCEL);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "tangential_accel_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_TANGENTIAL_ACCEL);
+	ADD_SUBGROUP("Damping", "");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_min", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_param_min", "get_param_min", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "damping_max", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_param_max", "get_param_max", PARAM_DAMPING);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "damping_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_DAMPING);
+	ADD_SUBGROUP("Attractor Interaction", "attractor_interaction_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "attractor_interaction_enabled"), "set_attractor_interaction_enabled", "is_attractor_interaction_enabled");
+
+	ADD_GROUP("Display", "");
+	ADD_SUBGROUP("Scale", "");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_SCALE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_SCALE);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture,CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_SCALE);
-	ADD_GROUP("Color", "");
+	ADD_SUBGROUP("Scale Over Velocity", "");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_over_velocity_min", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_min", "get_param_min", PARAM_SCALE_OVER_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "scale_over_velocity_max", PROPERTY_HINT_RANGE, "0,1000,0.01,or_greater"), "set_param_max", "get_param_max", PARAM_SCALE_OVER_VELOCITY);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "scale_over_velocity_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture,CurveXYZTexture"), "set_param_texture", "get_param_texture", PARAM_SCALE_OVER_VELOCITY);
+
+	ADD_SUBGROUP("Color Curves", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_ramp", PROPERTY_HINT_RESOURCE_TYPE, "GradientTexture1D"), "set_color_ramp", "get_color_ramp");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "color_initial_ramp", PROPERTY_HINT_RESOURCE_TYPE, "GradientTexture1D"), "set_color_initial_ramp", "get_color_initial_ramp");
-
-	ADD_GROUP("Hue Variation", "hue_");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "alpha_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_alpha_curve", "get_alpha_curve");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "emission_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_emission_curve", "get_emission_curve");
+	ADD_SUBGROUP("Hue Variation", "hue_");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_min", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_min", "get_param_min", PARAM_HUE_VARIATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "hue_variation_max", PROPERTY_HINT_RANGE, "-1,1,0.01"), "set_param_max", "get_param_max", PARAM_HUE_VARIATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "hue_variation_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_HUE_VARIATION);
+	ADD_SUBGROUP("Animation", "anim_");
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_min", PROPERTY_HINT_RANGE, "0,16,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_max", PROPERTY_HINT_RANGE, "0,16,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_speed_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_SPEED);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_min", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_param_min", "get_param_min", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_max", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_param_max", "get_param_max", PARAM_ANIM_OFFSET);
+	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_offset_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_OFFSET);
 
 	ADD_GROUP("Turbulence", "turbulence_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "turbulence_enabled"), "set_turbulence_enabled", "get_turbulence_enabled");
@@ -1781,28 +2144,17 @@ void ParticleProcessMaterial::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "turbulence_initial_displacement_max", PROPERTY_HINT_RANGE, "-100,100,0.1"), "set_param_max", "get_param_max", PARAM_TURB_INIT_DISPLACEMENT);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "turbulence_influence_over_life", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_TURB_INFLUENCE_OVER_LIFE);
 
-	ADD_GROUP("Animation", "anim_");
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_min", PROPERTY_HINT_RANGE, "0,16,0.01,or_less,or_greater"), "set_param_min", "get_param_min", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_speed_max", PROPERTY_HINT_RANGE, "0,16,0.01,or_less,or_greater"), "set_param_max", "get_param_max", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_speed_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_SPEED);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_min", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_param_min", "get_param_min", PARAM_ANIM_OFFSET);
-	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "anim_offset_max", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_param_max", "get_param_max", PARAM_ANIM_OFFSET);
-	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "anim_offset_curve", PROPERTY_HINT_RESOURCE_TYPE, "CurveTexture"), "set_param_texture", "get_param_texture", PARAM_ANIM_OFFSET);
-
+	ADD_GROUP("Collision", "collision_");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mode", PROPERTY_HINT_ENUM, "Disabled,Rigid,Hide On Contact"), "set_collision_mode", "get_collision_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_friction", "get_collision_friction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_bounce", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_bounce", "get_collision_bounce");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_use_scale"), "set_collision_use_scale", "is_collision_using_scale");
 	ADD_GROUP("Sub Emitter", "sub_emitter_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_mode", PROPERTY_HINT_ENUM, "Disabled,Constant,At End,At Collision"), "set_sub_emitter_mode", "get_sub_emitter_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sub_emitter_frequency", PROPERTY_HINT_RANGE, "0.01,100,0.01,suffix:Hz"), "set_sub_emitter_frequency", "get_sub_emitter_frequency");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_amount_at_end", PROPERTY_HINT_RANGE, "1,32,1"), "set_sub_emitter_amount_at_end", "get_sub_emitter_amount_at_end");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_emitter_amount_at_collision", PROPERTY_HINT_RANGE, "1,32,1"), "set_sub_emitter_amount_at_collision", "get_sub_emitter_amount_at_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sub_emitter_keep_velocity"), "set_sub_emitter_keep_velocity", "get_sub_emitter_keep_velocity");
-
-	ADD_GROUP("Attractor Interaction", "attractor_interaction_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "attractor_interaction_enabled"), "set_attractor_interaction_enabled", "is_attractor_interaction_enabled");
-	ADD_GROUP("Collision", "collision_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mode", PROPERTY_HINT_ENUM, "Disabled,Rigid,Hide On Contact"), "set_collision_mode", "get_collision_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_friction", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_friction", "get_collision_friction");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_bounce", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_collision_bounce", "get_collision_bounce");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collision_use_scale"), "set_collision_use_scale", "is_collision_using_scale");
 
 	BIND_ENUM_CONSTANT(PARAM_INITIAL_LINEAR_VELOCITY);
 	BIND_ENUM_CONSTANT(PARAM_ANGULAR_VELOCITY);
@@ -1816,11 +2168,15 @@ void ParticleProcessMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(PARAM_HUE_VARIATION);
 	BIND_ENUM_CONSTANT(PARAM_ANIM_SPEED);
 	BIND_ENUM_CONSTANT(PARAM_ANIM_OFFSET);
+	BIND_ENUM_CONSTANT(PARAM_RADIAL_VELOCITY);
+	BIND_ENUM_CONSTANT(PARAM_DIRECTIONAL_VELOCITY);
+	BIND_ENUM_CONSTANT(PARAM_SCALE_OVER_VELOCITY);
 	BIND_ENUM_CONSTANT(PARAM_MAX);
 
 	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY);
 	BIND_ENUM_CONSTANT(PARTICLE_FLAG_ROTATE_Y);
 	BIND_ENUM_CONSTANT(PARTICLE_FLAG_DISABLE_Z);
+	BIND_ENUM_CONSTANT(PARTICLE_FLAG_DAMPING_AS_FRICTION);
 	BIND_ENUM_CONSTANT(PARTICLE_FLAG_MAX);
 
 	BIND_ENUM_CONSTANT(EMISSION_SHAPE_POINT);
@@ -1877,6 +2233,8 @@ ParticleProcessMaterial::ParticleProcessMaterial() :
 	set_param_max(PARAM_HUE_VARIATION, 0);
 	set_param_max(PARAM_ANIM_SPEED, 0);
 	set_param_max(PARAM_ANIM_OFFSET, 0);
+	set_param_min(PARAM_DIRECTIONAL_VELOCITY, 1.0);
+	set_param_max(PARAM_DIRECTIONAL_VELOCITY, 1.0);
 	set_emission_shape(EMISSION_SHAPE_POINT);
 	set_emission_sphere_radius(1);
 	set_emission_box_extents(Vector3(1, 1, 1));
@@ -1884,6 +2242,8 @@ ParticleProcessMaterial::ParticleProcessMaterial() :
 	set_emission_ring_height(1);
 	set_emission_ring_radius(1);
 	set_emission_ring_inner_radius(0);
+	set_emission_shape_offset(Vector3(0.0, 0.0, 0.0));
+	set_emission_shape_scale(Vector3(1.0, 1.0, 1.0));
 
 	set_turbulence_enabled(false);
 	set_turbulence_noise_speed(Vector3(0.0, 0.0, 0.0));

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -32,6 +32,7 @@
 #define PARTICLE_PROCESS_MATERIAL_H
 
 #include "core/templates/rid.h"
+#include "core/templates/self_list.h"
 #include "scene/resources/material.h"
 
 /*
@@ -61,6 +62,9 @@ public:
 		PARAM_TURB_INFLUENCE_OVER_LIFE,
 		PARAM_TURB_VEL_INFLUENCE,
 		PARAM_TURB_INIT_DISPLACEMENT,
+		PARAM_RADIAL_VELOCITY,
+		PARAM_DIRECTIONAL_VELOCITY,
+		PARAM_SCALE_OVER_VELOCITY,
 		PARAM_MAX
 	};
 
@@ -69,6 +73,7 @@ public:
 		PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY,
 		PARTICLE_FLAG_ROTATE_Y,
 		PARTICLE_FLAG_DISABLE_Z,
+		PARTICLE_FLAG_DAMPING_AS_FRICTION,
 		PARTICLE_FLAG_MAX
 	};
 
@@ -102,35 +107,37 @@ public:
 	};
 
 private:
-	union MaterialKey {
-		// The bit size of the struct must be kept below or equal to 32 bits.
+	struct MaterialKey {
+		// The bit size of the struct must be kept below or equal to 64 bits.
 		// Consider this when extending ParticleFlags, EmissionShape, or SubEmitterMode.
-		struct {
-			uint32_t texture_mask : 16;
-			uint32_t texture_color : 1;
-			uint32_t particle_flags : 4;
-			uint32_t emission_shape : 3;
-			uint32_t invalid_key : 1;
-			uint32_t has_emission_color : 1;
-			uint32_t sub_emitter : 2;
-			uint32_t attractor_enabled : 1;
-			uint32_t collision_mode : 2;
-			uint32_t collision_scale : 1;
-			uint32_t turbulence_enabled : 1;
-		};
+		uint64_t texture_mask : PARAM_MAX;
+		uint64_t texture_color : 1;
+		uint64_t particle_flags : PARTICLE_FLAG_MAX - 1;
+		uint64_t emission_shape : 3;
+		uint64_t invalid_key : 1;
+		uint64_t has_emission_color : 1;
+		uint64_t sub_emitter : 2;
+		uint64_t attractor_enabled : 1;
+		uint64_t collision_mode : 2;
+		uint64_t collision_scale : 1;
+		uint64_t turbulence_enabled : 1;
+		uint64_t limiter_curve : 1;
+		uint64_t alpha_curve : 1;
+		uint64_t emission_curve : 1;
+		uint64_t has_initial_ramp : 1;
 
-		uint64_t key = 0;
+		MaterialKey() {
+			memset(this, 0, sizeof(MaterialKey));
+		}
 
 		static uint32_t hash(const MaterialKey &p_key) {
-			return hash_murmur3_one_32(p_key.key);
+			return hash_djb2_buffer((const uint8_t *)&p_key, sizeof(MaterialKey));
 		}
-
 		bool operator==(const MaterialKey &p_key) const {
-			return key == p_key.key;
+			return memcmp(this, &p_key, sizeof(MaterialKey)) == 0;
 		}
-
 		bool operator<(const MaterialKey &p_key) const {
-			return key < p_key.key;
+			return memcmp(this, &p_key, sizeof(MaterialKey)) < 0;
 		}
 	};
 
@@ -145,17 +152,6 @@ private:
 
 	_FORCE_INLINE_ MaterialKey _compute_key() const {
 		MaterialKey mk;
-		mk.key = 0;
-		for (int i = 0; i < PARAM_MAX; i++) {
-			if (tex_parameters[i].is_valid()) {
-				mk.texture_mask |= (1 << i);
-			}
-		}
-		for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
-			if (particle_flags[i]) {
-				mk.particle_flags |= (1 << i);
-			}
-		}
 
 		mk.texture_color = color_ramp.is_valid() ? 1 : 0;
 		mk.emission_shape = emission_shape;
@@ -165,6 +161,21 @@ private:
 		mk.attractor_enabled = attractor_interaction_enabled;
 		mk.collision_scale = collision_scale;
 		mk.turbulence_enabled = turbulence_enabled;
+		mk.limiter_curve = velocity_limit_curve.is_valid() ? 1 : 0;
+		mk.alpha_curve = alpha_curve.is_valid() ? 1 : 0;
+		mk.emission_curve = emission_curve.is_valid() ? 1 : 0;
+		mk.has_initial_ramp = color_initial_ramp.is_valid() ? 1 : 0;
+
+		for (int i = 0; i < PARAM_MAX; i++) {
+			if (tex_parameters[i].is_valid()) {
+				mk.texture_mask |= ((uint64_t)1 << i);
+			}
+		}
+		for (int i = 0; i < PARTICLE_FLAG_MAX; i++) {
+			if (particle_flags[i]) {
+				mk.particle_flags |= ((uint64_t)1 << i);
+			}
+		}
 
 		return mk;
 	}
@@ -180,43 +191,58 @@ private:
 		StringName initial_angle_min;
 		StringName angular_velocity_min;
 		StringName orbit_velocity_min;
+		StringName radial_velocity_min;
 		StringName linear_accel_min;
 		StringName radial_accel_min;
 		StringName tangent_accel_min;
 		StringName damping_min;
 		StringName scale_min;
+		StringName scale_over_velocity_min;
 		StringName hue_variation_min;
 		StringName anim_speed_min;
 		StringName anim_offset_min;
+		StringName directional_velocity_min;
 
 		StringName initial_linear_velocity_max;
 		StringName initial_angle_max;
 		StringName angular_velocity_max;
 		StringName orbit_velocity_max;
+		StringName radial_velocity_max;
 		StringName linear_accel_max;
 		StringName radial_accel_max;
 		StringName tangent_accel_max;
 		StringName damping_max;
 		StringName scale_max;
+		StringName scale_over_velocity_max;
 		StringName hue_variation_max;
 		StringName anim_speed_max;
 		StringName anim_offset_max;
+		StringName directional_velocity_max;
 
 		StringName angle_texture;
 		StringName angular_velocity_texture;
 		StringName orbit_velocity_texture;
+		StringName radial_velocity_texture;
 		StringName linear_accel_texture;
 		StringName radial_accel_texture;
 		StringName tangent_accel_texture;
 		StringName damping_texture;
 		StringName scale_texture;
+		StringName scale_over_velocity_texture;
 		StringName hue_variation_texture;
 		StringName anim_speed_texture;
 		StringName anim_offset_texture;
+		StringName velocity_limiter_texture;
+		StringName directional_velocity_texture;
 
 		StringName color;
 		StringName color_ramp;
+		StringName alpha_ramp;
+		StringName emission_ramp;
 		StringName color_initial_ramp;
+
+		StringName velocity_limit_curve;
+		StringName velocity_pivot;
 
 		StringName emission_sphere_radius;
 		StringName emission_box_extents;
@@ -228,6 +254,8 @@ private:
 		StringName emission_ring_height;
 		StringName emission_ring_radius;
 		StringName emission_ring_inner_radius;
+		StringName emission_shape_offset;
+		StringName emission_shape_scale;
 
 		StringName turbulence_enabled;
 		StringName turbulence_noise_strength;
@@ -241,6 +269,7 @@ private:
 		StringName turbulence_initial_displacement_max;
 
 		StringName gravity;
+		StringName inherit_emitter_velocity_ratio;
 
 		StringName lifetime_randomness;
 
@@ -272,7 +301,13 @@ private:
 	Ref<Texture2D> tex_parameters[PARAM_MAX];
 	Color color;
 	Ref<Texture2D> color_ramp;
+	Ref<Texture2D> alpha_curve;
+	Ref<Texture2D> emission_curve;
 	Ref<Texture2D> color_initial_ramp;
+	Ref<Texture2D> velocity_limit_curve;
+
+	bool directional_velocity_global = false;
+	Vector3 velocity_pivot;
 
 	bool particle_flags[PARTICLE_FLAG_MAX];
 
@@ -287,6 +322,8 @@ private:
 	real_t emission_ring_radius = 0.0f;
 	real_t emission_ring_inner_radius = 0.0f;
 	int emission_point_count = 1;
+	Vector3 emission_shape_offset;
+	Vector3 emission_shape_scale;
 
 	bool anim_loop = false;
 
@@ -300,6 +337,7 @@ private:
 	Vector3 gravity;
 
 	double lifetime_randomness = 0.0;
+	double inherit_emitter_velocity_ratio = 0.0;
 
 	SubEmitterMode sub_emitter_mode;
 	double sub_emitter_frequency = 0.0;
@@ -328,6 +366,9 @@ public:
 	void set_flatness(float p_flatness);
 	float get_flatness() const;
 
+	void set_velocity_pivot(const Vector3 &p_pivot);
+	Vector3 get_velocity_pivot();
+
 	void set_param_min(Parameter p_param, float p_value);
 	float get_param_min(Parameter p_param) const;
 
@@ -337,6 +378,11 @@ public:
 	void set_param_texture(Parameter p_param, const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_param_texture(Parameter p_param) const;
 
+	void set_velocity_limit_curve(const Ref<Texture2D> &p_texture);
+	Ref<Texture2D> get_velocity_limit_curve() const;
+
+	void set_alpha_curve(const Ref<Texture2D> &p_texture);
+	Ref<Texture2D> get_alpha_curve() const;
 	void set_color(const Color &p_color);
 	Color get_color() const;
 
@@ -345,6 +391,9 @@ public:
 
 	void set_color_initial_ramp(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_color_initial_ramp() const;
+
+	void set_emission_curve(const Ref<Texture2D> &p_texture);
+	Ref<Texture2D> get_emission_curve() const;
 
 	void set_particle_flag(ParticleFlags p_particle_flag, bool p_enable);
 	bool get_particle_flag(ParticleFlags p_particle_flag) const;
@@ -391,6 +440,9 @@ public:
 	void set_lifetime_randomness(double p_lifetime);
 	double get_lifetime_randomness() const;
 
+	void set_inherit_velocity_ratio(double p_ratio);
+	double get_inherit_velocity_ratio();
+
 	void set_attractor_interaction_enabled(bool p_enable);
 	bool is_attractor_interaction_enabled() const;
 
@@ -424,6 +476,12 @@ public:
 
 	void set_sub_emitter_keep_velocity(bool p_enable);
 	bool get_sub_emitter_keep_velocity() const;
+
+	void set_emission_shape_offset(const Vector3 &p_emission_shape_offset);
+	Vector3 get_emission_shape_offset() const;
+
+	void set_emission_shape_scale(const Vector3 &p_emission_shape_scale);
+	Vector3 get_emission_shape_scale() const;
 
 	virtual RID get_shader_rid() const override;
 

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -47,6 +47,7 @@ public:
 	virtual void particles_emit(RID p_particles, const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) override {}
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) override {}
 	virtual void particles_set_amount(RID p_particles, int p_amount) override {}
+	virtual void particles_set_amount_ratio(RID p_particles, float p_amount_ratio) override {}
 	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) override {}
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) override {}
 	virtual void particles_set_pre_process_time(RID p_particles, double p_time) override {}
@@ -81,6 +82,8 @@ public:
 	virtual AABB particles_get_aabb(RID p_particles) const override { return AABB(); }
 
 	virtual void particles_set_emission_transform(RID p_particles, const Transform3D &p_transform) override {}
+	virtual void particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) override {}
+	virtual void particles_set_interp_to_end(RID p_particles, float p_interp) override {}
 
 	virtual bool particles_get_emitting(RID p_particles) override { return false; }
 	virtual int particles_get_draw_passes(RID p_particles) const override { return 0; }

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -67,7 +67,7 @@ struct FrameParams {
 	float delta;
 
 	uint frame;
-	uint pad0;
+	float amount_ratio;
 	uint pad1;
 	uint pad2;
 
@@ -77,6 +77,8 @@ struct FrameParams {
 	float particle_size;
 
 	mat4 emission_transform;
+	vec3 emitter_velocity;
+	float interp_to_end;
 
 	Attractor attractors[MAX_ATTRACTORS];
 	Collider colliders[MAX_COLLIDERS];

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -123,7 +123,7 @@ private:
 		float delta;
 
 		uint32_t frame;
-		uint32_t pad0;
+		float amount_ratio;
 		uint32_t pad1;
 		uint32_t pad2;
 
@@ -133,6 +133,9 @@ private:
 		float particle_size;
 
 		float emission_transform[16];
+
+		float emitter_velocity[3];
+		float interp_to_end;
 
 		Attractor attractors[MAX_ATTRACTORS];
 		Collider colliders[MAX_COLLIDERS];
@@ -235,6 +238,9 @@ private:
 		bool force_sub_emit = false;
 
 		Transform3D emission_transform;
+		Vector3 emitter_velocity;
+		float interp_to_end = 0.0;
+		float amount_ratio = 1.0;
 
 		Vector<uint8_t> emission_buffer_data;
 
@@ -425,6 +431,7 @@ public:
 	virtual void particles_set_mode(RID p_particles, RS::ParticlesMode p_mode) override;
 	virtual void particles_set_emitting(RID p_particles, bool p_emitting) override;
 	virtual void particles_set_amount(RID p_particles, int p_amount) override;
+	virtual void particles_set_amount_ratio(RID p_particles, float p_amount_ratio) override;
 	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) override;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) override;
 	virtual void particles_set_pre_process_time(RID p_particles, double p_time) override;
@@ -460,6 +467,8 @@ public:
 	virtual AABB particles_get_aabb(RID p_particles) const override;
 
 	virtual void particles_set_emission_transform(RID p_particles, const Transform3D &p_transform) override;
+	virtual void particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) override;
+	virtual void particles_set_interp_to_end(RID p_particles, float p_interp_to_end) override;
 
 	virtual bool particles_get_emitting(RID p_particles) override;
 	virtual int particles_get_draw_passes(RID p_particles) const override;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -490,6 +490,7 @@ public:
 	FUNC2(particles_set_emitting, RID, bool)
 	FUNC1R(bool, particles_get_emitting, RID)
 	FUNC2(particles_set_amount, RID, int)
+	FUNC2(particles_set_amount_ratio, RID, float)
 	FUNC2(particles_set_lifetime, RID, double)
 	FUNC2(particles_set_one_shot, RID, bool)
 	FUNC2(particles_set_pre_process_time, RID, double)
@@ -521,6 +522,8 @@ public:
 
 	FUNC1R(AABB, particles_get_current_aabb, RID)
 	FUNC2(particles_set_emission_transform, RID, const Transform3D &)
+	FUNC2(particles_set_emitter_velocity, RID, const Vector3 &)
+	FUNC2(particles_set_interp_to_end, RID, float)
 
 	/* PARTICLES COLLISION */
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -348,6 +348,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["NUMBER"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["INDEX"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["EMISSION_TRANSFORM"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["EMITTER_VELOCITY"] = constt(ShaderLanguage::TYPE_VEC3);
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["INTERPOLATE_TO_END"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["RANDOM_SEED"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["FLAG_EMIT_POSITION"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["FLAG_EMIT_ROT_SCALE"] = constt(ShaderLanguage::TYPE_UINT);
@@ -359,6 +361,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["RESTART_VELOCITY"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["RESTART_COLOR"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["RESTART_CUSTOM"] = constt(ShaderLanguage::TYPE_BOOL);
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["AMOUNT_RATIO"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].main_function = true;
 
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["COLOR"] = ShaderLanguage::TYPE_VEC4;
@@ -379,6 +382,8 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["NUMBER"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["INDEX"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["EMISSION_TRANSFORM"] = constt(ShaderLanguage::TYPE_MAT4);
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["EMITTER_VELOCITY"] = constt(ShaderLanguage::TYPE_VEC3);
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["INTERPOLATE_TO_END"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["RANDOM_SEED"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["FLAG_EMIT_POSITION"] = constt(ShaderLanguage::TYPE_UINT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["FLAG_EMIT_ROT_SCALE"] = constt(ShaderLanguage::TYPE_UINT);
@@ -389,6 +394,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["COLLISION_NORMAL"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["COLLISION_DEPTH"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["ATTRACTOR_FORCE"] = constt(ShaderLanguage::TYPE_VEC3);
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["AMOUNT_RATIO"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].main_function = true;
 
 	{

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -49,6 +49,7 @@ public:
 	virtual bool particles_get_emitting(RID p_particles) = 0;
 
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
+	virtual void particles_set_amount_ratio(RID p_particles, float p_amount_ratio) = 0;
 	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;
 	virtual void particles_set_pre_process_time(RID p_particles, double p_time) = 0;
@@ -85,6 +86,8 @@ public:
 	virtual AABB particles_get_aabb(RID p_particles) const = 0;
 
 	virtual void particles_set_emission_transform(RID p_particles, const Transform3D &p_transform) = 0;
+	virtual void particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) = 0;
+	virtual void particles_set_interp_to_end(RID p_particles, float p_interp_to_end) = 0;
 
 	virtual int particles_get_draw_passes(RID p_particles) const = 0;
 	virtual RID particles_get_draw_pass_mesh(RID p_particles, int p_pass) const = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2497,11 +2497,14 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_set_emitting", "particles", "emitting"), &RenderingServer::particles_set_emitting);
 	ClassDB::bind_method(D_METHOD("particles_get_emitting", "particles"), &RenderingServer::particles_get_emitting);
 	ClassDB::bind_method(D_METHOD("particles_set_amount", "particles", "amount"), &RenderingServer::particles_set_amount);
+	ClassDB::bind_method(D_METHOD("particles_set_amount_ratio", "particles", "ratio"), &RenderingServer::particles_set_amount_ratio);
 	ClassDB::bind_method(D_METHOD("particles_set_lifetime", "particles", "lifetime"), &RenderingServer::particles_set_lifetime);
 	ClassDB::bind_method(D_METHOD("particles_set_one_shot", "particles", "one_shot"), &RenderingServer::particles_set_one_shot);
 	ClassDB::bind_method(D_METHOD("particles_set_pre_process_time", "particles", "time"), &RenderingServer::particles_set_pre_process_time);
 	ClassDB::bind_method(D_METHOD("particles_set_explosiveness_ratio", "particles", "ratio"), &RenderingServer::particles_set_explosiveness_ratio);
 	ClassDB::bind_method(D_METHOD("particles_set_randomness_ratio", "particles", "ratio"), &RenderingServer::particles_set_randomness_ratio);
+	ClassDB::bind_method(D_METHOD("particles_set_interp_to_end", "particles", "factor"), &RenderingServer::particles_set_interp_to_end);
+	ClassDB::bind_method(D_METHOD("particles_set_emitter_velocity", "particles", "velocity"), &RenderingServer::particles_set_emitter_velocity);
 	ClassDB::bind_method(D_METHOD("particles_set_custom_aabb", "particles", "aabb"), &RenderingServer::particles_set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("particles_set_speed_scale", "particles", "scale"), &RenderingServer::particles_set_speed_scale);
 	ClassDB::bind_method(D_METHOD("particles_set_use_local_coordinates", "particles", "enable"), &RenderingServer::particles_set_use_local_coordinates);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -660,6 +660,7 @@ public:
 	virtual void particles_set_emitting(RID p_particles, bool p_enable) = 0;
 	virtual bool particles_get_emitting(RID p_particles) = 0;
 	virtual void particles_set_amount(RID p_particles, int p_amount) = 0;
+	virtual void particles_set_amount_ratio(RID p_particles, float p_amount_ratio) = 0;
 	virtual void particles_set_lifetime(RID p_particles, double p_lifetime) = 0;
 	virtual void particles_set_one_shot(RID p_particles, bool p_one_shot) = 0;
 	virtual void particles_set_pre_process_time(RID p_particles, double p_time) = 0;
@@ -717,6 +718,8 @@ public:
 	virtual AABB particles_get_current_aabb(RID p_particles) = 0;
 
 	virtual void particles_set_emission_transform(RID p_particles, const Transform3D &p_transform) = 0; // This is only used for 2D, in 3D it's automatic.
+	virtual void particles_set_emitter_velocity(RID p_particles, const Vector3 &p_velocity) = 0;
+	virtual void particles_set_interp_to_end(RID p_particles, float p_interp) = 0;
 
 	/* PARTICLES COLLISION API */
 


### PR DESCRIPTION
# DO NOT TEST ON IMPORTANT PROJECTS! MAKE A COPY!

## How to test:
1. Login into github
2. Click the "checks" tab of this PR
3. On the right there's an "artifacts" button.
4. Download the appropriate build for your plaform

![image](https://github.com/godotengine/godot/assets/7917475/ba40d17f-8ba7-46cc-8dea-fc9758e383fb)

## What to test
1. Compatibility with existing projects! This should not break compatibility and if it does, if the particles look different, it's a bug.
2. Features: are the new features functioning properly?

**NOTE: this is GPUParticles only**

-------------

Description:

This is a gigaenormous rework to particles because adding code to them had become impossibly difficult.
Now parameters are stored in lovely neat structs and subdivided in display, dynamics, accelerations.
This closes probably 90% of the proposals and issues about particles i opened.

IDEALLY: this is 100% compatible with the existing one. Practically there may be some bugs and regressions introduced during the rewrite.

This is an attempt at implementing https://godotshaders.com/shader/particle-process-v2/ and keeping compat.

## How to conduct a test
Ideally, people will try to make something a little more complex than a single particle system.
I'm hoping something of the complexity of a crit hit effect (so I'm imagining 4-5 particle systems..?)
Sword slash, fireball, go for it!

Feel free to use my render material for testing it out (MPL license, means if you change a file you have to open source the changes to that specific file, but it doesn't spread like GPL)
[vfx_kit.zip](https://github.com/godotengine/godot/files/12063036/vfx_kit.zip)


## Overview of the changes:
### GPUParticles:
- add an `interp_to_end` parameter to force particles to run to the end of their lifetime fast. This can be animated in the animation player, or tweened to make a complex VFX scene disappeared in a desired time interval. cool isn't it?
- fixed billboard mode not taking into account angle stored in CUSTOM.x

### ParticleProcess:
- Shader entirely rearranged and reorganized. Data is split in different structs and there's function to generate the initial state that can be called from process(), so that there's no discrepancies (hopefully ....?)
- Parameters entirely rearranged in submenus.  I know this will be contentious but i arranged them based on my daily usage of said particles. The editor can remember unfolded submenus, since tweaking is like 80% of particle work, this shouldnt really be too much of an issue, i hope. It will be more prominent, of course, if the testing usage is "i make a lot of different particle systems"
**New features **
Under spawn section, inherit emitter velocity. Currently nonfucntional, will figure out how to make it functional later.

A completely new category of velocity: animated velocity. This is velocity entirely driven by curves. **it will not be subject to damping**
![image](https://github.com/godotengine/godot/assets/7917475/8c75d703-356d-4660-938a-e8e76ba0139c)

Available velocities:
- angular (rotates the particle if billboard, same as before)
- radial: velocity towards, or away, from a point
- orbit:  orbit velocity around XYZ axes. To use in compatibility mode, use flag enable z. To use in new mode, use CurveXYZ. Curve should be in degrees.
- Velocity limit: a curve that defines the maximum velocity magnitude (combined with accelerations) that a particle can have along its lifetime. functions only when assigned.

Accelerations are the same as before. gravity is under accelerations, together with attractor interaction.

Display parameters:
This is where color, scale and animation properties live.
![image](https://github.com/godotengine/godot/assets/7917475/3135d149-817b-456e-afdc-9556cac669d6)

Color got two new optional curves, alpha curve and emission curve (emission as in brightness. perhaps brightness would be a better term). emission just multiplies the color so it needs to be read in the render shader as such. Feel free to use the material provided above. a single color ramp will work as before.

![image](https://github.com/godotengine/godot/assets/7917475/fa11dd6c-b378-4daf-bfa5-d55e89c9b25e)

Scale over velocity!! This is really cool to add some sensation of smear for motion by scaling on the Y axis for example with a XYZ curve. The two min/max parameters indicate the range in which velocity is remapped onto the curve (so when do i make my scale biggest? when max velocity is 10, or 200? that's what the parameters are for)

## Addresses
https://github.com/godotengine/godot-proposals/issues/7082 - interp to end will make trails much easier: it offers a lifetime control.
https://github.com/godotengine/godot-proposals/issues/6779 - improves portability of particle systems and makes technology for VFX color palettes actually possible
https://github.com/godotengine/godot-proposals/issues/6657 - slightly different, but achievest almost all of the same results
https://github.com/godotengine/godot-proposals/issues/6573 - offers it as a property instead of a function, functions can be implemented on top later.
https://github.com/godotengine/godot-proposals/issues/5044 - emission transform built-ins
https://github.com/godotengine/godot/issues/79063 - uses custom.x rotation correctly

_Bugsquad edit: Fixes: https://github.com/godotengine/godot/issues/82837_

## Who whants this

Edit: look at the reaction. Aww. Thanks y'all <3

I know that discussions on proposals didn't really get a huge amount of traction on Github, but i brought up this work in multiple VFX spaces, incorporated feedback from various professionals, and researched how alternatives (Unity, Unreal) are built.
This has been months of research that ultimately condensed into this work.
I believe that what testers will be able to achieve with this PR will speak for itself.
