### PR TITLE
[Windows] Implement native file selection dialog support.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -109,7 +109,7 @@
 				Displays OS native dialog for selecting files or directories in the file system.
 				Callbacks have the following arguments: [code]bool status, PackedStringArray selected_paths[/code].
 				[b]Note:[/b] This method is implemented if the display server has the [code]FEATURE_NATIVE_DIALOG[/code] feature.
-				[b]Note:[/b] This method is implemented on macOS.
+				[b]Note:[/b] This method is implemented on Windows and macOS.
 				[b]Note:[/b] On macOS, native file dialogs have no title.
 				[b]Note:[/b] On macOS, sandboxed apps will save security-scoped bookmarks to retain access to the opened folders across multiple sessions. Use [method OS.get_granted_permissions] to get a list of saved bookmarks.
 			</description>

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -511,6 +511,8 @@ public:
 	virtual bool is_dark_mode() const override;
 	virtual Color get_accent_color() const override;
 
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) override;
+
 	virtual void mouse_set_mode(MouseMode p_mode) override;
 	virtual MouseMode mouse_get_mode() const override;
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -67,14 +67,14 @@ void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files) {
 		if (p_files.size() > 0) {
 			String f = p_files[0];
 			if (mode == FILE_MODE_OPEN_FILES) {
-				emit_signal("files_selected", p_files);
+				emit_signal(SNAME("files_selected"), p_files);
 			} else {
 				if (mode == FILE_MODE_SAVE_FILE) {
-					emit_signal("file_selected", f);
+					emit_signal(SNAME("file_selected"), f);
 				} else if ((mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_FILE) && dir_access->file_exists(f)) {
-					emit_signal("file_selected", f);
+					emit_signal(SNAME("file_selected"), f);
 				} else if (mode == FILE_MODE_OPEN_ANY || mode == FILE_MODE_OPEN_DIR) {
-					emit_signal("dir_selected", f);
+					emit_signal(SNAME("dir_selected"), f);
 				}
 			}
 			file->set_text(f);
@@ -82,7 +82,7 @@ void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files) {
 		}
 	} else {
 		file->set_text("");
-		emit_signal("cancelled");
+		emit_signal(SNAME("canceled"));
 	}
 }
 


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/47499

Implements `DisplayServer.file_dialog_show()` for Windows.

- *Production edit: This partially addresses https://github.com/godotengine/godot-proposals/issues/1123.*