### PR TITLE
[Web] Use `fvisibility=hidden` for side module when `dlink_enabled`.

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -70,6 +70,9 @@ if env["dlink_enabled"]:
     sys_env.Append(LINKFLAGS=["-s", "WARN_ON_UNDEFINED_SYMBOLS=0"])
     # Force exporting the standard library (printf, malloc, etc.)
     sys_env["ENV"]["EMCC_FORCE_STDLIBS"] = "libc,libc++,libc++abi"
+    sys_env["CCFLAGS"].remove("-fvisibility=hidden")
+    sys_env["LINKFLAGS"].remove("-fvisibility=hidden")
+
     # The main emscripten runtime, with exported standard libraries.
     sys = sys_env.Program(build_targets, ["web_runtime.cpp"])
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -211,6 +211,8 @@ def configure(env: "Environment"):
 
         env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])
         env.Append(LINKFLAGS=["-s", "SIDE_MODULE=2"])
+        env.Append(CCFLAGS=["-fvisibility=hidden"])
+        env.Append(LINKFLAGS=["-fvisibility=hidden"])
         env.extra_suffix = ".dlink" + env.extra_suffix
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).


### PR DESCRIPTION
This hugely reduces the number of exports, making it acceptable for browsers.

See https://github.com/emscripten-core/emscripten/issues/15487#issuecomment-1581124318

Note that dlink + threads is still not working due to upstream issues with the pthread emulation library (suspected root cause: https://github.com/emscripten-core/emscripten/issues/19425 ).

Should hopefully be solved once emscripten move to native WASM threads.