### PR TITLE
Prevent Popup from going out of screen

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1628,6 +1628,9 @@ void Window::popup(const Rect2i &p_screen_rect) {
 		}
 	}
 
+	set_transient(true);
+	set_visible(true);
+
 	// Update window size to calculate the actual window size based on contents minimum size and minimum size.
 	_update_window_size();
 
@@ -1650,9 +1653,6 @@ void Window::popup(const Rect2i &p_screen_rect) {
 			break;
 		}
 	}
-
-	set_transient(true);
-	set_visible(true);
 
 	Rect2i parent_rect;
 	if (is_embedded()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
* *Fixes #79675*

Explanation:
The `_update_window_size` function could not calculate the size of a window correctly as its children were invisible and their sizes were ignored. My solution is to call `set_visible(true)` first before the `_update_window_size` function call.