### PR TITLE
Fix Camera2D crash when edited scene root is null

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -41,7 +41,7 @@ void Camera2D::_update_scroll() {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		queue_redraw();
 		// Only set viewport transform when not bound to the main viewport.
-		if (get_viewport() == get_tree()->get_edited_scene_root()->get_viewport()) {
+		if (get_tree()->get_edited_scene_root() && get_viewport() == get_tree()->get_edited_scene_root()->get_viewport()) {
 			return;
 		}
 	}


### PR DESCRIPTION
The current code assumes that `get_tree()->get_edited_scene_root()` is available when `Engine::get_singleton->is_editor_hint()` is `true`, but it isn't when the Camera2D is instantiated as an editor plugin.

This PR simply adds a check.

Fixes #76035 
Fixes #77670
