### PR TITLE
Make `AnimationNodeBlendTree` use `RBMap` instead `HashMap`

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1178,8 +1178,6 @@ void AnimationNodeBlendTree::get_child_nodes(List<ChildNode> *r_child_nodes) {
 		ns.push_back(E.key);
 	}
 
-	ns.sort_custom<StringName::AlphCompare>();
-
 	for (int i = 0; i < ns.size(); i++) {
 		ChildNode cn;
 		cn.name = ns[i];
@@ -1435,7 +1433,6 @@ void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) cons
 	for (const KeyValue<StringName, Node> &E : nodes) {
 		names.push_back(E.key);
 	}
-	names.sort_custom<StringName::AlphCompare>();
 
 	for (const StringName &E : names) {
 		String prop_name = E;

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -388,7 +388,7 @@ class AnimationNodeBlendTree : public AnimationRootNode {
 		Vector<StringName> connections;
 	};
 
-	HashMap<StringName, Node> nodes;
+	RBMap<StringName, Node, StringName::AlphCompare> nodes;
 
 	Vector2 graph_offset;
 


### PR DESCRIPTION
Fixes #42788. Alternative PR of #79530.

`node_connections` is stored in ordered array, but the order of the array depends on the `HashMap nodes`, so every time the hash is changed, the `.tres` is changed.

This PR ensures uniqueness in the order of nodes by using an `RBMap` for nodes.

However, there seems to be a problem with inconsistent insertion locations when `StringName` is used as the key for `RBMap` (see also #79596). Therefore, `RBMap<String, Node>` should be used instead of `RBMap<StringName, Node>`.

Although not related to this PR, if you are using `RBMap<StringName, V>` in other classes, you may need to replace it with `HashMap<StringName, V>` or `RBMap<String, V>`.

