### PR TITLE
Allow GDExtension to access core singletons in `INITIALIZATION_LEVEL_SERVERS`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2111,7 +2111,6 @@ Error Main::setup2() {
 
 	register_server_types();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
-	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager || cmdline_tool) {
@@ -2316,6 +2315,7 @@ Error Main::setup2() {
 	xr_server = memnew(XRServer);
 
 	register_core_singletons();
+	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SERVERS);
 
 	MAIN_PRINT("Main: Setup Logo");
 


### PR DESCRIPTION
There are long-standing tricky problems with GDExtension accessing the core singletons, due to the order that they are registered and created.

This PR moves the execution of GDExtension's `INITALIZATION_LEVEL_SERVERS` until after the core singletons are registered.

This does create a difference between modules and GDExtensions: modules have `INITIALIZATION_LEVEL_SERVERS` run before the singletons are registered. However, modules don't actually need the singletons be registered, because they can fetch them directly!

So, while this is creating a difference, it's allowing the code in a GDExtension to _effectively_ be more similar to a module's, by allowing it to access singletons at all during this level.

EDIT: Marking this as a draft currently, as this is currently just a proposal for discussion on the GDExtension team. Will take it out of draft if folks think this makes sense!