### PR TITLE
Fix error spamming for 2d skeleton modifications

### DIFF
--- a/scene/resources/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_2d_ccdik.cpp
@@ -250,7 +250,7 @@ void SkeletonModification2DCCDIK::_draw_editor_gizmo() {
 	}
 
 	for (int i = 0; i < ccdik_data_chain.size(); i++) {
-		if (!ccdik_data_chain[i].editor_draw_gizmo) {
+		if (!ccdik_data_chain[i].editor_draw_gizmo || ccdik_data_chain[i].bone_idx < 0) {
 			continue;
 		}
 

--- a/scene/resources/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/skeleton_modification_2d_lookat.cpp
@@ -185,7 +185,7 @@ void SkeletonModification2DLookAt::_setup_modification(SkeletonModificationStack
 }
 
 void SkeletonModification2DLookAt::_draw_editor_gizmo() {
-	if (!enabled || !is_setup) {
+	if (!enabled || !is_setup || bone_idx < 0) {
 		return;
 	}
 

--- a/scene/resources/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_2d_twoboneik.cpp
@@ -197,7 +197,7 @@ void SkeletonModification2DTwoBoneIK::_setup_modification(SkeletonModificationSt
 }
 
 void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
-	if (!enabled || !is_setup) {
+	if (!enabled || !is_setup || joint_one_bone_idx < 0) {
 		return;
 	}
 


### PR DESCRIPTION
bone_id cannot be less than zero
Fixes https://github.com/godotengine/godot/issues/76712