### PR TITLE
Avoid duplicate filters and update icon on theme change

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3031,7 +3031,9 @@ void SceneTreeDock::_update_tree_menu() {
 }
 
 void SceneTreeDock::_update_filter_menu() {
-	_append_filter_options_to(filter->get_menu());
+	if (filter->get_menu()->get_item_idx_from_text(TTR("Filters")) == -1) {
+		_append_filter_options_to(filter->get_menu());
+	}
 }
 
 void SceneTreeDock::_filter_changed(const String &p_filter) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1385,6 +1385,11 @@ void SceneTreeDock::_notification(int p_what) {
 			button_tree_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
 			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+			// Also remember to update the theme icon in filter menu, if menu was ever opened
+			int filter_menu_search_icon_idx = filter->get_menu()->get_item_idx_from_text(TTR("Filters"));
+			if (filter_menu_search_icon_idx != -1) {
+				filter->get_menu()->set_item_icon(filter_menu_search_icon_idx, get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+			}
 
 			// These buttons are created on READY, because reasons...
 			if (button_2d) {


### PR DESCRIPTION
I found a bug while testing the change from @garychia in https://github.com/godotengine/godot/pull/79650

Actually, this bug existed before his change too.

Once the filter menu in scene tree dock had been opened, the search icon would be determined based on the current theme. However if you switched themes after opening the menu, the icon would never update.

Fixes #79630 and the additional issue described above.