### PR TITLE
Fix incorrect virtual function in `VideoStream.set_paused`

### DIFF
--- a/scene/resources/video_stream.cpp
+++ b/scene/resources/video_stream.cpp
@@ -75,7 +75,7 @@ bool VideoStreamPlayback::is_playing() const {
 }
 
 void VideoStreamPlayback::set_paused(bool p_paused) {
-	GDVIRTUAL_CALL(_is_playing, p_paused);
+	GDVIRTUAL_CALL(_set_paused, p_paused);
 }
 
 bool VideoStreamPlayback::is_paused() const {


### PR DESCRIPTION
* Fixes: #79709
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
