### PR TITLE
Fix GLES3 multimesh rendering when using colors or custom data

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1284,13 +1284,17 @@ void MeshStorage::multimesh_allocate_data(RID p_multimesh, int p_instances, RS::
 		multimesh->data_cache_used_dirty_regions = 0;
 	}
 
+	// If we have either color or custom data, reserve space for both to make data handling logic simpler.
+	// This way we can always treat them both as a single, compressed uvec4.
+	int color_and_custom_strides = (p_use_colors || p_use_custom_data) ? 2 : 0;
+
 	multimesh->instances = p_instances;
 	multimesh->xform_format = p_transform_format;
 	multimesh->uses_colors = p_use_colors;
 	multimesh->color_offset_cache = p_transform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12;
 	multimesh->uses_custom_data = p_use_custom_data;
-	multimesh->custom_data_offset_cache = multimesh->color_offset_cache + (p_use_colors ? 2 : 0);
-	multimesh->stride_cache = multimesh->custom_data_offset_cache + (p_use_custom_data ? 2 : 0);
+	multimesh->custom_data_offset_cache = multimesh->color_offset_cache + color_and_custom_strides;
+	multimesh->stride_cache = multimesh->custom_data_offset_cache + color_and_custom_strides;
 	multimesh->buffer_set = false;
 
 	multimesh->data_cache = Vector<float>();


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/71897

OpenGL compatibility renderer compresses the 4-float instance color and instance custom data into 2 floats each, which means that if you only use color OR custom data the component count given to glVertexAttribIPointer() will be wrong. This causes the last rendered element to access data outside the instance buffer and the value it will try to read will be invalid (or it might crash your driver if you're unlucky).

This PR adjusts the component count to use 2 if only color or custom data are used. If both are used, the count will be 4.