### PR TITLE
Compile OpenXR into MacOS build

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -28,6 +28,11 @@ elif env["platform"] == "linuxbsd":
     env_openxr.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
 elif env["platform"] == "windows":
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
+elif env["platform"] == "macos":
+    env_openxr.AppendUnique(CPPDEFINES=["XR_OS_APPLE"])
+
+    # There does not seem to be a XR_USE_PLATFORM_XYZ for Apple
+
 
 # may need to check and set:
 # - XR_USE_TIMESPEC
@@ -95,7 +100,7 @@ if env["platform"] == "android":
     env_openxr.add_source_files(module_obj, "extensions/openxr_android_extension.cpp")
 if env["vulkan"]:
     env_openxr.add_source_files(module_obj, "extensions/openxr_vulkan_extension.cpp")
-if env["opengl3"]:
+if env["opengl3"] and env["platform"] != "macos":
     env_openxr.add_source_files(module_obj, "extensions/openxr_opengl_extension.cpp")
 
 env_openxr.add_source_files(module_obj, "extensions/openxr_palm_pose_extension.cpp")

--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    if platform in ("linuxbsd", "windows", "android"):
+    if platform in ("linuxbsd", "windows", "android", "macos"):
         return env["openxr"] and not env["disable_3d"]
     else:
         # not supported on these platforms

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -47,7 +47,7 @@
 #ifdef VULKAN_ENABLED
 #define XR_USE_GRAPHICS_API_VULKAN
 #endif
-#ifdef GLES3_ENABLED
+#if defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
 #ifdef ANDROID_ENABLED
 #define XR_USE_GRAPHICS_API_OPENGL_ES
 #include <EGL/egl.h>
@@ -72,7 +72,7 @@
 #include "extensions/openxr_vulkan_extension.h"
 #endif
 
-#ifdef GLES3_ENABLED
+#if defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
 #include "extensions/openxr_opengl_extension.h"
 #endif
 
@@ -1306,7 +1306,7 @@ bool OpenXRAPI::initialize(const String &p_rendering_driver) {
 		ERR_FAIL_V(false);
 #endif
 	} else if (p_rendering_driver == "opengl3") {
-#ifdef GLES3_ENABLED
+#if defined(GLES3_ENABLED) && !defined(MACOS_ENABLED)
 		graphics_extension = memnew(OpenXROpenGLExtension);
 		register_extension_wrapper(graphics_extension);
 #else


### PR DESCRIPTION
Now that Khronos added OpenXR support on MacOS I've added support for it in Godot even though Apple doesn't do anything with XR on Mac.

As a bonus it nicely solves the issue of the action map editor not being available on Mac. You can developer Quest applications on Mac (and we have various people doing so) but you couldn't configure the action map so that was annoying.

Now obviously with MacOS support for OpenXR there are things in the works. I believe Monado is working on MacOS support which would allow various PCVR headsets to potentially work on Mac, and there are likely other options coming soon.

*Bugsquad edit: fixes #79582*
