### PR TITLE
Fix rename animation in SpriteFramesEditor

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1508,6 +1508,10 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	int base = 1;
 	String name = base_name;
 	while (state_machine->has_node(name)) {
+		if (name == prev_name) {
+			name_edit_popup->hide(); // The old name wins, the name doesn't change, just hide the popup.
+			return;
+		}
 		base++;
 		name = base_name + " " + itos(base);
 	}

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -949,13 +949,16 @@ void SpriteFramesEditor::_animation_name_edited() {
 	String name = new_name;
 	int counter = 0;
 	while (frames->has_animation(name)) {
+		if (name == String(edited_anim)) {
+			edited->set_text(0, name); // The name didn't change, just updated the column text to name.
+			return;
+		}
 		counter++;
 		name = new_name + "_" + itos(counter);
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Rename Animation"), UndoRedo::MERGE_DISABLE, EditorNode::get_singleton()->get_edited_scene());
-	_rename_node_animation(undo_redo, false, edited_anim, "", "");
 	undo_redo->add_do_method(frames.ptr(), "rename_animation", edited_anim, name);
 	undo_redo->add_undo_method(frames.ptr(), "rename_animation", name, edited_anim);
 	_rename_node_animation(undo_redo, false, edited_anim, name, name);


### PR DESCRIPTION
When the name suffix grows, the old name is used if it is obtained first.

Fix the case where the following error message would appear when renaming an animation.

```
ERROR: Animation '' doesn't exist.
   at: get_frame_count (scene/resources/sprite_frames.cpp:71)
```

Fix #73883.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
