### PR TITLE
Make the occlusion culling debug draw mode draw a translucent overlay

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -117,7 +117,6 @@ CopyEffects::CopyEffects(BitField<RasterEffects> p_raster_effects) {
 		copy_modes.push_back("\n#define MODE_PANORAMA_TO_DP\n"); // COPY_TO_FB_COPY_PANORAMA_TO_DP
 		copy_modes.push_back("\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_COPY2
 		copy_modes.push_back("\n#define MODE_SET_COLOR\n"); // COPY_TO_FB_SET_COLOR
-		copy_modes.push_back("\n#define MODE_OCCLUSION_CULLING_BUFFER\n"); // COPY_TO_FB_OCCLUSION_CULLING_BUFFER
 
 		copy_modes.push_back("\n#define USE_MULTIVIEW\n"); // COPY_TO_FB_MULTIVIEW
 		copy_modes.push_back("\n#define USE_MULTIVIEW\n#define MODE_TWO_SOURCES\n"); // COPY_TO_FB_MULTIVIEW_WITH_DEPTH
@@ -628,6 +627,10 @@ void CopyEffects::copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffe
 		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_NORMAL;
 	}
 
+	if (p_occlusion_culling_buffer) {
+		copy_to_fb.push_constant.flags |= COPY_TO_FB_FLAG_OCCLUSION_CULLING_BUFFER;
+	}
+
 	if (p_src_rect != Rect2()) {
 		copy_to_fb.push_constant.section[0] = p_src_rect.position.x;
 		copy_to_fb.push_constant.section[1] = p_src_rect.position.y;
@@ -646,10 +649,6 @@ void CopyEffects::copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffe
 		mode = p_secondary.is_valid() ? COPY_TO_FB_MULTIVIEW_WITH_DEPTH : COPY_TO_FB_MULTIVIEW;
 	} else {
 		mode = p_secondary.is_valid() ? COPY_TO_FB_COPY2 : COPY_TO_FB_COPY;
-
-		if (p_occlusion_culling_buffer) {
-			mode = COPY_TO_FB_OCCLUSION_CULLING_BUFFER;
-		}
 	}
 
 	RID shader = copy_to_fb.shader.version_get_shader(copy_to_fb.shader_version, mode);

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -181,6 +181,7 @@ private:
 		COPY_TO_FB_COPY_PANORAMA_TO_DP,
 		COPY_TO_FB_COPY2,
 		COPY_TO_FB_SET_COLOR,
+		COPY_TO_FB_OCCLUSION_CULLING_BUFFER,
 
 		// These variants are disabled unless XR shaders are enabled.
 		// They should be listed last.
@@ -365,7 +366,7 @@ public:
 	void copy_octmap_to_panorama(RID p_source_octmap, RID p_dest_panorama, const Size2i &p_panorama_size, float p_lod, bool p_is_array, const Size2 &p_source_octmap_border_size);
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
 	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
-	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false, bool alpha_to_one = false, bool p_linear = false, bool p_normal = false, const Rect2 &p_src_rect = Rect2(), float p_linear_luminance_multiplier = 1.0);
+	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false, bool alpha_to_one = false, bool p_linear = false, bool p_normal = false, const Rect2 &p_src_rect = Rect2(), bool p_occlusion_culling_buffer = false, float p_linear_luminance_multiplier = 1.0);
 	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
 	void copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFormatID p_fb_format, RID p_source_rd_texture, bool p_linear = false, float p_linear_luminance_multiplier = 1.0);
 	void copy_raster(RID p_source_texture, RID p_dest_framebuffer);

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -201,6 +201,7 @@ private:
 		COPY_TO_FB_FLAG_LINEAR = (1 << 6),
 		COPY_TO_FB_FLAG_NORMAL = (1 << 7),
 		COPY_TO_FB_FLAG_USE_SRC_SECTION = (1 << 8),
