### PR TITLE
Implement preliminary support for bezier patch subdivision surfaces

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -332,4 +332,18 @@ public:
 	virtual ~OS();
 };
 
+// Convenience macro, use this instead of #if 0.
+#ifdef DEV_ENABLED
+#define IF_DEV_VAR(m_var, m_code)                            \
+	{                                                        \
+		static const String DEV_VAR_VALUE =                  \
+				OS::get_singleton()->get_environment(m_var); \
+		if (!DEV_VAR_VALUE.is_empty()) {                     \
+			m_code                                           \
+		}                                                    \
+	}
+#else
+#define IF_DEV_VAR(m_var, m_code)
+#endif
+
 #endif // OS_H

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -321,6 +321,8 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 					if (idx < 2) {
 						idx = 1 ^ idx;
 					}
+					idx += 1;
+					idx %= 3;
 
 					if (face[idx].size() == 3) {
 						int norm = face[idx][2].to_int() - 1;
@@ -378,11 +380,12 @@ static Error _parse_obj(const String &p_path, List<Ref<Mesh>> &r_meshes, bool p_
 					surf_tool->generate_normals();
 				}
 
+				// Force triangle pairs to share tangents.
+				surf_tool->index();
+
 				if (generate_tangents && uvs.size()) {
 					surf_tool->generate_tangents();
 				}
-
-				surf_tool->index();
 
 				print_verbose("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
 				print_verbose("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -336,6 +336,19 @@ void MeshInstance3D::_notification(int p_what) {
 			}
 		} break;
 	}
+
+	IF_DEV_VAR("CHECK_QUADS", {
+		if (p_what == NOTIFICATION_READY) {
+			print_line(vformat("'%s':", get_name()));
+			if (!mesh.is_null()) {
+				for (int i = 0; i < mesh->get_surface_count(); i++) {
+					print_line(vformat("\tFound %s surface with %d indices",
+							mesh->is_surface_quads(i) ? "QUADS" : "TRIANGLES",
+							mesh->surface_get_array_index_len(i)));
+				}
+			}
+		}
+	});
 }
 
 int MeshInstance3D::get_surface_override_material_count() const {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -281,6 +281,21 @@ AABB Mesh::get_aabb() const {
 	return ret;
 }
 
+bool Mesh::is_surface_quads(int p_surface) const {
+	if (surface_get_primitive_type(p_surface) != PRIMITIVE_TRIANGLES) {
+		return false;
+	}
+
+	if (!(surface_get_format(p_surface) & ARRAY_FORMAT_INDEX)) {
+		return false;
+	}
+
+	int num_indices = surface_get_array_index_len(p_surface);
+	Vector<int> indices_vector = surface_get_arrays(p_surface)[ARRAY_INDEX];
+
+	return SurfaceTool::is_indices_quads(indices_vector.ptr(), num_indices);
+}
+
 Ref<TriangleMesh> Mesh::generate_triangle_mesh() const {
 	if (triangle_mesh.is_valid()) {
 		return triangle_mesh;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -168,6 +168,7 @@ public:
 	virtual void set_blend_shape_name(int p_index, const StringName &p_name);
 	virtual AABB get_aabb() const;
 
+	bool is_surface_quads(int p_surface) const;
 	Vector<Face3> get_faces() const;
 	Vector<Face3> get_surface_faces(int p_surface) const;
 	Ref<TriangleMesh> generate_triangle_mesh() const;

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -31,6 +31,7 @@
 #include "primitive_meshes.h"
 
 #include "core/config/project_settings.h"
+#include "scene/resources/surface_tool.h"
 #include "scene/resources/theme.h"
 #include "scene/theme/theme_db.h"
 #include "servers/rendering_server.h"
@@ -91,9 +92,11 @@ void PrimitiveMesh::_update() const {
 				}
 			}
 			arr[RS::ARRAY_NORMAL] = normals;
-			arr[RS::ARRAY_INDEX] = indices;
 		}
 	}
+
+	SurfaceTool::set_indices_quads(indices.ptrw(), indices.size());
+	arr[RS::ARRAY_INDEX] = indices;
 
 	if (add_uv2) {
 		// _create_mesh_array should populate our UV2, this is a fallback in case it doesn't.
@@ -528,6 +531,8 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 		thisrow = point;
 	}
 
+	SurfaceTool::set_indices_quads(indices.ptrw(), indices.size());
+
 	p_arr[RS::ARRAY_VERTEX] = points;
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
@@ -862,6 +867,8 @@ void BoxMesh::create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w, int
 		thisrow = point;
 	}
 
+	SurfaceTool::set_indices_quads(indices.ptrw(), indices.size());
+
 	p_arr[RS::ARRAY_VERTEX] = points;
 	p_arr[RS::ARRAY_NORMAL] = normals;
 	p_arr[RS::ARRAY_TANGENT] = tangents;
@@ -1007,7 +1014,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 		y = (height * 0.5) - y;
 
 		for (i = 0; i <= radial_segments; i++) {
-			u = i;
+			u = i % radial_segments; // Ensure that the first and last vertices don't get pushed apart by rounding errors.
 			u /= radial_segments;
 
 			x = sin(u * Math_TAU);
@@ -1127,6 +1134,8 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 			}
 		}
 	}
+
+	SurfaceTool::set_indices_quads(indices.ptrw(), indices.size());
 
 	p_arr[RS::ARRAY_VERTEX] = points;
 	p_arr[RS::ARRAY_NORMAL] = normals;
@@ -1853,6 +1862,8 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 		prevrow = thisrow;
 		thisrow = point;
 	}
