### PR TITLE
Add `proxy_to_pthread` option to `platform=web`

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -775,7 +775,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 		LocalVector<ParticleInstanceData3D> particle_vector;
 		particle_vector.resize(particles->amount);
 		particle_array = particle_vector.ptr();
-		glGetBufferSubData(GL_ARRAY_BUFFER, 0, particles->amount * sizeof(ParticleInstanceData3D), particle_array);
+		godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, particles->amount * sizeof(ParticleInstanceData3D), particle_array);
 #endif
 		SortArray<ParticleInstanceData3D, ParticlesViewSort> sorter;
 		sorter.compare.z_dir = axis;
@@ -1133,7 +1133,7 @@ void ParticlesStorage::_particles_reverse_lifetime_sort(Particles *particles) {
 	LocalVector<ParticleInstanceData> particle_vector;
 	particle_vector.resize(particles->amount);
 	particle_array = particle_vector.ptr();
-	glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
+	godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
 #endif
 
 	uint32_t lifetime_split = (MIN(int(particles->amount * particles->sort_buffer_phase), particles->amount - 1) + 1) % particles->amount;

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -115,7 +115,7 @@ Vector<uint8_t> Utilities::buffer_get_data(GLenum p_target, GLuint p_buffer, uin
 #if defined(__EMSCRIPTEN__)
 	{
 		uint8_t *w = ret.ptrw();
-		glGetBufferSubData(p_target, 0, p_buffer_size, w);
+		godot_webgl2_glGetBufferSubData(p_target, 0, p_buffer_size, w);
 	}
 #else
 	void *data = glMapBufferRange(p_target, 0, p_buffer_size, GL_MAP_READ_BIT);

--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -90,6 +90,7 @@ const GodotRTCDataChannel = {
 		},
 	},
 
+	godot_js_rtc_datachannel_ready_state_get__proxy: 'sync',
 	godot_js_rtc_datachannel_ready_state_get__sig: 'ii',
 	godot_js_rtc_datachannel_ready_state_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -110,6 +111,7 @@ const GodotRTCDataChannel = {
 		}
 	},
 
+	godot_js_rtc_datachannel_send__proxy: 'sync',
 	godot_js_rtc_datachannel_send__sig: 'iiiii',
 	godot_js_rtc_datachannel_send: function (p_id, p_buffer, p_length, p_raw) {
 		const ref = IDHandler.get(p_id);
@@ -131,16 +133,19 @@ const GodotRTCDataChannel = {
 		return 0;
 	},
 
+	godot_js_rtc_datachannel_is_ordered__proxy: 'sync',
 	godot_js_rtc_datachannel_is_ordered__sig: 'ii',
 	godot_js_rtc_datachannel_is_ordered: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'ordered', true);
 	},
 
+	godot_js_rtc_datachannel_id_get__proxy: 'sync',
 	godot_js_rtc_datachannel_id_get__sig: 'ii',
 	godot_js_rtc_datachannel_id_get: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'id', 65535);
 	},
 
+	godot_js_rtc_datachannel_max_packet_lifetime_get__proxy: 'sync',
 	godot_js_rtc_datachannel_max_packet_lifetime_get__sig: 'ii',
 	godot_js_rtc_datachannel_max_packet_lifetime_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -156,21 +161,25 @@ const GodotRTCDataChannel = {
 		return 65535;
 	},
 
+	godot_js_rtc_datachannel_max_retransmits_get__proxy: 'sync',
 	godot_js_rtc_datachannel_max_retransmits_get__sig: 'ii',
 	godot_js_rtc_datachannel_max_retransmits_get: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'maxRetransmits', 65535);
 	},
 
+	godot_js_rtc_datachannel_is_negotiated__proxy: 'sync',
 	godot_js_rtc_datachannel_is_negotiated__sig: 'ii',
 	godot_js_rtc_datachannel_is_negotiated: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'negotiated', 65535);
 	},
 
+	godot_js_rtc_datachannel_get_buffered_amount__proxy: 'sync',
 	godot_js_rtc_datachannel_get_buffered_amount__sig: 'ii',
 	godot_js_rtc_datachannel_get_buffered_amount: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'bufferedAmount', 0);
 	},
 
+	godot_js_rtc_datachannel_label_get__proxy: 'sync',
 	godot_js_rtc_datachannel_label_get__sig: 'ii',
 	godot_js_rtc_datachannel_label_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -189,12 +198,14 @@ const GodotRTCDataChannel = {
 		return GodotRuntime.allocString(ref.protocol);
 	},
 
+	godot_js_rtc_datachannel_destroy__proxy: 'sync',
 	godot_js_rtc_datachannel_destroy__sig: 'vi',
 	godot_js_rtc_datachannel_destroy: function (p_id) {
 		GodotRTCDataChannel.close(p_id);
 		IDHandler.remove(p_id);
 	},
 
+	godot_js_rtc_datachannel_connect__proxy: 'sync',
 	godot_js_rtc_datachannel_connect__sig: 'viiiiii',
 	godot_js_rtc_datachannel_connect: function (p_id, p_ref, p_on_open, p_on_message, p_on_error, p_on_close) {
 		const onopen = GodotRuntime.get_func(p_on_open).bind(null, p_ref);
@@ -204,6 +215,7 @@ const GodotRTCDataChannel = {
 		GodotRTCDataChannel.connect(p_id, onopen, onmessage, onerror, onclose);
 	},
 
+	godot_js_rtc_datachannel_close__proxy: 'sync',
 	godot_js_rtc_datachannel_close__sig: 'vi',
 	godot_js_rtc_datachannel_close: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -356,6 +368,7 @@ const GodotRTCPeerConnection = {
 		},
 	},
 
