### PR TITLE
Added texture offset for entire TileMap2D layer

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -173,6 +173,14 @@
 				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>
+		<method name="get_layer_texture_offset" qualifiers="const">
+			<return type="Vector2i" />
+			<param index="0" name="layer" type="int" />
+			<description>
+				Returns a TileMap layer's texture offset.
+				If [param layer] is negative, the layers are accessed from the last one.
+			</description>
+		</method>
 		<method name="get_layer_y_sort_origin" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="layer" type="int" />
@@ -387,6 +395,16 @@
 				Assigns a [NavigationServer2D] navigation map [RID] to the specified TileMap [param layer].
 				By default the TileMap uses the default [World2D] navigation map for the first TileMap layer. For each additional TileMap layer a new navigation map is created for the additional layer.
 				In order to make [NavigationAgent2D] switch between TileMap layer navigation maps use [method NavigationAgent2D.set_navigation_map] with the navigation map received from [method get_layer_navigation_map].
+				If [param layer] is negative, the layers are accessed from the last one.
+			</description>
+		</method>
+		<method name="set_layer_texture_offset">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="texture_offset" type="Vector2i" />
+			<description>
+				Sets a layer's texture offset. All tile textures in this layer are drawn at an offset position.
+				Does not affect the position of other properties like physics, navigation or occlusion masks.
 				If [param layer] is negative, the layers are accessed from the last one.
 			</description>
 		</method>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -253,7 +253,7 @@ void TileMapLayer::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::
 					}
 
 					// Drawing the tile in the canvas item.
