### PR TITLE
Clarify when the `changed` signal is emitted for `Resource` and `Material`

### DIFF
--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -32,7 +32,7 @@
 		<method name="emit_changed">
 			<return type="void" />
 			<description>
-				Emits the [signal changed] signal. This method is called automatically for built-in resources.
+				Emits the [signal changed] signal. This method is called automatically for some built-in resources.
 				[b]Note:[/b] For custom resources, it's recommended to call this method whenever a meaningful change occurs, such as a modified property. This ensures that custom [Object]s depending on the resource are properly updated.
 				[codeblock]
 				var damage:

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A material that uses a custom [Shader] program to render either items to screen or process particles. You can create multiple materials for the same shader but configure different values for the uniforms defined in the shader.
+		[b]Note:[/b] For performance reasons the [signal Resource.changed] signal is only emitted when the [member Resource.resource_name] is changed. Only in editor, is also emitted for [member shader] changes.
 	</description>
 	<tutorials>
 		<link title="Shaders documentation index">$DOCS_URL/tutorials/shaders/index.html</link>


### PR DESCRIPTION
Proposed fix to [#69571](https://github.com/godotengine/godot/issues/69571)

* *Bugsquad edit, fixes: #69571*