### PR TITLE
Fix `CanvasModulate` logic for modulating the canvas

### DIFF
--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -30,32 +30,67 @@
 
 #include "canvas_modulate.h"
 
+void CanvasModulate::_on_in_canvas_visibility_changed(bool p_new_visibility) {
+	RID canvas = get_canvas();
+	StringName group_name = "_canvas_modulate_" + itos(canvas.get_id());
+
+	ERR_FAIL_COND_MSG(p_new_visibility == is_in_group(group_name), vformat("CanvasModulate becoming %s in the canvas already %s in the modulate group. Buggy logic, please report.", p_new_visibility ? "visible" : "invisible", p_new_visibility ? "was" : "was not"));
+
+	if (p_new_visibility) {
+		bool has_active_canvas_modulate = get_tree()->has_group(group_name); // Group would be removed if empty; otherwise one CanvasModulate within must be active.
+		add_to_group(group_name);
+		if (!has_active_canvas_modulate) {
+			is_active = true;
+			RS::get_singleton()->canvas_set_modulate(canvas, color);
+		}
+	} else {
+		remove_from_group(group_name);
+		if (is_active) {
+			is_active = false;
+			CanvasModulate *new_active = Object::cast_to<CanvasModulate>(get_tree()->get_first_node_in_group(group_name));
+			if (new_active) {
+				new_active->is_active = true;
+				RS::get_singleton()->canvas_set_modulate(canvas, new_active->color);
+			} else {
+				RS::get_singleton()->canvas_set_modulate(canvas, Color(1, 1, 1, 1));
+			}
+		}
+	}
+
+	update_configuration_warnings();
+}
+
 void CanvasModulate::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_CANVAS: {
-			if (is_visible_in_tree()) {
-				RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
-				add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			is_in_canvas = true;
+			bool visible_in_tree = is_visible_in_tree();
+			if (visible_in_tree) {
+				_on_in_canvas_visibility_changed(true);
 			}
+			was_visible_in_tree = visible_in_tree;
 		} break;
 
 		case NOTIFICATION_EXIT_CANVAS: {
-			if (is_visible_in_tree()) {
-				RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
-				remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			is_in_canvas = false;
+			if (was_visible_in_tree) {
+				_on_in_canvas_visibility_changed(false);
 			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (is_visible_in_tree()) {
-				RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
-				add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
-			} else {
-				RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
-				remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			if (!is_in_canvas) {
+				return;
 			}
 
-			update_configuration_warnings();
+			bool visible_in_tree = is_visible_in_tree();
+			if (visible_in_tree == was_visible_in_tree) {
+				return;
+			}
+
+			_on_in_canvas_visibility_changed(visible_in_tree);
+
+			was_visible_in_tree = visible_in_tree;
 		} break;
 	}
 }
@@ -69,7 +104,7 @@ void CanvasModulate::_bind_methods() {
 
 void CanvasModulate::set_color(const Color &p_color) {
 	color = p_color;
-	if (is_visible_in_tree()) {
+	if (is_active) {
 		RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
 	}
 }
@@ -81,12 +116,12 @@ Color CanvasModulate::get_color() const {
 PackedStringArray CanvasModulate::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
-	if (is_visible_in_tree() && is_inside_tree()) {
+	if (is_in_canvas && is_visible_in_tree()) {
 		List<Node *> nodes;
 		get_tree()->get_nodes_in_group("_canvas_modulate_" + itos(get_canvas().get_id()), &nodes);
 
 		if (nodes.size() > 1) {
-			warnings.push_back(RTR("Only one visible CanvasModulate is allowed per scene (or set of instantiated scenes). The first created one will work, while the rest will be ignored."));
+			warnings.push_back(RTR("Only one visible CanvasModulate is allowed per canvas.\nWhen there are more than one, only one of them will be active. Which one is undefined."));
 		}
 	}
 

--- a/scene/2d/canvas_modulate.h
+++ b/scene/2d/canvas_modulate.h
@@ -38,6 +38,14 @@ class CanvasModulate : public Node2D {
 
 	Color color = Color(1, 1, 1, 1);
 
+	// CanvasModulate is in canvas-specific modulate group when both in canvas and visible in tree.
+	// Exactly one CanvasModulate in each such non-empty group is active.
+	bool is_in_canvas = false;
+	bool was_visible_in_tree = false; // Relevant only when in canvas.
+	bool is_active = false;
+
+	void _on_in_canvas_visibility_changed(bool p_new_visibility);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
CanvasModulate can modulate the canvas only when it is in some canvas and it is visible in the tree.

Previously CanvasModulate would update / try to update the canvas modulate color (within the RenderingServer) always on:
- entering/exiting the canvas,
- visibility changed notificiation.

This can fail in many different ways.

<details><summary>Some of them in v4.1.1.stable.official [bd6af8e0e] (click to expand).</summary>
<p>

- Failing to obtain the canvas when out of tree:
```gdscript
extends Node2D

func _ready() -> void:
	var cm := CanvasModulate.new()
	cm.visible = false
```
![Godot_v4 1 1-stable_win64_8GLsA27SNP](https://github.com/godotengine/godot/assets/9283098/a2af103a-fb6f-451a-bcd7-4e1431e31c53)

- "Fighting" for changing the canvas modulate color (last one changed takes over):
![yUoB12a0u3](https://github.com/godotengine/godot/assets/9283098/136be41b-bfda-4041-999d-88c4a3434a2b)


- Changing canvas modulate color regardless of other CanvasModulates:
![TEXd9UxoPG](https://github.com/godotengine/godot/assets/9283098/a583ed1c-f9a3-4e40-be84-6ac965eae7c1)
![G0VdFiGJSa](https://github.com/godotengine/godot/assets/9283098/0c23fbee-9d98-42fa-82bf-8eb6d7d86817)
(on deleting:)
![Nlyt5ND5uG](https://github.com/godotengine/godot/assets/9283098/368e26ea-16be-417f-b46e-4e2a0b8063b5)


Etc.

</p>
</details> 

---

This PR makes exactly one CanvasModulate be active (affecting the canvas modulation) in each (non-empty) canvas modulate group.
- When for a CanvasModulate the `(is_in_canvas, is_visible_in_tree)` tuple changes to / from `(true, true)`, it's being added to / removed from the canvas modulate group.
- When a CanvasModulate is added to the canvas modulate group, it becomes active only if the group was empty. Otherwise, there already was an active CanvasModulate in such group and it remains the active one.
- When an active CanvasModulate is removed from the canvas modulate group, it activates another CanvasModulate from the group (or restores canvas to no modulation if there are no more CanvasModulates left in the group).

Note that for more than one CanvasModulate in the given canvas modulate group it's said it's undefined which one is active. It could be implemented that the active one is always e.g. the topmost according to the tree order, or the one added to the canvas modulate group most/least recently or something like that. However, more than one CanvasModulate in such group is considered an invalid state, hence I find it not worth the additional burden (e.g. for tree ordering CanvasModulates would need to react to parent's `child_order_changed`). I think what's important is that after ending with a single CanvasModulate within such group, it should work as expected. This should be the case with this PR.


Fixes #73894.
Fixes #79679.

---

I think it's good for cherry-picking even if it possibly changes the previous buggy behavior for more than one CanvasModulate in the canvas. That's invalid state which shouldn't be relied upon and the previous message within the in-editor warning:
>Only one visible CanvasModulate is allowed per scene (or set of instantiated scenes). **The first created one will work, while the rest will be ignored.**

was misleading / not true anyway.