### PR TITLE
Add size check to prevent popup bigger than the screen itself

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1633,7 +1633,10 @@ void Window::popup(const Rect2i &p_screen_rect) {
 
 	if (p_screen_rect != Rect2i()) {
 		set_position(p_screen_rect.position);
-		set_size(p_screen_rect.size);
+		int screen_id = DisplayServer::get_singleton()->get_screen_from_rect(p_screen_rect);
+		Size2i screen_size = DisplayServer::get_singleton()->screen_get_usable_rect(screen_id).size;
+		Size2i new_size = p_screen_rect.size.min(screen_size);
+		set_size(new_size);
 	}
 
 	Rect2i adjust = _popup_adjust_rect();


### PR DESCRIPTION
Add size check to prevent popup bigger than the screen itself.

Fix #78594 however I'm not sure if this is the correct way to do it. Maybe if there's someone who can point me in the right direction. 
___
First, as per the issue #78594 to cause the freeze, have a ridiculous dialog_bounds value in your: 
`.godot/editor/project_metadata.cfg` 
```
[editor_metadata]

executable_path="C:/godok/bin/godot.windows.editor.x86_64.exe"

[debug_options]

run_live_debug=true
run_reload_scripts=true

[recent_files]

scenes=["res://node_2d.tscn"]

[linked_properties]

Node2D:scale=true

[dialog_bounds]

project_settings=Rect2(55, 55, 99999, 99999)
```
Second, open your Project Settings.

#### Before (without this pr)
- The Godot Engine will freeze when you try to open Project Settings 
![image](https://github.com/godotengine/godot/assets/13846022/0111b176-a955-47eb-a7f1-ad7f6f9f1a88)


#### After (with this pr applied)

- The editor will not spawn popup bigger than the user's screen, no more freeze. 
- The window might be off for a bit, but at least now the user can drag it back again and resize it.
![image](https://github.com/godotengine/godot/assets/13846022/842e9052-9222-4e52-9a58-5efe9b0dc87b)

