### PR TITLE
GDExtension: Fix `_get_property_list` not working correctly in parent classes

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -486,19 +486,21 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		const ObjectGDExtension *current_extension = _extension;
 		while (current_extension) {
 			p_list->push_back(PropertyInfo(Variant::NIL, current_extension->class_name, PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
-			ClassDB::get_property_list(current_extension->class_name, p_list, true, this);
-			current_extension = current_extension->parent;
-		}
-	}
 
-	if (_extension && _extension->get_property_list) {
-		uint32_t pcount;
-		const GDExtensionPropertyInfo *pinfo = _extension->get_property_list(_extension_instance, &pcount);
-		for (uint32_t i = 0; i < pcount; i++) {
-			p_list->push_back(PropertyInfo(pinfo[i]));
-		}
-		if (_extension->free_property_list) {
-			_extension->free_property_list(_extension_instance, pinfo);
+			ClassDB::get_property_list(current_extension->class_name, p_list, true, this);
+
+			if (current_extension->get_property_list) {
+				uint32_t pcount;
+				const GDExtensionPropertyInfo *pinfo = current_extension->get_property_list(_extension_instance, &pcount);
+				for (uint32_t i = 0; i < pcount; i++) {
+					p_list->push_back(PropertyInfo(pinfo[i]));
+				}
+				if (current_extension->free_property_list) {
+					current_extension->free_property_list(_extension_instance, pinfo);
+				}
+			}
+
+			current_extension = current_extension->parent;
 		}
 	}
 


### PR DESCRIPTION
Godot-side fix for https://github.com/godotengine/godot-cpp/issues/1183

The issue got really long as I spent all the evening investigating it, so in summary:

Godot used to get properties from extensions in two "passes" (first code by Reduz, later code by different contributors, but [latter one](https://github.com/godotengine/godot/pull/53710) was not a complete fix). First, it got all properties declared in `_bind_methods`, for every level of inheritance hierarchy.
And only after that, it called the extension instance `_get_property_list`, which only returned procedural properties of the most derived class.

Two problems:

- If parent classes declare `_get_property_list` too, their properties didn't appear anymore, because the code only queried the most derived one;
- Since it came after `ClassDB::get_property_list` of *every* inheritance level, procedural properties ended up in the wrong class group in the inspector (always the most-base extension class).

This fix replicates the behavior of `_get_property_listv` by properly interleaving properties added with `_get_property_list` with those added in `_bind_methods`, so they all get returned, and in the right place.

--------
There will be a GodotCpp-side fix to apply as well, because it seems GodotCpp sometimes returns the parent class `_get_property_list` when it should not, causing procedural properties to still sometimes appear in the wrong group.