### PR TITLE
Add placeholder items to TileSet layer list

### DIFF
--- a/editor/icons/Info.svg
+++ b/editor/icons/Info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M8 1a7 7 0 0 0 0 14A7 7 0 0 0 8 1m1 12H7v-2h2v2M4.5 6a3.5 3.4 0 1 1 7 0C11.3 8.9 9 8.5 9 10H7c.1-2.6 2.4-2.8 2.5-4a1.5 1.4 0 0 0-3 0z" fill="#e0e0e0"/></svg>

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -730,6 +730,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		tile_data_editors["probability"] = tile_data_probability_editor;
 	}
 
+	Color disabled_color = get_theme_color("disabled_font_color", "Editor");
+
 	// --- Physics ---
 	ADD_TILE_DATA_EDITOR_GROUP(TTR("Physics"));
 	for (int i = 0; i < tile_set->get_physics_layers_count(); i++) {
@@ -748,6 +750,16 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 		tile_data_editors.erase(vformat("physics_layer_%d", i));
 	}
 
+	if (tile_set->get_physics_layers_count() == 0) {
+		item = tile_data_editors_tree->create_item(group);
+		item->set_icon(0, get_theme_icon("Info", "EditorIcons"));
+		item->set_icon_modulate(0, disabled_color);
+		item->set_text(0, TTR("No physics layers"));
+		item->set_tooltip_text(0, TTR("Create and customize physics layers in the inspector of the TileSet resource."));
+		item->set_selectable(0, false);
+		item->set_custom_color(0, disabled_color);
+	}
+
 	// --- Navigation ---
 	ADD_TILE_DATA_EDITOR_GROUP(TTR("Navigation"));
 	for (int i = 0; i < tile_set->get_navigation_layers_count(); i++) {
@@ -764,6 +776,16 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	for (int i = tile_set->get_navigation_layers_count(); tile_data_editors.has(vformat("navigation_layer_%d", i)); i++) {
 		tile_data_editors[vformat("navigation_layer_%d", i)]->queue_free();
 		tile_data_editors.erase(vformat("navigation_layer_%d", i));
+	}
+
+	if (tile_set->get_navigation_layers_count() == 0) {
+		item = tile_data_editors_tree->create_item(group);
+		item->set_icon(0, get_theme_icon("Info", "EditorIcons"));
+		item->set_icon_modulate(0, disabled_color);
+		item->set_text(0, TTR("No navigation layers"));
+		item->set_tooltip_text(0, TTR("Create and customize navigation layers in the inspector of the TileSet resource."));
+		item->set_selectable(0, false);
+		item->set_custom_color(0, disabled_color);
 	}
 
 	// --- Custom Data ---
@@ -797,6 +819,16 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	for (int i = tile_set->get_custom_data_layers_count(); tile_data_editors.has(vformat("custom_data_%d", i)); i++) {
 		tile_data_editors[vformat("custom_data_%d", i)]->queue_free();
 		tile_data_editors.erase(vformat("custom_data_%d", i));
+	}
+
+	if (tile_set->get_custom_data_layers_count() == 0) {
+		item = tile_data_editors_tree->create_item(group);
+		item->set_icon(0, get_theme_icon("Info", "EditorIcons"));
+		item->set_icon_modulate(0, disabled_color);
+		item->set_text(0, TTR("No custom data layers"));
+		item->set_tooltip_text(0, TTR("Create and customize custom data layers in the inspector of the TileSet resource."));
+		item->set_selectable(0, false);
+		item->set_custom_color(0, disabled_color);
 	}
 
 #undef ADD_TILE_DATA_EDITOR_GROUP


### PR DESCRIPTION
Adds a fake item + tooltip telling how to setup layers:
![image](https://github.com/godotengine/godot/assets/2223172/84e30f70-2a07-423c-bb81-53f78f61033e)

Before:
![image](https://github.com/godotengine/godot/assets/2223172/17908407-f10f-481d-b1b3-1d8370114296)
