### PR TITLE
Revert the change of the limit for interpolation of F0 for dielectrics and metals for Screen Space Reflections

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -263,7 +263,9 @@ void main() {
 
 		// Schlick term.
 		float metallic = texelFetch(source_metallic, ssC << 1, 0).w;
-		float f0 = mix(0.04, 0.37, metallic); // The default value of R0 is 0.04 and the maximum value is considered to be Germanium with R0 value of 0.37
+		// F0 is the reflectance of normally incident light (perpendicular to the surface).
+		// Dielectric materials have a widely accepted default value of 0.04. We assume that metals reflect all light, so their F0 is 1.0.
+		float f0 = mix(0.04, 1.0, metallic);
 		float m = clamp(1.0 - dot(normal, -view_dir), 0.0, 1.0);
 		float m2 = m * m;
 		m = m2 * m2 * m; // pow(m,5)


### PR DESCRIPTION
Commit 2c000cb72fc04fd76c5d3b6bc53955f83bf50c71 changed the interpolation limits from (0.04, 1.0) to (0.04, 0.37). This is incorrect, as we want to have an F0 of 0.04 for dielectrics (materials with metalness of 0.0) and an F0 of 1.0 for metals. The Schlick approximation uses an F0 of 0.04 for all dielectrics.
The Fresnel effect does not occur with metals and their F0 has to be 1.0 (they fully reflect normally incident light). Note that the model only assumes metalness of 0.0 or 1.0 but in practice we will have intermediate values when sampling textures which is why interpolating is valid in this case (even if not physically correct).
Relevant to #79549 