+	godot_js_rtc_pc_create__proxy: 'sync',
 	godot_js_rtc_pc_create__sig: 'iiiiiiii',
 	godot_js_rtc_pc_create: function (p_config, p_ref, p_on_connection_state_change, p_on_ice_gathering_state_change, p_on_signaling_state_change, p_on_ice_candidate, p_on_datachannel) {
 		const wrap = function (p_func) {
@@ -371,6 +384,7 @@ const GodotRTCPeerConnection = {
 		);
 	},
 
+	godot_js_rtc_pc_close__proxy: 'sync',
 	godot_js_rtc_pc_close__sig: 'vi',
 	godot_js_rtc_pc_close: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -380,11 +394,13 @@ const GodotRTCPeerConnection = {
 		ref.close();
 	},
 
+	godot_js_rtc_pc_destroy__proxy: 'sync',
 	godot_js_rtc_pc_destroy__sig: 'vi',
 	godot_js_rtc_pc_destroy: function (p_id) {
 		GodotRTCPeerConnection.destroy(p_id);
 	},
 
+	godot_js_rtc_pc_offer_create__proxy: 'sync',
 	godot_js_rtc_pc_offer_create__sig: 'viiii',
 	godot_js_rtc_pc_offer_create: function (p_id, p_obj, p_on_session, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -400,6 +416,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_local_description_set__proxy: 'sync',
 	godot_js_rtc_pc_local_description_set__sig: 'viiiii',
 	godot_js_rtc_pc_local_description_set: function (p_id, p_type, p_sdp, p_obj, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -417,6 +434,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_remote_description_set__proxy: 'sync',
 	godot_js_rtc_pc_remote_description_set__sig: 'viiiiii',
 	godot_js_rtc_pc_remote_description_set: function (p_id, p_type, p_sdp, p_obj, p_session_created, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -442,6 +460,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_ice_candidate_add__proxy: 'sync',
 	godot_js_rtc_pc_ice_candidate_add__sig: 'viiii',
 	godot_js_rtc_pc_ice_candidate_add: function (p_id, p_mid_name, p_mline_idx, p_sdp) {
 		const ref = IDHandler.get(p_id);
@@ -458,6 +477,7 @@ const GodotRTCPeerConnection = {
 	},
 
 	godot_js_rtc_pc_datachannel_create__deps: ['$GodotRTCDataChannel'],
+	godot_js_rtc_pc_datachannel_create__proxy: 'sync',
 	godot_js_rtc_pc_datachannel_create__sig: 'iiii',
 	godot_js_rtc_pc_datachannel_create: function (p_id, p_label, p_config) {
 		try {

--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -144,6 +144,7 @@ const GodotWebSocket = {
 		},
 	},
 
+	godot_js_websocket_create__proxy: 'sync',
 	godot_js_websocket_create__sig: 'iiiiiiii',
 	godot_js_websocket_create: function (p_ref, p_url, p_proto, p_on_open, p_on_message, p_on_error, p_on_close) {
 		const on_open = GodotRuntime.get_func(p_on_open).bind(null, p_ref);
@@ -166,6 +167,7 @@ const GodotWebSocket = {
 		return GodotWebSocket.create(socket, on_open, on_message, on_error, on_close);
 	},
 
+	godot_js_websocket_send__proxy: 'sync',
 	godot_js_websocket_send__sig: 'iiiii',
 	godot_js_websocket_send: function (p_id, p_buf, p_buf_len, p_raw) {
 		const bytes_array = new Uint8Array(p_buf_len);
@@ -180,11 +182,13 @@ const GodotWebSocket = {
 		return GodotWebSocket.send(p_id, out);
 	},
 
+	godot_js_websocket_buffered_amount__proxy: 'sync',
 	godot_js_websocket_buffered_amount__sig: 'ii',
 	godot_js_websocket_buffered_amount: function (p_id) {
 		return GodotWebSocket.bufferedAmount(p_id);
 	},
 
+	godot_js_websocket_close__proxy: 'sync',
 	godot_js_websocket_close__sig: 'viii',
 	godot_js_websocket_close: function (p_id, p_code, p_reason) {
 		const code = p_code;
@@ -192,6 +196,7 @@ const GodotWebSocket = {
 		GodotWebSocket.close(p_id, code, reason);
 	},
 
+	godot_js_websocket_destroy__proxy: 'sync',
 	godot_js_websocket_destroy__sig: 'vi',
 	godot_js_websocket_destroy: function (p_id) {
 		GodotWebSocket.destroy(p_id);

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -41,6 +41,11 @@ def get_opts():
             "dlink_enabled", "Enable WebAssembly dynamic linking (GDExtension support). Produces bigger binaries", False
         ),
         BoolVariable("use_closure_compiler", "Use closure compiler to minimize JavaScript code", False),
+        BoolVariable(
+            "proxy_to_pthread",
+            "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
+            True,
+        ),
     ]
 
 
@@ -211,6 +216,10 @@ def configure(env: "Environment"):
             env.Append(LINKFLAGS=["-Wl,-u,scalbnf"])
 
     if env["dlink_enabled"]:
+        if env["proxy_to_pthread"]:
+            print("GDExtension support requires proxy_to_pthread=no, disabling")
+            env["proxy_to_pthread"] = False
+
         if cc_semver < (3, 1, 14):
             print("GDExtension support requires emscripten >= 3.1.14, detected: %s.%s.%s" % cc_semver)
             sys.exit(255)
@@ -220,6 +229,16 @@ def configure(env: "Environment"):
         env.Append(CCFLAGS=["-fvisibility=hidden"])
         env.Append(LINKFLAGS=["-fvisibility=hidden"])
         env.extra_suffix = ".dlink" + env.extra_suffix
+
+    # Run the main application in a web worker
+    if env["proxy_to_pthread"]:
+        env.Append(LINKFLAGS=["-s", "PROXY_TO_PTHREAD=1"])
+        env.Append(CPPDEFINES=["PROXY_TO_PTHREAD_ENABLED"])
+        env.Append(LINKFLAGS=["-s", "EXPORTED_RUNTIME_METHODS=['_emscripten_proxy_main']"])
+        # https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925
+        env.Append(LINKFLAGS=["-s", "TEXTDECODER=0"])
+        # BigInt support to pass object pointers between contexts
+        env.Append(LINKFLAGS=["-s", "WASM_BIGINT"])
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).
     env.Append(LINKFLAGS=["-s", "ENVIRONMENT=web,worker"])

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -35,6 +35,7 @@
 #include "os_web.h"
 
 #include "core/config/project_settings.h"
+#include "core/object/callable_method_pointer.h"
 #include "scene/resources/atlas_texture.h"
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
@@ -59,13 +60,26 @@ DisplayServerWeb *DisplayServerWeb::get_singleton() {
 bool DisplayServerWeb::check_size_force_redraw() {
 	bool size_changed = godot_js_display_size_update() != 0;
 	if (size_changed && !rect_changed_callback.is_null()) {
-		Variant size = Rect2i(Point2i(), window_get_size()); // TODO use window_get_position if implemented.
+		Size2i window_size = window_get_size();
+		Variant size = Rect2i(Point2i(), window_size); // TODO use window_get_position if implemented.
 		rect_changed_callback.call(size);
+		emscripten_set_canvas_element_size(canvas_id, window_size.x, window_size.y);
 	}
 	return size_changed;
 }
 
 void DisplayServerWeb::fullscreen_change_callback(int p_fullscreen) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_fullscreen_change_callback).bind(p_fullscreen).call_deferred();
+		return;
+	}
+#endif
+
+	_fullscreen_change_callback(p_fullscreen);
+}
+
+void DisplayServerWeb::_fullscreen_change_callback(int p_fullscreen) {
 	DisplayServerWeb *display = get_singleton();
 	if (p_fullscreen) {
 		display->window_mode = WINDOW_MODE_FULLSCREEN;
@@ -75,7 +89,23 @@ void DisplayServerWeb::fullscreen_change_callback(int p_fullscreen) {
 }
 
 // Drag and drop callback.
-void DisplayServerWeb::drop_files_js_callback(char **p_filev, int p_filec) {
+void DisplayServerWeb::drop_files_js_callback(const char **p_filev, int p_filec) {
+	Vector<String> files;
+	for (int i = 0; i < p_filec; i++) {
+		files.push_back(String::utf8(p_filev[i]));
+	}
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_drop_files_js_callback).bind(files).call_deferred();
+		return;
+	}
+#endif
+
+	_drop_files_js_callback(files);
+}
+
+void DisplayServerWeb::_drop_files_js_callback(const Vector<String> &p_files) {
 	DisplayServerWeb *ds = get_singleton();
 	if (!ds) {
 		ERR_FAIL_MSG("Unable to drop files because the DisplayServer is not active");
@@ -83,15 +113,22 @@ void DisplayServerWeb::drop_files_js_callback(char **p_filev, int p_filec) {
 	if (ds->drop_files_callback.is_null()) {
 		return;
 	}
-	Vector<String> files;
-	for (int i = 0; i < p_filec; i++) {
-		files.push_back(String::utf8(p_filev[i]));
-	}
-	ds->drop_files_callback.call(files);
+	ds->drop_files_callback.call(p_files);
 }
 
 // Web quit request callback.
 void DisplayServerWeb::request_quit_callback() {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_request_quit_callback).call_deferred();
+		return;
+	}
+#endif
+
+	_request_quit_callback();
+}
+
+void DisplayServerWeb::_request_quit_callback() {
 	DisplayServerWeb *ds = get_singleton();
 	if (ds && !ds->window_event_callback.is_null()) {
 		Variant event = int(DisplayServer::WINDOW_EVENT_CLOSE_REQUEST);
@@ -119,17 +156,32 @@ void DisplayServerWeb::dom2godot_mod(Ref<InputEventWithModifiers> ev, int p_mod,
 void DisplayServerWeb::key_callback(int p_pressed, int p_repeat, int p_modifiers) {
 	DisplayServerWeb *ds = get_singleton();
 	JSKeyEvent &key_event = ds->key_event;
+
+	const String code = String::utf8(key_event.code);
+	const String key = String::utf8(key_event.key);
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_key_callback).bind(code, key, p_pressed, p_repeat, p_modifiers).call_deferred();
+		return;
+	}
+#endif
+
+	_key_callback(code, key, p_pressed, p_repeat, p_modifiers);
+}
+
+void DisplayServerWeb::_key_callback(const String &p_key_event_code, const String &p_key_event_key, int p_pressed, int p_repeat, int p_modifiers) {
 	// Resume audio context after input in case autoplay was denied.
 	OS_Web::get_singleton()->resume_audio();
 
 	char32_t c = 0x00;
-	String unicode = String::utf8(key_event.key);
+	String unicode = p_key_event_key;
 	if (unicode.length() == 1) {
 		c = unicode[0];
 	}
 
-	Key keycode = dom_code2godot_scancode(key_event.code, key_event.key, false);
-	Key scancode = dom_code2godot_scancode(key_event.code, key_event.key, true);
+	Key keycode = dom_code2godot_scancode(p_key_event_code.utf8().get_data(), p_key_event_key.utf8().get_data(), false);
+	Key scancode = dom_code2godot_scancode(p_key_event_code.utf8().get_data(), p_key_event_key.utf8().get_data(), true);
 
 	Ref<InputEventKey> ev;
 	ev.instantiate();
@@ -150,6 +202,17 @@ void DisplayServerWeb::key_callback(int p_pressed, int p_repeat, int p_modifiers
 // Mouse
 
 int DisplayServerWeb::mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_mouse_button_callback).bind(p_pressed, p_button, p_x, p_y, p_modifiers).call_deferred();
+		return true;
+	}
+#endif
+
+	return _mouse_button_callback(p_pressed, p_button, p_x, p_y, p_modifiers);
+}
+
+int DisplayServerWeb::_mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers) {
 	DisplayServerWeb *ds = get_singleton();
 
 	Point2 pos(p_x, p_y);
@@ -226,6 +289,17 @@ int DisplayServerWeb::mouse_button_callback(int p_pressed, int p_button, double 
 }
 
 void DisplayServerWeb::mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_mouse_move_callback).bind(p_x, p_y, p_rel_x, p_rel_y, p_modifiers).call_deferred();
+		return;
+	}
+#endif
+
+	_mouse_move_callback(p_x, p_y, p_rel_x, p_rel_y, p_modifiers);
+}
+
+void DisplayServerWeb::_mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers) {
 	BitField<MouseButtonMask> input_mask = Input::get_singleton()->get_mouse_button_mask();
 	// For motion outside the canvas, only read mouse movement if dragging
 	// started inside the canvas; imitating desktop app behavior.
@@ -301,9 +375,25 @@ bool DisplayServerWeb::tts_is_paused() const {
 }
 
 void DisplayServerWeb::update_voices_callback(int p_size, const char **p_voice) {
-	get_singleton()->voices.clear();
+	Vector<String> voices;
 	for (int i = 0; i < p_size; i++) {
-		Vector<String> tokens = String::utf8(p_voice[i]).split(";", true, 2);
+		voices.append(String::utf8(p_voice[i]));
+	}
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_update_voices_callback).bind(voices).call_deferred();
+		return;
+	}
+#endif
+
+	_update_voices_callback(voices);
+}
+
+void DisplayServerWeb::_update_voices_callback(const Vector<String> &p_voices) {
+	get_singleton()->voices.clear();
+	for (int i = 0; i < p_voices.size(); i++) {
+		Vector<String> tokens = p_voices[i].split(";", true, 2);
 		if (tokens.size() == 2) {
 			Dictionary voice_d;
 			voice_d["name"] = tokens[1];
@@ -334,7 +424,7 @@ void DisplayServerWeb::tts_speak(const String &p_text, const String &p_voice, in
 	CharString string = p_text.utf8();
 	utterance_ids[p_utterance_id] = string;
 
-	godot_js_tts_speak(string.get_data(), p_voice.utf8().get_data(), CLAMP(p_volume, 0, 100), CLAMP(p_pitch, 0.f, 2.f), CLAMP(p_rate, 0.1f, 10.f), p_utterance_id, DisplayServerWeb::_js_utterance_callback);
+	godot_js_tts_speak(string.get_data(), p_voice.utf8().get_data(), CLAMP(p_volume, 0, 100), CLAMP(p_pitch, 0.f, 2.f), CLAMP(p_rate, 0.1f, 10.f), p_utterance_id, DisplayServerWeb::js_utterance_callback);
 }
 
 void DisplayServerWeb::tts_pause() {
@@ -354,6 +444,17 @@ void DisplayServerWeb::tts_stop() {
 	}
 	utterance_ids.clear();
 	godot_js_tts_stop();
+}
+
+void DisplayServerWeb::js_utterance_callback(int p_event, int p_id, int p_pos) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_js_utterance_callback).bind(p_event, p_id, p_pos).call_deferred();
+		return;
+	}
+#endif
+
+	_js_utterance_callback(p_event, p_id, p_pos);
 }
 
 void DisplayServerWeb::_js_utterance_callback(int p_event, int p_id, int p_pos) {
@@ -507,6 +608,17 @@ Point2i DisplayServerWeb::mouse_get_position() const {
 
 // Wheel
 int DisplayServerWeb::mouse_wheel_callback(double p_delta_x, double p_delta_y) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_mouse_wheel_callback).bind(p_delta_x, p_delta_y).call_deferred();
+		return true;
+	}
+#endif
+
+	return _mouse_wheel_callback(p_delta_x, p_delta_y);
+}
+
+int DisplayServerWeb::_mouse_wheel_callback(double p_delta_x, double p_delta_y) {
 	if (!godot_js_display_canvas_is_focused()) {
 		if (get_singleton()->cursor_inside_canvas) {
 			godot_js_display_canvas_focus();
@@ -559,6 +671,17 @@ int DisplayServerWeb::mouse_wheel_callback(double p_delta_x, double p_delta_y) {
 
 // Touch
 void DisplayServerWeb::touch_callback(int p_type, int p_count) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_touch_callback).bind(p_type, p_count).call_deferred();
+		return;
+	}
+#endif
+
+	_touch_callback(p_type, p_count);
+}
+
+void DisplayServerWeb::_touch_callback(int p_type, int p_count) {
 	DisplayServerWeb *ds = get_singleton();
 
 	const JSTouchEvent &touch_event = ds->touch_event;
@@ -603,13 +726,25 @@ bool DisplayServerWeb::is_touchscreen_available() const {
 
 // Virtual Keyboard
 void DisplayServerWeb::vk_input_text_callback(const char *p_text, int p_cursor) {
+	String text = p_text;
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_vk_input_text_callback).bind(text, p_cursor).call_deferred();
+		return;
+	}
+#endif
+
+	_vk_input_text_callback(text, p_cursor);
+}
+
+void DisplayServerWeb::_vk_input_text_callback(const String &p_text, int p_cursor) {
 	DisplayServerWeb *ds = DisplayServerWeb::get_singleton();
 	if (!ds || ds->input_text_callback.is_null()) {
 		return;
 	}
 	// Call input_text
-	Variant event = String::utf8(p_text);
-	ds->input_text_callback.call(event);
+	ds->input_text_callback.call(p_text);
 	// Insert key right to reach position.
 	Input *input = Input::get_singleton();
 	Ref<InputEventKey> k;
@@ -636,14 +771,39 @@ void DisplayServerWeb::virtual_keyboard_hide() {
 }
 
 void DisplayServerWeb::window_blur_callback() {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_window_blur_callback).call_deferred();
+		return;
+	}
+#endif
+
+	_window_blur_callback();
+}
+
+void DisplayServerWeb::_window_blur_callback() {
 	Input::get_singleton()->release_pressed_events();
 }
 
 // Gamepad
 void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid) {
+	String id = p_id;
+	String guid = p_guid;
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_gamepad_callback).bind(p_index, p_connected, id, guid).call_deferred();
+		return;
+	}
+#endif
+
+	_gamepad_callback(p_index, p_connected, id, guid);
+}
+
+void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
 	Input *input = Input::get_singleton();
 	if (p_connected) {
-		input->joy_connection_changed(p_index, true, String::utf8(p_id), String::utf8(p_guid));
+		input->joy_connection_changed(p_index, true, p_id, p_guid);
 	} else {
 		input->joy_connection_changed(p_index, false, "");
 	}
