### PR TITLE
Add ability to call code on rendering thread

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -27,6 +27,13 @@
 				Bakes the material data of the Mesh passed in the [param base] parameter with optional [param material_overrides] to a set of [Image]s of size [param image_size]. Returns an array of [Image]s containing material properties as specified in [enum BakeChannels].
 			</description>
 		</method>
+		<method name="call_on_render_thread">
+			<return type="void" />
+			<param index="0" name="callable" type="Callable" />
+			<description>
+				As the RenderingServer actual logic may run on an separate thread, accessing its internals from the main (or any other) thread will result in errors. To make it easier to run code that can safely access the rendering internals (such as [RenderingDevice] and similar RD classes), push a callable via this function so it will be executed on the render thread.
+			</description>
+		</method>
 		<method name="camera_attributes_create">
 			<return type="RID" />
 			<description>

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -386,6 +386,12 @@ void RenderingServerDefault::draw(bool p_swap_buffers, double frame_step) {
 	}
 }
 
+void RenderingServerDefault::_call_on_render_thread(const Callable &p_callable) {
+	Variant ret;
+	Callable::CallError ce;
+	p_callable.callp(nullptr, 0, ret, ce);
+}
+
 RenderingServerDefault::RenderingServerDefault(bool p_create_thread) :
 		command_queue(p_create_thread) {
 	RenderingServer::init();

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -97,6 +97,8 @@ class RenderingServerDefault : public RenderingServer {
 
 	void _free(RID p_rid);
 
+	void _call_on_render_thread(const Callable &p_callable);
+
 public:
 	//if editor is redrawing when it shouldn't, enable this and put a breakpoint in _changes_changed()
 	//#define DEBUG_CHANGES
@@ -986,6 +988,15 @@ public:
 	virtual bool has_changed() const override;
 	virtual void init() override;
 	virtual void finish() override;
+
+	virtual void call_on_render_thread(const Callable &p_callable) override {
+		if (Thread::get_caller_id() == server_thread) {
+			command_queue.flush_if_pending();
+			_call_on_render_thread(p_callable);
+		} else {
+			command_queue.push(this, &RenderingServerDefault::_call_on_render_thread, p_callable);
+		}
+	}
 
 	/* TESTING */
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2808,6 +2808,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("force_draw", "swap_buffers", "frame_step"), &RenderingServer::draw, DEFVAL(true), DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("get_rendering_device"), &RenderingServer::get_rendering_device);
 	ClassDB::bind_method(D_METHOD("create_local_rendering_device"), &RenderingServer::create_local_rendering_device);
+
+	ClassDB::bind_method(D_METHOD("call_on_render_thread", "callable"), &RenderingServer::call_on_render_thread);
 }
 
 void RenderingServer::mesh_add_surface_from_mesh_data(RID p_mesh, const Geometry3D::MeshData &p_mesh_data) {

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1599,6 +1599,8 @@ public:
 	bool is_render_loop_enabled() const;
 	void set_render_loop_enabled(bool p_enabled);
 
+	virtual void call_on_render_thread(const Callable &p_callable) = 0;
+
 	RenderingServer();
 	virtual ~RenderingServer();
 


### PR DESCRIPTION
As more users use compute in Godot 4, the way they do is most likely incompatible when running on separate threads and will start erroring soon as we improve the thread safety of the render thread.

To properly run code on the render thread, this function was added. Use like this:

```GDScript

func initialize_compute_code():
	....

func update_compute_code(custom_data):
	...

func _ready():
	RenderingServer.call_on_render_thread( initialize_compute_code )

func _process():
	RenderingServer.call_on_render_thread( update_compute_code.bind(with_data) )

```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
