### PR TITLE
[3.x] Prevent double input events on gamepad when running through steam input

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -72,6 +72,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);
 	ClassDB::bind_method(D_METHOD("get_joy_guid", "device"), &Input::get_joy_guid);
+	ClassDB::bind_method(D_METHOD("should_ignore_device", "vendor_id", "product_id"), &Input::should_ignore_device);
 	ClassDB::bind_method(D_METHOD("get_connected_joypads"), &Input::get_connected_joypads);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_strength", "device"), &Input::get_joy_vibration_strength);
 	ClassDB::bind_method(D_METHOD("get_joy_vibration_duration", "device"), &Input::get_joy_vibration_duration);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -100,6 +100,7 @@ public:
 	virtual void remove_joy_mapping(String p_guid) = 0;
 	virtual bool is_joy_known(int p_device) = 0;
 	virtual String get_joy_guid(int p_device) const = 0;
+	virtual bool should_ignore_device(int p_vendor_id, int p_product_id) const = 0;
 	virtual Vector2 get_joy_vibration_strength(int p_device) = 0;
 	virtual float get_joy_vibration_duration(int p_device) = 0;
 	virtual uint64_t get_joy_vibration_timestamp(int p_device) = 0;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -360,6 +360,15 @@
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
+		<method name="should_ignore_device" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="vendor_id" type="int" />
+			<argument index="1" name="product_id" type="int" />
+			<description>
+				Queries whether an input device should be ignored or not. Devices can be ignored by setting the environment variable [code]SDL_GAMECONTROLLER_IGNORE_DEVICES[/code]. Read the [url=https://wiki.libsdl.org/SDL2]SDL documentation[/url] for more information.
+				[b]Note:[/b] Some 3rd party tools can contribute to the list of ignored devices. For example, [i]SteamInput[/i] creates virtual devices from physical devices for remapping purposes. To avoid handling the same input device twice, the original device is added to the ignore list.
+			</description>
+		</method>
 		<method name="start_joy_vibration">
 			<return type="void" />
 			<argument index="0" name="device" type="int" />

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -193,6 +193,8 @@ private:
 
 	Vector<JoyDeviceMapping> map_db;
 
+	Set<uint32_t> ignored_device_ids;
+
 	JoyEvent _get_mapped_button_event(const JoyDeviceMapping &mapping, int p_button);
 	JoyEvent _get_mapped_axis_event(const JoyDeviceMapping &mapping, int p_axis, float p_value);
 	void _get_mapped_hat_events(const JoyDeviceMapping &mapping, int p_hat, JoyEvent r_events[HAT_MAX]);
@@ -294,6 +296,8 @@ public:
 	virtual void remove_joy_mapping(String p_guid);
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
+
+	bool should_ignore_device(int p_vendor_id, int p_product_id) const;
 
 	virtual String get_joy_button_string(int p_button);
 	virtual String get_joy_axis_string(int p_axis);

--- a/platform/x11/joypad_linux.cpp
+++ b/platform/x11/joypad_linux.cpp
@@ -387,6 +387,16 @@ void JoypadLinux::open_joypad(const char *p_path) {
 			return;
 		}
 
+		uint16_t vendor = BSWAP16(inpid.vendor);
+		uint16_t product = BSWAP16(inpid.product);
+		uint16_t version = BSWAP16(inpid.version);
+
+		if (input->should_ignore_device(vendor, product)) {
+			// This can be true in cases where Steam is passing information into the game to ignore
+			// original gamepads when using virtual rebindings (See SteamInput).
+			return;
+		}
+
 		MutexLock lock(joypads_mutex[joy_num]);
 		Joypad &joypad = joypads[joy_num];
 		joypad.reset();
@@ -395,10 +405,6 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		setup_joypad_properties(joypad);
 		sprintf(uid, "%04x%04x", BSWAP16(inpid.bustype), 0);
 		if (inpid.vendor && inpid.product && inpid.version) {
-			uint16_t vendor = BSWAP16(inpid.vendor);
-			uint16_t product = BSWAP16(inpid.product);
-			uint16_t version = BSWAP16(inpid.version);
-
 			sprintf(uid + String(uid).length(), "%04x%04x%04x%04x%04x%04x", vendor, 0, product, 0, version, 0);
 			input->joy_connection_changed(joy_num, true, name, uid);
 		} else {


### PR DESCRIPTION
Backported request #76045 from Eoin-ONeill-Yokai/steaminput-fix to branch 3.x.