### PR TITLE
GLES3: Don't call `glTexParameter*` for invalid filter and repeat modes

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -252,10 +252,10 @@ struct Texture {
 		}
 		Config *config = Config::get_singleton();
 		state_filter = p_filter;
-		GLenum pmin = GL_NEAREST; // param min
-		GLenum pmag = GL_NEAREST; // param mag
-		GLint max_lod = 1000;
-		float anisotropy = 1.0f;
+		GLenum pmin = GL_NEAREST;
+		GLenum pmag = GL_NEAREST;
+		GLint max_lod = 0;
+		GLfloat anisotropy = 1.0f;
 		switch (state_filter) {
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
 				pmin = GL_NEAREST;
@@ -278,8 +278,10 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_NEAREST_MIPMAP_NEAREST;
+					max_lod = 1000;
 				} else {
 					pmin = GL_NEAREST_MIPMAP_LINEAR;
+					max_lod = 1000;
 				}
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
@@ -293,11 +295,14 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_LINEAR_MIPMAP_NEAREST;
+					max_lod = 1000;
 				} else {
 					pmin = GL_LINEAR_MIPMAP_LINEAR;
+					max_lod = 1000;
 				}
 			} break;
 			default: {
+				return;
 			} break;
 		}
 		glTexParameteri(target, GL_TEXTURE_MIN_FILTER, pmin);
@@ -313,8 +318,11 @@ struct Texture {
 			return;
 		}
 		state_repeat = p_repeat;
-		GLenum prep = GL_CLAMP_TO_EDGE; // parameter repeat
+		GLenum prep = GL_CLAMP_TO_EDGE;
 		switch (state_repeat) {
+			case RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED: {
+				prep = GL_CLAMP_TO_EDGE;
+			} break;
 			case RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
 				prep = GL_REPEAT;
 			} break;
@@ -322,6 +330,7 @@ struct Texture {
 				prep = GL_MIRRORED_REPEAT;
 			} break;
 			default: {
+				return;
 			} break;
 		}
 		glTexParameteri(target, GL_TEXTURE_WRAP_T, prep);
@@ -330,8 +339,8 @@ struct Texture {
 	}
 
 private:
-	RS::CanvasItemTextureFilter state_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR;
-	RS::CanvasItemTextureRepeat state_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED;
+	RS::CanvasItemTextureFilter state_filter = RS::CANVAS_ITEM_TEXTURE_FILTER_MAX;
+	RS::CanvasItemTextureRepeat state_repeat = RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX;
 };
 
 struct RenderTarget {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This fixes #79315. That issue was caused by `TextureStorage::_clear_render_target` calling `Texture::gl_set_filter` and `Texture::gl_set_repeat` with the value `*_MAX`. The `gl_set_filter` and `gl_set_repeat` functions weren't designed to be called with the values (which appear to be used to force the next calls to make `glTexParameter*` calls), which results in whatever happens to be the currently bound OpenGL texture to be assigned unexpected parameters. This PR updates `Texture::gl_set_filter` and `Texture::gl_set_repeat` so that they only make calls to `glTexParameter*` when `p_filter`/`p_repeat` is a valid value.

I also made some small changes to these functions that shouldn't affect functionality, but figured would be nice to cleanup while I'm here. I removed the (IMO) unhelpful comments and updated how `max_lod` is assigned to be more consistent with the other local variables in `gl_set_filter`. I also changed the default values of `Texture::state_filter` and `Texture::state_repeat` to better represent their uninitialized state. This shouldn't have an effect on the engine, as these values get initialized in `TextureStorage::_texture_set_data` either way.

The only part of this I'm not sure about is the handling of `*_DEFAULT` as the argument. From what I can tell, they should never be used with these functions, so I didn't add a specific case for them, and chose to handle them the same a `*_MAX` (or any invalid enum value). If this needs to be changed, let me know what behavior you would want these to have, and I can update this PR.

This PR targets the master branch, but it should be safe to cherry-pick for a 4.1.X release. This PR may interact with #79568 and may require a rebase if that gets merged first.