### PR TITLE
Show valid types in SceneTreeDialog

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2797,7 +2797,7 @@ void EditorPropertyNodePath::_node_assign() {
 	if (!scene_tree) {
 		scene_tree = memnew(SceneTreeDialog);
 		scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
-		scene_tree->get_scene_tree()->set_valid_types(valid_types);
+		scene_tree->set_valid_types(valid_types);
 		add_child(scene_tree);
 		scene_tree->connect("selected", callable_mp(this, &EditorPropertyNodePath::_node_selected));
 	}
@@ -3145,7 +3145,7 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 
 			Vector<StringName> valid_types;
 			valid_types.push_back("Viewport");
-			scene_tree->get_scene_tree()->set_valid_types(valid_types);
+			scene_tree->set_valid_types(valid_types);
 			scene_tree->get_scene_tree()->set_show_enabled_subscene(true);
 
 			add_child(scene_tree);

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -35,6 +35,7 @@
 #include "scene/gui/tree.h"
 
 class EditorSelection;
+class TextureRect;
 
 class SceneTreeEditor : public Control {
 	GDCLASS(SceneTreeEditor, Control);
@@ -172,10 +173,10 @@ public:
 class SceneTreeDialog : public ConfirmationDialog {
 	GDCLASS(SceneTreeDialog, ConfirmationDialog);
 
+	VBoxContainer *content = nullptr;
 	SceneTreeEditor *tree = nullptr;
-	//Button *select;
-	//Button *cancel;
 	LineEdit *filter = nullptr;
+	LocalVector<TextureRect *> valid_type_icons;
 
 	void _select();
 	void _cancel();
@@ -189,8 +190,11 @@ protected:
 
 public:
 	void popup_scenetree_dialog();
+	void set_valid_types(const Vector<StringName> &p_valid);
+
 	SceneTreeEditor *get_scene_tree() { return tree; }
 	LineEdit *get_filter_line_edit() { return filter; }
+
 	SceneTreeDialog();
 	~SceneTreeDialog();
 };


### PR DESCRIPTION
When picking node for Node/NodePath property, allowed type is now displayed at the top:
![image](https://github.com/godotengine/godot/assets/2223172/2efcd105-1ec9-420a-8a41-c3dd7a04c317)

Multiple types:
![image](https://github.com/godotengine/godot/assets/2223172/08fd75d7-9df8-4e14-8894-5bdd37d63cdf)

Closes #62483