### PR TITLE
Add Ctrl+/ as a shortcut to toggle comment in addition to Ctrl+K

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2293,7 +2293,7 @@ void ScriptTextEditor::register_editor() {
 
 	ED_SHORTCUT("script_text_editor/indent", TTR("Indent"), Key::NONE);
 	ED_SHORTCUT("script_text_editor/unindent", TTR("Unindent"), KeyModifierMask::SHIFT | Key::TAB);
-	ED_SHORTCUT("script_text_editor/toggle_comment", TTR("Toggle Comment"), KeyModifierMask::CMD_OR_CTRL | Key::K);
+	ED_SHORTCUT_ARRAY("script_text_editor/toggle_comment", TTR("Toggle Comment"), { int32_t(KeyModifierMask::CMD_OR_CTRL | Key::K), int32_t(KeyModifierMask::CMD_OR_CTRL | Key::SLASH) });
 	ED_SHORTCUT("script_text_editor/toggle_fold_line", TTR("Fold/Unfold Line"), KeyModifierMask::ALT | Key::F);
 	ED_SHORTCUT_OVERRIDE("script_text_editor/toggle_fold_line", "macos", KeyModifierMask::CTRL | KeyModifierMask::META | Key::F);
 	ED_SHORTCUT("script_text_editor/fold_all_lines", TTR("Fold All Lines"), Key::NONE);


### PR DESCRIPTION
I am stuck in an infinite loop of habits: Try to press Ctrl+/ in Godot, doesn't work, press Ctrl+K instead, get used to Ctrl+K, switch to VS Code, try to press Ctrl+K, doesn't work, press Ctrl+/ instead, get used to Ctrl+/, switch to Godot, try to press Ctrl+/ in Godot, doesn't work, press Ctrl+K instead...

Considering GDScript uses `#` as the comment symbol, I think <kbd>K</kbd>omment makes more sense than Ctrl+/ conceptually speaking, but we can add Ctrl+/ as an additional shortcut for users with VS Code muscle memory. Since Ctrl+K is at the start of the shortcut array, the keyboard shortcut text in the menu is still Ctrl+K.