### PR TITLE
GLTF: Preserve the original bytes when extracting a texture while importing

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -59,6 +59,12 @@
 				Runs when generating a Godot scene node from a GLTFNode. The returned node will be added to the scene tree. Multiple nodes can be generated in this step if they are added as a child of the returned node.
 			</description>
 		</method>
+		<method name="_get_image_file_extension" qualifiers="virtual">
+			<return type="String" />
+			<description>
+				Returns the file extension to use for saving image data into, for example, [code]".png"[/code]. If defined, when this extension is used to handle images, and the images are saved to a separate file, the image bytes will be copied to a file with this extension. If this is set, there should be a [ResourceImporter] class able to import the file. If not defined or empty, Godot will save the image into a PNG file.
+			</description>
+		</method>
 		<method name="_get_supported_extensions" qualifiers="virtual">
 			<return type="PackedStringArray" />
 			<description>

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -36,6 +36,7 @@ void GLTFDocumentExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_supported_extensions);
 	GDVIRTUAL_BIND(_parse_node_extensions, "state", "gltf_node", "extensions");
 	GDVIRTUAL_BIND(_parse_image_data, "state", "image_data", "mime_type", "ret_image");
+	GDVIRTUAL_BIND(_get_image_file_extension);
 	GDVIRTUAL_BIND(_parse_texture_json, "state", "texture_json", "ret_gltf_texture");
 	GDVIRTUAL_BIND(_generate_scene_node, "state", "gltf_node", "scene_parent");
 	GDVIRTUAL_BIND(_import_post_parse, "state");
@@ -76,6 +77,12 @@ Error GLTFDocumentExtension::parse_image_data(Ref<GLTFState> p_state, const Pack
 	Error err = OK;
 	GDVIRTUAL_CALL(_parse_image_data, p_state, p_image_data, p_mime_type, r_image, err);
 	return err;
+}
+
+String GLTFDocumentExtension::get_image_file_extension() {
+	String ret;
+	GDVIRTUAL_CALL(_get_image_file_extension, ret);
+	return ret;
 }
 
 Error GLTFDocumentExtension::parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) {

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -45,6 +45,7 @@ public:
 	virtual Vector<String> get_supported_extensions();
 	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &p_extensions);
 	virtual Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image);
+	virtual String get_image_file_extension();
 	virtual Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture);
 	virtual Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent);
 	virtual Error import_post_parse(Ref<GLTFState> p_state);
@@ -61,6 +62,7 @@ public:
 	GDVIRTUAL0R(Vector<String>, _get_supported_extensions);
 	GDVIRTUAL3R(Error, _parse_node_extensions, Ref<GLTFState>, Ref<GLTFNode>, Dictionary);
 	GDVIRTUAL4R(Error, _parse_image_data, Ref<GLTFState>, PackedByteArray, String, Ref<Image>);
+	GDVIRTUAL0R(String, _get_image_file_extension);
 	GDVIRTUAL3R(Error, _parse_texture_json, Ref<GLTFState>, Dictionary, Ref<GLTFTexture>);
 	GDVIRTUAL3R(Node3D *, _generate_scene_node, Ref<GLTFState>, Ref<GLTFNode>, Node *);
 	GDVIRTUAL1R(Error, _import_post_parse, Ref<GLTFState>);

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
@@ -51,6 +51,10 @@ Error GLTFDocumentExtensionTextureWebP::parse_image_data(Ref<GLTFState> p_state,
 	return OK;
 }
 
+String GLTFDocumentExtensionTextureWebP::get_image_file_extension() {
+	return ".webp";
+}
+
 Error GLTFDocumentExtensionTextureWebP::parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) {
 	if (!p_texture_json.has("extensions")) {
 		return OK;

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.h
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.h
@@ -41,6 +41,7 @@ public:
 	Error import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) override;
 	Vector<String> get_supported_extensions() override;
 	Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image) override;
+	String get_image_file_extension() override;
 	Error parse_texture_json(Ref<GLTFState> p_state, const Dictionary &p_texture_json, Ref<GLTFTexture> r_gltf_texture) override;
 };
 

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -151,8 +151,8 @@ private:
 	Error _serialize_texture_samplers(Ref<GLTFState> p_state);
 	Error _serialize_images(Ref<GLTFState> p_state, const String &p_path);
 	Error _serialize_lights(Ref<GLTFState> p_state);
-	Ref<Image> _parse_image_bytes_into_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_mime_type, int p_index);
-	void _parse_image_save_image(Ref<GLTFState> p_state, const String &p_mime_type, int p_index, Ref<Image> p_image);
+	Ref<Image> _parse_image_bytes_into_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_mime_type, int p_index, String &r_file_extension);
+	void _parse_image_save_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_file_extension, int p_index, Ref<Image> p_image);
 	Error _parse_images(Ref<GLTFState> p_state, const String &p_base_path);
 	Error _parse_textures(Ref<GLTFState> p_state);
 	Error _parse_texture_samplers(Ref<GLTFState> p_state);


### PR DESCRIPTION
Before this PR, the GLTF importer will import images into an Image resource, and then use this to save a PNG file to disk. This means that JPG, WebP, etc images would be converted to PNG, using more disk space than necesssary, and being slower than necessary since it needs to re-encode the images.

As of this PR, when the importer wants to save the images to separate files, the image data in the GLTF will just be directly written to disk, for PNG and JPG always, and for other image formats it will save it into a file when the GLTFDocumentExtension defines `get_image_file_extension` to indicate what the file extension should be.

To be clear, preserving the original bytes for new image formats is optional (for the extension programmer). If a GLTFDocumentExtension class wants to import images and have Godot save them as PNG, just don't define `get_image_file_extension`. When this method is not defined, Godot will save an Image resource as a PNG like before.

Some test files I used with JPG/PNG/WebP all are extracted correctly:

<img width="298" alt="Screenshot 2023-07-16 at 12 20 53 AM" src="https://github.com/godotengine/godot/assets/1646875/9b0f32f5-86c3-4d47-9f00-2238007a23db">