-					tile_map_node->draw_tile(ci, E_cell.key - tile_position, tile_set, c.source_id, c.get_atlas_coords(), c.alternative_tile, -1, tile_map_node->get_self_modulate(), tile_data, random_animation_offset);
+					tile_map_node->draw_tile(ci, E_cell.key - tile_position + texture_offset, tile_set, c.source_id, c.get_atlas_coords(), c.alternative_tile, -1, tile_map_node->get_self_modulate(), tile_data, random_animation_offset);
 
 					// --- Occluders ---
 					for (int i = 0; i < tile_set->get_occlusion_layers_count(); i++) {
@@ -2230,6 +2230,20 @@ int TileMapLayer::get_y_sort_origin() const {
 	return y_sort_origin;
 }
 
+void TileMapLayer::set_texture_offset(Vector2i p_texture_offset) {
+	if (texture_offset == p_texture_offset) {
+		return;
+	}
+	texture_offset = p_texture_offset;
+	clear_internals();
+	recreate_internals();
+	tile_map_node->emit_signal(CoreStringNames::get_singleton()->changed);
+}
+
+Vector2i TileMapLayer::get_texture_offset() const {
+	return texture_offset;
+}
+
 void TileMapLayer::set_z_index(int p_z_index) {
 	if (z_index == p_z_index) {
 		return;
@@ -3096,6 +3110,14 @@ int TileMap::get_layer_y_sort_origin(int p_layer) const {
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, 0, get_y_sort_origin);
 }
 
+void TileMap::set_layer_texture_offset(int p_layer, Vector2i p_texture_offset) {
+	TILEMAP_CALL_FOR_LAYER(p_layer, set_texture_offset, p_texture_offset);
+}
+
+Vector2i TileMap::get_layer_texture_offset(int p_layer) const {
+	TILEMAP_CALL_FOR_LAYER_V(p_layer, Vector2i(), get_texture_offset);
+}
+
 void TileMap::set_layer_z_index(int p_layer, int p_z_index) {
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_z_index, p_z_index);
 }
@@ -3391,6 +3413,9 @@ bool TileMap::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (components[1] == "y_sort_origin") {
 			set_layer_y_sort_origin(index, p_value);
 			return true;
+		} else if (components[1] == "texture_offset") {
+			set_layer_texture_offset(index, p_value);
+			return true;
 		} else if (components[1] == "z_index") {
 			set_layer_z_index(index, p_value);
 			return true;
@@ -3431,6 +3456,9 @@ bool TileMap::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (components[1] == "y_sort_origin") {
 			r_ret = get_layer_y_sort_origin(index);
 			return true;
+		} else if (components[1] == "texture_offset") {
+			r_ret = get_layer_texture_offset(index);
+			return true;
 		} else if (components[1] == "z_index") {
 			r_ret = get_layer_z_index(index);
 			return true;
@@ -3453,6 +3481,7 @@ void TileMap::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::COLOR, vformat("layer_%d/modulate", i), PROPERTY_HINT_NONE));
 		p_list->push_back(PropertyInfo(Variant::BOOL, vformat("layer_%d/y_sort_enabled", i), PROPERTY_HINT_NONE));
 		p_list->push_back(PropertyInfo(Variant::INT, vformat("layer_%d/y_sort_origin", i), PROPERTY_HINT_NONE, "suffix:px"));
+		p_list->push_back(PropertyInfo(Variant::VECTOR2I, vformat("layer_%d/texture_offset", i), PROPERTY_HINT_NONE, "suffix:px"));
 		p_list->push_back(PropertyInfo(Variant::INT, vformat("layer_%d/z_index", i), PROPERTY_HINT_NONE));
 		p_list->push_back(PropertyInfo(Variant::OBJECT, vformat("layer_%d/tile_data", i), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 	}
@@ -4303,6 +4332,8 @@ void TileMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_layer_y_sort_enabled", "layer"), &TileMap::is_layer_y_sort_enabled);
 	ClassDB::bind_method(D_METHOD("set_layer_y_sort_origin", "layer", "y_sort_origin"), &TileMap::set_layer_y_sort_origin);
 	ClassDB::bind_method(D_METHOD("get_layer_y_sort_origin", "layer"), &TileMap::get_layer_y_sort_origin);
+	ClassDB::bind_method(D_METHOD("set_layer_texture_offset", "layer", "texture_offset"), &TileMap::set_layer_texture_offset);
+	ClassDB::bind_method(D_METHOD("get_layer_texture_offset", "layer"), &TileMap::get_layer_texture_offset);
 	ClassDB::bind_method(D_METHOD("set_layer_z_index", "layer", "z_index"), &TileMap::set_layer_z_index);
 	ClassDB::bind_method(D_METHOD("get_layer_z_index", "layer"), &TileMap::get_layer_z_index);
 	ClassDB::bind_method(D_METHOD("set_layer_navigation_map", "layer", "map"), &TileMap::set_layer_navigation_map);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -173,6 +173,7 @@ private:
 	Color modulate = Color(1, 1, 1, 1);
 	bool y_sort_enabled = false;
 	int y_sort_origin = 0;
+	Vector2i texture_offset;
 	int z_index = 0;
 	RID navigation_map;
 	bool uses_world_navigation_map = false;
@@ -305,6 +306,8 @@ public:
 	bool is_y_sort_enabled() const;
 	void set_y_sort_origin(int p_y_sort_origin);
 	int get_y_sort_origin() const;
+	void set_texture_offset(Vector2i p_texture_offset);
+	Vector2i get_texture_offset() const;
 	void set_z_index(int p_z_index);
 	int get_z_index() const;
 	void set_navigation_map(RID p_map);
@@ -410,6 +413,8 @@ public:
 	bool is_layer_y_sort_enabled(int p_layer) const;
 	void set_layer_y_sort_origin(int p_layer, int p_y_sort_origin);
 	int get_layer_y_sort_origin(int p_layer) const;
+	void set_layer_texture_offset(int p_layer, Vector2i p_texture_offset);
+	Vector2i get_layer_texture_offset(int p_layer) const;
 	void set_layer_z_index(int p_layer, int p_z_index);
 	int get_layer_z_index(int p_layer) const;
 	void set_layer_navigation_map(int p_layer, RID p_map);


### PR DESCRIPTION
This PR adds a simple texture offset for entire layers, allowing isometric/hex 2.5D worlds to be created with a layered tilemap.
Implements [proposal 6715](https://github.com/godotengine/godot-proposals/issues/6715)

I would argue this could even be considered a bugfix, since there is an inconsistency right now:
- Individual tiles in the tileset have a texture origin AND a y-sort offset.
- Layers only have a y-sort offset for the entire layer but no way to offset the textures.

Since the texture origin on individual tiles moves just the texture, and not collision masks/occlusions/navigation/etc, I assumed the texture offset for the entire layer should behave the same. This makes sense for the game I am making, when stacking blocks for a fake 3d voxel look, I want the collision shapes on the ground level and not offset by height.

I tested my code with the attached project.
The top row is non y-sorted and I used a quadrant of size 3 on purpose, this obviously fails but my changes do not make it worse.
The bottom row uses y-sorting.
![screenshot-tilemaps-noysort-and-ysort](https://github.com/godotengine/godot/assets/1334501/0de62283-754e-4c20-94dc-a820bc023d88)

[tilemap_test_project.zip](https://github.com/godotengine/godot/files/12088361/tilemap_test_project.zip)

EDIT: I also consider this change low-risk of breaking existing projects, as I have simply added a Vector2i to the render position of each tile. If this feature is not used, the vector will be (0,0) and nothing will change.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/6715*
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