@@ -687,7 +847,20 @@ Vector<String> DisplayServerWeb::get_rendering_drivers_func() {
 
 // Clipboard
 void DisplayServerWeb::update_clipboard_callback(const char *p_text) {
-	get_singleton()->clipboard = String::utf8(p_text);
+	String text = p_text;
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_update_clipboard_callback).bind(text).call_deferred();
+		return;
+	}
+#endif
+
+	_update_clipboard_callback(text);
+}
+
+void DisplayServerWeb::_update_clipboard_callback(const String &p_text) {
+	get_singleton()->clipboard = p_text;
 }
 
 void DisplayServerWeb::clipboard_set(const String &p_text) {
@@ -702,6 +875,17 @@ String DisplayServerWeb::clipboard_get() const {
 }
 
 void DisplayServerWeb::send_window_event_callback(int p_notification) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_send_window_event_callback).bind(p_notification).call_deferred();
+		return;
+	}
+#endif
+
+	_send_window_event_callback(p_notification);
+}
+
+void DisplayServerWeb::_send_window_event_callback(int p_notification) {
 	DisplayServerWeb *ds = get_singleton();
 	if (!ds) {
 		return;
@@ -816,19 +1000,19 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, WindowMode 
 	godot_js_input_mouse_wheel_cb(&DisplayServerWeb::mouse_wheel_callback);
 	godot_js_input_touch_cb(&DisplayServerWeb::touch_callback, touch_event.identifier, touch_event.coords);
 	godot_js_input_key_cb(&DisplayServerWeb::key_callback, key_event.code, key_event.key);
-	godot_js_input_paste_cb(update_clipboard_callback);
-	godot_js_input_drop_files_cb(drop_files_js_callback);
+	godot_js_input_paste_cb(&DisplayServerWeb::update_clipboard_callback);
+	godot_js_input_drop_files_cb(&DisplayServerWeb::drop_files_js_callback);
 	godot_js_input_gamepad_cb(&DisplayServerWeb::gamepad_callback);
 
 	// JS Display interface (js/libs/library_godot_display.js)
 	godot_js_display_fullscreen_cb(&DisplayServerWeb::fullscreen_change_callback);
-	godot_js_display_window_blur_cb(&window_blur_callback);
-	godot_js_display_notification_cb(&send_window_event_callback,
+	godot_js_display_window_blur_cb(&DisplayServerWeb::window_blur_callback);
+	godot_js_display_notification_cb(&DisplayServerWeb::send_window_event_callback,
 			WINDOW_EVENT_MOUSE_ENTER,
 			WINDOW_EVENT_MOUSE_EXIT,
 			WINDOW_EVENT_FOCUS_IN,
 			WINDOW_EVENT_FOCUS_OUT);
-	godot_js_display_vk_cb(&vk_input_text_callback);
+	godot_js_display_vk_cb(&DisplayServerWeb::vk_input_text_callback);
 
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_event);
 }

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -91,27 +91,42 @@ private:
 
 	// events
 	WASM_EXPORT static void fullscreen_change_callback(int p_fullscreen);
+	static void _fullscreen_change_callback(int p_fullscreen);
 	WASM_EXPORT static int mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
+	static int _mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
 	WASM_EXPORT static void mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers);
