### PR TITLE
[macOS] Fix uncapped frame rate for windows in the non-active workspaces.

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3256,14 +3256,14 @@ bool DisplayServerMacOS::window_is_focused(WindowID p_window) const {
 }
 
 bool DisplayServerMacOS::window_can_draw(WindowID p_window) const {
-	return window_get_mode(p_window) != WINDOW_MODE_MINIMIZED;
+	return (window_get_mode(p_window) != WINDOW_MODE_MINIMIZED) && [windows[p_window].window_object isOnActiveSpace];
 }
 
 bool DisplayServerMacOS::can_any_window_draw() const {
 	_THREAD_SAFE_METHOD_
 
 	for (const KeyValue<WindowID, WindowData> &E : windows) {
-		if (window_get_mode(E.key) != WINDOW_MODE_MINIMIZED) {
+		if ((window_get_mode(E.key) != WINDOW_MODE_MINIMIZED) && [E.value.window_object isOnActiveSpace]) {
 			return true;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/79569

With this change, windows in non-active workspaces should act the same way as minimized windows (frame rate caped by `application/run/low_processor_mode_sleep_usec` - 144 fps by default).

No idea if there's any way to force proper vsync for non-visibly windows (probably not since window it's not on the specific screen).