### PR TITLE
Fix that the border of StyleBoxFlat is not aligned when skewed

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -300,8 +300,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 				const real_t x = radius * (real_t)cos((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.x;
 				const real_t y = radius * (real_t)sin((corner_index + detail / (double)adapted_corner_detail) * (Math_TAU / 4.0) + Math_PI) + corner_point.y;
-				const float x_skew = -skew.x * (y - ring_rect.get_center().y);
-				const float y_skew = -skew.y * (x - ring_rect.get_center().x);
+				// Transform with the center point of style_rect as the coordinate origin.
+				const float x_skew = -skew.x * (y - style_rect.get_center().y);
+				const float y_skew = -skew.y * (x - style_rect.get_center().x);
 				verts.push_back(Vector2(x + x_skew, y + y_skew));
 				colors.push_back(color);
 			}
@@ -525,9 +526,10 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
 					outer_rect_aa_colored, ((blend_on) ? infill_rect : inner_rect_aa_colored), border_color_inner, border_color, corner_detail, skew);
 			if (!blend_on) {
+				bool has_bg_area = border_width[SIDE_LEFT] + border_width[SIDE_RIGHT] < p_rect.size.width && border_width[SIDE_TOP] + border_width[SIDE_BOTTOM] < p_rect.size.height;
 				// Add antialiasing on the ring inner border
 				draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,
-						inner_rect_aa_colored, inner_rect_aa_transparent, border_color_blend, border_color, corner_detail, skew);
+						inner_rect_aa_colored, inner_rect_aa_transparent, has_bg_area ? border_color_blend : border_color, border_color, corner_detail, skew);
 			}
 			// Add antialiasing on the ring outer border
 			draw_rounded_rectangle(verts, indices, colors, border_style_rect, adapted_corner,


### PR DESCRIPTION
The entire StyleBoxFlat is transformed by the center point for skew. Previously, the border rectangle and the background rectangle calculated skew transformations based on their respective center points. And when StyleBoxFlat has a pair of asymmetric border widths, the center point of the background rectangle is offset, but no skew transformation is applied. Causes the border rectangle and the background rectangle to be misaligned.

https://github.com/godotengine/godot/assets/30386067/ff146962-a2ec-4589-b1f7-2159b31e6e9a

Partially fixed #79672.

`anti_aliasing_size` is fixed, this may cause some display issues. It may be better to automatically use a smaller value when the background rectangle area is close to 0.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