+	static void _mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers);
 	WASM_EXPORT static int mouse_wheel_callback(double p_delta_x, double p_delta_y);
+	static int _mouse_wheel_callback(double p_delta_x, double p_delta_y);
 	WASM_EXPORT static void touch_callback(int p_type, int p_count);
+	static void _touch_callback(int p_type, int p_count);
 	WASM_EXPORT static void key_callback(int p_pressed, int p_repeat, int p_modifiers);
+	static void _key_callback(const String &p_key_event_code, const String &p_key_event_key, int p_pressed, int p_repeat, int p_modifiers);
 	WASM_EXPORT static void vk_input_text_callback(const char *p_text, int p_cursor);
+	static void _vk_input_text_callback(const String &p_text, int p_cursor);
 	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
+	static void _gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid);
+	WASM_EXPORT static void js_utterance_callback(int p_event, int p_id, int p_pos);
+	static void _js_utterance_callback(int p_event, int p_id, int p_pos);
+	WASM_EXPORT static void request_quit_callback();
+	static void _request_quit_callback();
+	WASM_EXPORT static void window_blur_callback();
+	static void _window_blur_callback();
+	WASM_EXPORT static void update_voices_callback(int p_size, const char **p_voice);
+	static void _update_voices_callback(const Vector<String> &p_voices);
+	WASM_EXPORT static void update_clipboard_callback(const char *p_text);
+	static void _update_clipboard_callback(const String &p_text);
+	WASM_EXPORT static void send_window_event_callback(int p_notification);
+	static void _send_window_event_callback(int p_notification);
+	WASM_EXPORT static void drop_files_js_callback(const char **p_filev, int p_filec);
+	static void _drop_files_js_callback(const Vector<String> &p_files);
+
 	void process_joypads();
-	WASM_EXPORT static void _js_utterance_callback(int p_event, int p_id, int p_pos);
 
 	static Vector<String> get_rendering_drivers_func();
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_window_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error);
 
 	static void _dispatch_input_event(const Ref<InputEvent> &p_event);
-
-	WASM_EXPORT static void request_quit_callback();
-	WASM_EXPORT static void window_blur_callback();
-	WASM_EXPORT static void update_voices_callback(int p_size, const char **p_voice);
-	WASM_EXPORT static void update_clipboard_callback(const char *p_text);
-	WASM_EXPORT static void send_window_event_callback(int p_notification);
-	WASM_EXPORT static void drop_files_js_callback(char **p_filev, int p_filec);
 
 protected:
 	int get_current_video_driver() const;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -38,6 +38,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
@@ -69,7 +70,7 @@ extern int godot_js_input_gamepad_sample();
 extern int godot_js_input_gamepad_sample_count();
 extern int godot_js_input_gamepad_sample_get(int p_idx, float r_btns[16], int32_t *r_btns_num, float r_axes[10], int32_t *r_axes_num, int32_t *r_standard);
 extern void godot_js_input_paste_cb(void (*p_callback)(const char *p_text));
-extern void godot_js_input_drop_files_cb(void (*p_callback)(char **p_filev, int p_filec));
+extern void godot_js_input_drop_files_cb(void (*p_callback)(const char **p_filev, int p_filec));
 
 // TTS
 extern int godot_js_tts_is_speaking();

--- a/platform/web/godot_webgl2.h
+++ b/platform/web/godot_webgl2.h
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 void godot_webgl2_glFramebufferTextureMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+void godot_webgl2_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
 
 #define glFramebufferTextureMultiviewOVR godot_webgl2_glFramebufferTextureMultiviewOVR
 

--- a/platform/web/javascript_bridge_singleton.cpp
+++ b/platform/web/javascript_bridge_singleton.cpp
@@ -72,7 +72,8 @@ private:
 	WASM_EXPORT static void _free_lock(void **p_lock, int p_type);
 	WASM_EXPORT static Variant _js2variant(int p_type, godot_js_wrapper_ex *p_val);
 	WASM_EXPORT static void *_alloc_variants(int p_size);
-	WASM_EXPORT static void _callback(void *p_ref, int p_arg_id, int p_argc);
+	WASM_EXPORT static void callback(void *p_ref, int p_arg_id, int p_argc);
+	static void _callback(const JavaScriptObjectImpl *obj, Variant arg);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value) override;
@@ -245,9 +246,10 @@ Variant JavaScriptObjectImpl::callp(const StringName &p_method, const Variant **
 	return _js2variant(type, &exchange);
 }
 
