### PR TITLE
C#: Finish documentation of GodotSharp public API

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
@@ -26,7 +26,7 @@ partial class AnimationNode
 
 partial class CodeEdit
 {
-    /// <inheritdoc cref="AddCodeCompletionOption(CodeCompletionKind, string, string, Nullable{Color}, Resource, Nullable{Variant})"/>
+    /// <inheritdoc cref="AddCodeCompletionOption(CodeCompletionKind, string, string, Nullable{Color}, Resource, Nullable{Variant}, int)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddCodeCompletionOption(CodeCompletionKind type, string displayText, string insertText, Nullable<Color> textColor, Resource icon, Nullable<Variant> value)
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -68,6 +68,11 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given <see cref="StringName"/> span.
+        /// </summary>
+        /// <param name="array">The StringNames to put in the new array.</param>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<StringName> array) : this()
         {
             if (array == null)
@@ -84,6 +89,11 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given <see cref="NodePath"/> span.
+        /// </summary>
+        /// <param name="array">The NodePaths to put in the new array.</param>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<NodePath> array) : this()
         {
             if (array == null)
@@ -100,6 +110,11 @@ namespace Godot.Collections
                 this[i] = array[i];
         }
 
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given <see cref="Rid"/> span.
+        /// </summary>
+        /// <param name="array">The Rids to put in the new array.</param>
+        /// <returns>A new Godot Array.</returns>
         public Array(Span<Rid> array) : this()
         {
             if (array == null)
@@ -120,6 +135,11 @@ namespace Godot.Collections
         // from derived types (e.g.: Node[]). Implicit conversion from Derived[] to Base[] are
         // fine as long as the array is not mutated. However, Span does this type checking at
         // instantiation, so it's not possible to use it even when not mutating anything.
+        /// <summary>
+        /// Constructs a new <see cref="Array"/> from the given <see cref="GodotObject"/> span.
+        /// </summary>
+        /// <param name="array">The GodotObjects to put in the new array.</param>
+        /// <returns>A new Godot Array.</returns>
         // ReSharper disable once RedundantNameQualifier
         public Array(ReadOnlySpan<GodotObject> array) : this()
         {
@@ -149,6 +169,9 @@ namespace Godot.Collections
         internal static Array CreateTakingOwnershipOfDisposableValue(godot_array nativeValueToOwn)
             => new Array(nativeValueToOwn);
 
+        /// <summary>
+        /// Deconstructs this <see cref="Array"/>.
+        /// </summary>
         ~Array()
         {
             Dispose(false);
@@ -163,6 +186,9 @@ namespace Godot.Collections
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Disposes implementation of this <see cref="Array"/>.
+        /// </summary>
         public void Dispose(bool disposing)
         {
             // Always dispose `NativeValue` even if disposing is true
@@ -1773,9 +1799,19 @@ namespace Godot.Collections
         /// <returns>A string representation of this array.</returns>
         public override string ToString() => _underlyingArray.ToString();
 
+        /// <summary>
+        /// Converts this <see cref="Array{T}"/> to a <see cref="Variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Array{T}"/> to convert.</param>
+        /// <returns>A <see cref="Variant"/> representation of this <see cref="Array{T}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Variant(Array<T> from) => Variant.CreateFrom(from);
 
+        /// <summary>
+        /// Converts this <see cref="Variant"/> to an <see cref="Array{T}"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Variant"/> to convert.</param>
+        /// <returns>An <see cref="Array{T}"/> representation of this <see cref="Variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Array<T>(Variant from) => from.AsGodotArray<T>();
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
@@ -16,6 +16,10 @@ namespace Godot
         /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Specify the original engine class name.
+        /// </summary>
+        /// <param name="name">Original engine class name.</param>
         public GodotClassNameAttribute(string name)
         {
             Name = name;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// Attribute that marks the current delegate as a signal, allowing it to
+    /// handle engine callbacks.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Delegate)]
     public sealed class SignalAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
@@ -2,6 +2,10 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// Attribute that marks the current script as a tool script, allowing it
+    /// to be loaded and executed by the editor.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ToolAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/AlcReloadCfg.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/AlcReloadCfg.cs
@@ -1,9 +1,16 @@
 namespace Godot.Bridge;
 
+/// <summary>
+/// A reload configuration for an assembly load context.
+/// </summary>
 public static class AlcReloadCfg
 {
     private static bool _configured = false;
 
+    /// <summary>
+    /// Configure this assembly load context.
+    /// </summary>
+    /// <param name="alcReloadEnabled">Specifies if a reload is enabled.</param>
     public static void Configure(bool alcReloadEnabled)
     {
         if (_configured)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotSerializationInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/GodotSerializationInfo.cs
@@ -4,11 +4,17 @@ using Godot.NativeInterop;
 
 namespace Godot.Bridge;
 
+/// <summary>
+/// Serialized information container for handling <see cref="Godot.GodotObject"/> data.
+/// </summary>
 public sealed class GodotSerializationInfo : IDisposable
 {
     private readonly Collections.Dictionary _properties;
     private readonly Collections.Dictionary _signalEvents;
 
+    /// <summary>
+    /// Disposes of this <see cref="GodotSerializationInfo"/>.
+    /// </summary>
     public void Dispose()
     {
         _properties?.Dispose();
@@ -30,16 +36,33 @@ public sealed class GodotSerializationInfo : IDisposable
             NativeFuncs.godotsharp_dictionary_new_copy(signalEvents));
     }
 
+    /// <summary>
+    /// Adds a property to this <see cref="GodotSerializationInfo"/>.
+    /// </summary>
+    /// <param name="name">The name of the property to add.</param>
+    /// <param name="value">The value to set for this property.</param>
     public void AddProperty(StringName name, Variant value)
     {
         _properties[name] = value;
     }
 
+    /// <summary>
+    /// Tries to get a property from this <see cref="GodotSerializationInfo"/>.
+    /// </summary>
+    /// <param name="name">The name of the property to parse.</param>
+    /// <param name="value">The value retrieved from this property.</param>
+    /// <returns><see langword="true"/> if a property was successfully retrieved;
+    /// otherwise, <see langword="false"/>.</returns>
     public bool TryGetProperty(StringName name, out Variant value)
     {
         return _properties.TryGetValue(name, out value);
     }
 
+    /// <summary>
+    /// Adds a signal event to this <see cref="GodotSerializationInfo"/>.
+    /// </summary>
+    /// <param name="name">The name of the signal to add.</param>
+    /// <param name="eventDelegate">The delegate to assign to this signal.</param>
     public void AddSignalEventDelegate(StringName name, Delegate eventDelegate)
     {
         var serializedData = new Collections.Array();
@@ -54,6 +77,14 @@ public sealed class GodotSerializationInfo : IDisposable
         }
     }
 
+    /// <summary>
+    /// Tries to get a signal from this <see cref="GodotSerializationInfo"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="Delegate"/> being retrieved.</typeparam>
+    /// <param name="name">The name of the signal to parse.</param>
+    /// <param name="value">The value retrieved from this signal.</param>
+    /// <returns><see langword="true"/> if a signal was successfully retrieved;
+    /// otherwise, <see langword="false"/>.</returns>
     public bool TryGetSignalEventDelegate<T>(StringName name, [MaybeNullWhen(false)] out T value)
         where T : Delegate
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -4,46 +4,155 @@ using Godot.NativeInterop;
 
 namespace Godot.Bridge
 {
+    /// <summary>
+    /// Collection of managed callbacks to handle a dotnet hot-reload environment.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct ManagedCallbacks
     {
         // @formatter:off
+        /// <summary>
+        /// Delegate for <see cref="SignalAwaiter.SignalCallback"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_variant**, int, godot_bool*, void> SignalAwaiter_SignalCallback;
+        /// <summary>
+        /// Delegate for <see cref="DelegateUtils.InvokeWithVariantArgs"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, void*, godot_variant**, int, godot_variant*, void> DelegateUtils_InvokeWithVariantArgs;
+        /// <summary>
+        /// Delegate for <see cref="DelegateUtils.DelegateEquals"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
+        /// <summary>
+        /// Delegate for <see cref="DelegateUtils.DelegateHash"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, int> DelegateUtils_DelegateHash;
+        /// <summary>
+        /// Delegate for <see cref="DelegateUtils.TrySerializeDelegateWithGCHandle"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
+        /// <summary>
+        /// Delegate for <see cref="DelegateUtils.TryDeserializeDelegateWithGCHandle"/>
+        /// </summary>
         public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.FrameCallback"/>
+        /// </summary>
         public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.CreateManagedForGodotObjectBinding"/>
+        /// </summary>
         public delegate* unmanaged<godot_string_name*, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedForGodotObjectBinding;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.CreateManagedForGodotObjectScriptInstance"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, IntPtr, godot_variant**, int, godot_bool> ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.GetScriptNativeName"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, void> ScriptManagerBridge_GetScriptNativeName;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.SetGodotObjectPtr"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, IntPtr, void> ScriptManagerBridge_SetGodotObjectPtr;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.RaiseEventSignal"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_bool*, void> ScriptManagerBridge_RaiseEventSignal;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.ScriptIsOrInherits"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> ScriptManagerBridge_ScriptIsOrInherits;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.AddScriptBridge"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool> ScriptManagerBridge_AddScriptBridge;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.GetOrCreateScriptBridgeForPath"/>
+        /// </summary>
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.RemoveScriptBridge"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.TryReloadRegisteredScriptWithClass"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.UpdateScriptClassInfo"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.SwapGCHandleForType"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.GetPropertyInfoList"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
+        /// <summary>
+        /// Delegate for <see cref="ScriptManagerBridge.GetPropertyDefaultValues"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.Call"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.Set"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.Get"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Get;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.CallDispose"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_bool, void> CSharpInstanceBridge_CallDispose;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.CallToString"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, void> CSharpInstanceBridge_CallToString;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.HasMethodUnknownParams"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_string_name*, godot_bool> CSharpInstanceBridge_HasMethodUnknownParams;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.SerializeState"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_SerializeState;
+        /// <summary>
+        /// Delegate for <see cref="CSharpInstanceBridge.DeserializeState"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_DeserializeState;
+        /// <summary>
+        /// Delegate for <see cref="GCHandleBridge.FreeGCHandle"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, void> GCHandleBridge_FreeGCHandle;
+        /// <summary>
+        /// Delegate for <see cref="GCHandleBridge.GCHandleIsTargetCollectible"/>
+        /// </summary>
         public delegate* unmanaged<IntPtr, godot_bool> GCHandleBridge_GCHandleIsTargetCollectible;
+        /// <summary>
+        /// Delegate for <see cref="DebuggingUtils.GetCurrentStackInfo"/>
+        /// </summary>
         public delegate* unmanaged<void*, void> DebuggingUtils_GetCurrentStackInfo;
+        /// <summary>
+        /// Delegate for <see cref="DisposablesTracker.OnGodotShuttingDown"/>
+        /// </summary>
         public delegate* unmanaged<void> DisposablesTracker_OnGodotShuttingDown;
+        /// <summary>
+        /// Delegate for <see cref="GD.OnCoreApiAssemblyLoaded"/>
+        /// </summary>
         public delegate* unmanaged<godot_bool, void> GD_OnCoreApiAssemblyLoaded;
         // @formatter:on
 
+        /// <summary>
+        /// Initializes various delegates for managed callbacks.
+        /// </summary>
+        /// <returns>The initialized delegates.</returns>
         public static ManagedCallbacks Create()
         {
             return new()
@@ -87,6 +196,10 @@ namespace Godot.Bridge
             };
         }
 
+        /// <summary>
+        /// Initializes various delegates for managed callbacks.
+        /// </summary>
+        /// <param name="outManagedCallbacks">The initialized delegates.</param>
         public static void Create(IntPtr outManagedCallbacks)
             => *(ManagedCallbacks*)outManagedCallbacks = Create();
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/MethodInfo.cs
@@ -4,15 +4,44 @@ namespace Godot.Bridge;
 
 #nullable enable
 
+/// <summary>
+/// Collection of information regarding a given method.
+/// </summary>
 public readonly struct MethodInfo
 {
+    /// <summary>
+    /// The name of this method.
+    /// </summary>
     public StringName Name { get; init; }
+    /// <summary>
+    /// The return value of this method.
+    /// </summary>
     public PropertyInfo ReturnVal { get; init; }
+    /// <summary>
+    /// Implementation flags for this method.
+    /// </summary>
     public MethodFlags Flags { get; init; }
+    /// <summary>
+    /// The id of this method.
+    /// </summary>
     public int Id { get; init; } = 0;
+    /// <summary>
+    /// A list of arguments for this method.
+    /// </summary>
     public List<PropertyInfo>? Arguments { get; init; }
+    /// <summary>
+    /// A list of default arguments for this method.
+    /// </summary>
     public List<Variant>? DefaultArguments { get; init; }
 
+    /// <summary>
+    /// Constructs a new <see cref="MethodInfo"/> with the provided arguments.
+    /// </summary>
+    /// <param name="name">The method's name.</param>
+    /// <param name="returnVal">The method's return value.</param>
+    /// <param name="flags">The method's implementation flags.</param>
+    /// <param name="arguments">The method's arguments.</param>
+    /// <param name="defaultArguments">The method's default arguments.</param>
     public MethodInfo(StringName name, PropertyInfo returnVal, MethodFlags flags,
         List<PropertyInfo>? arguments, List<Variant>? defaultArguments)
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/PropertyInfo.cs
@@ -2,20 +2,63 @@ namespace Godot.Bridge;
 
 #nullable enable
 
+/// <summary>
+/// Collection of information regarding a given property.
+/// </summary>
 public readonly struct PropertyInfo
 {
+    /// <summary>
+    /// The <see cref="Variant"/> type of this property.
+    /// </summary>
     public Variant.Type Type { get; init; }
+    /// <summary>
+    /// The name of this property.
+    /// </summary>
     public StringName Name { get; init; }
+    /// <summary>
+    /// The hint of this property.
+    /// </summary>
     public PropertyHint Hint { get; init; }
+    /// <summary>
+    /// The hint string of this property.
+    /// </summary>
     public string HintString { get; init; }
+    /// <summary>
+    /// The usage flags for this property.
+    /// </summary>
     public PropertyUsageFlags Usage { get; init; }
+    /// <summary>
+    /// The class name of this property.
+    /// </summary>
     public StringName? ClassName { get; init; }
+    /// <summary>
+    /// The export status of this property.
+    /// </summary>
     public bool Exported { get; init; }
 
+    /// <summary>
+    /// Constructs a new <see cref="PropertyInfo"/> with the provided arguments.
+    /// </summary>
+    /// <param name="type">The property's type.</param>
+    /// <param name="name">The property's name.</param>
+    /// <param name="hint">The property's hint.</param>
+    /// <param name="hintString">The property's hint string.</param>
+    /// <param name="usage">The property's usage flags.</param>
+    /// <param name="exported">The property's export state.</param>
     public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
         PropertyUsageFlags usage, bool exported)
         : this(type, name, hint, hintString, usage, className: null, exported) { }
 
+    /// <summary>
+    /// Constructs a new <see cref="PropertyInfo"/> with the provided arguments.
+    /// </summary>
+    /// <param name="type">The property's type.</param>
+    /// <param name="name">The property's name.</param>
+    /// <param name="hint">The property's hint.</param>
+    /// <param name="hintString">The property's hint string.</param>
+    /// <param name="usage">The property's usage flags.</param>
+    /// <param name="className">The property's class name.</param>
+    /// <param name="exported">The property's export state.</param>
     public PropertyInfo(Variant.Type type, StringName name, PropertyHint hint, string hintString,
         PropertyUsageFlags usage, StringName? className, bool exported)
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -15,6 +15,9 @@ using Godot.NativeInterop;
 namespace Godot.Bridge
 {
     // TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
+    /// <summary>
+    /// A bridge for script management; will eventually be made internal.
+    /// </summary>
     public static partial class ScriptManagerBridge
     {
         private static ConcurrentDictionary<AssemblyLoadContext, ConcurrentDictionary<Type, byte>>
@@ -56,6 +59,10 @@ namespace Godot.Bridge
             typesInAlc.TryAdd(type, 0);
         }
 
+        /// <summary>
+        /// Keeps track of a given <see cref="AssemblyLoadContext"/> to easily handle unloading.
+        /// </summary>
+        /// <param name="alc">The <see cref="AssemblyLoadContext"/> to keep track of.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void TrackAlcForUnloading(AssemblyLoadContext alc)
         {
@@ -284,6 +291,10 @@ namespace Godot.Bridge
         }
 
         // Called from GodotPlugins
+        /// <summary>
+        /// Looks up scripts from the provided <see cref="Assembly"/>.
+        /// </summary>
+        /// <param name="assembly">The <see cref="Assembly"/> to parse.</param>
         // ReSharper disable once UnusedMember.Local
         public static void LookupScriptsInAssembly(Assembly assembly)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
@@ -157,7 +157,7 @@ namespace Godot
         /// <list type="number">
         ///    <item>
         ///        <term>delegateObj</term>
-        ///        <description>The given <paramref name="delegate"/>, upcast to <see cref="object"/>.</description>
+        ///        <description>The given <paramref name="delegate"/>, upcast to <see langword="object"/>.</description>
         ///    </item>
         ///    <item>
         ///        <term>args</term>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -158,153 +158,297 @@ namespace Godot
             { "YELLOWGREEN", new Color(0x9ACD32FF) },
         };
 
-#pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
+        /// <value><c>(0.94, 0.97, 1, 1)</c></value>
         public static Color AliceBlue { get { return namedColors["ALICEBLUE"]; } }
+        /// <value><c>(0.98, 0.92, 0.84, 1)</c></value>
         public static Color AntiqueWhite { get { return namedColors["ANTIQUEWHITE"]; } }
+        /// <value><c>(0, 1, 1, 1)</c></value>
         public static Color Aqua { get { return namedColors["AQUA"]; } }
+        /// <value><c>(0.5, 1, 0.83, 1)</c></value>
         public static Color Aquamarine { get { return namedColors["AQUAMARINE"]; } }
+        /// <value><c>(0.94, 1, 1, 1)</c></value>
         public static Color Azure { get { return namedColors["AZURE"]; } }
+        /// <value><c>(0.96, 0.96, 0.86, 1)</c></value>
         public static Color Beige { get { return namedColors["BEIGE"]; } }
+        /// <value><c>(1, 0.89, 0.77, 1)</c></value>
         public static Color Bisque { get { return namedColors["BISQUE"]; } }
+        /// <value><c>(0, 0, 0, 1)</c></value>
         public static Color Black { get { return namedColors["BLACK"]; } }
+        /// <value><c>(1, 0.92, 0.8, 1)</c></value>
         public static Color BlanchedAlmond { get { return namedColors["BLANCHEDALMOND"]; } }
+        /// <value><c>(0, 0, 1, 1)</c></value>
         public static Color Blue { get { return namedColors["BLUE"]; } }
+        /// <value><c>(0.54, 0.17, 0.89, 1)</c></value>
         public static Color BlueViolet { get { return namedColors["BLUEVIOLET"]; } }
+        /// <value><c>(0.65, 0.16, 0.16, 1)</c></value>
         public static Color Brown { get { return namedColors["BROWN"]; } }
+        /// <value><c>(0.87, 0.72, 0.53, 1)</c></value>
         public static Color Burlywood { get { return namedColors["BURLYWOOD"]; } }
+        /// <value><c>(0.37, 0.62, 0.63, 1)</c></value>
         public static Color CadetBlue { get { return namedColors["CADETBLUE"]; } }
+        /// <value><c>(0.5, 1, 0, 1)</c></value>
         public static Color Chartreuse { get { return namedColors["CHARTREUSE"]; } }
+        /// <value><c>(0.82, 0.41, 0.12, 1)</c></value>
         public static Color Chocolate { get { return namedColors["CHOCOLATE"]; } }
+        /// <value><c>(1, 0.5, 0.31, 1)</c></value>
         public static Color Coral { get { return namedColors["CORAL"]; } }
+        /// <value><c>(0.39, 0.58, 0.93, 1)</c></value>
         public static Color CornflowerBlue { get { return namedColors["CORNFLOWERBLUE"]; } }
+        /// <value><c>(1, 0.97, 0.86, 1)</c></value>
         public static Color Cornsilk { get { return namedColors["CORNSILK"]; } }
+        /// <value><c>(0.86, 0.08, 0.24, 1)</c></value>
         public static Color Crimson { get { return namedColors["CRIMSON"]; } }
+        /// <value><c>(0, 1, 1, 1)</c></value>
         public static Color Cyan { get { return namedColors["CYAN"]; } }
+        /// <value><c>(0, 0, 0.55, 1)</c></value>
         public static Color DarkBlue { get { return namedColors["DARKBLUE"]; } }
+        /// <value><c>(0, 0.55, 0.55, 1)</c></value>
         public static Color DarkCyan { get { return namedColors["DARKCYAN"]; } }
+        /// <value><c>(0.72, 0.53, 0.04, 1)</c></value>
         public static Color DarkGoldenrod { get { return namedColors["DARKGOLDENROD"]; } }
+        /// <value><c>(0.66, 0.66, 0.66, 1)</c></value>
         public static Color DarkGray { get { return namedColors["DARKGRAY"]; } }
+        /// <value><c>(0, 0.39, 0, 1)</c></value>
         public static Color DarkGreen { get { return namedColors["DARKGREEN"]; } }
+        /// <value><c>(0.74, 0.72, 0.42, 1)</c></value>
         public static Color DarkKhaki { get { return namedColors["DARKKHAKI"]; } }
+        /// <value><c>(0.55, 0, 0.55, 1)</c></value>
         public static Color DarkMagenta { get { return namedColors["DARKMAGENTA"]; } }
+        /// <value><c>(0.33, 0.42, 0.18, 1)</c></value>
         public static Color DarkOliveGreen { get { return namedColors["DARKOLIVEGREEN"]; } }
+        /// <value><c>(1, 0.55, 0, 1)</c></value>
         public static Color DarkOrange { get { return namedColors["DARKORANGE"]; } }
+        /// <value><c>(0.6, 0.2, 0.8, 1)</c></value>
         public static Color DarkOrchid { get { return namedColors["DARKORCHID"]; } }
+        /// <value><c>(0.55, 0, 0, 1)</c></value>
         public static Color DarkRed { get { return namedColors["DARKRED"]; } }
+        /// <value><c>(0.91, 0.59, 0.48, 1)</c></value>
         public static Color DarkSalmon { get { return namedColors["DARKSALMON"]; } }
+        /// <value><c>(0.56, 0.74, 0.56, 1)</c></value>
         public static Color DarkSeaGreen { get { return namedColors["DARKSEAGREEN"]; } }
+        /// <value><c>(0.28, 0.24, 0.55, 1)</c></value>
         public static Color DarkSlateBlue { get { return namedColors["DARKSLATEBLUE"]; } }
+        /// <value><c>(0.18, 0.31, 0.31, 1)</c></value>
         public static Color DarkSlateGray { get { return namedColors["DARKSLATEGRAY"]; } }
+        /// <value><c>(0, 0.81, 0.82, 1)</c></value>
         public static Color DarkTurquoise { get { return namedColors["DARKTURQUOISE"]; } }
+        /// <value><c>(0.58, 0, 0.83, 1)</c></value>
         public static Color DarkViolet { get { return namedColors["DARKVIOLET"]; } }
+        /// <value><c>(1, 0.08, 0.58, 1)</c></value>
         public static Color DeepPink { get { return namedColors["DEEPPINK"]; } }
+        /// <value><c>(0, 0.75, 1, 1)</c></value>
         public static Color DeepSkyBlue { get { return namedColors["DEEPSKYBLUE"]; } }
+        /// <value><c>(0.41, 0.41, 0.41, 1)</c></value>
         public static Color DimGray { get { return namedColors["DIMGRAY"]; } }
+        /// <value><c>(0.12, 0.56, 1, 1)</c></value>
         public static Color DodgerBlue { get { return namedColors["DODGERBLUE"]; } }
+        /// <value><c>(0.7, 0.13, 0.13, 1)</c></value>
         public static Color Firebrick { get { return namedColors["FIREBRICK"]; } }
+        /// <value><c>(1, 0.98, 0.94, 1)</c></value>
         public static Color FloralWhite { get { return namedColors["FLORALWHITE"]; } }
+        /// <value><c>(0.13, 0.55, 0.13, 1)</c></value>
         public static Color ForestGreen { get { return namedColors["FORESTGREEN"]; } }
+        /// <value><c>(1, 0, 1, 1)</c></value>
         public static Color Fuchsia { get { return namedColors["FUCHSIA"]; } }
+        /// <value><c>(0.86, 0.86, 0.86, 1)</c></value>
         public static Color Gainsboro { get { return namedColors["GAINSBORO"]; } }
+        /// <value><c>(0.97, 0.97, 1, 1)</c></value>
         public static Color GhostWhite { get { return namedColors["GHOSTWHITE"]; } }
+        /// <value><c>(1, 0.84, 0, 1)</c></value>
         public static Color Gold { get { return namedColors["GOLD"]; } }
+        /// <value><c>(0.85, 0.65, 0.13, 1)</c></value>
         public static Color Goldenrod { get { return namedColors["GOLDENROD"]; } }
+        /// <value><c>(0.75, 0.75, 0.75, 1)</c></value>
         public static Color Gray { get { return namedColors["GRAY"]; } }
+        /// <value><c>(0, 1, 0, 1)</c></value>
         public static Color Green { get { return namedColors["GREEN"]; } }
+        /// <value><c>(0.68, 1, 0.18, 1)</c></value>
         public static Color GreenYellow { get { return namedColors["GREENYELLOW"]; } }
+        /// <value><c>(0.94, 1, 0.94, 1)</c></value>
         public static Color Honeydew { get { return namedColors["HONEYDEW"]; } }
+        /// <value><c>(1, 0.41, 0.71, 1)</c></value>
         public static Color HotPink { get { return namedColors["HOTPINK"]; } }
+        /// <value><c>(0.8, 0.36, 0.36, 1)</c></value>
         public static Color IndianRed { get { return namedColors["INDIANRED"]; } }
+        /// <value><c>(0.29, 0, 0.51, 1)</c></value>
         public static Color Indigo { get { return namedColors["INDIGO"]; } }
+        /// <value><c>(1, 1, 0.94, 1)</c></value>
         public static Color Ivory { get { return namedColors["IVORY"]; } }
+        /// <value><c>(0.94, 0.9, 0.55, 1)</c></value>
         public static Color Khaki { get { return namedColors["KHAKI"]; } }
+        /// <value><c>(0.9, 0.9, 0.98, 1)</c></value>
         public static Color Lavender { get { return namedColors["LAVENDER"]; } }
+        /// <value><c>(1, 0.94, 0.96, 1)</c></value>
         public static Color LavenderBlush { get { return namedColors["LAVENDERBLUSH"]; } }
+        /// <value><c>(0.49, 0.99, 0, 1)</c></value>
         public static Color LawnGreen { get { return namedColors["LAWNGREEN"]; } }
+        /// <value><c>(1, 0.98, 0.8, 1)</c></value>
         public static Color LemonChiffon { get { return namedColors["LEMONCHIFFON"]; } }
+        /// <value><c>(0.68, 0.85, 0.9, 1)</c></value>
         public static Color LightBlue { get { return namedColors["LIGHTBLUE"]; } }
+        /// <value><c>(0.94, 0.5, 0.5, 1)</c></value>
         public static Color LightCoral { get { return namedColors["LIGHTCORAL"]; } }
+        /// <value><c>(0.88, 1, 1, 1)</c></value>
         public static Color LightCyan { get { return namedColors["LIGHTCYAN"]; } }
+        /// <value><c>(0.98, 0.98, 0.82, 1)</c></value>
         public static Color LightGoldenrod { get { return namedColors["LIGHTGOLDENROD"]; } }
+        /// <value><c>(0.83, 0.83, 0.83, 1)</c></value>
         public static Color LightGray { get { return namedColors["LIGHTGRAY"]; } }
+        /// <value><c>(0.56, 0.93, 0.56, 1)</c></value>
         public static Color LightGreen { get { return namedColors["LIGHTGREEN"]; } }
+        /// <value><c>(1, 0.71, 0.76, 1)</c></value>
         public static Color LightPink { get { return namedColors["LIGHTPINK"]; } }
+        /// <value><c>(1, 0.63, 0.48, 1)</c></value>
         public static Color LightSalmon { get { return namedColors["LIGHTSALMON"]; } }
+        /// <value><c>(0.13, 0.7, 0.67, 1)</c></value>
         public static Color LightSeaGreen { get { return namedColors["LIGHTSEAGREEN"]; } }
+        /// <value><c>(0.53, 0.81, 0.98, 1)</c></value>
         public static Color LightSkyBlue { get { return namedColors["LIGHTSKYBLUE"]; } }
+        /// <value><c>(0.47, 0.53, 0.6, 1)</c></value>
         public static Color LightSlateGray { get { return namedColors["LIGHTSLATEGRAY"]; } }
+        /// <value><c>(0.69, 0.77, 0.87, 1)</c></value>
         public static Color LightSteelBlue { get { return namedColors["LIGHTSTEELBLUE"]; } }
+        /// <value><c>(1, 1, 0.88, 1)</c></value>
         public static Color LightYellow { get { return namedColors["LIGHTYELLOW"]; } }
+        /// <value><c>(0, 1, 0, 1)</c></value>
         public static Color Lime { get { return namedColors["LIME"]; } }
+        /// <value><c>(0.2, 0.8, 0.2, 1)</c></value>
         public static Color LimeGreen { get { return namedColors["LIMEGREEN"]; } }
+        /// <value><c>(0.98, 0.94, 0.9, 1)</c></value>
         public static Color Linen { get { return namedColors["LINEN"]; } }
+        /// <value><c>(1, 0, 1, 1)</c></value>
         public static Color Magenta { get { return namedColors["MAGENTA"]; } }
+        /// <value><c>(0.69, 0.19, 0.38, 1)</c></value>
         public static Color Maroon { get { return namedColors["MAROON"]; } }
+        /// <value><c>(0.4, 0.8, 0.67, 1)</c></value>
         public static Color MediumAquamarine { get { return namedColors["MEDIUMAQUAMARINE"]; } }
+        /// <value><c>(0, 0, 0.8, 1)</c></value>
         public static Color MediumBlue { get { return namedColors["MEDIUMBLUE"]; } }
+        /// <value><c>(0.73, 0.33, 0.83, 1)</c></value>
         public static Color MediumOrchid { get { return namedColors["MEDIUMORCHID"]; } }
+        /// <value><c>(0.58, 0.44, 0.86, 1)</c></value>
         public static Color MediumPurple { get { return namedColors["MEDIUMPURPLE"]; } }
+        /// <value><c>(0.24, 0.7, 0.44, 1)</c></value>
         public static Color MediumSeaGreen { get { return namedColors["MEDIUMSEAGREEN"]; } }
+        /// <value><c>(0.48, 0.41, 0.93, 1)</c></value>
         public static Color MediumSlateBlue { get { return namedColors["MEDIUMSLATEBLUE"]; } }
+        /// <value><c>(0, 0.98, 0.6, 1)</c></value>
         public static Color MediumSpringGreen { get { return namedColors["MEDIUMSPRINGGREEN"]; } }
+        /// <value><c>(0.28, 0.82, 0.8, 1)</c></value>
         public static Color MediumTurquoise { get { return namedColors["MEDIUMTURQUOISE"]; } }
+        /// <value><c>(0.78, 0.08, 0.52, 1)</c></value>
         public static Color MediumVioletRed { get { return namedColors["MEDIUMVIOLETRED"]; } }
+        /// <value><c>(0.1, 0.1, 0.44, 1)</c></value>
         public static Color MidnightBlue { get { return namedColors["MIDNIGHTBLUE"]; } }
+        /// <value><c>(0.96, 1, 0.98, 1)</c></value>
         public static Color MintCream { get { return namedColors["MINTCREAM"]; } }
+        /// <value><c>(1, 0.89, 0.88, 1)</c></value>
         public static Color MistyRose { get { return namedColors["MISTYROSE"]; } }
+        /// <value><c>(1, 0.89, 0.71, 1)</c></value>
         public static Color Moccasin { get { return namedColors["MOCCASIN"]; } }
+        /// <value><c>(1, 0.87, 0.68, 1)</c></value>
         public static Color NavajoWhite { get { return namedColors["NAVAJOWHITE"]; } }
+        /// <value><c>(0, 0, 0.5, 1)</c></value>
         public static Color NavyBlue { get { return namedColors["NAVYBLUE"]; } }
+        /// <value><c>(0.99, 0.96, 0.9, 1)</c></value>
         public static Color OldLace { get { return namedColors["OLDLACE"]; } }
+        /// <value><c>(0.5, 0.5, 0, 1)</c></value>
         public static Color Olive { get { return namedColors["OLIVE"]; } }
+        /// <value><c>(0.42, 0.56, 0.14, 1)</c></value>
         public static Color OliveDrab { get { return namedColors["OLIVEDRAB"]; } }
+        /// <value><c>(1, 0.65, 0, 1)</c></value>
         public static Color Orange { get { return namedColors["ORANGE"]; } }
+        /// <value><c>(1, 0.27, 0, 1)</c></value>
         public static Color OrangeRed { get { return namedColors["ORANGERED"]; } }
+        /// <value><c>(0.85, 0.44, 0.84, 1)</c></value>
         public static Color Orchid { get { return namedColors["ORCHID"]; } }
+        /// <value><c>(0.93, 0.91, 0.67, 1)</c></value>
         public static Color PaleGoldenrod { get { return namedColors["PALEGOLDENROD"]; } }
+        /// <value><c>(0.6, 0.98, 0.6, 1)</c></value>
         public static Color PaleGreen { get { return namedColors["PALEGREEN"]; } }
+        /// <value><c>(0.69, 0.93, 0.93, 1)</c></value>
         public static Color PaleTurquoise { get { return namedColors["PALETURQUOISE"]; } }
+        /// <value><c>(0.86, 0.44, 0.58, 1)</c></value>
         public static Color PaleVioletRed { get { return namedColors["PALEVIOLETRED"]; } }
+        /// <value><c>(1, 0.94, 0.84, 1)</c></value>
         public static Color PapayaWhip { get { return namedColors["PAPAYAWHIP"]; } }
+        /// <value><c>(1, 0.85, 0.73, 1)</c></value>
         public static Color PeachPuff { get { return namedColors["PEACHPUFF"]; } }
+        /// <value><c>(0.8, 0.52, 0.25, 1)</c></value>
         public static Color Peru { get { return namedColors["PERU"]; } }
+        /// <value><c>(1, 0.75, 0.8, 1)</c></value>
         public static Color Pink { get { return namedColors["PINK"]; } }
+        /// <value><c>(0.87, 0.63, 0.87, 1)</c></value>
         public static Color Plum { get { return namedColors["PLUM"]; } }
+        /// <value><c>(0.69, 0.88, 0.9, 1)</c></value>
         public static Color PowderBlue { get { return namedColors["POWDERBLUE"]; } }
+        /// <value><c>(0.63, 0.13, 0.94, 1)</c></value>
         public static Color Purple { get { return namedColors["PURPLE"]; } }
+        /// <value><c>(0.4, 0.2, 0.6, 1)</c></value>
         public static Color RebeccaPurple { get { return namedColors["REBECCAPURPLE"]; } }
+        /// <value><c>(1, 0, 0, 1)</c></value>
         public static Color Red { get { return namedColors["RED"]; } }
+        /// <value><c>(0.74, 0.56, 0.56, 1)</c></value>
         public static Color RosyBrown { get { return namedColors["ROSYBROWN"]; } }
+        /// <value><c>(0.25, 0.41, 0.88, 1)</c></value>
         public static Color RoyalBlue { get { return namedColors["ROYALBLUE"]; } }
+        /// <value><c>(0.55, 0.27, 0.07, 1)</c></value>
         public static Color SaddleBrown { get { return namedColors["SADDLEBROWN"]; } }
+        /// <value><c>(0.98, 0.5, 0.45, 1)</c></value>
         public static Color Salmon { get { return namedColors["SALMON"]; } }
+        /// <value><c>(0.96, 0.64, 0.38, 1)</c></value>
         public static Color SandyBrown { get { return namedColors["SANDYBROWN"]; } }
+        /// <value><c>(0.18, 0.55, 0.34, 1)</c></value>
         public static Color SeaGreen { get { return namedColors["SEAGREEN"]; } }
+        /// <value><c>(1, 0.96, 0.93, 1)</c></value>
         public static Color Seashell { get { return namedColors["SEASHELL"]; } }
+        /// <value><c>(0.63, 0.32, 0.18, 1)</c></value>
         public static Color Sienna { get { return namedColors["SIENNA"]; } }
+        /// <value><c>(0.75, 0.75, 0.75, 1)</c></value>
         public static Color Silver { get { return namedColors["SILVER"]; } }
+        /// <value><c>(0.53, 0.81, 0.92, 1)</c></value>
         public static Color SkyBlue { get { return namedColors["SKYBLUE"]; } }
+        /// <value><c>(0.42, 0.35, 0.8, 1)</c></value>
         public static Color SlateBlue { get { return namedColors["SLATEBLUE"]; } }
+        /// <value><c>(0.44, 0.5, 0.56, 1)</c></value>
         public static Color SlateGray { get { return namedColors["SLATEGRAY"]; } }
+        /// <value><c>(1, 0.98, 0.98, 1)</c></value>
         public static Color Snow { get { return namedColors["SNOW"]; } }
+        /// <value><c>(0, 1, 0.5, 1)</c></value>
         public static Color SpringGreen { get { return namedColors["SPRINGGREEN"]; } }
+        /// <value><c>(0.27, 0.51, 0.71, 1)</c></value>
         public static Color SteelBlue { get { return namedColors["STEELBLUE"]; } }
+        /// <value><c>(0.82, 0.71, 0.55, 1)</c></value>
         public static Color Tan { get { return namedColors["TAN"]; } }
+        /// <value><c>(0, 0.5, 0.5, 1)</c></value>
         public static Color Teal { get { return namedColors["TEAL"]; } }
+        /// <value><c>(0.85, 0.75, 0.85, 1)</c></value>
         public static Color Thistle { get { return namedColors["THISTLE"]; } }
+        /// <value><c>(1, 0.39, 0.28, 1)</c></value>
         public static Color Tomato { get { return namedColors["TOMATO"]; } }
+        /// <value><c>(1, 1, 1, 0)</c></value>
         public static Color Transparent { get { return namedColors["TRANSPARENT"]; } }
+        /// <value><c>(0.25, 0.88, 0.82, 1)</c></value>
         public static Color Turquoise { get { return namedColors["TURQUOISE"]; } }
+        /// <value><c>(0.93, 0.51, 0.93, 1)</c></value>
         public static Color Violet { get { return namedColors["VIOLET"]; } }
+        /// <value><c>(0.5, 0.5, 0.5, 1)</c></value>
         public static Color WebGray { get { return namedColors["WEBGRAY"]; } }
+        /// <value><c>(0, 0.5, 0, 1)</c></value>
         public static Color WebGreen { get { return namedColors["WEBGREEN"]; } }
+        /// <value><c>(0.5, 0, 0, 1)</c></value>
         public static Color WebMaroon { get { return namedColors["WEBMAROON"]; } }
+        /// <value><c>(0.5, 0, 0.5, 1)</c></value>
         public static Color WebPurple { get { return namedColors["WEBPURPLE"]; } }
+        /// <value><c>(0.96, 0.87, 0.7, 1)</c></value>
         public static Color Wheat { get { return namedColors["WHEAT"]; } }
+        /// <value><c>(1, 1, 1, 1)</c></value>
         public static Color White { get { return namedColors["WHITE"]; } }
+        /// <value><c>(0.96, 0.96, 0.96, 1)</c></value>
         public static Color WhiteSmoke { get { return namedColors["WHITESMOKE"]; } }
+        /// <value><c>(1, 1, 0, 1)</c></value>
         public static Color Yellow { get { return namedColors["YELLOW"]; } }
+        /// <value><c>(0.6, 0.8, 0.2, 1)</c></value>
         public static Color YellowGreen { get { return namedColors["YELLOWGREEN"]; } }
-#pragma warning restore CS1591
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/CustomGCHandle.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/CustomGCHandle.cs
@@ -23,6 +23,12 @@ public static class CustomGCHandle
     // Having the assembly load context as key won't prevent it from unloading.
     private static ConditionalWeakTable<AssemblyLoadContext, object?> _alcsBeingUnloaded = new();
 
+    /// <summary>
+    /// Determines if the provided <see cref="AssemblyLoadContext"/> is being unloaded.
+    /// </summary>
+    /// <param name="alc">The context to check.</param>
+    /// <returns><see langword="true"/> if the context is currently being unloaded;
+    /// otherwise, <see langword="false"/>.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool IsAlcBeingUnloaded(AssemblyLoadContext alc) => _alcsBeingUnloaded.TryGetValue(alc, out _);
 
@@ -43,10 +49,22 @@ public static class CustomGCHandle
         }
     }
 
+    /// <summary>
+    /// Initializes a strong <see cref="GCHandle"/> using the provided <paramref name="value"/>
+    /// </summary>
+    /// <param name="value">The value to assign a strong handle.</param>
+    /// <returns>A strong handle for the provided value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GCHandle AllocStrong(object value)
         => AllocStrong(value, value.GetType());
 
+    /// <summary>
+    /// Initializes a strong <see cref="GCHandle"/> using the provided <paramref name="value"/>
+    /// with the given <paramref name="valueType"/>
+    /// </summary>
+    /// <param name="value">The value to assign a strong handle.</param>
+    /// <param name="valueType">The type of the object.</param>
+    /// <returns>A strong handle for the provided value and type.</returns>
     public static GCHandle AllocStrong(object value, Type valueType)
     {
         if (AlcReloadCfg.IsAlcReloadingEnabled)
@@ -75,9 +93,18 @@ public static class CustomGCHandle
         return GCHandle.Alloc(value, GCHandleType.Normal);
     }
 
+    /// <summary>
+    /// Initializes a weak <see cref="GCHandle"/> using the provided <paramref name="value"/>
+    /// </summary>
+    /// <param name="value">The value to assign a weak handle.</param>
+    /// <returns>A weak handle for the provided value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static GCHandle AllocWeak(object value) => GCHandle.Alloc(value, GCHandleType.Weak);
 
+    /// <summary>
+    /// Releases a <see cref="GCHandle"/>.
+    /// </summary>
+    /// <param name="handle">The <see cref="GCHandle"/> to release.</param>
     public static void Free(GCHandle handle)
     {
         if (AlcReloadCfg.IsAlcReloadingEnabled)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -42,6 +42,9 @@ namespace Godot.Collections
         internal static Dictionary CreateTakingOwnershipOfDisposableValue(godot_dictionary nativeValueToOwn)
             => new Dictionary(nativeValueToOwn);
 
+        /// <summary>
+        /// Deconstructs this <see cref="Dictionary"/>.
+        /// </summary>
         ~Dictionary()
         {
             Dispose(false);
@@ -56,6 +59,9 @@ namespace Godot.Collections
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Disposes implementation of this <see cref="Dictionary"/>.
+        /// </summary>
         public void Dispose(bool disposing)
         {
             // Always dispose `NativeValue` even if disposing is true
@@ -881,9 +887,19 @@ namespace Godot.Collections
         /// <returns>A string representation of this dictionary.</returns>
         public override string ToString() => _underlyingDict.ToString();
 
+        /// <summary>
+        /// Converts this <see cref="Dictionary{TKey, TValue}"/> to a <see cref="Variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Dictionary{TKey, TValue}"/> to convert.</param>
+        /// <returns>A <see cref="Variant"/> representation of this <see cref="Dictionary{TKey, TValue}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Variant(Dictionary<TKey, TValue> from) => Variant.CreateFrom(from);
 
+        /// <summary>
+        /// Converts this <see cref="Variant"/> to a <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Variant"/> to convert.</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representation of this <see cref="Variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator Dictionary<TKey, TValue>(Variant from) =>
             from.AsGodotDictionary<TKey, TValue>();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
@@ -4,6 +4,9 @@ using Godot.NativeInterop;
 
 namespace Godot
 {
+    /// <summary>
+    /// Provides a dispatcher to handle task scheduling and invocations.
+    /// </summary>
     public static class Dispatcher
     {
         internal static GodotTaskScheduler DefaultGodotTaskScheduler;
@@ -14,6 +17,9 @@ namespace Godot
             DefaultGodotTaskScheduler = new GodotTaskScheduler();
         }
 
+        /// <summary>
+        /// Initializes the synchronization context as the context of the DefaultGodotTaskScheduler.
+        /// </summary>
         public static GodotSynchronizationContext SynchronizationContext => DefaultGodotTaskScheduler.Context;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -75,6 +75,9 @@ namespace Godot
             return instance.NativePtr;
         }
 
+        /// <summary>
+        /// Deconstructs this <see cref="GodotObject"/>.
+        /// </summary>
         ~GodotObject()
         {
             Dispose(false);
@@ -190,12 +193,24 @@ namespace Godot
             return null;
         }
 
+        /// <summary>
+        /// Sets the Godot class <paramref name="name"/> to the provided <paramref name="value"/>.
+        /// </summary>
+        /// <param name="name">The name of the Godot class to target.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns><see langword="true"/> if the value was set successfully; otherwise, <see langword="false"/>.</returns>
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         protected internal virtual bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
         {
             return false;
         }
 
+        /// <summary>
+        /// Gets a <paramref name="value"/> from the Godot class the Godot class <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name of the Godot class to target.</param>
+        /// <param name="value">The retrieved value.</param>
+        /// <returns><see langword="true"/> if a value was retrieved successfully; otherwise, <see langword="false"/>.</returns>
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         protected internal virtual bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
         {
@@ -203,12 +218,18 @@ namespace Godot
             return false;
         }
 
+        /// <summary>
+        /// Raises callbacks from the provided <paramref name="signal"/>.
+        /// </summary>
+        /// <param name="signal">The signal to trigger the callbacks.</param>
+        /// <param name="args">Array of <see cref="godot_variant"/> arguments.</param>
         // ReSharper disable once VirtualMemberNeverOverridden.Global
         protected internal virtual void RaiseGodotClassSignalCallbacks(in godot_string_name signal,
             NativeVariantPtrArgs args)
         {
         }
 
+        /// <exception cref="NativeMethodBindNotFoundException"/>
         internal static IntPtr ClassDB_get_method(StringName type, StringName method)
         {
             var typeSelf = (godot_string_name)type.NativeValue;
@@ -221,6 +242,7 @@ namespace Godot
             return methodBind;
         }
 
+        /// <exception cref="NativeConstructorNotFoundException"/>
         internal static unsafe delegate* unmanaged<IntPtr> ClassDB_get_constructor(StringName type)
         {
             // for some reason the '??' operator doesn't support 'delegate*'
@@ -233,11 +255,17 @@ namespace Godot
             return nativeConstructor;
         }
 
+        /// <summary>
+        /// Save data with the provided <paramref name="info"/>.
+        /// </summary>
         protected internal virtual void SaveGodotObjectData(GodotSerializationInfo info)
         {
         }
 
         // TODO: Should this be a constructor overload?
+        /// <summary>
+        /// Restore data with the provided <paramref name="info"/>.
+        /// </summary>
         protected internal virtual void RestoreGodotObjectData(GodotSerializationInfo info)
         {
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
@@ -7,22 +7,42 @@ namespace Godot
 {
     public partial class GodotObject
     {
+        /// <summary>
+        /// The general exception that is thrown when a native member cannot be found.
+        /// </summary>
         public class NativeMemberNotFoundException : Exception
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMemberNotFoundException"/> class with default properties.
+            /// </summary>
             public NativeMemberNotFoundException()
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMemberNotFoundException"/> class with a specified error message.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
             public NativeMemberNotFoundException(string? message) : base(message)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMemberNotFoundException"/> class with a specified error message
+            /// and a reference to the inner exception that is the cause of this exception.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="innerException">The exception that is the cause of the current exception. If the inner parameter
+            /// is not null, the current exception is raised in a catch block that handles the inner exception.</param>
             public NativeMemberNotFoundException(string? message, Exception? innerException)
                 : base(message, innerException)
             {
             }
         }
 
+        /// <summary>
+        /// The exception that is thrown when a native constructor cannot be found.
+        /// </summary>
         public class NativeConstructorNotFoundException : NativeMemberNotFoundException
         {
             private readonly string? _nativeClassName;
@@ -30,33 +50,64 @@ namespace Godot
             // ReSharper disable once InconsistentNaming
             private const string Arg_NativeConstructorNotFoundException = "Unable to find the native constructor.";
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeConstructorNotFoundException"/> class with default properties.
+            /// </summary>
             public NativeConstructorNotFoundException()
                 : base(Arg_NativeConstructorNotFoundException)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeConstructorNotFoundException"/> class with the native class name.
+            /// </summary>
+            /// <param name="nativeClassName">The native class name that failed to retrieve a constructor.</param>
             public NativeConstructorNotFoundException(string? nativeClassName)
                 : this(Arg_NativeConstructorNotFoundException, nativeClassName)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeConstructorNotFoundException"/> class with a specified error message
+            /// and a reference to the inner exception that is the cause of this exception.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="innerException">The exception that is the cause of the current exception. If the inner parameter
+            /// is not null, the current exception is raised in a catch block that handles the inner exception.</param>
             public NativeConstructorNotFoundException(string? message, Exception? innerException)
                 : base(message, innerException)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeConstructorNotFoundException"/> class with a specified error message
+            /// and the native class name.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="nativeClassName">The native class name that failed to retrieve a constructor.</param>
             public NativeConstructorNotFoundException(string? message, string? nativeClassName)
                 : base(message)
             {
                 _nativeClassName = nativeClassName;
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeConstructorNotFoundException"/> class with a specified error message,
+            /// the native class name, and a reference to the inner exception that is the cause of this exception.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="nativeClassName">The native class name that failed to retrieve a constructor.</param>
+            /// <param name="innerException">The exception that is the cause of the current exception. If the inner parameter
+            /// is not null, the current exception is raised in a catch block that handles the inner exception.</param>
             public NativeConstructorNotFoundException(string? message, string? nativeClassName, Exception? innerException)
                 : base(message, innerException)
             {
                 _nativeClassName = nativeClassName;
             }
 
+            /// <summary>
+            /// Gets the error message for this exception.
+            /// </summary>
             public override string Message
             {
                 get
@@ -81,6 +132,9 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// The exception that is thrown when a native method binding cannot be found.
+        /// </summary>
         public class NativeMethodBindNotFoundException : NativeMemberNotFoundException
         {
             private readonly string? _nativeMethodName;
@@ -88,33 +142,64 @@ namespace Godot
             // ReSharper disable once InconsistentNaming
             private const string Arg_NativeMethodBindNotFoundException = "Unable to find the native method bind.";
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMethodBindNotFoundException"/> class with default properties.
+            /// </summary>
             public NativeMethodBindNotFoundException()
                 : base(Arg_NativeMethodBindNotFoundException)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMethodBindNotFoundException"/> class with the native method name.
+            /// </summary>
+            /// <param name="nativeMethodName">The native method name that failed to bind.</param>
             public NativeMethodBindNotFoundException(string? nativeMethodName)
                 : this(Arg_NativeMethodBindNotFoundException, nativeMethodName)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMethodBindNotFoundException"/> class with a specified error message
+            /// and a reference to the inner exception that is the cause of this exception.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="innerException">The exception that is the cause of the current exception. If the inner parameter
+            /// is not null, the current exception is raised in a catch block that handles the inner exception.</param>
             public NativeMethodBindNotFoundException(string? message, Exception? innerException)
                 : base(message, innerException)
             {
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMethodBindNotFoundException"/> class with a specified error message
+            /// and the native method name.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="nativeMethodName">The native method name that failed to bind.</param>
             public NativeMethodBindNotFoundException(string? message, string? nativeMethodName)
                 : base(message)
             {
                 _nativeMethodName = nativeMethodName;
             }
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="NativeMethodBindNotFoundException"/> class with a specified error message,
+            /// the native method name, and a reference to the inner exception that is the cause of this exception.
+            /// </summary>
+            /// <param name="message">The error message that explains the reason for the exception.</param>
+            /// <param name="nativeMethodName">The native method name that failed to bind.</param>
+            /// <param name="innerException">The exception that is the cause of the current exception. If the inner parameter
+            /// is not null, the current exception is raised in a catch block that handles the inner exception.</param>
             public NativeMethodBindNotFoundException(string? message, string? nativeMethodName, Exception? innerException)
                 : base(message, innerException)
             {
                 _nativeMethodName = nativeMethodName;
             }
 
+            /// <summary>
+            /// Gets the error message for this exception.
+            /// </summary>
             public override string Message
             {
                 get

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -5,10 +5,18 @@ using System.Threading.Tasks;
 
 namespace Godot
 {
+    /// <summary>
+    /// Provides a synctronization context for the Godot task scheduler
+    /// </summary>
     public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
     {
         private readonly BlockingCollection<(SendOrPostCallback Callback, object State)> _queue = new();
 
+        /// <summary>
+        /// Dispatches a synchronous message to the Godot synchronization context.
+        /// </summary>
+        /// <param name="d">The <see cref="SendOrPostCallback"/> delegate to call.</param>
+        /// <param name="state">The object passed to the delegate.</param>
         public override void Send(SendOrPostCallback d, object state)
         {
             // Shortcut if we're already on this context
@@ -36,6 +44,11 @@ namespace Godot
             source.Task.Wait();
         }
 
+        /// <summary>
+        /// Dispatches an asynchronous message to the Godot synchronization context.
+        /// </summary>
+        /// <param name="d">The <see cref="SendOrPostCallback"/> delegate to call.</param>
+        /// <param name="state">The object passed to the delegate.</param>
         public override void Post(SendOrPostCallback d, object state)
         {
             _queue.Add((d, state));
@@ -52,6 +65,9 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="GodotSynchronizationContext"/>.
+        /// </summary>
         public void Dispose()
         {
             _queue.Dispose();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -31,6 +31,10 @@ namespace Godot
             SynchronizationContext.SetSynchronizationContext(Context);
         }
 
+        /// <summary>
+        /// Enqueues a new Task.
+        /// </summary>
+        /// <param name="task">The task to queue up.</param>
         protected sealed override void QueueTask(Task task)
         {
             lock (_tasks)
@@ -39,6 +43,14 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Tries to execute a new task.
+        /// </summary>
+        /// <param name="task">The task to execute.</param>
+        /// <param name="taskWasPreviouslyQueued">Whether or not the task
+        /// was previously queued.</param>
+        /// <returns><see langword="true"/> if the task was successfully
+        /// executed; otherwise, <see langword="false"/>.</returns>
         protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
         {
             if (SynchronizationContext.Current != Context)
@@ -50,6 +62,12 @@ namespace Godot
             return TryExecuteTask(task);
         }
 
+        /// <summary>
+        /// Tries to dequeue a task.
+        /// </summary>
+        /// <param name="task">The task to remove.</param>
+        /// <returns><see langword="true"/> if the task was successfully
+        /// dequeued; otherwise, <see langword="false"/>.</returns>
         protected sealed override bool TryDequeue(Task task)
         {
             lock (_tasks)
@@ -58,6 +76,10 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Get the currently scheduled tasks.
+        /// </summary>
+        /// <returns>The scheduled tasks.</returns>
         protected sealed override IEnumerable<Task> GetScheduledTasks()
         {
             lock (_tasks)
@@ -109,6 +131,9 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="GodotTaskScheduler"/>.
+        /// </summary>
         public void Dispose()
         {
             Context.Dispose();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -5,6 +5,9 @@ namespace Godot
     /// </summary>
     public interface IAwaitable
     {
+        /// <summary>
+        /// Gets a reference to the <see cref="IAwaiter"/>.
+        /// </summary>
         IAwaiter GetAwaiter();
     }
 
@@ -14,6 +17,9 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaitable<out TResult>
     {
+        /// <summary>
+        /// Gets a reference to the <see cref="IAwaiter{TResult}"/>.
+        /// </summary>
         IAwaiter<TResult> GetAwaiter();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -7,8 +7,14 @@ namespace Godot
     /// </summary>
     public interface IAwaiter : INotifyCompletion
     {
+        /// <summary>
+        /// Returns completion status.
+        /// </summary>
         bool IsCompleted { get; }
 
+        /// <summary>
+        /// Gets the result of completion.
+        /// </summary>
         void GetResult();
     }
 
@@ -18,8 +24,15 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaiter<out TResult> : INotifyCompletion
     {
+        /// <summary>
+        /// Returns completion status.
+        /// </summary>
         bool IsCompleted { get; }
 
+        /// <summary>
+        /// Gets the result of completion.
+        /// </summary>
+        /// <returns>The result of completion.</returns>
         TResult GetResult();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
@@ -5,7 +5,13 @@ namespace Godot
     /// </summary>
     public interface ISerializationListener
     {
+        /// <summary>
+        /// Receives a callback before Godot serializes the object.
+        /// </summary>
         void OnBeforeSerialize();
+        /// <summary>
+        /// Receives a callback after Godot deserialized the object.
+        /// </summary>
         void OnAfterDeserialize();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/CustomUnsafe.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/CustomUnsafe.cs
@@ -5,308 +5,692 @@ namespace Godot.NativeInterop;
 // Ref structs are not allowed as generic type parameters, so we can't use Unsafe.AsPointer<T>/AsRef<T>.
 // As a workaround we create our own overloads for our structs with some tricks under the hood.
 
+/// <summary>
+/// A collection of overloads for Godot structs to work around ref structs not
+/// being valid parameters for generic types.
+/// </summary>
 public static class CustomUnsafe
 {
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_ref"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_ref* AsPointer(ref godot_ref value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_ref"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_ref* ReadOnlyRefAsPointer(in godot_ref value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_ref"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_ref AsRef(godot_ref* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_ref"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_ref AsRef(in godot_ref source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_variant_call_error"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_variant_call_error* AsPointer(ref godot_variant_call_error value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_variant_call_error"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_variant_call_error* ReadOnlyRefAsPointer(in godot_variant_call_error value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_variant_call_error"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_variant_call_error AsRef(godot_variant_call_error* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_variant_call_error"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_variant_call_error AsRef(in godot_variant_call_error source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_variant"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_variant* AsPointer(ref godot_variant value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_variant"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_variant* ReadOnlyRefAsPointer(in godot_variant value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_variant"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_variant AsRef(godot_variant* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_variant"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_variant AsRef(in godot_variant source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_string"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_string* AsPointer(ref godot_string value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_string"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_string* ReadOnlyRefAsPointer(in godot_string value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_string"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_string AsRef(godot_string* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_string"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_string AsRef(in godot_string source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_string_name"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_string_name* AsPointer(ref godot_string_name value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_string_name"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_string_name* ReadOnlyRefAsPointer(in godot_string_name value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_string_name"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_string_name AsRef(godot_string_name* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_string_name"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_string_name AsRef(in godot_string_name source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_node_path"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_node_path* AsPointer(ref godot_node_path value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_node_path"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_node_path* ReadOnlyRefAsPointer(in godot_node_path value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_node_path"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_node_path AsRef(godot_node_path* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_node_path"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_node_path AsRef(in godot_node_path source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_signal"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_signal* AsPointer(ref godot_signal value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_signal"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_signal* ReadOnlyRefAsPointer(in godot_signal value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_signal"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_signal AsRef(godot_signal* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_signal"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_signal AsRef(in godot_signal source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_callable"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_callable* AsPointer(ref godot_callable value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_callable"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_callable* ReadOnlyRefAsPointer(in godot_callable value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_callable"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_callable AsRef(godot_callable* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_callable"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_callable AsRef(in godot_callable source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_array* AsPointer(ref godot_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_array* ReadOnlyRefAsPointer(in godot_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_array AsRef(godot_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_array AsRef(in godot_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_dictionary"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_dictionary* AsPointer(ref godot_dictionary value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_dictionary"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_dictionary* ReadOnlyRefAsPointer(in godot_dictionary value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_dictionary"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_dictionary AsRef(godot_dictionary* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_dictionary"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_dictionary AsRef(in godot_dictionary source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_byte_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_byte_array* AsPointer(ref godot_packed_byte_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_byte_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_byte_array* ReadOnlyRefAsPointer(in godot_packed_byte_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_byte_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_byte_array AsRef(godot_packed_byte_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_byte_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_byte_array AsRef(in godot_packed_byte_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_int32_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_int32_array* AsPointer(ref godot_packed_int32_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_int32_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_int32_array* ReadOnlyRefAsPointer(in godot_packed_int32_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_int32_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_int32_array AsRef(godot_packed_int32_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_int32_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_int32_array AsRef(in godot_packed_int32_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_int64_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_int64_array* AsPointer(ref godot_packed_int64_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_int64_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_int64_array* ReadOnlyRefAsPointer(in godot_packed_int64_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_int64_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_int64_array AsRef(godot_packed_int64_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_int64_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_int64_array AsRef(in godot_packed_int64_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_float32_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_float32_array* AsPointer(ref godot_packed_float32_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_float32_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_float32_array* ReadOnlyRefAsPointer(in godot_packed_float32_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_float32_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_float32_array AsRef(godot_packed_float32_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_float32_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_float32_array AsRef(in godot_packed_float32_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_float64_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_float64_array* AsPointer(ref godot_packed_float64_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_float64_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_float64_array* ReadOnlyRefAsPointer(in godot_packed_float64_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_float64_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_float64_array AsRef(godot_packed_float64_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_float64_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_float64_array AsRef(in godot_packed_float64_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_string_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_string_array* AsPointer(ref godot_packed_string_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_string_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_string_array* ReadOnlyRefAsPointer(in godot_packed_string_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_string_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_string_array AsRef(godot_packed_string_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_string_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_string_array AsRef(in godot_packed_string_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_vector2_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_vector2_array* AsPointer(ref godot_packed_vector2_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_vector2_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_vector2_array* ReadOnlyRefAsPointer(in godot_packed_vector2_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_vector2_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_vector2_array AsRef(godot_packed_vector2_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_vector2_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_vector2_array AsRef(in godot_packed_vector2_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_vector3_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_vector3_array* AsPointer(ref godot_packed_vector3_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_vector3_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_vector3_array* ReadOnlyRefAsPointer(in godot_packed_vector3_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_vector3_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_vector3_array AsRef(godot_packed_vector3_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_vector3_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_vector3_array AsRef(in godot_packed_vector3_array source)
         => ref *ReadOnlyRefAsPointer(in source);
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_color_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_color_array* AsPointer(ref godot_packed_color_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Read-only workaround method of <see cref="Unsafe.AsPointer{T}(ref T)"/> when passing ref struct <see cref="godot_packed_color_array"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="godot_ref"/> whose pointer is obtained.</param>
+    /// <returns>A pointer to the given value.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe godot_packed_color_array* ReadOnlyRefAsPointer(in godot_packed_color_array value)
         => value.GetUnsafeAddress();
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(void*)"/> when passing ref struct <see cref="godot_packed_color_array"/>.
+    /// </summary>
+    /// <param name="source">The location of the <see cref="godot_ref"/> to reference.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_color_array AsRef(godot_packed_color_array* source)
         => ref *source;
 
+    /// <summary>
+    /// Workaround method of <see cref="Unsafe.AsRef{T}(in T)"/> when passing ref struct <see cref="godot_packed_color_array"/>.
+    /// </summary>
+    /// <param name="source">The read-only <see cref="godot_ref"/> to reinterpret.</param>
+    /// <returns>A reference to a value of type <see cref="godot_ref"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ref godot_packed_color_array AsRef(in godot_packed_color_array source)
         => ref *ReadOnlyRefAsPointer(in source);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
@@ -6,15 +6,29 @@ using System.Runtime.InteropServices;
 
 namespace Godot.NativeInterop
 {
+    /// <summary>
+    /// Provides a resolver for handling dll imports from Godot.
+    /// </summary>
     public class GodotDllImportResolver
     {
         private IntPtr _internalHandle;
 
+        /// <summary>
+        /// Constructs a new <see cref="GodotDllImportResolver"/> using the provided handle.
+        /// </summary>
+        /// <param name="internalHandle">The pointer of the handle to resolve.</param>
         public GodotDllImportResolver(IntPtr internalHandle)
         {
             _internalHandle = internalHandle;
         }
 
+        /// <summary>
+        /// Called when the dll import process is resolved.
+        /// </summary>
+        /// <param name="libraryName">The library name for this dll.</param>
+        /// <param name="assembly">The assembly context of this dll.</param>
+        /// <param name="searchPath">The path to search.</param>
+        /// <returns>The internal handle of the resolved dll.</returns>
         public IntPtr OnResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
             if (libraryName == "__Internal")

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -8,14 +8,27 @@ namespace Godot.NativeInterop
     // NOTES:
     // ref structs cannot implement interfaces, but they still work in `using` directives if they declare Dispose()
 
+    /// <summary>
+    /// Collection of extensions for the Godot representation of a <see langword="bool"/>.
+    /// </summary>
     public static class GodotBoolExtensions
     {
+        /// <summary>
+        /// Handles conversion of a <see langword="bool"/> to a <see cref="godot_bool"/>.
+        /// </summary>
+        /// <param name="bool">The <see langword="bool"/> to convert.</param>
+        /// <returns>The newly converted <see cref="godot_bool"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe godot_bool ToGodotBool(this bool @bool)
         {
             return *(godot_bool*)&@bool;
         }
 
+        /// <summary>
+        /// Handles conversion of a <see cref="godot_bool"/> to a <see langword="bool"/>.
+        /// </summary>
+        /// <param name="godotBool">The <see cref="godot_bool"/> to convert.</param>
+        /// <returns>The newly converted <see langword="bool"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool ToBool(this godot_bool godotBool)
         {
@@ -24,13 +37,25 @@ namespace Godot.NativeInterop
     }
 
     // Apparently a struct with a byte is not blittable? It crashes when calling a UnmanagedCallersOnly function ptr.
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="bool"/>.
+    /// </summary>
     // ReSharper disable once InconsistentNaming
     public enum godot_bool : byte
     {
+        /// <summary>
+        /// <see langword="true"/>.
+        /// </summary>
         True = 1,
+        /// <summary>
+        /// <see langword="false"/>.
+        /// </summary>
         False = 0
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="ref"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_ref
@@ -41,6 +66,9 @@ namespace Godot.NativeInterop
 
         private IntPtr _reference;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_ref"/>.
+        /// </summary>
         public void Dispose()
         {
             if (_reference == IntPtr.Zero)
@@ -49,12 +77,18 @@ namespace Godot.NativeInterop
             _reference = IntPtr.Zero;
         }
 
+        /// <summary>
+        /// The pointer for this <see cref="godot_ref"/>.
+        /// </summary>
         public readonly IntPtr Reference
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _reference;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_ref"/> is null.
+        /// </summary>
         public readonly bool IsNull
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -62,17 +96,41 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent for the type of error that will be called.
+    /// </summary>
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public enum godot_variant_call_error_error
     {
+        /// <summary>
+        /// No error.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_OK = 0,
+        /// <summary>
+        /// Method passed was invalid.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD,
+        /// <summary>
+        /// Argument passed was invalid.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_ERROR_INVALID_ARGUMENT,
+        /// <summary>
+        /// Too many arguments were passed.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_ERROR_TOO_MANY_ARGUMENTS,
+        /// <summary>
+        /// Too few arguments were passed.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_ERROR_TOO_FEW_ARGUMENTS,
+        /// <summary>
+        /// The instance was null.
+        /// </summary>
         GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL,
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent for calling an error.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_variant_call_error
@@ -85,18 +143,27 @@ namespace Godot.NativeInterop
         private int argument;
         private int expected;
 
+        /// <summary>
+        /// The error state of this call.
+        /// </summary>
         public godot_variant_call_error_error Error
         {
             readonly get => error;
             set => error = value;
         }
 
+        /// <summary>
+        /// The argument for this call.
+        /// </summary>
         public int Argument
         {
             readonly get => argument;
             set => argument = value;
         }
 
+        /// <summary>
+        /// The expected type for this call.
+        /// </summary>
         public Godot.Variant.Type Expected
         {
             readonly get => (Godot.Variant.Type)expected;
@@ -104,6 +171,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Variant"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_variant
@@ -176,6 +246,9 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Variant.Type"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Variant.Type Type
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -184,6 +257,9 @@ namespace Godot.NativeInterop
             set => _typeField = (int)value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_bool"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_bool Bool
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -192,6 +268,9 @@ namespace Godot.NativeInterop
             set => _data._bool = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see langword="long"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public long Int
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -200,6 +279,9 @@ namespace Godot.NativeInterop
             set => _data._int = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see langword="double"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public double Float
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -208,36 +290,54 @@ namespace Godot.NativeInterop
             set => _data._float = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Transform2D"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly unsafe Transform2D* Transform2D
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._transform2d;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Aabb"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly unsafe Aabb* Aabb
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._aabb;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Basis"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly unsafe Basis* Basis
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._basis;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Transform3D"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly unsafe Transform3D* Transform3D
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._transform3d;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Projection"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly unsafe Projection* Projection
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._projection;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_string_name"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_string_name StringName
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -246,6 +346,9 @@ namespace Godot.NativeInterop
             set => _data._m_string_name = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_string"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_string String
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -254,6 +357,9 @@ namespace Godot.NativeInterop
             set => _data._m_string = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector4"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector4 Vector4
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -262,6 +368,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector4 = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector4I"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector4I Vector4I
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -270,6 +379,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector4i = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector3"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector3 Vector3
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -278,6 +390,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector3 = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector3I"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector3I Vector3I
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -286,6 +401,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector3i = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector2"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector2 Vector2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -294,6 +412,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector2 = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Vector2I"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Vector2I Vector2I
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -302,6 +423,9 @@ namespace Godot.NativeInterop
             set => _data._m_vector2i = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Rect2"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Rect2 Rect2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -310,6 +434,9 @@ namespace Godot.NativeInterop
             set => _data._m_rect2 = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Rect2I"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Rect2I Rect2I
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -318,6 +445,9 @@ namespace Godot.NativeInterop
             set => _data._m_rect2i = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Plane"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Plane Plane
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -326,6 +456,9 @@ namespace Godot.NativeInterop
             set => _data._m_plane = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Quaternion"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Quaternion Quaternion
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -334,6 +467,9 @@ namespace Godot.NativeInterop
             set => _data._m_quaternion = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Color"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Color Color
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -342,6 +478,9 @@ namespace Godot.NativeInterop
             set => _data._m_color = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_node_path"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_node_path NodePath
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -350,6 +489,9 @@ namespace Godot.NativeInterop
             set => _data._m_node_path = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="Godot.Rid"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public Rid Rid
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -358,6 +500,9 @@ namespace Godot.NativeInterop
             set => _data._m_rid = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_callable"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_callable Callable
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -366,6 +511,9 @@ namespace Godot.NativeInterop
             set => _data._m_callable = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_signal"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_signal Signal
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -374,6 +522,9 @@ namespace Godot.NativeInterop
             set => _data._m_signal = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_dictionary"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_dictionary Dictionary
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -382,6 +533,9 @@ namespace Godot.NativeInterop
             set => _data._m_dictionary = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="godot_array"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public godot_array Array
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -390,12 +544,18 @@ namespace Godot.NativeInterop
             set => _data._m_array = value;
         }
 
+        /// <summary>
+        /// Represents the internal <see cref="IntPtr"/> of this <see cref="godot_variant"/>.
+        /// </summary>
         public readonly IntPtr Object
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data._m_obj_data.obj;
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_variant"/>.
+        /// </summary>
         public void Dispose()
         {
             switch (Type)
@@ -445,6 +605,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="string"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_string
@@ -455,6 +618,9 @@ namespace Godot.NativeInterop
 
         private IntPtr _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_string"/>.
+        /// </summary>
         public void Dispose()
         {
             if (_ptr == IntPtr.Zero)
@@ -463,6 +629,9 @@ namespace Godot.NativeInterop
             _ptr = IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_string"/>.
+        /// </summary>
         public readonly IntPtr Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -470,6 +639,9 @@ namespace Godot.NativeInterop
         }
 
         // Size including the null termination character
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_string"/>, including the null ternimation character.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -477,6 +649,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="StringName"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_string_name
@@ -487,6 +662,9 @@ namespace Godot.NativeInterop
 
         private IntPtr _data;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_string_name"/>.
+        /// </summary>
         public void Dispose()
         {
             if (_data == IntPtr.Zero)
@@ -495,12 +673,18 @@ namespace Godot.NativeInterop
             _data = IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_string_name"/> has been allocated.
+        /// </summary>
         public readonly bool IsAllocated
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data != IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_string_name"/> is empty.
+        /// </summary>
         public readonly bool IsEmpty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -508,26 +692,57 @@ namespace Godot.NativeInterop
             get => _data == IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="godot_string_name"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="godot_string_name"/>.</param>
+        /// <param name="right">The right <see cref="godot_string_name"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="godot_string_name"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(godot_string_name left, godot_string_name right)
         {
             return left._data == right._data;
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="godot_string_name"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="godot_string_name"/>.</param>
+        /// <param name="right">The right <see cref="godot_string_name"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="godot_string_name"/> are
+        /// not equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(godot_string_name left, godot_string_name right)
         {
             return !(left == right);
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="godot_string_name"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="other">The <see cref="godot_string_name"/> to compare with.</param>
+        /// <returns><see langword="true"/> if these <see cref="godot_string_name"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(godot_string_name other)
         {
             return _data == other._data;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_string_name"/> is exactly equal to the
+        /// given object (<paramref name="obj"/>).
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns><see langword="true"/> if this <see cref="godot_string_name"/>and
+        /// the object are equal; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object obj)
         {
             return obj is StringName s && s.Equals(this);
         }
 
+        /// <summary>
+        /// Serves as the hash function for <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <returns>A hash code for this <see cref="godot_string_name"/>.</returns>
         public override int GetHashCode()
         {
             return _data.GetHashCode();
@@ -550,6 +765,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="NodePath"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_node_path
@@ -560,6 +778,9 @@ namespace Godot.NativeInterop
 
         private IntPtr _data;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_node_path"/>.
+        /// </summary>
         public void Dispose()
         {
             if (_data == IntPtr.Zero)
@@ -568,12 +789,18 @@ namespace Godot.NativeInterop
             _data = IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_node_path"/> has been allocated.
+        /// </summary>
         public readonly bool IsAllocated
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _data != IntPtr.Zero;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_node_path"/> is empty.
+        /// </summary>
         public readonly bool IsEmpty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -598,6 +825,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Signal"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_signal
@@ -614,24 +844,39 @@ namespace Godot.NativeInterop
 
         [FieldOffset(8)] private ulong _objectId;
 
+        /// <summary>
+        /// Constructs a new <see cref="godot_signal"/> with the given <paramref name="name"/>
+        /// and owner <paramref name="objectId"/>.
+        /// </summary>
+        /// <param name="name">The name of this signal.</param>
+        /// <param name="objectId">The objectId of this signal's owner.</param>
         public godot_signal(godot_string_name name, ulong objectId) : this()
         {
             _name = name;
             _objectId = objectId;
         }
 
+        /// <summary>
+        /// Retrieves the name of this <see cref="godot_signal"/>.
+        /// </summary>
         public godot_string_name Name
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _name;
         }
 
+        /// <summary>
+        /// Retrieves the ObjectId belonging to the owner of this <see cref="godot_signal"/>.
+        /// </summary>
         public ulong ObjectId
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _objectId;
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_signal"/>.
+        /// </summary>
         public void Dispose()
         {
             if (!_name.IsAllocated)
@@ -641,6 +886,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Callable"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_callable
@@ -659,12 +907,21 @@ namespace Godot.NativeInterop
         [FieldOffset(8)] private ulong _objectId;
         [FieldOffset(8)] private IntPtr _custom;
 
+        /// <summary>
+        /// Constructs a new <see cref="godot_signal"/> with the given <paramref name="method"/>
+        /// and owner <paramref name="objectId"/>.
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="objectId"></param>
         public godot_callable(godot_string_name method, ulong objectId) : this()
         {
             _method = method;
             _objectId = objectId;
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_callable"/>.
+        /// </summary>
         public void Dispose()
         {
             // _custom needs freeing as well
@@ -679,6 +936,9 @@ namespace Godot.NativeInterop
     // A correctly constructed value needs to call the native default constructor to allocate `_p`.
     // Don't pass a C# default constructed `godot_array` to native code, unless it's going to
     // be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of an <see cref="Collections.Array"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_array
@@ -728,30 +988,46 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Evaluates the <see cref="godot_variant"/> elements within
+        /// this <see cref="godot_array"/>.
+        /// </summary>
         public readonly unsafe godot_variant* Elements
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p->_arrayVector._ptr;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_array"/> has been allocated.
+        /// </summary>
         public readonly unsafe bool IsAllocated
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p != null;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_array"/> is empty.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p != null ? _p->Size : 0;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_array"/> is in a read-only state.
+        /// </summary>
         public readonly unsafe bool IsReadOnly
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p != null && _p->IsReadOnly;
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_p == null)
@@ -781,6 +1057,9 @@ namespace Godot.NativeInterop
     // A correctly constructed value needs to call the native default constructor to allocate `_p`.
     // Don't pass a C# default constructed `godot_dictionary` to native code, unless it's going to
     // be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Collections.Dictionary"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_dictionary
@@ -809,18 +1088,27 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_dictionary"/> has been allocated.
+        /// </summary>
         public readonly unsafe bool IsAllocated
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p != null;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_dictionary"/> is in a read-only state.
+        /// </summary>
         public readonly unsafe bool IsReadOnly
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _p != null && _p->IsReadOnly;
         }
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_dictionary"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_p == null)
@@ -846,6 +1134,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="byte"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_byte_array
@@ -857,6 +1148,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe byte* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_byte_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -865,12 +1159,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_byte_array"/>.
+        /// </summary>
         public readonly unsafe byte* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_byte_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -878,6 +1178,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of an <see langword="int"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_int32_array
@@ -889,6 +1192,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe int* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_int32_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -897,12 +1203,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_int32_array"/>.
+        /// </summary>
         public readonly unsafe int* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_int32_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -910,6 +1222,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="long"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_int64_array
@@ -921,6 +1236,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe long* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_int64_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -929,12 +1247,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_int64_array"/>.
+        /// </summary>
         public readonly unsafe long* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_int64_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -942,6 +1266,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="float"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_float32_array
@@ -953,6 +1280,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe float* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_float32_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -961,12 +1291,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_float32_array"/>.
+        /// </summary>
         public readonly unsafe float* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_float32_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -974,6 +1310,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="double"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_float64_array
@@ -985,6 +1324,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe double* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_float64_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -993,12 +1335,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_float64_array"/>.
+        /// </summary>
         public readonly unsafe double* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_float64_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1006,6 +1354,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see langword="string"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_string_array
@@ -1017,6 +1368,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe godot_string* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_string_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -1025,12 +1379,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_string_array"/>.
+        /// </summary>
         public readonly unsafe godot_string* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_string_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1038,6 +1398,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Vector2"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_vector2_array
@@ -1049,6 +1412,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe Vector2* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_vector2_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -1057,12 +1423,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_vector2_array"/>.
+        /// </summary>
         public readonly unsafe Vector2* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_vector2_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1070,6 +1442,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Vector3"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_vector3_array
@@ -1081,6 +1456,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe Vector3* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_vector3_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -1089,12 +1467,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_vector3_array"/>.
+        /// </summary>
         public readonly unsafe Vector3* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_vector3_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1102,6 +1486,9 @@ namespace Godot.NativeInterop
         }
     }
 
+    /// <summary>
+    /// Represents the <see cref="NativeInterop"/> equivalent of a <see cref="Color"/>[].
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
     public ref struct godot_packed_color_array
@@ -1113,6 +1500,9 @@ namespace Godot.NativeInterop
         private IntPtr _writeProxy;
         private unsafe Color* _ptr;
 
+        /// <summary>
+        /// Disposes of this <see cref="godot_packed_color_array"/>.
+        /// </summary>
         public unsafe void Dispose()
         {
             if (_ptr == null)
@@ -1121,12 +1511,18 @@ namespace Godot.NativeInterop
             _ptr = null;
         }
 
+        /// <summary>
+        /// Evaluates the buffer of this <see cref="godot_packed_color_array"/>.
+        /// </summary>
         public readonly unsafe Color* Buffer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _ptr;
         }
 
+        /// <summary>
+        /// Evaluates the size of this <see cref="godot_packed_color_array"/>.
+        /// </summary>
         public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -12,6 +12,9 @@ using Array = System.Array;
 
 namespace Godot.NativeInterop
 {
+    /// <summary>
+    /// A collection of methods for allocating unmanaged memory to and from Godot ref structs.
+    /// </summary>
     public static class Marshaling
     {
         internal static Variant.Type ConvertManagedTypeToVariantType(Type type, out bool r_nil_is_variant)
@@ -196,6 +199,11 @@ namespace Godot.NativeInterop
 
         // String
 
+        /// <summary>
+        /// Converts a <see langword="string"/> to a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="p_mono_string">The <see langword="string"/> to convert.</param>
+        /// <returns>A <see cref="godot_string"/> representation of this <see langword="string"/>.</returns>
         public static unsafe godot_string ConvertStringToNative(string? p_mono_string)
         {
             if (p_mono_string == null)
@@ -208,6 +216,11 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_string"/> to a <see langword="string"/>.
+        /// </summary>
+        /// <param name="p_string">The <see cref="godot_string"/> to convert.</param>
+        /// <returns>A <see langword="string"/> representation of this <see cref="godot_string"/>.</returns>
         public static unsafe string ConvertStringToManaged(in godot_string p_string)
         {
             if (p_string.Buffer == IntPtr.Zero)
@@ -225,6 +238,11 @@ namespace Godot.NativeInterop
 
         // Callable
 
+        /// <summary>
+        /// Converts a <see cref="Callable"/> to a <see cref="godot_callable"/>.
+        /// </summary>
+        /// <param name="p_managed_callable">The <see cref="Callable"/> to convert.</param>
+        /// <returns>A <see cref="godot_callable"/> representation of this <see cref="Callable"/>.</returns>
         public static godot_callable ConvertCallableToNative(in Callable p_managed_callable)
         {
             if (p_managed_callable.Delegate != null)
@@ -263,6 +281,11 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_callable"/> to a <see cref="Callable"/>.
+        /// </summary>
+        /// <param name="p_callable">The <see cref="godot_callable"/> to convert.</param>
+        /// <returns>A <see cref="Callable"/> representation of this <see cref="godot_callable"/>.</returns>
         public static Callable ConvertCallableToManaged(in godot_callable p_callable)
         {
             if (NativeFuncs.godotsharp_callable_get_data_for_marshalling(p_callable,
@@ -290,6 +313,11 @@ namespace Godot.NativeInterop
 
         // Signal
 
+        /// <summary>
+        /// Converts a <see cref="Signal"/> to a <see cref="godot_signal"/>.
+        /// </summary>
+        /// <param name="p_managed_signal">The <see cref="Signal"/> to convert.</param>
+        /// <returns>A <see cref="godot_signal"/> representation of this <see cref="Signal"/>.</returns>
         public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
         {
             ulong ownerId = p_managed_signal.Owner.GetInstanceId();
@@ -308,6 +336,11 @@ namespace Godot.NativeInterop
             return new godot_signal(name, ownerId);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_signal"/> to a <see cref="Signal"/>.
+        /// </summary>
+        /// <param name="p_signal">The <see cref="godot_signal"/> to convert.</param>
+        /// <returns>A <see cref="Signal"/> representation of this <see cref="godot_signal"/>.</returns>
         public static Signal ConvertSignalToManaged(in godot_signal p_signal)
         {
             var owner = GodotObject.InstanceFromId(p_signal.ObjectId);
@@ -377,6 +410,11 @@ namespace Godot.NativeInterop
 
         // PackedByteArray
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_byte_array"/> to a <see langword="byte"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_byte_array"/> to convert.</param>
+        /// <returns>A <see langword="byte"/>[] representation of this <see cref="godot_packed_byte_array"/>.</returns>
         public static unsafe byte[] ConvertNativePackedByteArrayToSystemArray(in godot_packed_byte_array p_array)
         {
             byte* buffer = p_array.Buffer;
@@ -389,6 +427,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see langword="byte"/> span to a <see cref="godot_packed_byte_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="byte"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_byte_array"/> representation of this <see langword="byte"/> span.</returns>
         public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
         {
             if (p_array.IsEmpty)
@@ -399,6 +442,11 @@ namespace Godot.NativeInterop
 
         // PackedInt32Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_int32_array"/> to an <see langword="int"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_int32_array"/> to convert.</param>
+        /// <returns>An <see langword="int"/>[] representation of this <see cref="godot_packed_int32_array"/>.</returns>
         public static unsafe int[] ConvertNativePackedInt32ArrayToSystemArray(godot_packed_int32_array p_array)
         {
             int* buffer = p_array.Buffer;
@@ -412,6 +460,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts an <see langword="int"/> span to a <see cref="godot_packed_int32_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="int"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_int32_array"/> representation of this <see langword="int"/> span.</returns>
         public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
         {
             if (p_array.IsEmpty)
@@ -422,6 +475,11 @@ namespace Godot.NativeInterop
 
         // PackedInt64Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_int64_array"/> to a <see langword="long"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_int64_array"/> to convert.</param>
+        /// <returns>A <see langword="long"/>[] representation of this <see cref="godot_packed_int64_array"/>.</returns>
         public static unsafe long[] ConvertNativePackedInt64ArrayToSystemArray(godot_packed_int64_array p_array)
         {
             long* buffer = p_array.Buffer;
@@ -435,6 +493,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see langword="long"/> span to a <see cref="godot_packed_int64_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="long"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_int64_array"/> representation of this <see langword="long"/> span.</returns>
         public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
         {
             if (p_array.IsEmpty)
@@ -445,6 +508,11 @@ namespace Godot.NativeInterop
 
         // PackedFloat32Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_float32_array"/> to a <see langword="float"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_float32_array"/> to convert.</param>
+        /// <returns>A <see langword="float"/>[] representation of this <see cref="godot_packed_float32_array"/>.</returns>
         public static unsafe float[] ConvertNativePackedFloat32ArrayToSystemArray(godot_packed_float32_array p_array)
         {
             float* buffer = p_array.Buffer;
@@ -458,6 +526,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see langword="float"/> span to a <see cref="godot_packed_float32_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="float"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_float32_array"/> representation of this <see langword="float"/> span.</returns>
         public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
             Span<float> p_array)
         {
@@ -469,6 +542,11 @@ namespace Godot.NativeInterop
 
         // PackedFloat64Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_float64_array"/> to a <see langword="double"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_float64_array"/> to convert.</param>
+        /// <returns>A <see langword="double"/>[] representation of this <see cref="godot_packed_float64_array"/>.</returns>
         public static unsafe double[] ConvertNativePackedFloat64ArrayToSystemArray(godot_packed_float64_array p_array)
         {
             double* buffer = p_array.Buffer;
@@ -482,6 +560,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see langword="double"/> span to a <see cref="godot_packed_float64_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="double"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_float64_array"/> representation of this <see langword="double"/> span.</returns>
         public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
             Span<double> p_array)
         {
@@ -493,6 +576,11 @@ namespace Godot.NativeInterop
 
         // PackedStringArray
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_string_array"/> to a <see langword="string"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_string_array"/> to convert.</param>
+        /// <returns>A <see langword="string"/>[] representation of this <see cref="godot_packed_string_array"/>.</returns>
         public static unsafe string[] ConvertNativePackedStringArrayToSystemArray(godot_packed_string_array p_array)
         {
             godot_string* buffer = p_array.Buffer;
@@ -505,6 +593,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see langword="string"/> span to a <see cref="godot_packed_string_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see langword="string"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_string_array"/> representation of this <see langword="string"/> span.</returns>
         public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
         {
             godot_packed_string_array dest = new godot_packed_string_array();
@@ -526,6 +619,11 @@ namespace Godot.NativeInterop
 
         // PackedVector2Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_vector2_array"/> to a <see cref="Vector2"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_vector2_array"/> to convert.</param>
+        /// <returns>A <see cref="Vector2"/>[] representation of this <see cref="godot_packed_vector2_array"/>.</returns>
         public static unsafe Vector2[] ConvertNativePackedVector2ArrayToSystemArray(godot_packed_vector2_array p_array)
         {
             Vector2* buffer = p_array.Buffer;
@@ -539,6 +637,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector2"/> span to a <see cref="godot_packed_vector2_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see cref="Vector2"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_vector2_array"/> representation of this <see cref="Vector2"/> span.</returns>
         public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
             Span<Vector2> p_array)
         {
@@ -550,6 +653,11 @@ namespace Godot.NativeInterop
 
         // PackedVector3Array
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_vector3_array"/> to a <see cref="Vector3"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_vector3_array"/> to convert.</param>
+        /// <returns>A <see cref="Vector3"/>[] representation of this <see cref="godot_packed_vector3_array"/>.</returns>
         public static unsafe Vector3[] ConvertNativePackedVector3ArrayToSystemArray(godot_packed_vector3_array p_array)
         {
             Vector3* buffer = p_array.Buffer;
@@ -563,6 +671,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector3"/> span to a <see cref="godot_packed_vector3_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see cref="Vector3"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_vector3_array"/> representation of this <see cref="Vector3"/> span.</returns>
         public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
             Span<Vector3> p_array)
         {
@@ -574,6 +687,11 @@ namespace Godot.NativeInterop
 
         // PackedColorArray
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_color_array"/> to a <see cref="Color"/>[].
+        /// </summary>
+        /// <param name="p_array">The <see cref="godot_packed_color_array"/> to convert.</param>
+        /// <returns>A <see cref="Color"/>[] representation of this <see cref="godot_packed_color_array"/>.</returns>
         public static unsafe Color[] ConvertNativePackedColorArrayToSystemArray(godot_packed_color_array p_array)
         {
             Color* buffer = p_array.Buffer;
@@ -587,6 +705,11 @@ namespace Godot.NativeInterop
             return array;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Color"/> span to a <see cref="godot_packed_color_array"/>.
+        /// </summary>
+        /// <param name="p_array">The <see cref="Color"/> span to convert.</param>
+        /// <returns>A <see cref="godot_packed_color_array"/> representation of this <see cref="Color"/> span.</returns>
         public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
         {
             if (p_array.IsEmpty)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -13,11 +13,21 @@ namespace Godot.NativeInterop
      * in the array defined at the bottom of 'glue/runtime_interop.cpp'.
      */
 
+    /// <summary>
+    /// Collection of native functions utilized within <see cref="Godot.NativeInterop"/>.
+    /// </summary>
     [GenerateUnmanagedCallbacks(typeof(UnmanagedCallbacks))]
     public static unsafe partial class NativeFuncs
     {
         private static bool initialized = false;
 
+        /// <summary>
+        /// Initializes the provided unmanaged callbacks.
+        /// </summary>
+        /// <param name="unmanagedCallbacks">A pointer of callbacks to initialize.</param>
+        /// <param name="unmanagedCallbacksSize">The amount of callbacks passed.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Global
         public static void Initialize(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
         {
@@ -39,12 +49,28 @@ namespace Godot.NativeInterop
 
         internal static partial godot_bool godotsharp_dotnet_module_is_initialized();
 
+        /// <summary>
+        /// Retrieves a bound method.
+        /// </summary>
+        /// <param name="p_classname">The name of the class.</param>
+        /// <param name="p_methodname">The name of the method.</param>
+        /// <returns>A pointer to the bound method.</returns>
         public static partial IntPtr godotsharp_method_bind_get_method(in godot_string_name p_classname,
             in godot_string_name p_methodname);
 
+        /// <summary>
+        /// Retrieves a class constructor.
+        /// </summary>
+        /// <param name="p_classname">The name of the class.</param>
+        /// <returns>A pointer delegate to the class constructor.</returns>
         public static partial delegate* unmanaged<IntPtr> godotsharp_get_class_constructor(
             in godot_string_name p_classname);
 
+        /// <summary>
+        /// Retrieves an engine singleton.
+        /// </summary>
+        /// <param name="p_name">The name of the singleton.</param>
+        /// <returns>A pointer to the engine singleton.</returns>
         public static partial IntPtr godotsharp_engine_get_singleton(in godot_string p_name);
 
 
@@ -102,49 +128,138 @@ namespace Godot.NativeInterop
         internal static partial void godotsharp_array_filter_godot_objects_by_non_native(in godot_array p_input,
             out godot_array r_output);
 
+        /// <summary>
+        /// Natively initializes an <see cref="IntPtr"/> as a new <see cref="godot_ref"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_ref"/>.</param>
+        /// <param name="p_ref_counted_ptr">The <see cref="IntPtr"/> to initialize from.</param>
         public static partial void godotsharp_ref_new_from_ref_counted_ptr(out godot_ref r_dest,
             IntPtr p_ref_counted_ptr);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_ref"/> instance.
+        /// </summary>
+        /// <param name="p_instance">The <see cref="godot_ref"/> instance to destroy.</param>
         public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string"/> as a new <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_ref"/>.</param>
+        /// <param name="p_name">The <see cref="godot_string"/> to initialize from.</param>
         public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
             in godot_string p_name);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string"/> as a new <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_node_path"/>.</param>
+        /// <param name="p_name">The <see cref="godot_string"/> to initialize from.</param>
         public static partial void godotsharp_node_path_new_from_string(out godot_node_path r_dest,
             in godot_string p_name);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string_name"/> as a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_string"/>.</param>
+        /// <param name="p_name">The <see cref="godot_string_name"/> to initialize from.</param>
         public static partial void
             godotsharp_string_name_as_string(out godot_string r_dest, in godot_string_name p_name);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_node_path"/> as a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_string"/>.</param>
+        /// <param name="p_np">The <see cref="godot_node_path"/> to initialize from.</param>
         public static partial void godotsharp_node_path_as_string(out godot_string r_dest, in godot_node_path p_np);
 
+        /// <summary>
+        /// Natively initializes a <see langword="byte"/> pointer as a <see cref="godot_packed_byte_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see langword="byte"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_byte_array"/> initialized from this <see langword="byte"/> pointer.</returns>
         public static partial godot_packed_byte_array godotsharp_packed_byte_array_new_mem_copy(byte* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes an <see langword="int"/> pointer as a <see cref="godot_packed_int32_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see langword="int"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_int32_array"/> initialized from this <see langword="int"/> pointer.</returns>
         public static partial godot_packed_int32_array godotsharp_packed_int32_array_new_mem_copy(int* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see langword="long"/> pointer as a <see cref="godot_packed_int64_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see langword="long"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_int64_array"/> initialized from this <see langword="long"/> pointer.</returns>
         public static partial godot_packed_int64_array godotsharp_packed_int64_array_new_mem_copy(long* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see langword="float"/> pointer as a <see cref="godot_packed_float32_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see langword="float"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_float32_array"/> initialized from this <see langword="float"/> pointer.</returns>
         public static partial godot_packed_float32_array godotsharp_packed_float32_array_new_mem_copy(float* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see langword="double"/> pointer as a <see cref="godot_packed_float64_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see langword="double"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_float64_array"/> initialized from this <see langword="double"/> pointer.</returns>
         public static partial godot_packed_float64_array godotsharp_packed_float64_array_new_mem_copy(double* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector2"/> pointer as a <see cref="godot_packed_vector2_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see cref="Vector2"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_vector2_array"/> initialized from this <see cref="Vector2"/> pointer.</returns>
         public static partial godot_packed_vector2_array godotsharp_packed_vector2_array_new_mem_copy(Vector2* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector3"/> pointer as a <see cref="godot_packed_vector3_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see cref="Vector3"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_vector3_array"/> initialized from this <see cref="Vector3"/> pointer.</returns>
         public static partial godot_packed_vector3_array godotsharp_packed_vector3_array_new_mem_copy(Vector3* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Color"/> pointer as a <see cref="godot_packed_color_array"/>.
+        /// </summary>
+        /// <param name="p_src">The <see cref="Color"/> pointer to initialize from.</param>
+        /// <param name="p_length">The container size of this pointer.</param>
+        /// <returns>A <see cref="godot_packed_color_array"/> initialized from this <see cref="Color"/> pointer.</returns>
         public static partial godot_packed_color_array godotsharp_packed_color_array_new_mem_copy(Color* p_src,
             int p_length);
 
+        /// <summary>
+        /// Natively appends a <see cref="godot_string"/> to a referenced <see cref="godot_packed_string_array"/>.
+        /// </summary>
+        /// <param name="r_dest">The <see cref="godot_packed_string_array"/> reference to append onto.</param>
+        /// <param name="p_element">The <see cref="godot_string"/> to be appended.</param>
         public static partial void godotsharp_packed_string_array_add(ref godot_packed_string_array r_dest,
             in godot_string p_element);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Callable"/> as a new <see cref="godot_callable"/>.
+        /// </summary>
+        /// <param name="p_delegate_handle">A pointer to the callable's GCHandle.</param>
+        /// <param name="p_trampoline">A pointer to the callable's Trampoline delegate.</param>
+        /// <param name="p_object">A pointer to the callable's target object.</param>
+        /// <param name="r_callable">The initialized <see cref="godot_callable"/>.</param>
         public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
             IntPtr p_object, out godot_callable r_callable);
 
@@ -163,331 +278,1017 @@ namespace Godot.NativeInterop
 
         // gdnative.h
 
+        /// <summary>
+        /// Natively calls to a bound method pointer.
+        /// </summary>
+        /// <param name="p_method_bind">A pointer to the bound method pointer to call.</param>
+        /// <param name="p_instance">A pointer to the instance that will make the call.</param>
+        /// <param name="p_args">A collection of arguments.</param>
+        /// <param name="p_ret">A pointer to the return value.</param>
         public static partial void godotsharp_method_bind_ptrcall(IntPtr p_method_bind, IntPtr p_instance, void** p_args,
             void* p_ret);
 
+        /// <summary>
+        /// Natively calls to a bound method.
+        /// </summary>
+        /// <param name="p_method_bind">A pointer to the bound method to call.</param>
+        /// <param name="p_instance">A pointer to the instance that will make the call.</param>
+        /// <param name="p_args">A collection of arguments.</param>
+        /// <param name="p_arg_count">The argument collection size.</param>
+        /// <param name="p_call_error">The resulting <see cref="godot_variant_call_error"/> from this call.</param>
+        /// <returns>The bound method's return value.</returns>
         public static partial godot_variant godotsharp_method_bind_call(IntPtr p_method_bind, IntPtr p_instance,
             godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
 
         // variant.h
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string_name"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_s">The <see cref="godot_string_name"/> to initialize from.</param>
         public static partial void
             godotsharp_variant_new_string_name(out godot_variant r_dest, in godot_string_name p_s);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_variant"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_src">The <see cref="godot_variant"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, in godot_variant p_src);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_node_path"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_np">The <see cref="godot_node_path"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, in godot_node_path p_np);
 
+        /// <summary>
+        /// Natively initializes a <see cref="IntPtr"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_obj">The <see cref="IntPtr"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_object(out godot_variant r_dest, IntPtr p_obj);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Transform2D"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_t2d">The <see cref="Transform2D"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Basis"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_basis">The <see cref="Basis"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Transform3D"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_trans">The <see cref="Transform3D"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Projection"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_proj">The <see cref="Projection"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, in Projection p_proj);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Aabb"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_aabb">The <see cref="Aabb"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, in Aabb p_aabb);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_dictionary"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_dict">The <see cref="godot_dictionary"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_dictionary(out godot_variant r_dest,
             in godot_dictionary p_dict);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_arr">The <see cref="godot_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_array(out godot_variant r_dest, in godot_array p_arr);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_byte_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pba">The <see cref="godot_packed_byte_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_byte_array(out godot_variant r_dest,
             in godot_packed_byte_array p_pba);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_int32_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pia">The <see cref="godot_packed_int32_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_int32_array(out godot_variant r_dest,
             in godot_packed_int32_array p_pia);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_int64_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pia">The <see cref="godot_packed_int64_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_int64_array(out godot_variant r_dest,
             in godot_packed_int64_array p_pia);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_float32_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pra">The <see cref="godot_packed_float32_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_float32_array(out godot_variant r_dest,
             in godot_packed_float32_array p_pra);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_float64_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pra">The <see cref="godot_packed_float64_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_float64_array(out godot_variant r_dest,
             in godot_packed_float64_array p_pra);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_string_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_psa">The <see cref="godot_packed_string_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_string_array(out godot_variant r_dest,
             in godot_packed_string_array p_psa);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_vector2_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pv2a">The <see cref="godot_packed_vector2_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_vector2_array(out godot_variant r_dest,
             in godot_packed_vector2_array p_pv2a);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_vector3_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pv3a">The <see cref="godot_packed_vector3_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_vector3_array(out godot_variant r_dest,
             in godot_packed_vector3_array p_pv3a);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_color_array"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_variant"/>.</param>
+        /// <param name="p_pca">The <see cref="godot_packed_color_array"/> to initialize from.</param>
         public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
             in godot_packed_color_array p_pca);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_bool"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_bool"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see langword="long"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see langword="long"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Int64 godotsharp_variant_as_int(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see langword="double"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see langword="double"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial double godotsharp_variant_as_float(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_string"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_string godotsharp_variant_as_string(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector2"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector2"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector2I"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector2I"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector2I godotsharp_variant_as_vector2i(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Rect2"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Rect2"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Rect2 godotsharp_variant_as_rect2(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Rect2I"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Rect2I"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Rect2I godotsharp_variant_as_rect2i(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector3"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector3"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector3 godotsharp_variant_as_vector3(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector3I"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector3I"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector3I godotsharp_variant_as_vector3i(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Transform2D"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Transform2D"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Transform2D godotsharp_variant_as_transform2d(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector4"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector4"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector4 godotsharp_variant_as_vector4(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Vector4I"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Vector4I"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Vector4I godotsharp_variant_as_vector4i(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Plane"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Plane"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Plane godotsharp_variant_as_plane(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Quaternion"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Quaternion"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Quaternion godotsharp_variant_as_quaternion(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Aabb"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Aabb"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Aabb godotsharp_variant_as_aabb(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Basis"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Basis"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Basis godotsharp_variant_as_basis(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Transform3D"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Transform3D"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Transform3D godotsharp_variant_as_transform3d(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Projection"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Projection"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Projection godotsharp_variant_as_projection(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Color"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Color"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string_name"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_string_name"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_string_name godotsharp_variant_as_string_name(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_node_path"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_node_path"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_node_path godotsharp_variant_as_node_path(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="Rid"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="Rid"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial Rid godotsharp_variant_as_rid(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_callable"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_callable"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_callable godotsharp_variant_as_callable(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_signal"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_signal"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_signal godotsharp_variant_as_signal(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_dictionary"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_dictionary"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_dictionary godotsharp_variant_as_dictionary(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_array godotsharp_variant_as_array(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_byte_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_byte_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_int32_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_int32_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_int64_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_int64_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_float32_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_float32_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
             in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_float64_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_float64_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
             in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_string_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_string_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
             in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_vector2_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_vector2_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
             in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_vector3_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_vector3_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
             in godot_variant p_self);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_packed_color_array"/> as a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>A <see cref="godot_packed_color_array"/> initialized from this <see cref="godot_variant"/>.</returns>
         public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(in godot_variant p_self);
 
+        /// <summary>
+        /// Natively evaluates if the <see cref="godot_variant"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="p_a">The left <see cref="godot_variant"/>.</param>
+        /// <param name="p_b">The right <see cref="godot_variant"/>.</param>
+        /// <returns><see cref="godot_bool.True"/> if these <see cref="godot_variant"/> are
+        /// exactly equal; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
 
         // string.h
 
+        /// <summary>
+        /// Natively initializes a <see langword="char"/> pointer as a new <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_string"/>.</param>
+        /// <param name="p_contents">The <see langword="char"/> pointer to initialize from.</param>
         public static partial void godotsharp_string_new_with_utf16_chars(out godot_string r_dest, char* p_contents);
 
         // string_name.h
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string_name"/> as a new <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_string"/>.</param>
+        /// <param name="p_src">The <see cref="godot_string_name"/> pointer to initialize from.</param>
         public static partial void godotsharp_string_name_new_copy(out godot_string_name r_dest,
             in godot_string_name p_src);
 
         // node_path.h
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_node_path"/> as a new <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_node_path"/>.</param>
+        /// <param name="p_src">The <see cref="godot_node_path"/> pointer to initialize from.</param>
         public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, in godot_node_path p_src);
 
         // array.h
 
+        /// <summary>
+        /// Natively initializes a new <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_array"/>.</param>
         public static partial void godotsharp_array_new(out godot_array r_dest);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_array"/> as a new <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_array"/>.</param>
+        /// <param name="p_src">The <see cref="godot_array"/> pointer to initialize from.</param>
         public static partial void godotsharp_array_new_copy(out godot_array r_dest, in godot_array p_src);
 
+        /// <summary>
+        /// Natively retrieves a <see cref="godot_variant"/> pointer collection from the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to retrieve the collection pointer from.</param>
+        /// <returns>A <see cref="godot_variant"/> pointer collection extracted from <paramref name="p_self"/>.</returns>
         public static partial godot_variant* godotsharp_array_ptrw(ref godot_array p_self);
 
         // dictionary.h
 
+        /// <summary>
+        /// Natively initializes a new <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_dictionary"/>.</param>
         public static partial void godotsharp_dictionary_new(out godot_dictionary r_dest);
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_dictionary"/> as a new <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="r_dest">The initialized <see cref="godot_dictionary"/>.</param>
+        /// <param name="p_src">The <see cref="godot_dictionary"/> pointer to initialize from.</param>
         public static partial void godotsharp_dictionary_new_copy(out godot_dictionary r_dest,
             in godot_dictionary p_src);
 
         // destroy functions
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_byte_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_byte_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_byte_array_destroy(ref godot_packed_byte_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_int32_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_int32_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_int32_array_destroy(ref godot_packed_int32_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_int64_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_int64_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_int64_array_destroy(ref godot_packed_int64_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_float32_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_float32_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_float32_array_destroy(ref godot_packed_float32_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_float64_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_float64_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_float64_array_destroy(ref godot_packed_float64_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_string_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_string_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_string_array_destroy(ref godot_packed_string_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_vector2_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_vector2_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_vector2_array_destroy(ref godot_packed_vector2_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_vector3_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_vector3_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_vector3_array_destroy(ref godot_packed_vector3_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_packed_color_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_packed_color_array"/> reference to destroy.</param>
         public static partial void godotsharp_packed_color_array_destroy(ref godot_packed_color_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_variant"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_variant"/> reference to destroy.</param>
         public static partial void godotsharp_variant_destroy(ref godot_variant p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_string"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string"/> reference to destroy.</param>
         public static partial void godotsharp_string_destroy(ref godot_string p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_string_name"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string_name"/> reference to destroy.</param>
         public static partial void godotsharp_string_name_destroy(ref godot_string_name p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_node_path"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> reference to destroy.</param>
         public static partial void godotsharp_node_path_destroy(ref godot_node_path p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_signal"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_signal"/> reference to destroy.</param>
         public static partial void godotsharp_signal_destroy(ref godot_signal p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_callable"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_callable"/> reference to destroy.</param>
         public static partial void godotsharp_callable_destroy(ref godot_callable p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_array"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> reference to destroy.</param>
         public static partial void godotsharp_array_destroy(ref godot_array p_self);
 
+        /// <summary>
+        /// Natively destroys the provided <see cref="godot_dictionary"/> reference.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> reference to destroy.</param>
         public static partial void godotsharp_dictionary_destroy(ref godot_dictionary p_self);
 
         // Array
 
+        /// <summary>
+        /// Natively adds a <see cref="godot_variant"/> to the end of the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to append onto.</param>
+        /// <param name="p_item">The <see cref="godot_variant"/> to add.</param>
         public static partial int godotsharp_array_add(ref godot_array p_self, in godot_variant p_item);
 
+        /// <summary>
+        /// Natively adds a <see cref="godot_array"/> to the end of the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to append onto.</param>
+        /// <param name="p_collection">The <see cref="godot_variant"/> to add.</param>
         public static partial int godotsharp_array_add_range(ref godot_array p_self, in godot_array p_collection);
 
+        /// <summary>
+        /// Natively finds the index of a <see cref="godot_variant"/> in the provided <see cref="godot_array"/>
+        /// using a binary search.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="p_index">The starting index to search.</param>
+        /// <param name="p_count">The amount of items to search.</param>
+        /// <param name="p_value">The <see cref="godot_variant"/> to find the index of.</param>
+        /// <returns>The index of the <see cref="godot_variant"/> in the <see cref="godot_array"/>.</returns>
         public static partial int godotsharp_array_binary_search(ref godot_array p_self, int p_index, int p_count, in godot_variant p_value);
 
+        /// <summary>
+        /// Natively duplicates a provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to duplicate.</param>
+        /// <param name="p_deep">Determines if a deep copy should be performed.</param>
+        /// <param name="r_dest">The newly duplicated <see cref="godot_array"/>.</param>
         public static partial void
             godotsharp_array_duplicate(ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
 
+        /// <summary>
+        /// Natively fills a provided <see cref="godot_array"/> with a given <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to be filled.</param>
+        /// <param name="p_value">The <see cref="godot_variant"/> to fill the <see cref="godot_array"/> with.</param>
         public static partial void godotsharp_array_fill(ref godot_array p_self, in godot_variant p_value);
 
+        /// <summary>
+        /// Natively finds the index of a <see cref="godot_variant"/> in the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="p_item">The <see cref="godot_variant"/> to find the index of.</param>
+        /// <param name="p_index">The starting index to search.</param>
+        /// <returns>The index of the <see cref="godot_variant"/> in the <see cref="godot_array"/>.</returns>
         public static partial int godotsharp_array_index_of(ref godot_array p_self, in godot_variant p_item, int p_index = 0);
 
+        /// <summary>
+        /// Natively inserts a <see cref="godot_variant"/> to the provided <see cref="godot_array"/> at the specified index.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to insert into.</param>
+        /// <param name="p_index">The <see cref="godot_variant"/> to be inserted.</param>
+        /// <param name="p_item">The index to insert at.</param>
         public static partial void godotsharp_array_insert(ref godot_array p_self, int p_index, in godot_variant p_item);
 
+        /// <summary>
+        /// Natively finds the last index of a <see cref="godot_variant"/> in the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="p_item">The <see cref="godot_variant"/> to find the last index of.</param>
+        /// <param name="p_index">The starting index to search.</param>
+        /// <returns>The index of the <see cref="godot_variant"/> in the <see cref="godot_array"/>.</returns>
         public static partial int godotsharp_array_last_index_of(ref godot_array p_self, in godot_variant p_item, int p_index);
 
+        /// <summary>
+        /// Natively makes the provided <see cref="godot_array"/> read-only.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to make read-only.</param>
         public static partial void godotsharp_array_make_read_only(ref godot_array p_self);
 
+        /// <summary>
+        /// Natively retrieves the maximum <see cref="godot_variant"/> value from the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="r_value">The parsed, max value <see cref="godot_variant"/>.</param>
         public static partial void godotsharp_array_max(ref godot_array p_self, out godot_variant r_value);
 
+        /// <summary>
+        /// Natively retrieves the minimum <see cref="godot_variant"/> value from the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="r_value">The parsed, min value <see cref="godot_variant"/>.</param>
         public static partial void godotsharp_array_min(ref godot_array p_self, out godot_variant r_value);
 
+        /// <summary>
+        /// Natively retrieves a random <see cref="godot_variant"/> value from the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to parse.</param>
+        /// <param name="r_value">The parsed, random value <see cref="godot_variant"/>.</param>
         public static partial void godotsharp_array_pick_random(ref godot_array p_self, out godot_variant r_value);
 
+        /// <summary>
+        /// Natively evaluates if the <see cref="godot_array"/> instances are recursively equal.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to equate.</param>
+        /// <param name="p_other">The <see cref="godot_array"/> to compare with.</param>
+        /// <returns><see cref="godot_bool.True"/> if these <see cref="godot_array"/> are
+        /// recursively equal; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_array_recursive_equal(ref godot_array p_self, in godot_array p_other);
 
+        /// <summary>
+        /// Natively removes an item from the provided <see cref="godot_array"/> at the specified index.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to remove from.</param>
+        /// <param name="p_index">The index to remove at.</param>
         public static partial void godotsharp_array_remove_at(ref godot_array p_self, int p_index);
 
+        /// <summary>
+        /// Natively resizes the provided <see cref="godot_array"/> to the specified size.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to resize.</param>
+        /// <param name="p_new_size">The new size of the <see cref="godot_array"/>.</param>
+        /// <returns>The <see cref="Error"/> status of this operation.</returns>
         public static partial Error godotsharp_array_resize(ref godot_array p_self, int p_new_size);
 
+        /// <summary>
+        /// Natively reverses the order of items in the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to invert.</param>
         public static partial void godotsharp_array_reverse(ref godot_array p_self);
 
+        /// <summary>
+        /// Natively shuffles the order of items in the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to randomize.</param>
         public static partial void godotsharp_array_shuffle(ref godot_array p_self);
 
+        /// <summary>
+        /// Natively slices the provided <see cref="godot_array"/> into a new <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to slice.</param>
+        /// <param name="p_start">The zero-based starting index.</param>
+        /// <param name="p_end">The zero-based ending index.</param>
+        /// <param name="p_step">The relative index between elements.</param>
+        /// <param name="p_deep">Determines if a deep copy should be performed.</param>
+        /// <param name="r_dest">The resulting <see cref="godot_array"/> from the slice.</param>
         public static partial void godotsharp_array_slice(ref godot_array p_self, int p_start, int p_end,
             int p_step, godot_bool p_deep, out godot_array r_dest);
 
+        /// <summary>
+        /// Natively sorts the order of items in the provided <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to organize.</param>
         public static partial void godotsharp_array_sort(ref godot_array p_self);
 
+        /// <summary>
+        /// Natively converts the specified <see cref="godot_array"/> to a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_array"/> to convert.</param>
+        /// <param name="r_str">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_array_to_string(ref godot_array p_self, out godot_string r_str);
 
         // Dictionary
 
+        /// <summary>
+        /// Natively tries to retrieve a value from the provided <see cref="godot_dictionary"/>
+        /// at the specified <paramref name="p_key"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <param name="p_key">The <see cref="godot_variant"/> key to search with.</param>
+        /// <param name="r_value">The parsed <see cref="godot_variant"/> value.</param>
+        /// <returns><see cref="godot_bool.True"/> if the <paramref name="r_value"/> was
+        /// successfully retrieved; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_dictionary_try_get_value(ref godot_dictionary p_self,
             in godot_variant p_key,
             out godot_variant r_value);
 
+        /// <summary>
+        /// Natively sets a value in the provided <see cref="godot_dictionary"/> at the
+        /// specified <paramref name="p_key"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to use.</param>
+        /// <param name="p_key">The <see cref="godot_variant"/> key to insert at.</param>
+        /// <param name="p_value">The <see cref="godot_variant"/> value to store.</param>
         public static partial void godotsharp_dictionary_set_value(ref godot_dictionary p_self, in godot_variant p_key,
             in godot_variant p_value);
 
+        /// <summary>
+        /// Natively retrieves a <see cref="godot_array"/> of keys from the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <param name="r_dest">An extracted <see cref="godot_array"/> of keys.</param>
         public static partial void godotsharp_dictionary_keys(ref godot_dictionary p_self, out godot_array r_dest);
 
+        /// <summary>
+        /// Natively retrieves a <see cref="godot_array"/> of values from the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <param name="r_dest">An extracted <see cref="godot_array"/> of values.</param>
         public static partial void godotsharp_dictionary_values(ref godot_dictionary p_self, out godot_array r_dest);
 
+        /// <summary>
+        /// Natively retrieves the number of items in the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <returns>The number of items.</returns>
         public static partial int godotsharp_dictionary_count(ref godot_dictionary p_self);
 
+        /// <summary>
+        /// Natively retrieves a key/value pair from the provided <see cref="godot_dictionary"/> at the specified index.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <param name="p_index">The index to search at.</param>
+        /// <param name="r_key">The extracted <see cref="godot_variant"/> key.</param>
+        /// <param name="r_value">The extracted <see cref="godot_variant"/> value.</param>
         public static partial void godotsharp_dictionary_key_value_pair_at(ref godot_dictionary p_self, int p_index,
             out godot_variant r_key, out godot_variant r_value);
 
+        /// <summary>
+        /// Natively adds a new key/value pair to the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to insert into.</param>
+        /// <param name="p_key">The <see cref="godot_variant"/> key to insert.</param>
+        /// <param name="p_value">The <see cref="godot_variant"/> value to insert.</param>
         public static partial void godotsharp_dictionary_add(ref godot_dictionary p_self, in godot_variant p_key,
             in godot_variant p_value);
 
+        /// <summary>
+        /// Natively clears all items from the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to expunge.</param>
         public static partial void godotsharp_dictionary_clear(ref godot_dictionary p_self);
 
+        /// <summary>
+        /// Natively determines if the provided <see cref="godot_dictionary"/> contains a specified <paramref name="p_key"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to parse.</param>
+        /// <param name="p_key">The <see cref="godot_variant"/> key to search for.</param>
+        /// <returns><see cref="godot_bool.True"/> if <paramref name="p_key"/> was found in the
+        /// provided <see cref="godot_dictionary"/>; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_dictionary_contains_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 
+        /// <summary>
+        /// Natively duplicates a provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to duplicate.</param>
+        /// <param name="p_deep">Determines if a deep copy should be performed.</param>
+        /// <param name="r_dest">The newly duplicated <see cref="godot_dictionary"/>.</param>
         public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
             out godot_dictionary r_dest);
 
+        /// <summary>
+        /// Natively merges a <see cref="godot_dictionary"/> with the provided <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to merge into.</param>
+        /// <param name="p_dictionary">The <see cref="godot_dictionary"/> to be merged.</param>
+        /// <param name="p_overwrite">Determines if duplicate keys should be overwritten.</param>
         public static partial void godotsharp_dictionary_merge(ref godot_dictionary p_self, in godot_dictionary p_dictionary, godot_bool p_overwrite);
 
+        /// <summary>
+        /// Natively evaluates if the <see cref="godot_dictionary"/> instances are recursively equal.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to equate.</param>
+        /// <param name="p_other">The <see cref="godot_dictionary"/> to compare with.</param>
+        /// <returns><see cref="godot_bool.True"/> if these <see cref="godot_dictionary"/> are
+        /// recursively equal; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_dictionary_recursive_equal(ref godot_dictionary p_self, in godot_dictionary p_other);
 
+        /// <summary>
+        /// Natively removes an item from the provided <see cref="godot_dictionary"/> at a specified <paramref name="p_key"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to remove from.</param>
+        /// <param name="p_key">The <see cref="godot_variant"/> key to remove.</param>
+        /// <returns></returns>
         public static partial godot_bool godotsharp_dictionary_remove_key(ref godot_dictionary p_self,
             in godot_variant p_key);
 
+        /// <summary>
+        /// Natively makes the provided <see cref="godot_dictionary"/> read-only.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to make read-only.</param>
         public static partial void godotsharp_dictionary_make_read_only(ref godot_dictionary p_self);
 
+        /// <summary>
+        /// Natively converts the specified <see cref="godot_dictionary"/> to a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_dictionary"/> to convert.</param>
+        /// <param name="r_str">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
 
         // StringExtensions
 
+        /// <summary>
+        /// Natively simplifies a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string"/> to simplify.</param>
+        /// <param name="r_simplified_path">The simplified <see cref="godot_string"/>.</param>
         public static partial void godotsharp_string_simplify_path(in godot_string p_self,
             out godot_string r_simplified_path);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_string"/> to camel case.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string"/> to convert.</param>
+        /// <param name="r_camel_case">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_string_to_camel_case(in godot_string p_self,
             out godot_string r_camel_case);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_string"/> to pascal case.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string"/> to convert.</param>
+        /// <param name="r_pascal_case">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_string_to_pascal_case(in godot_string p_self,
             out godot_string r_pascal_case);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_string"/> to snake case.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_string"/> to convert.</param>
+        /// <param name="r_snake_case">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_string_to_snake_case(in godot_string p_self,
             out godot_string r_snake_case);
 
         // NodePath
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_node_path"/> to a property path.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to convert.</param>
+        /// <param name="r_dest">The converted <see cref="godot_node_path"/>.</param>
         public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,
             ref godot_node_path r_dest);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_node_path"/> to a concatenated <see cref="godot_string"/> of names.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to convert.</param>
+        /// <param name="r_names">The concatenated <see cref="godot_string"/>.</param>
         public static partial void godotsharp_node_path_get_concatenated_names(in godot_node_path p_self,
             out godot_string r_names);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_node_path"/> to a concatenated <see cref="godot_string"/> of subnames.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to convert.</param>
+        /// <param name="r_subnames">The concatenated <see cref="godot_string"/>.</param>
         public static partial void godotsharp_node_path_get_concatenated_subnames(in godot_node_path p_self,
             out godot_string r_subnames);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_node_path"/> to a <see cref="godot_string"/> name.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to convert.</param>
+        /// <param name="p_idx">The index to search.</param>
+        /// <param name="r_name">The <see cref="godot_string"/> name.</param>
         public static partial void godotsharp_node_path_get_name(in godot_node_path p_self, int p_idx,
             out godot_string r_name);
 
+        /// <summary>
+        /// Natively retrieves the amount of names making up a <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to parse.</param>
+        /// <returns>The amount of names in this <see cref="godot_node_path"/>.</returns>
         public static partial int godotsharp_node_path_get_name_count(in godot_node_path p_self);
 
+        /// <summary>
+        /// Natively converts a <see cref="godot_node_path"/> to a <see cref="godot_string"/> subname.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to convert.</param>
+        /// <param name="p_idx">The index to search.</param>
+        /// <param name="r_subname">The <see cref="godot_string"/> r_subname.</param>
         public static partial void godotsharp_node_path_get_subname(in godot_node_path p_self, int p_idx,
             out godot_string r_subname);
 
+        /// <summary>
+        /// Natively retrieves the amount of subnames making up a <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to parse.</param>
+        /// <returns>The amount of subnames in this <see cref="godot_node_path"/>.</returns>
         public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
 
+        /// <summary>
+        /// Natively determines if a <see cref="godot_node_path"/> is absolute.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to parse.</param>
+        /// <returns><see cref="godot_bool.True"/> if this <see cref="godot_node_path"/>
+        /// is absolute; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_node_path_is_absolute(in godot_node_path p_self);
 
+        /// <summary>
+        /// Natively evaluates if the <see cref="godot_node_path"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to equate.</param>
+        /// <param name="p_other">The <see cref="godot_node_path"/> to compare with.</param>
+        /// <returns><see cref="godot_bool.True"/> if these <see cref="godot_node_path"/> are
+        /// exactly equal; otherwise, <see cref="godot_bool.False"/>.</returns>
         public static partial godot_bool godotsharp_node_path_equals(in godot_node_path p_self, in godot_node_path p_other);
 
+        /// <summary>
+        /// Natively retrieves the hash of a <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="p_self">The <see cref="godot_node_path"/> to parse.</param>
+        /// <returns>A hash code for this <see cref="godot_node_path"/>.</returns>
         public static partial int godotsharp_node_path_hash(in godot_node_path p_self);
 
         // GD, etc
@@ -505,6 +1306,10 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_print(in godot_string p_what);
 
+        /// <summary>
+        /// Natively prints a <see cref="godot_string"/> using rich text.
+        /// </summary>
+        /// <param name="p_what">The <see cref="godot_string"/> to print.</param>
         public static partial void godotsharp_print_rich(in godot_string p_what);
 
         internal static partial void godotsharp_printerr(in godot_string p_what);
@@ -546,6 +1351,11 @@ namespace Godot.NativeInterop
 
         // Object
 
+        /// <summary>
+        /// Natively converts an object <see cref="IntPtr"/> to a <see cref="godot_string"/>.
+        /// </summary>
+        /// <param name="ptr">The object <see cref="IntPtr"/> to convert from.</param>
+        /// <param name="r_str">The converted <see cref="godot_string"/>.</param>
         public static partial void godotsharp_object_to_string(IntPtr ptr, out godot_string r_str);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -4,6 +4,11 @@ namespace Godot.NativeInterop
 {
     public static partial class NativeFuncs
     {
+        /// <summary>
+        /// Natively initializes a <see cref="godot_variant"/> as a new <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="src">The <see cref="godot_variant"/> to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_variant"/>.</returns>
         public static godot_variant godotsharp_variant_new_copy(in godot_variant src)
         {
             switch (src.Type)
@@ -46,6 +51,11 @@ namespace Godot.NativeInterop
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string_name"/> as a new <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <param name="src">The <see cref="godot_string_name"/> pointer to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_string_name"/>.</returns>
         public static godot_string_name godotsharp_string_name_new_copy(in godot_string_name src)
         {
             if (src.IsEmpty)
@@ -54,6 +64,11 @@ namespace Godot.NativeInterop
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_node_path"/> as a new <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="src">The <see cref="godot_node_path"/> pointer to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_node_path"/>.</returns>
         public static godot_node_path godotsharp_node_path_new_copy(in godot_node_path src)
         {
             if (src.IsEmpty)
@@ -62,30 +77,53 @@ namespace Godot.NativeInterop
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a new <see cref="godot_array"/>.
+        /// </summary>
+        /// <returns>The initialized <see cref="godot_array"/>.</returns>
         public static godot_array godotsharp_array_new()
         {
             godotsharp_array_new(out godot_array ret);
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_array"/> as a new <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="src">The <see cref="godot_array"/> pointer to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_array"/>.</returns>
         public static godot_array godotsharp_array_new_copy(in godot_array src)
         {
             godotsharp_array_new_copy(out godot_array ret, src);
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a new <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <returns>The initialized <see cref="godot_dictionary"/>.</returns>
         public static godot_dictionary godotsharp_dictionary_new()
         {
             godotsharp_dictionary_new(out godot_dictionary ret);
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_dictionary"/> as a new <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="src">The <see cref="godot_dictionary"/> pointer to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_dictionary"/>.</returns>
         public static godot_dictionary godotsharp_dictionary_new_copy(in godot_dictionary src)
         {
             godotsharp_dictionary_new_copy(out godot_dictionary ret, src);
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string"/> as a new <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="godot_string"/> to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_string_name"/>.</returns>
         public static godot_string_name godotsharp_string_name_new_from_string(string name)
         {
             using godot_string src = Marshaling.ConvertStringToNative(name);
@@ -93,6 +131,11 @@ namespace Godot.NativeInterop
             return ret;
         }
 
+        /// <summary>
+        /// Natively initializes a <see cref="godot_string"/> as a new <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="name">The <see cref="godot_string"/> to initialize from.</param>
+        /// <returns>The initialized <see cref="godot_node_path"/>.</returns>
         public static godot_node_path godotsharp_node_path_new_from_string(string name)
         {
             using godot_string src = Marshaling.ConvertStringToNative(name);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
@@ -5,6 +5,10 @@ namespace Godot.NativeInterop
     // Our source generators will add trampolines methods that access variant arguments.
     // This struct makes that possible without having to enable `AllowUnsafeBlocks` in game projects.
 
+    /// <summary>
+    /// Enables trampoline methods that access variant arguments without having
+    /// to mark sections of code as "unsafe"
+    /// </summary>
     public unsafe ref struct NativeVariantPtrArgs
     {
         private godot_variant** _args;
@@ -25,6 +29,9 @@ namespace Godot.NativeInterop
             get => _argc;
         }
 
+        /// <summary>
+        /// Access variant pointers using their index.
+        /// </summary>
         public ref godot_variant this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -8,80 +8,189 @@ using Godot.Collections;
 
 namespace Godot.NativeInterop
 {
+    /// <summary>
+    /// Collection of conversion callbacks used for marshaling by callables
+    /// and generic Godot collections.
+    /// </summary>
     public static partial class VariantUtils
     {
+        /// <summary>
+        /// Converts an <see cref="Rid"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Rid"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Rid"/>.</returns>
         public static godot_variant CreateFromRid(Rid from)
             => new() { Type = Variant.Type.Rid, Rid = from };
 
+        /// <summary>
+        /// Converts a <see langword="bool"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="bool"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="bool"/>.</returns>
         public static godot_variant CreateFromBool(bool from)
             => new() { Type = Variant.Type.Bool, Bool = from.ToGodotBool() };
 
+        /// <summary>
+        /// Converts a <see langword="long"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="long"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="long"/>.</returns>
         public static godot_variant CreateFromInt(long from)
             => new() { Type = Variant.Type.Int, Int = from };
 
+        /// <summary>
+        /// Converts a <see langword="ulong"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="ulong"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="ulong"/>.</returns>
         public static godot_variant CreateFromInt(ulong from)
             => new() { Type = Variant.Type.Int, Int = (long)from };
 
+        /// <summary>
+        /// Converts a <see langword="double"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="double"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="double"/>.</returns>
         public static godot_variant CreateFromFloat(double from)
             => new() { Type = Variant.Type.Float, Float = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector2"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector2"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector2"/>.</returns>
         public static godot_variant CreateFromVector2(Vector2 from)
             => new() { Type = Variant.Type.Vector2, Vector2 = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector2I"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector2I"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector2I"/>.</returns>
         public static godot_variant CreateFromVector2I(Vector2I from)
             => new() { Type = Variant.Type.Vector2I, Vector2I = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector3"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector3"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector3"/>.</returns>
         public static godot_variant CreateFromVector3(Vector3 from)
             => new() { Type = Variant.Type.Vector3, Vector3 = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector3I"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector3I"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector3I"/>.</returns>
         public static godot_variant CreateFromVector3I(Vector3I from)
             => new() { Type = Variant.Type.Vector3I, Vector3I = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector4"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector4"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector4"/>.</returns>
         public static godot_variant CreateFromVector4(Vector4 from)
             => new() { Type = Variant.Type.Vector4, Vector4 = from };
 
+        /// <summary>
+        /// Converts a <see cref="Vector4I"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector4I"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector4I"/>.</returns>
         public static godot_variant CreateFromVector4I(Vector4I from)
             => new() { Type = Variant.Type.Vector4I, Vector4I = from };
 
+        /// <summary>
+        /// Converts a <see cref="Rect2"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Rect2"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Rect2"/>.</returns>
         public static godot_variant CreateFromRect2(Rect2 from)
             => new() { Type = Variant.Type.Rect2, Rect2 = from };
 
+        /// <summary>
+        /// Converts a <see cref="Rect2I"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Rect2I"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Rect2I"/>.</returns>
         public static godot_variant CreateFromRect2I(Rect2I from)
             => new() { Type = Variant.Type.Rect2I, Rect2I = from };
 
+        /// <summary>
+        /// Converts a <see cref="Quaternion"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Quaternion"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Quaternion"/>.</returns>
         public static godot_variant CreateFromQuaternion(Quaternion from)
             => new() { Type = Variant.Type.Quaternion, Quaternion = from };
 
+        /// <summary>
+        /// Converts a <see cref="Color"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Color"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Color"/>.</returns>
         public static godot_variant CreateFromColor(Color from)
             => new() { Type = Variant.Type.Color, Color = from };
 
+        /// <summary>
+        /// Converts a <see cref="Plane"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Plane"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Plane"/>.</returns>
         public static godot_variant CreateFromPlane(Plane from)
             => new() { Type = Variant.Type.Plane, Plane = from };
 
+        /// <summary>
+        /// Converts a <see cref="Transform2D"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Transform2D"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Transform2D"/>.</returns>
         public static godot_variant CreateFromTransform2D(Transform2D from)
         {
             NativeFuncs.godotsharp_variant_new_transform2d(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Basis"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Basis"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Basis"/>.</returns>
         public static godot_variant CreateFromBasis(Basis from)
         {
             NativeFuncs.godotsharp_variant_new_basis(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Transform3D"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Transform3D"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Transform3D"/>.</returns>
         public static godot_variant CreateFromTransform3D(Transform3D from)
         {
             NativeFuncs.godotsharp_variant_new_transform3d(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Projection"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Projection"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Projection"/>.</returns>
         public static godot_variant CreateFromProjection(Projection from)
         {
             NativeFuncs.godotsharp_variant_new_projection(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts an <see cref="Aabb"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Aabb"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Aabb"/>.</returns>
         public static godot_variant CreateFromAabb(Aabb from)
         {
             NativeFuncs.godotsharp_variant_new_aabb(out godot_variant ret, from);
@@ -89,85 +198,165 @@ namespace Godot.NativeInterop
         }
 
         // Explicit name to make it very clear
+        /// <summary>
+        /// Converts a <see cref="godot_callable"/> to a <see cref="godot_variant"/>, taking ownership of the disposable value in the process.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_callable"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_callable"/>.</returns>
         public static godot_variant CreateFromCallableTakingOwnershipOfDisposableValue(godot_callable from)
             => new() { Type = Variant.Type.Callable, Callable = from };
 
+        /// <summary>
+        /// Converts a <see cref="Callable"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Callable"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Callable"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromCallable(Callable from)
             => CreateFromCallableTakingOwnershipOfDisposableValue(
                 Marshaling.ConvertCallableToNative(from));
 
         // Explicit name to make it very clear
+        /// <summary>
+        /// Converts a <see cref="godot_signal"/> to a <see cref="godot_variant"/>, taking ownership of the disposable value in the process.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_signal"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_signal"/>.</returns>
         public static godot_variant CreateFromSignalTakingOwnershipOfDisposableValue(godot_signal from)
             => new() { Type = Variant.Type.Signal, Signal = from };
 
+        /// <summary>
+        /// Converts a <see cref="Signal"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Signal"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Signal"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromSignal(Signal from)
             => CreateFromSignalTakingOwnershipOfDisposableValue(
                 Marshaling.ConvertSignalToNative(from));
 
         // Explicit name to make it very clear
+        /// <summary>
+        /// Converts a <see cref="godot_string"/> to a <see cref="godot_variant"/>, taking ownership of the disposable value in the process.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_string"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_string"/>.</returns>
         public static godot_variant CreateFromStringTakingOwnershipOfDisposableValue(godot_string from)
             => new() { Type = Variant.Type.String, String = from };
 
+        /// <summary>
+        /// Converts a <see langword="string"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="string"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="string"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromString(string? from)
             => CreateFromStringTakingOwnershipOfDisposableValue(Marshaling.ConvertStringToNative(from));
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_byte_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_byte_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_byte_array"/>.</returns>
         public static godot_variant CreateFromPackedByteArray(in godot_packed_byte_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_byte_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_int32_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_int32_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_int32_array"/>.</returns>
         public static godot_variant CreateFromPackedInt32Array(in godot_packed_int32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int32_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_int64_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_int64_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_int64_array"/>.</returns>
         public static godot_variant CreateFromPackedInt64Array(in godot_packed_int64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_int64_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_float32_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_float32_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_float32_array"/>.</returns>
         public static godot_variant CreateFromPackedFloat32Array(in godot_packed_float32_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float32_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_float64_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_float64_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_float64_array"/>.</returns>
         public static godot_variant CreateFromPackedFloat64Array(in godot_packed_float64_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_float64_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_string_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_string_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_string_array"/>.</returns>
         public static godot_variant CreateFromPackedStringArray(in godot_packed_string_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_string_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_vector2_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_vector2_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_vector2_array"/>.</returns>
         public static godot_variant CreateFromPackedVector2Array(in godot_packed_vector2_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector2_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_vector3_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_vector3_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_vector3_array"/>.</returns>
         public static godot_variant CreateFromPackedVector3Array(in godot_packed_vector3_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_vector3_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_packed_color_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_packed_color_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_packed_color_array"/>.</returns>
         public static godot_variant CreateFromPackedColorArray(in godot_packed_color_array from)
         {
             NativeFuncs.godotsharp_variant_new_packed_color_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see langword="byte"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="byte"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="byte"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedByteArray(Span<byte> from)
         {
@@ -175,6 +364,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedByteArray(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts an <see langword="int"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="int"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="int"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedInt32Array(Span<int> from)
         {
@@ -182,6 +376,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedInt32Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see langword="long"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="long"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="long"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedInt64Array(Span<long> from)
         {
@@ -189,6 +388,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedInt64Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see langword="float"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="float"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="float"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedFloat32Array(Span<float> from)
         {
@@ -196,6 +400,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedFloat32Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see langword="double"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="double"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="double"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedFloat64Array(Span<double> from)
         {
@@ -203,6 +412,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedFloat64Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see langword="string"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see langword="string"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see langword="string"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedStringArray(Span<string> from)
         {
@@ -210,6 +424,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedStringArray(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector2"/> span to a <see cref="godot_variant"/> span.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector2"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector2"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedVector2Array(Span<Vector2> from)
         {
@@ -217,6 +436,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedVector2Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector3"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Vector3"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Vector3"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedVector3Array(Span<Vector3> from)
         {
@@ -224,6 +448,11 @@ namespace Godot.NativeInterop
             return CreateFromPackedVector3Array(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="Color"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Color"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Color"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromPackedColorArray(Span<Color> from)
         {
@@ -231,15 +460,35 @@ namespace Godot.NativeInterop
             return CreateFromPackedColorArray(nativePackedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="StringName"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="StringName"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="StringName"/> span.</returns>
         public static godot_variant CreateFromSystemArrayOfStringName(Span<StringName> from)
             => CreateFromArray(new Collections.Array(from));
 
+        /// <summary>
+        /// Converts a <see cref="NodePath"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="NodePath"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="NodePath"/> span.</returns>
         public static godot_variant CreateFromSystemArrayOfNodePath(Span<NodePath> from)
             => CreateFromArray(new Collections.Array(from));
 
+        /// <summary>
+        /// Converts an <see cref="Rid"/> span to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Rid"/> span to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Rid"/> span.</returns>
         public static godot_variant CreateFromSystemArrayOfRid(Span<Rid> from)
             => CreateFromArray(new Collections.Array(from));
 
+        /// <summary>
+        /// Converts a <see cref="GodotObject"/>[] to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="GodotObject"/>[] to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="GodotObject"/>[].</returns>
         // ReSharper disable once RedundantNameQualifier
         public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
         {
@@ -249,54 +498,109 @@ namespace Godot.NativeInterop
             return CreateFromArray((godot_array)fromGodot.NativeValue);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_array"/>.</returns>
         public static godot_variant CreateFromArray(godot_array from)
         {
             NativeFuncs.godotsharp_variant_new_array(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts an <see cref="Collections.Array"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Collections.Array"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Collections.Array"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromArray(Collections.Array? from)
             => from != null ? CreateFromArray((godot_array)from.NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="Array{T}"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Array{T}"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Array{T}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromArray<[MustBeVariant] T>(Array<T>? from)
             => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="godot_dictionary"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_dictionary"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_dictionary"/>.</returns>
         public static godot_variant CreateFromDictionary(godot_dictionary from)
         {
             NativeFuncs.godotsharp_variant_new_dictionary(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="Dictionary"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Dictionary"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Dictionary"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromDictionary(Dictionary? from)
             => from != null ? CreateFromDictionary((godot_dictionary)from.NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="Dictionary{TKey, TValue}"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="Dictionary{TKey, TValue}"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="Dictionary{TKey, TValue}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? from)
             => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="godot_string_name"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_string_name"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_string_name"/>.</returns>
         public static godot_variant CreateFromStringName(godot_string_name from)
         {
             NativeFuncs.godotsharp_variant_new_string_name(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="StringName"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="StringName"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="StringName"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromStringName(StringName? from)
             => from != null ? CreateFromStringName((godot_string_name)from.NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="godot_node_path"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="godot_node_path"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="godot_node_path"/>.</returns>
         public static godot_variant CreateFromNodePath(godot_node_path from)
         {
             NativeFuncs.godotsharp_variant_new_node_path(out godot_variant ret, from);
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="NodePath"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="NodePath"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="NodePath"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_variant CreateFromNodePath(NodePath? from)
             => from != null ? CreateFromNodePath((godot_node_path)from.NativeValue) : default;
 
+        /// <summary>
+        /// Converts a <see cref="IntPtr"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="IntPtr"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="IntPtr"/>.</returns>
         public static godot_variant CreateFromGodotObjectPtr(IntPtr from)
         {
             if (from == IntPtr.Zero)
@@ -305,6 +609,11 @@ namespace Godot.NativeInterop
             return ret;
         }
 
+        /// <summary>
+        /// Converts a <see cref="GodotObject"/> to a <see cref="godot_variant"/>.
+        /// </summary>
+        /// <param name="from">The <see cref="GodotObject"/> to convert.</param>
+        /// <returns>A <see cref="godot_variant"/> representation of this <see cref="GodotObject"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once RedundantNameQualifier
         public static godot_variant CreateFromGodotObject(GodotObject? from)
@@ -312,157 +621,317 @@ namespace Godot.NativeInterop
 
         // We avoid the internal call if the stored type is the same we want.
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="bool"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="bool"/> representation of this <see cref="godot_variant"/>.</returns>
         public static bool ConvertToBool(in godot_variant p_var)
             => p_var.Type == Variant.Type.Bool ?
                 p_var.Bool.ToBool() :
                 NativeFuncs.godotsharp_variant_as_bool(p_var).ToBool();
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="char"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="char"/> representation of this <see cref="godot_variant"/>.</returns>
         public static char ConvertToChar(in godot_variant p_var)
             => (char)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see langword="sbyte"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see langword="sbyte"/> representation of this <see cref="godot_variant"/>.</returns>
         public static sbyte ConvertToInt8(in godot_variant p_var)
             => (sbyte)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="short"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="short"/> representation of this <see cref="godot_variant"/>.</returns>
         public static short ConvertToInt16(in godot_variant p_var)
             => (short)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see langword="int"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see langword="int"/> representation of this <see cref="godot_variant"/>.</returns>
         public static int ConvertToInt32(in godot_variant p_var)
             => (int)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="long"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="long"/> representation of this <see cref="godot_variant"/>.</returns>
         public static long ConvertToInt64(in godot_variant p_var)
             => p_var.Type == Variant.Type.Int ? p_var.Int : NativeFuncs.godotsharp_variant_as_int(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="byte"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="byte"/> representation of this <see cref="godot_variant"/>.</returns>
         public static byte ConvertToUInt8(in godot_variant p_var)
             => (byte)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="ushort"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="ushort"/> representation of this <see cref="godot_variant"/>.</returns>
         public static ushort ConvertToUInt16(in godot_variant p_var)
             => (ushort)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="uint"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="uint"/> representation of this <see cref="godot_variant"/>.</returns>
         public static uint ConvertToUInt32(in godot_variant p_var)
             => (uint)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="ulong"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="ulong"/> representation of this <see cref="godot_variant"/>.</returns>
         public static ulong ConvertToUInt64(in godot_variant p_var)
             => (ulong)(p_var.Type == Variant.Type.Int ?
                 p_var.Int :
                 NativeFuncs.godotsharp_variant_as_int(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="float"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="float"/> representation of this <see cref="godot_variant"/>.</returns>
         public static float ConvertToFloat32(in godot_variant p_var)
             => (float)(p_var.Type == Variant.Type.Float ?
                 p_var.Float :
                 NativeFuncs.godotsharp_variant_as_float(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="double"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="double"/> representation of this <see cref="godot_variant"/>.</returns>
         public static double ConvertToFloat64(in godot_variant p_var)
             => p_var.Type == Variant.Type.Float ?
                 p_var.Float :
                 NativeFuncs.godotsharp_variant_as_float(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector2"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector2"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Vector2 ConvertToVector2(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector2 ?
                 p_var.Vector2 :
                 NativeFuncs.godotsharp_variant_as_vector2(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector2I"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector2I"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Vector2I ConvertToVector2I(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector2I ?
                 p_var.Vector2I :
                 NativeFuncs.godotsharp_variant_as_vector2i(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Rect2"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Rect2"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Rect2 ConvertToRect2(in godot_variant p_var)
             => p_var.Type == Variant.Type.Rect2 ?
                 p_var.Rect2 :
                 NativeFuncs.godotsharp_variant_as_rect2(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Rect2I"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Rect2I"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Rect2I ConvertToRect2I(in godot_variant p_var)
             => p_var.Type == Variant.Type.Rect2I ?
                 p_var.Rect2I :
                 NativeFuncs.godotsharp_variant_as_rect2i(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Transform2D"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Transform2D"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Transform2D ConvertToTransform2D(in godot_variant p_var)
             => p_var.Type == Variant.Type.Transform2D ?
                 *p_var.Transform2D :
                 NativeFuncs.godotsharp_variant_as_transform2d(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector3"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Vector3 ConvertToVector3(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector3 ?
                 p_var.Vector3 :
                 NativeFuncs.godotsharp_variant_as_vector3(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector3I"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector3I"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Vector3I ConvertToVector3I(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector3I ?
                 p_var.Vector3I :
                 NativeFuncs.godotsharp_variant_as_vector3i(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector4"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Vector4 ConvertToVector4(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector4 ?
                 p_var.Vector4 :
                 NativeFuncs.godotsharp_variant_as_vector4(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector4I"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector4I"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Vector4I ConvertToVector4I(in godot_variant p_var)
             => p_var.Type == Variant.Type.Vector4I ?
                 p_var.Vector4I :
                 NativeFuncs.godotsharp_variant_as_vector4i(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Basis"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Basis"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Basis ConvertToBasis(in godot_variant p_var)
             => p_var.Type == Variant.Type.Basis ?
                 *p_var.Basis :
                 NativeFuncs.godotsharp_variant_as_basis(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Quaternion"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Quaternion"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Quaternion ConvertToQuaternion(in godot_variant p_var)
             => p_var.Type == Variant.Type.Quaternion ?
                 p_var.Quaternion :
                 NativeFuncs.godotsharp_variant_as_quaternion(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Transform3D"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Transform3D"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Transform3D ConvertToTransform3D(in godot_variant p_var)
             => p_var.Type == Variant.Type.Transform3D ?
                 *p_var.Transform3D :
                 NativeFuncs.godotsharp_variant_as_transform3d(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Projection"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Projection"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Projection ConvertToProjection(in godot_variant p_var)
             => p_var.Type == Variant.Type.Projection ?
                 *p_var.Projection :
                 NativeFuncs.godotsharp_variant_as_projection(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Aabb"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Aabb"/> representation of this <see cref="godot_variant"/>.</returns>
         public static unsafe Aabb ConvertToAabb(in godot_variant p_var)
             => p_var.Type == Variant.Type.Aabb ?
                 *p_var.Aabb :
                 NativeFuncs.godotsharp_variant_as_aabb(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Color"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Color"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Color ConvertToColor(in godot_variant p_var)
             => p_var.Type == Variant.Type.Color ?
                 p_var.Color :
                 NativeFuncs.godotsharp_variant_as_color(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Plane"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Plane"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Plane ConvertToPlane(in godot_variant p_var)
             => p_var.Type == Variant.Type.Plane ?
                 p_var.Plane :
                 NativeFuncs.godotsharp_variant_as_plane(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Rid"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Rid"/> representation of this <see cref="godot_variant"/>.</returns>
         public static Rid ConvertToRid(in godot_variant p_var)
             => p_var.Type == Variant.Type.Rid ?
                 p_var.Rid :
                 NativeFuncs.godotsharp_variant_as_rid(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="IntPtr"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="IntPtr"/> representation of this <see cref="godot_variant"/>.</returns>
         public static IntPtr ConvertToGodotObjectPtr(in godot_variant p_var)
             => p_var.Type == Variant.Type.Object ? p_var.Object : IntPtr.Zero;
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="GodotObject"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="GodotObject"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // ReSharper disable once RedundantNameQualifier
         public static GodotObject ConvertToGodotObject(in godot_variant p_var)
             => InteropUtils.UnmanagedGetManaged(ConvertToGodotObjectPtr(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="string"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="string"/> representation of this <see cref="godot_variant"/>.</returns>
         public static string ConvertToString(in godot_variant p_var)
         {
             switch (p_var.Type)
@@ -482,138 +951,273 @@ namespace Godot.NativeInterop
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_string_name"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_string_name"/> representation of this <see cref="godot_variant"/>.</returns>
         public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
             => p_var.Type == Variant.Type.StringName ?
                 NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
                 NativeFuncs.godotsharp_variant_as_string_name(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="StringName"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="StringName"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StringName ConvertToStringName(in godot_variant p_var)
             => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_node_path"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_node_path"/> representation of this <see cref="godot_variant"/>.</returns>
         public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
             => p_var.Type == Variant.Type.NodePath ?
                 NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
                 NativeFuncs.godotsharp_variant_as_node_path(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="NodePath"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="NodePath"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static NodePath ConvertToNodePath(in godot_variant p_var)
             => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_callable"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_callable"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_callable(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Callable"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Callable"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Callable ConvertToCallable(in godot_variant p_var)
             => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_signal"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_signal"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
             => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Signal"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Signal"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Signal ConvertToSignal(in godot_variant p_var)
             => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_array"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_array"/> representation of this <see cref="godot_variant"/>.</returns>
         public static godot_array ConvertToNativeArray(in godot_variant p_var)
             => p_var.Type == Variant.Type.Array ?
                 NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
                 NativeFuncs.godotsharp_variant_as_array(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see cref="Collections.Array"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see cref="Collections.Array"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Collections.Array ConvertToArray(in godot_variant p_var)
             => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see cref="Array{T}"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see cref="Array{T}"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Array<T> ConvertToArray<[MustBeVariant] T>(in godot_variant p_var)
             => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="godot_dictionary"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="godot_dictionary"/> representation of this <see cref="godot_variant"/>.</returns>
         public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
             => p_var.Type == Variant.Type.Dictionary ?
                 NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
                 NativeFuncs.godotsharp_variant_as_dictionary(p_var);
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Dictionary"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Dictionary"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary ConvertToDictionary(in godot_variant p_var)
             => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representation of this <see cref="godot_variant"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Dictionary<TKey, TValue> ConvertToDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(in godot_variant p_var)
             => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="byte"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="byte"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static byte[] ConvertAsPackedByteArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_byte_array(p_var);
             return Marshaling.ConvertNativePackedByteArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see langword="int"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see langword="int"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static int[] ConvertAsPackedInt32ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int32_array(p_var);
             return Marshaling.ConvertNativePackedInt32ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="long"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="long"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static long[] ConvertAsPackedInt64ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int64_array(p_var);
             return Marshaling.ConvertNativePackedInt64ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="float"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="float"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static float[] ConvertAsPackedFloat32ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float32_array(p_var);
             return Marshaling.ConvertNativePackedFloat32ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="double"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="double"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static double[] ConvertAsPackedFloat64ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float64_array(p_var);
             return Marshaling.ConvertNativePackedFloat64ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see langword="string"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see langword="string"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static string[] ConvertAsPackedStringArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_string_array(p_var);
             return Marshaling.ConvertNativePackedStringArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector2"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector2"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static Vector2[] ConvertAsPackedVector2ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector2_array(p_var);
             return Marshaling.ConvertNativePackedVector2ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Vector3"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Vector3"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static Vector3[] ConvertAsPackedVector3ArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector3_array(p_var);
             return Marshaling.ConvertNativePackedVector3ArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="Color"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="Color"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static Color[] ConvertAsPackedColorArrayToSystemArray(in godot_variant p_var)
         {
             using var packedArray = NativeFuncs.godotsharp_variant_as_packed_color_array(p_var);
             return Marshaling.ConvertNativePackedColorArrayToSystemArray(packedArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="StringName"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="StringName"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static StringName[] ConvertToSystemArrayOfStringName(in godot_variant p_var)
         {
             using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
             return Marshaling.ConvertNativeGodotArrayToSystemArrayOfStringName(godotArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to a <see cref="NodePath"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>A <see cref="NodePath"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static NodePath[] ConvertToSystemArrayOfNodePath(in godot_variant p_var)
         {
             using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
             return Marshaling.ConvertNativeGodotArrayToSystemArrayOfNodePath(godotArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see cref="Rid"/>[].
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see cref="Rid"/>[] representation of this <see cref="godot_variant"/>.</returns>
         public static Rid[] ConvertToSystemArrayOfRid(in godot_variant p_var)
         {
             using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
             return Marshaling.ConvertNativeGodotArrayToSystemArrayOfRid(godotArray);
         }
 
+        /// <summary>
+        /// Converts a <see cref="godot_variant"/> to an <see cref="Array{T}"/>.
+        /// </summary>
+        /// <param name="p_var">The <see cref="godot_variant"/> to convert.</param>
+        /// <returns>An <see cref="Array{T}"/> representation of this <see cref="godot_variant"/>.</returns>
         public static T[] ConvertToSystemArrayOfGodotObject<T>(in godot_variant p_var)
             // ReSharper disable once RedundantNameQualifier
             where T : GodotObject

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.generic.cs
@@ -32,6 +32,11 @@ public partial class VariantUtils
         }
     }
 
+    /// <summary>
+    /// Converts a <typeparamref name="T"/> to a <see cref="godot_variant"/>.
+    /// </summary>
+    /// <param name="from">The <typeparamref name="T"/> to convert.</param>
+    /// <returns>A <see cref="godot_variant"/> representation of this <typeparamref name="T"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]
     public static godot_variant CreateFrom<[MustBeVariant] T>(in T from)
@@ -223,6 +228,11 @@ public partial class VariantUtils
         return GenericConversion<T>.ToVariant(from);
     }
 
+    /// <summary>
+    /// Converts a <see cref="godot_variant"/> to a <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="variant">The <see cref="godot_variant"/> to convert.</param>
+    /// <returns>A <typeparamref name="T"/> representation of this <see cref="godot_variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     [SuppressMessage("ReSharper", "RedundantNameQualifier")]
     public static T ConvertTo<[MustBeVariant] T>(in godot_variant variant)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -45,6 +45,9 @@ namespace Godot
 
         private WeakReference<IDisposable> _weakReferenceToSelf;
 
+        /// <summary>
+        /// Deconstructs this <see cref="NodePath"/>.
+        /// </summary>
         ~NodePath()
         {
             Dispose(false);
@@ -59,6 +62,9 @@ namespace Godot
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Disposes implementation of this <see cref="NodePath"/>.
+        /// </summary>
         public void Dispose(bool disposing)
         {
             // Always dispose `NativeValue` even if disposing is true
@@ -289,6 +295,13 @@ namespace Godot
         /// <returns>If the <see cref="NodePath"/> is empty.</returns>
         public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
 
+        /// <summary>
+        /// Evaluates if the <see cref="NodePath"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="NodePath"/>.</param>
+        /// <param name="right">The right <see cref="NodePath"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="NodePath"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(NodePath left, NodePath right)
         {
             if (left is null)
@@ -296,11 +309,24 @@ namespace Godot
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="NodePath"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="NodePath"/>.</param>
+        /// <param name="right">The right <see cref="NodePath"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="NodePath"/> are
+        /// not equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(NodePath left, NodePath right)
         {
             return !(left == right);
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="NodePath"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="other">The <see cref="NodePath"/> to compare with.</param>
+        /// <returns><see langword="true"/> if these <see cref="NodePath"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(NodePath other)
         {
             if (other is null)
@@ -310,11 +336,22 @@ namespace Godot
             return NativeFuncs.godotsharp_node_path_equals(self, otherNative).ToBool();
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="NodePath"/> is exactly equal to the
+        /// given object (<paramref name="obj"/>).
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns><see langword="true"/> if this <see cref="NodePath"/>and
+        /// the object are equal; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object obj)
         {
             return ReferenceEquals(this, obj) || (obj is NodePath other && Equals(other));
         }
 
+        /// <summary>
+        /// Serves as the hash function for <see cref="NodePath"/>.
+        /// </summary>
+        /// <returns>A hash code for this <see cref="NodePath"/>.</returns>
         public override int GetHashCode()
         {
             var self = (godot_node_path)NativeValue;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -256,6 +256,10 @@ namespace Godot
             return (X * b.X) + (Y * b.Y) + (Z * b.Z) + (W * b.W);
         }
 
+        /// <summary>
+        /// Returns the exponential of this quaternion.
+        /// </summary>
+        /// <returns>The exponential.</returns>
         public readonly Quaternion Exp()
         {
             Vector3 v = new Vector3(X, Y, Z);
@@ -268,11 +272,19 @@ namespace Godot
             return new Quaternion(v, theta);
         }
 
+        /// <summary>
+        /// Returns the angle of this quaternion.
+        /// </summary>
+        /// <returns>The angle.</returns>
         public readonly real_t GetAngle()
         {
             return 2 * Mathf.Acos(W);
         }
 
+        /// <summary>
+        /// Returns the axis of this quaternion.
+        /// </summary>
+        /// <returns>The axis.</returns>
         public readonly Vector3 GetAxis()
         {
             if (Mathf.Abs(W) > 1 - Mathf.Epsilon)
@@ -337,6 +349,10 @@ namespace Godot
             return Mathf.Abs(LengthSquared() - 1) <= Mathf.Epsilon;
         }
 
+        /// <summary>
+        /// Returns the logarithm of this quaternion.
+        /// </summary>
+        /// <returns>The logarithm.</returns>
         public readonly Quaternion Log()
         {
             Vector3 v = GetAxis() * GetAngle();
@@ -552,6 +568,12 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Constructs a <see cref="Quaternion"/> which rotates from
+        /// <paramref name="arcFrom"/> to <paramref name="arcTo"/>.
+        /// </summary>
+        /// <param name="arcFrom">The arc to rotate from.</param>
+        /// <param name="arcTo">The arc to rotate to.</param>
         public Quaternion(Vector3 arcFrom, Vector3 arcTo)
         {
             Vector3 c = arcFrom.Cross(arcTo);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
@@ -30,6 +30,10 @@ namespace Godot
             _signalName = name;
         }
 
+        /// <summary>
+        /// Retrieves this Signal's awaiter.
+        /// </summary>
+        /// <returns>This signal's awaiter.</returns>
         public IAwaiter<Variant[]> GetAwaiter()
         {
             return new SignalAwaiter(_owner, _signalName, _owner);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -4,12 +4,23 @@ using Godot.NativeInterop;
 
 namespace Godot
 {
+    /// <summary>
+    /// Represents an awaiter for when an instance emits a specified <see cref="Signal"/>
+    /// </summary>
     public class SignalAwaiter : IAwaiter<Variant[]>, IAwaitable<Variant[]>
     {
         private bool _completed;
         private Variant[] _result;
         private Action _continuation;
 
+        /// <summary>
+        /// Constructs a new <see cref="SignalAwaiter"/> that will complete when the instance
+        /// <paramref name="source"/> emits the signal specified by the <paramref name="signal"/>
+        /// parameter, thereby notifying <paramref name="target"/>.
+        /// </summary>
+        /// <param name="source">The instance this will listen to.</param>
+        /// <param name="signal">The signal this will be waiting for.</param>
+        /// <param name="target">The instance this will notify on completion.</param>
         public SignalAwaiter(GodotObject source, StringName signal, GodotObject target)
         {
             var awaiterGcHandle = CustomGCHandle.AllocStrong(this);
@@ -19,15 +30,30 @@ namespace Godot
                 GodotObject.GetPtr(target), GCHandle.ToIntPtr(awaiterGcHandle));
         }
 
+        /// <summary>
+        /// Returns the signal's completion status.
+        /// </summary>
         public bool IsCompleted => _completed;
 
+        /// <summary>
+        /// Called upon completion.
+        /// </summary>
+        /// <param name="continuation">The action to perform upon completion.</param>
         public void OnCompleted(Action continuation)
         {
             _continuation = continuation;
         }
 
+        /// <summary>
+        /// Gets the result of the signal's completion.
+        /// </summary>
+        /// <returns>The result of completion.</returns>
         public Variant[] GetResult() => _result;
 
+        /// <summary>
+        /// Retrieve this signal awaiter.
+        /// </summary>
+        /// <returns>This.</returns>
         public IAwaiter<Variant[]> GetAwaiter() => this;
 
         [UnmanagedCallersOnly]

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -16,6 +16,9 @@ namespace Godot
 
         private WeakReference<IDisposable> _weakReferenceToSelf;
 
+        /// <summary>
+        /// Deconstructs this <see cref="StringName"/>.
+        /// </summary>
         ~StringName()
         {
             Dispose(false);
@@ -30,6 +33,9 @@ namespace Godot
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Disposes implementation of this <see cref="StringName"/>.
+        /// </summary>
         public void Dispose(bool disposing)
         {
             // Always dispose `NativeValue` even if disposing is true
@@ -104,6 +110,13 @@ namespace Godot
         /// <returns>If the <see cref="StringName"/> is empty.</returns>
         public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
 
+        /// <summary>
+        /// Evaluates if the <see cref="StringName"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="StringName"/>.</param>
+        /// <param name="right">The right <see cref="StringName"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="StringName"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(StringName left, StringName right)
         {
             if (left is null)
@@ -111,11 +124,24 @@ namespace Godot
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="StringName"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The left <see cref="StringName"/>.</param>
+        /// <param name="right">The right <see cref="StringName"/>.</param>
+        /// <returns><see langword="true"/> if these <see cref="StringName"/> are
+        /// not equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringName left, StringName right)
         {
             return !(left == right);
         }
 
+        /// <summary>
+        /// Evaluates if the <see cref="StringName"/> instances are exactly equal.
+        /// </summary>
+        /// <param name="other">The <see cref="StringName"/> to compare with.</param>
+        /// <returns><see langword="true"/> if these <see cref="StringName"/> are
+        /// exactly equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(StringName other)
         {
             if (other is null)
@@ -123,6 +149,14 @@ namespace Godot
             return NativeValue.DangerousSelfRef == other.NativeValue.DangerousSelfRef;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="StringName"/> is exactly equal to the
+        /// given <see cref="godot_string_name"/>
+        /// </summary>
+        /// <param name="left">The left <see cref="StringName"/>.</param>
+        /// <param name="right">The right <see cref="godot_string_name"/>.</param>
+        /// <returns><see langword="true"/> if this <see cref="StringName"/>and the
+        /// <see cref="godot_string_name"/> are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(StringName left, in godot_string_name right)
         {
             if (left is null)
@@ -130,31 +164,73 @@ namespace Godot
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="StringName"/> is not equal to the
+        /// given <see cref="godot_string_name"/>
+        /// </summary>
+        /// <param name="left">The left <see cref="StringName"/>.</param>
+        /// <param name="right">The right <see cref="godot_string_name"/>.</param>
+        /// <returns><see langword="true"/> if this <see cref="StringName"/>and the
+        /// <see cref="godot_string_name"/> are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(StringName left, in godot_string_name right)
         {
             return !(left == right);
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_string_name"/> is exactly equal to the
+        /// given <see cref="StringName"/>
+        /// </summary>
+        /// <param name="left">The left <see cref="godot_string_name"/>.</param>
+        /// <param name="right">The right <see cref="StringName"/>.</param>
+        /// <returns><see langword="true"/> if this <see cref="godot_string_name"/>and the
+        /// <see cref="StringName"/> are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(in godot_string_name left, StringName right)
         {
             return right == left;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="godot_string_name"/> is not equal to the
+        /// given <see cref="StringName"/>
+        /// </summary>
+        /// <param name="left">The left <see cref="godot_string_name"/>.</param>
+        /// <param name="right">The right <see cref="StringName"/>.</param>
+        /// <returns><see langword="true"/> if this <see cref="godot_string_name"/>and the
+        /// <see cref="StringName"/> are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(in godot_string_name left, StringName right)
         {
             return !(right == left);
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="StringName"/> is exactly equal to the
+        /// given <see cref="godot_string_name"/>
+        /// </summary>
+        /// <param name="other">The <see cref="godot_string_name"/> to compare with.</param>
+        /// <returns><see langword="true"/> if this <see cref="StringName"/>and the
+        /// <see cref="godot_string_name"/> are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(in godot_string_name other)
         {
             return NativeValue.DangerousSelfRef == other;
         }
 
+        /// <summary>
+        /// Evaluates if this <see cref="StringName"/> is exactly equal to the
+        /// given object (<paramref name="obj"/>).
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns><see langword="true"/> if this <see cref="StringName"/>and
+        /// the object are equal; otherwise, <see langword="false"/>.</returns>
         public override bool Equals(object obj)
         {
             return ReferenceEquals(this, obj) || (obj is StringName other && Equals(other));
         }
 
+        /// <summary>
+        /// Serves as the hash function for <see cref="StringName"/>.
+        /// </summary>
+        /// <returns>A hash code for this <see cref="StringName"/>.</returns>
         public override int GetHashCode()
         {
             return NativeValue.GetHashCode();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -7,6 +7,59 @@ namespace Godot;
 
 #nullable enable
 
+/// <summary>
+/// <para>The most important data type in Godot.</para>
+/// <para>In computer programming, a Variant class is a class that is designed to store a variety of other types. Dynamic programming languages like PHP, Lua, JavaScript and GDScript like to use them to store variables' data on the backend. With these Variants, properties are able to change value types freely.</para>
+/// <para><code>
+/// // C# is statically typed. Once a variable has a type it cannot be changed. You can use the `var` keyword to let the compiler infer the type automatically.
+/// var foo = 2; // Foo is a 32-bit integer (int). Be cautious, integers in GDScript are 64-bit and the direct C# equivalent is `long`.
+/// // foo = "foo was and will always be an integer. It cannot be turned into a string!";
+/// var boo = "Boo is a string!";
+/// var ref = new RefCounted(); // var is especially useful when used together with a constructor.
+///
+/// // Godot also provides a Variant type that works like a union of all the Variant-compatible types.
+/// Variant fooVar = 2; // fooVar is dynamically an integer (stored as a `long` in the Variant type).
+/// fooVar = "Now fooVar is a string!";
+/// fooVar = new RefCounted(); // fooVar is a GodotObject.
+/// </code></para>
+/// <para>Godot tracks all scripting API variables within Variants. Without even realizing it, you use Variants all the time. When a particular language enforces its own rules for keeping data typed, then that language is applying its own custom logic over the base Variant scripting API.</para>
+/// <para>C# is statically typed, but uses its own implementation of the <c>Variant</c> type in place of Godot's Variant class when it needs to represent a dynamic value. A <c>Variant</c> can be assigned any compatible type implicitly but converting requires an explicit cast.</para>
+/// The global <c>@GlobalScope.typeof</c> function returns the enumerated value of the Variant type stored in the current variable (see <see cref="Godot.Variant.Type"/>).
+/// <para><code>
+/// Variant foo = 2;
+/// switch (foo.VariantType)
+/// {
+///     case Variant.Type.Nil:
+///         GD.Print("foo is null");
+///         break;
+///     case Variant.Type.Int:
+///         GD.Print("foo is an integer");
+///         break;
+///     case Variant.Type.Object:
+///         // Note that Objects are their own special category.
+///         // You can convert a Variant to a GodotObject and use reflection to get its name.
+///         GD.Print($"foo is a(n) {foo.AsGodotObject().GetType().Name}");
+///         break;
+/// }
+/// </code></para>
+/// <para>A Variant takes up only 20 bytes and can store almost any engine datatype inside of it. Variants are rarely used to hold information for long periods of time. Instead, they are used mainly for communication, editing, serialization and moving data around.</para>
+/// <para>Godot has specifically invested in making its Variant class as flexible as possible; so much so that it is used for a multitude of operations to facilitate communication between all of Godot's systems.</para>
+/// <para>A Variant:</para>
+/// <list type="bullet">
+/// <item>Can store almost any datatype.</item>
+/// <item>Can perform operations between many variants.</item>
+/// <item>Can be hashed, so it can be compared quickly to other variants.</item>
+/// <item>Can be used to convert safely between datatypes.</item>
+/// <item>Can be used to abstract calling methods and their arguments. Godot exports all its functions through variants.</item>
+/// <item>Can be used to defer calls or move data between threads.</item>
+/// <item>Can be serialized as binary and stored to disk, or transferred via network.</item>
+/// <item>Can be serialized to text and use it for printing values and editable settings.</item>
+/// <item>Can work as an exported property, so the editor can edit it universally.</item>
+/// <item>Can be used for dictionaries, arrays, parsers, etc.</item>
+/// </list>
+/// <para><b>Containers (Array and Dictionary):</b> Both are implemented using variants. A <see cref="Godot.Collections.Dictionary"/> can match any datatype used as key to any other datatype. An <see cref="Godot.Collections.Array"/> just holds an array of Variants. Of course, a Variant can also hold a <see cref="Godot.Collections.Dictionary"/> and an <see cref="Godot.Collections.Array"/> inside, making it even more flexible.</para>
+/// <para>Modifications to a container will modify all references to it. A <see cref="Godot.Mutex"/> should be created to lock it if multi-threaded access is desired.</para>
+/// </summary>
 [SuppressMessage("ReSharper", "RedundantNameQualifier")]
 public partial struct Variant : IDisposable
 {
@@ -81,11 +134,21 @@ public partial struct Variant : IDisposable
         }
     }
 
+    /// <summary>
+    /// Converts a <see cref="Godot.NativeInterop.godot_variant"/> to a <see cref="Variant"/>, taking ownership of the disposable value in the process.
+    /// </summary>
+    /// <param name="nativeValueToOwn">The <see cref="Godot.NativeInterop.godot_variant"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Godot.NativeInterop.godot_variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // Explicit name to make it very clear
     public static Variant CreateTakingOwnershipOfDisposableValue(in godot_variant nativeValueToOwn) =>
         new(nativeValueToOwn);
 
+    /// <summary>
+    /// Converts a <see cref="Godot.NativeInterop.godot_variant"/> to a <see cref="Variant"/>, copying borrowed values in the process.
+    /// </summary>
+    /// <param name="nativeValueToOwn">The <see cref="Godot.NativeInterop.godot_variant"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Godot.NativeInterop.godot_variant"/>.</returns>
     // Explicit name to make it very clear
     public static Variant CreateCopyingBorrowed(in godot_variant nativeValueToOwn) =>
         new(NativeFuncs.godotsharp_variant_new_copy(nativeValueToOwn));
@@ -97,6 +160,9 @@ public partial struct Variant : IDisposable
     public godot_variant CopyNativeVariant() =>
         NativeFuncs.godotsharp_variant_new_copy((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Disposes of this <see cref="Variant"/>.
+    /// </summary>
     public void Dispose()
     {
         _disposer?.Dispose();
@@ -105,10 +171,20 @@ public partial struct Variant : IDisposable
     }
 
     // TODO: Consider renaming Variant.Type to VariantType and this property to Type. VariantType would also avoid ambiguity with System.Type.
+    /// <summary>
+    /// The <see cref="Type"/> of this <see cref="Variant"/>.
+    /// </summary>
     public Type VariantType => NativeVar.DangerousSelfRef.Type;
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this Variant.</returns>
     public override string ToString() => AsString();
 
+    /// <summary>
+    /// The serialized internal object of this <see cref="Variant"/>.
+    /// </summary>
     public object? Obj =>
         _obj ??= NativeVar.DangerousSelfRef.Type switch
         {
@@ -154,779 +230,1810 @@ public partial struct Variant : IDisposable
                 throw new InvalidOperationException($"Invalid Variant type: {NativeVar.DangerousSelfRef.Type}"),
         };
 
+    /// <summary>
+    /// Converts a <typeparamref name="T"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <returns>The <see cref="Variant"/> representation of the provided <typeparamref name="T"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant From<[MustBeVariant] T>(in T from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFrom(from));
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <typeparamref name="T"/>.
+    /// </summary>
+    /// <returns>A <typeparamref name="T"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T As<[MustBeVariant] T>() =>
         VariantUtils.ConvertTo<T>(NativeVar.DangerousSelfRef);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="bool"/>.
+    /// </summary>
+    /// <returns>A <see langword="bool"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool AsBool() =>
         VariantUtils.ConvertToBool((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="char"/>.
+    /// </summary>
+    /// <returns>A <see langword="char"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public char AsChar() =>
         (char)VariantUtils.ConvertToUInt16((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see langword="sbyte"/>.
+    /// </summary>
+    /// <returns>An <see langword="sbyte"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public sbyte AsSByte() =>
         VariantUtils.ConvertToInt8((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="short"/>.
+    /// </summary>
+    /// <returns>A <see langword="short"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public short AsInt16() =>
         VariantUtils.ConvertToInt16((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see langword="int"/>.
+    /// </summary>
+    /// <returns>An <see langword="int"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int AsInt32() =>
         VariantUtils.ConvertToInt32((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="long"/>.
+    /// </summary>
+    /// <returns>A <see langword="long"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public long AsInt64() =>
         VariantUtils.ConvertToInt64((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="byte"/>.
+    /// </summary>
+    /// <returns>A <see langword="byte"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte AsByte() =>
         VariantUtils.ConvertToUInt8((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="ushort"/>.
+    /// </summary>
+    /// <returns>A <see langword="ushort"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ushort AsUInt16() =>
         VariantUtils.ConvertToUInt16((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="uint"/>.
+    /// </summary>
+    /// <returns>A <see langword="uint"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public uint AsUInt32() =>
         VariantUtils.ConvertToUInt32((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="ulong"/>.
+    /// </summary>
+    /// <returns>A <see langword="ulong"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ulong AsUInt64() =>
         VariantUtils.ConvertToUInt64((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="float"/>.
+    /// </summary>
+    /// <returns>A <see langword="float"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float AsSingle() =>
         VariantUtils.ConvertToFloat32((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="double"/>.
+    /// </summary>
+    /// <returns>A <see langword="double"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public double AsDouble() =>
         VariantUtils.ConvertToFloat64((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="string"/>.
+    /// </summary>
+    /// <returns>A <see langword="string"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string AsString() =>
         VariantUtils.ConvertToString((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector2"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector2"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector2 AsVector2() =>
         VariantUtils.ConvertToVector2((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector2I"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector2I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector2I AsVector2I() =>
         VariantUtils.ConvertToVector2I((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Rect2"/>.
+    /// </summary>
+    /// <returns>A <see cref="Rect2"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Rect2 AsRect2() =>
         VariantUtils.ConvertToRect2((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Rect2I"/>.
+    /// </summary>
+    /// <returns>A <see cref="Rect2I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Rect2I AsRect2I() =>
         VariantUtils.ConvertToRect2I((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Transform2D"/>.
+    /// </summary>
+    /// <returns>A <see cref="Transform2D"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Transform2D AsTransform2D() =>
         VariantUtils.ConvertToTransform2D((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector3"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector3"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector3 AsVector3() =>
         VariantUtils.ConvertToVector3((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector3I"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector3I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector3I AsVector3I() =>
         VariantUtils.ConvertToVector3I((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Basis"/>.
+    /// </summary>
+    /// <returns>A <see cref="Basis"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Basis AsBasis() =>
         VariantUtils.ConvertToBasis((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Quaternion"/>.
+    /// </summary>
+    /// <returns>A <see cref="Quaternion"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Quaternion AsQuaternion() =>
         VariantUtils.ConvertToQuaternion((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Transform3D"/>.
+    /// </summary>
+    /// <returns>A <see cref="Transform3D"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Transform3D AsTransform3D() =>
         VariantUtils.ConvertToTransform3D((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector4"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector4"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector4 AsVector4() =>
         VariantUtils.ConvertToVector4((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector4I"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector4I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector4I AsVector4I() =>
         VariantUtils.ConvertToVector4I((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Projection"/>.
+    /// </summary>
+    /// <returns>A <see cref="Projection"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Projection AsProjection() =>
         VariantUtils.ConvertToProjection((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A <see cref="Aabb"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Aabb AsAabb() =>
         VariantUtils.ConvertToAabb((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Color"/>.
+    /// </summary>
+    /// <returns>A <see cref="Color"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Color AsColor() =>
         VariantUtils.ConvertToColor((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Plane"/>.
+    /// </summary>
+    /// <returns>A <see cref="Plane"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Plane AsPlane() =>
         VariantUtils.ConvertToPlane((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Callable"/>.
+    /// </summary>
+    /// <returns>A <see cref="Callable"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Callable AsCallable() =>
         VariantUtils.ConvertToCallable((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Signal"/>.
+    /// </summary>
+    /// <returns>A <see cref="Signal"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Signal AsSignal() =>
         VariantUtils.ConvertToSignal((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="byte"/>[].
+    /// </summary>
+    /// <returns>A <see langword="byte"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte[] AsByteArray() =>
         VariantUtils.ConvertAsPackedByteArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see langword="int"/>[].
+    /// </summary>
+    /// <returns>An <see langword="int"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int[] AsInt32Array() =>
         VariantUtils.ConvertAsPackedInt32ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="long"/>[].
+    /// </summary>
+    /// <returns>A <see langword="long"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public long[] AsInt64Array() =>
         VariantUtils.ConvertAsPackedInt64ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="float"/>[].
+    /// </summary>
+    /// <returns>A <see langword="float"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float[] AsFloat32Array() =>
         VariantUtils.ConvertAsPackedFloat32ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="double"/>[].
+    /// </summary>
+    /// <returns>A <see langword="double"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public double[] AsFloat64Array() =>
         VariantUtils.ConvertAsPackedFloat64ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see langword="string"/>[].
+    /// </summary>
+    /// <returns>A <see langword="string"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string[] AsStringArray() =>
         VariantUtils.ConvertAsPackedStringArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector2"/>[].
+    /// </summary>
+    /// <returns>A <see cref="Vector2"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector2[] AsVector2Array() =>
         VariantUtils.ConvertAsPackedVector2ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Vector3"/>[].
+    /// </summary>
+    /// <returns>A <see cref="Vector3"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Vector3[] AsVector3Array() =>
         VariantUtils.ConvertAsPackedVector3ArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Color"/>[].
+    /// </summary>
+    /// <returns>A <see cref="Color"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Color[] AsColorArray() =>
         VariantUtils.ConvertAsPackedColorArrayToSystemArray((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <typeparamref name="T"/>[].
+    /// </summary>
+    /// <returns>A <typeparamref name="T"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T[] AsGodotObjectArray<T>()
         where T : GodotObject =>
         VariantUtils.ConvertToSystemArrayOfGodotObject<T>((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Collections.Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>A <see cref="Collections.Dictionary{TKey, TValue}"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Dictionary<TKey, TValue> AsGodotDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>() =>
         VariantUtils.ConvertToDictionary<TKey, TValue>((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see cref="Collections.Array{T}"/>.
+    /// </summary>
+    /// <returns>An <see cref="Collections.Array{T}"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Array<T> AsGodotArray<[MustBeVariant] T>() =>
         VariantUtils.ConvertToArray<T>((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="StringName"/>[].
+    /// </summary>
+    /// <returns>A <see cref="StringName"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public StringName[] AsSystemArrayOfStringName() =>
         VariantUtils.ConvertToSystemArrayOfStringName((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="NodePath"/>[].
+    /// </summary>
+    /// <returns>A <see cref="NodePath"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public NodePath[] AsSystemArrayOfNodePath() =>
         VariantUtils.ConvertToSystemArrayOfNodePath((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see cref="Rid"/>[].
+    /// </summary>
+    /// <returns>An <see cref="Rid"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Rid[] AsSystemArrayOfRid() =>
         VariantUtils.ConvertToSystemArrayOfRid((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="GodotObject"/>.
+    /// </summary>
+    /// <returns>A <see cref="GodotObject"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GodotObject AsGodotObject() =>
         VariantUtils.ConvertToGodotObject((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="StringName"/>.
+    /// </summary>
+    /// <returns>A <see cref="StringName"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public StringName AsStringName() =>
         VariantUtils.ConvertToStringName((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="NodePath"/>.
+    /// </summary>
+    /// <returns>A <see cref="NodePath"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public NodePath AsNodePath() =>
         VariantUtils.ConvertToNodePath((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see cref="Rid"/>.
+    /// </summary>
+    /// <returns>An <see cref="Rid"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Rid AsRid() =>
         VariantUtils.ConvertToRid((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to a <see cref="Collections.Dictionary"/>.
+    /// </summary>
+    /// <returns>A <see cref="Collections.Dictionary"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Dictionary AsGodotDictionary() =>
         VariantUtils.ConvertToDictionary((godot_variant)NativeVar);
 
+    /// <summary>
+    /// Converts this <see cref="Variant"/> to an <see cref="Collections.Array"/>.
+    /// </summary>
+    /// <returns>An <see cref="Collections.Array"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Collections.Array AsGodotArray() =>
         VariantUtils.ConvertToArray((godot_variant)NativeVar);
 
     // Explicit conversion operators to supported types
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="bool"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="bool"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator bool(Variant from) => from.AsBool();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="char"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="char"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator char(Variant from) => from.AsChar();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to an <see langword="sbyte"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>An <see langword="sbyte"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator sbyte(Variant from) => from.AsSByte();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="short"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="short"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator short(Variant from) => from.AsInt16();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to an <see langword="int"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>An <see langword="int"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator int(Variant from) => from.AsInt32();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="long"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="long"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator long(Variant from) => from.AsInt64();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="byte"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="byte"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator byte(Variant from) => from.AsByte();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="ushort"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="ushort"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator ushort(Variant from) => from.AsUInt16();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="uint"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="uint"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator uint(Variant from) => from.AsUInt32();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="ulong"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="ulong"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator ulong(Variant from) => from.AsUInt64();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="float"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="float"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator float(Variant from) => from.AsSingle();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="double"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="double"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator double(Variant from) => from.AsDouble();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="string"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="string"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator string(Variant from) => from.AsString();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector2"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector2(Variant from) => from.AsVector2();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector2I"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector2I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector2I(Variant from) => from.AsVector2I();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Rect2"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Rect2"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Rect2(Variant from) => from.AsRect2();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Rect2I"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Rect2I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Rect2I(Variant from) => from.AsRect2I();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Transform2D"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Transform2D"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Transform2D(Variant from) => from.AsTransform2D();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector3"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector3(Variant from) => from.AsVector3();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector3I"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector3I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector3I(Variant from) => from.AsVector3I();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Basis"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Basis"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Basis(Variant from) => from.AsBasis();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Quaternion"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Quaternion"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Quaternion(Variant from) => from.AsQuaternion();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Transform3D"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Transform3D"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Transform3D(Variant from) => from.AsTransform3D();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector4"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector4(Variant from) => from.AsVector4();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector4I"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector4I"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector4I(Variant from) => from.AsVector4I();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Projection"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Projection"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Projection(Variant from) => from.AsProjection();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Aabb"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Aabb"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Aabb(Variant from) => from.AsAabb();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Color"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Color"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Color(Variant from) => from.AsColor();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Plane"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Plane"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Plane(Variant from) => from.AsPlane();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Callable"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Callable"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Callable(Variant from) => from.AsCallable();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Signal"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Signal"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Signal(Variant from) => from.AsSignal();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="byte"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="byte"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator byte[](Variant from) => from.AsByteArray();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to an <see langword="int"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>An <see langword="int"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator int[](Variant from) => from.AsInt32Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="long"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="long"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator long[](Variant from) => from.AsInt64Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="float"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="float"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator float[](Variant from) => from.AsFloat32Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="double"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="double"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator double[](Variant from) => from.AsFloat64Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see langword="string"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see langword="string"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator string[](Variant from) => from.AsStringArray();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector2"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector2"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector2[](Variant from) => from.AsVector2Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Vector3"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Vector3"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Vector3[](Variant from) => from.AsVector3Array();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Color"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Color"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Color[](Variant from) => from.AsColorArray();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="StringName"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="StringName"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator StringName[](Variant from) => from.AsSystemArrayOfStringName();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="NodePath"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="NodePath"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator NodePath[](Variant from) => from.AsSystemArrayOfNodePath();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Rid"/>[].
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Rid"/>[] representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Rid[](Variant from) => from.AsSystemArrayOfRid();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="GodotObject"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="GodotObject"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator GodotObject(Variant from) => from.AsGodotObject();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="StringName"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="StringName"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator StringName(Variant from) => from.AsStringName();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="NodePath"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="NodePath"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator NodePath(Variant from) => from.AsNodePath();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Rid"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Rid"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Rid(Variant from) => from.AsRid();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to a <see cref="Collections"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>A <see cref="Collections"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Collections.Dictionary(Variant from) => from.AsGodotDictionary();
 
+    /// <summary>
+    /// Converts the provided <see cref="Variant"/> to an <see cref="Collections.Array"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Variant"/> to convert.</param>
+    /// <returns>An <see cref="Collections.Array"/> representation of this <see cref="Variant"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator Collections.Array(Variant from) => from.AsGodotArray();
 
     // While we provide implicit conversion operators, normal methods are still needed for
     // casts that are not done implicitly (e.g.: raw array to Span, enum to integer, etc).
 
+    /// <summary>
+    /// Converts the provided <see langword="bool"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="bool"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="bool"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(bool from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="char"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="char"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="char"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(char from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="sbyte"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="sbyte"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="sbyte"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(sbyte from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="short"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="short"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="short"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(short from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="int"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="int"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="int"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(int from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="long"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="long"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="long"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(long from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="byte"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="byte"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="byte"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(byte from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="ushort"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="ushort"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="ushort"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(ushort from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="uint"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="uint"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="uint"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(uint from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="ulong"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="ulong"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="ulong"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(ulong from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="float"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="float"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="float"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(float from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="double"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="double"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="double"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(double from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="string"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="string"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="string"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(string from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector2 from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector2I from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Rect2"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rect2"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rect2"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Rect2 from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Rect2I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rect2I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rect2I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Rect2I from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Transform2D"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Transform2D"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Transform2D"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Transform2D from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector3 from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector3I from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Basis"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Basis"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Basis"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Basis from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Quaternion"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Quaternion"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Quaternion"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Quaternion from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Transform3D"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Transform3D"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Transform3D"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Transform3D from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector4"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector4"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector4"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector4 from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector4I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector4I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector4I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Vector4I from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Projection"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Projection"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Projection"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Projection from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Aabb"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Aabb"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Aabb"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Aabb from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Color"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Color"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Color"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Color from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Plane"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Plane"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Plane"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Plane from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Callable"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Callable"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Callable"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Callable from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Signal"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Signal"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Signal"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Signal from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="byte"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="byte"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="byte"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<byte> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="int"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="int"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="int"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<int> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="long"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="long"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="long"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<long> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="float"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="float"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="float"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<float> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="double"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="double"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="double"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<double> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see langword="string"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="string"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="string"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<string> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<Vector2> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<Vector3> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Color"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Color"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Color"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<Color> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="GodotObject"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="GodotObject"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="GodotObject"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(GodotObject[] from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Dictionary{TKey, TValue}"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Dictionary{TKey, TValue}"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Dictionary{TKey, TValue}"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom<[MustBeVariant] TKey, [MustBeVariant] TValue>(Collections.Dictionary<TKey, TValue> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromDictionary(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Array{T}"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Array{T}"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Array{T}"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom<[MustBeVariant] T>(Collections.Array<T> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromArray(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="StringName"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="StringName"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<StringName> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="NodePath"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="NodePath"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<NodePath> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Rid"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rid"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rid"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Span<Rid> from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="GodotObject"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="GodotObject"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="GodotObject"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(GodotObject from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="StringName"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="StringName"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(StringName from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="NodePath"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="NodePath"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(NodePath from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Rid"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rid"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rid"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Rid from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Dictionary"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Dictionary"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Dictionary"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Collections.Dictionary from) => from;
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Array"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Array"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Array"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Variant CreateFrom(Collections.Array from) => from;
 
     // Implicit conversion operators
 
+    /// <summary>
+    /// Converts the provided <see langword="bool"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="bool"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="bool"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(bool from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromBool(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="char"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="char"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="char"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(char from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="sbyte"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="sbyte"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="sbyte"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(sbyte from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="short"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="short"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="short"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(short from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="int"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="int"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="int"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(int from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="long"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="long"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="long"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(long from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="byte"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="byte"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="byte"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(byte from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="ushort"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="ushort"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="ushort"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(ushort from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="uint"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="uint"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="uint"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(uint from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="ulong"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="ulong"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="ulong"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(ulong from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromInt(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="float"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="float"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="float"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(float from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromFloat(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="double"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="double"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="double"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(double from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromFloat(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="string"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="string"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="string"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(string from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromString(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector2 from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector2(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector2I from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector2I(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Rect2"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rect2"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rect2"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Rect2 from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromRect2(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Rect2I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rect2I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rect2I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Rect2I from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromRect2I(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Transform2D"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Transform2D"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Transform2D"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Transform2D from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromTransform2D(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector3 from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector3(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector3I from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector3I(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Basis"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Basis"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Basis"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Basis from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromBasis(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Quaternion"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Quaternion"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Quaternion"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Quaternion from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromQuaternion(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Transform3D"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Transform3D"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Transform3D"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Transform3D from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromTransform3D(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector4"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector4"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector4"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector4 from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector4(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector4I"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector4I"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector4I"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector4I from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromVector4I(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Projection"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Projection"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Projection"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Projection from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromProjection(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Aabb"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Aabb"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Aabb"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Aabb from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromAabb(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Color"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Color"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Color"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Color from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromColor(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Plane"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Plane"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Plane"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Plane from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPlane(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Callable"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Callable"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Callable"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Callable from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromCallable(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Signal"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Signal"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Signal"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Signal from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSignal(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="byte"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="byte"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="byte"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(byte[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="int"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="int"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="int"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(int[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="long"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="long"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="long"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(long[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="float"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="float"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="float"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(float[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="double"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="double"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="double"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(double[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="string"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="string"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="string"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(string[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector2[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Vector3[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="Color"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Color"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Color"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Color[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="GodotObject"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="GodotObject"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="GodotObject"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(GodotObject[] from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfGodotObject(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="StringName"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="StringName"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(StringName[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="NodePath"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="NodePath"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(NodePath[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see cref="Rid"/>[] to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rid"/>[] to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rid"/>[].</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Rid[] from) =>
         (Variant)from.AsSpan();
 
+    /// <summary>
+    /// Converts the provided <see langword="byte"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="byte"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="byte"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<byte> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedByteArray(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="int"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="int"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="int"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<int> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedInt32Array(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="long"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="long"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="long"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<long> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedInt64Array(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="float"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="float"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="float"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<float> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedFloat32Array(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="double"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="double"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="double"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<double> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedFloat64Array(from));
 
+    /// <summary>
+    /// Converts the provided <see langword="string"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see langword="string"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see langword="string"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<string> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedStringArray(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector2"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector2"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector2"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<Vector2> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedVector2Array(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Vector3"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Vector3"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Vector3"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<Vector3> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedVector3Array(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Color"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Color"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Color"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<Color> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromPackedColorArray(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="StringName"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="StringName"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<StringName> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfStringName(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="NodePath"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="NodePath"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<NodePath> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfNodePath(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Rid"/> span to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rid"/> span to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rid"/> span.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Span<Rid> from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromSystemArrayOfRid(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="GodotObject"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="GodotObject"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="GodotObject"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(GodotObject from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromGodotObject(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="StringName"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="StringName"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(StringName from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromStringName(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="NodePath"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="NodePath"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(NodePath from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromNodePath(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Rid"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Rid"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Rid"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Rid from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromRid(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Dictionary"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Dictionary"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Dictionary"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Collections.Dictionary from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromDictionary(from));
 
+    /// <summary>
+    /// Converts the provided <see cref="Collections.Array"/> to a <see cref="Variant"/>.
+    /// </summary>
+    /// <param name="from">The <see cref="Collections.Array"/> to convert.</param>
+    /// <returns>A <see cref="Variant"/> representation of this <see cref="Collections.Array"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Variant(Collections.Array from) =>
         CreateTakingOwnershipOfDisposableValue(VariantUtils.CreateFromArray(from));

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -11,9 +11,6 @@
     <LangVersion>10</LangVersion>
 
     <AnalysisMode>Recommended</AnalysisMode>
-
-    <!-- Disabled temporarily as it pollutes the warnings, but we need to document public APIs. -->
-    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Godot C# Core API.</Description>


### PR DESCRIPTION
This PR is exclusively aimed at documentation, so absolutely no code changes were made. The sole exception is `GodotSharp.csproj` with the removal of `<NoWarn>CS1591</NoWarn>`, as it now has an accompanying docstring for **every single public API**.

It's entirely possible that some parts of the documentation aren't fully representative of their implementation, as the catch-22 of this scenario was a lack of documentation to know what to document. In addition, many sections were implemented through automation; while I tried my best to double-check for any potential discrepancies, it's entirely possible some still slipped through the cracks. Nonetheless, I'm largely confident in what's in place now & making adjustments at this stage will be *significantly* easier.