### PR TITLE
Allow ui_undo and ui_redo to repeat while shortcut key is held

### DIFF
--- a/core/input/shortcut.h
+++ b/core/input/shortcut.h
@@ -51,6 +51,8 @@ public:
 	bool matches_event(const Ref<InputEvent> &p_event) const;
 	bool has_valid_event() const;
 
+	bool repeatable;
+
 	String get_as_text() const;
 
 	static bool is_event_array_equal(const Array &p_event_array1, const Array &p_event_array2);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1471,6 +1471,10 @@ Ref<Shortcut> EditorSettings::get_shortcut(const String &p_name) const {
 		}
 	}
 
+	if (p_name == "ui_undo" || p_name == "ui_redo") {
+		sc->repeatable = true;
+	}
+
 	if (sc.is_valid()) {
 		// Add the shortcut to the list.
 		shortcuts[p_name] = sc;

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -152,7 +152,7 @@ void MenuBar::shortcut_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	if (p_event->is_pressed() && !p_event->is_echo() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event) || Object::cast_to<InputEventShortcut>(*p_event))) {
+	if (p_event->is_pressed() && (Object::cast_to<InputEventKey>(p_event.ptr()) || Object::cast_to<InputEventJoypadButton>(p_event.ptr()) || Object::cast_to<InputEventAction>(*p_event) || Object::cast_to<InputEventShortcut>(*p_event))) {
 		if (!get_parent() || !is_visible_in_tree()) {
 			return;
 		}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1843,6 +1843,9 @@ bool PopupMenu::activate_item_by_event(const Ref<InputEvent> &p_event, bool p_fo
 		}
 
 		if (items[i].shortcut.is_valid() && items[i].shortcut->matches_event(p_event) && (items[i].shortcut_is_global || !p_for_global_only)) {
+			if (p_event->is_echo() && !items[i].shortcut->repeatable) {
+				return false;
+			}
 			activate_item(i);
 			return true;
 		}


### PR DESCRIPTION
Fixes #79181 

Adds a `repeatable` field to `Shortcut`, which is hard-coded to true for `ui_undo` and `ui_redo` within `editor_settings.cpp`. I'm not sure if that would be the appropriate place to specify that, but a more ideal solution may require restructuring the builtin shortcuts system, the knowledge for which I do not have.