### PR TITLE
Fix NullPointerException when registering the sensors

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -88,16 +88,16 @@ class Godot(private val context: Context) : SensorEventListener {
 	private val mSensorManager: SensorManager by lazy {
 		requireActivity().getSystemService(Context.SENSOR_SERVICE) as SensorManager
 	}
-	private val mAccelerometer: Sensor by lazy {
+	private val mAccelerometer: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
 	}
-	private val mGravity: Sensor by lazy {
+	private val mGravity: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY)
 	}
-	private val mMagnetometer: Sensor by lazy {
+	private val mMagnetometer: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
 	}
-	private val mGyroscope: Sensor by lazy {
+	private val mGyroscope: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
 	}
 	private val mClipboard: ClipboardManager by lazy {
@@ -492,10 +492,18 @@ class Godot(private val context: Context) : SensorEventListener {
 		}
 
 		renderView!!.onActivityResumed()
-		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME)
-		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME)
-		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME)
-		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME)
+		if (mAccelerometer != null) {
+			mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME)
+		}
+		if (mGravity != null) {
+			mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME)
+		}
+		if (mMagnetometer != null) {
+			mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME)
+		}
+		if (mGyroscope != null) {
+			mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME)
+		}
 		if (useImmersive) {
 			val window = requireActivity().window
 			window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or


### PR DESCRIPTION
Fix `NullPointerException` reported by the Google Play console

```
Exception Process: org.godotengine.editor.v4:GodotProjectManager, PID: 24936
java.lang.RuntimeException: Unable to resume activity {org.godotengine.editor.v4/org.godotengine.editor.GodotProjectManager}: java.lang.NullPointerException: <get-mMagnetometer>(...) must not be null
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4578)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:4610)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:52)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2144)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:240)
  at android.app.ActivityThread.main (ActivityThread.java:8000)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:603)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:947)
Caused by java.lang.NullPointerException: <get-mMagnetometer>(...) must not be null
  at org.godotengine.godot.Godot.getMMagnetometer (Godot.kt:97)
  at org.godotengine.godot.Godot.onResume (Godot.kt:497)
  at org.godotengine.godot.GodotFragment.onResume (GodotFragment.java:280)
  at androidx.fragment.app.Fragment.performResume (Fragment.java:3039)
  at androidx.fragment.app.FragmentStateManager.resume (FragmentStateManager.java:607)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:306)
  at androidx.fragment.app.FragmentStore.moveToExpectedState (FragmentStore.java:112)
  at androidx.fragment.app.FragmentManager.moveToState (FragmentManager.java:1647)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:3128)
  at androidx.fragment.app.FragmentManager.dispatchResume (FragmentManager.java:3086)
  at androidx.fragment.app.FragmentController.dispatchResume (FragmentController.java:273)
  at androidx.fragment.app.FragmentActivity.onResumeFragments (FragmentActivity.java:458)
  at androidx.fragment.app.FragmentActivity.onPostResume (FragmentActivity.java:447)
  at android.app.Activity.performResume (Activity.java:8238)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4565)
```

*Bugsquad edit:*
- Fixes #80120