### PR TITLE
[3.x] Sorts AnimationNodeBlendTree node connections for deterministic output

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1018,6 +1018,19 @@ void AnimationNodeBlendTree::get_node_connections(List<NodeConnection> *r_connec
 			}
 		}
 	}
+	// Keep node connections sorted for deterministic scene file output.
+	struct Comparator {
+		bool operator()(const NodeConnection &p_a, const NodeConnection &p_b) const {
+			if (p_a.input_node == p_b.input_node) {
+				if (p_a.input_index == p_b.input_index) {
+					return StringName::AlphCompare()(p_a.output_node, p_b.output_node);
+				}
+				return p_a.input_index < p_b.input_index;
+			}
+			return StringName::AlphCompare()(p_a.input_node, p_b.input_node);
+		}
+	};
+	r_connections->sort_custom<Comparator>();
 }
 
 String AnimationNodeBlendTree::get_caption() const {


### PR DESCRIPTION
This is the 3.x mirror of #79530 and should resolve #42788 for 3.x.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
