### PR TITLE
Remove unused struct from NavigationMesh

### DIFF
--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -43,19 +43,6 @@ class NavigationMesh : public Resource {
 	Vector<Polygon> polygons;
 	Ref<ArrayMesh> debug_mesh;
 
-	struct _EdgeKey {
-		Vector3 from;
-		Vector3 to;
-
-		static uint32_t hash(const _EdgeKey &p_key) {
-			return HashMapHasherDefault::hash(p_key.from) ^ HashMapHasherDefault::hash(p_key.to);
-		}
-
-		bool operator==(const _EdgeKey &p_with) const {
-			return HashMapComparatorDefault<Vector3>::compare(from, p_with.from) && HashMapComparatorDefault<Vector3>::compare(to, p_with.to);
-		}
-	};
-
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
Removes unused struct from NavigationMesh.

This `_EdgeKey` struct was used in the legacy navigation mesh debug to find the outline edges for the debug visuals.

With the new debug this is no longer in use. Should the outlines ever make a debug return the navigation mesh is not the place for it, especially since the Editor gizmo has still a redundant copy of this struct.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
