### PR TITLE
Fix arg count checks in `SceneDebugger`

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -163,6 +163,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		live_editor->_res_set_func(p_args[0], p_args[1], p_args[2]);
 
 	} else if (p_msg == "live_node_call") {
+		ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
 		LocalVector<Variant> args;
 		LocalVector<Variant *> argptrs;
 		args.resize(p_args.size() - 2);
@@ -171,11 +172,10 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 			args[i] = p_args[i + 2];
 			argptrs[i] = &args[i];
 		}
-		live_editor->_node_call_func(p_args[0], p_args[1], (const Variant **)argptrs.ptr(), argptrs.size());
+		live_editor->_node_call_func(p_args[0], p_args[1], argptrs.size() ? (const Variant **)argptrs.ptr() : nullptr, argptrs.size());
 
 	} else if (p_msg == "live_res_call") {
-		ERR_FAIL_COND_V(p_args.size() < 10, ERR_INVALID_DATA);
-
+		ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
 		LocalVector<Variant> args;
 		LocalVector<Variant *> argptrs;
 		args.resize(p_args.size() - 2);
@@ -184,7 +184,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 			args[i] = p_args[i + 2];
 			argptrs[i] = &args[i];
 		}
-		live_editor->_res_call_func(p_args[0], p_args[1], (const Variant **)argptrs.ptr(), argptrs.size());
+		live_editor->_res_call_func(p_args[0], p_args[1], argptrs.size() ? (const Variant **)argptrs.ptr() : nullptr, argptrs.size());
 
 	} else if (p_msg == "live_create_node") {
 		ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);


### PR DESCRIPTION
In #58929 args passed to `SceneDebugger::parse_message` were changed to no longer be fixed size. However:

- For `p_msg == "live_node_call"` case the error was removed, instead of modified to handle variadic arg count.
- For `p_msg == "live_res_call"` case the error was unchanged, instead of modified to handle variadic arg count.

This PR fixes error checking for both cases.

Fixes #79616.