+
+	SurfaceTool::set_indices_quads(indices.ptrw(), indices.size());
 
 	p_arr[RS::ARRAY_VERTEX] = points;
 	p_arr[RS::ARRAY_NORMAL] = normals;

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -218,6 +218,25 @@ public:
 
 	LocalVector<Vertex> &get_vertex_array() { return vertex_array; }
 
+	// Helper functions to detect/assign quad meshes. In the context of Godot,
+	// "quad meshes" are indexed triangle meshes where every two triangles are
+	// part of the same quad, with a specific ordering for the six indices
+	// to allow for easy processing.
+	static bool is_indices_quads(const int *p_indices, int p_index_count);
+	static void set_indices_quads(int *p_indices, int p_index_count);
+
+	// Convert input quads into a list of 4x4 bezier patches.
+	// The returned mesh includes indices in PRIMITIVE_TRIANGLES format
+	// so that the bezier cage can easily be visualized.
+	// To obtain bezier patch info, ignore the contents of Mesh::ARRAY_INDEX
+	// and process attributes in groups of 16.
+	static void quads_to_bezier_patch(Array &r_array, bool *r_is_manifold = nullptr);
+
+	// Interpolate bezier patch and return a mesh with LODs.
+	// Bezier patches are simple to implement and can be processed independently,
+	// making them a great candidate for porting to a tessellation or mesh shader.
+	static void tessellate_bezier_patch(Array &r_array, Dictionary &r_lods, int p_target_quad_count);
+
 	void create_from_triangle_arrays(const Array &p_arrays);
 	static void create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<Vertex> &ret, uint32_t *r_format = nullptr);
 	Array commit_to_arrays();


### PR DESCRIPTION
* Related to godotengine/godot-proposals#784
* See also [the Wikipedia article on Bezier surfaces](https://en.wikipedia.org/wiki/B%C3%A9zier_surface#B%C3%A9zier_surfaces_in_computer_graphics)


![1690833275](https://github.com/godotengine/godot/assets/103326468/8c9de893-7ff4-47b5-8fd1-b497978266fc)
![1690833137](https://github.com/godotengine/godot/assets/103326468/a01e60e0-7ce8-4c50-bb1d-ad07958b392c)
<sup>GREEN: Original lowpoly quad model ||| YELLOW: Bezier patch control points after preprocessing ||| RED: Final tessellated model ||| BLUE: Catmull-Clark subdivision for comparison ||| WHITE: Quad/Bezier patch borders</sup>

![1690833156](https://github.com/godotengine/godot/assets/103326468/63be45a2-1426-42fa-9fcf-b0c05cf72ffa)
<sup>Circle test. Note how bezier patch subdivision surfaces (RED) need fewer points than Catmull-Clark subdivision surfaces (BLUE) to create rounder circles.<sup>

![1690833235](https://github.com/godotengine/godot/assets/103326468/370c28c2-6664-4a26-8ca0-937c2247e3b1)
<sup>Bevel test. Support loops work the same way for both surfaces.</sup>

Bezier patch vs Catmull-Clark pros:
* Bezier patches are simpler to evaluate and their mathematical properties have been more thoroughly researched.
* Points on the limit surface can easily be directly evaluated (this is in fact the standard way to evaluate bezier curves/patches), unlike Catmull-Clark which by default must be iteratively refined and shrinks with every iteration
* Patches are completely independent of each other, making them friendlier towards a potential tessellation or mesh shader implementation
* More flexibility for the preprocessing algorithm to decide where to place control points, without affecting the complexity of bezier patch evaluation during runtime.

Cons:
* Bezier patches are not an industry standard subdivision surface. While this PR has made great efforts to ensure that traditional Catmull-Clark modeling rules work as expected (edges are sharpened with support loops, regular polygons result in circles, etc), they will not be able to match the curvature exactly. This becomes less of a problem as the model is subdivided to a higher density.
* The added flexibility of allowing the preprocessing algorithm freedom to assign control points doubles as a fantastic footgun.
* The preprocessing implementation in this PR only supports quads. Non-quad models will need to be pre-subdivided once in the DCC application to produce quads.

Contents of this PR:
* GLTF meshes suffixed with "-experimental-subd" are now treated as subdivision surfaces and automatically converted on load. This was done to simplify this PR as it aims to strictly focus on the backend. Replacing this with a proper interface in the future is highly recommended.
* Subdivision surfaces conversion is done via the following two-step process:
  1. **Preprocessing:** Convert the input quad model into a list of bezier patches at load time. Control points are assigned based on neighboring faces [to ensure G1 continuity](https://math.stackexchange.com/questions/2780637/c-vs-g-continuity) between patch seams like with Catmull-Clark subdivision surfaces. Most of the complexity lies in this function, although this is in terms of comprehensibility. Performance should not be an issue.
  2. **Tessellation:** Convert the bezier patch list into a standard triangle model, tessellating faces up to a target polycount (100,000 for now) and adding them as LODs. This is currently also done at load time. In the future, bezier patches can be sent directly to a tessellation or mesh shader for direct evaluation on the GPU, without needing to compute and store the intermediate highpoly triangle model, allowing for per-frame adaptive runtime tessellation and reducing VRAM and rasterizer usage.
* Standardizes a quad representation where every six indices form a triangle pair with the following ordering:
  ![1689912328](https://github.com/godotengine/godot/assets/103326468/a152f5c5-a361-438e-824f-c273301b7156)
  This allows the rest of Godot's rendering system to remain blissfully quad-unaware. Note that I haven't checked thoroughly to see if quads won't be clobbered by mesh processing somewhere, but at least with the basic testing I've done so far, quads are preserved correctly from import to render.
* Quad-based `PrimitiveMesh`es now always outputs in this format
* The GLTF importer now attempts to detect quads if possible. This may or may not work depending on how the file was exported, but Blender seems to always place triangles in the same polygon next to each other.
* Now preserves quads in OBJ files

