### PR TITLE
Fix gcc builds failing on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2409,8 +2409,8 @@ void DisplayServerWindows::set_icon(const Ref<Image> &p_icon) {
 		SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_BIG, (LPARAM)hicon);
 	} else {
 		icon = Ref<Image>();
-		SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_SMALL, NULL);
-		SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_BIG, NULL);
+		SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_SMALL, 0);
+		SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_BIG, 0);
 	}
 }
 

--- a/platform/windows/gl_manager_windows.cpp
+++ b/platform/windows/gl_manager_windows.cpp
@@ -53,6 +53,7 @@
 #if defined(__GNUC__)
 // Workaround GCC warning from -Wcast-function-type.
 #define wglGetProcAddress (void *)wglGetProcAddress
+#define GetProcAddress (void *)GetProcAddress
 #endif
 
 typedef HGLRC(APIENTRY *PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC, HGLRC, const int *);


### PR DESCRIPTION
Addresses 3 seperate errors/failings that occured for me when trying to build on windows with mingw

```
platform\windows\gl_manager_windows.cpp: In member function 'void GLManager_Windows::_nvapi_disable_threaded_optimization()':
platform\windows\gl_manager_windows.cpp:118:32: error: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'void* (*)(unsigned int)' [-Werror=cast-function-type]
  118 |         NvAPI_QueryInterface = (void *(__cdecl *)(unsigned int))GetProcAddress(nvapi, "nvapi_QueryInterface");
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
A define existed for `wglGetProcAddress`, but not `GetProcAddress` like most other Windows files; that's now fixed

```
platform\windows\display_server_windows.cpp: In member function 'virtual void DisplayServerWindows::set_icon(const Ref<Image>&)':
platform\windows\display_server_windows.cpp:2412:83: error: passing NULL to non-pointer argument 4 of 'LRESULT SendMessageA(HWND, UINT, WPARAM, LPARAM)' [-Werror=conversion-null]
 2412 |                 SendMessage(windows[MAIN_WINDOW_ID].hWnd, WM_SETICON, ICON_SMALL, NULL);
      |                                                                                   ^~~~
```
Typecasting the `NULL` values as `(LPARAM)NULL` fixed the errors

```
'C:/Tools/msys64/mingw64/bin/x86_64-w64-mingw32-objcopy' is not recognized as an internal or external command,
operable program or batch file.
'C:/Tools/msys64/mingw64/bin/x86_64-w64-mingw32-strip' is not recognized as an internal or external command,
operable program or batch file.
'C:/Tools/msys64/mingw64/bin/x86_64-w64-mingw32-objcopy' is not recognized as an internal or external command,
operable program or batch file.
```
Not technically an error, but `.debugsymbols` files weren't properly generating because `objcopy` and `strip` don't have any prefix. Passing an empty `arch` value returns the expected path but with no erroneous prefix