-void JavaScriptObjectImpl::_callback(void *p_ref, int p_args_id, int p_argc) {
+void JavaScriptObjectImpl::callback(void *p_ref, int p_args_id, int p_argc) {
 	const JavaScriptObjectImpl *obj = (JavaScriptObjectImpl *)p_ref;
 	ERR_FAIL_COND_MSG(obj->_callable.is_null(), "JavaScript callback failed.");
+
 	Vector<const Variant *> argp;
 	Array arg_arr;
 	for (int i = 0; i < p_argc; i++) {
@@ -256,7 +258,20 @@ void JavaScriptObjectImpl::_callback(void *p_ref, int p_args_id, int p_argc) {
 		int type = godot_js_wrapper_object_getvar(p_args_id, Variant::INT, &exchange);
 		arg_arr.push_back(_js2variant(type, &exchange));
 	}
-	obj->_callable.call(arg_arr);
+	Variant arg = arg_arr;
+
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(JavaScriptObjectImpl::_callback).bind(obj, arg).call_deferred();
+		return;
+	}
+#endif
+
+	_callback(obj, arg);
+}
+
+void JavaScriptObjectImpl::_callback(const JavaScriptObjectImpl *obj, Variant arg) {
+	obj->_callable.call(arg);
 
 	// Set return value
 	godot_js_wrapper_ex exchange;
@@ -273,7 +288,7 @@ void JavaScriptObjectImpl::_callback(void *p_ref, int p_args_id, int p_argc) {
 Ref<JavaScriptObject> JavaScriptBridge::create_callback(const Callable &p_callable) {
 	Ref<JavaScriptObjectImpl> out = memnew(JavaScriptObjectImpl);
 	out->_callable = p_callable;
-	out->_js_id = godot_js_wrapper_create_cb(out.ptr(), JavaScriptObjectImpl::_callback);
+	out->_js_id = godot_js_wrapper_create_cb(out.ptr(), JavaScriptObjectImpl::callback);
 	return out;
 }
 

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -159,16 +159,19 @@ const GodotAudio = {
 		return 1;
 	},
 
+	godot_audio_has_worklet__proxy: 'sync',
 	godot_audio_has_worklet__sig: 'i',
 	godot_audio_has_worklet: function () {
 		return (GodotAudio.ctx && GodotAudio.ctx.audioWorklet) ? 1 : 0;
 	},
 
+	godot_audio_has_script_processor__proxy: 'sync',
 	godot_audio_has_script_processor__sig: 'i',
 	godot_audio_has_script_processor: function () {
 		return (GodotAudio.ctx && GodotAudio.ctx.createScriptProcessor) ? 1 : 0;
 	},
 
+	godot_audio_init__proxy: 'sync',
 	godot_audio_init__sig: 'iiiii',
 	godot_audio_init: function (p_mix_rate, p_latency, p_state_change, p_latency_update) {
 		const statechange = GodotRuntime.get_func(p_state_change);
@@ -179,6 +182,7 @@ const GodotAudio = {
 		return channels;
 	},
 
+	godot_audio_resume__proxy: 'sync',
 	godot_audio_resume__sig: 'v',
 	godot_audio_resume: function () {
 		if (GodotAudio.ctx && GodotAudio.ctx.state !== 'running') {
@@ -358,6 +362,7 @@ const GodotAudioWorklet = {
 		},
 	},
 
+	godot_audio_worklet_create__proxy: 'sync',
 	godot_audio_worklet_create__sig: 'ii',
 	godot_audio_worklet_create: function (channels) {
 		try {
@@ -369,6 +374,7 @@ const GodotAudioWorklet = {
 		return 0;
 	},
 
+	godot_audio_worklet_start__proxy: 'sync',
 	godot_audio_worklet_start__sig: 'viiiii',
 	godot_audio_worklet_start: function (p_in_buf, p_in_size, p_out_buf, p_out_size, p_state) {
 		const out_buffer = GodotRuntime.heapSub(HEAPF32, p_out_buf, p_out_size);
@@ -377,6 +383,7 @@ const GodotAudioWorklet = {
 		GodotAudioWorklet.start(in_buffer, out_buffer, state);
 	},
 
+	godot_audio_worklet_start_no_threads__proxy: 'sync',
 	godot_audio_worklet_start_no_threads__sig: 'viiiiii',
 	godot_audio_worklet_start_no_threads: function (p_out_buf, p_out_size, p_out_callback, p_in_buf, p_in_size, p_in_callback) {
 		const out_callback = GodotRuntime.get_func(p_out_callback);
@@ -465,6 +472,7 @@ const GodotAudioScript = {
 		},
 	},
 
+	godot_audio_script_create__proxy: 'sync',
 	godot_audio_script_create__sig: 'iii',
 	godot_audio_script_create: function (buffer_length, channel_count) {
 		const buf_len = GodotRuntime.getHeapValue(buffer_length, 'i32');
@@ -478,6 +486,7 @@ const GodotAudioScript = {
 		return 0;
 	},
 
+	godot_audio_script_start__proxy: 'sync',
 	godot_audio_script_start__sig: 'viiiii',
 	godot_audio_script_start: function (p_in_buf, p_in_size, p_out_buf, p_out_size, p_cb) {
 		const onprocess = GodotRuntime.get_func(p_cb);

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -345,6 +345,7 @@ const GodotDisplay = {
 		},
 	},
 
+	godot_js_display_is_swap_ok_cancel__proxy: 'sync',
 	godot_js_display_is_swap_ok_cancel__sig: 'i',
 	godot_js_display_is_swap_ok_cancel: function () {
 		const win = (['Windows', 'Win64', 'Win32', 'WinCE']);
@@ -355,16 +356,19 @@ const GodotDisplay = {
 		return 0;
 	},
 
+	godot_js_tts_is_speaking__proxy: 'sync',
 	godot_js_tts_is_speaking__sig: 'i',
 	godot_js_tts_is_speaking: function () {
 		return window.speechSynthesis.speaking;
 	},
 
+	godot_js_tts_is_paused__proxy: 'sync',
 	godot_js_tts_is_paused__sig: 'i',
 	godot_js_tts_is_paused: function () {
 		return window.speechSynthesis.paused;
 	},
 
+	godot_js_tts_get_voices__proxy: 'sync',
 	godot_js_tts_get_voices__sig: 'vi',
 	godot_js_tts_get_voices: function (p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
@@ -382,6 +386,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_tts_speak__proxy: 'sync',
 	godot_js_tts_speak__sig: 'viiiffii',
 	godot_js_tts_speak: function (p_text, p_voice, p_volume, p_pitch, p_rate, p_utterance_id, p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
@@ -424,53 +429,63 @@ const GodotDisplay = {
 		window.speechSynthesis.speak(utterance);
 	},
 
+	godot_js_tts_pause__proxy: 'sync',
 	godot_js_tts_pause__sig: 'v',
 	godot_js_tts_pause: function () {
 		window.speechSynthesis.pause();
 	},
 
+	godot_js_tts_resume__proxy: 'sync',
 	godot_js_tts_resume__sig: 'v',
 	godot_js_tts_resume: function () {
 		window.speechSynthesis.resume();
 	},
 
+	godot_js_tts_stop__proxy: 'sync',
 	godot_js_tts_stop__sig: 'v',
 	godot_js_tts_stop: function () {
 		window.speechSynthesis.cancel();
 		window.speechSynthesis.resume();
 	},
 
+	godot_js_display_alert__proxy: 'sync',
 	godot_js_display_alert__sig: 'vi',
 	godot_js_display_alert: function (p_text) {
 		window.alert(GodotRuntime.parseString(p_text)); // eslint-disable-line no-alert
 	},
 
+	godot_js_display_screen_dpi_get__proxy: 'sync',
 	godot_js_display_screen_dpi_get__sig: 'i',
 	godot_js_display_screen_dpi_get: function () {
 		return GodotDisplay.getDPI();
 	},
 
+	godot_js_display_pixel_ratio_get__proxy: 'sync',
 	godot_js_display_pixel_ratio_get__sig: 'f',
 	godot_js_display_pixel_ratio_get: function () {
 		return GodotDisplayScreen.getPixelRatio();
 	},
 
+	godot_js_display_fullscreen_request__proxy: 'sync',
 	godot_js_display_fullscreen_request__sig: 'i',
 	godot_js_display_fullscreen_request: function () {
 		return GodotDisplayScreen.requestFullscreen();
 	},
 
+	godot_js_display_fullscreen_exit__proxy: 'sync',
 	godot_js_display_fullscreen_exit__sig: 'i',
 	godot_js_display_fullscreen_exit: function () {
 		return GodotDisplayScreen.exitFullscreen();
 	},
 
+	godot_js_display_desired_size_set__proxy: 'sync',
 	godot_js_display_desired_size_set__sig: 'vii',
 	godot_js_display_desired_size_set: function (width, height) {
 		GodotDisplayScreen.desired_size = [width, height];
 		GodotDisplayScreen.updateSize();
 	},
 
+	godot_js_display_size_update__proxy: 'sync',
 	godot_js_display_size_update__sig: 'i',
 	godot_js_display_size_update: function () {
 		const updated = GodotDisplayScreen.updateSize();
@@ -480,6 +495,7 @@ const GodotDisplay = {
 		return updated;
 	},
 
+	godot_js_display_screen_size_get__proxy: 'sync',
 	godot_js_display_screen_size_get__sig: 'vii',
 	godot_js_display_screen_size_get: function (width, height) {
 		const scale = GodotDisplayScreen.getPixelRatio();
@@ -487,12 +503,14 @@ const GodotDisplay = {
 		GodotRuntime.setHeapValue(height, window.screen.height * scale, 'i32');
 	},
 
+	godot_js_display_window_size_get__proxy: 'sync',
 	godot_js_display_window_size_get__sig: 'vii',
 	godot_js_display_window_size_get: function (p_width, p_height) {
 		GodotRuntime.setHeapValue(p_width, GodotConfig.canvas.width, 'i32');
 		GodotRuntime.setHeapValue(p_height, GodotConfig.canvas.height, 'i32');
 	},
 
+	godot_js_display_has_webgl__proxy: 'sync',
 	godot_js_display_has_webgl__sig: 'ii',
 	godot_js_display_has_webgl: function (p_version) {
 		if (p_version !== 1 && p_version !== 2) {
@@ -507,11 +525,13 @@ const GodotDisplay = {
 	/*
 	 * Canvas
 	 */
+	godot_js_display_canvas_focus__proxy: 'sync',
 	godot_js_display_canvas_focus__sig: 'v',
 	godot_js_display_canvas_focus: function () {
 		GodotConfig.canvas.focus();
 	},
 
+	godot_js_display_canvas_is_focused__proxy: 'sync',
 	godot_js_display_canvas_is_focused__sig: 'i',
 	godot_js_display_canvas_is_focused: function () {
 		return document.activeElement === GodotConfig.canvas;
@@ -520,6 +540,7 @@ const GodotDisplay = {
 	/*
 	 * Touchscreen
 	 */
+	godot_js_display_touchscreen_is_available__proxy: 'sync',
 	godot_js_display_touchscreen_is_available__sig: 'i',
 	godot_js_display_touchscreen_is_available: function () {
 		return 'ontouchstart' in window;
@@ -528,6 +549,7 @@ const GodotDisplay = {
 	/*
 	 * Clipboard
 	 */
+	godot_js_display_clipboard_set__proxy: 'sync',
 	godot_js_display_clipboard_set__sig: 'ii',
 	godot_js_display_clipboard_set: function (p_text) {
 		const text = GodotRuntime.parseString(p_text);
@@ -541,6 +563,7 @@ const GodotDisplay = {
 		return 0;
 	},
 
+	godot_js_display_clipboard_get__proxy: 'sync',
 	godot_js_display_clipboard_get__sig: 'ii',
 	godot_js_display_clipboard_get: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -560,11 +583,13 @@ const GodotDisplay = {
 	/*
 	 * Window
 	 */
+	godot_js_display_window_title_set__proxy: 'sync',
 	godot_js_display_window_title_set__sig: 'vi',
 	godot_js_display_window_title_set: function (p_data) {
 		document.title = GodotRuntime.parseString(p_data);
 	},
 
+	godot_js_display_window_icon_set__proxy: 'sync',
 	godot_js_display_window_icon_set__sig: 'vii',
 	godot_js_display_window_icon_set: function (p_ptr, p_len) {
 		let link = document.getElementById('-gd-engine-icon');
@@ -593,6 +618,7 @@ const GodotDisplay = {
 	/*
 	 * Cursor
 	 */
+	godot_js_display_cursor_set_visible__proxy: 'sync',
 	godot_js_display_cursor_set_visible__sig: 'vi',
 	godot_js_display_cursor_set_visible: function (p_visible) {
 		const visible = p_visible !== 0;
@@ -607,16 +633,19 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_is_hidden__proxy: 'sync',
 	godot_js_display_cursor_is_hidden__sig: 'i',
 	godot_js_display_cursor_is_hidden: function () {
 		return !GodotDisplayCursor.visible;
 	},
 
+	godot_js_display_cursor_set_shape__proxy: 'sync',
 	godot_js_display_cursor_set_shape__sig: 'vi',
 	godot_js_display_cursor_set_shape: function (p_string) {
 		GodotDisplayCursor.set_shape(GodotRuntime.parseString(p_string));
 	},
 
+	godot_js_display_cursor_set_custom_shape__proxy: 'sync',
 	godot_js_display_cursor_set_custom_shape__sig: 'viiiii',
 	godot_js_display_cursor_set_custom_shape: function (p_shape, p_ptr, p_len, p_hotspot_x, p_hotspot_y) {
 		const shape = GodotRuntime.parseString(p_shape);
@@ -640,6 +669,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_lock_set__proxy: 'sync',
 	godot_js_display_cursor_lock_set__sig: 'vi',
 	godot_js_display_cursor_lock_set: function (p_lock) {
 		if (p_lock) {
@@ -649,6 +679,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_is_locked__proxy: 'sync',
 	godot_js_display_cursor_is_locked__sig: 'i',
 	godot_js_display_cursor_is_locked: function () {
 		return GodotDisplayCursor.isPointerLocked() ? 1 : 0;
@@ -657,6 +688,7 @@ const GodotDisplay = {
 	/*
 	 * Listeners
 	 */
+	godot_js_display_fullscreen_cb__proxy: 'sync',
 	godot_js_display_fullscreen_cb__sig: 'vi',
 	godot_js_display_fullscreen_cb: function (callback) {
 		const canvas = GodotConfig.canvas;
@@ -671,6 +703,7 @@ const GodotDisplay = {
 		GodotEventListeners.add(document, 'webkitfullscreenchange', change_cb, false);
 	},
 
+	godot_js_display_window_blur_cb__proxy: 'sync',
 	godot_js_display_window_blur_cb__sig: 'vi',
 	godot_js_display_window_blur_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -679,6 +712,7 @@ const GodotDisplay = {
 		}, false);
 	},
 
+	godot_js_display_notification_cb__proxy: 'sync',
 	godot_js_display_notification_cb__sig: 'viiiii',
 	godot_js_display_notification_cb: function (callback, p_enter, p_exit, p_in, p_out) {
 		const canvas = GodotConfig.canvas;
@@ -691,6 +725,7 @@ const GodotDisplay = {
 		});
 	},
 
+	godot_js_display_setup_canvas__proxy: 'sync',
 	godot_js_display_setup_canvas__sig: 'viiii',
 	godot_js_display_setup_canvas: function (p_width, p_height, p_fullscreen, p_hidpi) {
 		const canvas = GodotConfig.canvas;
@@ -725,6 +760,7 @@ const GodotDisplay = {
 	/*
 	 * Virtual Keyboard
 	 */
+	godot_js_display_vk_show__proxy: 'sync',
 	godot_js_display_vk_show__sig: 'viiii',
 	godot_js_display_vk_show: function (p_text, p_type, p_start, p_end) {
 		const text = GodotRuntime.parseString(p_text);
@@ -733,21 +769,25 @@ const GodotDisplay = {
 		GodotDisplayVK.show(text, p_type, start, end);
 	},
 
+	godot_js_display_vk_hide__proxy: 'sync',
 	godot_js_display_vk_hide__sig: 'v',
 	godot_js_display_vk_hide: function () {
 		GodotDisplayVK.hide();
 	},
 
+	godot_js_display_vk_available__proxy: 'sync',
 	godot_js_display_vk_available__sig: 'i',
 	godot_js_display_vk_available: function () {
 		return GodotDisplayVK.available();
 	},
 
+	godot_js_display_tts_available__proxy: 'sync',
 	godot_js_display_tts_available__sig: 'i',
 	godot_js_display_tts_available: function () {
 		return 'speechSynthesis' in window;
 	},
 
+	godot_js_display_vk_cb__proxy: 'sync',
 	godot_js_display_vk_cb__sig: 'vi',
 	godot_js_display_vk_cb: function (p_input_cb) {
 		const input_cb = GodotRuntime.get_func(p_input_cb);

--- a/platform/web/js/libs/library_godot_fetch.js
+++ b/platform/web/js/libs/library_godot_fetch.js
@@ -125,6 +125,7 @@ const GodotFetch = {
 		},
 	},
 
+	godot_js_fetch_create__proxy: 'sync',
 	godot_js_fetch_create__sig: 'iiiiiii',
 	godot_js_fetch_create: function (p_method, p_url, p_headers, p_headers_size, p_body, p_body_size) {
 		const method = GodotRuntime.parseString(p_method);
@@ -145,6 +146,7 @@ const GodotFetch = {
 		}), body);
 	},
 
+	godot_js_fetch_state_get__proxy: 'sync',
 	godot_js_fetch_state_get__sig: 'ii',
 	godot_js_fetch_state_get: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -166,6 +168,7 @@ const GodotFetch = {
 		return -1;
 	},
 
+	godot_js_fetch_http_status_get__proxy: 'sync',
 	godot_js_fetch_http_status_get__sig: 'ii',
 	godot_js_fetch_http_status_get: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -175,6 +178,7 @@ const GodotFetch = {
 		return obj.status;
 	},
 
+	godot_js_fetch_read_headers__proxy: 'sync',
 	godot_js_fetch_read_headers__sig: 'iiii',
 	godot_js_fetch_read_headers: function (p_id, p_parse_cb, p_ref) {
 		const obj = IDHandler.get(p_id);
@@ -192,6 +196,7 @@ const GodotFetch = {
 		return 0;
 	},
 
+	godot_js_fetch_read_chunk__proxy: 'sync',
 	godot_js_fetch_read_chunk__sig: 'iiii',
 	godot_js_fetch_read_chunk: function (p_id, p_buf, p_buf_size) {
 		const obj = IDHandler.get(p_id);
@@ -218,6 +223,7 @@ const GodotFetch = {
 		return p_buf_size - to_read;
 	},
 
+	godot_js_fetch_is_chunked__proxy: 'sync',
 	godot_js_fetch_is_chunked__sig: 'ii',
 	godot_js_fetch_is_chunked: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -227,6 +233,7 @@ const GodotFetch = {
 		return obj.chunked ? 1 : 0;
 	},
 
+	godot_js_fetch_free__proxy: 'sync',
 	godot_js_fetch_free__sig: 'vi',
 	godot_js_fetch_free: function (id) {
 		GodotFetch.free(id);

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -356,6 +356,7 @@ const GodotInput = {
 	/*
 	 * Mouse API
 	 */
+	godot_js_input_mouse_move_cb__proxy: 'sync',
 	godot_js_input_mouse_move_cb__sig: 'vi',
 	godot_js_input_mouse_move_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -374,6 +375,7 @@ const GodotInput = {
 		GodotEventListeners.add(window, 'mousemove', move_cb, false);
 	},
 
+	godot_js_input_mouse_wheel_cb__proxy: 'sync',
 	godot_js_input_mouse_wheel_cb__sig: 'vi',
 	godot_js_input_mouse_wheel_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -385,6 +387,7 @@ const GodotInput = {
 		GodotEventListeners.add(GodotConfig.canvas, 'wheel', wheel_cb, false);
 	},
 
+	godot_js_input_mouse_button_cb__proxy: 'sync',
 	godot_js_input_mouse_button_cb__sig: 'vi',
 	godot_js_input_mouse_button_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -409,6 +412,7 @@ const GodotInput = {
 	/*
 	 * Touch API
 	 */
+	godot_js_input_touch_cb__proxy: 'sync',
 	godot_js_input_touch_cb__sig: 'viii',
 	godot_js_input_touch_cb: function (callback, ids, coords) {
 		const func = GodotRuntime.get_func(callback);
@@ -442,6 +446,7 @@ const GodotInput = {
 	/*
 	 * Key API
 	 */
+	godot_js_input_key_cb__proxy: 'sync',
 	godot_js_input_key_cb__sig: 'viii',
 	godot_js_input_key_cb: function (callback, code, key) {
 		const func = GodotRuntime.get_func(callback);
@@ -459,23 +464,27 @@ const GodotInput = {
 	/*
 	 * Gamepad API
 	 */
+	godot_js_input_gamepad_cb__proxy: 'sync',
 	godot_js_input_gamepad_cb__sig: 'vi',
 	godot_js_input_gamepad_cb: function (change_cb) {
 		const onchange = GodotRuntime.get_func(change_cb);
 		GodotInputGamepads.init(onchange);
 	},
 
+	godot_js_input_gamepad_sample_count__proxy: 'sync',
 	godot_js_input_gamepad_sample_count__sig: 'i',
 	godot_js_input_gamepad_sample_count: function () {
 		return GodotInputGamepads.get_samples().length;
 	},
 
+	godot_js_input_gamepad_sample__proxy: 'sync',
 	godot_js_input_gamepad_sample__sig: 'i',
 	godot_js_input_gamepad_sample: function () {
 		GodotInputGamepads.sample();
 		return 0;
 	},
 
+	godot_js_input_gamepad_sample_get__proxy: 'sync',
 	godot_js_input_gamepad_sample_get__sig: 'iiiiiii',
 	godot_js_input_gamepad_sample_get: function (p_index, r_btns, r_btns_num, r_axes, r_axes_num, r_standard) {
 		const sample = GodotInputGamepads.get_sample(p_index);
@@ -502,6 +511,7 @@ const GodotInput = {
 	/*
 	 * Drag/Drop API
 	 */
+	godot_js_input_drop_files_cb__proxy: 'sync',
 	godot_js_input_drop_files_cb__sig: 'vi',
 	godot_js_input_drop_files_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -524,6 +534,7 @@ const GodotInput = {
 	},
 
 	/* Paste API */
+	godot_js_input_paste_cb__proxy: 'sync',
 	godot_js_input_paste_cb__sig: 'vi',
 	godot_js_input_paste_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -535,6 +546,7 @@ const GodotInput = {
 		}, false);
 	},
 
+	godot_js_input_vibrate_handheld__proxy: 'sync',
 	godot_js_input_vibrate_handheld__sig: 'vi',
 	godot_js_input_vibrate_handheld: function (p_duration_ms) {
 		if (typeof navigator.vibrate !== 'function') {

--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -121,6 +121,7 @@ const GodotJSWrapper = {
 		},
 	},
 
+	godot_js_wrapper_interface_get__proxy: 'sync',
 	godot_js_wrapper_interface_get__sig: 'ii',
 	godot_js_wrapper_interface_get: function (p_name) {
 		const name = GodotRuntime.parseString(p_name);
@@ -130,6 +131,7 @@ const GodotJSWrapper = {
 		return 0;
 	},
 
+	godot_js_wrapper_object_get__proxy: 'sync',
 	godot_js_wrapper_object_get__sig: 'iiii',
 	godot_js_wrapper_object_get: function (p_id, p_exchange, p_prop) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -148,6 +150,7 @@ const GodotJSWrapper = {
 		return GodotJSWrapper.js2variant(obj, p_exchange);
 	},
 
+	godot_js_wrapper_object_set__proxy: 'sync',
 	godot_js_wrapper_object_set__sig: 'viiii',
 	godot_js_wrapper_object_set: function (p_id, p_name, p_type, p_exchange) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -162,6 +165,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_call__proxy: 'sync',
 	godot_js_wrapper_object_call__sig: 'iiiiiiiii',
 	godot_js_wrapper_object_call: function (p_id, p_method, p_args, p_argc, p_convert_callback, p_exchange, p_lock, p_free_lock_callback) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -189,6 +193,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_unref__proxy: 'sync',
 	godot_js_wrapper_object_unref__sig: 'vi',
 	godot_js_wrapper_object_unref: function (p_id) {
 		const proxy = IDHandler.get(p_id);
@@ -197,6 +202,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_create_cb__proxy: 'sync',
 	godot_js_wrapper_create_cb__sig: 'iii',
 	godot_js_wrapper_create_cb: function (p_ref, p_func) {
 		const func = GodotRuntime.get_func(p_func);
@@ -221,11 +227,13 @@ const GodotJSWrapper = {
 		return id;
 	},
 
+	godot_js_wrapper_object_set_cb_ret__proxy: 'sync',
 	godot_js_wrapper_object_set_cb_ret__sig: 'vii',
 	godot_js_wrapper_object_set_cb_ret: function (p_val_type, p_val_ex) {
 		GodotJSWrapper.cb_ret = GodotJSWrapper.variant2js(p_val_type, p_val_ex);
 	},
 
+	godot_js_wrapper_object_getvar__proxy: 'sync',
 	godot_js_wrapper_object_getvar__sig: 'iiii',
 	godot_js_wrapper_object_getvar: function (p_id, p_type, p_exchange) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -244,6 +252,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_setvar__proxy: 'sync',
 	godot_js_wrapper_object_setvar__sig: 'iiiiii',
 	godot_js_wrapper_object_setvar: function (p_id, p_key_type, p_key_ex, p_val_type, p_val_ex) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -260,6 +269,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_create_object__proxy: 'sync',
 	godot_js_wrapper_create_object__sig: 'iiiiiiii',
 	godot_js_wrapper_create_object: function (p_object, p_args, p_argc, p_convert_callback, p_exchange, p_lock, p_free_lock_callback) {
 		const name = GodotRuntime.parseString(p_object);

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -91,11 +91,13 @@ const GodotConfig = {
 		},
 	},
 
+	godot_js_config_canvas_id_get__proxy: 'sync',
 	godot_js_config_canvas_id_get__sig: 'vii',
 	godot_js_config_canvas_id_get: function (p_ptr, p_ptr_max) {
 		GodotRuntime.stringToHeap(`#${GodotConfig.canvas.id}`, p_ptr, p_ptr_max);
 	},
 
+	godot_js_config_locale_get__proxy: 'sync',
 	godot_js_config_locale_get__sig: 'vii',
 	godot_js_config_locale_get: function (p_ptr, p_ptr_max) {
 		GodotRuntime.stringToHeap(GodotConfig.locale, p_ptr, p_ptr_max);
@@ -266,22 +268,26 @@ const GodotOS = {
 		},
 	},
 
+	godot_js_os_finish_async__proxy: 'sync',
 	godot_js_os_finish_async__sig: 'vi',
 	godot_js_os_finish_async: function (p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
 		GodotOS.finish_async(func);
 	},
 
+	godot_js_os_request_quit_cb__proxy: 'sync',
 	godot_js_os_request_quit_cb__sig: 'vi',
 	godot_js_os_request_quit_cb: function (p_callback) {
 		GodotOS.request_quit = GodotRuntime.get_func(p_callback);
 	},
 
+	godot_js_os_fs_is_persistent__proxy: 'sync',
 	godot_js_os_fs_is_persistent__sig: 'i',
 	godot_js_os_fs_is_persistent: function () {
 		return GodotFS.is_persistent();
 	},
 
+	godot_js_os_fs_sync__proxy: 'sync',
 	godot_js_os_fs_sync__sig: 'vi',
 	godot_js_os_fs_sync: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -291,6 +297,7 @@ const GodotOS = {
 		});
 	},
 
+	godot_js_os_has_feature__proxy: 'sync',
 	godot_js_os_has_feature__sig: 'ii',
 	godot_js_os_has_feature: function (p_ftr) {
 		const ftr = GodotRuntime.parseString(p_ftr);
@@ -313,6 +320,7 @@ const GodotOS = {
 		return 0;
 	},
 
+	godot_js_os_execute__proxy: 'sync',
 	godot_js_os_execute__sig: 'ii',
 	godot_js_os_execute: function (p_json) {
 		const json_args = GodotRuntime.parseString(p_json);
@@ -324,11 +332,13 @@ const GodotOS = {
 		return 1;
 	},
 
+	godot_js_os_shell_open__proxy: 'sync',
 	godot_js_os_shell_open__sig: 'vi',
 	godot_js_os_shell_open: function (p_uri) {
 		window.open(GodotRuntime.parseString(p_uri), '_blank');
 	},
 
+	godot_js_os_hw_concurrency_get__proxy: 'sync',
 	godot_js_os_hw_concurrency_get__sig: 'i',
 	godot_js_os_hw_concurrency_get: function () {
 		// TODO Godot core needs fixing to avoid spawning too many threads (> 24).
@@ -336,6 +346,7 @@ const GodotOS = {
 		return concurrency < 2 ? concurrency : 2;
 	},
 
+	godot_js_os_download_buffer__proxy: 'sync',
 	godot_js_os_download_buffer__sig: 'viiii',
 	godot_js_os_download_buffer: function (p_ptr, p_size, p_name, p_mime) {
 		const buf = GodotRuntime.heapSlice(HEAP8, p_ptr, p_size);
@@ -426,6 +437,7 @@ const GodotPWA = {
 		},
 	},
 
+	godot_js_pwa_cb__proxy: 'sync',
 	godot_js_pwa_cb__sig: 'vi',
 	godot_js_pwa_cb: function (p_update_cb) {
 		if ('serviceWorker' in navigator) {
@@ -434,6 +446,7 @@ const GodotPWA = {
 		}
 	},
 
+	godot_js_pwa_update__proxy: 'sync',
 	godot_js_pwa_update__sig: 'i',
 	godot_js_pwa_update: function () {
 		if ('serviceWorker' in navigator && GodotPWA.hasUpdate) {

--- a/platform/web/js/libs/library_godot_webgl2.js
+++ b/platform/web/js/libs/library_godot_webgl2.js
@@ -32,6 +32,19 @@ const GodotWebGL2 = {
 	$GodotWebGL2__deps: ['$GL', '$GodotRuntime'],
 	$GodotWebGL2: {},
 
+	// This is implemented as "glGetBufferSubData" in new emscripten versions.
+	// Since we have to support older (pre 2.0.17) emscripten versions, we add this wrapper function instead.
+	godot_webgl2_glGetBufferSubData__proxy: 'sync',
+	godot_webgl2_glGetBufferSubData__sig: 'vippp',
+	godot_webgl2_glGetBufferSubData__deps: ['$GL', 'emscripten_webgl_get_current_context'],
+	godot_webgl2_glGetBufferSubData: function (target, offset, size, data) {
+		const gl_context_handle = _emscripten_webgl_get_current_context(); // eslint-disable-line no-undef
+		const gl = GL.getContext(gl_context_handle);
+		if (gl) {
+			gl.GLctx['getBufferSubData'](target, offset, HEAPU8, data, size);
+		}
+	},
+
 	godot_webgl2_glFramebufferTextureMultiviewOVR__deps: ['emscripten_webgl_get_current_context'],
 	godot_webgl2_glFramebufferTextureMultiviewOVR__proxy: 'sync',
 	godot_webgl2_glFramebufferTextureMultiviewOVR__sig: 'viiiiii',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -160,6 +160,12 @@ String OS_Web::get_name() const {
 	return "Web";
 }
 
+void OS_Web::add_frame_delay(bool p_can_draw) {
+#ifndef PROXY_TO_PTHREAD_ENABLED
+	OS::add_frame_delay(p_can_draw);
+#endif
+}
+
 void OS_Web::vibrate_handheld(int p_duration_ms) {
 	godot_js_input_vibrate_handheld(p_duration_ms);
 }

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -91,9 +91,10 @@ public:
 	String get_executable_path() const override;
 	Error shell_open(String p_uri) override;
 	String get_name() const override;
+
 	// Override default OS implementation which would block the main thread with delay_usec.
 	// Implemented in web_main.cpp loop callback instead.
-	void add_frame_delay(bool p_can_draw) override {}
+	void add_frame_delay(bool p_can_draw) override;
 
 	void vibrate_handheld(int p_duration_ms) override;
 


### PR DESCRIPTION
This PR adds the option `proxy_to_pthread` to the `web` platform (with `proxy_to_pthread=yes` as default value).

The emscripten library compiles C/C++ apps to WASM. Unfortunately, WASM, when ran in the main thread, runs synchronously, making it block the main thread. That makes it so that if the application is in a computing intensive task, it will block the page main thread, affecting the UI and the usability of that page.

When compiled with this PR, users can use the web page (like entering text in a form) without any noticeable issues. Currently, it is impossible to write such text while the engine is loading. [See that Firefox profiler as an example.](https://profiler.firefox.com/public/jvac57xxa4cfqaazyxshq37w0g8q7xqmc6jvc9g/calltree/?globalTrackOrder=d0wc&hiddenGlobalTracks=1w79wb&hiddenLocalTracksByPid=203065-1w4~212678-0~212002-01~203236-0w3~212359-0wbdwg&thread=d&v=9)

| ![image](https://github.com/godotengine/godot/assets/270928/440b939c-e7db-4396-a75f-7c56d8885b95) |
| :---: |
| See the red line in the Isolate Web Content row, user input is impossible during that time |

[Emscripten offers a linker option to run the application in a web worker](https://emscripten.org/docs/porting/pthreads.html#additional-flags), effectively fixing the issue mentioned above. Web workers are the equivalent of threads for the web platform.

With my PR, if the user add the `do_no_block_main_thread=yes` option to it's `platform=web` scons build, the builder adds `-s PROXY_TO_PTHREAD` to the linker options to create a stub `main()` function that will act as a proxy to the newly created main web worker.

> **Note** 
> My PR will add the `-s TEXTDECODER=0` option to the linker too, as there was [non-consistent issues about internal emscripten calls](https://github.com/emscripten-core/emscripten/issues/18034). The suggested solution from the developer seems to deactivate `TEXTDECODER`, as [there no big impact on the usability of the application](https://github.com/emscripten-core/emscripten/issues/18034#issuecomment-1277561925).

[The Javascript C API](https://emscripten.org/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.html#implement-a-c-api-in-javascript) ("platform/web/js/libs") had to be updated to specify the `__proxy` setting (now set to `sync`). This is because otherwise, the web worker will use it's default `Module` values that were initialized with the web worker. But all the data set before the initialization still reside in the main thread.

Setting the value `sync` to each function `__proxy` option makes it so that emscripten knows that the C API Javascript function must be run on the main thread instead of in the main web worker.

---

Here's a demo. Don't mind the non-fluid mouse movement, it's related to the screen capture, it was super smooth while recording. But notice how the HTML UI react even if either the editor blocks the thread when loading (as usual) or while the game blocks the thread each frame for a whole second.

[Capture vidéo du 2023-07-29 14-31-18.webm](https://github.com/godotengine/godot/assets/270928/ad53296c-9015-486f-97d8-6457ba937575)

---

**TL;DR** Your game will still freeze under heavy processing on the main thread. But, the web page hosting the game will not freeze, as the Godot game will run in it's own thread instead of running on the web page's main thread.

---

> **Note**
> ~~This PR needs testing. There's some issues known issues about this PR. (when fixed, this PR will drop it's draft status.)~~
> - ~~input is broken.~~ (fixed)