+		COPY_TO_FB_FLAG_OCCLUSION_CULLING_BUFFER = (1 << 9),
 	};
 
 	struct CopyToFbPushConstant {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1100,7 +1100,7 @@ void RendererSceneRenderRD::_render_buffers_debug_draw(const RenderDataRD *p_ren
 	if (debug_draw == RS::VIEWPORT_DEBUG_DRAW_OCCLUDERS) {
 		if (p_render_data->occluder_debug_tex.is_valid()) {
 			Size2i rtsize = texture_storage->render_target_get_size(render_target);
-			copy_effects->copy_to_fb_rect(texture_storage->texture_get_rd_texture(p_render_data->occluder_debug_tex), texture_storage->render_target_get_rd_framebuffer(render_target), Rect2i(Vector2(), rtsize), true, false);
+			copy_effects->copy_to_fb_rect(texture_storage->texture_get_rd_texture(p_render_data->occluder_debug_tex), texture_storage->render_target_get_rd_framebuffer(render_target), Rect2i(Vector2(), rtsize), true, false, false, false, RID(), false, false, false, false, Rect2(), true);
 		}
 	}
 

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -190,6 +190,14 @@ void main() {
 		color.rgb = normalize(color.rgb * 2.0 - 1.0) * 0.5 + 0.5;
 	}
 
+#ifdef MODE_OCCLUSION_CULLING_BUFFER
+	// Modify result to make the background partially visible,
+	// which helps with 3D navigation.
+	// This relies on the additive blend state from the `CopyEffects()` constructor.
+	color.a = (1.0 - color.r) * 0.5;
+	color.rgb = vec3(1.0, 0.0, 0.0);
+#endif // MODE_OCCLUSION_CULLING_BUFFER
+
 	frag_color = color / params.luminance_multiplier;
 #endif // MODE_SET_COLOR
 }

--- a/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy_to_fb.glsl
@@ -71,6 +71,7 @@ void main() {
 #define FLAG_ALPHA_TO_ONE (1 << 5)
 #define FLAG_LINEAR (1 << 6)
 #define FLAG_NORMAL (1 << 7)
+#define FLAG_OCCLUSION_CULLING_BUFFER (1 << 9)
 
 layout(push_constant, std430) uniform Params {
 	vec4 section;
@@ -189,14 +190,13 @@ void main() {
 	if (bool(params.flags & FLAG_NORMAL)) {
 		color.rgb = normalize(color.rgb * 2.0 - 1.0) * 0.5 + 0.5;
 	}
-
-#ifdef MODE_OCCLUSION_CULLING_BUFFER
-	// Modify result to make the background partially visible,
-	// which helps with 3D navigation.
-	// This relies on the additive blend state from the `CopyEffects()` constructor.
-	color.a = (1.0 - color.r) * 0.5;
-	color.rgb = vec3(1.0, 0.0, 0.0);
-#endif // MODE_OCCLUSION_CULLING_BUFFER
+	if (bool(params.flags & FLAG_OCCLUSION_CULLING_BUFFER)) {
+		// Modify result to make the background partially visible,
+		// which helps with 3D navigation.
+		// This relies on the additive blend state from the `CopyEffects()` constructor.
+		color.a = (1.0 - color.r) * 0.5;
+		color.rgb = vec3(1.0, 0.0, 0.0);
+	}
 
 	frag_color = color / params.luminance_multiplier;
 #endif // MODE_SET_COLOR


### PR DESCRIPTION
This allows for easy, depth-aware navigation in the 3D editor while being able to view which meshes are occluders and which meshes aren't.

I've tested this change with both Forward+ and Mobile rendering methods. No Vulkan validation errors are reported when running with `--gpu-validation` on either rendering method. (The Compatibility rendering method currently doesn't support most debug draw modes, including the occlusion culling buffer. Occlusion culling itself does work though.)

Thanks @myaaaaaaaaa for the [help](https://github.com/godotengine/godot-proposals/issues/2911#issuecomment-1579958923) :slightly_smiling_face:

**Testing project:** [test_occlusion_culling_buffer.zip](https://github.com/godotengine/godot/files/12115364/test_occlusion_culling_buffer.zip)

- This closes https://github.com/godotengine/godot-proposals/issues/2911.

## Preview

*The two cubes in the front have occluders, while the cube in the back doesn't.*

![image](https://github.com/user-attachments/assets/665af5de-d264-478e-b859-dc8c1686be7e)
