### PR TITLE
Mention expected resource type in ResourceLoader load error

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -275,10 +275,10 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 
 #ifdef TOOLS_ENABLED
 	Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-	ERR_FAIL_COND_V_MSG(!file_check->file_exists(p_path), Ref<Resource>(), "Resource file not found: " + p_path + ".");
+	ERR_FAIL_COND_V_MSG(!file_check->file_exists(p_path), Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint));
 #endif
 
-	ERR_FAIL_V_MSG(Ref<Resource>(), "No loader found for resource: " + p_path + ".");
+	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, p_type_hint));
 }
 
 void ResourceLoader::_thread_load_function(void *p_userdata) {


### PR DESCRIPTION
This helps troubleshoot issues due to incorrect import types.

- See https://github.com/godotengine/godot/issues/79729.

## Preview

```diff
-ERROR: Resource file not found: res://example.png (expected type: Texture2D)
   at: _load (./core/io/resource_loader.cpp:278)
```