### PR TITLE
GLES3: Change default texture repeat to disabled

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1297,7 +1297,7 @@ void TextureStorage::_texture_set_data(RID p_texture, const Ref<Image> &p_image,
 		texture->gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
 	}
 
-	texture->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+	texture->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
 	int w = img->get_width();
 	int h = img->get_height();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This is another attempt to fix #79315 (the previous one being #79367, which was declined for not being a direct fix for the issue).

I used RenderDoc to analyze how the texture is being initialized to see if I could get any insights into what's going on. (Side note: I was having trouble getting RenderDoc to work with Godot, and I eventually figured out that `GLManager_Windows::_nvapi_disable_threaded_optimization()` was crashing when running the editor through RenderDoc. If you want to use RenderDoc with Godot, you need to stub this function if you're using Windows and an Nvidia GPU.) Looking through the "Resource Initialization Parameters" for a texture exhibiting this bug, I noticed that it was first initializing the filtering mode to one that the final texture didn't use, set the texture (and mipmap) data with `glTexImage2D`, and then set the actual filter mode. The repeat mode was similarly enabled before the calls to `glTexImage2D`, but wasn't set (either enabled or disabled) again after. This seemed to confirm the second of the theories I mentioned in the description for #79367, which is that calling `glTexImage2D` was disabling the texture repeat.

I looked through the code and figured out that the initial calls to set the repeat mode before calling `glTexImage2D` was happening here:

https://github.com/godotengine/godot/blob/a33b548092433dbeddc05003b3cbd3e0991107d8/drivers/gles3/storage/texture_storage.cpp#L1293-L1300

The comment states that it's setting these to "default" values, which seems to indicate to me that it's here *specifically* to deal with `glTexImage2D` resetting parameters to default values. The problem is that the actual default appears to be to disable texture repeat, not enable it. Changing `RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED` to `RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED` in these defaults makes it so that `Texture::state_repeat` matches the state of the texture after calling `glTexImage2D`, which fixes the bug.

One part of this I'm not sure of is whether this behavior of `glTexImage2D` resetting the texture repeat state is part of the OpenGL / OpenGL ES standard, or is an implementation detail that may vary between drivers. I tried looking it up online, but I couldn't find any relevant documentation about this. While I did test this on the machines I had access to, and they all pointed to a repeat-disabled default, I can't say for certain that there aren't platforms out there where the opposite is true, which will make setting the repeat state to a "default" value here a challenge, and may require a different solution to fix this issue.

This PR targets the master branch, but this should be trivial to cherry-pick for a 4.1.X release.