### PR TITLE
Use current locale as the default in get_tool_locale()

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -713,7 +713,7 @@ String TranslationServer::get_tool_locale() {
 	{
 #endif
 		// Look for best matching loaded translation.
-		String best_locale = "en";
+		String best_locale = get_locale();
 		int best_score = 0;
 
 		for (const Ref<Translation> &E : translations) {


### PR DESCRIPTION
Fixes #79585
I wasn't sure if line 709 should have a similar change.