### PR TITLE
Project Manager navigation improve

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -265,6 +265,7 @@ private:
 	void _panel_input(const Ref<InputEvent> &p_ev, Node *p_hb);
 	void _favorite_pressed(Node *p_hb);
 	void _show_project(const String &p_path);
+	void _focus_entered(Node *p_hb);
 
 	void _clear_project_selection();
 	void _toggle_project(int p_index);
@@ -336,7 +337,7 @@ class ProjectManager : public Control {
 	LineEdit *search_box = nullptr;
 	Label *loading_label = nullptr;
 	OptionButton *filter_option = nullptr;
-	PanelContainer *search_panel = nullptr;
+	PanelContainer *project_panel = nullptr;
 
 	Button *create_btn = nullptr;
 	Button *import_btn = nullptr;
@@ -349,7 +350,7 @@ class ProjectManager : public Control {
 	Button *erase_missing_btn = nullptr;
 	Button *about_btn = nullptr;
 
-	HBoxContainer *local_projects_hb = nullptr;
+	VBoxContainer *local_projects_vb = nullptr;
 	EditorAssetLibrary *asset_library = nullptr;
 
 	Ref<StyleBox> tag_stylebox;


### PR DESCRIPTION
At the moment, keyboard navigation in the godot project manager is not intuitive. I tried to improve it
![project_manager](https://github.com/godotengine/godot/assets/139700982/16d6e00d-22dd-4fc8-8d06-3eeb6fad45a1)


Also, Buttons not related to local projects have moved to the top.
Before:
![before2](https://github.com/godotengine/godot/assets/139700982/456c905e-c324-4dda-b7b0-cac8f11b6d57)


After:
![After](https://github.com/godotengine/godot/assets/139700982/4cb9ba09-f0a4-462a-97bd-cd36a73073d8)
