### PR TITLE
Add `export_preserialize` to the GLTF export process

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -17,7 +17,7 @@
 			<param index="1" name="gltf_node" type="GLTFNode" />
 			<param index="2" name="scene_node" type="Node" />
 			<description>
-				Part of the export process. This method is run after [method _export_preflight] and before [method _export_node].
+				Part of the export process. This method is run after [method _export_preflight] and before [method _export_preserialize].
 				Runs when converting the data from a Godot scene node. This method can be used to process the Godot scene node data into a format that can be used by [method _export_node].
 			</description>
 		</method>
@@ -28,7 +28,7 @@
 			<param index="2" name="json" type="Dictionary" />
 			<param index="3" name="node" type="Node" />
 			<description>
-				Part of the export process. This method is run after [method _convert_scene_node] and before [method _export_post].
+				Part of the export process. This method is run after [method _export_preserialize] and before [method _export_post].
 				This method can be used to modify the final JSON of each node.
 			</description>
 		</method>
@@ -47,6 +47,14 @@
 			<description>
 				Part of the export process. This method is run first, before all other parts of the export process.
 				The return value is used to determine if this [GLTFDocumentExtension] instance should be used for exporting a given GLTF file. If [constant OK], the export will use this [GLTFDocumentExtension] instance. If not overridden, [constant OK] is returned.
+			</description>
+		</method>
+		<method name="_export_preserialize" qualifiers="virtual">
+			<return type="int" enum="Error" />
+			<param index="0" name="state" type="GLTFState" />
+			<description>
+				Part of the export process. This method is run after [method _convert_scene_node] and before [method _export_node].
+				This method can be used to alter the state before performing serialization. It runs every time when generating a buffer with [method GLTFDocument.generate_buffer] or writing to the file system with [method GLTFDocument.write_to_filesystem].
 			</description>
 		</method>
 		<method name="_generate_scene_node" qualifiers="virtual">

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -44,6 +44,7 @@ void GLTFDocumentExtension::_bind_methods() {
 	// Export process.
 	GDVIRTUAL_BIND(_export_preflight, "state", "root");
 	GDVIRTUAL_BIND(_convert_scene_node, "state", "gltf_node", "scene_node");
+	GDVIRTUAL_BIND(_export_preserialize, "state");
 	GDVIRTUAL_BIND(_export_node, "state", "gltf_node", "json", "node");
 	GDVIRTUAL_BIND(_export_post, "state");
 }
@@ -132,6 +133,13 @@ void GLTFDocumentExtension::convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFN
 	ERR_FAIL_NULL(p_gltf_node);
 	ERR_FAIL_NULL(p_scene_node);
 	GDVIRTUAL_CALL(_convert_scene_node, p_state, p_gltf_node, p_scene_node);
+}
+
+Error GLTFDocumentExtension::export_preserialize(Ref<GLTFState> p_state) {
+	ERR_FAIL_NULL_V(p_state, ERR_INVALID_PARAMETER);
+	Error err = OK;
+	GDVIRTUAL_CALL(_export_preserialize, p_state, err);
+	return err;
 }
 
 Error GLTFDocumentExtension::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -53,6 +53,7 @@ public:
 	// Export process.
 	virtual Error export_preflight(Ref<GLTFState> p_state, Node *p_root);
 	virtual void convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node);
+	virtual Error export_preserialize(Ref<GLTFState> p_state);
 	virtual Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node);
 	virtual Error export_post(Ref<GLTFState> p_state);
 
@@ -69,6 +70,7 @@ public:
 	// Export process.
 	GDVIRTUAL2R(Error, _export_preflight, Ref<GLTFState>, Node *);
 	GDVIRTUAL3(_convert_scene_node, Ref<GLTFState>, Ref<GLTFNode>, Node *);
+	GDVIRTUAL1R(Error, _export_preserialize, Ref<GLTFState>);
 	GDVIRTUAL4R(Error, _export_node, Ref<GLTFState>, Ref<GLTFNode>, Dictionary, Node *);
 	GDVIRTUAL1R(Error, _export_post, Ref<GLTFState>);
 };

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -115,6 +115,12 @@ Error GLTFDocument::_serialize(Ref<GLTFState> p_state, const String &p_path) {
 		p_state->buffers.push_back(Vector<uint8_t>());
 	}
 
+	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
+		ERR_CONTINUE(ext.is_null());
+		Error err = ext->export_preserialize(p_state);
+		ERR_CONTINUE(err != OK);
+	}
+
 	/* STEP CONVERT MESH INSTANCES */
 	_convert_mesh_instances(p_state);
 


### PR DESCRIPTION
This PR adds a new extension hook to the GLTF export process, `_export_preserialize`. This runs each time we serialize to a buffer or file. This allows extension authors to alter the data between converting Godot nodes to the state data, and converting the state data to JSON. This is also the earliest opportunity to read the destination file name and path.