### PR TITLE
Fix instance uniform data buffer update delay

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3994,11 +3994,12 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 }
 
 void RendererSceneCull::update_dirty_instances() {
-	RSG::utilities->update_dirty_resources();
-
 	while (_instance_update_list.first()) {
 		_update_dirty_instance(_instance_update_list.first()->self());
 	}
+
+	// Update dirty resources after dirty instances as instance updates may affect resources.
+	RSG::utilities->update_dirty_resources();
 }
 
 void RendererSceneCull::update() {


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/79602

This PR simply moves dirty resource updates after instance updates, as instance updates can cause some resources to become dirty. This can cause an extra frame of delay when updating instance uniforms, multimesh data or particle data. For example in the MRP project in the linked issue, the update order currently goes like this:

1) User code calls `set_instance_shader_parameter()`, data is sent to server.
2) Rendering loop eventually calls `RendererSceneCull::update_dirty_instances()`.
3) `RSG::utilities->update_dirty_resources()` updates dirty resources, more importantly in this scenario it calls `MaterialStorage::get_singleton()->_update_global_shader_uniforms()` which `buffer_update()`'s dirty instance+global uniform data to GPU.
4) Rendering code loops through dirty instances, calls `_update_dirty_instance()` for each of them and marks resources as dirty, including instance uniform buffer.

This PR basically reverses the order of steps 3 and 4. Because step 4 can actually mark resources as dirty but as the dirty resources were already uploaded to GPU in step 3 this will cause one frame update delay.

I tested this PR with some more complex demos and didn't notice any regressions, but these issues can be pretty subtle to notice.

Also, if this PR is accepted, the same reordering should probably done to this PR https://github.com/godotengine/godot/pull/77594 as it adds `RendererCanvasCull::update_dirty_instances(`) which is functionally similar to RendererSceneCull implementation.