### PR TITLE
Auto create tile for multiple atlases

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -270,7 +270,9 @@ private:
 	// -- Misc --
 	void _auto_create_tiles();
 	void _auto_remove_tiles();
+	void _cancel_auto_create_tiles();
 	AcceptDialog *confirm_auto_create_tiles = nullptr;
+	Vector<Ref<TileSetAtlasSource>> atlases_to_auto_create_tiles;
 	Vector2i _get_drag_offset_tile_coords(const Vector2i &p_offset) const;
 
 	void _tile_set_changed();
@@ -288,7 +290,7 @@ protected:
 
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_source, int p_source_id);
-	void init_source();
+	void init_new_atlases(const Vector<Ref<TileSetAtlasSource>> &p_atlases);
 
 	TileSetAtlasSourceEditor();
 	~TileSetAtlasSourceEditor();

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -68,6 +68,7 @@ private:
 
 	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void _load_texture_files(const Vector<String> &p_paths);
 
 	void _update_sources_list(int force_selected_id = -1);
 
@@ -78,7 +79,6 @@ private:
 	MenuButton *sources_advanced_menu_button = nullptr;
 	ItemList *sources_list = nullptr;
 	Ref<Texture2D> missing_texture_texture;
-	void _texture_file_selected(const String &p_path);
 	void _source_selected(int p_source_index);
 	void _source_delete_pressed();
 	void _source_add_id_pressed(int p_id_pressed);


### PR DESCRIPTION
Based on issues: #69273 #79473 
And PRs: #70790 #79558 

- Support for auto create tiles when adding multiple atlases
- Button to add Atlas can be used for multiple files
- Unify functions `TileSetEditor::_texture_file_selected()` and `TileSetEditor::_drop_data_fw()` into `TileSetEditor::_load_texture_files()`

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/69273
- Fixes https://github.com/godotengine/godot/issues/79473