### PR TITLE
Separate input-handled-state for different events during physics-picking

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -717,6 +717,7 @@ void Viewport::_process_picking() {
 	}
 
 	while (physics_picking_events.size()) {
+		local_input_handled = false;
 		Ref<InputEvent> ev = physics_picking_events.front()->get();
 		physics_picking_events.pop_front();
 


### PR DESCRIPTION
Currently the input-handled-state for different events during physics-picking can interfere with each other, which means, that `is_input_handled` works only for `Control`-nodes.
This PR makes sure, that the input_handled_state is reset before processing an InputEvent during physics-picking, so that `is_input_handled` can additionally be used for `Node2D`/`Node3D` physics-picking.

While #76439 is not fixed, this PR will not work, when physics-picking happens in a `SubViewportContainer`.

resolve #79539
