### PR TITLE
C#: GodotSharp namespace style sync

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@
 
 # Style: clang-format: Disable AllowShortIfStatementsOnASingleLine
 e956e80c1fa1cc8aefcb1533e5acf5cf3c8ffdd9
+
+# C#: GodotSharp namespace style sync
+13d89bd9509e22bc3503c49c744fd5fad47d100d

--- a/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/Main.cs
@@ -8,285 +8,284 @@ using System.Runtime.Loader;
 using Godot.Bridge;
 using Godot.NativeInterop;
 
-namespace GodotPlugins
+namespace GodotPlugins;
+
+public static class Main
 {
-    public static class Main
+    // IMPORTANT:
+    // Keeping strong references to the AssemblyLoadContext (our PluginLoadContext) prevents
+    // it from being unloaded. To avoid issues, we wrap the reference in this class, and mark
+    // all the methods that access it as non-inlineable. This way we prevent local references
+    // (either real or introduced by the JIT) to escape the scope of these methods due to
+    // inlining, which could keep the AssemblyLoadContext alive while trying to unload.
+    private sealed class PluginLoadContextWrapper
     {
-        // IMPORTANT:
-        // Keeping strong references to the AssemblyLoadContext (our PluginLoadContext) prevents
-        // it from being unloaded. To avoid issues, we wrap the reference in this class, and mark
-        // all the methods that access it as non-inlineable. This way we prevent local references
-        // (either real or introduced by the JIT) to escape the scope of these methods due to
-        // inlining, which could keep the AssemblyLoadContext alive while trying to unload.
-        private sealed class PluginLoadContextWrapper
+        private PluginLoadContext? _pluginLoadContext;
+        private readonly WeakReference _weakReference;
+
+        private PluginLoadContextWrapper(PluginLoadContext pluginLoadContext, WeakReference weakReference)
         {
-            private PluginLoadContext? _pluginLoadContext;
-            private readonly WeakReference _weakReference;
+            _pluginLoadContext = pluginLoadContext;
+            _weakReference = weakReference;
+        }
 
-            private PluginLoadContextWrapper(PluginLoadContext pluginLoadContext, WeakReference weakReference)
-            {
-                _pluginLoadContext = pluginLoadContext;
-                _weakReference = weakReference;
-            }
-
-            public string? AssemblyLoadedPath
-            {
-                [MethodImpl(MethodImplOptions.NoInlining)]
-                get => _pluginLoadContext?.AssemblyLoadedPath;
-            }
-
-            public bool IsCollectible
-            {
-                [MethodImpl(MethodImplOptions.NoInlining)]
-                // if _pluginLoadContext is null we already started unloading, so it was collectible
-                get => _pluginLoadContext?.IsCollectible ?? true;
-            }
-
-            public bool IsAlive
-            {
-                [MethodImpl(MethodImplOptions.NoInlining)]
-                get => _weakReference.IsAlive;
-            }
-
+        public string? AssemblyLoadedPath
+        {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public static (Assembly, PluginLoadContextWrapper) CreateAndLoadFromAssemblyName(
-                AssemblyName assemblyName,
-                string pluginPath,
-                ICollection<string> sharedAssemblies,
-                AssemblyLoadContext mainLoadContext,
-                bool isCollectible
-            )
-            {
-                var context = new PluginLoadContext(pluginPath, sharedAssemblies, mainLoadContext, isCollectible);
-                var reference = new WeakReference(context, trackResurrection: true);
-                var wrapper = new PluginLoadContextWrapper(context, reference);
-                var assembly = context.LoadFromAssemblyName(assemblyName);
-                return (assembly, wrapper);
-            }
+            get => _pluginLoadContext?.AssemblyLoadedPath;
+        }
 
+        public bool IsCollectible
+        {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            internal void Unload()
-            {
-                _pluginLoadContext?.Unload();
-                _pluginLoadContext = null;
-            }
+            // if _pluginLoadContext is null we already started unloading, so it was collectible
+            get => _pluginLoadContext?.IsCollectible ?? true;
         }
 
-        private static readonly List<AssemblyName> SharedAssemblies = new();
-        private static readonly Assembly CoreApiAssembly = typeof(global::Godot.GodotObject).Assembly;
-        private static Assembly? _editorApiAssembly;
-        private static PluginLoadContextWrapper? _projectLoadContext;
-        private static bool _editorHint = false;
-
-        private static readonly AssemblyLoadContext MainLoadContext =
-            AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ??
-            AssemblyLoadContext.Default;
-
-        private static DllImportResolver? _dllImportResolver;
-
-        // Right now we do it this way for simplicity as hot-reload is disabled. It will need to be changed later.
-        [UnmanagedCallersOnly]
-        // ReSharper disable once UnusedMember.Local
-        private static unsafe godot_bool InitializeFromEngine(IntPtr godotDllHandle, godot_bool editorHint,
-            PluginsCallbacks* pluginsCallbacks, ManagedCallbacks* managedCallbacks,
-            IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
+        public bool IsAlive
         {
-            try
-            {
-                _editorHint = editorHint.ToBool();
-
-                _dllImportResolver = new GodotDllImportResolver(godotDllHandle).OnResolveDllImport;
-
-                SharedAssemblies.Add(CoreApiAssembly.GetName());
-                NativeLibrary.SetDllImportResolver(CoreApiAssembly, _dllImportResolver);
-
-                AlcReloadCfg.Configure(alcReloadEnabled: _editorHint);
-                NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
-
-                if (_editorHint)
-                {
-                    _editorApiAssembly = Assembly.Load("GodotSharpEditor");
-                    SharedAssemblies.Add(_editorApiAssembly.GetName());
-                    NativeLibrary.SetDllImportResolver(_editorApiAssembly, _dllImportResolver);
-                }
-
-                *pluginsCallbacks = new()
-                {
-                    LoadProjectAssemblyCallback = &LoadProjectAssembly,
-                    LoadToolsAssemblyCallback = &LoadToolsAssembly,
-                    UnloadProjectPluginCallback = &UnloadProjectPlugin,
-                };
-
-                *managedCallbacks = ManagedCallbacks.Create();
-
-                return godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                Console.Error.WriteLine(e);
-                return godot_bool.False;
-            }
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get => _weakReference.IsAlive;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct PluginsCallbacks
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static (Assembly, PluginLoadContextWrapper) CreateAndLoadFromAssemblyName(
+            AssemblyName assemblyName,
+            string pluginPath,
+            ICollection<string> sharedAssemblies,
+            AssemblyLoadContext mainLoadContext,
+            bool isCollectible
+        )
         {
-            public unsafe delegate* unmanaged<char*, godot_string*, godot_bool> LoadProjectAssemblyCallback;
-            public unsafe delegate* unmanaged<char*, IntPtr, int, IntPtr> LoadToolsAssemblyCallback;
-            public unsafe delegate* unmanaged<godot_bool> UnloadProjectPluginCallback;
+            var context = new PluginLoadContext(pluginPath, sharedAssemblies, mainLoadContext, isCollectible);
+            var reference = new WeakReference(context, trackResurrection: true);
+            var wrapper = new PluginLoadContextWrapper(context, reference);
+            var assembly = context.LoadFromAssemblyName(assemblyName);
+            return (assembly, wrapper);
         }
 
-        [UnmanagedCallersOnly]
-        private static unsafe godot_bool LoadProjectAssembly(char* nAssemblyPath, godot_string* outLoadedAssemblyPath)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal void Unload()
         {
-            try
+            _pluginLoadContext?.Unload();
+            _pluginLoadContext = null;
+        }
+    }
+
+    private static readonly List<AssemblyName> SharedAssemblies = new();
+    private static readonly Assembly CoreApiAssembly = typeof(global::Godot.GodotObject).Assembly;
+    private static Assembly? _editorApiAssembly;
+    private static PluginLoadContextWrapper? _projectLoadContext;
+    private static bool _editorHint = false;
+
+    private static readonly AssemblyLoadContext MainLoadContext =
+        AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ??
+        AssemblyLoadContext.Default;
+
+    private static DllImportResolver? _dllImportResolver;
+
+    // Right now we do it this way for simplicity as hot-reload is disabled. It will need to be changed later.
+    [UnmanagedCallersOnly]
+    // ReSharper disable once UnusedMember.Local
+    private static unsafe godot_bool InitializeFromEngine(IntPtr godotDllHandle, godot_bool editorHint,
+        PluginsCallbacks* pluginsCallbacks, ManagedCallbacks* managedCallbacks,
+        IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
+    {
+        try
+        {
+            _editorHint = editorHint.ToBool();
+
+            _dllImportResolver = new GodotDllImportResolver(godotDllHandle).OnResolveDllImport;
+
+            SharedAssemblies.Add(CoreApiAssembly.GetName());
+            NativeLibrary.SetDllImportResolver(CoreApiAssembly, _dllImportResolver);
+
+            AlcReloadCfg.Configure(alcReloadEnabled: _editorHint);
+            NativeFuncs.Initialize(unmanagedCallbacks, unmanagedCallbacksSize);
+
+            if (_editorHint)
             {
-                if (_projectLoadContext != null)
-                    return godot_bool.True; // Already loaded
-
-                string assemblyPath = new(nAssemblyPath);
-
-                (var projectAssembly, _projectLoadContext) = LoadPlugin(assemblyPath, isCollectible: _editorHint);
-
-                string loadedAssemblyPath = _projectLoadContext.AssemblyLoadedPath ?? assemblyPath;
-                *outLoadedAssemblyPath = Marshaling.ConvertStringToNative(loadedAssemblyPath);
-
-                ScriptManagerBridge.LookupScriptsInAssembly(projectAssembly);
-
-                return godot_bool.True;
+                _editorApiAssembly = Assembly.Load("GodotSharpEditor");
+                SharedAssemblies.Add(_editorApiAssembly.GetName());
+                NativeLibrary.SetDllImportResolver(_editorApiAssembly, _dllImportResolver);
             }
-            catch (Exception e)
+
+            *pluginsCallbacks = new()
             {
-                Console.Error.WriteLine(e);
-                return godot_bool.False;
+                LoadProjectAssemblyCallback = &LoadProjectAssembly,
+                LoadToolsAssemblyCallback = &LoadToolsAssembly,
+                UnloadProjectPluginCallback = &UnloadProjectPlugin,
+            };
+
+            *managedCallbacks = ManagedCallbacks.Create();
+
+            return godot_bool.True;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e);
+            return godot_bool.False;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PluginsCallbacks
+    {
+        public unsafe delegate* unmanaged<char*, godot_string*, godot_bool> LoadProjectAssemblyCallback;
+        public unsafe delegate* unmanaged<char*, IntPtr, int, IntPtr> LoadToolsAssemblyCallback;
+        public unsafe delegate* unmanaged<godot_bool> UnloadProjectPluginCallback;
+    }
+
+    [UnmanagedCallersOnly]
+    private static unsafe godot_bool LoadProjectAssembly(char* nAssemblyPath, godot_string* outLoadedAssemblyPath)
+    {
+        try
+        {
+            if (_projectLoadContext != null)
+                return godot_bool.True; // Already loaded
+
+            string assemblyPath = new(nAssemblyPath);
+
+            (var projectAssembly, _projectLoadContext) = LoadPlugin(assemblyPath, isCollectible: _editorHint);
+
+            string loadedAssemblyPath = _projectLoadContext.AssemblyLoadedPath ?? assemblyPath;
+            *outLoadedAssemblyPath = Marshaling.ConvertStringToNative(loadedAssemblyPath);
+
+            ScriptManagerBridge.LookupScriptsInAssembly(projectAssembly);
+
+            return godot_bool.True;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    private static unsafe IntPtr LoadToolsAssembly(char* nAssemblyPath,
+        IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
+    {
+        try
+        {
+            string assemblyPath = new(nAssemblyPath);
+
+            if (_editorApiAssembly == null)
+                throw new InvalidOperationException("The Godot editor API assembly is not loaded.");
+
+            var (assembly, _) = LoadPlugin(assemblyPath, isCollectible: false);
+
+            NativeLibrary.SetDllImportResolver(assembly, _dllImportResolver!);
+
+            var method = assembly.GetType("GodotTools.GodotSharpEditor")?
+                .GetMethod("InternalCreateInstance",
+                    BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            if (method == null)
+            {
+                throw new MissingMethodException("GodotTools.GodotSharpEditor",
+                    "InternalCreateInstance");
             }
+
+            return (IntPtr?)method
+                       .Invoke(null, new object[] { unmanagedCallbacks, unmanagedCallbacksSize })
+                   ?? IntPtr.Zero;
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e);
+            return IntPtr.Zero;
+        }
+    }
+
+    private static (Assembly, PluginLoadContextWrapper) LoadPlugin(string assemblyPath, bool isCollectible)
+    {
+        string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+
+        var sharedAssemblies = new List<string>();
+
+        foreach (var sharedAssembly in SharedAssemblies)
+        {
+            string? sharedAssemblyName = sharedAssembly.Name;
+            if (sharedAssemblyName != null)
+                sharedAssemblies.Add(sharedAssemblyName);
         }
 
-        [UnmanagedCallersOnly]
-        private static unsafe IntPtr LoadToolsAssembly(char* nAssemblyPath,
-            IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
+        return PluginLoadContextWrapper.CreateAndLoadFromAssemblyName(
+            new AssemblyName(assemblyName), assemblyPath, sharedAssemblies, MainLoadContext, isCollectible);
+    }
+
+    [UnmanagedCallersOnly]
+    private static godot_bool UnloadProjectPlugin()
+    {
+        try
         {
-            try
-            {
-                string assemblyPath = new(nAssemblyPath);
-
-                if (_editorApiAssembly == null)
-                    throw new InvalidOperationException("The Godot editor API assembly is not loaded.");
-
-                var (assembly, _) = LoadPlugin(assemblyPath, isCollectible: false);
-
-                NativeLibrary.SetDllImportResolver(assembly, _dllImportResolver!);
-
-                var method = assembly.GetType("GodotTools.GodotSharpEditor")?
-                    .GetMethod("InternalCreateInstance",
-                        BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
-
-                if (method == null)
-                {
-                    throw new MissingMethodException("GodotTools.GodotSharpEditor",
-                        "InternalCreateInstance");
-                }
-
-                return (IntPtr?)method
-                           .Invoke(null, new object[] { unmanagedCallbacks, unmanagedCallbacksSize })
-                       ?? IntPtr.Zero;
-            }
-            catch (Exception e)
-            {
-                Console.Error.WriteLine(e);
-                return IntPtr.Zero;
-            }
+            return UnloadPlugin(ref _projectLoadContext).ToGodotBool();
         }
-
-        private static (Assembly, PluginLoadContextWrapper) LoadPlugin(string assemblyPath, bool isCollectible)
+        catch (Exception e)
         {
-            string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-
-            var sharedAssemblies = new List<string>();
-
-            foreach (var sharedAssembly in SharedAssemblies)
-            {
-                string? sharedAssemblyName = sharedAssembly.Name;
-                if (sharedAssemblyName != null)
-                    sharedAssemblies.Add(sharedAssemblyName);
-            }
-
-            return PluginLoadContextWrapper.CreateAndLoadFromAssemblyName(
-                new AssemblyName(assemblyName), assemblyPath, sharedAssemblies, MainLoadContext, isCollectible);
+            Console.Error.WriteLine(e);
+            return godot_bool.False;
         }
+    }
 
-        [UnmanagedCallersOnly]
-        private static godot_bool UnloadProjectPlugin()
+    private static bool UnloadPlugin(ref PluginLoadContextWrapper? pluginLoadContext)
+    {
+        try
         {
-            try
-            {
-                return UnloadPlugin(ref _projectLoadContext).ToGodotBool();
-            }
-            catch (Exception e)
-            {
-                Console.Error.WriteLine(e);
-                return godot_bool.False;
-            }
-        }
-
-        private static bool UnloadPlugin(ref PluginLoadContextWrapper? pluginLoadContext)
-        {
-            try
-            {
-                if (pluginLoadContext == null)
-                    return true;
-
-                if (!pluginLoadContext.IsCollectible)
-                {
-                    Console.Error.WriteLine("Cannot unload a non-collectible assembly load context.");
-                    return false;
-                }
-
-                Console.WriteLine("Unloading assembly load context...");
-
-                pluginLoadContext.Unload();
-
-                int startTimeMs = Environment.TickCount;
-                bool takingTooLong = false;
-
-                while (pluginLoadContext.IsAlive)
-                {
-                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-                    GC.WaitForPendingFinalizers();
-
-                    if (!pluginLoadContext.IsAlive)
-                        break;
-
-                    int elapsedTimeMs = Environment.TickCount - startTimeMs;
-
-                    if (!takingTooLong && elapsedTimeMs >= 200)
-                    {
-                        takingTooLong = true;
-
-                        // TODO: How to log from GodotPlugins? (delegate pointer?)
-                        Console.Error.WriteLine("Assembly unloading is taking longer than expected...");
-                    }
-                    else if (elapsedTimeMs >= 1000)
-                    {
-                        // TODO: How to log from GodotPlugins? (delegate pointer?)
-                        Console.Error.WriteLine(
-                            "Failed to unload assemblies. Possible causes: Strong GC handles, running threads, etc.");
-
-                        return false;
-                    }
-                }
-
-                Console.WriteLine("Assembly load context unloaded successfully.");
-
-                pluginLoadContext = null;
+            if (pluginLoadContext == null)
                 return true;
-            }
-            catch (Exception e)
+
+            if (!pluginLoadContext.IsCollectible)
             {
-                // TODO: How to log exceptions from GodotPlugins? (delegate pointer?)
-                Console.Error.WriteLine(e);
+                Console.Error.WriteLine("Cannot unload a non-collectible assembly load context.");
                 return false;
             }
+
+            Console.WriteLine("Unloading assembly load context...");
+
+            pluginLoadContext.Unload();
+
+            int startTimeMs = Environment.TickCount;
+            bool takingTooLong = false;
+
+            while (pluginLoadContext.IsAlive)
+            {
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+                GC.WaitForPendingFinalizers();
+
+                if (!pluginLoadContext.IsAlive)
+                    break;
+
+                int elapsedTimeMs = Environment.TickCount - startTimeMs;
+
+                if (!takingTooLong && elapsedTimeMs >= 200)
+                {
+                    takingTooLong = true;
+
+                    // TODO: How to log from GodotPlugins? (delegate pointer?)
+                    Console.Error.WriteLine("Assembly unloading is taking longer than expected...");
+                }
+                else if (elapsedTimeMs >= 1000)
+                {
+                    // TODO: How to log from GodotPlugins? (delegate pointer?)
+                    Console.Error.WriteLine(
+                        "Failed to unload assemblies. Possible causes: Strong GC handles, running threads, etc.");
+
+                    return false;
+                }
+            }
+
+            Console.WriteLine("Assembly load context unloaded successfully.");
+
+            pluginLoadContext = null;
+            return true;
+        }
+        catch (Exception e)
+        {
+            // TODO: How to log exceptions from GodotPlugins? (delegate pointer?)
+            Console.Error.WriteLine(e);
+            return false;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotPlugins/PluginLoadContext.cs
@@ -4,81 +4,80 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 
-namespace GodotPlugins
+namespace GodotPlugins;
+
+public class PluginLoadContext : AssemblyLoadContext
 {
-    public class PluginLoadContext : AssemblyLoadContext
+    private readonly AssemblyDependencyResolver _resolver;
+    private readonly ICollection<string> _sharedAssemblies;
+    private readonly AssemblyLoadContext _mainLoadContext;
+
+    public string? AssemblyLoadedPath { get; private set; }
+
+    public PluginLoadContext(string pluginPath, ICollection<string> sharedAssemblies,
+        AssemblyLoadContext mainLoadContext, bool isCollectible)
+        : base(isCollectible)
     {
-        private readonly AssemblyDependencyResolver _resolver;
-        private readonly ICollection<string> _sharedAssemblies;
-        private readonly AssemblyLoadContext _mainLoadContext;
+        _resolver = new AssemblyDependencyResolver(pluginPath);
+        _sharedAssemblies = sharedAssemblies;
+        _mainLoadContext = mainLoadContext;
 
-        public string? AssemblyLoadedPath { get; private set; }
-
-        public PluginLoadContext(string pluginPath, ICollection<string> sharedAssemblies,
-            AssemblyLoadContext mainLoadContext, bool isCollectible)
-            : base(isCollectible)
+        if (string.IsNullOrEmpty(AppContext.BaseDirectory))
         {
-            _resolver = new AssemblyDependencyResolver(pluginPath);
-            _sharedAssemblies = sharedAssemblies;
-            _mainLoadContext = mainLoadContext;
-
-            if (string.IsNullOrEmpty(AppContext.BaseDirectory))
+            // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs#L17-L35
+            // but Assembly.Location is unavailable, because we load assemblies from memory.
+            string? baseDirectory = Path.GetDirectoryName(pluginPath);
+            if (baseDirectory != null)
             {
-                // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs#L17-L35
-                // but Assembly.Location is unavailable, because we load assemblies from memory.
-                string? baseDirectory = Path.GetDirectoryName(pluginPath);
-                if (baseDirectory != null)
-                {
-                    if (!Path.EndsInDirectorySeparator(baseDirectory))
-                        baseDirectory += Path.DirectorySeparatorChar;
-                    // This SetData call effectively sets AppContext.BaseDirectory
-                    // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.cs#L21-L25
-                    AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", baseDirectory);
-                }
-                else
-                {
-                    // TODO: How to log from GodotPlugins? (delegate pointer?)
-                    Console.Error.WriteLine("Failed to set AppContext.BaseDirectory. Dynamic loading of libraries may fail.");
-                }
+                if (!Path.EndsInDirectorySeparator(baseDirectory))
+                    baseDirectory += Path.DirectorySeparatorChar;
+                // This SetData call effectively sets AppContext.BaseDirectory
+                // See https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/AppContext.cs#L21-L25
+                AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", baseDirectory);
+            }
+            else
+            {
+                // TODO: How to log from GodotPlugins? (delegate pointer?)
+                Console.Error.WriteLine("Failed to set AppContext.BaseDirectory. Dynamic loading of libraries may fail.");
             }
         }
+    }
 
-        protected override Assembly? Load(AssemblyName assemblyName)
-        {
-            if (assemblyName.Name == null)
-                return null;
-
-            if (_sharedAssemblies.Contains(assemblyName.Name))
-                return _mainLoadContext.LoadFromAssemblyName(assemblyName);
-
-            string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            if (assemblyPath != null)
-            {
-                AssemblyLoadedPath = assemblyPath;
-
-                // Load in memory to prevent locking the file
-                using var assemblyFile = File.Open(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
-
-                if (File.Exists(pdbPath))
-                {
-                    using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-                    return LoadFromStream(assemblyFile, pdbFile);
-                }
-
-                return LoadFromStream(assemblyFile);
-            }
-
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (assemblyName.Name == null)
             return null;
-        }
 
-        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        if (_sharedAssemblies.Contains(assemblyName.Name))
+            return _mainLoadContext.LoadFromAssemblyName(assemblyName);
+
+        string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
         {
-            string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
-            if (libraryPath != null)
-                return LoadUnmanagedDllFromPath(libraryPath);
+            AssemblyLoadedPath = assemblyPath;
 
-            return IntPtr.Zero;
+            // Load in memory to prevent locking the file
+            using var assemblyFile = File.Open(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+
+            if (File.Exists(pdbPath))
+            {
+                using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                return LoadFromStream(assemblyFile, pdbFile);
+            }
+
+            return LoadFromStream(assemblyFile);
         }
+
+        return null;
+    }
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (libraryPath != null)
+            return LoadUnmanagedDllFromPath(libraryPath);
+
+        return IntPtr.Zero;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -1,476 +1,476 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Axis-Aligned Bounding Box. AABB consists of a position, a size, and
+/// several utility functions. It is typically used for fast overlap tests.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Aabb : IEquatable<Aabb>
 {
+    private Vector3 _position;
+    private Vector3 _size;
+
     /// <summary>
-    /// Axis-Aligned Bounding Box. AABB consists of a position, a size, and
-    /// several utility functions. It is typically used for fast overlap tests.
+    /// Beginning corner. Typically has values lower than <see cref="End"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Aabb : IEquatable<Aabb>
+    /// <value>Directly uses a private field.</value>
+    public Vector3 Position
     {
-        private Vector3 _position;
-        private Vector3 _size;
+        readonly get { return _position; }
+        set { _position = value; }
+    }
 
-        /// <summary>
-        /// Beginning corner. Typically has values lower than <see cref="End"/>.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector3 Position
+    /// <summary>
+    /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
+    /// If the size is negative, you can use <see cref="Abs"/> to fix it.
+    /// </summary>
+    /// <value>Directly uses a private field.</value>
+    public Vector3 Size
+    {
+        readonly get { return _size; }
+        set { _size = value; }
+    }
+
+    /// <summary>
+    /// Ending corner. This is calculated as <see cref="Position"/> plus
+    /// <see cref="Size"/>. Setting this value will change the size.
+    /// </summary>
+    /// <value>
+    /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
+    /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
+    /// </value>
+    public Vector3 End
+    {
+        readonly get { return _position + _size; }
+        set { _size = value - _position; }
+    }
+
+    /// <summary>
+    /// The volume of this <see cref="Aabb"/>.
+    /// See also <see cref="HasVolume"/>.
+    /// </summary>
+    public readonly real_t Volume
+    {
+        get { return _size.X * _size.Y * _size.Z; }
+    }
+
+    /// <summary>
+    /// Returns an <see cref="Aabb"/> with equivalent position and size, modified so that
+    /// the most-negative corner is the origin and the size is positive.
+    /// </summary>
+    /// <returns>The modified <see cref="Aabb"/>.</returns>
+    public readonly Aabb Abs()
+    {
+        Vector3 end = End;
+        Vector3 topLeft = new Vector3(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y), Mathf.Min(_position.Z, end.Z));
+        return new Aabb(topLeft, _size.Abs());
+    }
+
+    /// <summary>
+    /// Returns the center of the <see cref="Aabb"/>, which is equal
+    /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
+    /// </summary>
+    /// <returns>The center.</returns>
+    public readonly Vector3 GetCenter()
+    {
+        return _position + (_size * 0.5f);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Aabb"/> completely encloses another one.
+    /// </summary>
+    /// <param name="with">The other <see cref="Aabb"/> that may be enclosed.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not this <see cref="Aabb"/> encloses <paramref name="with"/>.
+    /// </returns>
+    public readonly bool Encloses(Aabb with)
+    {
+        Vector3 srcMin = _position;
+        Vector3 srcMax = _position + _size;
+        Vector3 dstMin = with._position;
+        Vector3 dstMax = with._position + with._size;
+
+        return srcMin.X <= dstMin.X &&
+               srcMax.X > dstMax.X &&
+               srcMin.Y <= dstMin.Y &&
+               srcMax.Y > dstMax.Y &&
+               srcMin.Z <= dstMin.Z &&
+               srcMax.Z > dstMax.Z;
+    }
+
+    /// <summary>
+    /// Returns this <see cref="Aabb"/> expanded to include a given point.
+    /// </summary>
+    /// <param name="point">The point to include.</param>
+    /// <returns>The expanded <see cref="Aabb"/>.</returns>
+    public readonly Aabb Expand(Vector3 point)
+    {
+        Vector3 begin = _position;
+        Vector3 end = _position + _size;
+
+        if (point.X < begin.X)
         {
-            readonly get { return _position; }
-            set { _position = value; }
+            begin.X = point.X;
+        }
+        if (point.Y < begin.Y)
+        {
+            begin.Y = point.Y;
+        }
+        if (point.Z < begin.Z)
+        {
+            begin.Z = point.Z;
         }
 
-        /// <summary>
-        /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
-        /// If the size is negative, you can use <see cref="Abs"/> to fix it.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector3 Size
+        if (point.X > end.X)
         {
-            readonly get { return _size; }
-            set { _size = value; }
+            end.X = point.X;
+        }
+        if (point.Y > end.Y)
+        {
+            end.Y = point.Y;
+        }
+        if (point.Z > end.Z)
+        {
+            end.Z = point.Z;
         }
 
-        /// <summary>
-        /// Ending corner. This is calculated as <see cref="Position"/> plus
-        /// <see cref="Size"/>. Setting this value will change the size.
-        /// </summary>
-        /// <value>
-        /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
-        /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
-        /// </value>
-        public Vector3 End
+        return new Aabb(begin, end - begin);
+    }
+
+    /// <summary>
+    /// Gets the position of one of the 8 endpoints of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <param name="idx">Which endpoint to get.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="idx"/> is less than 0 or greater than 7.
+    /// </exception>
+    /// <returns>An endpoint of the <see cref="Aabb"/>.</returns>
+    public readonly Vector3 GetEndpoint(int idx)
+    {
+        switch (idx)
         {
-            readonly get { return _position + _size; }
-            set { _size = value - _position; }
-        }
-
-        /// <summary>
-        /// The volume of this <see cref="Aabb"/>.
-        /// See also <see cref="HasVolume"/>.
-        /// </summary>
-        public readonly real_t Volume
-        {
-            get { return _size.X * _size.Y * _size.Z; }
-        }
-
-        /// <summary>
-        /// Returns an <see cref="Aabb"/> with equivalent position and size, modified so that
-        /// the most-negative corner is the origin and the size is positive.
-        /// </summary>
-        /// <returns>The modified <see cref="Aabb"/>.</returns>
-        public readonly Aabb Abs()
-        {
-            Vector3 end = End;
-            Vector3 topLeft = new Vector3(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y), Mathf.Min(_position.Z, end.Z));
-            return new Aabb(topLeft, _size.Abs());
-        }
-
-        /// <summary>
-        /// Returns the center of the <see cref="Aabb"/>, which is equal
-        /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
-        /// </summary>
-        /// <returns>The center.</returns>
-        public readonly Vector3 GetCenter()
-        {
-            return _position + (_size * 0.5f);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Aabb"/> completely encloses another one.
-        /// </summary>
-        /// <param name="with">The other <see cref="Aabb"/> that may be enclosed.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not this <see cref="Aabb"/> encloses <paramref name="with"/>.
-        /// </returns>
-        public readonly bool Encloses(Aabb with)
-        {
-            Vector3 srcMin = _position;
-            Vector3 srcMax = _position + _size;
-            Vector3 dstMin = with._position;
-            Vector3 dstMax = with._position + with._size;
-
-            return srcMin.X <= dstMin.X &&
-                   srcMax.X > dstMax.X &&
-                   srcMin.Y <= dstMin.Y &&
-                   srcMax.Y > dstMax.Y &&
-                   srcMin.Z <= dstMin.Z &&
-                   srcMax.Z > dstMax.Z;
-        }
-
-        /// <summary>
-        /// Returns this <see cref="Aabb"/> expanded to include a given point.
-        /// </summary>
-        /// <param name="point">The point to include.</param>
-        /// <returns>The expanded <see cref="Aabb"/>.</returns>
-        public readonly Aabb Expand(Vector3 point)
-        {
-            Vector3 begin = _position;
-            Vector3 end = _position + _size;
-
-            if (point.X < begin.X)
+            case 0:
+                return new Vector3(_position.X, _position.Y, _position.Z);
+            case 1:
+                return new Vector3(_position.X, _position.Y, _position.Z + _size.Z);
+            case 2:
+                return new Vector3(_position.X, _position.Y + _size.Y, _position.Z);
+            case 3:
+                return new Vector3(_position.X, _position.Y + _size.Y, _position.Z + _size.Z);
+            case 4:
+                return new Vector3(_position.X + _size.X, _position.Y, _position.Z);
+            case 5:
+                return new Vector3(_position.X + _size.X, _position.Y, _position.Z + _size.Z);
+            case 6:
+                return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z);
+            case 7:
+                return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z);
+            default:
             {
-                begin.X = point.X;
-            }
-            if (point.Y < begin.Y)
-            {
-                begin.Y = point.Y;
-            }
-            if (point.Z < begin.Z)
-            {
-                begin.Z = point.Z;
-            }
-
-            if (point.X > end.X)
-            {
-                end.X = point.X;
-            }
-            if (point.Y > end.Y)
-            {
-                end.Y = point.Y;
-            }
-            if (point.Z > end.Z)
-            {
-                end.Z = point.Z;
-            }
-
-            return new Aabb(begin, end - begin);
-        }
-
-        /// <summary>
-        /// Gets the position of one of the 8 endpoints of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <param name="idx">Which endpoint to get.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="idx"/> is less than 0 or greater than 7.
-        /// </exception>
-        /// <returns>An endpoint of the <see cref="Aabb"/>.</returns>
-        public readonly Vector3 GetEndpoint(int idx)
-        {
-            switch (idx)
-            {
-                case 0:
-                    return new Vector3(_position.X, _position.Y, _position.Z);
-                case 1:
-                    return new Vector3(_position.X, _position.Y, _position.Z + _size.Z);
-                case 2:
-                    return new Vector3(_position.X, _position.Y + _size.Y, _position.Z);
-                case 3:
-                    return new Vector3(_position.X, _position.Y + _size.Y, _position.Z + _size.Z);
-                case 4:
-                    return new Vector3(_position.X + _size.X, _position.Y, _position.Z);
-                case 5:
-                    return new Vector3(_position.X + _size.X, _position.Y, _position.Z + _size.Z);
-                case 6:
-                    return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z);
-                case 7:
-                    return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z);
-                default:
-                {
-                    throw new ArgumentOutOfRangeException(nameof(idx),
-                        $"Index is {idx}, but a value from 0 to 7 is expected.");
-                }
+                throw new ArgumentOutOfRangeException(nameof(idx),
+                    $"Index is {idx}, but a value from 0 to 7 is expected.");
             }
         }
+    }
 
-        /// <summary>
-        /// Returns the normalized longest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>A vector representing the normalized longest axis of the <see cref="Aabb"/>.</returns>
-        public readonly Vector3 GetLongestAxis()
+    /// <summary>
+    /// Returns the normalized longest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A vector representing the normalized longest axis of the <see cref="Aabb"/>.</returns>
+    public readonly Vector3 GetLongestAxis()
+    {
+        var axis = new Vector3(1f, 0f, 0f);
+        real_t maxSize = _size.X;
+
+        if (_size.Y > maxSize)
         {
-            var axis = new Vector3(1f, 0f, 0f);
-            real_t maxSize = _size.X;
-
-            if (_size.Y > maxSize)
-            {
-                axis = new Vector3(0f, 1f, 0f);
-                maxSize = _size.Y;
-            }
-
-            if (_size.Z > maxSize)
-            {
-                axis = new Vector3(0f, 0f, 1f);
-            }
-
-            return axis;
+            axis = new Vector3(0f, 1f, 0f);
+            maxSize = _size.Y;
         }
 
-        /// <summary>
-        /// Returns the <see cref="Vector3.Axis"/> index of the longest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>A <see cref="Vector3.Axis"/> index for which axis is longest.</returns>
-        public readonly Vector3.Axis GetLongestAxisIndex()
+        if (_size.Z > maxSize)
         {
-            var axis = Vector3.Axis.X;
-            real_t maxSize = _size.X;
-
-            if (_size.Y > maxSize)
-            {
-                axis = Vector3.Axis.Y;
-                maxSize = _size.Y;
-            }
-
-            if (_size.Z > maxSize)
-            {
-                axis = Vector3.Axis.Z;
-            }
-
-            return axis;
+            axis = new Vector3(0f, 0f, 1f);
         }
 
-        /// <summary>
-        /// Returns the scalar length of the longest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>The scalar length of the longest axis of the <see cref="Aabb"/>.</returns>
-        public readonly real_t GetLongestAxisSize()
+        return axis;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Vector3.Axis"/> index of the longest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector3.Axis"/> index for which axis is longest.</returns>
+    public readonly Vector3.Axis GetLongestAxisIndex()
+    {
+        var axis = Vector3.Axis.X;
+        real_t maxSize = _size.X;
+
+        if (_size.Y > maxSize)
         {
-            real_t maxSize = _size.X;
-
-            if (_size.Y > maxSize)
-                maxSize = _size.Y;
-
-            if (_size.Z > maxSize)
-                maxSize = _size.Z;
-
-            return maxSize;
+            axis = Vector3.Axis.Y;
+            maxSize = _size.Y;
         }
 
-        /// <summary>
-        /// Returns the normalized shortest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>A vector representing the normalized shortest axis of the <see cref="Aabb"/>.</returns>
-        public readonly Vector3 GetShortestAxis()
+        if (_size.Z > maxSize)
         {
-            var axis = new Vector3(1f, 0f, 0f);
-            real_t maxSize = _size.X;
-
-            if (_size.Y < maxSize)
-            {
-                axis = new Vector3(0f, 1f, 0f);
-                maxSize = _size.Y;
-            }
-
-            if (_size.Z < maxSize)
-            {
-                axis = new Vector3(0f, 0f, 1f);
-            }
-
-            return axis;
+            axis = Vector3.Axis.Z;
         }
 
-        /// <summary>
-        /// Returns the <see cref="Vector3.Axis"/> index of the shortest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>A <see cref="Vector3.Axis"/> index for which axis is shortest.</returns>
-        public readonly Vector3.Axis GetShortestAxisIndex()
+        return axis;
+    }
+
+    /// <summary>
+    /// Returns the scalar length of the longest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>The scalar length of the longest axis of the <see cref="Aabb"/>.</returns>
+    public readonly real_t GetLongestAxisSize()
+    {
+        real_t maxSize = _size.X;
+
+        if (_size.Y > maxSize)
+            maxSize = _size.Y;
+
+        if (_size.Z > maxSize)
+            maxSize = _size.Z;
+
+        return maxSize;
+    }
+
+    /// <summary>
+    /// Returns the normalized shortest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A vector representing the normalized shortest axis of the <see cref="Aabb"/>.</returns>
+    public readonly Vector3 GetShortestAxis()
+    {
+        var axis = new Vector3(1f, 0f, 0f);
+        real_t maxSize = _size.X;
+
+        if (_size.Y < maxSize)
         {
-            var axis = Vector3.Axis.X;
-            real_t maxSize = _size.X;
-
-            if (_size.Y < maxSize)
-            {
-                axis = Vector3.Axis.Y;
-                maxSize = _size.Y;
-            }
-
-            if (_size.Z < maxSize)
-            {
-                axis = Vector3.Axis.Z;
-            }
-
-            return axis;
+            axis = new Vector3(0f, 1f, 0f);
+            maxSize = _size.Y;
         }
 
-        /// <summary>
-        /// Returns the scalar length of the shortest axis of the <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>The scalar length of the shortest axis of the <see cref="Aabb"/>.</returns>
-        public readonly real_t GetShortestAxisSize()
+        if (_size.Z < maxSize)
         {
-            real_t maxSize = _size.X;
-
-            if (_size.Y < maxSize)
-                maxSize = _size.Y;
-
-            if (_size.Z < maxSize)
-                maxSize = _size.Z;
-
-            return maxSize;
+            axis = new Vector3(0f, 0f, 1f);
         }
 
-        /// <summary>
-        /// Returns the support point in a given direction.
-        /// This is useful for collision detection algorithms.
-        /// </summary>
-        /// <param name="dir">The direction to find support for.</param>
-        /// <returns>A vector representing the support.</returns>
-        public readonly Vector3 GetSupport(Vector3 dir)
-        {
-            Vector3 halfExtents = _size * 0.5f;
-            Vector3 ofs = _position + halfExtents;
+        return axis;
+    }
 
-            return ofs + new Vector3(
-                dir.X > 0f ? -halfExtents.X : halfExtents.X,
-                dir.Y > 0f ? -halfExtents.Y : halfExtents.Y,
-                dir.Z > 0f ? -halfExtents.Z : halfExtents.Z);
+    /// <summary>
+    /// Returns the <see cref="Vector3.Axis"/> index of the shortest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A <see cref="Vector3.Axis"/> index for which axis is shortest.</returns>
+    public readonly Vector3.Axis GetShortestAxisIndex()
+    {
+        var axis = Vector3.Axis.X;
+        real_t maxSize = _size.X;
+
+        if (_size.Y < maxSize)
+        {
+            axis = Vector3.Axis.Y;
+            maxSize = _size.Y;
         }
 
-        /// <summary>
-        /// Returns a copy of the <see cref="Aabb"/> grown a given amount of units towards all the sides.
-        /// </summary>
-        /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown <see cref="Aabb"/>.</returns>
-        public readonly Aabb Grow(real_t by)
+        if (_size.Z < maxSize)
         {
-            Aabb res = this;
-
-            res._position.X -= by;
-            res._position.Y -= by;
-            res._position.Z -= by;
-            res._size.X += 2.0f * by;
-            res._size.Y += 2.0f * by;
-            res._size.Z += 2.0f * by;
-
-            return res;
+            axis = Vector3.Axis.Z;
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/> contains a point,
-        /// or <see langword="false"/> otherwise.
-        /// </summary>
-        /// <param name="point">The point to check.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> contains <paramref name="point"/>.
-        /// </returns>
-        public readonly bool HasPoint(Vector3 point)
-        {
-            if (point.X < _position.X)
-                return false;
-            if (point.Y < _position.Y)
-                return false;
-            if (point.Z < _position.Z)
-                return false;
-            if (point.X > _position.X + _size.X)
-                return false;
-            if (point.Y > _position.Y + _size.Y)
-                return false;
-            if (point.Z > _position.Z + _size.Z)
-                return false;
+        return axis;
+    }
 
-            return true;
+    /// <summary>
+    /// Returns the scalar length of the shortest axis of the <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>The scalar length of the shortest axis of the <see cref="Aabb"/>.</returns>
+    public readonly real_t GetShortestAxisSize()
+    {
+        real_t maxSize = _size.X;
+
+        if (_size.Y < maxSize)
+            maxSize = _size.Y;
+
+        if (_size.Z < maxSize)
+            maxSize = _size.Z;
+
+        return maxSize;
+    }
+
+    /// <summary>
+    /// Returns the support point in a given direction.
+    /// This is useful for collision detection algorithms.
+    /// </summary>
+    /// <param name="dir">The direction to find support for.</param>
+    /// <returns>A vector representing the support.</returns>
+    public readonly Vector3 GetSupport(Vector3 dir)
+    {
+        Vector3 halfExtents = _size * 0.5f;
+        Vector3 ofs = _position + halfExtents;
+
+        return ofs + new Vector3(
+            dir.X > 0f ? -halfExtents.X : halfExtents.X,
+            dir.Y > 0f ? -halfExtents.Y : halfExtents.Y,
+            dir.Z > 0f ? -halfExtents.Z : halfExtents.Z);
+    }
+
+    /// <summary>
+    /// Returns a copy of the <see cref="Aabb"/> grown a given amount of units towards all the sides.
+    /// </summary>
+    /// <param name="by">The amount to grow by.</param>
+    /// <returns>The grown <see cref="Aabb"/>.</returns>
+    public readonly Aabb Grow(real_t by)
+    {
+        Aabb res = this;
+
+        res._position.X -= by;
+        res._position.Y -= by;
+        res._position.Z -= by;
+        res._size.X += 2.0f * by;
+        res._size.Y += 2.0f * by;
+        res._size.Z += 2.0f * by;
+
+        return res;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/> contains a point,
+    /// or <see langword="false"/> otherwise.
+    /// </summary>
+    /// <param name="point">The point to check.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> contains <paramref name="point"/>.
+    /// </returns>
+    public readonly bool HasPoint(Vector3 point)
+    {
+        if (point.X < _position.X)
+            return false;
+        if (point.Y < _position.Y)
+            return false;
+        if (point.Z < _position.Z)
+            return false;
+        if (point.X > _position.X + _size.X)
+            return false;
+        if (point.Y > _position.Y + _size.Y)
+            return false;
+        if (point.Z > _position.Z + _size.Z)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/>
+    /// has a surface or a length, and <see langword="false"/>
+    /// if the <see cref="Aabb"/> is empty (all components
+    /// of <see cref="Size"/> are zero or negative).
+    /// </summary>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> has surface.
+    /// </returns>
+    public readonly bool HasSurface()
+    {
+        return _size.X > 0.0f || _size.Y > 0.0f || _size.Z > 0.0f;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/> has
+    /// area, and <see langword="false"/> if the <see cref="Aabb"/>
+    /// is linear, empty, or has a negative <see cref="Size"/>.
+    /// See also <see cref="Volume"/>.
+    /// </summary>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> has volume.
+    /// </returns>
+    public readonly bool HasVolume()
+    {
+        return _size.X > 0.0f && _size.Y > 0.0f && _size.Z > 0.0f;
+    }
+
+    /// <summary>
+    /// Returns the intersection of this <see cref="Aabb"/> and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other <see cref="Aabb"/>.</param>
+    /// <returns>The clipped <see cref="Aabb"/>.</returns>
+    public readonly Aabb Intersection(Aabb with)
+    {
+        Vector3 srcMin = _position;
+        Vector3 srcMax = _position + _size;
+        Vector3 dstMin = with._position;
+        Vector3 dstMax = with._position + with._size;
+
+        Vector3 min, max;
+
+        if (srcMin.X > dstMax.X || srcMax.X < dstMin.X)
+        {
+            return new Aabb();
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/>
-        /// has a surface or a length, and <see langword="false"/>
-        /// if the <see cref="Aabb"/> is empty (all components
-        /// of <see cref="Size"/> are zero or negative).
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> has surface.
-        /// </returns>
-        public readonly bool HasSurface()
+        min.X = srcMin.X > dstMin.X ? srcMin.X : dstMin.X;
+        max.X = srcMax.X < dstMax.X ? srcMax.X : dstMax.X;
+
+        if (srcMin.Y > dstMax.Y || srcMax.Y < dstMin.Y)
         {
-            return _size.X > 0.0f || _size.Y > 0.0f || _size.Z > 0.0f;
+            return new Aabb();
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/> has
-        /// area, and <see langword="false"/> if the <see cref="Aabb"/>
-        /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="Volume"/>.
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> has volume.
-        /// </returns>
-        public readonly bool HasVolume()
+        min.Y = srcMin.Y > dstMin.Y ? srcMin.Y : dstMin.Y;
+        max.Y = srcMax.Y < dstMax.Y ? srcMax.Y : dstMax.Y;
+
+        if (srcMin.Z > dstMax.Z || srcMax.Z < dstMin.Z)
         {
-            return _size.X > 0.0f && _size.Y > 0.0f && _size.Z > 0.0f;
+            return new Aabb();
         }
 
-        /// <summary>
-        /// Returns the intersection of this <see cref="Aabb"/> and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other <see cref="Aabb"/>.</param>
-        /// <returns>The clipped <see cref="Aabb"/>.</returns>
-        public readonly Aabb Intersection(Aabb with)
+        min.Z = srcMin.Z > dstMin.Z ? srcMin.Z : dstMin.Z;
+        max.Z = srcMax.Z < dstMax.Z ? srcMax.Z : dstMax.Z;
+
+        return new Aabb(min, max - min);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/> overlaps with <paramref name="with"/>
+    /// (i.e. they have at least one point in common).
+    /// </summary>
+    /// <param name="with">The other <see cref="Aabb"/> to check for intersections with.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not they are intersecting.
+    /// </returns>
+    public readonly bool Intersects(Aabb with)
+    {
+        if (_position.X >= with._position.X + with._size.X)
+            return false;
+        if (_position.X + _size.X <= with._position.X)
+            return false;
+        if (_position.Y >= with._position.Y + with._size.Y)
+            return false;
+        if (_position.Y + _size.Y <= with._position.Y)
+            return false;
+        if (_position.Z >= with._position.Z + with._size.Z)
+            return false;
+        if (_position.Z + _size.Z <= with._position.Z)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/> is on both sides of <paramref name="plane"/>.
+    /// </summary>
+    /// <param name="plane">The <see cref="Plane"/> to check for intersection.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> intersects the <see cref="Plane"/>.
+    /// </returns>
+    public readonly bool IntersectsPlane(Plane plane)
+    {
+        Vector3[] points =
         {
-            Vector3 srcMin = _position;
-            Vector3 srcMax = _position + _size;
-            Vector3 dstMin = with._position;
-            Vector3 dstMax = with._position + with._size;
-
-            Vector3 min, max;
-
-            if (srcMin.X > dstMax.X || srcMax.X < dstMin.X)
-            {
-                return new Aabb();
-            }
-
-            min.X = srcMin.X > dstMin.X ? srcMin.X : dstMin.X;
-            max.X = srcMax.X < dstMax.X ? srcMax.X : dstMax.X;
-
-            if (srcMin.Y > dstMax.Y || srcMax.Y < dstMin.Y)
-            {
-                return new Aabb();
-            }
-
-            min.Y = srcMin.Y > dstMin.Y ? srcMin.Y : dstMin.Y;
-            max.Y = srcMax.Y < dstMax.Y ? srcMax.Y : dstMax.Y;
-
-            if (srcMin.Z > dstMax.Z || srcMax.Z < dstMin.Z)
-            {
-                return new Aabb();
-            }
-
-            min.Z = srcMin.Z > dstMin.Z ? srcMin.Z : dstMin.Z;
-            max.Z = srcMax.Z < dstMax.Z ? srcMax.Z : dstMax.Z;
-
-            return new Aabb(min, max - min);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/> overlaps with <paramref name="with"/>
-        /// (i.e. they have at least one point in common).
-        /// </summary>
-        /// <param name="with">The other <see cref="Aabb"/> to check for intersections with.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not they are intersecting.
-        /// </returns>
-        public readonly bool Intersects(Aabb with)
-        {
-            if (_position.X >= with._position.X + with._size.X)
-                return false;
-            if (_position.X + _size.X <= with._position.X)
-                return false;
-            if (_position.Y >= with._position.Y + with._size.Y)
-                return false;
-            if (_position.Y + _size.Y <= with._position.Y)
-                return false;
-            if (_position.Z >= with._position.Z + with._size.Z)
-                return false;
-            if (_position.Z + _size.Z <= with._position.Z)
-                return false;
-
-            return true;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/> is on both sides of <paramref name="plane"/>.
-        /// </summary>
-        /// <param name="plane">The <see cref="Plane"/> to check for intersection.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> intersects the <see cref="Plane"/>.
-        /// </returns>
-        public readonly bool IntersectsPlane(Plane plane)
-        {
-            Vector3[] points =
-            {
                 new Vector3(_position.X, _position.Y, _position.Z),
                 new Vector3(_position.X, _position.Y, _position.Z + _size.Z),
                 new Vector3(_position.X, _position.Y + _size.Y, _position.Z),
@@ -481,267 +481,266 @@ namespace Godot
                 new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z)
             };
 
-            bool over = false;
-            bool under = false;
+        bool over = false;
+        bool under = false;
 
-            for (int i = 0; i < 8; i++)
+        for (int i = 0; i < 8; i++)
+        {
+            if (plane.DistanceTo(points[i]) > 0)
             {
-                if (plane.DistanceTo(points[i]) > 0)
-                {
-                    over = true;
-                }
-                else
-                {
-                    under = true;
-                }
+                over = true;
             }
-
-            return under && over;
+            else
+            {
+                under = true;
+            }
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Aabb"/> intersects
-        /// the line segment between <paramref name="from"/> and <paramref name="to"/>.
-        /// </summary>
-        /// <param name="from">The start of the line segment.</param>
-        /// <param name="to">The end of the line segment.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> intersects the line segment.
-        /// </returns>
-        public readonly bool IntersectsSegment(Vector3 from, Vector3 to)
+        return under && over;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Aabb"/> intersects
+    /// the line segment between <paramref name="from"/> and <paramref name="to"/>.
+    /// </summary>
+    /// <param name="from">The start of the line segment.</param>
+    /// <param name="to">The end of the line segment.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> intersects the line segment.
+    /// </returns>
+    public readonly bool IntersectsSegment(Vector3 from, Vector3 to)
+    {
+        real_t min = 0f;
+        real_t max = 1f;
+
+        for (int i = 0; i < 3; i++)
         {
-            real_t min = 0f;
-            real_t max = 1f;
+            real_t segFrom = from[i];
+            real_t segTo = to[i];
+            real_t boxBegin = _position[i];
+            real_t boxEnd = boxBegin + _size[i];
+            real_t cmin, cmax;
 
-            for (int i = 0; i < 3; i++)
+            if (segFrom < segTo)
             {
-                real_t segFrom = from[i];
-                real_t segTo = to[i];
-                real_t boxBegin = _position[i];
-                real_t boxEnd = boxBegin + _size[i];
-                real_t cmin, cmax;
-
-                if (segFrom < segTo)
-                {
-                    if (segFrom > boxEnd || segTo < boxBegin)
-                    {
-                        return false;
-                    }
-
-                    real_t length = segTo - segFrom;
-                    cmin = segFrom < boxBegin ? (boxBegin - segFrom) / length : 0f;
-                    cmax = segTo > boxEnd ? (boxEnd - segFrom) / length : 1f;
-                }
-                else
-                {
-                    if (segTo > boxEnd || segFrom < boxBegin)
-                    {
-                        return false;
-                    }
-
-                    real_t length = segTo - segFrom;
-                    cmin = segFrom > boxEnd ? (boxEnd - segFrom) / length : 0f;
-                    cmax = segTo < boxBegin ? (boxBegin - segFrom) / length : 1f;
-                }
-
-                if (cmin > min)
-                {
-                    min = cmin;
-                }
-
-                if (cmax < max)
-                {
-                    max = cmax;
-                }
-                if (max < min)
+                if (segFrom > boxEnd || segTo < boxBegin)
                 {
                     return false;
                 }
+
+                real_t length = segTo - segFrom;
+                cmin = segFrom < boxBegin ? (boxBegin - segFrom) / length : 0f;
+                cmax = segTo > boxEnd ? (boxEnd - segFrom) / length : 1f;
+            }
+            else
+            {
+                if (segTo > boxEnd || segFrom < boxBegin)
+                {
+                    return false;
+                }
+
+                real_t length = segTo - segFrom;
+                cmin = segFrom > boxEnd ? (boxEnd - segFrom) / length : 0f;
+                cmax = segTo < boxBegin ? (boxBegin - segFrom) / length : 1f;
             }
 
-            return true;
+            if (cmin > min)
+            {
+                min = cmin;
+            }
+
+            if (cmax < max)
+            {
+                max = cmax;
+            }
+            if (max < min)
+            {
+                return false;
+            }
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Aabb"/> is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return _position.IsFinite() && _size.IsFinite();
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Returns a larger <see cref="Aabb"/> that contains this <see cref="Aabb"/> and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other <see cref="Aabb"/>.</param>
-        /// <returns>The merged <see cref="Aabb"/>.</returns>
-        public readonly Aabb Merge(Aabb with)
-        {
-            Vector3 beg1 = _position;
-            Vector3 beg2 = with._position;
-            var end1 = new Vector3(_size.X, _size.Y, _size.Z) + beg1;
-            var end2 = new Vector3(with._size.X, with._size.Y, with._size.Z) + beg2;
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Aabb"/> is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return _position.IsFinite() && _size.IsFinite();
+    }
 
-            var min = new Vector3(
-                beg1.X < beg2.X ? beg1.X : beg2.X,
-                beg1.Y < beg2.Y ? beg1.Y : beg2.Y,
-                beg1.Z < beg2.Z ? beg1.Z : beg2.Z
-            );
+    /// <summary>
+    /// Returns a larger <see cref="Aabb"/> that contains this <see cref="Aabb"/> and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other <see cref="Aabb"/>.</param>
+    /// <returns>The merged <see cref="Aabb"/>.</returns>
+    public readonly Aabb Merge(Aabb with)
+    {
+        Vector3 beg1 = _position;
+        Vector3 beg2 = with._position;
+        var end1 = new Vector3(_size.X, _size.Y, _size.Z) + beg1;
+        var end2 = new Vector3(with._size.X, with._size.Y, with._size.Z) + beg2;
 
-            var max = new Vector3(
-                end1.X > end2.X ? end1.X : end2.X,
-                end1.Y > end2.Y ? end1.Y : end2.Y,
-                end1.Z > end2.Z ? end1.Z : end2.Z
-            );
+        var min = new Vector3(
+            beg1.X < beg2.X ? beg1.X : beg2.X,
+            beg1.Y < beg2.Y ? beg1.Y : beg2.Y,
+            beg1.Z < beg2.Z ? beg1.Z : beg2.Z
+        );
 
-            return new Aabb(min, max - min);
-        }
+        var max = new Vector3(
+            end1.X > end2.X ? end1.X : end2.X,
+            end1.Y > end2.Y ? end1.Y : end2.Y,
+            end1.Z > end2.Z ? end1.Z : end2.Z
+        );
 
-        /// <summary>
-        /// Constructs an <see cref="Aabb"/> from a position and size.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="size">The size, typically positive.</param>
-        public Aabb(Vector3 position, Vector3 size)
-        {
-            _position = position;
-            _size = size;
-        }
+        return new Aabb(min, max - min);
+    }
 
-        /// <summary>
-        /// Constructs an <see cref="Aabb"/> from a <paramref name="position"/>,
-        /// <paramref name="width"/>, <paramref name="height"/>, and <paramref name="depth"/>.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="width">The width, typically positive.</param>
-        /// <param name="height">The height, typically positive.</param>
-        /// <param name="depth">The depth, typically positive.</param>
-        public Aabb(Vector3 position, real_t width, real_t height, real_t depth)
-        {
-            _position = position;
-            _size = new Vector3(width, height, depth);
-        }
+    /// <summary>
+    /// Constructs an <see cref="Aabb"/> from a position and size.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="size">The size, typically positive.</param>
+    public Aabb(Vector3 position, Vector3 size)
+    {
+        _position = position;
+        _size = size;
+    }
 
-        /// <summary>
-        /// Constructs an <see cref="Aabb"/> from <paramref name="x"/>,
-        /// <paramref name="y"/>, <paramref name="z"/>, and <paramref name="size"/>.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="z">The position's Z coordinate.</param>
-        /// <param name="size">The size, typically positive.</param>
-        public Aabb(real_t x, real_t y, real_t z, Vector3 size)
-        {
-            _position = new Vector3(x, y, z);
-            _size = size;
-        }
+    /// <summary>
+    /// Constructs an <see cref="Aabb"/> from a <paramref name="position"/>,
+    /// <paramref name="width"/>, <paramref name="height"/>, and <paramref name="depth"/>.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="width">The width, typically positive.</param>
+    /// <param name="height">The height, typically positive.</param>
+    /// <param name="depth">The depth, typically positive.</param>
+    public Aabb(Vector3 position, real_t width, real_t height, real_t depth)
+    {
+        _position = position;
+        _size = new Vector3(width, height, depth);
+    }
 
-        /// <summary>
-        /// Constructs an <see cref="Aabb"/> from <paramref name="x"/>,
-        /// <paramref name="y"/>, <paramref name="z"/>, <paramref name="width"/>,
-        /// <paramref name="height"/>, and <paramref name="depth"/>.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="z">The position's Z coordinate.</param>
-        /// <param name="width">The width, typically positive.</param>
-        /// <param name="height">The height, typically positive.</param>
-        /// <param name="depth">The depth, typically positive.</param>
-        public Aabb(real_t x, real_t y, real_t z, real_t width, real_t height, real_t depth)
-        {
-            _position = new Vector3(x, y, z);
-            _size = new Vector3(width, height, depth);
-        }
+    /// <summary>
+    /// Constructs an <see cref="Aabb"/> from <paramref name="x"/>,
+    /// <paramref name="y"/>, <paramref name="z"/>, and <paramref name="size"/>.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="z">The position's Z coordinate.</param>
+    /// <param name="size">The size, typically positive.</param>
+    public Aabb(real_t x, real_t y, real_t z, Vector3 size)
+    {
+        _position = new Vector3(x, y, z);
+        _size = size;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the AABBs are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left AABB.</param>
-        /// <param name="right">The right AABB.</param>
-        /// <returns>Whether or not the AABBs are exactly equal.</returns>
-        public static bool operator ==(Aabb left, Aabb right)
-        {
-            return left.Equals(right);
-        }
+    /// <summary>
+    /// Constructs an <see cref="Aabb"/> from <paramref name="x"/>,
+    /// <paramref name="y"/>, <paramref name="z"/>, <paramref name="width"/>,
+    /// <paramref name="height"/>, and <paramref name="depth"/>.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="z">The position's Z coordinate.</param>
+    /// <param name="width">The width, typically positive.</param>
+    /// <param name="height">The height, typically positive.</param>
+    /// <param name="depth">The depth, typically positive.</param>
+    public Aabb(real_t x, real_t y, real_t z, real_t width, real_t height, real_t depth)
+    {
+        _position = new Vector3(x, y, z);
+        _size = new Vector3(width, height, depth);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the AABBs are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left AABB.</param>
-        /// <param name="right">The right AABB.</param>
-        /// <returns>Whether or not the AABBs are not equal.</returns>
-        public static bool operator !=(Aabb left, Aabb right)
-        {
-            return !left.Equals(right);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the AABBs are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left AABB.</param>
+    /// <param name="right">The right AABB.</param>
+    /// <returns>Whether or not the AABBs are exactly equal.</returns>
+    public static bool operator ==(Aabb left, Aabb right)
+    {
+        return left.Equals(right);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the AABB is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the AABB and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Aabb other && Equals(other);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the AABBs are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left AABB.</param>
+    /// <param name="right">The right AABB.</param>
+    /// <returns>Whether or not the AABBs are not equal.</returns>
+    public static bool operator !=(Aabb left, Aabb right)
+    {
+        return !left.Equals(right);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the AABBs are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other AABB.</param>
-        /// <returns>Whether or not the AABBs are exactly equal.</returns>
-        public readonly bool Equals(Aabb other)
-        {
-            return _position == other._position && _size == other._size;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the AABB is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the AABB and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Aabb other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this AABB and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other AABB to compare.</param>
-        /// <returns>Whether or not the AABBs structures are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Aabb other)
-        {
-            return _position.IsEqualApprox(other._position) && _size.IsEqualApprox(other._size);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the AABBs are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other AABB.</param>
+    /// <returns>Whether or not the AABBs are exactly equal.</returns>
+    public readonly bool Equals(Aabb other)
+    {
+        return _position == other._position && _size == other._size;
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Aabb"/>.
-        /// </summary>
-        /// <returns>A hash code for this AABB.</returns>
-        public override readonly int GetHashCode()
-        {
-            return _position.GetHashCode() ^ _size.GetHashCode();
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this AABB and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other AABB to compare.</param>
+    /// <returns>Whether or not the AABBs structures are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Aabb other)
+    {
+        return _position.IsEqualApprox(other._position) && _size.IsEqualApprox(other._size);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Aabb"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this AABB.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Aabb"/>.
+    /// </summary>
+    /// <returns>A hash code for this AABB.</returns>
+    public override readonly int GetHashCode()
+    {
+        return _position.GetHashCode() ^ _size.GetHashCode();
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Aabb"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this AABB.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
-        }
+    /// <summary>
+    /// Converts this <see cref="Aabb"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this AABB.</returns>
+    public override readonly string ToString()
+    {
+        return $"{_position}, {_size}";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Aabb"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this AABB.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"{_position.ToString(format)}, {_size.ToString(format)}";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -6,1785 +6,1784 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
 
-namespace Godot.Collections
+namespace Godot.Collections;
+
+/// <summary>
+/// Wrapper around Godot's Array class, an array of Variant
+/// typed elements allocated in the engine in C++. Useful when
+/// interfacing with the engine. Otherwise prefer .NET collections
+/// such as <see cref="System.Array"/> or <see cref="List{T}"/>.
+/// </summary>
+public sealed class Array :
+    IList<Variant>,
+    IReadOnlyList<Variant>,
+    ICollection,
+    IDisposable
 {
+    internal godot_array.movable NativeValue;
+
+    private WeakReference<IDisposable> _weakReferenceToSelf;
+
     /// <summary>
-    /// Wrapper around Godot's Array class, an array of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine. Otherwise prefer .NET collections
-    /// such as <see cref="System.Array"/> or <see cref="List{T}"/>.
+    /// Constructs a new empty <see cref="Array"/>.
     /// </summary>
-    public sealed class Array :
-        IList<Variant>,
-        IReadOnlyList<Variant>,
-        ICollection,
-        IDisposable
+    public Array()
     {
-        internal godot_array.movable NativeValue;
-
-        private WeakReference<IDisposable> _weakReferenceToSelf;
-
-        /// <summary>
-        /// Constructs a new empty <see cref="Array"/>.
-        /// </summary>
-        public Array()
-        {
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Array"/> from the given collection's elements.
-        /// </summary>
-        /// <param name="collection">The collection of elements to construct from.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array(IEnumerable<Variant> collection) : this()
-        {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
-
-            foreach (Variant element in collection)
-                Add(element);
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Array"/> from the given objects.
-        /// </summary>
-        /// <param name="array">The objects to put in the new array.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array(Variant[] array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-
-            int length = array.Length;
-
-            Resize(length);
-
-            for (int i = 0; i < length; i++)
-                this[i] = array[i];
-        }
-
-        public Array(Span<StringName> array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-
-            int length = array.Length;
-
-            Resize(length);
-
-            for (int i = 0; i < length; i++)
-                this[i] = array[i];
-        }
-
-        public Array(Span<NodePath> array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-
-            int length = array.Length;
-
-            Resize(length);
-
-            for (int i = 0; i < length; i++)
-                this[i] = array[i];
-        }
-
-        public Array(Span<Rid> array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-
-            int length = array.Length;
-
-            Resize(length);
-
-            for (int i = 0; i < length; i++)
-                this[i] = array[i];
-        }
-
-        // We must use ReadOnlySpan instead of Span here as this can accept implicit conversions
-        // from derived types (e.g.: Node[]). Implicit conversion from Derived[] to Base[] are
-        // fine as long as the array is not mutated. However, Span does this type checking at
-        // instantiation, so it's not possible to use it even when not mutating anything.
-        // ReSharper disable once RedundantNameQualifier
-        public Array(ReadOnlySpan<GodotObject> array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-
-            int length = array.Length;
-
-            Resize(length);
-
-            for (int i = 0; i < length; i++)
-                this[i] = array[i];
-        }
-
-        private Array(godot_array nativeValueToOwn)
-        {
-            NativeValue = (godot_array.movable)(nativeValueToOwn.IsAllocated ?
-                nativeValueToOwn :
-                NativeFuncs.godotsharp_array_new());
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-        }
-
-        // Explicit name to make it very clear
-        internal static Array CreateTakingOwnershipOfDisposableValue(godot_array nativeValueToOwn)
-            => new Array(nativeValueToOwn);
-
-        ~Array()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Disposes of this <see cref="Array"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public void Dispose(bool disposing)
-        {
-            // Always dispose `NativeValue` even if disposing is true
-            NativeValue.DangerousSelfRef.Dispose();
-
-            if (_weakReferenceToSelf != null)
-            {
-                DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
-            }
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Array"/>.
-        /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy if performed:
-        /// all nested arrays and dictionaries are duplicated and will not be shared with
-        /// the original array. If <see langword="false"/>, a shallow copy is made and
-        /// references to the original nested arrays and dictionaries are kept, so that
-        /// modifying a sub-array or dictionary in the copy will also impact those
-        /// referenced in the source array. Note that any <see cref="GodotObject"/> derived
-        /// elements will be shallow copied regardless of the <paramref name="deep"/>
-        /// setting.
-        /// </summary>
-        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array Duplicate(bool deep = false)
-        {
-            godot_array newArray;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_duplicate(ref self, deep.ToGodotBool(), out newArray);
-            return CreateTakingOwnershipOfDisposableValue(newArray);
-        }
-
-        /// <summary>
-        /// Assigns the given value to all elements in the array. This can typically be
-        /// used together with <see cref="Resize(int)"/> to create an array with a given
-        /// size and initialized elements.
-        /// Note: If <paramref name="value"/> is of a reference type (<see cref="GodotObject"/>
-        /// derived, <see cref="Array"/> or <see cref="Dictionary"/>, etc.) then the array
-        /// is filled with the references to the same object, i.e. no duplicates are
-        /// created.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var array = new Godot.Collections.Array();
-        /// array.Resize(10);
-        /// array.Fill(0); // Initialize the 10 elements to 0.
-        /// </code>
-        /// </example>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="value">The value to fill the array with.</param>
-        public void Fill(Variant value)
-        {
-            ThrowIfReadOnly();
-
-            godot_variant variantValue = (godot_variant)value.NativeVar;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_fill(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Returns the maximum value contained in the array if all elements are of
-        /// comparable types. If the elements can't be compared, <see langword="null"/>
-        /// is returned.
-        /// </summary>
-        /// <returns>The maximum value contained in the array.</returns>
-        public Variant Max()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_max(ref self, out resVariant);
-            return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
-        }
-
-        /// <summary>
-        /// Returns the minimum value contained in the array if all elements are of
-        /// comparable types. If the elements can't be compared, <see langword="null"/>
-        /// is returned.
-        /// </summary>
-        /// <returns>The minimum value contained in the array.</returns>
-        public Variant Min()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_min(ref self, out resVariant);
-            return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
-        }
-
-        /// <summary>
-        /// Returns a random value from the target array.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var array = new Godot.Collections.Array { 1, 2, 3, 4 };
-        /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
-        /// </code>
-        /// </example>
-        /// <returns>A random element from the array.</returns>
-        public Variant PickRandom()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
-            return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
-        }
-
-        /// <summary>
-        /// Compares this <see cref="Array"/> against the <paramref name="other"/>
-        /// <see cref="Array"/> recursively. Returns <see langword="true"/> if the
-        /// sizes and contents of the arrays are equal, <see langword="false"/>
-        /// otherwise.
-        /// </summary>
-        /// <param name="other">The other array to compare against.</param>
-        /// <returns>
-        /// <see langword="true"/> if the sizes and contents of the arrays are equal,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool RecursiveEqual(Array other)
-        {
-            var self = (godot_array)NativeValue;
-            var otherVariant = (godot_array)other.NativeValue;
-            return NativeFuncs.godotsharp_array_recursive_equal(ref self, otherVariant).ToBool();
-        }
-
-        /// <summary>
-        /// Resizes the array to contain a different number of elements. If the array
-        /// size is smaller, elements are cleared, if bigger, new elements are
-        /// <see langword="null"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="newSize">The new size of the array.</param>
-        /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
-        public Error Resize(int newSize)
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_resize(ref self, newSize);
-        }
-
-        /// <summary>
-        /// Reverses the order of the elements in the array.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Reverse()
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_reverse(ref self);
-        }
-
-        /// <summary>
-        /// Shuffles the array such that the items will have a random order.
-        /// This method uses the global random number generator common to methods
-        /// such as <see cref="GD.Randi"/>. Call <see cref="GD.Randomize"/> to
-        /// ensure that a new seed will be used each time if you want
-        /// non-reproducible shuffling.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Shuffle()
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_shuffle(ref self);
-        }
-
-        /// <summary>
-        /// Creates a shallow copy of a range of elements in the source <see cref="Array"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="start"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        public Array Slice(int start)
-        {
-            if (start < 0 || start > Count)
-                throw new ArgumentOutOfRangeException(nameof(start));
-
-            return GetSliceRange(start, Count, step: 1, deep: false);
-        }
-
-        /// <summary>
-        /// Creates a shallow copy of a range of elements in the source <see cref="Array"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="start"/> is less than 0 or greater than the array's size.
-        /// -or-
-        /// <paramref name="length"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <param name="length">The length of the range.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        // The Slice method must have this signature to get implicit Range support.
-        public Array Slice(int start, int length)
-        {
-            if (start < 0 || start > Count)
-                throw new ArgumentOutOfRangeException(nameof(start));
-
-            if (length < 0 || length > Count)
-                throw new ArgumentOutOfRangeException(nameof(start));
-
-            return GetSliceRange(start, start + length, step: 1, deep: false);
-        }
-
-        /// <summary>
-        /// Returns the slice of the <see cref="Array"/>, from <paramref name="start"/>
-        /// (inclusive) to <paramref name="end"/> (exclusive), as a new <see cref="Array"/>.
-        /// The absolute value of <paramref name="start"/> and <paramref name="end"/>
-        /// will be clamped to the array size.
-        /// If either <paramref name="start"/> or <paramref name="end"/> are negative, they
-        /// will be relative to the end of the array (i.e. <c>arr.GetSliceRange(0, -2)</c>
-        /// is a shorthand for <c>arr.GetSliceRange(0, arr.Count - 2)</c>).
-        /// If specified, <paramref name="step"/> is the relative index between source
-        /// elements. It can be negative, then <paramref name="start"/> must be higher than
-        /// <paramref name="end"/>. For example, <c>[0, 1, 2, 3, 4, 5].GetSliceRange(5, 1, -2)</c>
-        /// returns <c>[5, 3]</c>.
-        /// If <paramref name="deep"/> is true, each element will be copied by value
-        /// rather than by reference.
-        /// </summary>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <param name="end">The zero-based index at which the range ends.</param>
-        /// <param name="step">The relative index between source elements to take.</param>
-        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        public Array GetSliceRange(int start, int end, int step = 1, bool deep = false)
-        {
-            godot_array newArray;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_slice(ref self, start, end, step, deep.ToGodotBool(), out newArray);
-            return CreateTakingOwnershipOfDisposableValue(newArray);
-        }
-
-        /// <summary>
-        /// Sorts the array.
-        /// Note: The sorting algorithm used is not stable. This means that values
-        /// considered equal may have their order changed when using <see cref="Sort"/>.
-        /// Note: Strings are sorted in alphabetical order (as opposed to natural order).
-        /// This may lead to unexpected behavior when sorting an array of strings ending
-        /// with a sequence of numbers.
-        /// To sort with a custom predicate use
-        /// <see cref="Enumerable.OrderBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey})"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var strings = new Godot.Collections.Array { "string1", "string2", "string10", "string11" };
-        /// strings.Sort();
-        /// GD.Print(strings); // Prints [string1, string10, string11, string2]
-        /// </code>
-        /// </example>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Sort()
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_sort(ref self);
-        }
-
-        /// <summary>
-        /// Concatenates two <see cref="Array"/>s together, with the <paramref name="right"/>
-        /// being added to the end of the <see cref="Array"/> specified in <paramref name="left"/>.
-        /// For example, <c>[1, 2] + [3, 4]</c> results in <c>[1, 2, 3, 4]</c>.
-        /// </summary>
-        /// <param name="left">The first array.</param>
-        /// <param name="right">The second array.</param>
-        /// <returns>A new Godot Array with the contents of both arrays.</returns>
-        public static Array operator +(Array left, Array right)
-        {
-            if (left == null)
-            {
-                if (right == null)
-                    return new Array();
-
-                return right.Duplicate(deep: false);
-            }
-
-            if (right == null)
-                return left.Duplicate(deep: false);
-
-            int leftCount = left.Count;
-            int rightCount = right.Count;
-
-            Array newArray = left.Duplicate(deep: false);
-            newArray.Resize(leftCount + rightCount);
-
-            for (int i = 0; i < rightCount; i++)
-                newArray[i + leftCount] = right[i];
-
-            return newArray;
-        }
-
-        /// <summary>
-        /// Returns the item at the given <paramref name="index"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The property is assigned and the array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <value>The <see cref="Variant"/> item at the given <paramref name="index"/>.</value>
-        public unsafe Variant this[int index]
-        {
-            get
-            {
-                GetVariantBorrowElementAt(index, out godot_variant borrowElem);
-                return Variant.CreateCopyingBorrowed(borrowElem);
-            }
-            set
-            {
-                ThrowIfReadOnly();
-
-                if (index < 0 || index >= Count)
-                    throw new ArgumentOutOfRangeException(nameof(index));
-
-                var self = (godot_array)NativeValue;
-                godot_variant* ptrw = NativeFuncs.godotsharp_array_ptrw(ref self);
-                godot_variant* itemPtr = &ptrw[index];
-                (*itemPtr).Dispose();
-                *itemPtr = value.CopyNativeVariant();
-            }
-        }
-
-        /// <summary>
-        /// Adds an item to the end of this <see cref="Array"/>.
-        /// This is the same as <c>append</c> or <c>push_back</c> in GDScript.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to add.</param>
-        public void Add(Variant item)
-        {
-            ThrowIfReadOnly();
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            _ = NativeFuncs.godotsharp_array_add(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Adds the elements of the specified collection to the end of this <see cref="Array"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// The <paramref name="collection"/> is <see langword="null"/>.
-        /// </exception>
-        /// <param name="collection">Collection of <see cref="Variant"/> items to add.</param>
-        public void AddRange<[MustBeVariant] T>(IEnumerable<T> collection)
-        {
-            ThrowIfReadOnly();
-
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection), "Value cannot be null.");
-
-            // If the collection is another Godot Array, we can add the items
-            // with a single interop call.
-            if (collection is Array array)
-            {
-                var self = (godot_array)NativeValue;
-                var collectionNative = (godot_array)array.NativeValue;
-                _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
-                return;
-            }
-            if (collection is Array<T> typedArray)
-            {
-                var self = (godot_array)NativeValue;
-                var collectionNative = (godot_array)typedArray.NativeValue;
-                _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
-                return;
-            }
-
-            // If we can retrieve the count of the collection without enumerating it
-            // (e.g.: the collections is a List<T>), use it to resize the array once
-            // instead of growing it as we add items.
-            if (collection.TryGetNonEnumeratedCount(out int count))
-            {
-                int oldCount = Count;
-                Resize(Count + count);
-
-                using var enumerator = collection.GetEnumerator();
-
-                for (int i = 0; i < count; i++)
-                {
-                    enumerator.MoveNext();
-                    this[oldCount + i] = Variant.From(enumerator.Current);
-                }
-
-                return;
-            }
-
-            foreach (var item in collection)
-            {
-                Add(Variant.From(item));
-            }
-        }
-
-        /// <summary>
-        /// Finds the index of an existing value using binary search.
-        /// If the value is not present in the array, it returns the bitwise
-        /// complement of the insertion index that maintains sorting order.
-        /// Note: Calling <see cref="BinarySearch(int, int, Variant)"/> on an
-        /// unsorted array results in unexpected behavior.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0.
-        /// -or-
-        /// <paramref name="count"/> is less than 0.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="index"/> and <paramref name="count"/> do not denote
-        /// a valid range in the <see cref="Array"/>.
-        /// </exception>
-        /// <param name="index">The starting index of the range to search.</param>
-        /// <param name="count">The length of the range to search.</param>
-        /// <param name="item">The object to locate.</param>
-        /// <returns>
-        /// The index of the item in the array, if <paramref name="item"/> is found;
-        /// otherwise, a negative number that is the bitwise complement of the index
-        /// of the next element that is larger than <paramref name="item"/> or, if
-        /// there is no larger element, the bitwise complement of <see cref="Count"/>.
-        /// </returns>
-        public int BinarySearch(int index, int count, Variant item)
-        {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), "index cannot be negative.");
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), "count cannot be negative.");
-            if (Count - index < count)
-                throw new ArgumentException("length is out of bounds or count is greater than the number of elements.");
-
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_binary_search(ref self, index, count, variantValue);
-        }
-
-        /// <summary>
-        /// Finds the index of an existing value using binary search.
-        /// If the value is not present in the array, it returns the bitwise
-        /// complement of the insertion index that maintains sorting order.
-        /// Note: Calling <see cref="BinarySearch(Variant)"/> on an unsorted
-        /// array results in unexpected behavior.
-        /// </summary>
-        /// <param name="item">The object to locate.</param>
-        /// <returns>
-        /// The index of the item in the array, if <paramref name="item"/> is found;
-        /// otherwise, a negative number that is the bitwise complement of the index
-        /// of the next element that is larger than <paramref name="item"/> or, if
-        /// there is no larger element, the bitwise complement of <see cref="Count"/>.
-        /// </returns>
-        public int BinarySearch(Variant item)
-        {
-            return BinarySearch(0, Count, item);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the array contains the given value.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var arr = new Godot.Collections.Array { "inside", 7 };
-        /// GD.Print(arr.Contains("inside")); // True
-        /// GD.Print(arr.Contains("outside")); // False
-        /// GD.Print(arr.Contains(7)); // True
-        /// GD.Print(arr.Contains("7")); // False
-        /// </code>
-        /// </example>
-        /// <param name="item">The <see cref="Variant"/> item to look for.</param>
-        /// <returns>Whether or not this array contains the given item.</returns>
-        public bool Contains(Variant item) => IndexOf(item) != -1;
-
-        /// <summary>
-        /// Clears the array. This is the equivalent to using <see cref="Resize(int)"/>
-        /// with a size of <c>0</c>
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Clear() => Resize(0);
-
-        /// <summary>
-        /// Searches the array for a value and returns its index or <c>-1</c> if not found.
-        /// </summary>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int IndexOf(Variant item)
-        {
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_index_of(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Searches the array for a value and returns its index or <c>-1</c> if not found.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <param name="index">The initial search index to start from.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int IndexOf(Variant item, int index)
-        {
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_index_of(ref self, variantValue, index);
-        }
-
-        /// <summary>
-        /// Searches the array for a value in reverse order and returns its index
-        /// or <c>-1</c> if not found.
-        /// </summary>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int LastIndexOf(Variant item)
-        {
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, Count - 1);
-        }
-
-        /// <summary>
-        /// Searches the array for a value in reverse order and returns its index
-        /// or <c>-1</c> if not found.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <param name="index">The initial search index to start from.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int LastIndexOf(Variant item, int index)
-        {
-            if (index < 0 || index >= Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, index);
-        }
-
-        /// <summary>
-        /// Inserts a new element at a given position in the array. The position
-        /// must be valid, or at the end of the array (<c>pos == Count - 1</c>).
-        /// Existing items will be moved to the right.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="index">The index to insert at.</param>
-        /// <param name="item">The <see cref="Variant"/> item to insert.</param>
-        public void Insert(int index, Variant item)
-        {
-            ThrowIfReadOnly();
-
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            godot_variant variantValue = (godot_variant)item.NativeVar;
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_insert(ref self, index, variantValue);
-        }
-
-        /// <summary>
-        /// Removes the first occurrence of the specified <paramref name="item"/>
-        /// from this <see cref="Array"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="item">The value to remove.</param>
-        public bool Remove(Variant item)
-        {
-            ThrowIfReadOnly();
-
-            int index = IndexOf(item);
-            if (index >= 0)
-            {
-                RemoveAt(index);
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Removes an element from the array by index.
-        /// To remove an element by searching for its value, use
-        /// <see cref="Remove(Variant)"/> instead.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="index">The index of the element to remove.</param>
-        public void RemoveAt(int index)
-        {
-            ThrowIfReadOnly();
-
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_remove_at(ref self, index);
-        }
-
-        // ICollection
-
-        /// <summary>
-        /// Returns the number of elements in this <see cref="Array"/>.
-        /// This is also known as the size or length of the array.
-        /// </summary>
-        /// <returns>The number of elements.</returns>
-        public int Count => NativeValue.DangerousSelfRef.Size;
-
-        bool ICollection.IsSynchronized => false;
-
-        object ICollection.SyncRoot => false;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the array is read-only.
-        /// See <see cref="MakeReadOnly"/>.
-        /// </summary>
-        public bool IsReadOnly => NativeValue.DangerousSelfRef.IsReadOnly;
-
-        /// <summary>
-        /// Makes the <see cref="Array"/> read-only, i.e. disabled modying of the
-        /// array's elements. Does not apply to nested content, e.g. content of
-        /// nested arrays.
-        /// </summary>
-        public void MakeReadOnly()
-        {
-            if (IsReadOnly)
-            {
-                // Avoid interop call when the array is already read-only.
-                return;
-            }
-
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_make_read_only(ref self);
-        }
-
-        /// <summary>
-        /// Copies the elements of this <see cref="Array"/> to the given
-        /// <see cref="Variant"/> C# array, starting at the given index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="array">The array to copy to.</param>
-        /// <param name="arrayIndex">The index to start at.</param>
-        public void CopyTo(Variant[] array, int arrayIndex)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array), "Value cannot be null.");
-
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex),
-                    "Number was less than the array's lower bound in the first dimension.");
-            }
-
-            int count = Count;
-
-            if (array.Length < (arrayIndex + count))
-            {
-                throw new ArgumentException(
-                    "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
-            }
-
-            unsafe
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    array[arrayIndex] = Variant.CreateCopyingBorrowed(NativeValue.DangerousSelfRef.Elements[i]);
-                    arrayIndex++;
-                }
-            }
-        }
-
-        void ICollection.CopyTo(System.Array array, int index)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array), "Value cannot be null.");
-
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index),
-                    "Number was less than the array's lower bound in the first dimension.");
-            }
-
-            int count = Count;
-
-            if (array.Length < (index + count))
-            {
-                throw new ArgumentException(
-                    "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
-            }
-
-            unsafe
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    object boxedVariant = Variant.CreateCopyingBorrowed(NativeValue.DangerousSelfRef.Elements[i]);
-                    array.SetValue(boxedVariant, index);
-                    index++;
-                }
-            }
-        }
-
-        // IEnumerable
-
-        /// <summary>
-        /// Gets an enumerator for this <see cref="Array"/>.
-        /// </summary>
-        /// <returns>An enumerator.</returns>
-        public IEnumerator<Variant> GetEnumerator()
-        {
-            int count = Count;
-
-            for (int i = 0; i < count; i++)
-            {
-                yield return this[i];
-            }
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Converts this <see cref="Array"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this array.</returns>
-        public override string ToString()
-        {
-            var self = (godot_array)NativeValue;
-            NativeFuncs.godotsharp_array_to_string(ref self, out godot_string str);
-            using (str)
-                return Marshaling.ConvertStringToManaged(str);
-        }
-
-        /// <summary>
-        /// The variant returned via the <paramref name="elem"/> parameter is owned by the Array and must not be disposed.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        internal void GetVariantBorrowElementAt(int index, out godot_variant elem)
-        {
-            if (index < 0 || index >= Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-            GetVariantBorrowElementAtUnchecked(index, out elem);
-        }
-
-        /// <summary>
-        /// The variant returned via the <paramref name="elem"/> parameter is owned by the Array and must not be disposed.
-        /// </summary>
-        internal unsafe void GetVariantBorrowElementAtUnchecked(int index, out godot_variant elem)
-        {
-            elem = NativeValue.DangerousSelfRef.Elements[index];
-        }
-
-        private void ThrowIfReadOnly()
-        {
-            if (IsReadOnly)
-            {
-                throw new InvalidOperationException("Array instance is read-only.");
-            }
-        }
-    }
-
-    internal interface IGenericGodotArray
-    {
-        public Array UnderlyingArray { get; }
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
     }
 
     /// <summary>
-    /// Typed wrapper around Godot's Array class, an array of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine. Otherwise prefer .NET collections
-    /// such as arrays or <see cref="List{T}"/>.
+    /// Constructs a new <see cref="Array"/> from the given collection's elements.
     /// </summary>
-    /// <typeparam name="T">The type of the array.</typeparam>
-    [SuppressMessage("ReSharper", "RedundantExtendsListEntry")]
-    [SuppressMessage("Naming", "CA1710", MessageId = "Identifiers should have correct suffix")]
-    public sealed class Array<[MustBeVariant] T> :
-        IList<T>,
-        IReadOnlyList<T>,
-        ICollection<T>,
-        IEnumerable<T>,
-        IGenericGodotArray
+    /// <param name="collection">The collection of elements to construct from.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array(IEnumerable<Variant> collection) : this()
     {
-        private static godot_variant ToVariantFunc(in Array<T> godotArray) =>
-            VariantUtils.CreateFromArray(godotArray);
+        if (collection == null)
+            throw new ArgumentNullException(nameof(collection));
 
-        private static Array<T> FromVariantFunc(in godot_variant variant) =>
-            VariantUtils.ConvertToArray<T>(variant);
+        foreach (Variant element in collection)
+            Add(element);
+    }
 
-        static unsafe Array()
+    /// <summary>
+    /// Constructs a new <see cref="Array"/> from the given objects.
+    /// </summary>
+    /// <param name="array">The objects to put in the new array.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array(Variant[] array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+        int length = array.Length;
+
+        Resize(length);
+
+        for (int i = 0; i < length; i++)
+            this[i] = array[i];
+    }
+
+    public Array(Span<StringName> array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+        int length = array.Length;
+
+        Resize(length);
+
+        for (int i = 0; i < length; i++)
+            this[i] = array[i];
+    }
+
+    public Array(Span<NodePath> array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+        int length = array.Length;
+
+        Resize(length);
+
+        for (int i = 0; i < length; i++)
+            this[i] = array[i];
+    }
+
+    public Array(Span<Rid> array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+        int length = array.Length;
+
+        Resize(length);
+
+        for (int i = 0; i < length; i++)
+            this[i] = array[i];
+    }
+
+    // We must use ReadOnlySpan instead of Span here as this can accept implicit conversions
+    // from derived types (e.g.: Node[]). Implicit conversion from Derived[] to Base[] are
+    // fine as long as the array is not mutated. However, Span does this type checking at
+    // instantiation, so it's not possible to use it even when not mutating anything.
+    // ReSharper disable once RedundantNameQualifier
+    public Array(ReadOnlySpan<GodotObject> array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        NativeValue = (godot_array.movable)NativeFuncs.godotsharp_array_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+        int length = array.Length;
+
+        Resize(length);
+
+        for (int i = 0; i < length; i++)
+            this[i] = array[i];
+    }
+
+    private Array(godot_array nativeValueToOwn)
+    {
+        NativeValue = (godot_array.movable)(nativeValueToOwn.IsAllocated ?
+            nativeValueToOwn :
+            NativeFuncs.godotsharp_array_new());
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+    }
+
+    // Explicit name to make it very clear
+    internal static Array CreateTakingOwnershipOfDisposableValue(godot_array nativeValueToOwn)
+        => new Array(nativeValueToOwn);
+
+    ~Array()
+    {
+        Dispose(false);
+    }
+
+    /// <summary>
+    /// Disposes of this <see cref="Array"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public void Dispose(bool disposing)
+    {
+        // Always dispose `NativeValue` even if disposing is true
+        NativeValue.DangerousSelfRef.Dispose();
+
+        if (_weakReferenceToSelf != null)
         {
-            VariantUtils.GenericConversion<Array<T>>.ToVariantCb = &ToVariantFunc;
-            VariantUtils.GenericConversion<Array<T>>.FromVariantCb = &FromVariantFunc;
+            DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
+        }
+    }
+
+    /// <summary>
+    /// Returns a copy of the <see cref="Array"/>.
+    /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy if performed:
+    /// all nested arrays and dictionaries are duplicated and will not be shared with
+    /// the original array. If <see langword="false"/>, a shallow copy is made and
+    /// references to the original nested arrays and dictionaries are kept, so that
+    /// modifying a sub-array or dictionary in the copy will also impact those
+    /// referenced in the source array. Note that any <see cref="GodotObject"/> derived
+    /// elements will be shallow copied regardless of the <paramref name="deep"/>
+    /// setting.
+    /// </summary>
+    /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array Duplicate(bool deep = false)
+    {
+        godot_array newArray;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_duplicate(ref self, deep.ToGodotBool(), out newArray);
+        return CreateTakingOwnershipOfDisposableValue(newArray);
+    }
+
+    /// <summary>
+    /// Assigns the given value to all elements in the array. This can typically be
+    /// used together with <see cref="Resize(int)"/> to create an array with a given
+    /// size and initialized elements.
+    /// Note: If <paramref name="value"/> is of a reference type (<see cref="GodotObject"/>
+    /// derived, <see cref="Array"/> or <see cref="Dictionary"/>, etc.) then the array
+    /// is filled with the references to the same object, i.e. no duplicates are
+    /// created.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var array = new Godot.Collections.Array();
+    /// array.Resize(10);
+    /// array.Fill(0); // Initialize the 10 elements to 0.
+    /// </code>
+    /// </example>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="value">The value to fill the array with.</param>
+    public void Fill(Variant value)
+    {
+        ThrowIfReadOnly();
+
+        godot_variant variantValue = (godot_variant)value.NativeVar;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_fill(ref self, variantValue);
+    }
+
+    /// <summary>
+    /// Returns the maximum value contained in the array if all elements are of
+    /// comparable types. If the elements can't be compared, <see langword="null"/>
+    /// is returned.
+    /// </summary>
+    /// <returns>The maximum value contained in the array.</returns>
+    public Variant Max()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_max(ref self, out resVariant);
+        return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
+    }
+
+    /// <summary>
+    /// Returns the minimum value contained in the array if all elements are of
+    /// comparable types. If the elements can't be compared, <see langword="null"/>
+    /// is returned.
+    /// </summary>
+    /// <returns>The minimum value contained in the array.</returns>
+    public Variant Min()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_min(ref self, out resVariant);
+        return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
+    }
+
+    /// <summary>
+    /// Returns a random value from the target array.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var array = new Godot.Collections.Array { 1, 2, 3, 4 };
+    /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
+    /// </code>
+    /// </example>
+    /// <returns>A random element from the array.</returns>
+    public Variant PickRandom()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
+        return Variant.CreateTakingOwnershipOfDisposableValue(resVariant);
+    }
+
+    /// <summary>
+    /// Compares this <see cref="Array"/> against the <paramref name="other"/>
+    /// <see cref="Array"/> recursively. Returns <see langword="true"/> if the
+    /// sizes and contents of the arrays are equal, <see langword="false"/>
+    /// otherwise.
+    /// </summary>
+    /// <param name="other">The other array to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if the sizes and contents of the arrays are equal,
+    /// <see langword="false"/> otherwise.
+    /// </returns>
+    public bool RecursiveEqual(Array other)
+    {
+        var self = (godot_array)NativeValue;
+        var otherVariant = (godot_array)other.NativeValue;
+        return NativeFuncs.godotsharp_array_recursive_equal(ref self, otherVariant).ToBool();
+    }
+
+    /// <summary>
+    /// Resizes the array to contain a different number of elements. If the array
+    /// size is smaller, elements are cleared, if bigger, new elements are
+    /// <see langword="null"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="newSize">The new size of the array.</param>
+    /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
+    public Error Resize(int newSize)
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_resize(ref self, newSize);
+    }
+
+    /// <summary>
+    /// Reverses the order of the elements in the array.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Reverse()
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_reverse(ref self);
+    }
+
+    /// <summary>
+    /// Shuffles the array such that the items will have a random order.
+    /// This method uses the global random number generator common to methods
+    /// such as <see cref="GD.Randi"/>. Call <see cref="GD.Randomize"/> to
+    /// ensure that a new seed will be used each time if you want
+    /// non-reproducible shuffling.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Shuffle()
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_shuffle(ref self);
+    }
+
+    /// <summary>
+    /// Creates a shallow copy of a range of elements in the source <see cref="Array"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="start"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    public Array Slice(int start)
+    {
+        if (start < 0 || start > Count)
+            throw new ArgumentOutOfRangeException(nameof(start));
+
+        return GetSliceRange(start, Count, step: 1, deep: false);
+    }
+
+    /// <summary>
+    /// Creates a shallow copy of a range of elements in the source <see cref="Array"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="start"/> is less than 0 or greater than the array's size.
+    /// -or-
+    /// <paramref name="length"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <param name="length">The length of the range.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    // The Slice method must have this signature to get implicit Range support.
+    public Array Slice(int start, int length)
+    {
+        if (start < 0 || start > Count)
+            throw new ArgumentOutOfRangeException(nameof(start));
+
+        if (length < 0 || length > Count)
+            throw new ArgumentOutOfRangeException(nameof(start));
+
+        return GetSliceRange(start, start + length, step: 1, deep: false);
+    }
+
+    /// <summary>
+    /// Returns the slice of the <see cref="Array"/>, from <paramref name="start"/>
+    /// (inclusive) to <paramref name="end"/> (exclusive), as a new <see cref="Array"/>.
+    /// The absolute value of <paramref name="start"/> and <paramref name="end"/>
+    /// will be clamped to the array size.
+    /// If either <paramref name="start"/> or <paramref name="end"/> are negative, they
+    /// will be relative to the end of the array (i.e. <c>arr.GetSliceRange(0, -2)</c>
+    /// is a shorthand for <c>arr.GetSliceRange(0, arr.Count - 2)</c>).
+    /// If specified, <paramref name="step"/> is the relative index between source
+    /// elements. It can be negative, then <paramref name="start"/> must be higher than
+    /// <paramref name="end"/>. For example, <c>[0, 1, 2, 3, 4, 5].GetSliceRange(5, 1, -2)</c>
+    /// returns <c>[5, 3]</c>.
+    /// If <paramref name="deep"/> is true, each element will be copied by value
+    /// rather than by reference.
+    /// </summary>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <param name="end">The zero-based index at which the range ends.</param>
+    /// <param name="step">The relative index between source elements to take.</param>
+    /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    public Array GetSliceRange(int start, int end, int step = 1, bool deep = false)
+    {
+        godot_array newArray;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_slice(ref self, start, end, step, deep.ToGodotBool(), out newArray);
+        return CreateTakingOwnershipOfDisposableValue(newArray);
+    }
+
+    /// <summary>
+    /// Sorts the array.
+    /// Note: The sorting algorithm used is not stable. This means that values
+    /// considered equal may have their order changed when using <see cref="Sort"/>.
+    /// Note: Strings are sorted in alphabetical order (as opposed to natural order).
+    /// This may lead to unexpected behavior when sorting an array of strings ending
+    /// with a sequence of numbers.
+    /// To sort with a custom predicate use
+    /// <see cref="Enumerable.OrderBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey})"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var strings = new Godot.Collections.Array { "string1", "string2", "string10", "string11" };
+    /// strings.Sort();
+    /// GD.Print(strings); // Prints [string1, string10, string11, string2]
+    /// </code>
+    /// </example>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Sort()
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_sort(ref self);
+    }
+
+    /// <summary>
+    /// Concatenates two <see cref="Array"/>s together, with the <paramref name="right"/>
+    /// being added to the end of the <see cref="Array"/> specified in <paramref name="left"/>.
+    /// For example, <c>[1, 2] + [3, 4]</c> results in <c>[1, 2, 3, 4]</c>.
+    /// </summary>
+    /// <param name="left">The first array.</param>
+    /// <param name="right">The second array.</param>
+    /// <returns>A new Godot Array with the contents of both arrays.</returns>
+    public static Array operator +(Array left, Array right)
+    {
+        if (left == null)
+        {
+            if (right == null)
+                return new Array();
+
+            return right.Duplicate(deep: false);
         }
 
-        private readonly Array _underlyingArray;
+        if (right == null)
+            return left.Duplicate(deep: false);
 
-        Array IGenericGodotArray.UnderlyingArray => _underlyingArray;
+        int leftCount = left.Count;
+        int rightCount = right.Count;
 
-        internal ref godot_array.movable NativeValue
+        Array newArray = left.Duplicate(deep: false);
+        newArray.Resize(leftCount + rightCount);
+
+        for (int i = 0; i < rightCount; i++)
+            newArray[i + leftCount] = right[i];
+
+        return newArray;
+    }
+
+    /// <summary>
+    /// Returns the item at the given <paramref name="index"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The property is assigned and the array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <value>The <see cref="Variant"/> item at the given <paramref name="index"/>.</value>
+    public unsafe Variant this[int index]
+    {
+        get
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref _underlyingArray.NativeValue;
+            GetVariantBorrowElementAt(index, out godot_variant borrowElem);
+            return Variant.CreateCopyingBorrowed(borrowElem);
         }
-
-        /// <summary>
-        /// Constructs a new empty <see cref="Array{T}"/>.
-        /// </summary>
-        public Array()
-        {
-            _underlyingArray = new Array();
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Array{T}"/> from the given collection's elements.
-        /// </summary>
-        /// <param name="collection">The collection of elements to construct from.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array(IEnumerable<T> collection)
-        {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
-
-            _underlyingArray = new Array();
-
-            foreach (T element in collection)
-                Add(element);
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Array{T}"/> from the given items.
-        /// </summary>
-        /// <param name="array">The items to put in the new array.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array(T[] array) : this()
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array));
-
-            _underlyingArray = new Array();
-
-            foreach (T element in array)
-                Add(element);
-        }
-
-        /// <summary>
-        /// Constructs a typed <see cref="Array{T}"/> from an untyped <see cref="Array"/>.
-        /// </summary>
-        /// <param name="array">The untyped array to construct from.</param>
-        public Array(Array array)
-        {
-            _underlyingArray = array;
-        }
-
-        // Explicit name to make it very clear
-        internal static Array<T> CreateTakingOwnershipOfDisposableValue(godot_array nativeValueToOwn)
-            => new Array<T>(Array.CreateTakingOwnershipOfDisposableValue(nativeValueToOwn));
-
-        /// <summary>
-        /// Converts this typed <see cref="Array{T}"/> to an untyped <see cref="Array"/>.
-        /// </summary>
-        /// <param name="from">The typed array to convert.</param>
-        public static explicit operator Array(Array<T> from)
-        {
-            return from?._underlyingArray;
-        }
-
-        /// <summary>
-        /// Duplicates this <see cref="Array{T}"/>.
-        /// </summary>
-        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
-        /// <returns>A new Godot Array.</returns>
-        public Array<T> Duplicate(bool deep = false)
-        {
-            return new Array<T>(_underlyingArray.Duplicate(deep));
-        }
-
-        /// <summary>
-        /// Assigns the given value to all elements in the array. This can typically be
-        /// used together with <see cref="Resize(int)"/> to create an array with a given
-        /// size and initialized elements.
-        /// Note: If <paramref name="value"/> is of a reference type (<see cref="GodotObject"/>
-        /// derived, <see cref="Array"/> or <see cref="Dictionary"/>, etc.) then the array
-        /// is filled with the references to the same object, i.e. no duplicates are
-        /// created.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var array = new Godot.Collections.Array&lt;int&gt;();
-        /// array.Resize(10);
-        /// array.Fill(0); // Initialize the 10 elements to 0.
-        /// </code>
-        /// </example>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="value">The value to fill the array with.</param>
-        public void Fill(T value)
+        set
         {
             ThrowIfReadOnly();
 
-            godot_variant variantValue = VariantUtils.CreateFrom(value);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_fill(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Returns the maximum value contained in the array if all elements are of
-        /// comparable types. If the elements can't be compared, <see langword="default"/>
-        /// is returned.
-        /// </summary>
-        /// <returns>The maximum value contained in the array.</returns>
-        public T Max()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_max(ref self, out resVariant);
-            return VariantUtils.ConvertTo<T>(resVariant);
-        }
-
-        /// <summary>
-        /// Returns the minimum value contained in the array if all elements are of
-        /// comparable types. If the elements can't be compared, <see langword="default"/>
-        /// is returned.
-        /// </summary>
-        /// <returns>The minimum value contained in the array.</returns>
-        public T Min()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_min(ref self, out resVariant);
-            return VariantUtils.ConvertTo<T>(resVariant);
-        }
-
-        /// <summary>
-        /// Returns a random value from the target array.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var array = new Godot.Collections.Array&lt;int&gt; { 1, 2, 3, 4 };
-        /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
-        /// </code>
-        /// </example>
-        /// <returns>A random element from the array.</returns>
-        public T PickRandom()
-        {
-            godot_variant resVariant;
-            var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
-            return VariantUtils.ConvertTo<T>(resVariant);
-        }
-
-        /// <summary>
-        /// Compares this <see cref="Array{T}"/> against the <paramref name="other"/>
-        /// <see cref="Array{T}"/> recursively. Returns <see langword="true"/> if the
-        /// sizes and contents of the arrays are equal, <see langword="false"/>
-        /// otherwise.
-        /// </summary>
-        /// <param name="other">The other array to compare against.</param>
-        /// <returns>
-        /// <see langword="true"/> if the sizes and contents of the arrays are equal,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool RecursiveEqual(Array<T> other)
-        {
-            return _underlyingArray.RecursiveEqual(other._underlyingArray);
-        }
-
-        /// <summary>
-        /// Resizes this <see cref="Array{T}"/> to the given size.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="newSize">The new size of the array.</param>
-        /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
-        public Error Resize(int newSize)
-        {
-            return _underlyingArray.Resize(newSize);
-        }
-
-        /// <summary>
-        /// Reverses the order of the elements in the array.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Reverse()
-        {
-            _underlyingArray.Reverse();
-        }
-
-        /// <summary>
-        /// Shuffles the array such that the items will have a random order.
-        /// This method uses the global random number generator common to methods
-        /// such as <see cref="GD.Randi"/>. Call <see cref="GD.Randomize"/> to
-        /// ensure that a new seed will be used each time if you want
-        /// non-reproducible shuffling.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Shuffle()
-        {
-            _underlyingArray.Shuffle();
-        }
-
-        /// <summary>
-        /// Creates a shallow copy of a range of elements in the source <see cref="Array{T}"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="start"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        public Array<T> Slice(int start)
-        {
-            return GetSliceRange(start, Count, step: 1, deep: false);
-        }
-
-        /// <summary>
-        /// Creates a shallow copy of a range of elements in the source <see cref="Array{T}"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="start"/> is less than 0 or greater than the array's size.
-        /// -or-
-        /// <paramref name="length"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <param name="length">The length of the range.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        // The Slice method must have this signature to get implicit Range support.
-        public Array<T> Slice(int start, int length)
-        {
-            return GetSliceRange(start, start + length, step: 1, deep: false);
-        }
-
-        /// <summary>
-        /// Returns the slice of the <see cref="Array{T}"/>, from <paramref name="start"/>
-        /// (inclusive) to <paramref name="end"/> (exclusive), as a new <see cref="Array{T}"/>.
-        /// The absolute value of <paramref name="start"/> and <paramref name="end"/>
-        /// will be clamped to the array size.
-        /// If either <paramref name="start"/> or <paramref name="end"/> are negative, they
-        /// will be relative to the end of the array (i.e. <c>arr.GetSliceRange(0, -2)</c>
-        /// is a shorthand for <c>arr.GetSliceRange(0, arr.Count - 2)</c>).
-        /// If specified, <paramref name="step"/> is the relative index between source
-        /// elements. It can be negative, then <paramref name="start"/> must be higher than
-        /// <paramref name="end"/>. For example, <c>[0, 1, 2, 3, 4, 5].GetSliceRange(5, 1, -2)</c>
-        /// returns <c>[5, 3]</c>.
-        /// If <paramref name="deep"/> is true, each element will be copied by value
-        /// rather than by reference.
-        /// </summary>
-        /// <param name="start">The zero-based index at which the range starts.</param>
-        /// <param name="end">The zero-based index at which the range ends.</param>
-        /// <param name="step">The relative index between source elements to take.</param>
-        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
-        /// <returns>A new array that contains the elements inside the slice range.</returns>
-        public Array<T> GetSliceRange(int start, int end, int step = 1, bool deep = false)
-        {
-            return new Array<T>(_underlyingArray.GetSliceRange(start, end, step, deep));
-        }
-
-        /// <summary>
-        /// Sorts the array.
-        /// Note: The sorting algorithm used is not stable. This means that values
-        /// considered equal may have their order changed when using <see cref="Sort"/>.
-        /// Note: Strings are sorted in alphabetical order (as opposed to natural order).
-        /// This may lead to unexpected behavior when sorting an array of strings ending
-        /// with a sequence of numbers.
-        /// To sort with a custom predicate use
-        /// <see cref="Enumerable.OrderBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey})"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var strings = new Godot.Collections.Array&lt;string&gt; { "string1", "string2", "string10", "string11" };
-        /// strings.Sort();
-        /// GD.Print(strings); // Prints [string1, string10, string11, string2]
-        /// </code>
-        /// </example>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Sort()
-        {
-            _underlyingArray.Sort();
-        }
-
-        /// <summary>
-        /// Concatenates two <see cref="Array{T}"/>s together, with the <paramref name="right"/>
-        /// being added to the end of the <see cref="Array{T}"/> specified in <paramref name="left"/>.
-        /// For example, <c>[1, 2] + [3, 4]</c> results in <c>[1, 2, 3, 4]</c>.
-        /// </summary>
-        /// <param name="left">The first array.</param>
-        /// <param name="right">The second array.</param>
-        /// <returns>A new Godot Array with the contents of both arrays.</returns>
-        public static Array<T> operator +(Array<T> left, Array<T> right)
-        {
-            if (left == null)
-            {
-                if (right == null)
-                    return new Array<T>();
-
-                return right.Duplicate(deep: false);
-            }
-
-            if (right == null)
-                return left.Duplicate(deep: false);
-
-            return new Array<T>(left._underlyingArray + right._underlyingArray);
-        }
-
-        // IList<T>
-
-        /// <summary>
-        /// Returns the item at the given <paramref name="index"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The property is assigned and the array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <value>The <see cref="Variant"/> item at the given <paramref name="index"/>.</value>
-        public unsafe T this[int index]
-        {
-            get
-            {
-                _underlyingArray.GetVariantBorrowElementAt(index, out godot_variant borrowElem);
-                return VariantUtils.ConvertTo<T>(borrowElem);
-            }
-            set
-            {
-                ThrowIfReadOnly();
-
-                if (index < 0 || index >= Count)
-                    throw new ArgumentOutOfRangeException(nameof(index));
-
-                var self = (godot_array)_underlyingArray.NativeValue;
-                godot_variant* ptrw = NativeFuncs.godotsharp_array_ptrw(ref self);
-                godot_variant* itemPtr = &ptrw[index];
-                (*itemPtr).Dispose();
-                *itemPtr = VariantUtils.CreateFrom(value);
-            }
-        }
-
-        /// <summary>
-        /// Searches the array for a value and returns its index or <c>-1</c> if not found.
-        /// </summary>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int IndexOf(T item)
-        {
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            using var variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            return NativeFuncs.godotsharp_array_index_of(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Searches the array for a value and returns its index or <c>-1</c> if not found.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <param name="index">The initial search index to start from.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int IndexOf(T item, int index)
-        {
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            return NativeFuncs.godotsharp_array_index_of(ref self, variantValue, index);
-        }
-
-        /// <summary>
-        /// Searches the array for a value in reverse order and returns its index
-        /// or <c>-1</c> if not found.
-        /// </summary>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int LastIndexOf(Variant item)
-        {
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            godot_variant variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, Count - 1);
-        }
-
-        /// <summary>
-        /// Searches the array for a value in reverse order and returns its index
-        /// or <c>-1</c> if not found.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to search for.</param>
-        /// <param name="index">The initial search index to start from.</param>
-        /// <returns>The index of the item, or -1 if not found.</returns>
-        public int LastIndexOf(Variant item, int index)
-        {
             if (index < 0 || index >= Count)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
+            var self = (godot_array)NativeValue;
+            godot_variant* ptrw = NativeFuncs.godotsharp_array_ptrw(ref self);
+            godot_variant* itemPtr = &ptrw[index];
+            (*itemPtr).Dispose();
+            *itemPtr = value.CopyNativeVariant();
+        }
+    }
 
-            godot_variant variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, index);
+    /// <summary>
+    /// Adds an item to the end of this <see cref="Array"/>.
+    /// This is the same as <c>append</c> or <c>push_back</c> in GDScript.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to add.</param>
+    public void Add(Variant item)
+    {
+        ThrowIfReadOnly();
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        _ = NativeFuncs.godotsharp_array_add(ref self, variantValue);
+    }
+
+    /// <summary>
+    /// Adds the elements of the specified collection to the end of this <see cref="Array"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="collection"/> is <see langword="null"/>.
+    /// </exception>
+    /// <param name="collection">Collection of <see cref="Variant"/> items to add.</param>
+    public void AddRange<[MustBeVariant] T>(IEnumerable<T> collection)
+    {
+        ThrowIfReadOnly();
+
+        if (collection == null)
+            throw new ArgumentNullException(nameof(collection), "Value cannot be null.");
+
+        // If the collection is another Godot Array, we can add the items
+        // with a single interop call.
+        if (collection is Array array)
+        {
+            var self = (godot_array)NativeValue;
+            var collectionNative = (godot_array)array.NativeValue;
+            _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
+            return;
+        }
+        if (collection is Array<T> typedArray)
+        {
+            var self = (godot_array)NativeValue;
+            var collectionNative = (godot_array)typedArray.NativeValue;
+            _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
+            return;
         }
 
-        /// <summary>
-        /// Inserts a new element at a given position in the array. The position
-        /// must be valid, or at the end of the array (<c>pos == Count - 1</c>).
-        /// Existing items will be moved to the right.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="index">The index to insert at.</param>
-        /// <param name="item">The <see cref="Variant"/> item to insert.</param>
-        public void Insert(int index, T item)
+        // If we can retrieve the count of the collection without enumerating it
+        // (e.g.: the collections is a List<T>), use it to resize the array once
+        // instead of growing it as we add items.
+        if (collection.TryGetNonEnumeratedCount(out int count))
         {
-            ThrowIfReadOnly();
+            int oldCount = Count;
+            Resize(Count + count);
 
-            if (index < 0 || index > Count)
-                throw new ArgumentOutOfRangeException(nameof(index));
-
-            using var variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            NativeFuncs.godotsharp_array_insert(ref self, index, variantValue);
-        }
-
-        /// <summary>
-        /// Removes an element from the array by index.
-        /// To remove an element by searching for its value, use
-        /// <see cref="Remove(T)"/> instead.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="index">The index of the element to remove.</param>
-        public void RemoveAt(int index)
-        {
-            _underlyingArray.RemoveAt(index);
-        }
-
-        // ICollection<T>
-
-        /// <summary>
-        /// Returns the number of elements in this <see cref="Array{T}"/>.
-        /// This is also known as the size or length of the array.
-        /// </summary>
-        /// <returns>The number of elements.</returns>
-        public int Count => _underlyingArray.Count;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the array is read-only.
-        /// See <see cref="MakeReadOnly"/>.
-        /// </summary>
-        public bool IsReadOnly => _underlyingArray.IsReadOnly;
-
-        /// <summary>
-        /// Makes the <see cref="Array{T}"/> read-only, i.e. disabled modying of the
-        /// array's elements. Does not apply to nested content, e.g. content of
-        /// nested arrays.
-        /// </summary>
-        public void MakeReadOnly()
-        {
-            _underlyingArray.MakeReadOnly();
-        }
-
-        /// <summary>
-        /// Adds an item to the end of this <see cref="Array{T}"/>.
-        /// This is the same as <c>append</c> or <c>push_back</c> in GDScript.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="item">The <see cref="Variant"/> item to add.</param>
-        public void Add(T item)
-        {
-            ThrowIfReadOnly();
-
-            using var variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            _ = NativeFuncs.godotsharp_array_add(ref self, variantValue);
-        }
-
-        /// <summary>
-        /// Adds the elements of the specified collection to the end of this <see cref="Array{T}"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentNullException">
-        /// The <paramref name="collection"/> is <see langword="null"/>.
-        /// </exception>
-        /// <param name="collection">Collection of <see cref="Variant"/> items to add.</param>
-        public void AddRange(IEnumerable<T> collection)
-        {
-            ThrowIfReadOnly();
-
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection), "Value cannot be null.");
-
-            // If the collection is another Godot Array, we can add the items
-            // with a single interop call.
-            if (collection is Array array)
-            {
-                var self = (godot_array)_underlyingArray.NativeValue;
-                var collectionNative = (godot_array)array.NativeValue;
-                _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
-                return;
-            }
-            if (collection is Array<T> typedArray)
-            {
-                var self = (godot_array)_underlyingArray.NativeValue;
-                var collectionNative = (godot_array)typedArray._underlyingArray.NativeValue;
-                _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
-                return;
-            }
-
-            // If we can retrieve the count of the collection without enumerating it
-            // (e.g.: the collections is a List<T>), use it to resize the array once
-            // instead of growing it as we add items.
-            if (collection.TryGetNonEnumeratedCount(out int count))
-            {
-                int oldCount = Count;
-                Resize(Count + count);
-
-                using var enumerator = collection.GetEnumerator();
-
-                for (int i = 0; i < count; i++)
-                {
-                    enumerator.MoveNext();
-                    this[oldCount + i] = enumerator.Current;
-                }
-
-                return;
-            }
-
-            foreach (var item in collection)
-            {
-                Add(item);
-            }
-        }
-
-        /// <summary>
-        /// Finds the index of an existing value using binary search.
-        /// If the value is not present in the array, it returns the bitwise
-        /// complement of the insertion index that maintains sorting order.
-        /// Note: Calling <see cref="BinarySearch(int, int, T)"/> on an unsorted
-        /// array results in unexpected behavior.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is less than 0.
-        /// -or-
-        /// <paramref name="count"/> is less than 0.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="index"/> and <paramref name="count"/> do not denote
-        /// a valid range in the <see cref="Array{T}"/>.
-        /// </exception>
-        /// <param name="index">The starting index of the range to search.</param>
-        /// <param name="count">The length of the range to search.</param>
-        /// <param name="item">The object to locate.</param>
-        /// <returns>
-        /// The index of the item in the array, if <paramref name="item"/> is found;
-        /// otherwise, a negative number that is the bitwise complement of the index
-        /// of the next element that is larger than <paramref name="item"/> or, if
-        /// there is no larger element, the bitwise complement of <see cref="Count"/>.
-        /// </returns>
-        public int BinarySearch(int index, int count, T item)
-        {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), "index cannot be negative.");
-            if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count), "count cannot be negative.");
-            if (Count - index < count)
-                throw new ArgumentException("length is out of bounds or count is greater than the number of elements.");
-
-            if (Count == 0)
-            {
-                // Special case for empty array to avoid an interop call.
-                return -1;
-            }
-
-            using var variantValue = VariantUtils.CreateFrom(item);
-            var self = (godot_array)_underlyingArray.NativeValue;
-            return NativeFuncs.godotsharp_array_binary_search(ref self, index, count, variantValue);
-        }
-
-        /// <summary>
-        /// Finds the index of an existing value using binary search.
-        /// If the value is not present in the array, it returns the bitwise
-        /// complement of the insertion index that maintains sorting order.
-        /// Note: Calling <see cref="BinarySearch(T)"/> on an unsorted
-        /// array results in unexpected behavior.
-        /// </summary>
-        /// <param name="item">The object to locate.</param>
-        /// <returns>
-        /// The index of the item in the array, if <paramref name="item"/> is found;
-        /// otherwise, a negative number that is the bitwise complement of the index
-        /// of the next element that is larger than <paramref name="item"/> or, if
-        /// there is no larger element, the bitwise complement of <see cref="Count"/>.
-        /// </returns>
-        public int BinarySearch(T item)
-        {
-            return BinarySearch(0, Count, item);
-        }
-
-        /// <summary>
-        /// Clears the array. This is the equivalent to using <see cref="Resize(int)"/>
-        /// with a size of <c>0</c>
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        public void Clear()
-        {
-            _underlyingArray.Clear();
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the array contains the given value.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var arr = new Godot.Collections.Array&lt;string&gt; { "inside", "7" };
-        /// GD.Print(arr.Contains("inside")); // True
-        /// GD.Print(arr.Contains("outside")); // False
-        /// GD.Print(arr.Contains(7)); // False
-        /// GD.Print(arr.Contains("7")); // True
-        /// </code>
-        /// </example>
-        /// <param name="item">The item to look for.</param>
-        /// <returns>Whether or not this array contains the given item.</returns>
-        public bool Contains(T item) => IndexOf(item) != -1;
-
-        /// <summary>
-        /// Copies the elements of this <see cref="Array{T}"/> to the given
-        /// C# array, starting at the given index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
-        /// </exception>
-        /// <param name="array">The C# array to copy to.</param>
-        /// <param name="arrayIndex">The index to start at.</param>
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array), "Value cannot be null.");
-
-            if (arrayIndex < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex),
-                    "Number was less than the array's lower bound in the first dimension.");
-            }
-
-            int count = Count;
-
-            if (array.Length < (arrayIndex + count))
-            {
-                throw new ArgumentException(
-                    "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
-            }
+            using var enumerator = collection.GetEnumerator();
 
             for (int i = 0; i < count; i++)
             {
-                array[arrayIndex] = this[i];
+                enumerator.MoveNext();
+                this[oldCount + i] = Variant.From(enumerator.Current);
+            }
+
+            return;
+        }
+
+        foreach (var item in collection)
+        {
+            Add(Variant.From(item));
+        }
+    }
+
+    /// <summary>
+    /// Finds the index of an existing value using binary search.
+    /// If the value is not present in the array, it returns the bitwise
+    /// complement of the insertion index that maintains sorting order.
+    /// Note: Calling <see cref="BinarySearch(int, int, Variant)"/> on an
+    /// unsorted array results in unexpected behavior.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0.
+    /// -or-
+    /// <paramref name="count"/> is less than 0.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="index"/> and <paramref name="count"/> do not denote
+    /// a valid range in the <see cref="Array"/>.
+    /// </exception>
+    /// <param name="index">The starting index of the range to search.</param>
+    /// <param name="count">The length of the range to search.</param>
+    /// <param name="item">The object to locate.</param>
+    /// <returns>
+    /// The index of the item in the array, if <paramref name="item"/> is found;
+    /// otherwise, a negative number that is the bitwise complement of the index
+    /// of the next element that is larger than <paramref name="item"/> or, if
+    /// there is no larger element, the bitwise complement of <see cref="Count"/>.
+    /// </returns>
+    public int BinarySearch(int index, int count, Variant item)
+    {
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index), "index cannot be negative.");
+        if (count < 0)
+            throw new ArgumentOutOfRangeException(nameof(count), "count cannot be negative.");
+        if (Count - index < count)
+            throw new ArgumentException("length is out of bounds or count is greater than the number of elements.");
+
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_binary_search(ref self, index, count, variantValue);
+    }
+
+    /// <summary>
+    /// Finds the index of an existing value using binary search.
+    /// If the value is not present in the array, it returns the bitwise
+    /// complement of the insertion index that maintains sorting order.
+    /// Note: Calling <see cref="BinarySearch(Variant)"/> on an unsorted
+    /// array results in unexpected behavior.
+    /// </summary>
+    /// <param name="item">The object to locate.</param>
+    /// <returns>
+    /// The index of the item in the array, if <paramref name="item"/> is found;
+    /// otherwise, a negative number that is the bitwise complement of the index
+    /// of the next element that is larger than <paramref name="item"/> or, if
+    /// there is no larger element, the bitwise complement of <see cref="Count"/>.
+    /// </returns>
+    public int BinarySearch(Variant item)
+    {
+        return BinarySearch(0, Count, item);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the array contains the given value.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var arr = new Godot.Collections.Array { "inside", 7 };
+    /// GD.Print(arr.Contains("inside")); // True
+    /// GD.Print(arr.Contains("outside")); // False
+    /// GD.Print(arr.Contains(7)); // True
+    /// GD.Print(arr.Contains("7")); // False
+    /// </code>
+    /// </example>
+    /// <param name="item">The <see cref="Variant"/> item to look for.</param>
+    /// <returns>Whether or not this array contains the given item.</returns>
+    public bool Contains(Variant item) => IndexOf(item) != -1;
+
+    /// <summary>
+    /// Clears the array. This is the equivalent to using <see cref="Resize(int)"/>
+    /// with a size of <c>0</c>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Clear() => Resize(0);
+
+    /// <summary>
+    /// Searches the array for a value and returns its index or <c>-1</c> if not found.
+    /// </summary>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int IndexOf(Variant item)
+    {
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_index_of(ref self, variantValue);
+    }
+
+    /// <summary>
+    /// Searches the array for a value and returns its index or <c>-1</c> if not found.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <param name="index">The initial search index to start from.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int IndexOf(Variant item, int index)
+    {
+        if (index < 0 || index > Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_index_of(ref self, variantValue, index);
+    }
+
+    /// <summary>
+    /// Searches the array for a value in reverse order and returns its index
+    /// or <c>-1</c> if not found.
+    /// </summary>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int LastIndexOf(Variant item)
+    {
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, Count - 1);
+    }
+
+    /// <summary>
+    /// Searches the array for a value in reverse order and returns its index
+    /// or <c>-1</c> if not found.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <param name="index">The initial search index to start from.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int LastIndexOf(Variant item, int index)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, index);
+    }
+
+    /// <summary>
+    /// Inserts a new element at a given position in the array. The position
+    /// must be valid, or at the end of the array (<c>pos == Count - 1</c>).
+    /// Existing items will be moved to the right.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="index">The index to insert at.</param>
+    /// <param name="item">The <see cref="Variant"/> item to insert.</param>
+    public void Insert(int index, Variant item)
+    {
+        ThrowIfReadOnly();
+
+        if (index < 0 || index > Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        godot_variant variantValue = (godot_variant)item.NativeVar;
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_insert(ref self, index, variantValue);
+    }
+
+    /// <summary>
+    /// Removes the first occurrence of the specified <paramref name="item"/>
+    /// from this <see cref="Array"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="item">The value to remove.</param>
+    public bool Remove(Variant item)
+    {
+        ThrowIfReadOnly();
+
+        int index = IndexOf(item);
+        if (index >= 0)
+        {
+            RemoveAt(index);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Removes an element from the array by index.
+    /// To remove an element by searching for its value, use
+    /// <see cref="Remove(Variant)"/> instead.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="index">The index of the element to remove.</param>
+    public void RemoveAt(int index)
+    {
+        ThrowIfReadOnly();
+
+        if (index < 0 || index > Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_remove_at(ref self, index);
+    }
+
+    // ICollection
+
+    /// <summary>
+    /// Returns the number of elements in this <see cref="Array"/>.
+    /// This is also known as the size or length of the array.
+    /// </summary>
+    /// <returns>The number of elements.</returns>
+    public int Count => NativeValue.DangerousSelfRef.Size;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => false;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the array is read-only.
+    /// See <see cref="MakeReadOnly"/>.
+    /// </summary>
+    public bool IsReadOnly => NativeValue.DangerousSelfRef.IsReadOnly;
+
+    /// <summary>
+    /// Makes the <see cref="Array"/> read-only, i.e. disabled modying of the
+    /// array's elements. Does not apply to nested content, e.g. content of
+    /// nested arrays.
+    /// </summary>
+    public void MakeReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            // Avoid interop call when the array is already read-only.
+            return;
+        }
+
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_make_read_only(ref self);
+    }
+
+    /// <summary>
+    /// Copies the elements of this <see cref="Array"/> to the given
+    /// <see cref="Variant"/> C# array, starting at the given index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="array">The array to copy to.</param>
+    /// <param name="arrayIndex">The index to start at.</param>
+    public void CopyTo(Variant[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array), "Value cannot be null.");
+
+        if (arrayIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex),
+                "Number was less than the array's lower bound in the first dimension.");
+        }
+
+        int count = Count;
+
+        if (array.Length < (arrayIndex + count))
+        {
+            throw new ArgumentException(
+                "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
+        }
+
+        unsafe
+        {
+            for (int i = 0; i < count; i++)
+            {
+                array[arrayIndex] = Variant.CreateCopyingBorrowed(NativeValue.DangerousSelfRef.Elements[i]);
                 arrayIndex++;
             }
         }
+    }
 
-        /// <summary>
-        /// Removes the first occurrence of the specified <paramref name="item"/>
-        /// from this <see cref="Array{T}"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The array is read-only.
-        /// </exception>
-        /// <param name="item">The value to remove.</param>
-        /// <returns>A <see langword="bool"/> indicating success or failure.</returns>
-        public bool Remove(T item)
+    void ICollection.CopyTo(System.Array array, int index)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array), "Value cannot be null.");
+
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index),
+                "Number was less than the array's lower bound in the first dimension.");
+        }
+
+        int count = Count;
+
+        if (array.Length < (index + count))
+        {
+            throw new ArgumentException(
+                "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
+        }
+
+        unsafe
+        {
+            for (int i = 0; i < count; i++)
+            {
+                object boxedVariant = Variant.CreateCopyingBorrowed(NativeValue.DangerousSelfRef.Elements[i]);
+                array.SetValue(boxedVariant, index);
+                index++;
+            }
+        }
+    }
+
+    // IEnumerable
+
+    /// <summary>
+    /// Gets an enumerator for this <see cref="Array"/>.
+    /// </summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<Variant> GetEnumerator()
+    {
+        int count = Count;
+
+        for (int i = 0; i < count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Converts this <see cref="Array"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this array.</returns>
+    public override string ToString()
+    {
+        var self = (godot_array)NativeValue;
+        NativeFuncs.godotsharp_array_to_string(ref self, out godot_string str);
+        using (str)
+            return Marshaling.ConvertStringToManaged(str);
+    }
+
+    /// <summary>
+    /// The variant returned via the <paramref name="elem"/> parameter is owned by the Array and must not be disposed.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    internal void GetVariantBorrowElementAt(int index, out godot_variant elem)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+        GetVariantBorrowElementAtUnchecked(index, out elem);
+    }
+
+    /// <summary>
+    /// The variant returned via the <paramref name="elem"/> parameter is owned by the Array and must not be disposed.
+    /// </summary>
+    internal unsafe void GetVariantBorrowElementAtUnchecked(int index, out godot_variant elem)
+    {
+        elem = NativeValue.DangerousSelfRef.Elements[index];
+    }
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Array instance is read-only.");
+        }
+    }
+}
+
+internal interface IGenericGodotArray
+{
+    public Array UnderlyingArray { get; }
+}
+
+/// <summary>
+/// Typed wrapper around Godot's Array class, an array of Variant
+/// typed elements allocated in the engine in C++. Useful when
+/// interfacing with the engine. Otherwise prefer .NET collections
+/// such as arrays or <see cref="List{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of the array.</typeparam>
+[SuppressMessage("ReSharper", "RedundantExtendsListEntry")]
+[SuppressMessage("Naming", "CA1710", MessageId = "Identifiers should have correct suffix")]
+public sealed class Array<[MustBeVariant] T> :
+    IList<T>,
+    IReadOnlyList<T>,
+    ICollection<T>,
+    IEnumerable<T>,
+    IGenericGodotArray
+{
+    private static godot_variant ToVariantFunc(in Array<T> godotArray) =>
+        VariantUtils.CreateFromArray(godotArray);
+
+    private static Array<T> FromVariantFunc(in godot_variant variant) =>
+        VariantUtils.ConvertToArray<T>(variant);
+
+    static unsafe Array()
+    {
+        VariantUtils.GenericConversion<Array<T>>.ToVariantCb = &ToVariantFunc;
+        VariantUtils.GenericConversion<Array<T>>.FromVariantCb = &FromVariantFunc;
+    }
+
+    private readonly Array _underlyingArray;
+
+    Array IGenericGodotArray.UnderlyingArray => _underlyingArray;
+
+    internal ref godot_array.movable NativeValue
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref _underlyingArray.NativeValue;
+    }
+
+    /// <summary>
+    /// Constructs a new empty <see cref="Array{T}"/>.
+    /// </summary>
+    public Array()
+    {
+        _underlyingArray = new Array();
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Array{T}"/> from the given collection's elements.
+    /// </summary>
+    /// <param name="collection">The collection of elements to construct from.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array(IEnumerable<T> collection)
+    {
+        if (collection == null)
+            throw new ArgumentNullException(nameof(collection));
+
+        _underlyingArray = new Array();
+
+        foreach (T element in collection)
+            Add(element);
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Array{T}"/> from the given items.
+    /// </summary>
+    /// <param name="array">The items to put in the new array.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array(T[] array) : this()
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        _underlyingArray = new Array();
+
+        foreach (T element in array)
+            Add(element);
+    }
+
+    /// <summary>
+    /// Constructs a typed <see cref="Array{T}"/> from an untyped <see cref="Array"/>.
+    /// </summary>
+    /// <param name="array">The untyped array to construct from.</param>
+    public Array(Array array)
+    {
+        _underlyingArray = array;
+    }
+
+    // Explicit name to make it very clear
+    internal static Array<T> CreateTakingOwnershipOfDisposableValue(godot_array nativeValueToOwn)
+        => new Array<T>(Array.CreateTakingOwnershipOfDisposableValue(nativeValueToOwn));
+
+    /// <summary>
+    /// Converts this typed <see cref="Array{T}"/> to an untyped <see cref="Array"/>.
+    /// </summary>
+    /// <param name="from">The typed array to convert.</param>
+    public static explicit operator Array(Array<T> from)
+    {
+        return from?._underlyingArray;
+    }
+
+    /// <summary>
+    /// Duplicates this <see cref="Array{T}"/>.
+    /// </summary>
+    /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+    /// <returns>A new Godot Array.</returns>
+    public Array<T> Duplicate(bool deep = false)
+    {
+        return new Array<T>(_underlyingArray.Duplicate(deep));
+    }
+
+    /// <summary>
+    /// Assigns the given value to all elements in the array. This can typically be
+    /// used together with <see cref="Resize(int)"/> to create an array with a given
+    /// size and initialized elements.
+    /// Note: If <paramref name="value"/> is of a reference type (<see cref="GodotObject"/>
+    /// derived, <see cref="Array"/> or <see cref="Dictionary"/>, etc.) then the array
+    /// is filled with the references to the same object, i.e. no duplicates are
+    /// created.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var array = new Godot.Collections.Array&lt;int&gt;();
+    /// array.Resize(10);
+    /// array.Fill(0); // Initialize the 10 elements to 0.
+    /// </code>
+    /// </example>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="value">The value to fill the array with.</param>
+    public void Fill(T value)
+    {
+        ThrowIfReadOnly();
+
+        godot_variant variantValue = VariantUtils.CreateFrom(value);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        NativeFuncs.godotsharp_array_fill(ref self, variantValue);
+    }
+
+    /// <summary>
+    /// Returns the maximum value contained in the array if all elements are of
+    /// comparable types. If the elements can't be compared, <see langword="default"/>
+    /// is returned.
+    /// </summary>
+    /// <returns>The maximum value contained in the array.</returns>
+    public T Max()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)_underlyingArray.NativeValue;
+        NativeFuncs.godotsharp_array_max(ref self, out resVariant);
+        return VariantUtils.ConvertTo<T>(resVariant);
+    }
+
+    /// <summary>
+    /// Returns the minimum value contained in the array if all elements are of
+    /// comparable types. If the elements can't be compared, <see langword="default"/>
+    /// is returned.
+    /// </summary>
+    /// <returns>The minimum value contained in the array.</returns>
+    public T Min()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)_underlyingArray.NativeValue;
+        NativeFuncs.godotsharp_array_min(ref self, out resVariant);
+        return VariantUtils.ConvertTo<T>(resVariant);
+    }
+
+    /// <summary>
+    /// Returns a random value from the target array.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var array = new Godot.Collections.Array&lt;int&gt; { 1, 2, 3, 4 };
+    /// GD.Print(array.PickRandom()); // Prints either of the four numbers.
+    /// </code>
+    /// </example>
+    /// <returns>A random element from the array.</returns>
+    public T PickRandom()
+    {
+        godot_variant resVariant;
+        var self = (godot_array)_underlyingArray.NativeValue;
+        NativeFuncs.godotsharp_array_pick_random(ref self, out resVariant);
+        return VariantUtils.ConvertTo<T>(resVariant);
+    }
+
+    /// <summary>
+    /// Compares this <see cref="Array{T}"/> against the <paramref name="other"/>
+    /// <see cref="Array{T}"/> recursively. Returns <see langword="true"/> if the
+    /// sizes and contents of the arrays are equal, <see langword="false"/>
+    /// otherwise.
+    /// </summary>
+    /// <param name="other">The other array to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if the sizes and contents of the arrays are equal,
+    /// <see langword="false"/> otherwise.
+    /// </returns>
+    public bool RecursiveEqual(Array<T> other)
+    {
+        return _underlyingArray.RecursiveEqual(other._underlyingArray);
+    }
+
+    /// <summary>
+    /// Resizes this <see cref="Array{T}"/> to the given size.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="newSize">The new size of the array.</param>
+    /// <returns><see cref="Error.Ok"/> if successful, or an error code.</returns>
+    public Error Resize(int newSize)
+    {
+        return _underlyingArray.Resize(newSize);
+    }
+
+    /// <summary>
+    /// Reverses the order of the elements in the array.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Reverse()
+    {
+        _underlyingArray.Reverse();
+    }
+
+    /// <summary>
+    /// Shuffles the array such that the items will have a random order.
+    /// This method uses the global random number generator common to methods
+    /// such as <see cref="GD.Randi"/>. Call <see cref="GD.Randomize"/> to
+    /// ensure that a new seed will be used each time if you want
+    /// non-reproducible shuffling.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Shuffle()
+    {
+        _underlyingArray.Shuffle();
+    }
+
+    /// <summary>
+    /// Creates a shallow copy of a range of elements in the source <see cref="Array{T}"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="start"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    public Array<T> Slice(int start)
+    {
+        return GetSliceRange(start, Count, step: 1, deep: false);
+    }
+
+    /// <summary>
+    /// Creates a shallow copy of a range of elements in the source <see cref="Array{T}"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="start"/> is less than 0 or greater than the array's size.
+    /// -or-
+    /// <paramref name="length"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <param name="length">The length of the range.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    // The Slice method must have this signature to get implicit Range support.
+    public Array<T> Slice(int start, int length)
+    {
+        return GetSliceRange(start, start + length, step: 1, deep: false);
+    }
+
+    /// <summary>
+    /// Returns the slice of the <see cref="Array{T}"/>, from <paramref name="start"/>
+    /// (inclusive) to <paramref name="end"/> (exclusive), as a new <see cref="Array{T}"/>.
+    /// The absolute value of <paramref name="start"/> and <paramref name="end"/>
+    /// will be clamped to the array size.
+    /// If either <paramref name="start"/> or <paramref name="end"/> are negative, they
+    /// will be relative to the end of the array (i.e. <c>arr.GetSliceRange(0, -2)</c>
+    /// is a shorthand for <c>arr.GetSliceRange(0, arr.Count - 2)</c>).
+    /// If specified, <paramref name="step"/> is the relative index between source
+    /// elements. It can be negative, then <paramref name="start"/> must be higher than
+    /// <paramref name="end"/>. For example, <c>[0, 1, 2, 3, 4, 5].GetSliceRange(5, 1, -2)</c>
+    /// returns <c>[5, 3]</c>.
+    /// If <paramref name="deep"/> is true, each element will be copied by value
+    /// rather than by reference.
+    /// </summary>
+    /// <param name="start">The zero-based index at which the range starts.</param>
+    /// <param name="end">The zero-based index at which the range ends.</param>
+    /// <param name="step">The relative index between source elements to take.</param>
+    /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+    /// <returns>A new array that contains the elements inside the slice range.</returns>
+    public Array<T> GetSliceRange(int start, int end, int step = 1, bool deep = false)
+    {
+        return new Array<T>(_underlyingArray.GetSliceRange(start, end, step, deep));
+    }
+
+    /// <summary>
+    /// Sorts the array.
+    /// Note: The sorting algorithm used is not stable. This means that values
+    /// considered equal may have their order changed when using <see cref="Sort"/>.
+    /// Note: Strings are sorted in alphabetical order (as opposed to natural order).
+    /// This may lead to unexpected behavior when sorting an array of strings ending
+    /// with a sequence of numbers.
+    /// To sort with a custom predicate use
+    /// <see cref="Enumerable.OrderBy{TSource, TKey}(IEnumerable{TSource}, Func{TSource, TKey})"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var strings = new Godot.Collections.Array&lt;string&gt; { "string1", "string2", "string10", "string11" };
+    /// strings.Sort();
+    /// GD.Print(strings); // Prints [string1, string10, string11, string2]
+    /// </code>
+    /// </example>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Sort()
+    {
+        _underlyingArray.Sort();
+    }
+
+    /// <summary>
+    /// Concatenates two <see cref="Array{T}"/>s together, with the <paramref name="right"/>
+    /// being added to the end of the <see cref="Array{T}"/> specified in <paramref name="left"/>.
+    /// For example, <c>[1, 2] + [3, 4]</c> results in <c>[1, 2, 3, 4]</c>.
+    /// </summary>
+    /// <param name="left">The first array.</param>
+    /// <param name="right">The second array.</param>
+    /// <returns>A new Godot Array with the contents of both arrays.</returns>
+    public static Array<T> operator +(Array<T> left, Array<T> right)
+    {
+        if (left == null)
+        {
+            if (right == null)
+                return new Array<T>();
+
+            return right.Duplicate(deep: false);
+        }
+
+        if (right == null)
+            return left.Duplicate(deep: false);
+
+        return new Array<T>(left._underlyingArray + right._underlyingArray);
+    }
+
+    // IList<T>
+
+    /// <summary>
+    /// Returns the item at the given <paramref name="index"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The property is assigned and the array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <value>The <see cref="Variant"/> item at the given <paramref name="index"/>.</value>
+    public unsafe T this[int index]
+    {
+        get
+        {
+            _underlyingArray.GetVariantBorrowElementAt(index, out godot_variant borrowElem);
+            return VariantUtils.ConvertTo<T>(borrowElem);
+        }
+        set
         {
             ThrowIfReadOnly();
 
-            int index = IndexOf(item);
-            if (index >= 0)
-            {
-                RemoveAt(index);
-                return true;
-            }
+            if (index < 0 || index >= Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
 
-            return false;
+            var self = (godot_array)_underlyingArray.NativeValue;
+            godot_variant* ptrw = NativeFuncs.godotsharp_array_ptrw(ref self);
+            godot_variant* itemPtr = &ptrw[index];
+            (*itemPtr).Dispose();
+            *itemPtr = VariantUtils.CreateFrom(value);
+        }
+    }
+
+    /// <summary>
+    /// Searches the array for a value and returns its index or <c>-1</c> if not found.
+    /// </summary>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int IndexOf(T item)
+    {
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
         }
 
-        // IEnumerable<T>
+        using var variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        return NativeFuncs.godotsharp_array_index_of(ref self, variantValue);
+    }
 
-        /// <summary>
-        /// Gets an enumerator for this <see cref="Array{T}"/>.
-        /// </summary>
-        /// <returns>An enumerator.</returns>
-        public IEnumerator<T> GetEnumerator()
+    /// <summary>
+    /// Searches the array for a value and returns its index or <c>-1</c> if not found.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <param name="index">The initial search index to start from.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int IndexOf(T item, int index)
+    {
+        if (index < 0 || index > Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        if (Count == 0)
         {
-            int count = _underlyingArray.Count;
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        return NativeFuncs.godotsharp_array_index_of(ref self, variantValue, index);
+    }
+
+    /// <summary>
+    /// Searches the array for a value in reverse order and returns its index
+    /// or <c>-1</c> if not found.
+    /// </summary>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int LastIndexOf(Variant item)
+    {
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, Count - 1);
+    }
+
+    /// <summary>
+    /// Searches the array for a value in reverse order and returns its index
+    /// or <c>-1</c> if not found.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to search for.</param>
+    /// <param name="index">The initial search index to start from.</param>
+    /// <returns>The index of the item, or -1 if not found.</returns>
+    public int LastIndexOf(Variant item, int index)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        godot_variant variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        return NativeFuncs.godotsharp_array_last_index_of(ref self, variantValue, index);
+    }
+
+    /// <summary>
+    /// Inserts a new element at a given position in the array. The position
+    /// must be valid, or at the end of the array (<c>pos == Count - 1</c>).
+    /// Existing items will be moved to the right.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="index">The index to insert at.</param>
+    /// <param name="item">The <see cref="Variant"/> item to insert.</param>
+    public void Insert(int index, T item)
+    {
+        ThrowIfReadOnly();
+
+        if (index < 0 || index > Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        using var variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        NativeFuncs.godotsharp_array_insert(ref self, index, variantValue);
+    }
+
+    /// <summary>
+    /// Removes an element from the array by index.
+    /// To remove an element by searching for its value, use
+    /// <see cref="Remove(T)"/> instead.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="index">The index of the element to remove.</param>
+    public void RemoveAt(int index)
+    {
+        _underlyingArray.RemoveAt(index);
+    }
+
+    // ICollection<T>
+
+    /// <summary>
+    /// Returns the number of elements in this <see cref="Array{T}"/>.
+    /// This is also known as the size or length of the array.
+    /// </summary>
+    /// <returns>The number of elements.</returns>
+    public int Count => _underlyingArray.Count;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the array is read-only.
+    /// See <see cref="MakeReadOnly"/>.
+    /// </summary>
+    public bool IsReadOnly => _underlyingArray.IsReadOnly;
+
+    /// <summary>
+    /// Makes the <see cref="Array{T}"/> read-only, i.e. disabled modying of the
+    /// array's elements. Does not apply to nested content, e.g. content of
+    /// nested arrays.
+    /// </summary>
+    public void MakeReadOnly()
+    {
+        _underlyingArray.MakeReadOnly();
+    }
+
+    /// <summary>
+    /// Adds an item to the end of this <see cref="Array{T}"/>.
+    /// This is the same as <c>append</c> or <c>push_back</c> in GDScript.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="item">The <see cref="Variant"/> item to add.</param>
+    public void Add(T item)
+    {
+        ThrowIfReadOnly();
+
+        using var variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        _ = NativeFuncs.godotsharp_array_add(ref self, variantValue);
+    }
+
+    /// <summary>
+    /// Adds the elements of the specified collection to the end of this <see cref="Array{T}"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="collection"/> is <see langword="null"/>.
+    /// </exception>
+    /// <param name="collection">Collection of <see cref="Variant"/> items to add.</param>
+    public void AddRange(IEnumerable<T> collection)
+    {
+        ThrowIfReadOnly();
+
+        if (collection == null)
+            throw new ArgumentNullException(nameof(collection), "Value cannot be null.");
+
+        // If the collection is another Godot Array, we can add the items
+        // with a single interop call.
+        if (collection is Array array)
+        {
+            var self = (godot_array)_underlyingArray.NativeValue;
+            var collectionNative = (godot_array)array.NativeValue;
+            _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
+            return;
+        }
+        if (collection is Array<T> typedArray)
+        {
+            var self = (godot_array)_underlyingArray.NativeValue;
+            var collectionNative = (godot_array)typedArray._underlyingArray.NativeValue;
+            _ = NativeFuncs.godotsharp_array_add_range(ref self, collectionNative);
+            return;
+        }
+
+        // If we can retrieve the count of the collection without enumerating it
+        // (e.g.: the collections is a List<T>), use it to resize the array once
+        // instead of growing it as we add items.
+        if (collection.TryGetNonEnumeratedCount(out int count))
+        {
+            int oldCount = Count;
+            Resize(Count + count);
+
+            using var enumerator = collection.GetEnumerator();
 
             for (int i = 0; i < count; i++)
             {
-                yield return this[i];
+                enumerator.MoveNext();
+                this[oldCount + i] = enumerator.Current;
             }
+
+            return;
         }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Converts this <see cref="Array{T}"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this array.</returns>
-        public override string ToString() => _underlyingArray.ToString();
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Variant(Array<T> from) => Variant.CreateFrom(from);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator Array<T>(Variant from) => from.AsGodotArray<T>();
-
-        private void ThrowIfReadOnly()
+        foreach (var item in collection)
         {
-            if (IsReadOnly)
-            {
-                throw new InvalidOperationException("Array instance is read-only.");
-            }
+            Add(item);
+        }
+    }
+
+    /// <summary>
+    /// Finds the index of an existing value using binary search.
+    /// If the value is not present in the array, it returns the bitwise
+    /// complement of the insertion index that maintains sorting order.
+    /// Note: Calling <see cref="BinarySearch(int, int, T)"/> on an unsorted
+    /// array results in unexpected behavior.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is less than 0.
+    /// -or-
+    /// <paramref name="count"/> is less than 0.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="index"/> and <paramref name="count"/> do not denote
+    /// a valid range in the <see cref="Array{T}"/>.
+    /// </exception>
+    /// <param name="index">The starting index of the range to search.</param>
+    /// <param name="count">The length of the range to search.</param>
+    /// <param name="item">The object to locate.</param>
+    /// <returns>
+    /// The index of the item in the array, if <paramref name="item"/> is found;
+    /// otherwise, a negative number that is the bitwise complement of the index
+    /// of the next element that is larger than <paramref name="item"/> or, if
+    /// there is no larger element, the bitwise complement of <see cref="Count"/>.
+    /// </returns>
+    public int BinarySearch(int index, int count, T item)
+    {
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index), "index cannot be negative.");
+        if (count < 0)
+            throw new ArgumentOutOfRangeException(nameof(count), "count cannot be negative.");
+        if (Count - index < count)
+            throw new ArgumentException("length is out of bounds or count is greater than the number of elements.");
+
+        if (Count == 0)
+        {
+            // Special case for empty array to avoid an interop call.
+            return -1;
+        }
+
+        using var variantValue = VariantUtils.CreateFrom(item);
+        var self = (godot_array)_underlyingArray.NativeValue;
+        return NativeFuncs.godotsharp_array_binary_search(ref self, index, count, variantValue);
+    }
+
+    /// <summary>
+    /// Finds the index of an existing value using binary search.
+    /// If the value is not present in the array, it returns the bitwise
+    /// complement of the insertion index that maintains sorting order.
+    /// Note: Calling <see cref="BinarySearch(T)"/> on an unsorted
+    /// array results in unexpected behavior.
+    /// </summary>
+    /// <param name="item">The object to locate.</param>
+    /// <returns>
+    /// The index of the item in the array, if <paramref name="item"/> is found;
+    /// otherwise, a negative number that is the bitwise complement of the index
+    /// of the next element that is larger than <paramref name="item"/> or, if
+    /// there is no larger element, the bitwise complement of <see cref="Count"/>.
+    /// </returns>
+    public int BinarySearch(T item)
+    {
+        return BinarySearch(0, Count, item);
+    }
+
+    /// <summary>
+    /// Clears the array. This is the equivalent to using <see cref="Resize(int)"/>
+    /// with a size of <c>0</c>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    public void Clear()
+    {
+        _underlyingArray.Clear();
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the array contains the given value.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var arr = new Godot.Collections.Array&lt;string&gt; { "inside", "7" };
+    /// GD.Print(arr.Contains("inside")); // True
+    /// GD.Print(arr.Contains("outside")); // False
+    /// GD.Print(arr.Contains(7)); // False
+    /// GD.Print(arr.Contains("7")); // True
+    /// </code>
+    /// </example>
+    /// <param name="item">The item to look for.</param>
+    /// <returns>Whether or not this array contains the given item.</returns>
+    public bool Contains(T item) => IndexOf(item) != -1;
+
+    /// <summary>
+    /// Copies the elements of this <see cref="Array{T}"/> to the given
+    /// C# array, starting at the given index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="arrayIndex"/> is less than 0 or greater than the array's size.
+    /// </exception>
+    /// <param name="array">The C# array to copy to.</param>
+    /// <param name="arrayIndex">The index to start at.</param>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array), "Value cannot be null.");
+
+        if (arrayIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex),
+                "Number was less than the array's lower bound in the first dimension.");
+        }
+
+        int count = Count;
+
+        if (array.Length < (arrayIndex + count))
+        {
+            throw new ArgumentException(
+                "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
+        }
+
+        for (int i = 0; i < count; i++)
+        {
+            array[arrayIndex] = this[i];
+            arrayIndex++;
+        }
+    }
+
+    /// <summary>
+    /// Removes the first occurrence of the specified <paramref name="item"/>
+    /// from this <see cref="Array{T}"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The array is read-only.
+    /// </exception>
+    /// <param name="item">The value to remove.</param>
+    /// <returns>A <see langword="bool"/> indicating success or failure.</returns>
+    public bool Remove(T item)
+    {
+        ThrowIfReadOnly();
+
+        int index = IndexOf(item);
+        if (index >= 0)
+        {
+            RemoveAt(index);
+            return true;
+        }
+
+        return false;
+    }
+
+    // IEnumerable<T>
+
+    /// <summary>
+    /// Gets an enumerator for this <see cref="Array{T}"/>.
+    /// </summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<T> GetEnumerator()
+    {
+        int count = _underlyingArray.Count;
+
+        for (int i = 0; i < count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Converts this <see cref="Array{T}"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this array.</returns>
+    public override string ToString() => _underlyingArray.ToString();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Array<T> from) => Variant.CreateFrom(from);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Array<T>(Variant from) => from.AsGodotArray<T>();
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Array instance is read-only.");
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
@@ -3,47 +3,46 @@ using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Attribute that determines that the assembly contains Godot scripts and, optionally, the
+/// collection of types that implement scripts; otherwise, retrieving the types requires lookup.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly)]
+public sealed class AssemblyHasScriptsAttribute : Attribute
 {
     /// <summary>
-    /// Attribute that determines that the assembly contains Godot scripts and, optionally, the
-    /// collection of types that implement scripts; otherwise, retrieving the types requires lookup.
+    /// If the Godot scripts contained in the assembly require lookup
+    /// and can't rely on <see cref="ScriptTypes"/>.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly)]
-    public sealed class AssemblyHasScriptsAttribute : Attribute
+    [MemberNotNullWhen(false, nameof(ScriptTypes))]
+    public bool RequiresLookup { get; }
+
+    /// <summary>
+    /// The collection of types that implement a Godot script.
+    /// </summary>
+    public Type[]? ScriptTypes { get; }
+
+    /// <summary>
+    /// Constructs a new AssemblyHasScriptsAttribute instance
+    /// that requires lookup to get the Godot scripts.
+    /// </summary>
+    public AssemblyHasScriptsAttribute()
     {
-        /// <summary>
-        /// If the Godot scripts contained in the assembly require lookup
-        /// and can't rely on <see cref="ScriptTypes"/>.
-        /// </summary>
-        [MemberNotNullWhen(false, nameof(ScriptTypes))]
-        public bool RequiresLookup { get; }
+        RequiresLookup = true;
+        ScriptTypes = null;
+    }
 
-        /// <summary>
-        /// The collection of types that implement a Godot script.
-        /// </summary>
-        public Type[]? ScriptTypes { get; }
-
-        /// <summary>
-        /// Constructs a new AssemblyHasScriptsAttribute instance
-        /// that requires lookup to get the Godot scripts.
-        /// </summary>
-        public AssemblyHasScriptsAttribute()
-        {
-            RequiresLookup = true;
-            ScriptTypes = null;
-        }
-
-        /// <summary>
-        /// Constructs a new AssemblyHasScriptsAttribute instance
-        /// that includes the Godot script types and requires no lookup.
-        /// </summary>
-        /// <param name="scriptTypes">The collection of types that implement a Godot script.</param>
-        public AssemblyHasScriptsAttribute(Type[] scriptTypes)
-        {
-            RequiresLookup = false;
-            ScriptTypes = scriptTypes;
-        }
+    /// <summary>
+    /// Constructs a new AssemblyHasScriptsAttribute instance
+    /// that includes the Godot script types and requires no lookup.
+    /// </summary>
+    /// <param name="scriptTypes">The collection of types that implement a Godot script.</param>
+    public AssemblyHasScriptsAttribute(Type[] scriptTypes)
+    {
+        RequiresLookup = false;
+        ScriptTypes = scriptTypes;
     }
 }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -1,32 +1,31 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Exports the annotated member as a property of the Godot Object.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class ExportAttribute : Attribute
 {
     /// <summary>
-    /// Exports the annotated member as a property of the Godot Object.
+    /// Optional hint that determines how the property should be handled by the editor.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ExportAttribute : Attribute
+    public PropertyHint Hint { get; }
+
+    /// <summary>
+    /// Optional string that can contain additional metadata for the <see cref="Hint"/>.
+    /// </summary>
+    public string HintString { get; }
+
+    /// <summary>
+    /// Constructs a new ExportAttribute Instance.
+    /// </summary>
+    /// <param name="hint">The hint for the exported property.</param>
+    /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
+    public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
     {
-        /// <summary>
-        /// Optional hint that determines how the property should be handled by the editor.
-        /// </summary>
-        public PropertyHint Hint { get; }
-
-        /// <summary>
-        /// Optional string that can contain additional metadata for the <see cref="Hint"/>.
-        /// </summary>
-        public string HintString { get; }
-
-        /// <summary>
-        /// Constructs a new ExportAttribute Instance.
-        /// </summary>
-        /// <param name="hint">The hint for the exported property.</param>
-        /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
-        public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
-        {
-            Hint = hint;
-            HintString = hintString;
-        }
+        Hint = hint;
+        HintString = hintString;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportCategoryAttribute.cs
@@ -1,25 +1,24 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Define a new category for the following exported properties. This helps to organize properties in the Inspector dock.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class ExportCategoryAttribute : Attribute
 {
     /// <summary>
-    /// Define a new category for the following exported properties. This helps to organize properties in the Inspector dock.
+    /// Name of the category.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ExportCategoryAttribute : Attribute
-    {
-        /// <summary>
-        /// Name of the category.
-        /// </summary>
-        public string Name { get; }
+    public string Name { get; }
 
-        /// <summary>
-        /// Define a new category for the following exported properties.
-        /// </summary>
-        /// <param name="name">The name of the category.</param>
-        public ExportCategoryAttribute(string name)
-        {
-            Name = name;
-        }
+    /// <summary>
+    /// Define a new category for the following exported properties.
+    /// </summary>
+    /// <param name="name">The name of the category.</param>
+    public ExportCategoryAttribute(string name)
+    {
+        Name = name;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportGroupAttribute.cs
@@ -2,33 +2,32 @@ using System;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Define a new group for the following exported properties. This helps to organize properties in the Inspector dock.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class ExportGroupAttribute : Attribute
 {
     /// <summary>
-    /// Define a new group for the following exported properties. This helps to organize properties in the Inspector dock.
+    /// Name of the group.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ExportGroupAttribute : Attribute
+    public string Name { get; }
+
+    /// <summary>
+    /// If provided, the prefix that all properties must have to be considered part of the group.
+    /// </summary>
+    public string? Prefix { get; }
+
+    /// <summary>
+    /// Define a new group for the following exported properties.
+    /// </summary>
+    /// <param name="name">The name of the group.</param>
+    /// <param name="prefix">If provided, the group would make group to only consider properties that have this prefix.</param>
+    public ExportGroupAttribute(string name, string prefix = "")
     {
-        /// <summary>
-        /// Name of the group.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// If provided, the prefix that all properties must have to be considered part of the group.
-        /// </summary>
-        public string? Prefix { get; }
-
-        /// <summary>
-        /// Define a new group for the following exported properties.
-        /// </summary>
-        /// <param name="name">The name of the group.</param>
-        /// <param name="prefix">If provided, the group would make group to only consider properties that have this prefix.</param>
-        public ExportGroupAttribute(string name, string prefix = "")
-        {
-            Name = name;
-            Prefix = prefix;
-        }
+        Name = name;
+        Prefix = prefix;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportSubgroupAttribute.cs
@@ -2,33 +2,32 @@ using System;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public sealed class ExportSubgroupAttribute : Attribute
 {
+    /// <summary>
+    /// Name of the subgroup.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// If provided, the prefix that all properties must have to be considered part of the subgroup.
+    /// </summary>
+    public string? Prefix { get; }
+
     /// <summary>
     /// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
-    public sealed class ExportSubgroupAttribute : Attribute
+    /// <param name="name">The name of the subgroup.</param>
+    /// <param name="prefix">If provided, the subgroup would make group to only consider properties that have this prefix.</param>
+    public ExportSubgroupAttribute(string name, string prefix = "")
     {
-        /// <summary>
-        /// Name of the subgroup.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// If provided, the prefix that all properties must have to be considered part of the subgroup.
-        /// </summary>
-        public string? Prefix { get; }
-
-        /// <summary>
-        /// Define a new subgroup for the following exported properties. This helps to organize properties in the Inspector dock.
-        /// </summary>
-        /// <param name="name">The name of the subgroup.</param>
-        /// <param name="prefix">If provided, the subgroup would make group to only consider properties that have this prefix.</param>
-        public ExportSubgroupAttribute(string name, string prefix = "")
-        {
-            Name = name;
-            Prefix = prefix;
-        }
+        Name = name;
+        Prefix = prefix;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GlobalClassAttribute.cs
@@ -2,11 +2,10 @@ using System;
 
 #nullable enable
 
-namespace Godot
-{
-    /// <summary>
-    /// Exposes the target class as a global script class to Godot Engine.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    public sealed class GlobalClassAttribute : Attribute { }
-}
+namespace Godot;
+
+/// <summary>
+/// Exposes the target class as a global script class to Godot Engine.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class GlobalClassAttribute : Attribute { }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
@@ -1,24 +1,23 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Attribute that specifies the engine class name when it's not the same
+/// as the generated C# class name. This allows introspection code to find
+/// the name associated with the class. If the attribute is not present,
+/// the C# class name can be used instead.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class GodotClassNameAttribute : Attribute
 {
     /// <summary>
-    /// Attribute that specifies the engine class name when it's not the same
-    /// as the generated C# class name. This allows introspection code to find
-    /// the name associated with the class. If the attribute is not present,
-    /// the C# class name can be used instead.
+    /// Original engine class name.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    public class GodotClassNameAttribute : Attribute
-    {
-        /// <summary>
-        /// Original engine class name.
-        /// </summary>
-        public string Name { get; }
+    public string Name { get; }
 
-        public GodotClassNameAttribute(string name)
-        {
-            Name = name;
-        }
+    public GodotClassNameAttribute(string name)
+    {
+        Name = name;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/IconAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/IconAttribute.cs
@@ -1,25 +1,24 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Specifies a custom icon for representing this class in the Godot Editor.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class IconAttribute : Attribute
 {
     /// <summary>
-    /// Specifies a custom icon for representing this class in the Godot Editor.
+    /// File path to a custom icon for representing this class in the Godot Editor.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
-    public sealed class IconAttribute : Attribute
-    {
-        /// <summary>
-        /// File path to a custom icon for representing this class in the Godot Editor.
-        /// </summary>
-        public string Path { get; }
+    public string Path { get; }
 
-        /// <summary>
-        /// Specify the custom icon that represents the class.
-        /// </summary>
-        /// <param name="path">File path to the custom icon.</param>
-        public IconAttribute(string path)
-        {
-            Path = path;
-        }
+    /// <summary>
+    /// Specify the custom icon that represents the class.
+    /// </summary>
+    /// <param name="path">File path to the custom icon.</param>
+    public IconAttribute(string path)
+    {
+        Path = path;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/MustBeVariantAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/MustBeVariantAttribute.cs
@@ -1,11 +1,10 @@
 using System;
 
-namespace Godot
-{
-    /// <summary>
-    /// Attribute that restricts generic type parameters to be only types
-    /// that can be marshaled from/to a <see cref="Variant"/>.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.GenericParameter)]
-    public sealed class MustBeVariantAttribute : Attribute { }
-}
+namespace Godot;
+
+/// <summary>
+/// Attribute that restricts generic type parameters to be only types
+/// that can be marshaled from/to a <see cref="Variant"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.GenericParameter)]
+public sealed class MustBeVariantAttribute : Attribute { }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RpcAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RpcAttribute.cs
@@ -1,43 +1,42 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Attribute that changes the RPC mode for the annotated <c>method</c> to the given <see cref="Mode"/>,
+/// optionally specifying the <see cref="TransferMode"/> and <see cref="TransferChannel"/> (on supported peers).
+/// See <see cref="MultiplayerApi.RpcMode"/> and <see cref="MultiplayerPeer.TransferModeEnum"/>.
+/// By default, methods are not exposed to networking (and RPCs).
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class RpcAttribute : Attribute
 {
     /// <summary>
-    /// Attribute that changes the RPC mode for the annotated <c>method</c> to the given <see cref="Mode"/>,
-    /// optionally specifying the <see cref="TransferMode"/> and <see cref="TransferChannel"/> (on supported peers).
-    /// See <see cref="MultiplayerApi.RpcMode"/> and <see cref="MultiplayerPeer.TransferModeEnum"/>.
-    /// By default, methods are not exposed to networking (and RPCs).
+    /// RPC mode for the annotated method.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class RpcAttribute : Attribute
+    public MultiplayerApi.RpcMode Mode { get; } = MultiplayerApi.RpcMode.Disabled;
+
+    /// <summary>
+    /// If the method will also be called locally; otherwise, it is only called remotely.
+    /// </summary>
+    public bool CallLocal { get; init; } = false;
+
+    /// <summary>
+    /// Transfer mode for the annotated method.
+    /// </summary>
+    public MultiplayerPeer.TransferModeEnum TransferMode { get; init; } = MultiplayerPeer.TransferModeEnum.Reliable;
+
+    /// <summary>
+    /// Transfer channel for the annotated mode.
+    /// </summary>
+    public int TransferChannel { get; init; } = 0;
+
+    /// <summary>
+    /// Constructs a <see cref="RpcAttribute"/> instance.
+    /// </summary>
+    /// <param name="mode">The RPC mode to use.</param>
+    public RpcAttribute(MultiplayerApi.RpcMode mode = MultiplayerApi.RpcMode.Authority)
     {
-        /// <summary>
-        /// RPC mode for the annotated method.
-        /// </summary>
-        public MultiplayerApi.RpcMode Mode { get; } = MultiplayerApi.RpcMode.Disabled;
-
-        /// <summary>
-        /// If the method will also be called locally; otherwise, it is only called remotely.
-        /// </summary>
-        public bool CallLocal { get; init; } = false;
-
-        /// <summary>
-        /// Transfer mode for the annotated method.
-        /// </summary>
-        public MultiplayerPeer.TransferModeEnum TransferMode { get; init; } = MultiplayerPeer.TransferModeEnum.Reliable;
-
-        /// <summary>
-        /// Transfer channel for the annotated mode.
-        /// </summary>
-        public int TransferChannel { get; init; } = 0;
-
-        /// <summary>
-        /// Constructs a <see cref="RpcAttribute"/> instance.
-        /// </summary>
-        /// <param name="mode">The RPC mode to use.</param>
-        public RpcAttribute(MultiplayerApi.RpcMode mode = MultiplayerApi.RpcMode.Authority)
-        {
-            Mode = mode;
-        }
+        Mode = mode;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
@@ -1,25 +1,24 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// An attribute that contains the path to the object's script.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class ScriptPathAttribute : Attribute
 {
     /// <summary>
-    /// An attribute that contains the path to the object's script.
+    /// File path to the script.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public sealed class ScriptPathAttribute : Attribute
-    {
-        /// <summary>
-        /// File path to the script.
-        /// </summary>
-        public string Path { get; }
+    public string Path { get; }
 
-        /// <summary>
-        /// Constructs a new ScriptPathAttribute instance.
-        /// </summary>
-        /// <param name="path">The file path to the script</param>
-        public ScriptPathAttribute(string path)
-        {
-            Path = path;
-        }
+    /// <summary>
+    /// Constructs a new ScriptPathAttribute instance.
+    /// </summary>
+    /// <param name="path">The file path to the script</param>
+    public ScriptPathAttribute(string path)
+    {
+        Path = path;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Godot
-{
-    [AttributeUsage(AttributeTargets.Delegate)]
-    public sealed class SignalAttribute : Attribute { }
-}
+namespace Godot;
+
+[AttributeUsage(AttributeTargets.Delegate)]
+public sealed class SignalAttribute : Attribute { }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
@@ -1,7 +1,6 @@
 using System;
 
-namespace Godot
-{
-    [AttributeUsage(AttributeTargets.Class)]
-    public sealed class ToolAttribute : Attribute { }
-}
+namespace Godot;
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ToolAttribute : Attribute { }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Basis.cs
@@ -2,789 +2,789 @@ using System;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 3×3 matrix used for 3D rotation and scale.
+/// Almost always used as an orthogonal basis for a Transform.
+///
+/// Contains 3 vector fields X, Y and Z as its columns, which are typically
+/// interpreted as the local basis vectors of a 3D transformation. For such use,
+/// it is composed of a scaling and a rotation matrix, in that order (M = R.S).
+///
+/// Can also be accessed as array of 3D vectors. These vectors are normally
+/// orthogonal to each other, but are not necessarily normalized (due to scaling).
+///
+/// For more information, read this documentation article:
+/// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Basis : IEquatable<Basis>
 {
+    // NOTE: x, y and z are public-only. Use Column0, Column1 and Column2 internally.
+
     /// <summary>
-    /// 3×3 matrix used for 3D rotation and scale.
-    /// Almost always used as an orthogonal basis for a Transform.
-    ///
-    /// Contains 3 vector fields X, Y and Z as its columns, which are typically
-    /// interpreted as the local basis vectors of a 3D transformation. For such use,
-    /// it is composed of a scaling and a rotation matrix, in that order (M = R.S).
-    ///
-    /// Can also be accessed as array of 3D vectors. These vectors are normally
-    /// orthogonal to each other, but are not necessarily normalized (due to scaling).
-    ///
-    /// For more information, read this documentation article:
-    /// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+    /// The basis matrix's X vector (column 0).
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Basis : IEquatable<Basis>
+    /// <value>Equivalent to <see cref="Column0"/> and array index <c>[0]</c>.</value>
+    public Vector3 X
     {
-        // NOTE: x, y and z are public-only. Use Column0, Column1 and Column2 internally.
+        readonly get => Column0;
+        set => Column0 = value;
+    }
 
-        /// <summary>
-        /// The basis matrix's X vector (column 0).
-        /// </summary>
-        /// <value>Equivalent to <see cref="Column0"/> and array index <c>[0]</c>.</value>
-        public Vector3 X
+    /// <summary>
+    /// The basis matrix's Y vector (column 1).
+    /// </summary>
+    /// <value>Equivalent to <see cref="Column1"/> and array index <c>[1]</c>.</value>
+    public Vector3 Y
+    {
+        readonly get => Column1;
+        set => Column1 = value;
+    }
+
+    /// <summary>
+    /// The basis matrix's Z vector (column 2).
+    /// </summary>
+    /// <value>Equivalent to <see cref="Column2"/> and array index <c>[2]</c>.</value>
+    public Vector3 Z
+    {
+        readonly get => Column2;
+        set => Column2 = value;
+    }
+
+    /// <summary>
+    /// Row 0 of the basis matrix. Shows which vectors contribute
+    /// to the X direction. Rows are not very useful for user code,
+    /// but are more efficient for some internal calculations.
+    /// </summary>
+    public Vector3 Row0;
+
+    /// <summary>
+    /// Row 1 of the basis matrix. Shows which vectors contribute
+    /// to the Y direction. Rows are not very useful for user code,
+    /// but are more efficient for some internal calculations.
+    /// </summary>
+    public Vector3 Row1;
+
+    /// <summary>
+    /// Row 2 of the basis matrix. Shows which vectors contribute
+    /// to the Z direction. Rows are not very useful for user code,
+    /// but are more efficient for some internal calculations.
+    /// </summary>
+    public Vector3 Row2;
+
+    /// <summary>
+    /// Column 0 of the basis matrix (the X vector).
+    /// </summary>
+    /// <value>Equivalent to <see cref="X"/> and array index <c>[0]</c>.</value>
+    public Vector3 Column0
+    {
+        readonly get => new Vector3(Row0.X, Row1.X, Row2.X);
+        set
         {
-            readonly get => Column0;
-            set => Column0 = value;
+            Row0.X = value.X;
+            Row1.X = value.Y;
+            Row2.X = value.Z;
         }
+    }
 
-        /// <summary>
-        /// The basis matrix's Y vector (column 1).
-        /// </summary>
-        /// <value>Equivalent to <see cref="Column1"/> and array index <c>[1]</c>.</value>
-        public Vector3 Y
+    /// <summary>
+    /// Column 1 of the basis matrix (the Y vector).
+    /// </summary>
+    /// <value>Equivalent to <see cref="Y"/> and array index <c>[1]</c>.</value>
+    public Vector3 Column1
+    {
+        readonly get => new Vector3(Row0.Y, Row1.Y, Row2.Y);
+        set
         {
-            readonly get => Column1;
-            set => Column1 = value;
+            Row0.Y = value.X;
+            Row1.Y = value.Y;
+            Row2.Y = value.Z;
         }
+    }
 
-        /// <summary>
-        /// The basis matrix's Z vector (column 2).
-        /// </summary>
-        /// <value>Equivalent to <see cref="Column2"/> and array index <c>[2]</c>.</value>
-        public Vector3 Z
+    /// <summary>
+    /// Column 2 of the basis matrix (the Z vector).
+    /// </summary>
+    /// <value>Equivalent to <see cref="Z"/> and array index <c>[2]</c>.</value>
+    public Vector3 Column2
+    {
+        readonly get => new Vector3(Row0.Z, Row1.Z, Row2.Z);
+        set
         {
-            readonly get => Column2;
-            set => Column2 = value;
+            Row0.Z = value.X;
+            Row1.Z = value.Y;
+            Row2.Z = value.Z;
         }
+    }
 
-        /// <summary>
-        /// Row 0 of the basis matrix. Shows which vectors contribute
-        /// to the X direction. Rows are not very useful for user code,
-        /// but are more efficient for some internal calculations.
-        /// </summary>
-        public Vector3 Row0;
-
-        /// <summary>
-        /// Row 1 of the basis matrix. Shows which vectors contribute
-        /// to the Y direction. Rows are not very useful for user code,
-        /// but are more efficient for some internal calculations.
-        /// </summary>
-        public Vector3 Row1;
-
-        /// <summary>
-        /// Row 2 of the basis matrix. Shows which vectors contribute
-        /// to the Z direction. Rows are not very useful for user code,
-        /// but are more efficient for some internal calculations.
-        /// </summary>
-        public Vector3 Row2;
-
-        /// <summary>
-        /// Column 0 of the basis matrix (the X vector).
-        /// </summary>
-        /// <value>Equivalent to <see cref="X"/> and array index <c>[0]</c>.</value>
-        public Vector3 Column0
+    /// <summary>
+    /// Assuming that the matrix is the combination of a rotation and scaling,
+    /// return the absolute value of scaling factors along each axis.
+    /// </summary>
+    public readonly Vector3 Scale
+    {
+        get
         {
-            readonly get => new Vector3(Row0.X, Row1.X, Row2.X);
-            set
+            real_t detSign = Mathf.Sign(Determinant());
+            return detSign * new Vector3
+            (
+                Column0.Length(),
+                Column1.Length(),
+                Column2.Length()
+            );
+        }
+    }
+
+    /// <summary>
+    /// Access whole columns in the form of <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="column">Which column vector.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="column"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    /// <value>The basis column.</value>
+    public Vector3 this[int column]
+    {
+        readonly get
+        {
+            switch (column)
             {
-                Row0.X = value.X;
-                Row1.X = value.Y;
-                Row2.X = value.Z;
+                case 0:
+                    return Column0;
+                case 1:
+                    return Column1;
+                case 2:
+                    return Column2;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
-
-        /// <summary>
-        /// Column 1 of the basis matrix (the Y vector).
-        /// </summary>
-        /// <value>Equivalent to <see cref="Y"/> and array index <c>[1]</c>.</value>
-        public Vector3 Column1
+        set
         {
-            readonly get => new Vector3(Row0.Y, Row1.Y, Row2.Y);
-            set
+            switch (column)
             {
-                Row0.Y = value.X;
-                Row1.Y = value.Y;
-                Row2.Y = value.Z;
+                case 0:
+                    Column0 = value;
+                    return;
+                case 1:
+                    Column1 = value;
+                    return;
+                case 2:
+                    Column2 = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
+    }
 
-        /// <summary>
-        /// Column 2 of the basis matrix (the Z vector).
-        /// </summary>
-        /// <value>Equivalent to <see cref="Z"/> and array index <c>[2]</c>.</value>
-        public Vector3 Column2
+    /// <summary>
+    /// Access matrix elements in column-major order.
+    /// </summary>
+    /// <param name="column">Which column, the matrix horizontal position.</param>
+    /// <param name="row">Which row, the matrix vertical position.</param>
+    /// <value>The matrix element.</value>
+    public real_t this[int column, int row]
+    {
+        readonly get
         {
-            readonly get => new Vector3(Row0.Z, Row1.Z, Row2.Z);
-            set
-            {
-                Row0.Z = value.X;
-                Row1.Z = value.Y;
-                Row2.Z = value.Z;
-            }
+            return this[column][row];
         }
-
-        /// <summary>
-        /// Assuming that the matrix is the combination of a rotation and scaling,
-        /// return the absolute value of scaling factors along each axis.
-        /// </summary>
-        public readonly Vector3 Scale
+        set
         {
-            get
-            {
-                real_t detSign = Mathf.Sign(Determinant());
-                return detSign * new Vector3
-                (
-                    Column0.Length(),
-                    Column1.Length(),
-                    Column2.Length()
-                );
-            }
+            Vector3 columnVector = this[column];
+            columnVector[row] = value;
+            this[column] = columnVector;
         }
+    }
 
-        /// <summary>
-        /// Access whole columns in the form of <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="column">Which column vector.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="column"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        /// <value>The basis column.</value>
-        public Vector3 this[int column]
+    internal void SetQuaternionScale(Quaternion quaternion, Vector3 scale)
+    {
+        SetDiagonal(scale);
+        Rotate(quaternion);
+    }
+
+    private void Rotate(Quaternion quaternion)
+    {
+        this *= new Basis(quaternion);
+    }
+
+    private void SetDiagonal(Vector3 diagonal)
+    {
+        Row0 = new Vector3(diagonal.X, 0, 0);
+        Row1 = new Vector3(0, diagonal.Y, 0);
+        Row2 = new Vector3(0, 0, diagonal.Z);
+    }
+
+    /// <summary>
+    /// Returns the determinant of the basis matrix. If the basis is
+    /// uniformly scaled, its determinant is the square of the scale.
+    ///
+    /// A negative determinant means the basis has a negative scale.
+    /// A zero determinant means the basis isn't invertible,
+    /// and is usually considered invalid.
+    /// </summary>
+    /// <returns>The determinant of the basis matrix.</returns>
+    public readonly real_t Determinant()
+    {
+        real_t cofac00 = Row1[1] * Row2[2] - Row1[2] * Row2[1];
+        real_t cofac10 = Row1[2] * Row2[0] - Row1[0] * Row2[2];
+        real_t cofac20 = Row1[0] * Row2[1] - Row1[1] * Row2[0];
+
+        return Row0[0] * cofac00 + Row0[1] * cofac10 + Row0[2] * cofac20;
+    }
+
+    /// <summary>
+    /// Returns the basis's rotation in the form of Euler angles.
+    /// The Euler order depends on the [param order] parameter,
+    /// by default it uses the YXZ convention: when decomposing,
+    /// first Z, then X, and Y last. The returned vector contains
+    /// the rotation angles in the format (X angle, Y angle, Z angle).
+    ///
+    /// Consider using the <see cref="GetRotationQuaternion"/> method instead, which
+    /// returns a <see cref="Quaternion"/> quaternion instead of Euler angles.
+    /// </summary>
+    /// <param name="order">The Euler order to use. By default, use YXZ order (most common).</param>
+    /// <returns>A <see cref="Vector3"/> representing the basis rotation in Euler angles.</returns>
+    public readonly Vector3 GetEuler(EulerOrder order = EulerOrder.Yxz)
+    {
+        switch (order)
         {
-            readonly get
+            case EulerOrder.Xyz:
             {
-                switch (column)
+                // Euler angles in XYZ convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz          -cy*sz           sy
+                //        cz*sx*sy+cx*sz  cx*cz-sx*sy*sz -cy*sx
+                //       -cx*cz*sy+sx*sz  cz*sx+cx*sy*sz  cx*cy
+                Vector3 euler;
+                real_t sy = Row0[2];
+                if (sy < (1.0f - Mathf.Epsilon))
                 {
-                    case 0:
-                        return Column0;
-                    case 1:
-                        return Column1;
-                    case 2:
-                        return Column2;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-            set
-            {
-                switch (column)
-                {
-                    case 0:
-                        Column0 = value;
-                        return;
-                    case 1:
-                        Column1 = value;
-                        return;
-                    case 2:
-                        Column2 = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Access matrix elements in column-major order.
-        /// </summary>
-        /// <param name="column">Which column, the matrix horizontal position.</param>
-        /// <param name="row">Which row, the matrix vertical position.</param>
-        /// <value>The matrix element.</value>
-        public real_t this[int column, int row]
-        {
-            readonly get
-            {
-                return this[column][row];
-            }
-            set
-            {
-                Vector3 columnVector = this[column];
-                columnVector[row] = value;
-                this[column] = columnVector;
-            }
-        }
-
-        internal void SetQuaternionScale(Quaternion quaternion, Vector3 scale)
-        {
-            SetDiagonal(scale);
-            Rotate(quaternion);
-        }
-
-        private void Rotate(Quaternion quaternion)
-        {
-            this *= new Basis(quaternion);
-        }
-
-        private void SetDiagonal(Vector3 diagonal)
-        {
-            Row0 = new Vector3(diagonal.X, 0, 0);
-            Row1 = new Vector3(0, diagonal.Y, 0);
-            Row2 = new Vector3(0, 0, diagonal.Z);
-        }
-
-        /// <summary>
-        /// Returns the determinant of the basis matrix. If the basis is
-        /// uniformly scaled, its determinant is the square of the scale.
-        ///
-        /// A negative determinant means the basis has a negative scale.
-        /// A zero determinant means the basis isn't invertible,
-        /// and is usually considered invalid.
-        /// </summary>
-        /// <returns>The determinant of the basis matrix.</returns>
-        public readonly real_t Determinant()
-        {
-            real_t cofac00 = Row1[1] * Row2[2] - Row1[2] * Row2[1];
-            real_t cofac10 = Row1[2] * Row2[0] - Row1[0] * Row2[2];
-            real_t cofac20 = Row1[0] * Row2[1] - Row1[1] * Row2[0];
-
-            return Row0[0] * cofac00 + Row0[1] * cofac10 + Row0[2] * cofac20;
-        }
-
-        /// <summary>
-        /// Returns the basis's rotation in the form of Euler angles.
-        /// The Euler order depends on the [param order] parameter,
-        /// by default it uses the YXZ convention: when decomposing,
-        /// first Z, then X, and Y last. The returned vector contains
-        /// the rotation angles in the format (X angle, Y angle, Z angle).
-        ///
-        /// Consider using the <see cref="GetRotationQuaternion"/> method instead, which
-        /// returns a <see cref="Quaternion"/> quaternion instead of Euler angles.
-        /// </summary>
-        /// <param name="order">The Euler order to use. By default, use YXZ order (most common).</param>
-        /// <returns>A <see cref="Vector3"/> representing the basis rotation in Euler angles.</returns>
-        public readonly Vector3 GetEuler(EulerOrder order = EulerOrder.Yxz)
-        {
-            switch (order)
-            {
-                case EulerOrder.Xyz:
-                {
-                    // Euler angles in XYZ convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cy*cz          -cy*sz           sy
-                    //        cz*sx*sy+cx*sz  cx*cz-sx*sy*sz -cy*sx
-                    //       -cx*cz*sy+sx*sz  cz*sx+cx*sy*sz  cx*cy
-                    Vector3 euler;
-                    real_t sy = Row0[2];
-                    if (sy < (1.0f - Mathf.Epsilon))
+                    if (sy > -(1.0f - Mathf.Epsilon))
                     {
-                        if (sy > -(1.0f - Mathf.Epsilon))
+                        // is this a pure Y rotation?
+                        if (Row1[0] == 0 && Row0[1] == 0 && Row1[2] == 0 && Row2[1] == 0 && Row1[1] == 1)
                         {
-                            // is this a pure Y rotation?
-                            if (Row1[0] == 0 && Row0[1] == 0 && Row1[2] == 0 && Row2[1] == 0 && Row1[1] == 1)
-                            {
-                                // return the simplest form (human friendlier in editor and scripts)
-                                euler.X = 0;
-                                euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
-                                euler.Z = 0;
-                            }
-                            else
-                            {
-                                euler.X = Mathf.Atan2(-Row1[2], Row2[2]);
-                                euler.Y = Mathf.Asin(sy);
-                                euler.Z = Mathf.Atan2(-Row0[1], Row0[0]);
-                            }
+                            // return the simplest form (human friendlier in editor and scripts)
+                            euler.X = 0;
+                            euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
+                            euler.Z = 0;
                         }
                         else
                         {
-                            euler.X = Mathf.Atan2(Row2[1], Row1[1]);
-                            euler.Y = -Mathf.Tau / 4.0f;
-                            euler.Z = 0.0f;
+                            euler.X = Mathf.Atan2(-Row1[2], Row2[2]);
+                            euler.Y = Mathf.Asin(sy);
+                            euler.Z = Mathf.Atan2(-Row0[1], Row0[0]);
                         }
                     }
                     else
                     {
                         euler.X = Mathf.Atan2(Row2[1], Row1[1]);
-                        euler.Y = Mathf.Tau / 4.0f;
+                        euler.Y = -Mathf.Tau / 4.0f;
                         euler.Z = 0.0f;
                     }
-                    return euler;
                 }
-                case EulerOrder.Xzy:
+                else
                 {
-                    // Euler angles in XZY convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cz*cy             -sz             cz*sy
-                    //        sx*sy+cx*cy*sz    cx*cz           cx*sz*sy-cy*sx
-                    //        cy*sx*sz          cz*sx           cx*cy+sx*sz*sy
-                    Vector3 euler;
-                    real_t sz = Row0[1];
-                    if (sz < (1.0f - Mathf.Epsilon))
+                    euler.X = Mathf.Atan2(Row2[1], Row1[1]);
+                    euler.Y = Mathf.Tau / 4.0f;
+                    euler.Z = 0.0f;
+                }
+                return euler;
+            }
+            case EulerOrder.Xzy:
+            {
+                // Euler angles in XZY convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy             -sz             cz*sy
+                //        sx*sy+cx*cy*sz    cx*cz           cx*sz*sy-cy*sx
+                //        cy*sx*sz          cz*sx           cx*cy+sx*sz*sy
+                Vector3 euler;
+                real_t sz = Row0[1];
+                if (sz < (1.0f - Mathf.Epsilon))
+                {
+                    if (sz > -(1.0f - Mathf.Epsilon))
                     {
-                        if (sz > -(1.0f - Mathf.Epsilon))
-                        {
-                            euler.X = Mathf.Atan2(Row2[1], Row1[1]);
-                            euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
-                            euler.Z = Mathf.Asin(-sz);
-                        }
-                        else
-                        {
-                            // It's -1
-                            euler.X = -Mathf.Atan2(Row1[2], Row2[2]);
-                            euler.Y = 0.0f;
-                            euler.Z = Mathf.Tau / 4.0f;
-                        }
+                        euler.X = Mathf.Atan2(Row2[1], Row1[1]);
+                        euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
+                        euler.Z = Mathf.Asin(-sz);
                     }
                     else
                     {
-                        // It's 1
+                        // It's -1
                         euler.X = -Mathf.Atan2(Row1[2], Row2[2]);
-                        euler.Y = 0.0f;
-                        euler.Z = -Mathf.Tau / 4.0f;
-                    }
-                    return euler;
-                }
-                case EulerOrder.Yxz:
-                {
-                    // Euler angles in YXZ convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cy*cz+sy*sx*sz    cz*sy*sx-cy*sz        cx*sy
-                    //        cx*sz             cx*cz                 -sx
-                    //        cy*sx*sz-cz*sy    cy*cz*sx+sy*sz        cy*cx
-                    Vector3 euler;
-                    real_t m12 = Row1[2];
-                    if (m12 < (1 - Mathf.Epsilon))
-                    {
-                        if (m12 > -(1 - Mathf.Epsilon))
-                        {
-                            // is this a pure X rotation?
-                            if (Row1[0] == 0 && Row0[1] == 0 && Row0[2] == 0 && Row2[0] == 0 && Row0[0] == 1)
-                            {
-                                // return the simplest form (human friendlier in editor and scripts)
-                                euler.X = Mathf.Atan2(-m12, Row1[1]);
-                                euler.Y = 0;
-                                euler.Z = 0;
-                            }
-                            else
-                            {
-                                euler.X = Mathf.Asin(-m12);
-                                euler.Y = Mathf.Atan2(Row0[2], Row2[2]);
-                                euler.Z = Mathf.Atan2(Row1[0], Row1[1]);
-                            }
-                        }
-                        else
-                        { // m12 == -1
-                            euler.X = Mathf.Tau / 4.0f;
-                            euler.Y = Mathf.Atan2(Row0[1], Row0[0]);
-                            euler.Z = 0;
-                        }
-                    }
-                    else
-                    { // m12 == 1
-                        euler.X = -Mathf.Tau / 4.0f;
-                        euler.Y = -Mathf.Atan2(Row0[1], Row0[0]);
-                        euler.Z = 0;
-                    }
-
-                    return euler;
-                }
-                case EulerOrder.Yzx:
-                {
-                    // Euler angles in YZX convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cy*cz             sy*sx-cy*cx*sz     cx*sy+cy*sz*sx
-                    //        sz                cz*cx              -cz*sx
-                    //        -cz*sy            cy*sx+cx*sy*sz     cy*cx-sy*sz*sx
-                    Vector3 euler;
-                    real_t sz = Row1[0];
-                    if (sz < (1.0f - Mathf.Epsilon))
-                    {
-                        if (sz > -(1.0f - Mathf.Epsilon))
-                        {
-                            euler.X = Mathf.Atan2(-Row1[2], Row1[1]);
-                            euler.Y = Mathf.Atan2(-Row2[0], Row0[0]);
-                            euler.Z = Mathf.Asin(sz);
-                        }
-                        else
-                        {
-                            // It's -1
-                            euler.X = Mathf.Atan2(Row2[1], Row2[2]);
-                            euler.Y = 0.0f;
-                            euler.Z = -Mathf.Tau / 4.0f;
-                        }
-                    }
-                    else
-                    {
-                        // It's 1
-                        euler.X = Mathf.Atan2(Row2[1], Row2[2]);
                         euler.Y = 0.0f;
                         euler.Z = Mathf.Tau / 4.0f;
                     }
-                    return euler;
                 }
-                case EulerOrder.Zxy:
+                else
                 {
-                    // Euler angles in ZXY convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cz*cy-sz*sx*sy    -cx*sz                cz*sy+cy*sz*sx
-                    //        cy*sz+cz*sx*sy    cz*cx                 sz*sy-cz*cy*sx
-                    //        -cx*sy            sx                    cx*cy
-                    Vector3 euler;
-                    real_t sx = Row2[1];
-                    if (sx < (1.0f - Mathf.Epsilon))
+                    // It's 1
+                    euler.X = -Mathf.Atan2(Row1[2], Row2[2]);
+                    euler.Y = 0.0f;
+                    euler.Z = -Mathf.Tau / 4.0f;
+                }
+                return euler;
+            }
+            case EulerOrder.Yxz:
+            {
+                // Euler angles in YXZ convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz+sy*sx*sz    cz*sy*sx-cy*sz        cx*sy
+                //        cx*sz             cx*cz                 -sx
+                //        cy*sx*sz-cz*sy    cy*cz*sx+sy*sz        cy*cx
+                Vector3 euler;
+                real_t m12 = Row1[2];
+                if (m12 < (1 - Mathf.Epsilon))
+                {
+                    if (m12 > -(1 - Mathf.Epsilon))
                     {
-                        if (sx > -(1.0f - Mathf.Epsilon))
+                        // is this a pure X rotation?
+                        if (Row1[0] == 0 && Row0[1] == 0 && Row0[2] == 0 && Row2[0] == 0 && Row0[0] == 1)
                         {
-                            euler.X = Mathf.Asin(sx);
-                            euler.Y = Mathf.Atan2(-Row2[0], Row2[2]);
-                            euler.Z = Mathf.Atan2(-Row0[1], Row1[1]);
+                            // return the simplest form (human friendlier in editor and scripts)
+                            euler.X = Mathf.Atan2(-m12, Row1[1]);
+                            euler.Y = 0;
+                            euler.Z = 0;
                         }
                         else
                         {
-                            // It's -1
-                            euler.X = -Mathf.Tau / 4.0f;
-                            euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
-                            euler.Z = 0;
+                            euler.X = Mathf.Asin(-m12);
+                            euler.Y = Mathf.Atan2(Row0[2], Row2[2]);
+                            euler.Z = Mathf.Atan2(Row1[0], Row1[1]);
                         }
                     }
                     else
-                    {
-                        // It's 1
+                    { // m12 == -1
                         euler.X = Mathf.Tau / 4.0f;
+                        euler.Y = Mathf.Atan2(Row0[1], Row0[0]);
+                        euler.Z = 0;
+                    }
+                }
+                else
+                { // m12 == 1
+                    euler.X = -Mathf.Tau / 4.0f;
+                    euler.Y = -Mathf.Atan2(Row0[1], Row0[0]);
+                    euler.Z = 0;
+                }
+
+                return euler;
+            }
+            case EulerOrder.Yzx:
+            {
+                // Euler angles in YZX convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cy*cz             sy*sx-cy*cx*sz     cx*sy+cy*sz*sx
+                //        sz                cz*cx              -cz*sx
+                //        -cz*sy            cy*sx+cx*sy*sz     cy*cx-sy*sz*sx
+                Vector3 euler;
+                real_t sz = Row1[0];
+                if (sz < (1.0f - Mathf.Epsilon))
+                {
+                    if (sz > -(1.0f - Mathf.Epsilon))
+                    {
+                        euler.X = Mathf.Atan2(-Row1[2], Row1[1]);
+                        euler.Y = Mathf.Atan2(-Row2[0], Row0[0]);
+                        euler.Z = Mathf.Asin(sz);
+                    }
+                    else
+                    {
+                        // It's -1
+                        euler.X = Mathf.Atan2(Row2[1], Row2[2]);
+                        euler.Y = 0.0f;
+                        euler.Z = -Mathf.Tau / 4.0f;
+                    }
+                }
+                else
+                {
+                    // It's 1
+                    euler.X = Mathf.Atan2(Row2[1], Row2[2]);
+                    euler.Y = 0.0f;
+                    euler.Z = Mathf.Tau / 4.0f;
+                }
+                return euler;
+            }
+            case EulerOrder.Zxy:
+            {
+                // Euler angles in ZXY convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy-sz*sx*sy    -cx*sz                cz*sy+cy*sz*sx
+                //        cy*sz+cz*sx*sy    cz*cx                 sz*sy-cz*cy*sx
+                //        -cx*sy            sx                    cx*cy
+                Vector3 euler;
+                real_t sx = Row2[1];
+                if (sx < (1.0f - Mathf.Epsilon))
+                {
+                    if (sx > -(1.0f - Mathf.Epsilon))
+                    {
+                        euler.X = Mathf.Asin(sx);
+                        euler.Y = Mathf.Atan2(-Row2[0], Row2[2]);
+                        euler.Z = Mathf.Atan2(-Row0[1], Row1[1]);
+                    }
+                    else
+                    {
+                        // It's -1
+                        euler.X = -Mathf.Tau / 4.0f;
                         euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
                         euler.Z = 0;
                     }
-                    return euler;
                 }
-                case EulerOrder.Zyx:
+                else
                 {
-                    // Euler angles in ZYX convention.
-                    // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-                    //
-                    // rot =  cz*cy             cz*sy*sx-cx*sz        sz*sx+cz*cx*cy
-                    //        cy*sz             cz*cx+sz*sy*sx        cx*sz*sy-cz*sx
-                    //        -sy               cy*sx                 cy*cx
-                    Vector3 euler;
-                    real_t sy = Row2[0];
-                    if (sy < (1.0f - Mathf.Epsilon))
+                    // It's 1
+                    euler.X = Mathf.Tau / 4.0f;
+                    euler.Y = Mathf.Atan2(Row0[2], Row0[0]);
+                    euler.Z = 0;
+                }
+                return euler;
+            }
+            case EulerOrder.Zyx:
+            {
+                // Euler angles in ZYX convention.
+                // See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
+                //
+                // rot =  cz*cy             cz*sy*sx-cx*sz        sz*sx+cz*cx*cy
+                //        cy*sz             cz*cx+sz*sy*sx        cx*sz*sy-cz*sx
+                //        -sy               cy*sx                 cy*cx
+                Vector3 euler;
+                real_t sy = Row2[0];
+                if (sy < (1.0f - Mathf.Epsilon))
+                {
+                    if (sy > -(1.0f - Mathf.Epsilon))
                     {
-                        if (sy > -(1.0f - Mathf.Epsilon))
-                        {
-                            euler.X = Mathf.Atan2(Row2[1], Row2[2]);
-                            euler.Y = Mathf.Asin(-sy);
-                            euler.Z = Mathf.Atan2(Row1[0], Row0[0]);
-                        }
-                        else
-                        {
-                            // It's -1
-                            euler.X = 0;
-                            euler.Y = Mathf.Tau / 4.0f;
-                            euler.Z = -Mathf.Atan2(Row0[1], Row1[1]);
-                        }
+                        euler.X = Mathf.Atan2(Row2[1], Row2[2]);
+                        euler.Y = Mathf.Asin(-sy);
+                        euler.Z = Mathf.Atan2(Row1[0], Row0[0]);
                     }
                     else
                     {
-                        // It's 1
+                        // It's -1
                         euler.X = 0;
-                        euler.Y = -Mathf.Tau / 4.0f;
+                        euler.Y = Mathf.Tau / 4.0f;
                         euler.Z = -Mathf.Atan2(Row0[1], Row1[1]);
                     }
-                    return euler;
                 }
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(order));
+                else
+                {
+                    // It's 1
+                    euler.X = 0;
+                    euler.Y = -Mathf.Tau / 4.0f;
+                    euler.Z = -Mathf.Atan2(Row0[1], Row1[1]);
+                }
+                return euler;
             }
+            default:
+                throw new ArgumentOutOfRangeException(nameof(order));
         }
+    }
 
-        internal readonly Quaternion GetQuaternion()
+    internal readonly Quaternion GetQuaternion()
+    {
+        real_t trace = Row0[0] + Row1[1] + Row2[2];
+
+        if (trace > 0.0f)
         {
-            real_t trace = Row0[0] + Row1[1] + Row2[2];
-
-            if (trace > 0.0f)
-            {
-                real_t s = Mathf.Sqrt(trace + 1.0f) * 2f;
-                real_t inv_s = 1f / s;
-                return new Quaternion(
-                    (Row2[1] - Row1[2]) * inv_s,
-                    (Row0[2] - Row2[0]) * inv_s,
-                    (Row1[0] - Row0[1]) * inv_s,
-                    s * 0.25f
-                );
-            }
-
-            if (Row0[0] > Row1[1] && Row0[0] > Row2[2])
-            {
-                real_t s = Mathf.Sqrt(Row0[0] - Row1[1] - Row2[2] + 1.0f) * 2f;
-                real_t inv_s = 1f / s;
-                return new Quaternion(
-                    s * 0.25f,
-                    (Row0[1] + Row1[0]) * inv_s,
-                    (Row0[2] + Row2[0]) * inv_s,
-                    (Row2[1] - Row1[2]) * inv_s
-                );
-            }
-
-            if (Row1[1] > Row2[2])
-            {
-                real_t s = Mathf.Sqrt(-Row0[0] + Row1[1] - Row2[2] + 1.0f) * 2f;
-                real_t inv_s = 1f / s;
-                return new Quaternion(
-                    (Row0[1] + Row1[0]) * inv_s,
-                    s * 0.25f,
-                    (Row1[2] + Row2[1]) * inv_s,
-                    (Row0[2] - Row2[0]) * inv_s
-                );
-            }
-            else
-            {
-                real_t s = Mathf.Sqrt(-Row0[0] - Row1[1] + Row2[2] + 1.0f) * 2f;
-                real_t inv_s = 1f / s;
-                return new Quaternion(
-                    (Row0[2] + Row2[0]) * inv_s,
-                    (Row1[2] + Row2[1]) * inv_s,
-                    s * 0.25f,
-                    (Row1[0] - Row0[1]) * inv_s
-                );
-            }
-        }
-
-        /// <summary>
-        /// Returns the <see cref="Basis"/>'s rotation in the form of a
-        /// <see cref="Quaternion"/>. See <see cref="GetEuler"/> if you
-        /// need Euler angles, but keep in mind quaternions should generally
-        /// be preferred to Euler angles.
-        /// </summary>
-        /// <returns>The basis rotation.</returns>
-        public readonly Quaternion GetRotationQuaternion()
-        {
-            Basis orthonormalizedBasis = Orthonormalized();
-            real_t det = orthonormalizedBasis.Determinant();
-            if (det < 0)
-            {
-                // Ensure that the determinant is 1, such that result is a proper
-                // rotation matrix which can be represented by Euler angles.
-                orthonormalizedBasis = orthonormalizedBasis.Scaled(-Vector3.One);
-            }
-
-            return orthonormalizedBasis.GetQuaternion();
-        }
-
-        /// <summary>
-        /// Returns the inverse of the matrix.
-        /// </summary>
-        /// <returns>The inverse matrix.</returns>
-        public readonly Basis Inverse()
-        {
-            real_t cofac00 = Row1[1] * Row2[2] - Row1[2] * Row2[1];
-            real_t cofac10 = Row1[2] * Row2[0] - Row1[0] * Row2[2];
-            real_t cofac20 = Row1[0] * Row2[1] - Row1[1] * Row2[0];
-
-            real_t det = Row0[0] * cofac00 + Row0[1] * cofac10 + Row0[2] * cofac20;
-
-            if (det == 0)
-            {
-                throw new InvalidOperationException("Matrix determinant is zero and cannot be inverted.");
-            }
-
-            real_t detInv = 1.0f / det;
-
-            real_t cofac01 = Row0[2] * Row2[1] - Row0[1] * Row2[2];
-            real_t cofac02 = Row0[1] * Row1[2] - Row0[2] * Row1[1];
-            real_t cofac11 = Row0[0] * Row2[2] - Row0[2] * Row2[0];
-            real_t cofac12 = Row0[2] * Row1[0] - Row0[0] * Row1[2];
-            real_t cofac21 = Row0[1] * Row2[0] - Row0[0] * Row2[1];
-            real_t cofac22 = Row0[0] * Row1[1] - Row0[1] * Row1[0];
-
-            return new Basis
-            (
-                cofac00 * detInv, cofac01 * detInv, cofac02 * detInv,
-                cofac10 * detInv, cofac11 * detInv, cofac12 * detInv,
-                cofac20 * detInv, cofac21 * detInv, cofac22 * detInv
+            real_t s = Mathf.Sqrt(trace + 1.0f) * 2f;
+            real_t inv_s = 1f / s;
+            return new Quaternion(
+                (Row2[1] - Row1[2]) * inv_s,
+                (Row0[2] - Row2[0]) * inv_s,
+                (Row1[0] - Row0[1]) * inv_s,
+                s * 0.25f
             );
         }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this basis is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
+        if (Row0[0] > Row1[1] && Row0[0] > Row2[2])
         {
-            return Row0.IsFinite() && Row1.IsFinite() && Row2.IsFinite();
+            real_t s = Mathf.Sqrt(Row0[0] - Row1[1] - Row2[2] + 1.0f) * 2f;
+            real_t inv_s = 1f / s;
+            return new Quaternion(
+                s * 0.25f,
+                (Row0[1] + Row1[0]) * inv_s,
+                (Row0[2] + Row2[0]) * inv_s,
+                (Row2[1] - Row1[2]) * inv_s
+            );
         }
 
-        internal readonly Basis Lerp(Basis to, real_t weight)
+        if (Row1[1] > Row2[2])
         {
-            Basis b = this;
-            b.Row0 = Row0.Lerp(to.Row0, weight);
-            b.Row1 = Row1.Lerp(to.Row1, weight);
-            b.Row2 = Row2.Lerp(to.Row2, weight);
-            return b;
+            real_t s = Mathf.Sqrt(-Row0[0] + Row1[1] - Row2[2] + 1.0f) * 2f;
+            real_t inv_s = 1f / s;
+            return new Quaternion(
+                (Row0[1] + Row1[0]) * inv_s,
+                s * 0.25f,
+                (Row1[2] + Row2[1]) * inv_s,
+                (Row0[2] - Row2[0]) * inv_s
+            );
+        }
+        else
+        {
+            real_t s = Mathf.Sqrt(-Row0[0] - Row1[1] + Row2[2] + 1.0f) * 2f;
+            real_t inv_s = 1f / s;
+            return new Quaternion(
+                (Row0[2] + Row2[0]) * inv_s,
+                (Row1[2] + Row2[1]) * inv_s,
+                s * 0.25f,
+                (Row1[0] - Row0[1]) * inv_s
+            );
+        }
+    }
+
+    /// <summary>
+    /// Returns the <see cref="Basis"/>'s rotation in the form of a
+    /// <see cref="Quaternion"/>. See <see cref="GetEuler"/> if you
+    /// need Euler angles, but keep in mind quaternions should generally
+    /// be preferred to Euler angles.
+    /// </summary>
+    /// <returns>The basis rotation.</returns>
+    public readonly Quaternion GetRotationQuaternion()
+    {
+        Basis orthonormalizedBasis = Orthonormalized();
+        real_t det = orthonormalizedBasis.Determinant();
+        if (det < 0)
+        {
+            // Ensure that the determinant is 1, such that result is a proper
+            // rotation matrix which can be represented by Euler angles.
+            orthonormalizedBasis = orthonormalizedBasis.Scaled(-Vector3.One);
         }
 
-        /// <summary>
-        /// Creates a <see cref="Basis"/> with a rotation such that the forward
-        /// axis (-Z) points towards the <paramref name="target"/> position.
-        /// The up axis (+Y) points as close to the <paramref name="up"/> vector
-        /// as possible while staying perpendicular to the forward axis.
-        /// The resulting Basis is orthonormalized.
-        /// The <paramref name="target"/> and <paramref name="up"/> vectors
-        /// cannot be zero, and cannot be parallel to each other.
-        /// </summary>
-        /// <param name="target">The position to look at.</param>
-        /// <param name="up">The relative up direction.</param>
-        /// <param name="useModelFront">
-        /// If true, then the model is oriented in reverse,
-        /// towards the model front axis (+Z, Vector3.ModelFront),
-        /// which is more useful for orienting 3D models.
-        /// </param>
-        /// <returns>The resulting basis matrix.</returns>
-        public static Basis LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
+        return orthonormalizedBasis.GetQuaternion();
+    }
+
+    /// <summary>
+    /// Returns the inverse of the matrix.
+    /// </summary>
+    /// <returns>The inverse matrix.</returns>
+    public readonly Basis Inverse()
+    {
+        real_t cofac00 = Row1[1] * Row2[2] - Row1[2] * Row2[1];
+        real_t cofac10 = Row1[2] * Row2[0] - Row1[0] * Row2[2];
+        real_t cofac20 = Row1[0] * Row2[1] - Row1[1] * Row2[0];
+
+        real_t det = Row0[0] * cofac00 + Row0[1] * cofac10 + Row0[2] * cofac20;
+
+        if (det == 0)
         {
-            up ??= Vector3.Up;
+            throw new InvalidOperationException("Matrix determinant is zero and cannot be inverted.");
+        }
+
+        real_t detInv = 1.0f / det;
+
+        real_t cofac01 = Row0[2] * Row2[1] - Row0[1] * Row2[2];
+        real_t cofac02 = Row0[1] * Row1[2] - Row0[2] * Row1[1];
+        real_t cofac11 = Row0[0] * Row2[2] - Row0[2] * Row2[0];
+        real_t cofac12 = Row0[2] * Row1[0] - Row0[0] * Row1[2];
+        real_t cofac21 = Row0[1] * Row2[0] - Row0[0] * Row2[1];
+        real_t cofac22 = Row0[0] * Row1[1] - Row0[1] * Row1[0];
+
+        return new Basis
+        (
+            cofac00 * detInv, cofac01 * detInv, cofac02 * detInv,
+            cofac10 * detInv, cofac11 * detInv, cofac12 * detInv,
+            cofac20 * detInv, cofac21 * detInv, cofac22 * detInv
+        );
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this basis is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Row0.IsFinite() && Row1.IsFinite() && Row2.IsFinite();
+    }
+
+    internal readonly Basis Lerp(Basis to, real_t weight)
+    {
+        Basis b = this;
+        b.Row0 = Row0.Lerp(to.Row0, weight);
+        b.Row1 = Row1.Lerp(to.Row1, weight);
+        b.Row2 = Row2.Lerp(to.Row2, weight);
+        return b;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Basis"/> with a rotation such that the forward
+    /// axis (-Z) points towards the <paramref name="target"/> position.
+    /// The up axis (+Y) points as close to the <paramref name="up"/> vector
+    /// as possible while staying perpendicular to the forward axis.
+    /// The resulting Basis is orthonormalized.
+    /// The <paramref name="target"/> and <paramref name="up"/> vectors
+    /// cannot be zero, and cannot be parallel to each other.
+    /// </summary>
+    /// <param name="target">The position to look at.</param>
+    /// <param name="up">The relative up direction.</param>
+    /// <param name="useModelFront">
+    /// If true, then the model is oriented in reverse,
+    /// towards the model front axis (+Z, Vector3.ModelFront),
+    /// which is more useful for orienting 3D models.
+    /// </param>
+    /// <returns>The resulting basis matrix.</returns>
+    public static Basis LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
+    {
+        up ??= Vector3.Up;
 #if DEBUG
-            if (target.IsZeroApprox())
-            {
-                throw new ArgumentException("The vector can't be zero.", nameof(target));
-            }
-            if (up.Value.IsZeroApprox())
-            {
-                throw new ArgumentException("The vector can't be zero.", nameof(up));
-            }
+        if (target.IsZeroApprox())
+        {
+            throw new ArgumentException("The vector can't be zero.", nameof(target));
+        }
+        if (up.Value.IsZeroApprox())
+        {
+            throw new ArgumentException("The vector can't be zero.", nameof(up));
+        }
 #endif
-            Vector3 column2 = target.Normalized();
-            if (!useModelFront)
-            {
-                column2 = -column2;
-            }
-            Vector3 column0 = up.Value.Cross(column2);
+        Vector3 column2 = target.Normalized();
+        if (!useModelFront)
+        {
+            column2 = -column2;
+        }
+        Vector3 column0 = up.Value.Cross(column2);
 #if DEBUG
-            if (column0.IsZeroApprox())
-            {
-                throw new ArgumentException("The target vector and up vector can't be parallel to each other.");
-            }
+        if (column0.IsZeroApprox())
+        {
+            throw new ArgumentException("The target vector and up vector can't be parallel to each other.");
+        }
 #endif
-            column0.Normalize();
-            Vector3 column1 = column2.Cross(column0);
-            return new Basis(column0, column1, column2);
-        }
+        column0.Normalize();
+        Vector3 column1 = column2.Cross(column0);
+        return new Basis(column0, column1, column2);
+    }
 
-        /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Basis LookingAt(Vector3 target, Vector3 up)
-        {
-            return LookingAt(target, up, false);
-        }
+    /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static Basis LookingAt(Vector3 target, Vector3 up)
+    {
+        return LookingAt(target, up, false);
+    }
 
-        /// <summary>
-        /// Returns the orthonormalized version of the basis matrix (useful to
-        /// call occasionally to avoid rounding errors for orthogonal matrices).
-        /// This performs a Gram-Schmidt orthonormalization on the basis of the matrix.
-        /// </summary>
-        /// <returns>An orthonormalized basis matrix.</returns>
-        public readonly Basis Orthonormalized()
-        {
-            Vector3 column0 = this[0];
-            Vector3 column1 = this[1];
-            Vector3 column2 = this[2];
+    /// <summary>
+    /// Returns the orthonormalized version of the basis matrix (useful to
+    /// call occasionally to avoid rounding errors for orthogonal matrices).
+    /// This performs a Gram-Schmidt orthonormalization on the basis of the matrix.
+    /// </summary>
+    /// <returns>An orthonormalized basis matrix.</returns>
+    public readonly Basis Orthonormalized()
+    {
+        Vector3 column0 = this[0];
+        Vector3 column1 = this[1];
+        Vector3 column2 = this[2];
 
-            column0.Normalize();
-            column1 = column1 - column0 * column0.Dot(column1);
-            column1.Normalize();
-            column2 = column2 - column0 * column0.Dot(column2) - column1 * column1.Dot(column2);
-            column2.Normalize();
+        column0.Normalize();
+        column1 = column1 - column0 * column0.Dot(column1);
+        column1.Normalize();
+        column2 = column2 - column0 * column0.Dot(column2) - column1 * column1.Dot(column2);
+        column2.Normalize();
 
-            return new Basis(column0, column1, column2);
-        }
+        return new Basis(column0, column1, column2);
+    }
 
-        /// <summary>
-        /// Introduce an additional rotation around the given <paramref name="axis"/>
-        /// by <paramref name="angle"/> (in radians). The axis must be a normalized vector.
-        /// </summary>
-        /// <param name="axis">The axis to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        /// <returns>The rotated basis matrix.</returns>
-        public readonly Basis Rotated(Vector3 axis, real_t angle)
-        {
-            return new Basis(axis, angle) * this;
-        }
+    /// <summary>
+    /// Introduce an additional rotation around the given <paramref name="axis"/>
+    /// by <paramref name="angle"/> (in radians). The axis must be a normalized vector.
+    /// </summary>
+    /// <param name="axis">The axis to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    /// <returns>The rotated basis matrix.</returns>
+    public readonly Basis Rotated(Vector3 axis, real_t angle)
+    {
+        return new Basis(axis, angle) * this;
+    }
 
-        /// <summary>
-        /// Introduce an additional scaling specified by the given 3D scaling factor.
-        /// </summary>
-        /// <param name="scale">The scale to introduce.</param>
-        /// <returns>The scaled basis matrix.</returns>
-        public readonly Basis Scaled(Vector3 scale)
-        {
-            Basis b = this;
-            b.Row0 *= scale.X;
-            b.Row1 *= scale.Y;
-            b.Row2 *= scale.Z;
-            return b;
-        }
+    /// <summary>
+    /// Introduce an additional scaling specified by the given 3D scaling factor.
+    /// </summary>
+    /// <param name="scale">The scale to introduce.</param>
+    /// <returns>The scaled basis matrix.</returns>
+    public readonly Basis Scaled(Vector3 scale)
+    {
+        Basis b = this;
+        b.Row0 *= scale.X;
+        b.Row1 *= scale.Y;
+        b.Row2 *= scale.Z;
+        return b;
+    }
 
-        /// <summary>
-        /// Assuming that the matrix is a proper rotation matrix, slerp performs
-        /// a spherical-linear interpolation with another rotation matrix.
-        /// </summary>
-        /// <param name="target">The destination basis for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting basis matrix of the interpolation.</returns>
-        public readonly Basis Slerp(Basis target, real_t weight)
-        {
-            Quaternion from = new Quaternion(this);
-            Quaternion to = new Quaternion(target);
+    /// <summary>
+    /// Assuming that the matrix is a proper rotation matrix, slerp performs
+    /// a spherical-linear interpolation with another rotation matrix.
+    /// </summary>
+    /// <param name="target">The destination basis for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting basis matrix of the interpolation.</returns>
+    public readonly Basis Slerp(Basis target, real_t weight)
+    {
+        Quaternion from = new Quaternion(this);
+        Quaternion to = new Quaternion(target);
 
-            Basis b = new Basis(from.Slerp(to, weight));
-            b.Row0 *= Mathf.Lerp(Row0.Length(), target.Row0.Length(), weight);
-            b.Row1 *= Mathf.Lerp(Row1.Length(), target.Row1.Length(), weight);
-            b.Row2 *= Mathf.Lerp(Row2.Length(), target.Row2.Length(), weight);
+        Basis b = new Basis(from.Slerp(to, weight));
+        b.Row0 *= Mathf.Lerp(Row0.Length(), target.Row0.Length(), weight);
+        b.Row1 *= Mathf.Lerp(Row1.Length(), target.Row1.Length(), weight);
+        b.Row2 *= Mathf.Lerp(Row2.Length(), target.Row2.Length(), weight);
 
-            return b;
-        }
+        return b;
+    }
 
-        /// <summary>
-        /// Transposed dot product with the X axis of the matrix.
-        /// </summary>
-        /// <param name="with">A vector to calculate the dot product with.</param>
-        /// <returns>The resulting dot product.</returns>
-        public readonly real_t Tdotx(Vector3 with)
-        {
-            return Row0[0] * with[0] + Row1[0] * with[1] + Row2[0] * with[2];
-        }
+    /// <summary>
+    /// Transposed dot product with the X axis of the matrix.
+    /// </summary>
+    /// <param name="with">A vector to calculate the dot product with.</param>
+    /// <returns>The resulting dot product.</returns>
+    public readonly real_t Tdotx(Vector3 with)
+    {
+        return Row0[0] * with[0] + Row1[0] * with[1] + Row2[0] * with[2];
+    }
 
-        /// <summary>
-        /// Transposed dot product with the Y axis of the matrix.
-        /// </summary>
-        /// <param name="with">A vector to calculate the dot product with.</param>
-        /// <returns>The resulting dot product.</returns>
-        public readonly real_t Tdoty(Vector3 with)
-        {
-            return Row0[1] * with[0] + Row1[1] * with[1] + Row2[1] * with[2];
-        }
+    /// <summary>
+    /// Transposed dot product with the Y axis of the matrix.
+    /// </summary>
+    /// <param name="with">A vector to calculate the dot product with.</param>
+    /// <returns>The resulting dot product.</returns>
+    public readonly real_t Tdoty(Vector3 with)
+    {
+        return Row0[1] * with[0] + Row1[1] * with[1] + Row2[1] * with[2];
+    }
 
-        /// <summary>
-        /// Transposed dot product with the Z axis of the matrix.
-        /// </summary>
-        /// <param name="with">A vector to calculate the dot product with.</param>
-        /// <returns>The resulting dot product.</returns>
-        public readonly real_t Tdotz(Vector3 with)
-        {
-            return Row0[2] * with[0] + Row1[2] * with[1] + Row2[2] * with[2];
-        }
+    /// <summary>
+    /// Transposed dot product with the Z axis of the matrix.
+    /// </summary>
+    /// <param name="with">A vector to calculate the dot product with.</param>
+    /// <returns>The resulting dot product.</returns>
+    public readonly real_t Tdotz(Vector3 with)
+    {
+        return Row0[2] * with[0] + Row1[2] * with[1] + Row2[2] * with[2];
+    }
 
-        /// <summary>
-        /// Returns the transposed version of the basis matrix.
-        /// </summary>
-        /// <returns>The transposed basis matrix.</returns>
-        public readonly Basis Transposed()
-        {
-            Basis tr = this;
+    /// <summary>
+    /// Returns the transposed version of the basis matrix.
+    /// </summary>
+    /// <returns>The transposed basis matrix.</returns>
+    public readonly Basis Transposed()
+    {
+        Basis tr = this;
 
-            tr.Row0[1] = Row1[0];
-            tr.Row1[0] = Row0[1];
+        tr.Row0[1] = Row1[0];
+        tr.Row1[0] = Row0[1];
 
-            tr.Row0[2] = Row2[0];
-            tr.Row2[0] = Row0[2];
+        tr.Row0[2] = Row2[0];
+        tr.Row2[0] = Row0[2];
 
-            tr.Row1[2] = Row2[1];
-            tr.Row2[1] = Row1[2];
+        tr.Row1[2] = Row2[1];
+        tr.Row2[1] = Row1[2];
 
-            return tr;
-        }
+        return tr;
+    }
 
-        private static readonly Basis[] _orthoBases = {
+    private static readonly Basis[] _orthoBases = {
             new Basis(1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f),
             new Basis(0f, -1f, 0f, 1f, 0f, 0f, 0f, 0f, 1f),
             new Basis(-1f, 0f, 0f, 0f, -1f, 0f, 0f, 0f, 1f),
@@ -811,337 +811,336 @@ namespace Godot
             new Basis(0f, -1f, 0f, 0f, 0f, -1f, 1f, 0f, 0f)
         };
 
-        private static readonly Basis _identity = new Basis(1, 0, 0, 0, 1, 0, 0, 0, 1);
-        private static readonly Basis _flipX = new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
-        private static readonly Basis _flipY = new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
-        private static readonly Basis _flipZ = new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
+    private static readonly Basis _identity = new Basis(1, 0, 0, 0, 1, 0, 0, 0, 1);
+    private static readonly Basis _flipX = new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+    private static readonly Basis _flipY = new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
+    private static readonly Basis _flipZ = new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
 
-        /// <summary>
-        /// The identity basis, with no rotation or scaling applied.
-        /// This is used as a replacement for <c>Basis()</c> in GDScript.
-        /// Do not use <c>new Basis()</c> with no arguments in C#, because it sets all values to zero.
-        /// </summary>
-        /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Back)</c>.</value>
-        public static Basis Identity { get { return _identity; } }
-        /// <summary>
-        /// The basis that will flip something along the X axis when used in a transformation.
-        /// </summary>
-        /// <value>Equivalent to <c>new Basis(Vector3.Left, Vector3.Up, Vector3.Back)</c>.</value>
-        public static Basis FlipX { get { return _flipX; } }
-        /// <summary>
-        /// The basis that will flip something along the Y axis when used in a transformation.
-        /// </summary>
-        /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Down, Vector3.Back)</c>.</value>
-        public static Basis FlipY { get { return _flipY; } }
-        /// <summary>
-        /// The basis that will flip something along the Z axis when used in a transformation.
-        /// </summary>
-        /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Forward)</c>.</value>
-        public static Basis FlipZ { get { return _flipZ; } }
+    /// <summary>
+    /// The identity basis, with no rotation or scaling applied.
+    /// This is used as a replacement for <c>Basis()</c> in GDScript.
+    /// Do not use <c>new Basis()</c> with no arguments in C#, because it sets all values to zero.
+    /// </summary>
+    /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Back)</c>.</value>
+    public static Basis Identity { get { return _identity; } }
+    /// <summary>
+    /// The basis that will flip something along the X axis when used in a transformation.
+    /// </summary>
+    /// <value>Equivalent to <c>new Basis(Vector3.Left, Vector3.Up, Vector3.Back)</c>.</value>
+    public static Basis FlipX { get { return _flipX; } }
+    /// <summary>
+    /// The basis that will flip something along the Y axis when used in a transformation.
+    /// </summary>
+    /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Down, Vector3.Back)</c>.</value>
+    public static Basis FlipY { get { return _flipY; } }
+    /// <summary>
+    /// The basis that will flip something along the Z axis when used in a transformation.
+    /// </summary>
+    /// <value>Equivalent to <c>new Basis(Vector3.Right, Vector3.Up, Vector3.Forward)</c>.</value>
+    public static Basis FlipZ { get { return _flipZ; } }
 
-        /// <summary>
-        /// Constructs a pure rotation basis matrix from the given quaternion.
-        /// </summary>
-        /// <param name="quaternion">The quaternion to create the basis from.</param>
-        public Basis(Quaternion quaternion)
+    /// <summary>
+    /// Constructs a pure rotation basis matrix from the given quaternion.
+    /// </summary>
+    /// <param name="quaternion">The quaternion to create the basis from.</param>
+    public Basis(Quaternion quaternion)
+    {
+        real_t s = 2.0f / quaternion.LengthSquared();
+
+        real_t xs = quaternion.X * s;
+        real_t ys = quaternion.Y * s;
+        real_t zs = quaternion.Z * s;
+        real_t wx = quaternion.W * xs;
+        real_t wy = quaternion.W * ys;
+        real_t wz = quaternion.W * zs;
+        real_t xx = quaternion.X * xs;
+        real_t xy = quaternion.X * ys;
+        real_t xz = quaternion.X * zs;
+        real_t yy = quaternion.Y * ys;
+        real_t yz = quaternion.Y * zs;
+        real_t zz = quaternion.Z * zs;
+
+        Row0 = new Vector3(1.0f - (yy + zz), xy - wz, xz + wy);
+        Row1 = new Vector3(xy + wz, 1.0f - (xx + zz), yz - wx);
+        Row2 = new Vector3(xz - wy, yz + wx, 1.0f - (xx + yy));
+    }
+
+    /// <summary>
+    /// Constructs a pure rotation basis matrix, rotated around the given <paramref name="axis"/>
+    /// by <paramref name="angle"/> (in radians). The axis must be a normalized vector.
+    /// </summary>
+    /// <param name="axis">The axis to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    public Basis(Vector3 axis, real_t angle)
+    {
+        Vector3 axisSq = new Vector3(axis.X * axis.X, axis.Y * axis.Y, axis.Z * axis.Z);
+        (real_t sin, real_t cos) = Mathf.SinCos(angle);
+
+        Row0.X = axisSq.X + cos * (1.0f - axisSq.X);
+        Row1.Y = axisSq.Y + cos * (1.0f - axisSq.Y);
+        Row2.Z = axisSq.Z + cos * (1.0f - axisSq.Z);
+
+        real_t t = 1.0f - cos;
+
+        real_t xyzt = axis.X * axis.Y * t;
+        real_t zyxs = axis.Z * sin;
+        Row0.Y = xyzt - zyxs;
+        Row1.X = xyzt + zyxs;
+
+        xyzt = axis.X * axis.Z * t;
+        zyxs = axis.Y * sin;
+        Row0.Z = xyzt + zyxs;
+        Row2.X = xyzt - zyxs;
+
+        xyzt = axis.Y * axis.Z * t;
+        zyxs = axis.X * sin;
+        Row1.Z = xyzt - zyxs;
+        Row2.Y = xyzt + zyxs;
+    }
+
+    /// <summary>
+    /// Constructs a basis matrix from 3 axis vectors (matrix columns).
+    /// </summary>
+    /// <param name="column0">The X vector, or Column0.</param>
+    /// <param name="column1">The Y vector, or Column1.</param>
+    /// <param name="column2">The Z vector, or Column2.</param>
+    public Basis(Vector3 column0, Vector3 column1, Vector3 column2)
+    {
+        Row0 = new Vector3(column0.X, column1.X, column2.X);
+        Row1 = new Vector3(column0.Y, column1.Y, column2.Y);
+        Row2 = new Vector3(column0.Z, column1.Z, column2.Z);
+        // Same as:
+        // Column0 = column0;
+        // Column1 = column1;
+        // Column2 = column2;
+        // We need to assign the struct fields here first so we can't do it that way...
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from the given components.
+    /// Arguments are named such that xy is equal to calling <c>X.Y</c>.
+    /// </summary>
+    /// <param name="xx">The X component of the X column vector, accessed via <c>b.X.X</c> or <c>[0][0]</c>.</param>
+    /// <param name="yx">The X component of the Y column vector, accessed via <c>b.Y.X</c> or <c>[1][0]</c>.</param>
+    /// <param name="zx">The X component of the Z column vector, accessed via <c>b.Z.X</c> or <c>[2][0]</c>.</param>
+    /// <param name="xy">The Y component of the X column vector, accessed via <c>b.X.Y</c> or <c>[0][1]</c>.</param>
+    /// <param name="yy">The Y component of the Y column vector, accessed via <c>b.Y.Y</c> or <c>[1][1]</c>.</param>
+    /// <param name="zy">The Y component of the Z column vector, accessed via <c>b.Y.Y</c> or <c>[2][1]</c>.</param>
+    /// <param name="xz">The Z component of the X column vector, accessed via <c>b.X.Y</c> or <c>[0][2]</c>.</param>
+    /// <param name="yz">The Z component of the Y column vector, accessed via <c>b.Y.Y</c> or <c>[1][2]</c>.</param>
+    /// <param name="zz">The Z component of the Z column vector, accessed via <c>b.Y.Y</c> or <c>[2][2]</c>.</param>
+    public Basis(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz)
+    {
+        Row0 = new Vector3(xx, yx, zx);
+        Row1 = new Vector3(xy, yy, zy);
+        Row2 = new Vector3(xz, yz, zz);
+    }
+
+    /// <summary>
+    /// Constructs a Basis matrix from Euler angles in the specified rotation order. By default, use YXZ order (most common).
+    /// </summary>
+    /// <param name="euler">The Euler angles to use.</param>
+    /// <param name="order">The order to compose the Euler angles.</param>
+    public static Basis FromEuler(Vector3 euler, EulerOrder order = EulerOrder.Yxz)
+    {
+        (real_t sin, real_t cos) = Mathf.SinCos(euler.X);
+        Basis xmat = new Basis
+        (
+            new Vector3(1, 0, 0),
+            new Vector3(0, cos, sin),
+            new Vector3(0, -sin, cos)
+        );
+
+        (sin, cos) = Mathf.SinCos(euler.Y);
+        Basis ymat = new Basis
+        (
+            new Vector3(cos, 0, -sin),
+            new Vector3(0, 1, 0),
+            new Vector3(sin, 0, cos)
+        );
+
+        (sin, cos) = Mathf.SinCos(euler.Z);
+        Basis zmat = new Basis
+        (
+            new Vector3(cos, sin, 0),
+            new Vector3(-sin, cos, 0),
+            new Vector3(0, 0, 1)
+        );
+
+        switch (order)
         {
-            real_t s = 2.0f / quaternion.LengthSquared();
-
-            real_t xs = quaternion.X * s;
-            real_t ys = quaternion.Y * s;
-            real_t zs = quaternion.Z * s;
-            real_t wx = quaternion.W * xs;
-            real_t wy = quaternion.W * ys;
-            real_t wz = quaternion.W * zs;
-            real_t xx = quaternion.X * xs;
-            real_t xy = quaternion.X * ys;
-            real_t xz = quaternion.X * zs;
-            real_t yy = quaternion.Y * ys;
-            real_t yz = quaternion.Y * zs;
-            real_t zz = quaternion.Z * zs;
-
-            Row0 = new Vector3(1.0f - (yy + zz), xy - wz, xz + wy);
-            Row1 = new Vector3(xy + wz, 1.0f - (xx + zz), yz - wx);
-            Row2 = new Vector3(xz - wy, yz + wx, 1.0f - (xx + yy));
+            case EulerOrder.Xyz:
+                return xmat * ymat * zmat;
+            case EulerOrder.Xzy:
+                return xmat * zmat * ymat;
+            case EulerOrder.Yxz:
+                return ymat * xmat * zmat;
+            case EulerOrder.Yzx:
+                return ymat * zmat * xmat;
+            case EulerOrder.Zxy:
+                return zmat * xmat * ymat;
+            case EulerOrder.Zyx:
+                return zmat * ymat * xmat;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(order));
         }
+    }
 
-        /// <summary>
-        /// Constructs a pure rotation basis matrix, rotated around the given <paramref name="axis"/>
-        /// by <paramref name="angle"/> (in radians). The axis must be a normalized vector.
-        /// </summary>
-        /// <param name="axis">The axis to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        public Basis(Vector3 axis, real_t angle)
-        {
-            Vector3 axisSq = new Vector3(axis.X * axis.X, axis.Y * axis.Y, axis.Z * axis.Z);
-            (real_t sin, real_t cos) = Mathf.SinCos(angle);
+    /// <summary>
+    /// Constructs a pure scale basis matrix with no rotation or shearing.
+    /// The scale values are set as the main diagonal of the matrix,
+    /// and all of the other parts of the matrix are zero.
+    /// </summary>
+    /// <param name="scale">The scale Vector3.</param>
+    /// <returns>A pure scale Basis matrix.</returns>
+    public static Basis FromScale(Vector3 scale)
+    {
+        return new Basis(
+            scale.X, 0, 0,
+            0, scale.Y, 0,
+            0, 0, scale.Z
+        );
+    }
 
-            Row0.X = axisSq.X + cos * (1.0f - axisSq.X);
-            Row1.Y = axisSq.Y + cos * (1.0f - axisSq.Y);
-            Row2.Z = axisSq.Z + cos * (1.0f - axisSq.Z);
+    /// <summary>
+    /// Composes these two basis matrices by multiplying them
+    /// together. This has the effect of transforming the second basis
+    /// (the child) by the first basis (the parent).
+    /// </summary>
+    /// <param name="left">The parent basis.</param>
+    /// <param name="right">The child basis.</param>
+    /// <returns>The composed basis.</returns>
+    public static Basis operator *(Basis left, Basis right)
+    {
+        return new Basis
+        (
+            right.Tdotx(left.Row0), right.Tdoty(left.Row0), right.Tdotz(left.Row0),
+            right.Tdotx(left.Row1), right.Tdoty(left.Row1), right.Tdotz(left.Row1),
+            right.Tdotx(left.Row2), right.Tdoty(left.Row2), right.Tdotz(left.Row2)
+        );
+    }
 
-            real_t t = 1.0f - cos;
+    /// <summary>
+    /// Returns a Vector3 transformed (multiplied) by the basis matrix.
+    /// </summary>
+    /// <param name="basis">The basis matrix transformation to apply.</param>
+    /// <param name="vector">A Vector3 to transform.</param>
+    /// <returns>The transformed Vector3.</returns>
+    public static Vector3 operator *(Basis basis, Vector3 vector)
+    {
+        return new Vector3
+        (
+            basis.Row0.Dot(vector),
+            basis.Row1.Dot(vector),
+            basis.Row2.Dot(vector)
+        );
+    }
 
-            real_t xyzt = axis.X * axis.Y * t;
-            real_t zyxs = axis.Z * sin;
-            Row0.Y = xyzt - zyxs;
-            Row1.X = xyzt + zyxs;
+    /// <summary>
+    /// Returns a Vector3 transformed (multiplied) by the transposed basis matrix.
+    ///
+    /// Note: This results in a multiplication by the inverse of the
+    /// basis matrix only if it represents a rotation-reflection.
+    /// </summary>
+    /// <param name="vector">A Vector3 to inversely transform.</param>
+    /// <param name="basis">The basis matrix transformation to apply.</param>
+    /// <returns>The inversely transformed vector.</returns>
+    public static Vector3 operator *(Vector3 vector, Basis basis)
+    {
+        return new Vector3
+        (
+            basis.Row0[0] * vector.X + basis.Row1[0] * vector.Y + basis.Row2[0] * vector.Z,
+            basis.Row0[1] * vector.X + basis.Row1[1] * vector.Y + basis.Row2[1] * vector.Z,
+            basis.Row0[2] * vector.X + basis.Row1[2] * vector.Y + basis.Row2[2] * vector.Z
+        );
+    }
 
-            xyzt = axis.X * axis.Z * t;
-            zyxs = axis.Y * sin;
-            Row0.Z = xyzt + zyxs;
-            Row2.X = xyzt - zyxs;
+    /// <summary>
+    /// Returns <see langword="true"/> if the basis matrices are exactly
+    /// equal. Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left basis.</param>
+    /// <param name="right">The right basis.</param>
+    /// <returns>Whether or not the basis matrices are exactly equal.</returns>
+    public static bool operator ==(Basis left, Basis right)
+    {
+        return left.Equals(right);
+    }
 
-            xyzt = axis.Y * axis.Z * t;
-            zyxs = axis.X * sin;
-            Row1.Z = xyzt - zyxs;
-            Row2.Y = xyzt + zyxs;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the basis matrices are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left basis.</param>
+    /// <param name="right">The right basis.</param>
+    /// <returns>Whether or not the basis matrices are not equal.</returns>
+    public static bool operator !=(Basis left, Basis right)
+    {
+        return !left.Equals(right);
+    }
 
-        /// <summary>
-        /// Constructs a basis matrix from 3 axis vectors (matrix columns).
-        /// </summary>
-        /// <param name="column0">The X vector, or Column0.</param>
-        /// <param name="column1">The Y vector, or Column1.</param>
-        /// <param name="column2">The Z vector, or Column2.</param>
-        public Basis(Vector3 column0, Vector3 column1, Vector3 column2)
-        {
-            Row0 = new Vector3(column0.X, column1.X, column2.X);
-            Row1 = new Vector3(column0.Y, column1.Y, column2.Y);
-            Row2 = new Vector3(column0.Z, column1.Z, column2.Z);
-            // Same as:
-            // Column0 = column0;
-            // Column1 = column1;
-            // Column2 = column2;
-            // We need to assign the struct fields here first so we can't do it that way...
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Basis"/> is
+    /// exactly equal to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the basis matrix and the object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Basis other && Equals(other);
+    }
 
-        /// <summary>
-        /// Constructs a transformation matrix from the given components.
-        /// Arguments are named such that xy is equal to calling <c>X.Y</c>.
-        /// </summary>
-        /// <param name="xx">The X component of the X column vector, accessed via <c>b.X.X</c> or <c>[0][0]</c>.</param>
-        /// <param name="yx">The X component of the Y column vector, accessed via <c>b.Y.X</c> or <c>[1][0]</c>.</param>
-        /// <param name="zx">The X component of the Z column vector, accessed via <c>b.Z.X</c> or <c>[2][0]</c>.</param>
-        /// <param name="xy">The Y component of the X column vector, accessed via <c>b.X.Y</c> or <c>[0][1]</c>.</param>
-        /// <param name="yy">The Y component of the Y column vector, accessed via <c>b.Y.Y</c> or <c>[1][1]</c>.</param>
-        /// <param name="zy">The Y component of the Z column vector, accessed via <c>b.Y.Y</c> or <c>[2][1]</c>.</param>
-        /// <param name="xz">The Z component of the X column vector, accessed via <c>b.X.Y</c> or <c>[0][2]</c>.</param>
-        /// <param name="yz">The Z component of the Y column vector, accessed via <c>b.Y.Y</c> or <c>[1][2]</c>.</param>
-        /// <param name="zz">The Z component of the Z column vector, accessed via <c>b.Y.Y</c> or <c>[2][2]</c>.</param>
-        public Basis(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz)
-        {
-            Row0 = new Vector3(xx, yx, zx);
-            Row1 = new Vector3(xy, yy, zy);
-            Row2 = new Vector3(xz, yz, zz);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the basis matrices are exactly
+    /// equal. Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other basis.</param>
+    /// <returns>Whether or not the basis matrices are exactly equal.</returns>
+    public readonly bool Equals(Basis other)
+    {
+        return Row0.Equals(other.Row0) && Row1.Equals(other.Row1) && Row2.Equals(other.Row2);
+    }
 
-        /// <summary>
-        /// Constructs a Basis matrix from Euler angles in the specified rotation order. By default, use YXZ order (most common).
-        /// </summary>
-        /// <param name="euler">The Euler angles to use.</param>
-        /// <param name="order">The order to compose the Euler angles.</param>
-        public static Basis FromEuler(Vector3 euler, EulerOrder order = EulerOrder.Yxz)
-        {
-            (real_t sin, real_t cos) = Mathf.SinCos(euler.X);
-            Basis xmat = new Basis
-            (
-                new Vector3(1, 0, 0),
-                new Vector3(0, cos, sin),
-                new Vector3(0, -sin, cos)
-            );
+    /// <summary>
+    /// Returns <see langword="true"/> if this basis and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other basis to compare.</param>
+    /// <returns>Whether or not the bases are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Basis other)
+    {
+        return Row0.IsEqualApprox(other.Row0) && Row1.IsEqualApprox(other.Row1) && Row2.IsEqualApprox(other.Row2);
+    }
 
-            (sin, cos) = Mathf.SinCos(euler.Y);
-            Basis ymat = new Basis
-            (
-                new Vector3(cos, 0, -sin),
-                new Vector3(0, 1, 0),
-                new Vector3(sin, 0, cos)
-            );
+    /// <summary>
+    /// Serves as the hash function for <see cref="Basis"/>.
+    /// </summary>
+    /// <returns>A hash code for this basis.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
+    }
 
-            (sin, cos) = Mathf.SinCos(euler.Z);
-            Basis zmat = new Basis
-            (
-                new Vector3(cos, sin, 0),
-                new Vector3(-sin, cos, 0),
-                new Vector3(0, 0, 1)
-            );
+    /// <summary>
+    /// Converts this <see cref="Basis"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this basis.</returns>
+    public override readonly string ToString()
+    {
+        return $"[X: {X}, Y: {Y}, Z: {Z}]";
+    }
 
-            switch (order)
-            {
-                case EulerOrder.Xyz:
-                    return xmat * ymat * zmat;
-                case EulerOrder.Xzy:
-                    return xmat * zmat * ymat;
-                case EulerOrder.Yxz:
-                    return ymat * xmat * zmat;
-                case EulerOrder.Yzx:
-                    return ymat * zmat * xmat;
-                case EulerOrder.Zxy:
-                    return zmat * xmat * ymat;
-                case EulerOrder.Zyx:
-                    return zmat * ymat * xmat;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(order));
-            }
-        }
-
-        /// <summary>
-        /// Constructs a pure scale basis matrix with no rotation or shearing.
-        /// The scale values are set as the main diagonal of the matrix,
-        /// and all of the other parts of the matrix are zero.
-        /// </summary>
-        /// <param name="scale">The scale Vector3.</param>
-        /// <returns>A pure scale Basis matrix.</returns>
-        public static Basis FromScale(Vector3 scale)
-        {
-            return new Basis(
-                scale.X, 0, 0,
-                0, scale.Y, 0,
-                0, 0, scale.Z
-            );
-        }
-
-        /// <summary>
-        /// Composes these two basis matrices by multiplying them
-        /// together. This has the effect of transforming the second basis
-        /// (the child) by the first basis (the parent).
-        /// </summary>
-        /// <param name="left">The parent basis.</param>
-        /// <param name="right">The child basis.</param>
-        /// <returns>The composed basis.</returns>
-        public static Basis operator *(Basis left, Basis right)
-        {
-            return new Basis
-            (
-                right.Tdotx(left.Row0), right.Tdoty(left.Row0), right.Tdotz(left.Row0),
-                right.Tdotx(left.Row1), right.Tdoty(left.Row1), right.Tdotz(left.Row1),
-                right.Tdotx(left.Row2), right.Tdoty(left.Row2), right.Tdotz(left.Row2)
-            );
-        }
-
-        /// <summary>
-        /// Returns a Vector3 transformed (multiplied) by the basis matrix.
-        /// </summary>
-        /// <param name="basis">The basis matrix transformation to apply.</param>
-        /// <param name="vector">A Vector3 to transform.</param>
-        /// <returns>The transformed Vector3.</returns>
-        public static Vector3 operator *(Basis basis, Vector3 vector)
-        {
-            return new Vector3
-            (
-                basis.Row0.Dot(vector),
-                basis.Row1.Dot(vector),
-                basis.Row2.Dot(vector)
-            );
-        }
-
-        /// <summary>
-        /// Returns a Vector3 transformed (multiplied) by the transposed basis matrix.
-        ///
-        /// Note: This results in a multiplication by the inverse of the
-        /// basis matrix only if it represents a rotation-reflection.
-        /// </summary>
-        /// <param name="vector">A Vector3 to inversely transform.</param>
-        /// <param name="basis">The basis matrix transformation to apply.</param>
-        /// <returns>The inversely transformed vector.</returns>
-        public static Vector3 operator *(Vector3 vector, Basis basis)
-        {
-            return new Vector3
-            (
-                basis.Row0[0] * vector.X + basis.Row1[0] * vector.Y + basis.Row2[0] * vector.Z,
-                basis.Row0[1] * vector.X + basis.Row1[1] * vector.Y + basis.Row2[1] * vector.Z,
-                basis.Row0[2] * vector.X + basis.Row1[2] * vector.Y + basis.Row2[2] * vector.Z
-            );
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the basis matrices are exactly
-        /// equal. Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left basis.</param>
-        /// <param name="right">The right basis.</param>
-        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
-        public static bool operator ==(Basis left, Basis right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the basis matrices are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left basis.</param>
-        /// <param name="right">The right basis.</param>
-        /// <returns>Whether or not the basis matrices are not equal.</returns>
-        public static bool operator !=(Basis left, Basis right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Basis"/> is
-        /// exactly equal to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the basis matrix and the object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Basis other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the basis matrices are exactly
-        /// equal. Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other basis.</param>
-        /// <returns>Whether or not the basis matrices are exactly equal.</returns>
-        public readonly bool Equals(Basis other)
-        {
-            return Row0.Equals(other.Row0) && Row1.Equals(other.Row1) && Row2.Equals(other.Row2);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this basis and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other basis to compare.</param>
-        /// <returns>Whether or not the bases are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Basis other)
-        {
-            return Row0.IsEqualApprox(other.Row0) && Row1.IsEqualApprox(other.Row1) && Row2.IsEqualApprox(other.Row2);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Basis"/>.
-        /// </summary>
-        /// <returns>A hash code for this basis.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Row0.GetHashCode() ^ Row1.GetHashCode() ^ Row2.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Basis"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this basis.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {X}, Y: {Y}, Z: {Z}]";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Basis"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this basis.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, Z: {Z.ToString(format)}]";
-        }
+    /// <summary>
+    /// Converts this <see cref="Basis"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this basis.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, Z: {Z.ToString(format)}]";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs
@@ -2,268 +2,267 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot.Bridge
+namespace Godot.Bridge;
+
+internal static class CSharpInstanceBridge
 {
-    internal static class CSharpInstanceBridge
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool Call(IntPtr godotObjectGCHandle, godot_string_name* method,
+        godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
     {
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool Call(IntPtr godotObjectGCHandle, godot_string_name* method,
-            godot_variant** args, int argCount, godot_variant_call_error* refCallError, godot_variant* ret)
+        try
         {
-            try
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (godotObject == null)
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (godotObject == null)
-                {
-                    *ret = default;
-                    (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;
-                    return godot_bool.False;
-                }
-
-                bool methodInvoked = godotObject.InvokeGodotClassMethod(CustomUnsafe.AsRef(method),
-                    new NativeVariantPtrArgs(args, argCount), out godot_variant retValue);
-
-                if (!methodInvoked)
-                {
-                    *ret = default;
-                    // This is important, as it tells Object::call that no method was called.
-                    // Otherwise, it would prevent Object::call from calling native methods.
-                    (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD;
-                    return godot_bool.False;
-                }
-
-                *ret = retValue;
-                return godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
                 *ret = default;
+                (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL;
                 return godot_bool.False;
             }
-        }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool Set(IntPtr godotObjectGCHandle, godot_string_name* name, godot_variant* value)
-        {
-            try
+            bool methodInvoked = godotObject.InvokeGodotClassMethod(CustomUnsafe.AsRef(method),
+                new NativeVariantPtrArgs(args, argCount), out godot_variant retValue);
+
+            if (!methodInvoked)
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (godotObject == null)
-                    throw new InvalidOperationException();
-
-                if (godotObject.SetGodotClassPropertyValue(CustomUnsafe.AsRef(name), CustomUnsafe.AsRef(value)))
-                {
-                    return godot_bool.True;
-                }
-
-                var nameManaged = StringName.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(name)));
-
-                Variant valueManaged = Variant.CreateCopyingBorrowed(*value);
-
-                return godotObject._Set(nameManaged, valueManaged).ToGodotBool();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
+                *ret = default;
+                // This is important, as it tells Object::call that no method was called.
+                // Otherwise, it would prevent Object::call from calling native methods.
+                (*refCallError).Error = godot_variant_call_error_error.GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD;
                 return godot_bool.False;
             }
+
+            *ret = retValue;
+            return godot_bool.True;
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool Get(IntPtr godotObjectGCHandle, godot_string_name* name,
-            godot_variant* outRet)
+        catch (Exception e)
         {
-            try
+            ExceptionUtils.LogException(e);
+            *ret = default;
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool Set(IntPtr godotObjectGCHandle, godot_string_name* name, godot_variant* value)
+    {
+        try
+        {
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (godotObject == null)
+                throw new InvalidOperationException();
+
+            if (godotObject.SetGodotClassPropertyValue(CustomUnsafe.AsRef(name), CustomUnsafe.AsRef(value)))
             {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (godotObject == null)
-                    throw new InvalidOperationException();
-
-                // Properties
-                if (godotObject.GetGodotClassPropertyValue(CustomUnsafe.AsRef(name), out godot_variant outRetValue))
-                {
-                    *outRet = outRetValue;
-                    return godot_bool.True;
-                }
-
-                // Signals
-                if (godotObject.HasGodotClassSignal(CustomUnsafe.AsRef(name)))
-                {
-                    godot_signal signal = new godot_signal(*name, godotObject.GetInstanceId());
-                    *outRet = VariantUtils.CreateFromSignalTakingOwnershipOfDisposableValue(signal);
-                    return godot_bool.True;
-                }
-
-                // Methods
-                if (godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(name)))
-                {
-                    godot_callable method = new godot_callable(*name, godotObject.GetInstanceId());
-                    *outRet = VariantUtils.CreateFromCallableTakingOwnershipOfDisposableValue(method);
-                    return godot_bool.True;
-                }
-
-                var nameManaged = StringName.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(name)));
-
-                Variant ret = godotObject._Get(nameManaged);
-
-                if (ret.VariantType == Variant.Type.Nil)
-                {
-                    *outRet = default;
-                    return godot_bool.False;
-                }
-
-                *outRet = ret.CopyNativeVariant();
                 return godot_bool.True;
             }
-            catch (Exception e)
+
+            var nameManaged = StringName.CreateTakingOwnershipOfDisposableValue(
+                NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(name)));
+
+            Variant valueManaged = Variant.CreateCopyingBorrowed(*value);
+
+            return godotObject._Set(nameManaged, valueManaged).ToGodotBool();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool Get(IntPtr godotObjectGCHandle, godot_string_name* name,
+        godot_variant* outRet)
+    {
+        try
+        {
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (godotObject == null)
+                throw new InvalidOperationException();
+
+            // Properties
+            if (godotObject.GetGodotClassPropertyValue(CustomUnsafe.AsRef(name), out godot_variant outRetValue))
             {
-                ExceptionUtils.LogException(e);
+                *outRet = outRetValue;
+                return godot_bool.True;
+            }
+
+            // Signals
+            if (godotObject.HasGodotClassSignal(CustomUnsafe.AsRef(name)))
+            {
+                godot_signal signal = new godot_signal(*name, godotObject.GetInstanceId());
+                *outRet = VariantUtils.CreateFromSignalTakingOwnershipOfDisposableValue(signal);
+                return godot_bool.True;
+            }
+
+            // Methods
+            if (godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(name)))
+            {
+                godot_callable method = new godot_callable(*name, godotObject.GetInstanceId());
+                *outRet = VariantUtils.CreateFromCallableTakingOwnershipOfDisposableValue(method);
+                return godot_bool.True;
+            }
+
+            var nameManaged = StringName.CreateTakingOwnershipOfDisposableValue(
+                NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(name)));
+
+            Variant ret = godotObject._Get(nameManaged);
+
+            if (ret.VariantType == Variant.Type.Nil)
+            {
                 *outRet = default;
                 return godot_bool.False;
             }
+
+            *outRet = ret.CopyNativeVariant();
+            return godot_bool.True;
         }
-
-        [UnmanagedCallersOnly]
-        internal static void CallDispose(IntPtr godotObjectGCHandle, godot_bool okIfNull)
+        catch (Exception e)
         {
-            try
-            {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (okIfNull.ToBool())
-                    godotObject?.Dispose();
-                else
-                    godotObject!.Dispose();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+            ExceptionUtils.LogException(e);
+            *outRet = default;
+            return godot_bool.False;
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void CallToString(IntPtr godotObjectGCHandle, godot_string* outRes, godot_bool* outValid)
+    [UnmanagedCallersOnly]
+    internal static void CallDispose(IntPtr godotObjectGCHandle, godot_bool okIfNull)
+    {
+        try
         {
-            try
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (okIfNull.ToBool())
+                godotObject?.Dispose();
+            else
+                godotObject!.Dispose();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void CallToString(IntPtr godotObjectGCHandle, godot_string* outRes, godot_bool* outValid)
+    {
+        try
+        {
+            var self = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (self == null)
             {
-                var self = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (self == null)
-                {
-                    *outRes = default;
-                    *outValid = godot_bool.False;
-                    return;
-                }
-
-                var resultStr = self.ToString();
-
-                if (resultStr == null)
-                {
-                    *outRes = default;
-                    *outValid = godot_bool.False;
-                    return;
-                }
-
-                *outRes = Marshaling.ConvertStringToNative(resultStr);
-                *outValid = godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
                 *outRes = default;
                 *outValid = godot_bool.False;
+                return;
             }
+
+            var resultStr = self.ToString();
+
+            if (resultStr == null)
+            {
+                *outRes = default;
+                *outValid = godot_bool.False;
+                return;
+            }
+
+            *outRes = Marshaling.ConvertStringToNative(resultStr);
+            *outValid = godot_bool.True;
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool HasMethodUnknownParams(IntPtr godotObjectGCHandle, godot_string_name* method)
+        catch (Exception e)
         {
-            try
-            {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+            ExceptionUtils.LogException(e);
+            *outRes = default;
+            *outValid = godot_bool.False;
+        }
+    }
 
-                if (godotObject == null)
-                    return godot_bool.False;
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool HasMethodUnknownParams(IntPtr godotObjectGCHandle, godot_string_name* method)
+    {
+        try
+        {
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
-                return godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(method)).ToGodotBool();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
+            if (godotObject == null)
                 return godot_bool.False;
-            }
+
+            return godotObject.HasGodotClassMethod(CustomUnsafe.AsRef(method)).ToGodotBool();
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void SerializeState(
-            IntPtr godotObjectGCHandle,
-            godot_dictionary* propertiesState,
-            godot_dictionary* signalEventsState
-        )
+        catch (Exception e)
         {
-            try
-            {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
-
-                if (godotObject == null)
-                    return;
-
-                // Call OnBeforeSerialize
-
-                // ReSharper disable once SuspiciousTypeConversion.Global
-                if (godotObject is ISerializationListener serializationListener)
-                    serializationListener.OnBeforeSerialize();
-
-                // Save instance state
-
-                using var info = GodotSerializationInfo.CreateCopyingBorrowed(
-                    *propertiesState, *signalEventsState);
-
-                godotObject.SaveGodotObjectData(info);
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void DeserializeState(
-            IntPtr godotObjectGCHandle,
-            godot_dictionary* propertiesState,
-            godot_dictionary* signalEventsState
-        )
+    [UnmanagedCallersOnly]
+    internal static unsafe void SerializeState(
+        IntPtr godotObjectGCHandle,
+        godot_dictionary* propertiesState,
+        godot_dictionary* signalEventsState
+    )
+    {
+        try
         {
-            try
-            {
-                var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
 
-                if (godotObject == null)
-                    return;
+            if (godotObject == null)
+                return;
 
-                // Restore instance state
+            // Call OnBeforeSerialize
 
-                using var info = GodotSerializationInfo.CreateCopyingBorrowed(
-                    *propertiesState, *signalEventsState);
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            if (godotObject is ISerializationListener serializationListener)
+                serializationListener.OnBeforeSerialize();
 
-                godotObject.RestoreGodotObjectData(info);
+            // Save instance state
 
-                // Call OnAfterDeserialize
+            using var info = GodotSerializationInfo.CreateCopyingBorrowed(
+                *propertiesState, *signalEventsState);
 
-                // ReSharper disable once SuspiciousTypeConversion.Global
-                if (godotObject is ISerializationListener serializationListener)
-                    serializationListener.OnAfterDeserialize();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+            godotObject.SaveGodotObjectData(info);
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void DeserializeState(
+        IntPtr godotObjectGCHandle,
+        godot_dictionary* propertiesState,
+        godot_dictionary* signalEventsState
+    )
+    {
+        try
+        {
+            var godotObject = (GodotObject)GCHandle.FromIntPtr(godotObjectGCHandle).Target;
+
+            if (godotObject == null)
+                return;
+
+            // Restore instance state
+
+            using var info = GodotSerializationInfo.CreateCopyingBorrowed(
+                *propertiesState, *signalEventsState);
+
+            godotObject.RestoreGodotObjectData(info);
+
+            // Call OnAfterDeserialize
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            if (godotObject is ISerializationListener serializationListener)
+                serializationListener.OnAfterDeserialize();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -2,92 +2,91 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot.Bridge
+namespace Godot.Bridge;
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct ManagedCallbacks
 {
-    [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct ManagedCallbacks
+    // @formatter:off
+    public delegate* unmanaged<IntPtr, godot_variant**, int, godot_bool*, void> SignalAwaiter_SignalCallback;
+    public delegate* unmanaged<IntPtr, void*, godot_variant**, int, godot_variant*, void> DelegateUtils_InvokeWithVariantArgs;
+    public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
+    public delegate* unmanaged<IntPtr, int> DelegateUtils_DelegateHash;
+    public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
+    public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
+    public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
+    public delegate* unmanaged<godot_string_name*, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedForGodotObjectBinding;
+    public delegate* unmanaged<IntPtr, IntPtr, godot_variant**, int, godot_bool> ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance;
+    public delegate* unmanaged<IntPtr, godot_string_name*, void> ScriptManagerBridge_GetScriptNativeName;
+    public delegate* unmanaged<IntPtr, IntPtr, void> ScriptManagerBridge_SetGodotObjectPtr;
+    public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_bool*, void> ScriptManagerBridge_RaiseEventSignal;
+    public delegate* unmanaged<IntPtr, IntPtr, godot_bool> ScriptManagerBridge_ScriptIsOrInherits;
+    public delegate* unmanaged<IntPtr, godot_string*, godot_bool> ScriptManagerBridge_AddScriptBridge;
+    public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
+    public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
+    public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
+    public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
+    public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
+    public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
+    public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
+    public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
+    public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
+    public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Get;
+    public delegate* unmanaged<IntPtr, godot_bool, void> CSharpInstanceBridge_CallDispose;
+    public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, void> CSharpInstanceBridge_CallToString;
+    public delegate* unmanaged<IntPtr, godot_string_name*, godot_bool> CSharpInstanceBridge_HasMethodUnknownParams;
+    public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_SerializeState;
+    public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_DeserializeState;
+    public delegate* unmanaged<IntPtr, void> GCHandleBridge_FreeGCHandle;
+    public delegate* unmanaged<IntPtr, godot_bool> GCHandleBridge_GCHandleIsTargetCollectible;
+    public delegate* unmanaged<void*, void> DebuggingUtils_GetCurrentStackInfo;
+    public delegate* unmanaged<void> DisposablesTracker_OnGodotShuttingDown;
+    public delegate* unmanaged<godot_bool, void> GD_OnCoreApiAssemblyLoaded;
+    // @formatter:on
+
+    public static ManagedCallbacks Create()
     {
-        // @formatter:off
-        public delegate* unmanaged<IntPtr, godot_variant**, int, godot_bool*, void> SignalAwaiter_SignalCallback;
-        public delegate* unmanaged<IntPtr, void*, godot_variant**, int, godot_variant*, void> DelegateUtils_InvokeWithVariantArgs;
-        public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
-        public delegate* unmanaged<IntPtr, int> DelegateUtils_DelegateHash;
-        public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
-        public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
-        public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
-        public delegate* unmanaged<godot_string_name*, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedForGodotObjectBinding;
-        public delegate* unmanaged<IntPtr, IntPtr, godot_variant**, int, godot_bool> ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance;
-        public delegate* unmanaged<IntPtr, godot_string_name*, void> ScriptManagerBridge_GetScriptNativeName;
-        public delegate* unmanaged<IntPtr, IntPtr, void> ScriptManagerBridge_SetGodotObjectPtr;
-        public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_bool*, void> ScriptManagerBridge_RaiseEventSignal;
-        public delegate* unmanaged<IntPtr, IntPtr, godot_bool> ScriptManagerBridge_ScriptIsOrInherits;
-        public delegate* unmanaged<IntPtr, godot_string*, godot_bool> ScriptManagerBridge_AddScriptBridge;
-        public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
-        public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
-        public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
-        public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
-        public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
-        public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
-        public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;
-        public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant**, int, godot_variant_call_error*, godot_variant*, godot_bool> CSharpInstanceBridge_Call;
-        public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Set;
-        public delegate* unmanaged<IntPtr, godot_string_name*, godot_variant*, godot_bool> CSharpInstanceBridge_Get;
-        public delegate* unmanaged<IntPtr, godot_bool, void> CSharpInstanceBridge_CallDispose;
-        public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, void> CSharpInstanceBridge_CallToString;
-        public delegate* unmanaged<IntPtr, godot_string_name*, godot_bool> CSharpInstanceBridge_HasMethodUnknownParams;
-        public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_SerializeState;
-        public delegate* unmanaged<IntPtr, godot_dictionary*, godot_dictionary*, void> CSharpInstanceBridge_DeserializeState;
-        public delegate* unmanaged<IntPtr, void> GCHandleBridge_FreeGCHandle;
-        public delegate* unmanaged<IntPtr, godot_bool> GCHandleBridge_GCHandleIsTargetCollectible;
-        public delegate* unmanaged<void*, void> DebuggingUtils_GetCurrentStackInfo;
-        public delegate* unmanaged<void> DisposablesTracker_OnGodotShuttingDown;
-        public delegate* unmanaged<godot_bool, void> GD_OnCoreApiAssemblyLoaded;
-        // @formatter:on
-
-        public static ManagedCallbacks Create()
+        return new()
         {
-            return new()
-            {
-                // @formatter:off
-                SignalAwaiter_SignalCallback = &SignalAwaiter.SignalCallback,
-                DelegateUtils_InvokeWithVariantArgs = &DelegateUtils.InvokeWithVariantArgs,
-                DelegateUtils_DelegateEquals = &DelegateUtils.DelegateEquals,
-                DelegateUtils_DelegateHash = &DelegateUtils.DelegateHash,
-                DelegateUtils_TrySerializeDelegateWithGCHandle = &DelegateUtils.TrySerializeDelegateWithGCHandle,
-                DelegateUtils_TryDeserializeDelegateWithGCHandle = &DelegateUtils.TryDeserializeDelegateWithGCHandle,
-                ScriptManagerBridge_FrameCallback = &ScriptManagerBridge.FrameCallback,
-                ScriptManagerBridge_CreateManagedForGodotObjectBinding = &ScriptManagerBridge.CreateManagedForGodotObjectBinding,
-                ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance = &ScriptManagerBridge.CreateManagedForGodotObjectScriptInstance,
-                ScriptManagerBridge_GetScriptNativeName = &ScriptManagerBridge.GetScriptNativeName,
-                ScriptManagerBridge_SetGodotObjectPtr = &ScriptManagerBridge.SetGodotObjectPtr,
-                ScriptManagerBridge_RaiseEventSignal = &ScriptManagerBridge.RaiseEventSignal,
-                ScriptManagerBridge_ScriptIsOrInherits = &ScriptManagerBridge.ScriptIsOrInherits,
-                ScriptManagerBridge_AddScriptBridge = &ScriptManagerBridge.AddScriptBridge,
-                ScriptManagerBridge_GetOrCreateScriptBridgeForPath = &ScriptManagerBridge.GetOrCreateScriptBridgeForPath,
-                ScriptManagerBridge_RemoveScriptBridge = &ScriptManagerBridge.RemoveScriptBridge,
-                ScriptManagerBridge_TryReloadRegisteredScriptWithClass = &ScriptManagerBridge.TryReloadRegisteredScriptWithClass,
-                ScriptManagerBridge_UpdateScriptClassInfo = &ScriptManagerBridge.UpdateScriptClassInfo,
-                ScriptManagerBridge_SwapGCHandleForType = &ScriptManagerBridge.SwapGCHandleForType,
-                ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,
-                ScriptManagerBridge_GetPropertyDefaultValues = &ScriptManagerBridge.GetPropertyDefaultValues,
-                CSharpInstanceBridge_Call = &CSharpInstanceBridge.Call,
-                CSharpInstanceBridge_Set = &CSharpInstanceBridge.Set,
-                CSharpInstanceBridge_Get = &CSharpInstanceBridge.Get,
-                CSharpInstanceBridge_CallDispose = &CSharpInstanceBridge.CallDispose,
-                CSharpInstanceBridge_CallToString = &CSharpInstanceBridge.CallToString,
-                CSharpInstanceBridge_HasMethodUnknownParams = &CSharpInstanceBridge.HasMethodUnknownParams,
-                CSharpInstanceBridge_SerializeState = &CSharpInstanceBridge.SerializeState,
-                CSharpInstanceBridge_DeserializeState = &CSharpInstanceBridge.DeserializeState,
-                GCHandleBridge_FreeGCHandle = &GCHandleBridge.FreeGCHandle,
-                GCHandleBridge_GCHandleIsTargetCollectible = &GCHandleBridge.GCHandleIsTargetCollectible,
-                DebuggingUtils_GetCurrentStackInfo = &DebuggingUtils.GetCurrentStackInfo,
-                DisposablesTracker_OnGodotShuttingDown = &DisposablesTracker.OnGodotShuttingDown,
-                GD_OnCoreApiAssemblyLoaded = &GD.OnCoreApiAssemblyLoaded,
-                // @formatter:on
-            };
-        }
-
-        public static void Create(IntPtr outManagedCallbacks)
-            => *(ManagedCallbacks*)outManagedCallbacks = Create();
+            // @formatter:off
+            SignalAwaiter_SignalCallback = &SignalAwaiter.SignalCallback,
+            DelegateUtils_InvokeWithVariantArgs = &DelegateUtils.InvokeWithVariantArgs,
+            DelegateUtils_DelegateEquals = &DelegateUtils.DelegateEquals,
+            DelegateUtils_DelegateHash = &DelegateUtils.DelegateHash,
+            DelegateUtils_TrySerializeDelegateWithGCHandle = &DelegateUtils.TrySerializeDelegateWithGCHandle,
+            DelegateUtils_TryDeserializeDelegateWithGCHandle = &DelegateUtils.TryDeserializeDelegateWithGCHandle,
+            ScriptManagerBridge_FrameCallback = &ScriptManagerBridge.FrameCallback,
+            ScriptManagerBridge_CreateManagedForGodotObjectBinding = &ScriptManagerBridge.CreateManagedForGodotObjectBinding,
+            ScriptManagerBridge_CreateManagedForGodotObjectScriptInstance = &ScriptManagerBridge.CreateManagedForGodotObjectScriptInstance,
+            ScriptManagerBridge_GetScriptNativeName = &ScriptManagerBridge.GetScriptNativeName,
+            ScriptManagerBridge_SetGodotObjectPtr = &ScriptManagerBridge.SetGodotObjectPtr,
+            ScriptManagerBridge_RaiseEventSignal = &ScriptManagerBridge.RaiseEventSignal,
+            ScriptManagerBridge_ScriptIsOrInherits = &ScriptManagerBridge.ScriptIsOrInherits,
+            ScriptManagerBridge_AddScriptBridge = &ScriptManagerBridge.AddScriptBridge,
+            ScriptManagerBridge_GetOrCreateScriptBridgeForPath = &ScriptManagerBridge.GetOrCreateScriptBridgeForPath,
+            ScriptManagerBridge_RemoveScriptBridge = &ScriptManagerBridge.RemoveScriptBridge,
+            ScriptManagerBridge_TryReloadRegisteredScriptWithClass = &ScriptManagerBridge.TryReloadRegisteredScriptWithClass,
+            ScriptManagerBridge_UpdateScriptClassInfo = &ScriptManagerBridge.UpdateScriptClassInfo,
+            ScriptManagerBridge_SwapGCHandleForType = &ScriptManagerBridge.SwapGCHandleForType,
+            ScriptManagerBridge_GetPropertyInfoList = &ScriptManagerBridge.GetPropertyInfoList,
+            ScriptManagerBridge_GetPropertyDefaultValues = &ScriptManagerBridge.GetPropertyDefaultValues,
+            CSharpInstanceBridge_Call = &CSharpInstanceBridge.Call,
+            CSharpInstanceBridge_Set = &CSharpInstanceBridge.Set,
+            CSharpInstanceBridge_Get = &CSharpInstanceBridge.Get,
+            CSharpInstanceBridge_CallDispose = &CSharpInstanceBridge.CallDispose,
+            CSharpInstanceBridge_CallToString = &CSharpInstanceBridge.CallToString,
+            CSharpInstanceBridge_HasMethodUnknownParams = &CSharpInstanceBridge.HasMethodUnknownParams,
+            CSharpInstanceBridge_SerializeState = &CSharpInstanceBridge.SerializeState,
+            CSharpInstanceBridge_DeserializeState = &CSharpInstanceBridge.DeserializeState,
+            GCHandleBridge_FreeGCHandle = &GCHandleBridge.FreeGCHandle,
+            GCHandleBridge_GCHandleIsTargetCollectible = &GCHandleBridge.GCHandleIsTargetCollectible,
+            DebuggingUtils_GetCurrentStackInfo = &DebuggingUtils.GetCurrentStackInfo,
+            DisposablesTracker_OnGodotShuttingDown = &DisposablesTracker.OnGodotShuttingDown,
+            GD_OnCoreApiAssemblyLoaded = &GD.OnCoreApiAssemblyLoaded,
+            // @formatter:on
+        };
     }
+
+    public static void Create(IntPtr outManagedCallbacks)
+        => *(ManagedCallbacks*)outManagedCallbacks = Create();
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -12,438 +12,457 @@ using System.Runtime.Loader;
 using System.Runtime.Serialization;
 using Godot.NativeInterop;
 
-namespace Godot.Bridge
+namespace Godot.Bridge;
+
+// TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
+public static partial class ScriptManagerBridge
 {
-    // TODO: Make class internal once we replace LookupScriptsInAssembly (the only public member) with source generators
-    public static partial class ScriptManagerBridge
+    private static ConcurrentDictionary<AssemblyLoadContext, ConcurrentDictionary<Type, byte>>
+        _alcData = new();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void OnAlcUnloading(AssemblyLoadContext alc)
     {
-        private static ConcurrentDictionary<AssemblyLoadContext, ConcurrentDictionary<Type, byte>>
-            _alcData = new();
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void OnAlcUnloading(AssemblyLoadContext alc)
+        if (_alcData.TryRemove(alc, out var typesInAlc))
         {
-            if (_alcData.TryRemove(alc, out var typesInAlc))
+            foreach (var type in typesInAlc.Keys)
             {
-                foreach (var type in typesInAlc.Keys)
+                if (_scriptTypeBiMap.RemoveByScriptType(type, out IntPtr scriptPtr) &&
+                    !_pathTypeBiMap.TryGetScriptPath(type, out _))
                 {
-                    if (_scriptTypeBiMap.RemoveByScriptType(type, out IntPtr scriptPtr) &&
-                        !_pathTypeBiMap.TryGetScriptPath(type, out _))
-                    {
-                        // For scripts without a path, we need to keep the class qualified name for reloading
-                        _scriptDataForReload.TryAdd(scriptPtr,
-                            (type.Assembly.GetName().Name, type.FullName ?? type.ToString()));
-                    }
-
-                    _pathTypeBiMap.RemoveByScriptType(type);
+                    // For scripts without a path, we need to keep the class qualified name for reloading
+                    _scriptDataForReload.TryAdd(scriptPtr,
+                        (type.Assembly.GetName().Name, type.FullName ?? type.ToString()));
                 }
+
+                _pathTypeBiMap.RemoveByScriptType(type);
             }
         }
+    }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void AddTypeForAlcReloading(Type type)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AddTypeForAlcReloading(Type type)
+    {
+        var alc = AssemblyLoadContext.GetLoadContext(type.Assembly);
+        if (alc == null)
+            return;
+
+        var typesInAlc = _alcData.GetOrAdd(alc,
+            static alc =>
+            {
+                alc.Unloading += OnAlcUnloading;
+                return new();
+            });
+        typesInAlc.TryAdd(type, 0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TrackAlcForUnloading(AssemblyLoadContext alc)
+    {
+        _ = _alcData.GetOrAdd(alc,
+            static alc =>
+            {
+                alc.Unloading += OnAlcUnloading;
+                return new();
+            });
+    }
+
+    private static ScriptTypeBiMap _scriptTypeBiMap = new();
+    private static PathScriptTypeBiMap _pathTypeBiMap = new();
+
+    private static ConcurrentDictionary<IntPtr, (string? assemblyName, string classFullName)>
+        _scriptDataForReload = new();
+
+    [UnmanagedCallersOnly]
+    internal static void FrameCallback()
+    {
+        try
         {
-            var alc = AssemblyLoadContext.GetLoadContext(type.Assembly);
-            if (alc == null)
-                return;
-
-            var typesInAlc = _alcData.GetOrAdd(alc,
-                static alc =>
-                {
-                    alc.Unloading += OnAlcUnloading;
-                    return new();
-                });
-            typesInAlc.TryAdd(type, 0);
+            Dispatcher.DefaultGodotTaskScheduler?.Activate();
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void TrackAlcForUnloading(AssemblyLoadContext alc)
+        catch (Exception e)
         {
-            _ = _alcData.GetOrAdd(alc,
-                static alc =>
-                {
-                    alc.Unloading += OnAlcUnloading;
-                    return new();
-                });
+            ExceptionUtils.LogException(e);
         }
+    }
 
-        private static ScriptTypeBiMap _scriptTypeBiMap = new();
-        private static PathScriptTypeBiMap _pathTypeBiMap = new();
+    [UnmanagedCallersOnly]
+    internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName,
+        IntPtr godotObject)
+    {
+        // TODO: Optimize with source generators and delegate pointers
 
-        private static ConcurrentDictionary<IntPtr, (string? assemblyName, string classFullName)>
-            _scriptDataForReload = new();
-
-        [UnmanagedCallersOnly]
-        internal static void FrameCallback()
+        try
         {
-            try
-            {
-                Dispatcher.DefaultGodotTaskScheduler?.Activate();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+            using var stringName = StringName.CreateTakingOwnershipOfDisposableValue(
+                NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(nativeTypeName)));
+            string nativeTypeNameStr = stringName.ToString();
+
+            Type nativeType = TypeGetProxyClass(nativeTypeNameStr) ?? throw new InvalidOperationException(
+                "Wrapper class not found for type: " + nativeTypeNameStr);
+            var obj = (GodotObject)FormatterServices.GetUninitializedObject(nativeType);
+
+            var ctor = nativeType.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                null, Type.EmptyTypes, null);
+
+            obj.NativePtr = godotObject;
+
+            _ = ctor!.Invoke(obj, null);
+
+            return GCHandle.ToIntPtr(CustomGCHandle.AllocStrong(obj));
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe IntPtr CreateManagedForGodotObjectBinding(godot_string_name* nativeTypeName,
-            IntPtr godotObject)
+        catch (Exception e)
         {
-            // TODO: Optimize with source generators and delegate pointers
-
-            try
-            {
-                using var stringName = StringName.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_string_name_new_copy(CustomUnsafe.AsRef(nativeTypeName)));
-                string nativeTypeNameStr = stringName.ToString();
-
-                Type nativeType = TypeGetProxyClass(nativeTypeNameStr) ?? throw new InvalidOperationException(
-                    "Wrapper class not found for type: " + nativeTypeNameStr);
-                var obj = (GodotObject)FormatterServices.GetUninitializedObject(nativeType);
-
-                var ctor = nativeType.GetConstructor(
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, Type.EmptyTypes, null);
-
-                obj.NativePtr = godotObject;
-
-                _ = ctor!.Invoke(obj, null);
-
-                return GCHandle.ToIntPtr(CustomGCHandle.AllocStrong(obj));
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return IntPtr.Zero;
-            }
+            ExceptionUtils.LogException(e);
+            return IntPtr.Zero;
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool CreateManagedForGodotObjectScriptInstance(IntPtr scriptPtr,
-            IntPtr godotObject,
-            godot_variant** args, int argCount)
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool CreateManagedForGodotObjectScriptInstance(IntPtr scriptPtr,
+        IntPtr godotObject,
+        godot_variant** args, int argCount)
+    {
+        // TODO: Optimize with source generators and delegate pointers
+
+        try
         {
-            // TODO: Optimize with source generators and delegate pointers
+            // Performance is not critical here as this will be replaced with source generators.
+            Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
 
-            try
-            {
-                // Performance is not critical here as this will be replaced with source generators.
-                Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
-
-                var ctor = scriptType
-                    .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                    .Where(c => c.GetParameters().Length == argCount)
-                    .FirstOrDefault();
-
-                if (ctor == null)
-                {
-                    if (argCount == 0)
-                    {
-                        throw new MissingMemberException(
-                            $"Cannot create script instance. The class '{scriptType.FullName}' does not define a parameterless constructor.");
-                    }
-                    else
-                    {
-                        throw new MissingMemberException(
-                            $"The class '{scriptType.FullName}' does not define a constructor that takes x parameters.");
-                    }
-                }
-
-                var obj = (GodotObject)FormatterServices.GetUninitializedObject(scriptType);
-
-                var parameters = ctor.GetParameters();
-                int paramCount = parameters.Length;
-
-                var invokeParams = new object?[paramCount];
-
-                for (int i = 0; i < paramCount; i++)
-                {
-                    invokeParams[i] = DelegateUtils.RuntimeTypeConversionHelper.ConvertToObjectOfType(
-                        *args[i], parameters[i].ParameterType);
-                }
-
-                obj.NativePtr = godotObject;
-
-                _ = ctor.Invoke(obj, invokeParams);
-
-
-                return godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return godot_bool.False;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void GetScriptNativeName(IntPtr scriptPtr, godot_string_name* outRes)
-        {
-            try
-            {
-                // Performance is not critical here as this will be replaced with source generators.
-                if (!_scriptTypeBiMap.TryGetScriptType(scriptPtr, out Type? scriptType))
-                {
-                    *outRes = default;
-                    return;
-                }
-
-                var native = GodotObject.InternalGetClassNativeBase(scriptType);
-
-                var field = native?.GetField("NativeName", BindingFlags.DeclaredOnly | BindingFlags.Static |
-                                                           BindingFlags.Public | BindingFlags.NonPublic);
-
-                if (field == null)
-                {
-                    *outRes = default;
-                    return;
-                }
-
-                var nativeName = (StringName?)field.GetValue(null);
-
-                if (nativeName == null)
-                {
-                    *outRes = default;
-                    return;
-                }
-
-                *outRes = NativeFuncs.godotsharp_string_name_new_copy((godot_string_name)nativeName.NativeValue);
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                *outRes = default;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static void SetGodotObjectPtr(IntPtr gcHandlePtr, IntPtr newPtr)
-        {
-            try
-            {
-                var target = (GodotObject?)GCHandle.FromIntPtr(gcHandlePtr).Target;
-                if (target != null)
-                    target.NativePtr = newPtr;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
-        }
-
-        private static Type? TypeGetProxyClass(string nativeTypeNameStr)
-        {
-            // Performance is not critical here as this will be replaced with a generated dictionary.
-
-            if (nativeTypeNameStr[0] == '_')
-                nativeTypeNameStr = nativeTypeNameStr.Substring(1);
-
-            Type? wrapperType = typeof(GodotObject).Assembly.GetType("Godot." + nativeTypeNameStr);
-
-            if (wrapperType == null)
-            {
-                wrapperType = GetTypeByGodotClassAttr(typeof(GodotObject).Assembly, nativeTypeNameStr);
-            }
-
-            if (wrapperType == null)
-            {
-                var editorAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                    .FirstOrDefault(a => a.GetName().Name == "GodotSharpEditor");
-                wrapperType = editorAssembly?.GetType("Godot." + nativeTypeNameStr);
-
-                if (wrapperType == null)
-                {
-                    wrapperType = GetTypeByGodotClassAttr(editorAssembly, nativeTypeNameStr);
-                }
-            }
-
-            static Type? GetTypeByGodotClassAttr(Assembly assembly, string nativeTypeNameStr)
-            {
-                var types = assembly.GetTypes();
-                foreach (var type in types)
-                {
-                    var attr = type.GetCustomAttribute<GodotClassNameAttribute>();
-                    if (attr?.Name == nativeTypeNameStr)
-                    {
-                        return type;
-                    }
-                }
-                return null;
-            }
-
-            static bool IsStatic(Type type) => type.IsAbstract && type.IsSealed;
-
-            if (wrapperType != null && IsStatic(wrapperType))
-            {
-                // A static class means this is a Godot singleton class. If an instance is needed we use GodotObject.
-                return typeof(GodotObject);
-            }
-
-            return wrapperType;
-        }
-
-        // Called from GodotPlugins
-        // ReSharper disable once UnusedMember.Local
-        public static void LookupScriptsInAssembly(Assembly assembly)
-        {
-            static void LookupScriptForClass(Type type)
-            {
-                var scriptPathAttr = type.GetCustomAttributes(inherit: false)
-                    .OfType<ScriptPathAttribute>()
-                    .FirstOrDefault();
-
-                if (scriptPathAttr == null)
-                    return;
-
-                _pathTypeBiMap.Add(scriptPathAttr.Path, type);
-
-                // This method may be called before initialization.
-                if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
-                {
-                    using godot_string scriptPath = Marshaling.ConvertStringToNative(scriptPathAttr.Path);
-                    NativeFuncs.godotsharp_internal_editor_file_system_update_file(scriptPath);
-                }
-
-                if (AlcReloadCfg.IsAlcReloadingEnabled)
-                {
-                    AddTypeForAlcReloading(type);
-                }
-            }
-
-            var assemblyHasScriptsAttr = assembly.GetCustomAttributes(inherit: false)
-                .OfType<AssemblyHasScriptsAttribute>()
+            var ctor = scriptType
+                .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(c => c.GetParameters().Length == argCount)
                 .FirstOrDefault();
 
-            if (assemblyHasScriptsAttr == null)
+            if (ctor == null)
+            {
+                if (argCount == 0)
+                {
+                    throw new MissingMemberException(
+                        $"Cannot create script instance. The class '{scriptType.FullName}' does not define a parameterless constructor.");
+                }
+                else
+                {
+                    throw new MissingMemberException(
+                        $"The class '{scriptType.FullName}' does not define a constructor that takes x parameters.");
+                }
+            }
+
+            var obj = (GodotObject)FormatterServices.GetUninitializedObject(scriptType);
+
+            var parameters = ctor.GetParameters();
+            int paramCount = parameters.Length;
+
+            var invokeParams = new object?[paramCount];
+
+            for (int i = 0; i < paramCount; i++)
+            {
+                invokeParams[i] = DelegateUtils.RuntimeTypeConversionHelper.ConvertToObjectOfType(
+                    *args[i], parameters[i].ParameterType);
+            }
+
+            obj.NativePtr = godotObject;
+
+            _ = ctor.Invoke(obj, invokeParams);
+
+
+            return godot_bool.True;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void GetScriptNativeName(IntPtr scriptPtr, godot_string_name* outRes)
+    {
+        try
+        {
+            // Performance is not critical here as this will be replaced with source generators.
+            if (!_scriptTypeBiMap.TryGetScriptType(scriptPtr, out Type? scriptType))
+            {
+                *outRes = default;
+                return;
+            }
+
+            var native = GodotObject.InternalGetClassNativeBase(scriptType);
+
+            var field = native?.GetField("NativeName", BindingFlags.DeclaredOnly | BindingFlags.Static |
+                                                       BindingFlags.Public | BindingFlags.NonPublic);
+
+            if (field == null)
+            {
+                *outRes = default;
+                return;
+            }
+
+            var nativeName = (StringName?)field.GetValue(null);
+
+            if (nativeName == null)
+            {
+                *outRes = default;
+                return;
+            }
+
+            *outRes = NativeFuncs.godotsharp_string_name_new_copy((godot_string_name)nativeName.NativeValue);
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            *outRes = default;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static void SetGodotObjectPtr(IntPtr gcHandlePtr, IntPtr newPtr)
+    {
+        try
+        {
+            var target = (GodotObject?)GCHandle.FromIntPtr(gcHandlePtr).Target;
+            if (target != null)
+                target.NativePtr = newPtr;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    private static Type? TypeGetProxyClass(string nativeTypeNameStr)
+    {
+        // Performance is not critical here as this will be replaced with a generated dictionary.
+
+        if (nativeTypeNameStr[0] == '_')
+            nativeTypeNameStr = nativeTypeNameStr.Substring(1);
+
+        Type? wrapperType = typeof(GodotObject).Assembly.GetType("Godot." + nativeTypeNameStr);
+
+        if (wrapperType == null)
+        {
+            wrapperType = GetTypeByGodotClassAttr(typeof(GodotObject).Assembly, nativeTypeNameStr);
+        }
+
+        if (wrapperType == null)
+        {
+            var editorAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == "GodotSharpEditor");
+            wrapperType = editorAssembly?.GetType("Godot." + nativeTypeNameStr);
+
+            if (wrapperType == null)
+            {
+                wrapperType = GetTypeByGodotClassAttr(editorAssembly, nativeTypeNameStr);
+            }
+        }
+
+        static Type? GetTypeByGodotClassAttr(Assembly assembly, string nativeTypeNameStr)
+        {
+            var types = assembly.GetTypes();
+            foreach (var type in types)
+            {
+                var attr = type.GetCustomAttribute<GodotClassNameAttribute>();
+                if (attr?.Name == nativeTypeNameStr)
+                {
+                    return type;
+                }
+            }
+            return null;
+        }
+
+        static bool IsStatic(Type type) => type.IsAbstract && type.IsSealed;
+
+        if (wrapperType != null && IsStatic(wrapperType))
+        {
+            // A static class means this is a Godot singleton class. If an instance is needed we use GodotObject.
+            return typeof(GodotObject);
+        }
+
+        return wrapperType;
+    }
+
+    // Called from GodotPlugins
+    // ReSharper disable once UnusedMember.Local
+    public static void LookupScriptsInAssembly(Assembly assembly)
+    {
+        static void LookupScriptForClass(Type type)
+        {
+            var scriptPathAttr = type.GetCustomAttributes(inherit: false)
+                .OfType<ScriptPathAttribute>()
+                .FirstOrDefault();
+
+            if (scriptPathAttr == null)
                 return;
 
-            if (assemblyHasScriptsAttr.RequiresLookup)
+            _pathTypeBiMap.Add(scriptPathAttr.Path, type);
+
+            // This method may be called before initialization.
+            if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
             {
-                // This is supported for scenarios where specifying all types would be cumbersome,
-                // such as when disabling C# source generators (for whatever reason) or when using a
-                // language other than C# that has nothing similar to source generators to automate it.
+                using godot_string scriptPath = Marshaling.ConvertStringToNative(scriptPathAttr.Path);
+                NativeFuncs.godotsharp_internal_editor_file_system_update_file(scriptPath);
+            }
 
-                var typeOfGodotObject = typeof(GodotObject);
+            if (AlcReloadCfg.IsAlcReloadingEnabled)
+            {
+                AddTypeForAlcReloading(type);
+            }
+        }
 
-                foreach (var type in assembly.GetTypes())
+        var assemblyHasScriptsAttr = assembly.GetCustomAttributes(inherit: false)
+            .OfType<AssemblyHasScriptsAttribute>()
+            .FirstOrDefault();
+
+        if (assemblyHasScriptsAttr == null)
+            return;
+
+        if (assemblyHasScriptsAttr.RequiresLookup)
+        {
+            // This is supported for scenarios where specifying all types would be cumbersome,
+            // such as when disabling C# source generators (for whatever reason) or when using a
+            // language other than C# that has nothing similar to source generators to automate it.
+
+            var typeOfGodotObject = typeof(GodotObject);
+
+            foreach (var type in assembly.GetTypes())
+            {
+                if (type.IsNested || type.IsGenericType)
+                    continue;
+
+                if (!typeOfGodotObject.IsAssignableFrom(type))
+                    continue;
+
+                LookupScriptForClass(type);
+            }
+        }
+        else
+        {
+            // This is the most likely scenario as we use C# source generators
+
+            var scriptTypes = assemblyHasScriptsAttr.ScriptTypes;
+
+            if (scriptTypes != null)
+            {
+                foreach (var type in scriptTypes)
                 {
-                    if (type.IsNested || type.IsGenericType)
-                        continue;
-
-                    if (!typeOfGodotObject.IsAssignableFrom(type))
+                    if (type.IsGenericType)
                         continue;
 
                     LookupScriptForClass(type);
                 }
             }
-            else
-            {
-                // This is the most likely scenario as we use C# source generators
-
-                var scriptTypes = assemblyHasScriptsAttr.ScriptTypes;
-
-                if (scriptTypes != null)
-                {
-                    foreach (var type in scriptTypes)
-                    {
-                        if (type.IsGenericType)
-                            continue;
-
-                        LookupScriptForClass(type);
-                    }
-                }
-            }
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void RaiseEventSignal(IntPtr ownerGCHandlePtr,
-            godot_string_name* eventSignalName, godot_variant** args, int argCount, godot_bool* outOwnerIsNull)
+    [UnmanagedCallersOnly]
+    internal static unsafe void RaiseEventSignal(IntPtr ownerGCHandlePtr,
+        godot_string_name* eventSignalName, godot_variant** args, int argCount, godot_bool* outOwnerIsNull)
+    {
+        try
         {
-            try
+            var owner = (GodotObject?)GCHandle.FromIntPtr(ownerGCHandlePtr).Target;
+
+            if (owner == null)
             {
-                var owner = (GodotObject?)GCHandle.FromIntPtr(ownerGCHandlePtr).Target;
-
-                if (owner == null)
-                {
-                    *outOwnerIsNull = godot_bool.True;
-                    return;
-                }
-
-                *outOwnerIsNull = godot_bool.False;
-
-                owner.RaiseGodotClassSignalCallbacks(CustomUnsafe.AsRef(eventSignalName),
-                    new NativeVariantPtrArgs(args, argCount));
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                *outOwnerIsNull = godot_bool.False;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static godot_bool ScriptIsOrInherits(IntPtr scriptPtr, IntPtr scriptPtrMaybeBase)
-        {
-            try
-            {
-                if (!_scriptTypeBiMap.TryGetScriptType(scriptPtr, out Type? scriptType))
-                    return godot_bool.False;
-
-                if (!_scriptTypeBiMap.TryGetScriptType(scriptPtrMaybeBase, out Type? maybeBaseType))
-                    return godot_bool.False;
-
-                return (scriptType == maybeBaseType || maybeBaseType.IsAssignableFrom(scriptType)).ToGodotBool();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return godot_bool.False;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool AddScriptBridge(IntPtr scriptPtr, godot_string* scriptPath)
-        {
-            try
-            {
-                lock (_scriptTypeBiMap.ReadWriteLock)
-                {
-                    if (!_scriptTypeBiMap.IsScriptRegistered(scriptPtr))
-                    {
-                        string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
-
-                        if (!_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
-                            return godot_bool.False;
-
-                        _scriptTypeBiMap.Add(scriptPtr, scriptType);
-                    }
-                }
-
-                return godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return godot_bool.False;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void GetOrCreateScriptBridgeForPath(godot_string* scriptPath, godot_ref* outScript)
-        {
-            string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
-
-            if (!_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
-            {
-                NativeFuncs.godotsharp_internal_new_csharp_script(outScript);
+                *outOwnerIsNull = godot_bool.True;
                 return;
             }
 
-            GetOrCreateScriptBridgeForType(scriptType, outScript);
+            *outOwnerIsNull = godot_bool.False;
+
+            owner.RaiseGodotClassSignalCallbacks(CustomUnsafe.AsRef(eventSignalName),
+                new NativeVariantPtrArgs(args, argCount));
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            *outOwnerIsNull = godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static godot_bool ScriptIsOrInherits(IntPtr scriptPtr, IntPtr scriptPtrMaybeBase)
+    {
+        try
+        {
+            if (!_scriptTypeBiMap.TryGetScriptType(scriptPtr, out Type? scriptType))
+                return godot_bool.False;
+
+            if (!_scriptTypeBiMap.TryGetScriptType(scriptPtrMaybeBase, out Type? maybeBaseType))
+                return godot_bool.False;
+
+            return (scriptType == maybeBaseType || maybeBaseType.IsAssignableFrom(scriptType)).ToGodotBool();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool AddScriptBridge(IntPtr scriptPtr, godot_string* scriptPath)
+    {
+        try
+        {
+            lock (_scriptTypeBiMap.ReadWriteLock)
+            {
+                if (!_scriptTypeBiMap.IsScriptRegistered(scriptPtr))
+                {
+                    string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
+
+                    if (!_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
+                        return godot_bool.False;
+
+                    _scriptTypeBiMap.Add(scriptPtr, scriptType);
+                }
+            }
+
+            return godot_bool.True;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void GetOrCreateScriptBridgeForPath(godot_string* scriptPath, godot_ref* outScript)
+    {
+        string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
+
+        if (!_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
+        {
+            NativeFuncs.godotsharp_internal_new_csharp_script(outScript);
+            return;
         }
 
-        private static unsafe void GetOrCreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
+        GetOrCreateScriptBridgeForType(scriptType, outScript);
+    }
+
+    private static unsafe void GetOrCreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
+    {
+        lock (_scriptTypeBiMap.ReadWriteLock)
+        {
+            if (_scriptTypeBiMap.TryGetScriptPtr(scriptType, out IntPtr scriptPtr))
+            {
+                // Use existing
+                NativeFuncs.godotsharp_ref_new_from_ref_counted_ptr(out *outScript, scriptPtr);
+                return;
+            }
+
+            // This path is slower, but it's only executed for the first instantiation of the type
+            CreateScriptBridgeForType(scriptType, outScript);
+        }
+    }
+
+    internal static unsafe void GetOrLoadOrCreateScriptForType(Type scriptType, godot_ref* outScript)
+    {
+        static bool GetPathOtherwiseGetOrCreateScript(Type scriptType, godot_ref* outScript,
+            [MaybeNullWhen(false)] out string scriptPath)
         {
             lock (_scriptTypeBiMap.ReadWriteLock)
             {
@@ -451,663 +470,643 @@ namespace Godot.Bridge
                 {
                     // Use existing
                     NativeFuncs.godotsharp_ref_new_from_ref_counted_ptr(out *outScript, scriptPtr);
-                    return;
-                }
-
-                // This path is slower, but it's only executed for the first instantiation of the type
-                CreateScriptBridgeForType(scriptType, outScript);
-            }
-        }
-
-        internal static unsafe void GetOrLoadOrCreateScriptForType(Type scriptType, godot_ref* outScript)
-        {
-            static bool GetPathOtherwiseGetOrCreateScript(Type scriptType, godot_ref* outScript,
-                [MaybeNullWhen(false)] out string scriptPath)
-            {
-                lock (_scriptTypeBiMap.ReadWriteLock)
-                {
-                    if (_scriptTypeBiMap.TryGetScriptPtr(scriptType, out IntPtr scriptPtr))
-                    {
-                        // Use existing
-                        NativeFuncs.godotsharp_ref_new_from_ref_counted_ptr(out *outScript, scriptPtr);
-                        scriptPath = null;
-                        return false;
-                    }
-
-                    // This path is slower, but it's only executed for the first instantiation of the type
-
-                    if (_pathTypeBiMap.TryGetScriptPath(scriptType, out scriptPath))
-                        return true;
-
-                    CreateScriptBridgeForType(scriptType, outScript);
                     scriptPath = null;
                     return false;
                 }
-            }
 
-            if (GetPathOtherwiseGetOrCreateScript(scriptType, outScript, out string? scriptPath))
-            {
                 // This path is slower, but it's only executed for the first instantiation of the type
 
-                // This must be done outside the read-write lock, as the script resource loading can lock it
-                using godot_string scriptPathIn = Marshaling.ConvertStringToNative(scriptPath);
-                if (!NativeFuncs.godotsharp_internal_script_load(scriptPathIn, outScript).ToBool())
-                {
-                    GD.PushError($"Cannot load script for type '{scriptType.FullName}'. Path: '{scriptPath}'.");
+                if (_pathTypeBiMap.TryGetScriptPath(scriptType, out scriptPath))
+                    return true;
 
-                    // If loading of the script fails, best we can do create a new script
-                    // with no path, as we do for types without an associated script file.
-                    GetOrCreateScriptBridgeForType(scriptType, outScript);
-                }
+                CreateScriptBridgeForType(scriptType, outScript);
+                scriptPath = null;
+                return false;
             }
         }
 
-        private static unsafe void CreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
+        if (GetPathOtherwiseGetOrCreateScript(scriptType, outScript, out string? scriptPath))
         {
-            NativeFuncs.godotsharp_internal_new_csharp_script(outScript);
-            IntPtr scriptPtr = outScript->Reference;
+            // This path is slower, but it's only executed for the first instantiation of the type
 
-            // Caller takes care of locking
-            _scriptTypeBiMap.Add(scriptPtr, scriptType);
-
-            NativeFuncs.godotsharp_internal_reload_registered_script(scriptPtr);
-        }
-
-        [UnmanagedCallersOnly]
-        internal static void RemoveScriptBridge(IntPtr scriptPtr)
-        {
-            try
+            // This must be done outside the read-write lock, as the script resource loading can lock it
+            using godot_string scriptPathIn = Marshaling.ConvertStringToNative(scriptPath);
+            if (!NativeFuncs.godotsharp_internal_script_load(scriptPathIn, outScript).ToBool())
             {
-                lock (_scriptTypeBiMap.ReadWriteLock)
-                {
-                    _scriptTypeBiMap.Remove(scriptPtr);
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
+                GD.PushError($"Cannot load script for type '{scriptType.FullName}'. Path: '{scriptPath}'.");
+
+                // If loading of the script fails, best we can do create a new script
+                // with no path, as we do for types without an associated script file.
+                GetOrCreateScriptBridgeForType(scriptType, outScript);
             }
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static godot_bool TryReloadRegisteredScriptWithClass(IntPtr scriptPtr)
+    private static unsafe void CreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
+    {
+        NativeFuncs.godotsharp_internal_new_csharp_script(outScript);
+        IntPtr scriptPtr = outScript->Reference;
+
+        // Caller takes care of locking
+        _scriptTypeBiMap.Add(scriptPtr, scriptType);
+
+        NativeFuncs.godotsharp_internal_reload_registered_script(scriptPtr);
+    }
+
+    [UnmanagedCallersOnly]
+    internal static void RemoveScriptBridge(IntPtr scriptPtr)
+    {
+        try
         {
-            try
+            lock (_scriptTypeBiMap.ReadWriteLock)
             {
-                lock (_scriptTypeBiMap.ReadWriteLock)
+                _scriptTypeBiMap.Remove(scriptPtr);
+            }
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static godot_bool TryReloadRegisteredScriptWithClass(IntPtr scriptPtr)
+    {
+        try
+        {
+            lock (_scriptTypeBiMap.ReadWriteLock)
+            {
+                if (_scriptTypeBiMap.TryGetScriptType(scriptPtr, out _))
                 {
-                    if (_scriptTypeBiMap.TryGetScriptType(scriptPtr, out _))
-                    {
-                        // NOTE:
-                        // Currently, we reload all scripts, not only the ones from the unloaded ALC.
-                        // As such, we need to handle this case instead of treating it as an error.
-                        NativeFuncs.godotsharp_internal_reload_registered_script(scriptPtr);
-                        return godot_bool.True;
-                    }
-
-                    if (!_scriptDataForReload.TryGetValue(scriptPtr, out var dataForReload))
-                    {
-                        GD.PushError("Missing class qualified name for reloading script");
-                        return godot_bool.False;
-                    }
-
-                    _ = _scriptDataForReload.TryRemove(scriptPtr, out _);
-
-                    if (dataForReload.assemblyName == null)
-                    {
-                        GD.PushError(
-                            $"Missing assembly name of class '{dataForReload.classFullName}' for reloading script");
-                        return godot_bool.False;
-                    }
-
-                    var scriptType = ReflectionUtils.FindTypeInLoadedAssemblies(dataForReload.assemblyName,
-                        dataForReload.classFullName);
-
-                    if (scriptType == null)
-                    {
-                        // The class was removed, can't reload
-                        return godot_bool.False;
-                    }
-
-                    // ReSharper disable once RedundantNameQualifier
-                    if (!typeof(GodotObject).IsAssignableFrom(scriptType))
-                    {
-                        // The class no longer inherits GodotObject, can't reload
-                        return godot_bool.False;
-                    }
-
-                    _scriptTypeBiMap.Add(scriptPtr, scriptType);
-
+                    // NOTE:
+                    // Currently, we reload all scripts, not only the ones from the unloaded ALC.
+                    // As such, we need to handle this case instead of treating it as an error.
                     NativeFuncs.godotsharp_internal_reload_registered_script(scriptPtr);
-
                     return godot_bool.True;
                 }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return godot_bool.False;
+
+                if (!_scriptDataForReload.TryGetValue(scriptPtr, out var dataForReload))
+                {
+                    GD.PushError("Missing class qualified name for reloading script");
+                    return godot_bool.False;
+                }
+
+                _ = _scriptDataForReload.TryRemove(scriptPtr, out _);
+
+                if (dataForReload.assemblyName == null)
+                {
+                    GD.PushError(
+                        $"Missing assembly name of class '{dataForReload.classFullName}' for reloading script");
+                    return godot_bool.False;
+                }
+
+                var scriptType = ReflectionUtils.FindTypeInLoadedAssemblies(dataForReload.assemblyName,
+                    dataForReload.classFullName);
+
+                if (scriptType == null)
+                {
+                    // The class was removed, can't reload
+                    return godot_bool.False;
+                }
+
+                // ReSharper disable once RedundantNameQualifier
+                if (!typeof(GodotObject).IsAssignableFrom(scriptType))
+                {
+                    // The class no longer inherits GodotObject, can't reload
+                    return godot_bool.False;
+                }
+
+                _scriptTypeBiMap.Add(scriptPtr, scriptType);
+
+                NativeFuncs.godotsharp_internal_reload_registered_script(scriptPtr);
+
+                return godot_bool.True;
             }
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void UpdateScriptClassInfo(IntPtr scriptPtr, godot_string* outClassName,
-            godot_bool* outTool, godot_bool* outGlobal, godot_string* outIconPath,
-            godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest,
-            godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript)
+        catch (Exception e)
         {
-            try
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void UpdateScriptClassInfo(IntPtr scriptPtr, godot_string* outClassName,
+        godot_bool* outTool, godot_bool* outGlobal, godot_string* outIconPath,
+        godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest,
+        godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript)
+    {
+        try
+        {
+            // Performance is not critical here as this will be replaced with source generators.
+            var scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
+
+            *outClassName = Marshaling.ConvertStringToNative(scriptType.Name);
+
+            *outTool = scriptType.GetCustomAttributes(inherit: false)
+                .OfType<ToolAttribute>()
+                .Any().ToGodotBool();
+
+            if (!(*outTool).ToBool() && scriptType.IsNested)
             {
-                // Performance is not critical here as this will be replaced with source generators.
-                var scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
-
-                *outClassName = Marshaling.ConvertStringToNative(scriptType.Name);
-
-                *outTool = scriptType.GetCustomAttributes(inherit: false)
+                *outTool = (scriptType.DeclaringType?.GetCustomAttributes(inherit: false)
                     .OfType<ToolAttribute>()
-                    .Any().ToGodotBool();
-
-                if (!(*outTool).ToBool() && scriptType.IsNested)
-                {
-                    *outTool = (scriptType.DeclaringType?.GetCustomAttributes(inherit: false)
-                        .OfType<ToolAttribute>()
-                        .Any() ?? false).ToGodotBool();
-                }
-
-                if (!(*outTool).ToBool() && scriptType.Assembly.GetName().Name == "GodotTools")
-                    *outTool = godot_bool.True;
-
-                var globalAttr = scriptType.GetCustomAttributes(inherit: false)
-                    .OfType<GlobalClassAttribute>()
-                    .FirstOrDefault();
-
-                *outGlobal = (globalAttr != null).ToGodotBool();
-
-                var iconAttr = scriptType.GetCustomAttributes(inherit: false)
-                    .OfType<IconAttribute>()
-                    .FirstOrDefault();
-
-                *outIconPath = Marshaling.ConvertStringToNative(iconAttr?.Path);
-
-                // Methods
-
-                // Performance is not critical here as this will be replaced with source generators.
-                using var methods = new Collections.Array();
-
-                Type? top = scriptType;
-                Type native = GodotObject.InternalGetClassNativeBase(top);
-
-                while (top != null && top != native)
-                {
-                    var methodList = GetMethodListForType(top);
-
-                    if (methodList != null)
-                    {
-                        foreach (var method in methodList)
-                        {
-                            var methodInfo = new Collections.Dictionary();
-
-                            methodInfo.Add("name", method.Name);
-
-                            var methodParams = new Collections.Array();
-
-                            if (method.Arguments != null)
-                            {
-                                foreach (var param in method.Arguments)
-                                {
-                                    var pinfo = new Collections.Dictionary()
-                                    {
-                                        { "name", param.Name },
-                                        { "type", (int)param.Type },
-                                        { "usage", (int)param.Usage }
-                                    };
-                                    if (param.ClassName != null)
-                                    {
-                                        pinfo["class_name"] = param.ClassName;
-                                    }
-
-                                    methodParams.Add(pinfo);
-                                }
-                            }
-
-                            methodInfo.Add("params", methodParams);
-
-                            methods.Add(methodInfo);
-                        }
-                    }
-
-                    top = top.BaseType;
-                }
-
-                *outMethodsDest = NativeFuncs.godotsharp_array_new_copy(
-                    (godot_array)methods.NativeValue);
-
-                // RPC functions
-
-                Collections.Dictionary rpcFunctions = new();
-
-                top = scriptType;
-
-                while (top != null && top != native)
-                {
-                    foreach (var method in top.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance |
-                                                          BindingFlags.NonPublic | BindingFlags.Public))
-                    {
-                        if (method.IsStatic)
-                            continue;
-
-                        string methodName = method.Name;
-
-                        if (rpcFunctions.ContainsKey(methodName))
-                            continue;
-
-                        var rpcAttr = method.GetCustomAttributes(inherit: false)
-                            .OfType<RpcAttribute>().FirstOrDefault();
-
-                        if (rpcAttr == null)
-                            continue;
-
-                        var rpcConfig = new Collections.Dictionary();
-
-                        rpcConfig["rpc_mode"] = (long)rpcAttr.Mode;
-                        rpcConfig["call_local"] = rpcAttr.CallLocal;
-                        rpcConfig["transfer_mode"] = (long)rpcAttr.TransferMode;
-                        rpcConfig["channel"] = rpcAttr.TransferChannel;
-
-                        rpcFunctions.Add(methodName, rpcConfig);
-                    }
-
-                    top = top.BaseType;
-                }
-
-                *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new_copy(
-                    (godot_dictionary)rpcFunctions.NativeValue);
-
-                // Event signals
-
-                // Performance is not critical here as this will be replaced with source generators.
-                using var signals = new Collections.Dictionary();
-
-                top = scriptType;
-
-                while (top != null && top != native)
-                {
-                    var signalList = GetSignalListForType(top);
-
-                    if (signalList != null)
-                    {
-                        foreach (var signal in signalList)
-                        {
-                            string signalName = signal.Name;
-
-                            if (signals.ContainsKey(signalName))
-                                continue;
-
-                            var signalParams = new Collections.Array();
-
-                            if (signal.Arguments != null)
-                            {
-                                foreach (var param in signal.Arguments)
-                                {
-                                    var pinfo = new Collections.Dictionary()
-                                    {
-                                        { "name", param.Name },
-                                        { "type", (int)param.Type },
-                                        { "usage", (int)param.Usage }
-                                    };
-                                    if (param.ClassName != null)
-                                    {
-                                        pinfo["class_name"] = param.ClassName;
-                                    }
-
-                                    signalParams.Add(pinfo);
-                                }
-                            }
-
-                            signals.Add(signalName, signalParams);
-                        }
-                    }
-
-                    top = top.BaseType;
-                }
-
-                *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new_copy(
-                    (godot_dictionary)signals.NativeValue);
-
-                // Base script
-
-                var baseType = scriptType.BaseType;
-                if (baseType != null && baseType != native)
-                {
-                    GetOrLoadOrCreateScriptForType(baseType, outBaseScript);
-                }
-                else
-                {
-                    *outBaseScript = default;
-                }
+                    .Any() ?? false).ToGodotBool();
             }
-            catch (Exception e)
+
+            if (!(*outTool).ToBool() && scriptType.Assembly.GetName().Name == "GodotTools")
+                *outTool = godot_bool.True;
+
+            var globalAttr = scriptType.GetCustomAttributes(inherit: false)
+                .OfType<GlobalClassAttribute>()
+                .FirstOrDefault();
+
+            *outGlobal = (globalAttr != null).ToGodotBool();
+
+            var iconAttr = scriptType.GetCustomAttributes(inherit: false)
+                .OfType<IconAttribute>()
+                .FirstOrDefault();
+
+            *outIconPath = Marshaling.ConvertStringToNative(iconAttr?.Path);
+
+            // Methods
+
+            // Performance is not critical here as this will be replaced with source generators.
+            using var methods = new Collections.Array();
+
+            Type? top = scriptType;
+            Type native = GodotObject.InternalGetClassNativeBase(top);
+
+            while (top != null && top != native)
             {
-                ExceptionUtils.LogException(e);
-                *outClassName = default;
-                *outTool = godot_bool.False;
-                *outGlobal = godot_bool.False;
-                *outIconPath = default;
-                *outMethodsDest = NativeFuncs.godotsharp_array_new();
-                *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new();
-                *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new();
+                var methodList = GetMethodListForType(top);
+
+                if (methodList != null)
+                {
+                    foreach (var method in methodList)
+                    {
+                        var methodInfo = new Collections.Dictionary();
+
+                        methodInfo.Add("name", method.Name);
+
+                        var methodParams = new Collections.Array();
+
+                        if (method.Arguments != null)
+                        {
+                            foreach (var param in method.Arguments)
+                            {
+                                var pinfo = new Collections.Dictionary()
+                                    {
+                                        { "name", param.Name },
+                                        { "type", (int)param.Type },
+                                        { "usage", (int)param.Usage }
+                                    };
+                                if (param.ClassName != null)
+                                {
+                                    pinfo["class_name"] = param.ClassName;
+                                }
+
+                                methodParams.Add(pinfo);
+                            }
+                        }
+
+                        methodInfo.Add("params", methodParams);
+
+                        methods.Add(methodInfo);
+                    }
+                }
+
+                top = top.BaseType;
+            }
+
+            *outMethodsDest = NativeFuncs.godotsharp_array_new_copy(
+                (godot_array)methods.NativeValue);
+
+            // RPC functions
+
+            Collections.Dictionary rpcFunctions = new();
+
+            top = scriptType;
+
+            while (top != null && top != native)
+            {
+                foreach (var method in top.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance |
+                                                      BindingFlags.NonPublic | BindingFlags.Public))
+                {
+                    if (method.IsStatic)
+                        continue;
+
+                    string methodName = method.Name;
+
+                    if (rpcFunctions.ContainsKey(methodName))
+                        continue;
+
+                    var rpcAttr = method.GetCustomAttributes(inherit: false)
+                        .OfType<RpcAttribute>().FirstOrDefault();
+
+                    if (rpcAttr == null)
+                        continue;
+
+                    var rpcConfig = new Collections.Dictionary();
+
+                    rpcConfig["rpc_mode"] = (long)rpcAttr.Mode;
+                    rpcConfig["call_local"] = rpcAttr.CallLocal;
+                    rpcConfig["transfer_mode"] = (long)rpcAttr.TransferMode;
+                    rpcConfig["channel"] = rpcAttr.TransferChannel;
+
+                    rpcFunctions.Add(methodName, rpcConfig);
+                }
+
+                top = top.BaseType;
+            }
+
+            *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new_copy(
+                (godot_dictionary)rpcFunctions.NativeValue);
+
+            // Event signals
+
+            // Performance is not critical here as this will be replaced with source generators.
+            using var signals = new Collections.Dictionary();
+
+            top = scriptType;
+
+            while (top != null && top != native)
+            {
+                var signalList = GetSignalListForType(top);
+
+                if (signalList != null)
+                {
+                    foreach (var signal in signalList)
+                    {
+                        string signalName = signal.Name;
+
+                        if (signals.ContainsKey(signalName))
+                            continue;
+
+                        var signalParams = new Collections.Array();
+
+                        if (signal.Arguments != null)
+                        {
+                            foreach (var param in signal.Arguments)
+                            {
+                                var pinfo = new Collections.Dictionary()
+                                    {
+                                        { "name", param.Name },
+                                        { "type", (int)param.Type },
+                                        { "usage", (int)param.Usage }
+                                    };
+                                if (param.ClassName != null)
+                                {
+                                    pinfo["class_name"] = param.ClassName;
+                                }
+
+                                signalParams.Add(pinfo);
+                            }
+                        }
+
+                        signals.Add(signalName, signalParams);
+                    }
+                }
+
+                top = top.BaseType;
+            }
+
+            *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new_copy(
+                (godot_dictionary)signals.NativeValue);
+
+            // Base script
+
+            var baseType = scriptType.BaseType;
+            if (baseType != null && baseType != native)
+            {
+                GetOrLoadOrCreateScriptForType(baseType, outBaseScript);
+            }
+            else
+            {
                 *outBaseScript = default;
             }
         }
-
-        private static List<MethodInfo>? GetSignalListForType(Type type)
+        catch (Exception e)
         {
-            var getGodotSignalListMethod = type.GetMethod(
-                "GetGodotSignalList",
+            ExceptionUtils.LogException(e);
+            *outClassName = default;
+            *outTool = godot_bool.False;
+            *outGlobal = godot_bool.False;
+            *outIconPath = default;
+            *outMethodsDest = NativeFuncs.godotsharp_array_new();
+            *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new();
+            *outEventSignalsDest = NativeFuncs.godotsharp_dictionary_new();
+            *outBaseScript = default;
+        }
+    }
+
+    private static List<MethodInfo>? GetSignalListForType(Type type)
+    {
+        var getGodotSignalListMethod = type.GetMethod(
+            "GetGodotSignalList",
+            BindingFlags.DeclaredOnly | BindingFlags.Static |
+            BindingFlags.NonPublic | BindingFlags.Public);
+
+        if (getGodotSignalListMethod == null)
+            return null;
+
+        return (List<MethodInfo>?)getGodotSignalListMethod.Invoke(null, null);
+    }
+
+    private static List<MethodInfo>? GetMethodListForType(Type type)
+    {
+        var getGodotMethodListMethod = type.GetMethod(
+            "GetGodotMethodList",
+            BindingFlags.DeclaredOnly | BindingFlags.Static |
+            BindingFlags.NonPublic | BindingFlags.Public);
+
+        if (getGodotMethodListMethod == null)
+            return null;
+
+        return (List<MethodInfo>?)getGodotMethodListMethod.Invoke(null, null);
+    }
+
+    // ReSharper disable once InconsistentNaming
+    [SuppressMessage("ReSharper", "NotAccessedField.Local")]
+    [StructLayout(LayoutKind.Sequential)]
+    private ref struct godotsharp_property_info
+    {
+        // Careful with padding...
+        public godot_string_name Name; // Not owned
+        public godot_string HintString;
+        public int Type;
+        public int Hint;
+        public int Usage;
+        public godot_bool Exported;
+
+        public void Dispose()
+        {
+            HintString.Dispose();
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void GetPropertyInfoList(IntPtr scriptPtr,
+        delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc)
+    {
+        try
+        {
+            Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
+            GetPropertyInfoListForType(scriptType, scriptPtr, addPropInfoFunc);
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    private static unsafe void GetPropertyInfoListForType(Type type, IntPtr scriptPtr,
+        delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc)
+    {
+        try
+        {
+            var getGodotPropertyListMethod = type.GetMethod(
+                "GetGodotPropertyList",
                 BindingFlags.DeclaredOnly | BindingFlags.Static |
                 BindingFlags.NonPublic | BindingFlags.Public);
 
-            if (getGodotSignalListMethod == null)
-                return null;
+            if (getGodotPropertyListMethod == null)
+                return;
 
-            return (List<MethodInfo>?)getGodotSignalListMethod.Invoke(null, null);
+            var properties = (List<PropertyInfo>?)
+                getGodotPropertyListMethod.Invoke(null, null);
+
+            if (properties == null || properties.Count <= 0)
+                return;
+
+            int length = properties.Count;
+
+            // There's no recursion here, so it's ok to go with a big enough number for most cases
+            // stackMaxSize = stackMaxLength * sizeof(godotsharp_property_info)
+            const int stackMaxLength = 32;
+            bool useStack = length < stackMaxLength;
+
+            godotsharp_property_info* interopProperties;
+
+            if (useStack)
+            {
+                // Weird limitation, hence the need for aux:
+                // "In the case of pointer types, you can use a stackalloc expression only in a local variable declaration to initialize the variable."
+                var aux = stackalloc godotsharp_property_info[stackMaxLength];
+                interopProperties = aux;
+            }
+            else
+            {
+                interopProperties = ((godotsharp_property_info*)NativeMemory.Alloc(
+                    (nuint)length, (nuint)sizeof(godotsharp_property_info)))!;
+            }
+
+            try
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    var property = properties[i];
+
+                    godotsharp_property_info interopProperty = new()
+                    {
+                        Type = (int)property.Type,
+                        Name = (godot_string_name)property.Name.NativeValue, // Not owned
+                        Hint = (int)property.Hint,
+                        HintString = Marshaling.ConvertStringToNative(property.HintString),
+                        Usage = (int)property.Usage,
+                        Exported = property.Exported.ToGodotBool()
+                    };
+
+                    interopProperties[i] = interopProperty;
+                }
+
+                using godot_string currentClassName = Marshaling.ConvertStringToNative(type.Name);
+
+                addPropInfoFunc(scriptPtr, &currentClassName, interopProperties, length);
+
+                // We're borrowing the native value of the StringName entries.
+                // The dictionary needs to be kept alive until `addPropInfoFunc` returns.
+                GC.KeepAlive(properties);
+            }
+            finally
+            {
+                for (int i = 0; i < length; i++)
+                    interopProperties[i].Dispose();
+
+                if (!useStack)
+                    NativeMemory.Free(interopProperties);
+            }
         }
-
-        private static List<MethodInfo>? GetMethodListForType(Type type)
+        catch (Exception e)
         {
-            var getGodotMethodListMethod = type.GetMethod(
-                "GetGodotMethodList",
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    // ReSharper disable once InconsistentNaming
+    [SuppressMessage("ReSharper", "NotAccessedField.Local")]
+    [StructLayout(LayoutKind.Sequential)]
+    private ref struct godotsharp_property_def_val_pair
+    {
+        // Careful with padding...
+        public godot_string_name Name; // Not owned
+        public godot_variant Value; // Not owned
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void GetPropertyDefaultValues(IntPtr scriptPtr,
+        delegate* unmanaged<IntPtr, void*, int, void> addDefValFunc)
+    {
+        try
+        {
+            Type? top = _scriptTypeBiMap.GetScriptType(scriptPtr);
+            Type native = GodotObject.InternalGetClassNativeBase(top);
+
+            while (top != null && top != native)
+            {
+                GetPropertyDefaultValuesForType(top, scriptPtr, addDefValFunc);
+
+                top = top.BaseType;
+            }
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    [SkipLocalsInit]
+    private static unsafe void GetPropertyDefaultValuesForType(Type type, IntPtr scriptPtr,
+        delegate* unmanaged<IntPtr, void*, int, void> addDefValFunc)
+    {
+        try
+        {
+            var getGodotPropertyDefaultValuesMethod = type.GetMethod(
+                "GetGodotPropertyDefaultValues",
                 BindingFlags.DeclaredOnly | BindingFlags.Static |
                 BindingFlags.NonPublic | BindingFlags.Public);
 
-            if (getGodotMethodListMethod == null)
-                return null;
+            if (getGodotPropertyDefaultValuesMethod == null)
+                return;
 
-            return (List<MethodInfo>?)getGodotMethodListMethod.Invoke(null, null);
-        }
+            var defaultValuesObj = getGodotPropertyDefaultValuesMethod.Invoke(null, null);
 
-        // ReSharper disable once InconsistentNaming
-        [SuppressMessage("ReSharper", "NotAccessedField.Local")]
-        [StructLayout(LayoutKind.Sequential)]
-        private ref struct godotsharp_property_info
-        {
-            // Careful with padding...
-            public godot_string_name Name; // Not owned
-            public godot_string HintString;
-            public int Type;
-            public int Hint;
-            public int Usage;
-            public godot_bool Exported;
+            if (defaultValuesObj == null)
+                return;
 
-            public void Dispose()
+            Dictionary<StringName, Variant> defaultValues;
+
+            if (defaultValuesObj is Dictionary<StringName, object> defaultValuesLegacy)
             {
-                HintString.Dispose();
-            }
-        }
+                // We have to support this for some time, otherwise this could cause data loss for projects
+                // built with previous releases. Ideally, we should remove this before Godot 4.0 stable.
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void GetPropertyInfoList(IntPtr scriptPtr,
-            delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc)
-        {
-            try
-            {
-                Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
-                GetPropertyInfoListForType(scriptType, scriptPtr, addPropInfoFunc);
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
-        }
-
-        private static unsafe void GetPropertyInfoListForType(Type type, IntPtr scriptPtr,
-            delegate* unmanaged<IntPtr, godot_string*, void*, int, void> addPropInfoFunc)
-        {
-            try
-            {
-                var getGodotPropertyListMethod = type.GetMethod(
-                    "GetGodotPropertyList",
-                    BindingFlags.DeclaredOnly | BindingFlags.Static |
-                    BindingFlags.NonPublic | BindingFlags.Public);
-
-                if (getGodotPropertyListMethod == null)
+                if (defaultValuesLegacy.Count <= 0)
                     return;
 
-                var properties = (List<PropertyInfo>?)
-                    getGodotPropertyListMethod.Invoke(null, null);
+                defaultValues = new();
 
-                if (properties == null || properties.Count <= 0)
-                    return;
-
-                int length = properties.Count;
-
-                // There's no recursion here, so it's ok to go with a big enough number for most cases
-                // stackMaxSize = stackMaxLength * sizeof(godotsharp_property_info)
-                const int stackMaxLength = 32;
-                bool useStack = length < stackMaxLength;
-
-                godotsharp_property_info* interopProperties;
-
-                if (useStack)
+                foreach (var pair in defaultValuesLegacy)
                 {
-                    // Weird limitation, hence the need for aux:
-                    // "In the case of pointer types, you can use a stackalloc expression only in a local variable declaration to initialize the variable."
-                    var aux = stackalloc godotsharp_property_info[stackMaxLength];
-                    interopProperties = aux;
+                    defaultValues[pair.Key] = Variant.CreateTakingOwnershipOfDisposableValue(
+                        DelegateUtils.RuntimeTypeConversionHelper.ConvertToVariant(pair.Value));
                 }
-                else
-                {
-                    interopProperties = ((godotsharp_property_info*)NativeMemory.Alloc(
-                        (nuint)length, (nuint)sizeof(godotsharp_property_info)))!;
-                }
+            }
+            else
+            {
+                defaultValues = (Dictionary<StringName, Variant>)defaultValuesObj;
+            }
 
-                try
+            if (defaultValues.Count <= 0)
+                return;
+
+            int length = defaultValues.Count;
+
+            // There's no recursion here, so it's ok to go with a big enough number for most cases
+            // stackMaxSize = stackMaxLength * sizeof(godotsharp_property_def_val_pair)
+            const int stackMaxLength = 32;
+            bool useStack = length < stackMaxLength;
+
+            godotsharp_property_def_val_pair* interopDefaultValues;
+
+            if (useStack)
+            {
+                // Weird limitation, hence the need for aux:
+                // "In the case of pointer types, you can use a stackalloc expression only in a local variable declaration to initialize the variable."
+                var aux = stackalloc godotsharp_property_def_val_pair[stackMaxLength];
+                interopDefaultValues = aux;
+            }
+            else
+            {
+                interopDefaultValues = ((godotsharp_property_def_val_pair*)NativeMemory.Alloc(
+                    (nuint)length, (nuint)sizeof(godotsharp_property_def_val_pair)))!;
+            }
+
+            try
+            {
+                int i = 0;
+                foreach (var defaultValuePair in defaultValues)
                 {
-                    for (int i = 0; i < length; i++)
+                    godotsharp_property_def_val_pair interopProperty = new()
                     {
-                        var property = properties[i];
+                        Name = (godot_string_name)defaultValuePair.Key.NativeValue, // Not owned
+                        Value = (godot_variant)defaultValuePair.Value.NativeVar // Not owned
+                    };
 
-                        godotsharp_property_info interopProperty = new()
-                        {
-                            Type = (int)property.Type,
-                            Name = (godot_string_name)property.Name.NativeValue, // Not owned
-                            Hint = (int)property.Hint,
-                            HintString = Marshaling.ConvertStringToNative(property.HintString),
-                            Usage = (int)property.Usage,
-                            Exported = property.Exported.ToGodotBool()
-                        };
+                    interopDefaultValues[i] = interopProperty;
 
-                        interopProperties[i] = interopProperty;
-                    }
-
-                    using godot_string currentClassName = Marshaling.ConvertStringToNative(type.Name);
-
-                    addPropInfoFunc(scriptPtr, &currentClassName, interopProperties, length);
-
-                    // We're borrowing the native value of the StringName entries.
-                    // The dictionary needs to be kept alive until `addPropInfoFunc` returns.
-                    GC.KeepAlive(properties);
+                    i++;
                 }
-                finally
-                {
-                    for (int i = 0; i < length; i++)
-                        interopProperties[i].Dispose();
 
-                    if (!useStack)
-                        NativeMemory.Free(interopProperties);
-                }
+                addDefValFunc(scriptPtr, interopDefaultValues, length);
+
+                // We're borrowing the native value of the StringName and Variant entries.
+                // The dictionary needs to be kept alive until `addDefValFunc` returns.
+                GC.KeepAlive(defaultValues);
             }
-            catch (Exception e)
+            finally
             {
-                ExceptionUtils.LogException(e);
+                if (!useStack)
+                    NativeMemory.Free(interopDefaultValues);
             }
         }
-
-        // ReSharper disable once InconsistentNaming
-        [SuppressMessage("ReSharper", "NotAccessedField.Local")]
-        [StructLayout(LayoutKind.Sequential)]
-        private ref struct godotsharp_property_def_val_pair
+        catch (Exception e)
         {
-            // Careful with padding...
-            public godot_string_name Name; // Not owned
-            public godot_variant Value; // Not owned
+            ExceptionUtils.LogException(e);
         }
+    }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void GetPropertyDefaultValues(IntPtr scriptPtr,
-            delegate* unmanaged<IntPtr, void*, int, void> addDefValFunc)
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool SwapGCHandleForType(IntPtr oldGCHandlePtr, IntPtr* outNewGCHandlePtr,
+        godot_bool createWeak)
+    {
+        try
         {
-            try
+            var oldGCHandle = GCHandle.FromIntPtr(oldGCHandlePtr);
+
+            object? target = oldGCHandle.Target;
+
+            if (target == null)
             {
-                Type? top = _scriptTypeBiMap.GetScriptType(scriptPtr);
-                Type native = GodotObject.InternalGetClassNativeBase(top);
-
-                while (top != null && top != native)
-                {
-                    GetPropertyDefaultValuesForType(top, scriptPtr, addDefValFunc);
-
-                    top = top.BaseType;
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
-        }
-
-        [SkipLocalsInit]
-        private static unsafe void GetPropertyDefaultValuesForType(Type type, IntPtr scriptPtr,
-            delegate* unmanaged<IntPtr, void*, int, void> addDefValFunc)
-        {
-            try
-            {
-                var getGodotPropertyDefaultValuesMethod = type.GetMethod(
-                    "GetGodotPropertyDefaultValues",
-                    BindingFlags.DeclaredOnly | BindingFlags.Static |
-                    BindingFlags.NonPublic | BindingFlags.Public);
-
-                if (getGodotPropertyDefaultValuesMethod == null)
-                    return;
-
-                var defaultValuesObj = getGodotPropertyDefaultValuesMethod.Invoke(null, null);
-
-                if (defaultValuesObj == null)
-                    return;
-
-                Dictionary<StringName, Variant> defaultValues;
-
-                if (defaultValuesObj is Dictionary<StringName, object> defaultValuesLegacy)
-                {
-                    // We have to support this for some time, otherwise this could cause data loss for projects
-                    // built with previous releases. Ideally, we should remove this before Godot 4.0 stable.
-
-                    if (defaultValuesLegacy.Count <= 0)
-                        return;
-
-                    defaultValues = new();
-
-                    foreach (var pair in defaultValuesLegacy)
-                    {
-                        defaultValues[pair.Key] = Variant.CreateTakingOwnershipOfDisposableValue(
-                            DelegateUtils.RuntimeTypeConversionHelper.ConvertToVariant(pair.Value));
-                    }
-                }
-                else
-                {
-                    defaultValues = (Dictionary<StringName, Variant>)defaultValuesObj;
-                }
-
-                if (defaultValues.Count <= 0)
-                    return;
-
-                int length = defaultValues.Count;
-
-                // There's no recursion here, so it's ok to go with a big enough number for most cases
-                // stackMaxSize = stackMaxLength * sizeof(godotsharp_property_def_val_pair)
-                const int stackMaxLength = 32;
-                bool useStack = length < stackMaxLength;
-
-                godotsharp_property_def_val_pair* interopDefaultValues;
-
-                if (useStack)
-                {
-                    // Weird limitation, hence the need for aux:
-                    // "In the case of pointer types, you can use a stackalloc expression only in a local variable declaration to initialize the variable."
-                    var aux = stackalloc godotsharp_property_def_val_pair[stackMaxLength];
-                    interopDefaultValues = aux;
-                }
-                else
-                {
-                    interopDefaultValues = ((godotsharp_property_def_val_pair*)NativeMemory.Alloc(
-                        (nuint)length, (nuint)sizeof(godotsharp_property_def_val_pair)))!;
-                }
-
-                try
-                {
-                    int i = 0;
-                    foreach (var defaultValuePair in defaultValues)
-                    {
-                        godotsharp_property_def_val_pair interopProperty = new()
-                        {
-                            Name = (godot_string_name)defaultValuePair.Key.NativeValue, // Not owned
-                            Value = (godot_variant)defaultValuePair.Value.NativeVar // Not owned
-                        };
-
-                        interopDefaultValues[i] = interopProperty;
-
-                        i++;
-                    }
-
-                    addDefValFunc(scriptPtr, interopDefaultValues, length);
-
-                    // We're borrowing the native value of the StringName and Variant entries.
-                    // The dictionary needs to be kept alive until `addDefValFunc` returns.
-                    GC.KeepAlive(defaultValues);
-                }
-                finally
-                {
-                    if (!useStack)
-                        NativeMemory.Free(interopDefaultValues);
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool SwapGCHandleForType(IntPtr oldGCHandlePtr, IntPtr* outNewGCHandlePtr,
-            godot_bool createWeak)
-        {
-            try
-            {
-                var oldGCHandle = GCHandle.FromIntPtr(oldGCHandlePtr);
-
-                object? target = oldGCHandle.Target;
-
-                if (target == null)
-                {
-                    CustomGCHandle.Free(oldGCHandle);
-                    *outNewGCHandlePtr = IntPtr.Zero;
-                    return godot_bool.False; // Called after the managed side was collected, so nothing to do here
-                }
-
-                // Release the current weak handle and replace it with a strong handle.
-                var newGCHandle = createWeak.ToBool() ?
-                    CustomGCHandle.AllocWeak(target) :
-                    CustomGCHandle.AllocStrong(target);
-
                 CustomGCHandle.Free(oldGCHandle);
-                *outNewGCHandlePtr = GCHandle.ToIntPtr(newGCHandle);
-                return godot_bool.True;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
                 *outNewGCHandlePtr = IntPtr.Zero;
-                return godot_bool.False;
+                return godot_bool.False; // Called after the managed side was collected, so nothing to do here
             }
+
+            // Release the current weak handle and replace it with a strong handle.
+            var newGCHandle = createWeak.ToBool() ?
+                CustomGCHandle.AllocWeak(target) :
+                CustomGCHandle.AllocStrong(target);
+
+            CustomGCHandle.Free(oldGCHandle);
+            *outNewGCHandlePtr = GCHandle.ToIntPtr(newGCHandle);
+            return godot_bool.True;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            *outNewGCHandlePtr = IntPtr.Zero;
+            return godot_bool.False;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Callable.cs
@@ -3,201 +3,200 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Callable is a first class object which can be held in variables and passed to functions.
+/// It represents a given method in an Object, and is typically used for signal callbacks.
+/// </summary>
+/// <example>
+/// <code>
+/// public void PrintArgs(object ar1, object arg2, object arg3 = null)
+/// {
+///     GD.PrintS(arg1, arg2, arg3);
+/// }
+///
+/// public void Test()
+/// {
+///     // This Callable object will call the PrintArgs method defined above.
+///     Callable callable = new Callable(this, nameof(PrintArgs));
+///     callable.Call("hello", "world"); // Prints "hello world null".
+///     callable.Call(Vector2.Up, 42, callable); // Prints "(0, -1) 42 Node(Node.cs)::PrintArgs".
+///     callable.Call("invalid"); // Invalid call, should have at least 2 arguments.
+/// }
+/// </code>
+/// </example>
+public readonly partial struct Callable
 {
+    private readonly GodotObject _target;
+    private readonly StringName _method;
+    private readonly Delegate _delegate;
+    private readonly unsafe delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> _trampoline;
+
     /// <summary>
-    /// Callable is a first class object which can be held in variables and passed to functions.
-    /// It represents a given method in an Object, and is typically used for signal callbacks.
+    /// Object that contains the method.
+    /// </summary>
+    public GodotObject Target => _target;
+
+    /// <summary>
+    /// Name of the method that will be called.
+    /// </summary>
+    public StringName Method => _method;
+
+    /// <summary>
+    /// Delegate of the method that will be called.
+    /// </summary>
+    public Delegate Delegate => _delegate;
+
+    /// <summary>
+    /// Trampoline function pointer for dynamically invoking <see cref="Callable.Delegate"/>.
+    /// </summary>
+    public unsafe delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> Trampoline
+        => _trampoline;
+
+    /// <summary>
+    /// Constructs a new <see cref="Callable"/> for the method called <paramref name="method"/>
+    /// in the specified <paramref name="target"/>.
+    /// </summary>
+    /// <param name="target">Object that contains the method.</param>
+    /// <param name="method">Name of the method that will be called.</param>
+    public unsafe Callable(GodotObject target, StringName method)
+    {
+        _target = target;
+        _method = method;
+        _delegate = null;
+        _trampoline = null;
+    }
+
+    private unsafe Callable(Delegate @delegate,
+        delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
+    {
+        _target = @delegate?.Target as GodotObject;
+        _method = null;
+        _delegate = @delegate;
+        _trampoline = trampoline;
+    }
+
+    private const int VarArgsSpanThreshold = 10;
+
+    /// <summary>
+    /// Calls the method represented by this <see cref="Callable"/>.
+    /// Arguments can be passed and should match the method's signature.
+    /// </summary>
+    /// <param name="args">Arguments that will be passed to the method call.</param>
+    /// <returns>The value returned by the method.</returns>
+    public unsafe Variant Call(params Variant[] args)
+    {
+        using godot_callable callable = Marshaling.ConvertCallableToNative(this);
+
+        int argc = args.Length;
+
+        Span<godot_variant.movable> argsStoreSpan = argc <= VarArgsSpanThreshold ?
+            stackalloc godot_variant.movable[VarArgsSpanThreshold] :
+            new godot_variant.movable[argc];
+
+        Span<IntPtr> argsSpan = argc <= VarArgsSpanThreshold ?
+            stackalloc IntPtr[VarArgsSpanThreshold] :
+            new IntPtr[argc];
+
+        fixed (godot_variant* varargs = &MemoryMarshal.GetReference(argsStoreSpan).DangerousSelfRef)
+        fixed (IntPtr* argsPtr = &MemoryMarshal.GetReference(argsSpan))
+        {
+            for (int i = 0; i < argc; i++)
+            {
+                varargs[i] = (godot_variant)args[i].NativeVar;
+                argsPtr[i] = new IntPtr(&varargs[i]);
+            }
+
+            godot_variant ret = NativeFuncs.godotsharp_callable_call(callable,
+                (godot_variant**)argsPtr, argc, out _);
+            return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+        }
+    }
+
+    /// <summary>
+    /// Calls the method represented by this <see cref="Callable"/> in deferred mode, i.e. during the idle frame.
+    /// Arguments can be passed and should match the method's signature.
+    /// </summary>
+    /// <param name="args">Arguments that will be passed to the method call.</param>
+    public unsafe void CallDeferred(params Variant[] args)
+    {
+        using godot_callable callable = Marshaling.ConvertCallableToNative(this);
+
+        int argc = args.Length;
+
+        Span<godot_variant.movable> argsStoreSpan = argc <= VarArgsSpanThreshold ?
+            stackalloc godot_variant.movable[VarArgsSpanThreshold] :
+            new godot_variant.movable[argc];
+
+        Span<IntPtr> argsSpan = argc <= VarArgsSpanThreshold ?
+            stackalloc IntPtr[VarArgsSpanThreshold] :
+            new IntPtr[argc];
+
+        fixed (godot_variant* varargs = &MemoryMarshal.GetReference(argsStoreSpan).DangerousSelfRef)
+        fixed (IntPtr* argsPtr = &MemoryMarshal.GetReference(argsSpan))
+        {
+            for (int i = 0; i < argc; i++)
+            {
+                varargs[i] = (godot_variant)args[i].NativeVar;
+                argsPtr[i] = new IntPtr(&varargs[i]);
+            }
+
+            NativeFuncs.godotsharp_callable_call_deferred(callable, (godot_variant**)argsPtr, argc);
+        }
+    }
+
+    /// <summary>
+    /// <para>
+    /// Constructs a new <see cref="Callable"/> using the <paramref name="trampoline"/>
+    /// function pointer to dynamically invoke the given <paramref name="delegate"/>.
+    /// </para>
+    /// <para>
+    /// The parameters passed to the <paramref name="trampoline"/> function are:
+    /// </para>
+    /// <list type="number">
+    ///    <item>
+    ///        <term>delegateObj</term>
+    ///        <description>The given <paramref name="delegate"/>, upcast to <see cref="object"/>.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>args</term>
+    ///        <description>Array of <see cref="godot_variant"/> arguments.</description>
+    ///    </item>
+    ///    <item>
+    ///        <term>ret</term>
+    ///        <description>Return value of type <see cref="godot_variant"/>.</description>
+    ///    </item>
+    ///</list>
+    /// <para>
+    /// The delegate should be downcast to a more specific delegate type before invoking.
+    /// </para>
     /// </summary>
     /// <example>
-    /// <code>
-    /// public void PrintArgs(object ar1, object arg2, object arg3 = null)
-    /// {
-    ///     GD.PrintS(arg1, arg2, arg3);
-    /// }
+    /// Usage example:
     ///
-    /// public void Test()
-    /// {
-    ///     // This Callable object will call the PrintArgs method defined above.
-    ///     Callable callable = new Callable(this, nameof(PrintArgs));
-    ///     callable.Call("hello", "world"); // Prints "hello world null".
-    ///     callable.Call(Vector2.Up, 42, callable); // Prints "(0, -1) 42 Node(Node.cs)::PrintArgs".
-    ///     callable.Call("invalid"); // Invalid call, should have at least 2 arguments.
-    /// }
+    /// <code>
+    ///     static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
+    ///     {
+    ///         if (args.Count != 1)
+    ///             throw new ArgumentException($&quot;Callable expected {1} arguments but received {args.Count}.&quot;);
+    ///
+    ///         TResult res = ((Func&lt;int, string&gt;)delegateObj)(
+    ///             VariantConversionCallbacks.GetToManagedCallback&lt;int&gt;()(args[0])
+    ///         );
+    ///
+    ///         ret = VariantConversionCallbacks.GetToVariantCallback&lt;string&gt;()(res);
+    ///     }
+    ///
+    ///     var callable = Callable.CreateWithUnsafeTrampoline((int num) =&gt; &quot;foo&quot; + num.ToString(), &amp;Trampoline);
+    ///     var res = (string)callable.Call(10);
+    ///     Console.WriteLine(res);
     /// </code>
     /// </example>
-    public readonly partial struct Callable
-    {
-        private readonly GodotObject _target;
-        private readonly StringName _method;
-        private readonly Delegate _delegate;
-        private readonly unsafe delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> _trampoline;
-
-        /// <summary>
-        /// Object that contains the method.
-        /// </summary>
-        public GodotObject Target => _target;
-
-        /// <summary>
-        /// Name of the method that will be called.
-        /// </summary>
-        public StringName Method => _method;
-
-        /// <summary>
-        /// Delegate of the method that will be called.
-        /// </summary>
-        public Delegate Delegate => _delegate;
-
-        /// <summary>
-        /// Trampoline function pointer for dynamically invoking <see cref="Callable.Delegate"/>.
-        /// </summary>
-        public unsafe delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> Trampoline
-            => _trampoline;
-
-        /// <summary>
-        /// Constructs a new <see cref="Callable"/> for the method called <paramref name="method"/>
-        /// in the specified <paramref name="target"/>.
-        /// </summary>
-        /// <param name="target">Object that contains the method.</param>
-        /// <param name="method">Name of the method that will be called.</param>
-        public unsafe Callable(GodotObject target, StringName method)
-        {
-            _target = target;
-            _method = method;
-            _delegate = null;
-            _trampoline = null;
-        }
-
-        private unsafe Callable(Delegate @delegate,
-            delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
-        {
-            _target = @delegate?.Target as GodotObject;
-            _method = null;
-            _delegate = @delegate;
-            _trampoline = trampoline;
-        }
-
-        private const int VarArgsSpanThreshold = 10;
-
-        /// <summary>
-        /// Calls the method represented by this <see cref="Callable"/>.
-        /// Arguments can be passed and should match the method's signature.
-        /// </summary>
-        /// <param name="args">Arguments that will be passed to the method call.</param>
-        /// <returns>The value returned by the method.</returns>
-        public unsafe Variant Call(params Variant[] args)
-        {
-            using godot_callable callable = Marshaling.ConvertCallableToNative(this);
-
-            int argc = args.Length;
-
-            Span<godot_variant.movable> argsStoreSpan = argc <= VarArgsSpanThreshold ?
-                stackalloc godot_variant.movable[VarArgsSpanThreshold] :
-                new godot_variant.movable[argc];
-
-            Span<IntPtr> argsSpan = argc <= VarArgsSpanThreshold ?
-                stackalloc IntPtr[VarArgsSpanThreshold] :
-                new IntPtr[argc];
-
-            fixed (godot_variant* varargs = &MemoryMarshal.GetReference(argsStoreSpan).DangerousSelfRef)
-            fixed (IntPtr* argsPtr = &MemoryMarshal.GetReference(argsSpan))
-            {
-                for (int i = 0; i < argc; i++)
-                {
-                    varargs[i] = (godot_variant)args[i].NativeVar;
-                    argsPtr[i] = new IntPtr(&varargs[i]);
-                }
-
-                godot_variant ret = NativeFuncs.godotsharp_callable_call(callable,
-                    (godot_variant**)argsPtr, argc, out _);
-                return Variant.CreateTakingOwnershipOfDisposableValue(ret);
-            }
-        }
-
-        /// <summary>
-        /// Calls the method represented by this <see cref="Callable"/> in deferred mode, i.e. during the idle frame.
-        /// Arguments can be passed and should match the method's signature.
-        /// </summary>
-        /// <param name="args">Arguments that will be passed to the method call.</param>
-        public unsafe void CallDeferred(params Variant[] args)
-        {
-            using godot_callable callable = Marshaling.ConvertCallableToNative(this);
-
-            int argc = args.Length;
-
-            Span<godot_variant.movable> argsStoreSpan = argc <= VarArgsSpanThreshold ?
-                stackalloc godot_variant.movable[VarArgsSpanThreshold] :
-                new godot_variant.movable[argc];
-
-            Span<IntPtr> argsSpan = argc <= VarArgsSpanThreshold ?
-                stackalloc IntPtr[VarArgsSpanThreshold] :
-                new IntPtr[argc];
-
-            fixed (godot_variant* varargs = &MemoryMarshal.GetReference(argsStoreSpan).DangerousSelfRef)
-            fixed (IntPtr* argsPtr = &MemoryMarshal.GetReference(argsSpan))
-            {
-                for (int i = 0; i < argc; i++)
-                {
-                    varargs[i] = (godot_variant)args[i].NativeVar;
-                    argsPtr[i] = new IntPtr(&varargs[i]);
-                }
-
-                NativeFuncs.godotsharp_callable_call_deferred(callable, (godot_variant**)argsPtr, argc);
-            }
-        }
-
-        /// <summary>
-        /// <para>
-        /// Constructs a new <see cref="Callable"/> using the <paramref name="trampoline"/>
-        /// function pointer to dynamically invoke the given <paramref name="delegate"/>.
-        /// </para>
-        /// <para>
-        /// The parameters passed to the <paramref name="trampoline"/> function are:
-        /// </para>
-        /// <list type="number">
-        ///    <item>
-        ///        <term>delegateObj</term>
-        ///        <description>The given <paramref name="delegate"/>, upcast to <see cref="object"/>.</description>
-        ///    </item>
-        ///    <item>
-        ///        <term>args</term>
-        ///        <description>Array of <see cref="godot_variant"/> arguments.</description>
-        ///    </item>
-        ///    <item>
-        ///        <term>ret</term>
-        ///        <description>Return value of type <see cref="godot_variant"/>.</description>
-        ///    </item>
-        ///</list>
-        /// <para>
-        /// The delegate should be downcast to a more specific delegate type before invoking.
-        /// </para>
-        /// </summary>
-        /// <example>
-        /// Usage example:
-        ///
-        /// <code>
-        ///     static void Trampoline(object delegateObj, NativeVariantPtrArgs args, out godot_variant ret)
-        ///     {
-        ///         if (args.Count != 1)
-        ///             throw new ArgumentException($&quot;Callable expected {1} arguments but received {args.Count}.&quot;);
-        ///
-        ///         TResult res = ((Func&lt;int, string&gt;)delegateObj)(
-        ///             VariantConversionCallbacks.GetToManagedCallback&lt;int&gt;()(args[0])
-        ///         );
-        ///
-        ///         ret = VariantConversionCallbacks.GetToVariantCallback&lt;string&gt;()(res);
-        ///     }
-        ///
-        ///     var callable = Callable.CreateWithUnsafeTrampoline((int num) =&gt; &quot;foo&quot; + num.ToString(), &amp;Trampoline);
-        ///     var res = (string)callable.Call(10);
-        ///     Console.WriteLine(res);
-        /// </code>
-        /// </example>
-        /// <param name="delegate">Delegate method that will be called.</param>
-        /// <param name="trampoline">Trampoline function pointer for invoking the delegate.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Callable CreateWithUnsafeTrampoline(Delegate @delegate,
-            delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
-            => new(@delegate, trampoline);
-    }
+    /// <param name="delegate">Delegate method that will be called.</param>
+    /// <param name="trampoline">Trampoline function pointer for invoking the delegate.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe Callable CreateWithUnsafeTrampoline(Delegate @delegate,
+        delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void> trampoline)
+        => new(@delegate, trampoline);
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -2,1331 +2,1330 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// A color represented by red, green, blue, and alpha (RGBA) components.
+/// The alpha component is often used for transparency.
+/// Values are in floating-point and usually range from 0 to 1.
+/// Some properties (such as <see cref="CanvasItem.Modulate"/>) may accept values
+/// greater than 1 (overbright or HDR colors).
+///
+/// If you want to supply values in a range of 0 to 255, you should use
+/// <see cref="Color8"/> and the <c>r8</c>/<c>g8</c>/<c>b8</c>/<c>a8</c> properties.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Color : IEquatable<Color>
 {
     /// <summary>
-    /// A color represented by red, green, blue, and alpha (RGBA) components.
-    /// The alpha component is often used for transparency.
-    /// Values are in floating-point and usually range from 0 to 1.
-    /// Some properties (such as <see cref="CanvasItem.Modulate"/>) may accept values
-    /// greater than 1 (overbright or HDR colors).
-    ///
-    /// If you want to supply values in a range of 0 to 255, you should use
-    /// <see cref="Color8"/> and the <c>r8</c>/<c>g8</c>/<c>b8</c>/<c>a8</c> properties.
+    /// The color's red component, typically on the range of 0 to 1.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Color : IEquatable<Color>
+    public float R;
+
+    /// <summary>
+    /// The color's green component, typically on the range of 0 to 1.
+    /// </summary>
+    public float G;
+
+    /// <summary>
+    /// The color's blue component, typically on the range of 0 to 1.
+    /// </summary>
+    public float B;
+
+    /// <summary>
+    /// The color's alpha (transparency) component, typically on the range of 0 to 1.
+    /// </summary>
+    public float A;
+
+    /// <summary>
+    /// Wrapper for <see cref="R"/> that uses the range 0 to 255 instead of 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+    public int R8
     {
-        /// <summary>
-        /// The color's red component, typically on the range of 0 to 1.
-        /// </summary>
-        public float R;
-
-        /// <summary>
-        /// The color's green component, typically on the range of 0 to 1.
-        /// </summary>
-        public float G;
-
-        /// <summary>
-        /// The color's blue component, typically on the range of 0 to 1.
-        /// </summary>
-        public float B;
-
-        /// <summary>
-        /// The color's alpha (transparency) component, typically on the range of 0 to 1.
-        /// </summary>
-        public float A;
-
-        /// <summary>
-        /// Wrapper for <see cref="R"/> that uses the range 0 to 255 instead of 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
-        public int R8
+        readonly get
         {
-            readonly get
-            {
-                return (int)Math.Round(R * 255.0f);
-            }
-            set
-            {
-                R = value / 255.0f;
-            }
+            return (int)Math.Round(R * 255.0f);
         }
-
-        /// <summary>
-        /// Wrapper for <see cref="G"/> that uses the range 0 to 255 instead of 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
-        public int G8
+        set
         {
-            readonly get
-            {
-                return (int)Math.Round(G * 255.0f);
-            }
-            set
-            {
-                G = value / 255.0f;
-            }
+            R = value / 255.0f;
         }
+    }
 
-        /// <summary>
-        /// Wrapper for <see cref="B"/> that uses the range 0 to 255 instead of 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
-        public int B8
+    /// <summary>
+    /// Wrapper for <see cref="G"/> that uses the range 0 to 255 instead of 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+    public int G8
+    {
+        readonly get
         {
-            readonly get
-            {
-                return (int)Math.Round(B * 255.0f);
-            }
-            set
-            {
-                B = value / 255.0f;
-            }
+            return (int)Math.Round(G * 255.0f);
         }
-
-        /// <summary>
-        /// Wrapper for <see cref="A"/> that uses the range 0 to 255 instead of 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
-        public int A8
+        set
         {
-            readonly get
-            {
-                return (int)Math.Round(A * 255.0f);
-            }
-            set
-            {
-                A = value / 255.0f;
-            }
+            G = value / 255.0f;
         }
+    }
 
-        /// <summary>
-        /// The HSV hue of this color, on the range 0 to 1.
-        /// </summary>
-        /// <value>Getting is a long process, refer to the source code for details. Setting uses <see cref="FromHsv"/>.</value>
-        public float H
+    /// <summary>
+    /// Wrapper for <see cref="B"/> that uses the range 0 to 255 instead of 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+    public int B8
+    {
+        readonly get
         {
-            readonly get
-            {
-                float max = Math.Max(R, Math.Max(G, B));
-                float min = Math.Min(R, Math.Min(G, B));
-
-                float delta = max - min;
-
-                if (delta == 0)
-                {
-                    return 0;
-                }
-
-                float h;
-
-                if (R == max)
-                {
-                    h = (G - B) / delta; // Between yellow & magenta
-                }
-                else if (G == max)
-                {
-                    h = 2 + ((B - R) / delta); // Between cyan & yellow
-                }
-                else
-                {
-                    h = 4 + ((R - G) / delta); // Between magenta & cyan
-                }
-
-                h /= 6.0f;
-
-                if (h < 0)
-                {
-                    h += 1.0f;
-                }
-
-                return h;
-            }
-            set
-            {
-                this = FromHsv(value, S, V, A);
-            }
+            return (int)Math.Round(B * 255.0f);
         }
-
-        /// <summary>
-        /// The HSV saturation of this color, on the range 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to the ratio between the min and max RGB value. Setting uses <see cref="FromHsv"/>.</value>
-        public float S
+        set
         {
-            readonly get
-            {
-                float max = Math.Max(R, Math.Max(G, B));
-                float min = Math.Min(R, Math.Min(G, B));
-
-                float delta = max - min;
-
-                return max == 0 ? 0 : delta / max;
-            }
-            set
-            {
-                this = FromHsv(H, value, V, A);
-            }
+            B = value / 255.0f;
         }
+    }
 
-        /// <summary>
-        /// The HSV value (brightness) of this color, on the range 0 to 1.
-        /// </summary>
-        /// <value>Getting is equivalent to using <see cref="Math.Max(float, float)"/> on the RGB components. Setting uses <see cref="FromHsv"/>.</value>
-        public float V
+    /// <summary>
+    /// Wrapper for <see cref="A"/> that uses the range 0 to 255 instead of 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to multiplying by 255 and rounding. Setting is equivalent to dividing by 255.</value>
+    public int A8
+    {
+        readonly get
         {
-            readonly get
-            {
-                return Math.Max(R, Math.Max(G, B));
-            }
-            set
-            {
-                this = FromHsv(H, S, value, A);
-            }
+            return (int)Math.Round(A * 255.0f);
         }
-
-        /// <summary>
-        /// Returns the light intensity of the color, as a value between 0.0 and 1.0 (inclusive).
-        /// This is useful when determining light or dark color. Colors with a luminance smaller
-        /// than 0.5 can be generally considered dark.
-        /// Note: <see cref="Luminance"/> relies on the color being in the linear color space to
-        /// return an accurate relative luminance value. If the color is in the sRGB color space
-        /// use <see cref="SrgbToLinear"/> to convert it to the linear color space first.
-        /// </summary>
-        public readonly float Luminance
+        set
         {
-            get { return 0.2126f * R + 0.7152f * G + 0.0722f * B; }
+            A = value / 255.0f;
         }
+    }
 
-        /// <summary>
-        /// Access color components using their index.
-        /// </summary>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="R"/>,
-        /// <c>[1]</c> is equivalent to <see cref="G"/>,
-        /// <c>[2]</c> is equivalent to <see cref="B"/>,
-        /// <c>[3]</c> is equivalent to <see cref="A"/>.
-        /// </value>
-        public float this[int index]
+    /// <summary>
+    /// The HSV hue of this color, on the range 0 to 1.
+    /// </summary>
+    /// <value>Getting is a long process, refer to the source code for details. Setting uses <see cref="FromHsv"/>.</value>
+    public float H
+    {
+        readonly get
         {
-            readonly get
-            {
-                switch (index)
-                {
-                    case 0:
-                        return R;
-                    case 1:
-                        return G;
-                    case 2:
-                        return B;
-                    case 3:
-                        return A;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        R = value;
-                        return;
-                    case 1:
-                        G = value;
-                        return;
-                    case 2:
-                        B = value;
-                        return;
-                    case 3:
-                        A = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Returns a new color resulting from blending this color over another.
-        /// If the color is opaque, the result is also opaque.
-        /// The second color may have a range of alpha values.
-        /// </summary>
-        /// <param name="over">The color to blend over.</param>
-        /// <returns>This color blended over <paramref name="over"/>.</returns>
-        public readonly Color Blend(Color over)
-        {
-            Color res;
-
-            float sa = 1.0f - over.A;
-            res.A = (A * sa) + over.A;
-
-            if (res.A == 0)
-            {
-                return new Color(0, 0, 0, 0);
-            }
-
-            res.R = ((R * A * sa) + (over.R * over.A)) / res.A;
-            res.G = ((G * A * sa) + (over.G * over.A)) / res.A;
-            res.B = ((B * A * sa) + (over.B * over.A)) / res.A;
-
-            return res;
-        }
-
-        /// <summary>
-        /// Returns a new color with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/>
-        /// using <see cref="Mathf.Clamp(float, float, float)"/>.
-        /// </summary>
-        /// <param name="min">The color with minimum allowed values.</param>
-        /// <param name="max">The color with maximum allowed values.</param>
-        /// <returns>The color with all components clamped.</returns>
-        public readonly Color Clamp(Color? min = null, Color? max = null)
-        {
-            Color minimum = min ?? new Color(0, 0, 0, 0);
-            Color maximum = max ?? new Color(1, 1, 1, 1);
-            return new Color
-            (
-                (float)Mathf.Clamp(R, minimum.R, maximum.R),
-                (float)Mathf.Clamp(G, minimum.G, maximum.G),
-                (float)Mathf.Clamp(B, minimum.B, maximum.B),
-                (float)Mathf.Clamp(A, minimum.A, maximum.A)
-            );
-        }
-
-        /// <summary>
-        /// Returns a new color resulting from making this color darker
-        /// by the specified ratio (on the range of 0 to 1).
-        /// </summary>
-        /// <param name="amount">The ratio to darken by.</param>
-        /// <returns>The darkened color.</returns>
-        public readonly Color Darkened(float amount)
-        {
-            Color res = this;
-            res.R *= 1.0f - amount;
-            res.G *= 1.0f - amount;
-            res.B *= 1.0f - amount;
-            return res;
-        }
-
-        /// <summary>
-        /// Returns the inverted color: <c>(1 - r, 1 - g, 1 - b, a)</c>.
-        /// </summary>
-        /// <returns>The inverted color.</returns>
-        public readonly Color Inverted()
-        {
-            return new Color(
-                1.0f - R,
-                1.0f - G,
-                1.0f - B,
-                A
-            );
-        }
-
-        /// <summary>
-        /// Returns a new color resulting from making this color lighter
-        /// by the specified ratio (on the range of 0 to 1).
-        /// </summary>
-        /// <param name="amount">The ratio to lighten by.</param>
-        /// <returns>The darkened color.</returns>
-        public readonly Color Lightened(float amount)
-        {
-            Color res = this;
-            res.R += (1.0f - res.R) * amount;
-            res.G += (1.0f - res.G) * amount;
-            res.B += (1.0f - res.B) * amount;
-            return res;
-        }
-
-        /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this color and <paramref name="to"/> by amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination color for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting color of the interpolation.</returns>
-        public readonly Color Lerp(Color to, real_t weight)
-        {
-            return new Color
-            (
-                (float)Mathf.Lerp(R, to.R, weight),
-                (float)Mathf.Lerp(G, to.G, weight),
-                (float)Mathf.Lerp(B, to.B, weight),
-                (float)Mathf.Lerp(A, to.A, weight)
-            );
-        }
-
-        /// <summary>
-        /// Returns the color converted to the sRGB color space.
-        /// This method assumes the original color is in the linear color space.
-        /// See also <see cref="SrgbToLinear"/> which performs the opposite operation.
-        /// </summary>
-        /// <returns>The sRGB color.</returns>
-        public readonly Color LinearToSrgb()
-        {
-            return new Color(
-                R < 0.0031308f ? 12.92f * R : (1.0f + 0.055f) * (float)Mathf.Pow(R, 1.0f / 2.4f) - 0.055f,
-                G < 0.0031308f ? 12.92f * G : (1.0f + 0.055f) * (float)Mathf.Pow(G, 1.0f / 2.4f) - 0.055f,
-                B < 0.0031308f ? 12.92f * B : (1.0f + 0.055f) * (float)Mathf.Pow(B, 1.0f / 2.4f) - 0.055f, A);
-        }
-
-        /// <summary>
-        /// Returns the color converted to linear color space.
-        /// This method assumes the original color already is in sRGB color space.
-        /// See also <see cref="LinearToSrgb"/> which performs the opposite operation.
-        /// </summary>
-        /// <returns>The color in linear color space.</returns>
-        public readonly Color SrgbToLinear()
-        {
-            return new Color(
-                R < 0.04045f ? R * (1.0f / 12.92f) : (float)Mathf.Pow((R + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-                G < 0.04045f ? G * (1.0f / 12.92f) : (float)Mathf.Pow((G + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-                B < 0.04045f ? B * (1.0f / 12.92f) : (float)Mathf.Pow((B + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-                A);
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 32-bit integer in ABGR
-        /// format (each byte represents a color channel).
-        /// ABGR is the reversed version of the default format.
-        /// </summary>
-        /// <returns>A <see langword="uint"/> representing this color in ABGR32 format.</returns>
-        public readonly uint ToAbgr32()
-        {
-            uint c = (byte)Math.Round(A * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(B * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(G * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(R * 255);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 64-bit integer in ABGR
-        /// format (each word represents a color channel).
-        /// ABGR is the reversed version of the default format.
-        /// </summary>
-        /// <returns>A <see langword="ulong"/> representing this color in ABGR64 format.</returns>
-        public readonly ulong ToAbgr64()
-        {
-            ulong c = (ushort)Math.Round(A * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(B * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(G * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(R * 65535);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 32-bit integer in ARGB
-        /// format (each byte represents a color channel).
-        /// ARGB is more compatible with DirectX, but not used much in Godot.
-        /// </summary>
-        /// <returns>A <see langword="uint"/> representing this color in ARGB32 format.</returns>
-        public readonly uint ToArgb32()
-        {
-            uint c = (byte)Math.Round(A * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(R * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(G * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(B * 255);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 64-bit integer in ARGB
-        /// format (each word represents a color channel).
-        /// ARGB is more compatible with DirectX, but not used much in Godot.
-        /// </summary>
-        /// <returns>A <see langword="ulong"/> representing this color in ARGB64 format.</returns>
-        public readonly ulong ToArgb64()
-        {
-            ulong c = (ushort)Math.Round(A * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(R * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(G * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(B * 65535);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 32-bit integer in RGBA
-        /// format (each byte represents a color channel).
-        /// RGBA is Godot's default and recommended format.
-        /// </summary>
-        /// <returns>A <see langword="uint"/> representing this color in RGBA32 format.</returns>
-        public readonly uint ToRgba32()
-        {
-            uint c = (byte)Math.Round(R * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(G * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(B * 255);
-            c <<= 8;
-            c |= (byte)Math.Round(A * 255);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color converted to an unsigned 64-bit integer in RGBA
-        /// format (each word represents a color channel).
-        /// RGBA is Godot's default and recommended format.
-        /// </summary>
-        /// <returns>A <see langword="ulong"/> representing this color in RGBA64 format.</returns>
-        public readonly ulong ToRgba64()
-        {
-            ulong c = (ushort)Math.Round(R * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(G * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(B * 65535);
-            c <<= 16;
-            c |= (ushort)Math.Round(A * 65535);
-
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the color's HTML hexadecimal color string in RGBA format.
-        /// </summary>
-        /// <param name="includeAlpha">
-        /// Whether or not to include alpha. If <see langword="false"/>, the color is RGB instead of RGBA.
-        /// </param>
-        /// <returns>A string for the HTML hexadecimal representation of this color.</returns>
-        public readonly string ToHtml(bool includeAlpha = true)
-        {
-            string txt = string.Empty;
-
-            txt += ToHex32(R);
-            txt += ToHex32(G);
-            txt += ToHex32(B);
-
-            if (includeAlpha)
-            {
-                txt += ToHex32(A);
-            }
-
-            return txt;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> from RGBA values, typically on the range of 0 to 1.
-        /// </summary>
-        /// <param name="r">The color's red component, typically on the range of 0 to 1.</param>
-        /// <param name="g">The color's green component, typically on the range of 0 to 1.</param>
-        /// <param name="b">The color's blue component, typically on the range of 0 to 1.</param>
-        /// <param name="a">The color's alpha (transparency) value, typically on the range of 0 to 1. Default: 1.</param>
-        public Color(float r, float g, float b, float a = 1.0f)
-        {
-            R = r;
-            G = g;
-            B = b;
-            A = a;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> from an existing color and an alpha value.
-        /// </summary>
-        /// <param name="c">The color to construct from. Only its RGB values are used.</param>
-        /// <param name="a">The color's alpha (transparency) value, typically on the range of 0 to 1. Default: 1.</param>
-        public Color(Color c, float a = 1.0f)
-        {
-            R = c.R;
-            G = c.G;
-            B = c.B;
-            A = a;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> from an unsigned 32-bit integer in RGBA format
-        /// (each byte represents a color channel).
-        /// </summary>
-        /// <param name="rgba">The <see langword="uint"/> representing the color as 0xRRGGBBAA.</param>
-        public Color(uint rgba)
-        {
-            A = (rgba & 0xFF) / 255.0f;
-            rgba >>= 8;
-            B = (rgba & 0xFF) / 255.0f;
-            rgba >>= 8;
-            G = (rgba & 0xFF) / 255.0f;
-            rgba >>= 8;
-            R = (rgba & 0xFF) / 255.0f;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> from an unsigned 64-bit integer in RGBA format
-        /// (each word represents a color channel).
-        /// </summary>
-        /// <param name="rgba">The <see langword="ulong"/> representing the color as 0xRRRRGGGGBBBBAAAA.</param>
-        public Color(ulong rgba)
-        {
-            A = (rgba & 0xFFFF) / 65535.0f;
-            rgba >>= 16;
-            B = (rgba & 0xFFFF) / 65535.0f;
-            rgba >>= 16;
-            G = (rgba & 0xFFFF) / 65535.0f;
-            rgba >>= 16;
-            R = (rgba & 0xFFFF) / 65535.0f;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> either from an HTML color code or from a
-        /// standardized color name. Supported color names are the same as the
-        /// <see cref="Colors"/> constants.
-        /// </summary>
-        /// <param name="code">The HTML color code or color name to construct from.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// A color cannot be inferred from the given <paramref name="code"/>.
-        /// It was invalid HTML and a color with that name was not found.
-        /// </exception>
-        public Color(string code)
-        {
-            if (HtmlIsValid(code))
-            {
-                this = FromHtml(code);
-            }
-            else
-            {
-                this = Named(code);
-            }
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> either from an HTML color code or from a
-        /// standardized color name, with <paramref name="alpha"/> on the range of 0 to 1. Supported
-        /// color names are the same as the <see cref="Colors"/> constants.
-        /// </summary>
-        /// <param name="code">The HTML color code or color name to construct from.</param>
-        /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
-        public Color(string code, float alpha)
-        {
-            this = new Color(code);
-            A = alpha;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Color"/> from the HTML hexadecimal color string in RGBA format.
-        /// </summary>
-        /// <param name="rgba">A string for the HTML hexadecimal representation of this color.</param>
-        /// <exception name="ArgumentOutOfRangeException">
-        /// <paramref name="rgba"/> color code is invalid.
-        /// </exception>
-        public static Color FromHtml(ReadOnlySpan<char> rgba)
-        {
-            Color c;
-            if (rgba.Length == 0)
-            {
-                c.R = 0f;
-                c.G = 0f;
-                c.B = 0f;
-                c.A = 1.0f;
-                return c;
-            }
-
-            if (rgba[0] == '#')
-            {
-                rgba = rgba.Slice(1);
-            }
-
-            // If enabled, use 1 hex digit per channel instead of 2.
-            // Other sizes aren't in the HTML/CSS spec but we could add them if desired.
-            bool isShorthand = rgba.Length < 5;
-            bool alpha;
-
-            if (rgba.Length == 8)
-            {
-                alpha = true;
-            }
-            else if (rgba.Length == 6)
-            {
-                alpha = false;
-            }
-            else if (rgba.Length == 4)
-            {
-                alpha = true;
-            }
-            else if (rgba.Length == 3)
-            {
-                alpha = false;
-            }
-            else
-            {
-                throw new ArgumentOutOfRangeException(
-                    $"Invalid color code. Length is {rgba.Length}, but a length of 6 or 8 is expected: {rgba}");
-            }
-
-            c.A = 1.0f;
-            if (isShorthand)
-            {
-                c.R = ParseCol4(rgba, 0) / 15f;
-                c.G = ParseCol4(rgba, 1) / 15f;
-                c.B = ParseCol4(rgba, 2) / 15f;
-                if (alpha)
-                {
-                    c.A = ParseCol4(rgba, 3) / 15f;
-                }
-            }
-            else
-            {
-                c.R = ParseCol8(rgba, 0) / 255f;
-                c.G = ParseCol8(rgba, 2) / 255f;
-                c.B = ParseCol8(rgba, 4) / 255f;
-                if (alpha)
-                {
-                    c.A = ParseCol8(rgba, 6) / 255f;
-                }
-            }
-
-            if (c.R < 0)
-            {
-                throw new ArgumentOutOfRangeException($"Invalid color code. Red part is not valid hexadecimal: {rgba}");
-            }
-
-            if (c.G < 0)
-            {
-                throw new ArgumentOutOfRangeException($"Invalid color code. Green part is not valid hexadecimal: {rgba}");
-            }
-
-            if (c.B < 0)
-            {
-                throw new ArgumentOutOfRangeException($"Invalid color code. Blue part is not valid hexadecimal: {rgba}");
-            }
-
-            if (c.A < 0)
-            {
-                throw new ArgumentOutOfRangeException($"Invalid color code. Alpha part is not valid hexadecimal: {rgba}");
-            }
-            return c;
-        }
-
-        /// <summary>
-        /// Returns a color constructed from integer red, green, blue, and alpha channels.
-        /// Each channel should have 8 bits of information ranging from 0 to 255.
-        /// </summary>
-        /// <param name="r8">The red component represented on the range of 0 to 255.</param>
-        /// <param name="g8">The green component represented on the range of 0 to 255.</param>
-        /// <param name="b8">The blue component represented on the range of 0 to 255.</param>
-        /// <param name="a8">The alpha (transparency) component represented on the range of 0 to 255.</param>
-        /// <returns>The constructed color.</returns>
-        public static Color Color8(byte r8, byte g8, byte b8, byte a8 = 255)
-        {
-            return new Color(r8 / 255f, g8 / 255f, b8 / 255f, a8 / 255f);
-        }
-
-        /// <summary>
-        /// Returns a color according to the standardized name, with the
-        /// specified alpha value. Supported color names are the same as
-        /// the constants defined in <see cref="Colors"/>.
-        /// </summary>
-        /// <param name="name">The name of the color.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// A color with the given name is not found.
-        /// </exception>
-        /// <returns>The constructed color.</returns>
-        private static Color Named(string name)
-        {
-            if (!FindNamedColor(name, out Color color))
-            {
-                throw new ArgumentOutOfRangeException($"Invalid Color Name: {name}");
-            }
-
-            return color;
-        }
-
-        /// <summary>
-        /// Returns a color according to the standardized name, with the
-        /// specified alpha value. Supported color names are the same as
-        /// the constants defined in <see cref="Colors"/>.
-        /// If a color with the given name is not found, it returns
-        /// <paramref name="default"/>.
-        /// </summary>
-        /// <param name="name">The name of the color.</param>
-        /// <param name="default">
-        /// The default color to return when a color with the given name
-        /// is not found.
-        /// </param>
-        /// <returns>The constructed color.</returns>
-        private static Color Named(string name, Color @default)
-        {
-            if (!FindNamedColor(name, out Color color))
-            {
-                return @default;
-            }
-
-            return color;
-        }
-
-        private static bool FindNamedColor(string name, out Color color)
-        {
-            name = name.Replace(" ", string.Empty);
-            name = name.Replace("-", string.Empty);
-            name = name.Replace("_", string.Empty);
-            name = name.Replace("'", string.Empty);
-            name = name.Replace(".", string.Empty);
-            name = name.ToUpperInvariant();
-
-            return Colors.namedColors.TryGetValue(name, out color);
-        }
-
-        /// <summary>
-        /// Constructs a color from an HSV profile. The <paramref name="hue"/>,
-        /// <paramref name="saturation"/>, and <paramref name="value"/> are typically
-        /// between 0.0 and 1.0.
-        /// </summary>
-        /// <param name="hue">The HSV hue, typically on the range of 0 to 1.</param>
-        /// <param name="saturation">The HSV saturation, typically on the range of 0 to 1.</param>
-        /// <param name="value">The HSV value (brightness), typically on the range of 0 to 1.</param>
-        /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
-        /// <returns>The constructed color.</returns>
-        public static Color FromHsv(float hue, float saturation, float value, float alpha = 1.0f)
-        {
-            if (saturation == 0)
-            {
-                // Achromatic (gray)
-                return new Color(value, value, value, alpha);
-            }
-
-            int i;
-            float f, p, q, t;
-
-            hue *= 6.0f;
-            hue %= 6f;
-            i = (int)hue;
-
-            f = hue - i;
-            p = value * (1 - saturation);
-            q = value * (1 - (saturation * f));
-            t = value * (1 - (saturation * (1 - f)));
-
-            switch (i)
-            {
-                case 0: // Red is the dominant color
-                    return new Color(value, t, p, alpha);
-                case 1: // Green is the dominant color
-                    return new Color(q, value, p, alpha);
-                case 2:
-                    return new Color(p, value, t, alpha);
-                case 3: // Blue is the dominant color
-                    return new Color(p, q, value, alpha);
-                case 4:
-                    return new Color(t, p, value, alpha);
-                default: // (5) Red is the dominant color
-                    return new Color(value, p, q, alpha);
-            }
-        }
-
-        /// <summary>
-        /// Converts a color to HSV values. This is equivalent to using each of
-        /// the <c>h</c>/<c>s</c>/<c>v</c> properties, but much more efficient.
-        /// </summary>
-        /// <param name="hue">Output parameter for the HSV hue.</param>
-        /// <param name="saturation">Output parameter for the HSV saturation.</param>
-        /// <param name="value">Output parameter for the HSV value.</param>
-        public readonly void ToHsv(out float hue, out float saturation, out float value)
-        {
-            float max = (float)Mathf.Max(R, Mathf.Max(G, B));
-            float min = (float)Mathf.Min(R, Mathf.Min(G, B));
+            float max = Math.Max(R, Math.Max(G, B));
+            float min = Math.Min(R, Math.Min(G, B));
 
             float delta = max - min;
 
             if (delta == 0)
             {
-                hue = 0;
+                return 0;
+            }
+
+            float h;
+
+            if (R == max)
+            {
+                h = (G - B) / delta; // Between yellow & magenta
+            }
+            else if (G == max)
+            {
+                h = 2 + ((B - R) / delta); // Between cyan & yellow
             }
             else
             {
-                if (R == max)
-                {
-                    hue = (G - B) / delta; // Between yellow & magenta
-                }
-                else if (G == max)
-                {
-                    hue = 2 + ((B - R) / delta); // Between cyan & yellow
-                }
-                else
-                {
-                    hue = 4 + ((R - G) / delta); // Between magenta & cyan
-                }
-
-                hue /= 6.0f;
-
-                if (hue < 0)
-                    hue += 1.0f;
+                h = 4 + ((R - G) / delta); // Between magenta & cyan
             }
 
-            if (max == 0)
-                saturation = 0;
+            h /= 6.0f;
+
+            if (h < 0)
+            {
+                h += 1.0f;
+            }
+
+            return h;
+        }
+        set
+        {
+            this = FromHsv(value, S, V, A);
+        }
+    }
+
+    /// <summary>
+    /// The HSV saturation of this color, on the range 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to the ratio between the min and max RGB value. Setting uses <see cref="FromHsv"/>.</value>
+    public float S
+    {
+        readonly get
+        {
+            float max = Math.Max(R, Math.Max(G, B));
+            float min = Math.Min(R, Math.Min(G, B));
+
+            float delta = max - min;
+
+            return max == 0 ? 0 : delta / max;
+        }
+        set
+        {
+            this = FromHsv(H, value, V, A);
+        }
+    }
+
+    /// <summary>
+    /// The HSV value (brightness) of this color, on the range 0 to 1.
+    /// </summary>
+    /// <value>Getting is equivalent to using <see cref="Math.Max(float, float)"/> on the RGB components. Setting uses <see cref="FromHsv"/>.</value>
+    public float V
+    {
+        readonly get
+        {
+            return Math.Max(R, Math.Max(G, B));
+        }
+        set
+        {
+            this = FromHsv(H, S, value, A);
+        }
+    }
+
+    /// <summary>
+    /// Returns the light intensity of the color, as a value between 0.0 and 1.0 (inclusive).
+    /// This is useful when determining light or dark color. Colors with a luminance smaller
+    /// than 0.5 can be generally considered dark.
+    /// Note: <see cref="Luminance"/> relies on the color being in the linear color space to
+    /// return an accurate relative luminance value. If the color is in the sRGB color space
+    /// use <see cref="SrgbToLinear"/> to convert it to the linear color space first.
+    /// </summary>
+    public readonly float Luminance
+    {
+        get { return 0.2126f * R + 0.7152f * G + 0.0722f * B; }
+    }
+
+    /// <summary>
+    /// Access color components using their index.
+    /// </summary>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="R"/>,
+    /// <c>[1]</c> is equivalent to <see cref="G"/>,
+    /// <c>[2]</c> is equivalent to <see cref="B"/>,
+    /// <c>[3]</c> is equivalent to <see cref="A"/>.
+    /// </value>
+    public float this[int index]
+    {
+        readonly get
+        {
+            switch (index)
+            {
+                case 0:
+                    return R;
+                case 1:
+                    return G;
+                case 2:
+                    return B;
+                case 3:
+                    return A;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+        set
+        {
+            switch (index)
+            {
+                case 0:
+                    R = value;
+                    return;
+                case 1:
+                    G = value;
+                    return;
+                case 2:
+                    B = value;
+                    return;
+                case 3:
+                    A = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns a new color resulting from blending this color over another.
+    /// If the color is opaque, the result is also opaque.
+    /// The second color may have a range of alpha values.
+    /// </summary>
+    /// <param name="over">The color to blend over.</param>
+    /// <returns>This color blended over <paramref name="over"/>.</returns>
+    public readonly Color Blend(Color over)
+    {
+        Color res;
+
+        float sa = 1.0f - over.A;
+        res.A = (A * sa) + over.A;
+
+        if (res.A == 0)
+        {
+            return new Color(0, 0, 0, 0);
+        }
+
+        res.R = ((R * A * sa) + (over.R * over.A)) / res.A;
+        res.G = ((G * A * sa) + (over.G * over.A)) / res.A;
+        res.B = ((B * A * sa) + (over.B * over.A)) / res.A;
+
+        return res;
+    }
+
+    /// <summary>
+    /// Returns a new color with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/>
+    /// using <see cref="Mathf.Clamp(float, float, float)"/>.
+    /// </summary>
+    /// <param name="min">The color with minimum allowed values.</param>
+    /// <param name="max">The color with maximum allowed values.</param>
+    /// <returns>The color with all components clamped.</returns>
+    public readonly Color Clamp(Color? min = null, Color? max = null)
+    {
+        Color minimum = min ?? new Color(0, 0, 0, 0);
+        Color maximum = max ?? new Color(1, 1, 1, 1);
+        return new Color
+        (
+            (float)Mathf.Clamp(R, minimum.R, maximum.R),
+            (float)Mathf.Clamp(G, minimum.G, maximum.G),
+            (float)Mathf.Clamp(B, minimum.B, maximum.B),
+            (float)Mathf.Clamp(A, minimum.A, maximum.A)
+        );
+    }
+
+    /// <summary>
+    /// Returns a new color resulting from making this color darker
+    /// by the specified ratio (on the range of 0 to 1).
+    /// </summary>
+    /// <param name="amount">The ratio to darken by.</param>
+    /// <returns>The darkened color.</returns>
+    public readonly Color Darkened(float amount)
+    {
+        Color res = this;
+        res.R *= 1.0f - amount;
+        res.G *= 1.0f - amount;
+        res.B *= 1.0f - amount;
+        return res;
+    }
+
+    /// <summary>
+    /// Returns the inverted color: <c>(1 - r, 1 - g, 1 - b, a)</c>.
+    /// </summary>
+    /// <returns>The inverted color.</returns>
+    public readonly Color Inverted()
+    {
+        return new Color(
+            1.0f - R,
+            1.0f - G,
+            1.0f - B,
+            A
+        );
+    }
+
+    /// <summary>
+    /// Returns a new color resulting from making this color lighter
+    /// by the specified ratio (on the range of 0 to 1).
+    /// </summary>
+    /// <param name="amount">The ratio to lighten by.</param>
+    /// <returns>The darkened color.</returns>
+    public readonly Color Lightened(float amount)
+    {
+        Color res = this;
+        res.R += (1.0f - res.R) * amount;
+        res.G += (1.0f - res.G) * amount;
+        res.B += (1.0f - res.B) * amount;
+        return res;
+    }
+
+    /// <summary>
+    /// Returns the result of the linear interpolation between
+    /// this color and <paramref name="to"/> by amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="to">The destination color for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting color of the interpolation.</returns>
+    public readonly Color Lerp(Color to, real_t weight)
+    {
+        return new Color
+        (
+            (float)Mathf.Lerp(R, to.R, weight),
+            (float)Mathf.Lerp(G, to.G, weight),
+            (float)Mathf.Lerp(B, to.B, weight),
+            (float)Mathf.Lerp(A, to.A, weight)
+        );
+    }
+
+    /// <summary>
+    /// Returns the color converted to the sRGB color space.
+    /// This method assumes the original color is in the linear color space.
+    /// See also <see cref="SrgbToLinear"/> which performs the opposite operation.
+    /// </summary>
+    /// <returns>The sRGB color.</returns>
+    public readonly Color LinearToSrgb()
+    {
+        return new Color(
+            R < 0.0031308f ? 12.92f * R : (1.0f + 0.055f) * (float)Mathf.Pow(R, 1.0f / 2.4f) - 0.055f,
+            G < 0.0031308f ? 12.92f * G : (1.0f + 0.055f) * (float)Mathf.Pow(G, 1.0f / 2.4f) - 0.055f,
+            B < 0.0031308f ? 12.92f * B : (1.0f + 0.055f) * (float)Mathf.Pow(B, 1.0f / 2.4f) - 0.055f, A);
+    }
+
+    /// <summary>
+    /// Returns the color converted to linear color space.
+    /// This method assumes the original color already is in sRGB color space.
+    /// See also <see cref="LinearToSrgb"/> which performs the opposite operation.
+    /// </summary>
+    /// <returns>The color in linear color space.</returns>
+    public readonly Color SrgbToLinear()
+    {
+        return new Color(
+            R < 0.04045f ? R * (1.0f / 12.92f) : (float)Mathf.Pow((R + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+            G < 0.04045f ? G * (1.0f / 12.92f) : (float)Mathf.Pow((G + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+            B < 0.04045f ? B * (1.0f / 12.92f) : (float)Mathf.Pow((B + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+            A);
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 32-bit integer in ABGR
+    /// format (each byte represents a color channel).
+    /// ABGR is the reversed version of the default format.
+    /// </summary>
+    /// <returns>A <see langword="uint"/> representing this color in ABGR32 format.</returns>
+    public readonly uint ToAbgr32()
+    {
+        uint c = (byte)Math.Round(A * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(B * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(G * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(R * 255);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 64-bit integer in ABGR
+    /// format (each word represents a color channel).
+    /// ABGR is the reversed version of the default format.
+    /// </summary>
+    /// <returns>A <see langword="ulong"/> representing this color in ABGR64 format.</returns>
+    public readonly ulong ToAbgr64()
+    {
+        ulong c = (ushort)Math.Round(A * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(B * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(G * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(R * 65535);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 32-bit integer in ARGB
+    /// format (each byte represents a color channel).
+    /// ARGB is more compatible with DirectX, but not used much in Godot.
+    /// </summary>
+    /// <returns>A <see langword="uint"/> representing this color in ARGB32 format.</returns>
+    public readonly uint ToArgb32()
+    {
+        uint c = (byte)Math.Round(A * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(R * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(G * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(B * 255);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 64-bit integer in ARGB
+    /// format (each word represents a color channel).
+    /// ARGB is more compatible with DirectX, but not used much in Godot.
+    /// </summary>
+    /// <returns>A <see langword="ulong"/> representing this color in ARGB64 format.</returns>
+    public readonly ulong ToArgb64()
+    {
+        ulong c = (ushort)Math.Round(A * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(R * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(G * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(B * 65535);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 32-bit integer in RGBA
+    /// format (each byte represents a color channel).
+    /// RGBA is Godot's default and recommended format.
+    /// </summary>
+    /// <returns>A <see langword="uint"/> representing this color in RGBA32 format.</returns>
+    public readonly uint ToRgba32()
+    {
+        uint c = (byte)Math.Round(R * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(G * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(B * 255);
+        c <<= 8;
+        c |= (byte)Math.Round(A * 255);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color converted to an unsigned 64-bit integer in RGBA
+    /// format (each word represents a color channel).
+    /// RGBA is Godot's default and recommended format.
+    /// </summary>
+    /// <returns>A <see langword="ulong"/> representing this color in RGBA64 format.</returns>
+    public readonly ulong ToRgba64()
+    {
+        ulong c = (ushort)Math.Round(R * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(G * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(B * 65535);
+        c <<= 16;
+        c |= (ushort)Math.Round(A * 65535);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the color's HTML hexadecimal color string in RGBA format.
+    /// </summary>
+    /// <param name="includeAlpha">
+    /// Whether or not to include alpha. If <see langword="false"/>, the color is RGB instead of RGBA.
+    /// </param>
+    /// <returns>A string for the HTML hexadecimal representation of this color.</returns>
+    public readonly string ToHtml(bool includeAlpha = true)
+    {
+        string txt = string.Empty;
+
+        txt += ToHex32(R);
+        txt += ToHex32(G);
+        txt += ToHex32(B);
+
+        if (includeAlpha)
+        {
+            txt += ToHex32(A);
+        }
+
+        return txt;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> from RGBA values, typically on the range of 0 to 1.
+    /// </summary>
+    /// <param name="r">The color's red component, typically on the range of 0 to 1.</param>
+    /// <param name="g">The color's green component, typically on the range of 0 to 1.</param>
+    /// <param name="b">The color's blue component, typically on the range of 0 to 1.</param>
+    /// <param name="a">The color's alpha (transparency) value, typically on the range of 0 to 1. Default: 1.</param>
+    public Color(float r, float g, float b, float a = 1.0f)
+    {
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> from an existing color and an alpha value.
+    /// </summary>
+    /// <param name="c">The color to construct from. Only its RGB values are used.</param>
+    /// <param name="a">The color's alpha (transparency) value, typically on the range of 0 to 1. Default: 1.</param>
+    public Color(Color c, float a = 1.0f)
+    {
+        R = c.R;
+        G = c.G;
+        B = c.B;
+        A = a;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> from an unsigned 32-bit integer in RGBA format
+    /// (each byte represents a color channel).
+    /// </summary>
+    /// <param name="rgba">The <see langword="uint"/> representing the color as 0xRRGGBBAA.</param>
+    public Color(uint rgba)
+    {
+        A = (rgba & 0xFF) / 255.0f;
+        rgba >>= 8;
+        B = (rgba & 0xFF) / 255.0f;
+        rgba >>= 8;
+        G = (rgba & 0xFF) / 255.0f;
+        rgba >>= 8;
+        R = (rgba & 0xFF) / 255.0f;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> from an unsigned 64-bit integer in RGBA format
+    /// (each word represents a color channel).
+    /// </summary>
+    /// <param name="rgba">The <see langword="ulong"/> representing the color as 0xRRRRGGGGBBBBAAAA.</param>
+    public Color(ulong rgba)
+    {
+        A = (rgba & 0xFFFF) / 65535.0f;
+        rgba >>= 16;
+        B = (rgba & 0xFFFF) / 65535.0f;
+        rgba >>= 16;
+        G = (rgba & 0xFFFF) / 65535.0f;
+        rgba >>= 16;
+        R = (rgba & 0xFFFF) / 65535.0f;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> either from an HTML color code or from a
+    /// standardized color name. Supported color names are the same as the
+    /// <see cref="Colors"/> constants.
+    /// </summary>
+    /// <param name="code">The HTML color code or color name to construct from.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A color cannot be inferred from the given <paramref name="code"/>.
+    /// It was invalid HTML and a color with that name was not found.
+    /// </exception>
+    public Color(string code)
+    {
+        if (HtmlIsValid(code))
+        {
+            this = FromHtml(code);
+        }
+        else
+        {
+            this = Named(code);
+        }
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> either from an HTML color code or from a
+    /// standardized color name, with <paramref name="alpha"/> on the range of 0 to 1. Supported
+    /// color names are the same as the <see cref="Colors"/> constants.
+    /// </summary>
+    /// <param name="code">The HTML color code or color name to construct from.</param>
+    /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
+    public Color(string code, float alpha)
+    {
+        this = new Color(code);
+        A = alpha;
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="Color"/> from the HTML hexadecimal color string in RGBA format.
+    /// </summary>
+    /// <param name="rgba">A string for the HTML hexadecimal representation of this color.</param>
+    /// <exception name="ArgumentOutOfRangeException">
+    /// <paramref name="rgba"/> color code is invalid.
+    /// </exception>
+    public static Color FromHtml(ReadOnlySpan<char> rgba)
+    {
+        Color c;
+        if (rgba.Length == 0)
+        {
+            c.R = 0f;
+            c.G = 0f;
+            c.B = 0f;
+            c.A = 1.0f;
+            return c;
+        }
+
+        if (rgba[0] == '#')
+        {
+            rgba = rgba.Slice(1);
+        }
+
+        // If enabled, use 1 hex digit per channel instead of 2.
+        // Other sizes aren't in the HTML/CSS spec but we could add them if desired.
+        bool isShorthand = rgba.Length < 5;
+        bool alpha;
+
+        if (rgba.Length == 8)
+        {
+            alpha = true;
+        }
+        else if (rgba.Length == 6)
+        {
+            alpha = false;
+        }
+        else if (rgba.Length == 4)
+        {
+            alpha = true;
+        }
+        else if (rgba.Length == 3)
+        {
+            alpha = false;
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(
+                $"Invalid color code. Length is {rgba.Length}, but a length of 6 or 8 is expected: {rgba}");
+        }
+
+        c.A = 1.0f;
+        if (isShorthand)
+        {
+            c.R = ParseCol4(rgba, 0) / 15f;
+            c.G = ParseCol4(rgba, 1) / 15f;
+            c.B = ParseCol4(rgba, 2) / 15f;
+            if (alpha)
+            {
+                c.A = ParseCol4(rgba, 3) / 15f;
+            }
+        }
+        else
+        {
+            c.R = ParseCol8(rgba, 0) / 255f;
+            c.G = ParseCol8(rgba, 2) / 255f;
+            c.B = ParseCol8(rgba, 4) / 255f;
+            if (alpha)
+            {
+                c.A = ParseCol8(rgba, 6) / 255f;
+            }
+        }
+
+        if (c.R < 0)
+        {
+            throw new ArgumentOutOfRangeException($"Invalid color code. Red part is not valid hexadecimal: {rgba}");
+        }
+
+        if (c.G < 0)
+        {
+            throw new ArgumentOutOfRangeException($"Invalid color code. Green part is not valid hexadecimal: {rgba}");
+        }
+
+        if (c.B < 0)
+        {
+            throw new ArgumentOutOfRangeException($"Invalid color code. Blue part is not valid hexadecimal: {rgba}");
+        }
+
+        if (c.A < 0)
+        {
+            throw new ArgumentOutOfRangeException($"Invalid color code. Alpha part is not valid hexadecimal: {rgba}");
+        }
+        return c;
+    }
+
+    /// <summary>
+    /// Returns a color constructed from integer red, green, blue, and alpha channels.
+    /// Each channel should have 8 bits of information ranging from 0 to 255.
+    /// </summary>
+    /// <param name="r8">The red component represented on the range of 0 to 255.</param>
+    /// <param name="g8">The green component represented on the range of 0 to 255.</param>
+    /// <param name="b8">The blue component represented on the range of 0 to 255.</param>
+    /// <param name="a8">The alpha (transparency) component represented on the range of 0 to 255.</param>
+    /// <returns>The constructed color.</returns>
+    public static Color Color8(byte r8, byte g8, byte b8, byte a8 = 255)
+    {
+        return new Color(r8 / 255f, g8 / 255f, b8 / 255f, a8 / 255f);
+    }
+
+    /// <summary>
+    /// Returns a color according to the standardized name, with the
+    /// specified alpha value. Supported color names are the same as
+    /// the constants defined in <see cref="Colors"/>.
+    /// </summary>
+    /// <param name="name">The name of the color.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A color with the given name is not found.
+    /// </exception>
+    /// <returns>The constructed color.</returns>
+    private static Color Named(string name)
+    {
+        if (!FindNamedColor(name, out Color color))
+        {
+            throw new ArgumentOutOfRangeException($"Invalid Color Name: {name}");
+        }
+
+        return color;
+    }
+
+    /// <summary>
+    /// Returns a color according to the standardized name, with the
+    /// specified alpha value. Supported color names are the same as
+    /// the constants defined in <see cref="Colors"/>.
+    /// If a color with the given name is not found, it returns
+    /// <paramref name="default"/>.
+    /// </summary>
+    /// <param name="name">The name of the color.</param>
+    /// <param name="default">
+    /// The default color to return when a color with the given name
+    /// is not found.
+    /// </param>
+    /// <returns>The constructed color.</returns>
+    private static Color Named(string name, Color @default)
+    {
+        if (!FindNamedColor(name, out Color color))
+        {
+            return @default;
+        }
+
+        return color;
+    }
+
+    private static bool FindNamedColor(string name, out Color color)
+    {
+        name = name.Replace(" ", string.Empty);
+        name = name.Replace("-", string.Empty);
+        name = name.Replace("_", string.Empty);
+        name = name.Replace("'", string.Empty);
+        name = name.Replace(".", string.Empty);
+        name = name.ToUpperInvariant();
+
+        return Colors.namedColors.TryGetValue(name, out color);
+    }
+
+    /// <summary>
+    /// Constructs a color from an HSV profile. The <paramref name="hue"/>,
+    /// <paramref name="saturation"/>, and <paramref name="value"/> are typically
+    /// between 0.0 and 1.0.
+    /// </summary>
+    /// <param name="hue">The HSV hue, typically on the range of 0 to 1.</param>
+    /// <param name="saturation">The HSV saturation, typically on the range of 0 to 1.</param>
+    /// <param name="value">The HSV value (brightness), typically on the range of 0 to 1.</param>
+    /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
+    /// <returns>The constructed color.</returns>
+    public static Color FromHsv(float hue, float saturation, float value, float alpha = 1.0f)
+    {
+        if (saturation == 0)
+        {
+            // Achromatic (gray)
+            return new Color(value, value, value, alpha);
+        }
+
+        int i;
+        float f, p, q, t;
+
+        hue *= 6.0f;
+        hue %= 6f;
+        i = (int)hue;
+
+        f = hue - i;
+        p = value * (1 - saturation);
+        q = value * (1 - (saturation * f));
+        t = value * (1 - (saturation * (1 - f)));
+
+        switch (i)
+        {
+            case 0: // Red is the dominant color
+                return new Color(value, t, p, alpha);
+            case 1: // Green is the dominant color
+                return new Color(q, value, p, alpha);
+            case 2:
+                return new Color(p, value, t, alpha);
+            case 3: // Blue is the dominant color
+                return new Color(p, q, value, alpha);
+            case 4:
+                return new Color(t, p, value, alpha);
+            default: // (5) Red is the dominant color
+                return new Color(value, p, q, alpha);
+        }
+    }
+
+    /// <summary>
+    /// Converts a color to HSV values. This is equivalent to using each of
+    /// the <c>h</c>/<c>s</c>/<c>v</c> properties, but much more efficient.
+    /// </summary>
+    /// <param name="hue">Output parameter for the HSV hue.</param>
+    /// <param name="saturation">Output parameter for the HSV saturation.</param>
+    /// <param name="value">Output parameter for the HSV value.</param>
+    public readonly void ToHsv(out float hue, out float saturation, out float value)
+    {
+        float max = (float)Mathf.Max(R, Mathf.Max(G, B));
+        float min = (float)Mathf.Min(R, Mathf.Min(G, B));
+
+        float delta = max - min;
+
+        if (delta == 0)
+        {
+            hue = 0;
+        }
+        else
+        {
+            if (R == max)
+            {
+                hue = (G - B) / delta; // Between yellow & magenta
+            }
+            else if (G == max)
+            {
+                hue = 2 + ((B - R) / delta); // Between cyan & yellow
+            }
             else
-                saturation = 1 - (min / max);
-
-            value = max;
-        }
-
-        private static int ParseCol4(ReadOnlySpan<char> str, int index)
-        {
-            char character = str[index];
-
-            if (character >= '0' && character <= '9')
             {
-                return character - '0';
+                hue = 4 + ((R - G) / delta); // Between magenta & cyan
             }
-            else if (character >= 'a' && character <= 'f')
-            {
-                return character + (10 - 'a');
-            }
-            else if (character >= 'A' && character <= 'F')
-            {
-                return character + (10 - 'A');
-            }
-            return -1;
+
+            hue /= 6.0f;
+
+            if (hue < 0)
+                hue += 1.0f;
         }
 
-        private static int ParseCol8(ReadOnlySpan<char> str, int index)
+        if (max == 0)
+            saturation = 0;
+        else
+            saturation = 1 - (min / max);
+
+        value = max;
+    }
+
+    private static int ParseCol4(ReadOnlySpan<char> str, int index)
+    {
+        char character = str[index];
+
+        if (character >= '0' && character <= '9')
         {
-            return ParseCol4(str, index) * 16 + ParseCol4(str, index + 1);
+            return character - '0';
+        }
+        else if (character >= 'a' && character <= 'f')
+        {
+            return character + (10 - 'a');
+        }
+        else if (character >= 'A' && character <= 'F')
+        {
+            return character + (10 - 'A');
+        }
+        return -1;
+    }
+
+    private static int ParseCol8(ReadOnlySpan<char> str, int index)
+    {
+        return ParseCol4(str, index) * 16 + ParseCol4(str, index + 1);
+    }
+
+    /// <summary>
+    /// Constructs a color from an OK HSL profile. The <paramref name="hue"/>,
+    /// <paramref name="saturation"/>, and <paramref name="lightness"/> are typically
+    /// between 0.0 and 1.0.
+    /// </summary>
+    /// <param name="hue">The OK HSL hue, typically on the range of 0 to 1.</param>
+    /// <param name="saturation">The OK HSL saturation, typically on the range of 0 to 1.</param>
+    /// <param name="lightness">The OK HSL lightness, typically on the range of 0 to 1.</param>
+    /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
+    /// <returns>The constructed color.</returns>
+    public static Color FromOkHsl(float hue, float saturation, float lightness, float alpha = 1.0f)
+    {
+        return NativeFuncs.godotsharp_color_from_ok_hsl(hue, saturation, lightness, alpha);
+    }
+
+    /// <summary>
+    /// Encodes a <see cref="Color"/> from a RGBE9995 format integer.
+    /// See <see cref="Image.Format.Rgbe9995"/>.
+    /// </summary>
+    /// <param name="rgbe">The RGBE9995 encoded color.</param>
+    /// <returns>The constructed color.</returns>
+    public static Color FromRgbe9995(uint rgbe)
+    {
+        float r = rgbe & 0x1ff;
+        float g = (rgbe >> 9) & 0x1ff;
+        float b = (rgbe >> 18) & 0x1ff;
+        float e = rgbe >> 27;
+        float m = (float)Mathf.Pow(2.0f, e - 15.0f - 9.0f);
+
+        float rd = r * m;
+        float gd = g * m;
+        float bd = b * m;
+
+        return new Color(rd, gd, bd, 1.0f);
+    }
+
+    /// <summary>
+    /// Constructs a color from the given string, which can be either an HTML color
+    /// code or a named color. Returns <paramref name="default"/> if the color cannot
+    /// be inferred from the string. Supported color names are the same as the
+    /// <see cref="Colors"/> constants.
+    /// </summary>
+    /// <param name="str">The HTML color code or color name.</param>
+    /// <param name="default">The fallback color to return if the color cannot be inferred.</param>
+    /// <returns>The constructed color.</returns>
+    public static Color FromString(string str, Color @default)
+    {
+        if (HtmlIsValid(str))
+        {
+            return FromHtml(str);
+        }
+        else
+        {
+            return Named(str, @default);
+        }
+    }
+
+    private static string ToHex32(float val)
+    {
+        byte b = (byte)Mathf.RoundToInt(Mathf.Clamp(val * 255, 0, 255));
+        return b.HexEncode();
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="color"/> is a valid HTML hexadecimal
+    /// color string. The string must be a hexadecimal value (case-insensitive) of either 3,
+    /// 4, 6 or 8 digits, and may be prefixed by a hash sign (<c>#</c>). This method is
+    /// identical to <see cref="StringExtensions.IsValidHtmlColor(string)"/>.
+    /// </summary>
+    /// <param name="color">The HTML hexadecimal color string.</param>
+    /// <returns>Whether or not the string was a valid HTML hexadecimal color string.</returns>
+    public static bool HtmlIsValid(ReadOnlySpan<char> color)
+    {
+        if (color.IsEmpty)
+        {
+            return false;
         }
 
-        /// <summary>
-        /// Constructs a color from an OK HSL profile. The <paramref name="hue"/>,
-        /// <paramref name="saturation"/>, and <paramref name="lightness"/> are typically
-        /// between 0.0 and 1.0.
-        /// </summary>
-        /// <param name="hue">The OK HSL hue, typically on the range of 0 to 1.</param>
-        /// <param name="saturation">The OK HSL saturation, typically on the range of 0 to 1.</param>
-        /// <param name="lightness">The OK HSL lightness, typically on the range of 0 to 1.</param>
-        /// <param name="alpha">The alpha (transparency) value, typically on the range of 0 to 1.</param>
-        /// <returns>The constructed color.</returns>
-        public static Color FromOkHsl(float hue, float saturation, float lightness, float alpha = 1.0f)
+        if (color[0] == '#')
         {
-            return NativeFuncs.godotsharp_color_from_ok_hsl(hue, saturation, lightness, alpha);
+            color = color.Slice(1);
         }
 
-        /// <summary>
-        /// Encodes a <see cref="Color"/> from a RGBE9995 format integer.
-        /// See <see cref="Image.Format.Rgbe9995"/>.
-        /// </summary>
-        /// <param name="rgbe">The RGBE9995 encoded color.</param>
-        /// <returns>The constructed color.</returns>
-        public static Color FromRgbe9995(uint rgbe)
+        // Check if the amount of hex digits is valid.
+        int len = color.Length;
+        if (!(len == 3 || len == 4 || len == 6 || len == 8))
         {
-            float r = rgbe & 0x1ff;
-            float g = (rgbe >> 9) & 0x1ff;
-            float b = (rgbe >> 18) & 0x1ff;
-            float e = rgbe >> 27;
-            float m = (float)Mathf.Pow(2.0f, e - 15.0f - 9.0f);
-
-            float rd = r * m;
-            float gd = g * m;
-            float bd = b * m;
-
-            return new Color(rd, gd, bd, 1.0f);
+            return false;
         }
 
-        /// <summary>
-        /// Constructs a color from the given string, which can be either an HTML color
-        /// code or a named color. Returns <paramref name="default"/> if the color cannot
-        /// be inferred from the string. Supported color names are the same as the
-        /// <see cref="Colors"/> constants.
-        /// </summary>
-        /// <param name="str">The HTML color code or color name.</param>
-        /// <param name="default">The fallback color to return if the color cannot be inferred.</param>
-        /// <returns>The constructed color.</returns>
-        public static Color FromString(string str, Color @default)
+        // Check if each hex digit is valid.
+        for (int i = 0; i < len; i++)
         {
-            if (HtmlIsValid(str))
-            {
-                return FromHtml(str);
-            }
-            else
-            {
-                return Named(str, @default);
-            }
-        }
-
-        private static string ToHex32(float val)
-        {
-            byte b = (byte)Mathf.RoundToInt(Mathf.Clamp(val * 255, 0, 255));
-            return b.HexEncode();
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="color"/> is a valid HTML hexadecimal
-        /// color string. The string must be a hexadecimal value (case-insensitive) of either 3,
-        /// 4, 6 or 8 digits, and may be prefixed by a hash sign (<c>#</c>). This method is
-        /// identical to <see cref="StringExtensions.IsValidHtmlColor(string)"/>.
-        /// </summary>
-        /// <param name="color">The HTML hexadecimal color string.</param>
-        /// <returns>Whether or not the string was a valid HTML hexadecimal color string.</returns>
-        public static bool HtmlIsValid(ReadOnlySpan<char> color)
-        {
-            if (color.IsEmpty)
+            if (ParseCol4(color, i) == -1)
             {
                 return false;
             }
+        }
 
-            if (color[0] == '#')
-            {
-                color = color.Slice(1);
-            }
+        return true;
+    }
 
-            // Check if the amount of hex digits is valid.
-            int len = color.Length;
-            if (!(len == 3 || len == 4 || len == 6 || len == 8))
-            {
-                return false;
-            }
+    /// <summary>
+    /// Adds each component of the <see cref="Color"/>
+    /// with the components of the given <see cref="Color"/>.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>The added color.</returns>
+    public static Color operator +(Color left, Color right)
+    {
+        left.R += right.R;
+        left.G += right.G;
+        left.B += right.B;
+        left.A += right.A;
+        return left;
+    }
 
-            // Check if each hex digit is valid.
-            for (int i = 0; i < len; i++)
+    /// <summary>
+    /// Subtracts each component of the <see cref="Color"/>
+    /// by the components of the given <see cref="Color"/>.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>The subtracted color.</returns>
+    public static Color operator -(Color left, Color right)
+    {
+        left.R -= right.R;
+        left.G -= right.G;
+        left.B -= right.B;
+        left.A -= right.A;
+        return left;
+    }
+
+    /// <summary>
+    /// Inverts the given color. This is equivalent to
+    /// <c>Colors.White - c</c> or
+    /// <c>new Color(1 - c.R, 1 - c.G, 1 - c.B, 1 - c.A)</c>.
+    /// </summary>
+    /// <param name="color">The color to invert.</param>
+    /// <returns>The inverted color.</returns>
+    public static Color operator -(Color color)
+    {
+        return Colors.White - color;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Color"/>
+    /// by the given <see langword="float"/>.
+    /// </summary>
+    /// <param name="color">The color to multiply.</param>
+    /// <param name="scale">The value to multiply by.</param>
+    /// <returns>The multiplied color.</returns>
+    public static Color operator *(Color color, float scale)
+    {
+        color.R *= scale;
+        color.G *= scale;
+        color.B *= scale;
+        color.A *= scale;
+        return color;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Color"/>
+    /// by the given <see langword="float"/>.
+    /// </summary>
+    /// <param name="scale">The value to multiply by.</param>
+    /// <param name="color">The color to multiply.</param>
+    /// <returns>The multiplied color.</returns>
+    public static Color operator *(float scale, Color color)
+    {
+        color.R *= scale;
+        color.G *= scale;
+        color.B *= scale;
+        color.A *= scale;
+        return color;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Color"/>
+    /// by the components of the given <see cref="Color"/>.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>The multiplied color.</returns>
+    public static Color operator *(Color left, Color right)
+    {
+        left.R *= right.R;
+        left.G *= right.G;
+        left.B *= right.B;
+        left.A *= right.A;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Color"/>
+    /// by the given <see langword="float"/>.
+    /// </summary>
+    /// <param name="color">The dividend vector.</param>
+    /// <param name="scale">The divisor value.</param>
+    /// <returns>The divided color.</returns>
+    public static Color operator /(Color color, float scale)
+    {
+        color.R /= scale;
+        color.G /= scale;
+        color.B /= scale;
+        color.A /= scale;
+        return color;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Color"/>
+    /// by the components of the given <see cref="Color"/>.
+    /// </summary>
+    /// <param name="left">The dividend color.</param>
+    /// <param name="right">The divisor color.</param>
+    /// <returns>The divided color.</returns>
+    public static Color operator /(Color left, Color right)
+    {
+        left.R /= right.R;
+        left.G /= right.G;
+        left.B /= right.B;
+        left.A /= right.A;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the colors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the colors are equal.</returns>
+    public static bool operator ==(Color left, Color right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the colors are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the colors are equal.</returns>
+    public static bool operator !=(Color left, Color right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Color"/>s by first checking if
+    /// the red value of the <paramref name="left"/> color is less than
+    /// the red value of the <paramref name="right"/> color.
+    /// If the red values are exactly equal, then it repeats this check
+    /// with the green values of the two colors, then with the blue values,
+    /// and then with the alpha value.
+    /// This operator is useful for sorting colors.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Color left, Color right)
+    {
+        if (left.R == right.R)
+        {
+            if (left.G == right.G)
             {
-                if (ParseCol4(color, i) == -1)
+                if (left.B == right.B)
                 {
-                    return false;
+                    return left.A < right.A;
                 }
+                return left.B < right.B;
             }
-
-            return true;
+            return left.G < right.G;
         }
+        return left.R < right.R;
+    }
 
-        /// <summary>
-        /// Adds each component of the <see cref="Color"/>
-        /// with the components of the given <see cref="Color"/>.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>The added color.</returns>
-        public static Color operator +(Color left, Color right)
+    /// <summary>
+    /// Compares two <see cref="Color"/>s by first checking if
+    /// the red value of the <paramref name="left"/> color is greater than
+    /// the red value of the <paramref name="right"/> color.
+    /// If the red values are exactly equal, then it repeats this check
+    /// with the green values of the two colors, then with the blue values,
+    /// and then with the alpha value.
+    /// This operator is useful for sorting colors.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Color left, Color right)
+    {
+        if (left.R == right.R)
         {
-            left.R += right.R;
-            left.G += right.G;
-            left.B += right.B;
-            left.A += right.A;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Color"/>
-        /// by the components of the given <see cref="Color"/>.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>The subtracted color.</returns>
-        public static Color operator -(Color left, Color right)
-        {
-            left.R -= right.R;
-            left.G -= right.G;
-            left.B -= right.B;
-            left.A -= right.A;
-            return left;
-        }
-
-        /// <summary>
-        /// Inverts the given color. This is equivalent to
-        /// <c>Colors.White - c</c> or
-        /// <c>new Color(1 - c.R, 1 - c.G, 1 - c.B, 1 - c.A)</c>.
-        /// </summary>
-        /// <param name="color">The color to invert.</param>
-        /// <returns>The inverted color.</returns>
-        public static Color operator -(Color color)
-        {
-            return Colors.White - color;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Color"/>
-        /// by the given <see langword="float"/>.
-        /// </summary>
-        /// <param name="color">The color to multiply.</param>
-        /// <param name="scale">The value to multiply by.</param>
-        /// <returns>The multiplied color.</returns>
-        public static Color operator *(Color color, float scale)
-        {
-            color.R *= scale;
-            color.G *= scale;
-            color.B *= scale;
-            color.A *= scale;
-            return color;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Color"/>
-        /// by the given <see langword="float"/>.
-        /// </summary>
-        /// <param name="scale">The value to multiply by.</param>
-        /// <param name="color">The color to multiply.</param>
-        /// <returns>The multiplied color.</returns>
-        public static Color operator *(float scale, Color color)
-        {
-            color.R *= scale;
-            color.G *= scale;
-            color.B *= scale;
-            color.A *= scale;
-            return color;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Color"/>
-        /// by the components of the given <see cref="Color"/>.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>The multiplied color.</returns>
-        public static Color operator *(Color left, Color right)
-        {
-            left.R *= right.R;
-            left.G *= right.G;
-            left.B *= right.B;
-            left.A *= right.A;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Color"/>
-        /// by the given <see langword="float"/>.
-        /// </summary>
-        /// <param name="color">The dividend vector.</param>
-        /// <param name="scale">The divisor value.</param>
-        /// <returns>The divided color.</returns>
-        public static Color operator /(Color color, float scale)
-        {
-            color.R /= scale;
-            color.G /= scale;
-            color.B /= scale;
-            color.A /= scale;
-            return color;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Color"/>
-        /// by the components of the given <see cref="Color"/>.
-        /// </summary>
-        /// <param name="left">The dividend color.</param>
-        /// <param name="right">The divisor color.</param>
-        /// <returns>The divided color.</returns>
-        public static Color operator /(Color left, Color right)
-        {
-            left.R /= right.R;
-            left.G /= right.G;
-            left.B /= right.B;
-            left.A /= right.A;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the colors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the colors are equal.</returns>
-        public static bool operator ==(Color left, Color right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the colors are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the colors are equal.</returns>
-        public static bool operator !=(Color left, Color right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Color"/>s by first checking if
-        /// the red value of the <paramref name="left"/> color is less than
-        /// the red value of the <paramref name="right"/> color.
-        /// If the red values are exactly equal, then it repeats this check
-        /// with the green values of the two colors, then with the blue values,
-        /// and then with the alpha value.
-        /// This operator is useful for sorting colors.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Color left, Color right)
-        {
-            if (left.R == right.R)
+            if (left.G == right.G)
             {
-                if (left.G == right.G)
+                if (left.B == right.B)
                 {
-                    if (left.B == right.B)
-                    {
-                        return left.A < right.A;
-                    }
-                    return left.B < right.B;
+                    return left.A > right.A;
                 }
-                return left.G < right.G;
+                return left.B > right.B;
             }
-            return left.R < right.R;
+            return left.G > right.G;
         }
+        return left.R > right.R;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Color"/>s by first checking if
-        /// the red value of the <paramref name="left"/> color is greater than
-        /// the red value of the <paramref name="right"/> color.
-        /// If the red values are exactly equal, then it repeats this check
-        /// with the green values of the two colors, then with the blue values,
-        /// and then with the alpha value.
-        /// This operator is useful for sorting colors.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Color left, Color right)
+    /// <summary>
+    /// Compares two <see cref="Color"/>s by first checking if
+    /// the red value of the <paramref name="left"/> color is less than
+    /// or equal to the red value of the <paramref name="right"/> color.
+    /// If the red values are exactly equal, then it repeats this check
+    /// with the green values of the two colors, then with the blue values,
+    /// and then with the alpha value.
+    /// This operator is useful for sorting colors.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Color left, Color right)
+    {
+        if (left.R == right.R)
         {
-            if (left.R == right.R)
+            if (left.G == right.G)
             {
-                if (left.G == right.G)
+                if (left.B == right.B)
                 {
-                    if (left.B == right.B)
-                    {
-                        return left.A > right.A;
-                    }
-                    return left.B > right.B;
+                    return left.A <= right.A;
                 }
-                return left.G > right.G;
+                return left.B < right.B;
             }
-            return left.R > right.R;
+            return left.G < right.G;
         }
+        return left.R < right.R;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Color"/>s by first checking if
-        /// the red value of the <paramref name="left"/> color is less than
-        /// or equal to the red value of the <paramref name="right"/> color.
-        /// If the red values are exactly equal, then it repeats this check
-        /// with the green values of the two colors, then with the blue values,
-        /// and then with the alpha value.
-        /// This operator is useful for sorting colors.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Color left, Color right)
+    /// <summary>
+    /// Compares two <see cref="Color"/>s by first checking if
+    /// the red value of the <paramref name="left"/> color is greater than
+    /// or equal to the red value of the <paramref name="right"/> color.
+    /// If the red values are exactly equal, then it repeats this check
+    /// with the green values of the two colors, then with the blue values,
+    /// and then with the alpha value.
+    /// This operator is useful for sorting colors.
+    /// </summary>
+    /// <param name="left">The left color.</param>
+    /// <param name="right">The right color.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Color left, Color right)
+    {
+        if (left.R == right.R)
         {
-            if (left.R == right.R)
+            if (left.G == right.G)
             {
-                if (left.G == right.G)
+                if (left.B == right.B)
                 {
-                    if (left.B == right.B)
-                    {
-                        return left.A <= right.A;
-                    }
-                    return left.B < right.B;
+                    return left.A >= right.A;
                 }
-                return left.G < right.G;
+                return left.B > right.B;
             }
-            return left.R < right.R;
+            return left.G > right.G;
         }
+        return left.R > right.R;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Color"/>s by first checking if
-        /// the red value of the <paramref name="left"/> color is greater than
-        /// or equal to the red value of the <paramref name="right"/> color.
-        /// If the red values are exactly equal, then it repeats this check
-        /// with the green values of the two colors, then with the blue values,
-        /// and then with the alpha value.
-        /// This operator is useful for sorting colors.
-        /// </summary>
-        /// <param name="left">The left color.</param>
-        /// <param name="right">The right color.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Color left, Color right)
-        {
-            if (left.R == right.R)
-            {
-                if (left.G == right.G)
-                {
-                    if (left.B == right.B)
-                    {
-                        return left.A >= right.A;
-                    }
-                    return left.B > right.B;
-                }
-                return left.G > right.G;
-            }
-            return left.R > right.R;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this color and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the color and the other object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Color other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this color and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the color and the other object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Color other && Equals(other);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the colors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other color.</param>
+    /// <returns>Whether or not the colors are equal.</returns>
+    public readonly bool Equals(Color other)
+    {
+        return R == other.R && G == other.G && B == other.B && A == other.A;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the colors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other color.</param>
-        /// <returns>Whether or not the colors are equal.</returns>
-        public readonly bool Equals(Color other)
-        {
-            return R == other.R && G == other.G && B == other.B && A == other.A;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this color and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Mathf.IsEqualApprox(float, float)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other color to compare.</param>
+    /// <returns>Whether or not the colors are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Color other)
+    {
+        return Mathf.IsEqualApprox(R, other.R) && Mathf.IsEqualApprox(G, other.G) && Mathf.IsEqualApprox(B, other.B) && Mathf.IsEqualApprox(A, other.A);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this color and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Mathf.IsEqualApprox(float, float)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other color to compare.</param>
-        /// <returns>Whether or not the colors are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Color other)
-        {
-            return Mathf.IsEqualApprox(R, other.R) && Mathf.IsEqualApprox(G, other.G) && Mathf.IsEqualApprox(B, other.B) && Mathf.IsEqualApprox(A, other.A);
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Color"/>.
+    /// </summary>
+    /// <returns>A hash code for this color.</returns>
+    public override readonly int GetHashCode()
+    {
+        return R.GetHashCode() ^ G.GetHashCode() ^ B.GetHashCode() ^ A.GetHashCode();
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Color"/>.
-        /// </summary>
-        /// <returns>A hash code for this color.</returns>
-        public override readonly int GetHashCode()
-        {
-            return R.GetHashCode() ^ G.GetHashCode() ^ B.GetHashCode() ^ A.GetHashCode();
-        }
+    /// <summary>
+    /// Converts this <see cref="Color"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this color.</returns>
+    public override readonly string ToString()
+    {
+        return $"({R}, {G}, {B}, {A})";
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Color"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this color.</returns>
-        public override readonly string ToString()
-        {
-            return $"({R}, {G}, {B}, {A})";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Color"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this color.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({R.ToString(format)}, {G.ToString(format)}, {B.ToString(format)}, {A.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Color"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this color.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({R.ToString(format)}, {G.ToString(format)}, {B.ToString(format)}, {A.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Colors.cs
@@ -1,310 +1,309 @@
 using System.Collections.Generic;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// This class contains color constants created from standardized color names.
+/// The standardized color set is based on the X11 and .NET color names.
+/// </summary>
+public static class Colors
 {
-    /// <summary>
-    /// This class contains color constants created from standardized color names.
-    /// The standardized color set is based on the X11 and .NET color names.
-    /// </summary>
-    public static class Colors
-    {
-        // Color names and values are derived from core/math/color_names.inc
-        internal static readonly Dictionary<string, Color> namedColors = new Dictionary<string, Color> {
-            { "ALICEBLUE", new Color(0xF0F8FFFF) },
-            { "ANTIQUEWHITE", new Color(0xFAEBD7FF) },
-            { "AQUA", new Color(0x00FFFFFF) },
-            { "AQUAMARINE", new Color(0x7FFFD4FF) },
-            { "AZURE", new Color(0xF0FFFFFF) },
-            { "BEIGE", new Color(0xF5F5DCFF) },
-            { "BISQUE", new Color(0xFFE4C4FF) },
-            { "BLACK", new Color(0x000000FF) },
-            { "BLANCHEDALMOND", new Color(0xFFEBCDFF) },
-            { "BLUE", new Color(0x0000FFFF) },
-            { "BLUEVIOLET", new Color(0x8A2BE2FF) },
-            { "BROWN", new Color(0xA52A2AFF) },
-            { "BURLYWOOD", new Color(0xDEB887FF) },
-            { "CADETBLUE", new Color(0x5F9EA0FF) },
-            { "CHARTREUSE", new Color(0x7FFF00FF) },
-            { "CHOCOLATE", new Color(0xD2691EFF) },
-            { "CORAL", new Color(0xFF7F50FF) },
-            { "CORNFLOWERBLUE", new Color(0x6495EDFF) },
-            { "CORNSILK", new Color(0xFFF8DCFF) },
-            { "CRIMSON", new Color(0xDC143CFF) },
-            { "CYAN", new Color(0x00FFFFFF) },
-            { "DARKBLUE", new Color(0x00008BFF) },
-            { "DARKCYAN", new Color(0x008B8BFF) },
-            { "DARKGOLDENROD", new Color(0xB8860BFF) },
-            { "DARKGRAY", new Color(0xA9A9A9FF) },
-            { "DARKGREEN", new Color(0x006400FF) },
-            { "DARKKHAKI", new Color(0xBDB76BFF) },
-            { "DARKMAGENTA", new Color(0x8B008BFF) },
-            { "DARKOLIVEGREEN", new Color(0x556B2FFF) },
-            { "DARKORANGE", new Color(0xFF8C00FF) },
-            { "DARKORCHID", new Color(0x9932CCFF) },
-            { "DARKRED", new Color(0x8B0000FF) },
-            { "DARKSALMON", new Color(0xE9967AFF) },
-            { "DARKSEAGREEN", new Color(0x8FBC8FFF) },
-            { "DARKSLATEBLUE", new Color(0x483D8BFF) },
-            { "DARKSLATEGRAY", new Color(0x2F4F4FFF) },
-            { "DARKTURQUOISE", new Color(0x00CED1FF) },
-            { "DARKVIOLET", new Color(0x9400D3FF) },
-            { "DEEPPINK", new Color(0xFF1493FF) },
-            { "DEEPSKYBLUE", new Color(0x00BFFFFF) },
-            { "DIMGRAY", new Color(0x696969FF) },
-            { "DODGERBLUE", new Color(0x1E90FFFF) },
-            { "FIREBRICK", new Color(0xB22222FF) },
-            { "FLORALWHITE", new Color(0xFFFAF0FF) },
-            { "FORESTGREEN", new Color(0x228B22FF) },
-            { "FUCHSIA", new Color(0xFF00FFFF) },
-            { "GAINSBORO", new Color(0xDCDCDCFF) },
-            { "GHOSTWHITE", new Color(0xF8F8FFFF) },
-            { "GOLD", new Color(0xFFD700FF) },
-            { "GOLDENROD", new Color(0xDAA520FF) },
-            { "GRAY", new Color(0xBEBEBEFF) },
-            { "GREEN", new Color(0x00FF00FF) },
-            { "GREENYELLOW", new Color(0xADFF2FFF) },
-            { "HONEYDEW", new Color(0xF0FFF0FF) },
-            { "HOTPINK", new Color(0xFF69B4FF) },
-            { "INDIANRED", new Color(0xCD5C5CFF) },
-            { "INDIGO", new Color(0x4B0082FF) },
-            { "IVORY", new Color(0xFFFFF0FF) },
-            { "KHAKI", new Color(0xF0E68CFF) },
-            { "LAVENDER", new Color(0xE6E6FAFF) },
-            { "LAVENDERBLUSH", new Color(0xFFF0F5FF) },
-            { "LAWNGREEN", new Color(0x7CFC00FF) },
-            { "LEMONCHIFFON", new Color(0xFFFACDFF) },
-            { "LIGHTBLUE", new Color(0xADD8E6FF) },
-            { "LIGHTCORAL", new Color(0xF08080FF) },
-            { "LIGHTCYAN", new Color(0xE0FFFFFF) },
-            { "LIGHTGOLDENROD", new Color(0xFAFAD2FF) },
-            { "LIGHTGRAY", new Color(0xD3D3D3FF) },
-            { "LIGHTGREEN", new Color(0x90EE90FF) },
-            { "LIGHTPINK", new Color(0xFFB6C1FF) },
-            { "LIGHTSALMON", new Color(0xFFA07AFF) },
-            { "LIGHTSEAGREEN", new Color(0x20B2AAFF) },
-            { "LIGHTSKYBLUE", new Color(0x87CEFAFF) },
-            { "LIGHTSLATEGRAY", new Color(0x778899FF) },
-            { "LIGHTSTEELBLUE", new Color(0xB0C4DEFF) },
-            { "LIGHTYELLOW", new Color(0xFFFFE0FF) },
-            { "LIME", new Color(0x00FF00FF) },
-            { "LIMEGREEN", new Color(0x32CD32FF) },
-            { "LINEN", new Color(0xFAF0E6FF) },
-            { "MAGENTA", new Color(0xFF00FFFF) },
-            { "MAROON", new Color(0xB03060FF) },
-            { "MEDIUMAQUAMARINE", new Color(0x66CDAAFF) },
-            { "MEDIUMBLUE", new Color(0x0000CDFF) },
-            { "MEDIUMORCHID", new Color(0xBA55D3FF) },
-            { "MEDIUMPURPLE", new Color(0x9370DBFF) },
-            { "MEDIUMSEAGREEN", new Color(0x3CB371FF) },
-            { "MEDIUMSLATEBLUE", new Color(0x7B68EEFF) },
-            { "MEDIUMSPRINGGREEN", new Color(0x00FA9AFF) },
-            { "MEDIUMTURQUOISE", new Color(0x48D1CCFF) },
-            { "MEDIUMVIOLETRED", new Color(0xC71585FF) },
-            { "MIDNIGHTBLUE", new Color(0x191970FF) },
-            { "MINTCREAM", new Color(0xF5FFFAFF) },
-            { "MISTYROSE", new Color(0xFFE4E1FF) },
-            { "MOCCASIN", new Color(0xFFE4B5FF) },
-            { "NAVAJOWHITE", new Color(0xFFDEADFF) },
-            { "NAVYBLUE", new Color(0x000080FF) },
-            { "OLDLACE", new Color(0xFDF5E6FF) },
-            { "OLIVE", new Color(0x808000FF) },
-            { "OLIVEDRAB", new Color(0x6B8E23FF) },
-            { "ORANGE", new Color(0xFFA500FF) },
-            { "ORANGERED", new Color(0xFF4500FF) },
-            { "ORCHID", new Color(0xDA70D6FF) },
-            { "PALEGOLDENROD", new Color(0xEEE8AAFF) },
-            { "PALEGREEN", new Color(0x98FB98FF) },
-            { "PALETURQUOISE", new Color(0xAFEEEEFF) },
-            { "PALEVIOLETRED", new Color(0xDB7093FF) },
-            { "PAPAYAWHIP", new Color(0xFFEFD5FF) },
-            { "PEACHPUFF", new Color(0xFFDAB9FF) },
-            { "PERU", new Color(0xCD853FFF) },
-            { "PINK", new Color(0xFFC0CBFF) },
-            { "PLUM", new Color(0xDDA0DDFF) },
-            { "POWDERBLUE", new Color(0xB0E0E6FF) },
-            { "PURPLE", new Color(0xA020F0FF) },
-            { "REBECCAPURPLE", new Color(0x663399FF) },
-            { "RED", new Color(0xFF0000FF) },
-            { "ROSYBROWN", new Color(0xBC8F8FFF) },
-            { "ROYALBLUE", new Color(0x4169E1FF) },
-            { "SADDLEBROWN", new Color(0x8B4513FF) },
-            { "SALMON", new Color(0xFA8072FF) },
-            { "SANDYBROWN", new Color(0xF4A460FF) },
-            { "SEAGREEN", new Color(0x2E8B57FF) },
-            { "SEASHELL", new Color(0xFFF5EEFF) },
-            { "SIENNA", new Color(0xA0522DFF) },
-            { "SILVER", new Color(0xC0C0C0FF) },
-            { "SKYBLUE", new Color(0x87CEEBFF) },
-            { "SLATEBLUE", new Color(0x6A5ACDFF) },
-            { "SLATEGRAY", new Color(0x708090FF) },
-            { "SNOW", new Color(0xFFFAFAFF) },
-            { "SPRINGGREEN", new Color(0x00FF7FFF) },
-            { "STEELBLUE", new Color(0x4682B4FF) },
-            { "TAN", new Color(0xD2B48CFF) },
-            { "TEAL", new Color(0x008080FF) },
-            { "THISTLE", new Color(0xD8BFD8FF) },
-            { "TOMATO", new Color(0xFF6347FF) },
-            { "TRANSPARENT", new Color(0xFFFFFF00) },
-            { "TURQUOISE", new Color(0x40E0D0FF) },
-            { "VIOLET", new Color(0xEE82EEFF) },
-            { "WEBGRAY", new Color(0x808080FF) },
-            { "WEBGREEN", new Color(0x008000FF) },
-            { "WEBMAROON", new Color(0x800000FF) },
-            { "WEBPURPLE", new Color(0x800080FF) },
-            { "WHEAT", new Color(0xF5DEB3FF) },
-            { "WHITE", new Color(0xFFFFFFFF) },
-            { "WHITESMOKE", new Color(0xF5F5F5FF) },
-            { "YELLOW", new Color(0xFFFF00FF) },
-            { "YELLOWGREEN", new Color(0x9ACD32FF) },
-        };
+    // Color names and values are derived from core/math/color_names.inc
+    internal static readonly Dictionary<string, Color> namedColors = new Dictionary<string, Color> {
+        { "ALICEBLUE", new Color(0xF0F8FFFF) },
+        { "ANTIQUEWHITE", new Color(0xFAEBD7FF) },
+        { "AQUA", new Color(0x00FFFFFF) },
+        { "AQUAMARINE", new Color(0x7FFFD4FF) },
+        { "AZURE", new Color(0xF0FFFFFF) },
+        { "BEIGE", new Color(0xF5F5DCFF) },
+        { "BISQUE", new Color(0xFFE4C4FF) },
+        { "BLACK", new Color(0x000000FF) },
+        { "BLANCHEDALMOND", new Color(0xFFEBCDFF) },
+        { "BLUE", new Color(0x0000FFFF) },
+        { "BLUEVIOLET", new Color(0x8A2BE2FF) },
+        { "BROWN", new Color(0xA52A2AFF) },
+        { "BURLYWOOD", new Color(0xDEB887FF) },
+        { "CADETBLUE", new Color(0x5F9EA0FF) },
+        { "CHARTREUSE", new Color(0x7FFF00FF) },
+        { "CHOCOLATE", new Color(0xD2691EFF) },
+        { "CORAL", new Color(0xFF7F50FF) },
+        { "CORNFLOWERBLUE", new Color(0x6495EDFF) },
+        { "CORNSILK", new Color(0xFFF8DCFF) },
+        { "CRIMSON", new Color(0xDC143CFF) },
+        { "CYAN", new Color(0x00FFFFFF) },
+        { "DARKBLUE", new Color(0x00008BFF) },
+        { "DARKCYAN", new Color(0x008B8BFF) },
+        { "DARKGOLDENROD", new Color(0xB8860BFF) },
+        { "DARKGRAY", new Color(0xA9A9A9FF) },
+        { "DARKGREEN", new Color(0x006400FF) },
+        { "DARKKHAKI", new Color(0xBDB76BFF) },
+        { "DARKMAGENTA", new Color(0x8B008BFF) },
+        { "DARKOLIVEGREEN", new Color(0x556B2FFF) },
+        { "DARKORANGE", new Color(0xFF8C00FF) },
+        { "DARKORCHID", new Color(0x9932CCFF) },
+        { "DARKRED", new Color(0x8B0000FF) },
+        { "DARKSALMON", new Color(0xE9967AFF) },
+        { "DARKSEAGREEN", new Color(0x8FBC8FFF) },
+        { "DARKSLATEBLUE", new Color(0x483D8BFF) },
+        { "DARKSLATEGRAY", new Color(0x2F4F4FFF) },
+        { "DARKTURQUOISE", new Color(0x00CED1FF) },
+        { "DARKVIOLET", new Color(0x9400D3FF) },
+        { "DEEPPINK", new Color(0xFF1493FF) },
+        { "DEEPSKYBLUE", new Color(0x00BFFFFF) },
+        { "DIMGRAY", new Color(0x696969FF) },
+        { "DODGERBLUE", new Color(0x1E90FFFF) },
+        { "FIREBRICK", new Color(0xB22222FF) },
+        { "FLORALWHITE", new Color(0xFFFAF0FF) },
+        { "FORESTGREEN", new Color(0x228B22FF) },
+        { "FUCHSIA", new Color(0xFF00FFFF) },
+        { "GAINSBORO", new Color(0xDCDCDCFF) },
+        { "GHOSTWHITE", new Color(0xF8F8FFFF) },
+        { "GOLD", new Color(0xFFD700FF) },
+        { "GOLDENROD", new Color(0xDAA520FF) },
+        { "GRAY", new Color(0xBEBEBEFF) },
+        { "GREEN", new Color(0x00FF00FF) },
+        { "GREENYELLOW", new Color(0xADFF2FFF) },
+        { "HONEYDEW", new Color(0xF0FFF0FF) },
+        { "HOTPINK", new Color(0xFF69B4FF) },
+        { "INDIANRED", new Color(0xCD5C5CFF) },
+        { "INDIGO", new Color(0x4B0082FF) },
+        { "IVORY", new Color(0xFFFFF0FF) },
+        { "KHAKI", new Color(0xF0E68CFF) },
+        { "LAVENDER", new Color(0xE6E6FAFF) },
+        { "LAVENDERBLUSH", new Color(0xFFF0F5FF) },
+        { "LAWNGREEN", new Color(0x7CFC00FF) },
+        { "LEMONCHIFFON", new Color(0xFFFACDFF) },
+        { "LIGHTBLUE", new Color(0xADD8E6FF) },
+        { "LIGHTCORAL", new Color(0xF08080FF) },
+        { "LIGHTCYAN", new Color(0xE0FFFFFF) },
+        { "LIGHTGOLDENROD", new Color(0xFAFAD2FF) },
+        { "LIGHTGRAY", new Color(0xD3D3D3FF) },
+        { "LIGHTGREEN", new Color(0x90EE90FF) },
+        { "LIGHTPINK", new Color(0xFFB6C1FF) },
+        { "LIGHTSALMON", new Color(0xFFA07AFF) },
+        { "LIGHTSEAGREEN", new Color(0x20B2AAFF) },
+        { "LIGHTSKYBLUE", new Color(0x87CEFAFF) },
+        { "LIGHTSLATEGRAY", new Color(0x778899FF) },
+        { "LIGHTSTEELBLUE", new Color(0xB0C4DEFF) },
+        { "LIGHTYELLOW", new Color(0xFFFFE0FF) },
+        { "LIME", new Color(0x00FF00FF) },
+        { "LIMEGREEN", new Color(0x32CD32FF) },
+        { "LINEN", new Color(0xFAF0E6FF) },
+        { "MAGENTA", new Color(0xFF00FFFF) },
+        { "MAROON", new Color(0xB03060FF) },
+        { "MEDIUMAQUAMARINE", new Color(0x66CDAAFF) },
+        { "MEDIUMBLUE", new Color(0x0000CDFF) },
+        { "MEDIUMORCHID", new Color(0xBA55D3FF) },
+        { "MEDIUMPURPLE", new Color(0x9370DBFF) },
+        { "MEDIUMSEAGREEN", new Color(0x3CB371FF) },
+        { "MEDIUMSLATEBLUE", new Color(0x7B68EEFF) },
+        { "MEDIUMSPRINGGREEN", new Color(0x00FA9AFF) },
+        { "MEDIUMTURQUOISE", new Color(0x48D1CCFF) },
+        { "MEDIUMVIOLETRED", new Color(0xC71585FF) },
+        { "MIDNIGHTBLUE", new Color(0x191970FF) },
+        { "MINTCREAM", new Color(0xF5FFFAFF) },
+        { "MISTYROSE", new Color(0xFFE4E1FF) },
+        { "MOCCASIN", new Color(0xFFE4B5FF) },
+        { "NAVAJOWHITE", new Color(0xFFDEADFF) },
+        { "NAVYBLUE", new Color(0x000080FF) },
+        { "OLDLACE", new Color(0xFDF5E6FF) },
+        { "OLIVE", new Color(0x808000FF) },
+        { "OLIVEDRAB", new Color(0x6B8E23FF) },
+        { "ORANGE", new Color(0xFFA500FF) },
+        { "ORANGERED", new Color(0xFF4500FF) },
+        { "ORCHID", new Color(0xDA70D6FF) },
+        { "PALEGOLDENROD", new Color(0xEEE8AAFF) },
+        { "PALEGREEN", new Color(0x98FB98FF) },
+        { "PALETURQUOISE", new Color(0xAFEEEEFF) },
+        { "PALEVIOLETRED", new Color(0xDB7093FF) },
+        { "PAPAYAWHIP", new Color(0xFFEFD5FF) },
+        { "PEACHPUFF", new Color(0xFFDAB9FF) },
+        { "PERU", new Color(0xCD853FFF) },
+        { "PINK", new Color(0xFFC0CBFF) },
+        { "PLUM", new Color(0xDDA0DDFF) },
+        { "POWDERBLUE", new Color(0xB0E0E6FF) },
+        { "PURPLE", new Color(0xA020F0FF) },
+        { "REBECCAPURPLE", new Color(0x663399FF) },
+        { "RED", new Color(0xFF0000FF) },
+        { "ROSYBROWN", new Color(0xBC8F8FFF) },
+        { "ROYALBLUE", new Color(0x4169E1FF) },
+        { "SADDLEBROWN", new Color(0x8B4513FF) },
+        { "SALMON", new Color(0xFA8072FF) },
+        { "SANDYBROWN", new Color(0xF4A460FF) },
+        { "SEAGREEN", new Color(0x2E8B57FF) },
+        { "SEASHELL", new Color(0xFFF5EEFF) },
+        { "SIENNA", new Color(0xA0522DFF) },
+        { "SILVER", new Color(0xC0C0C0FF) },
+        { "SKYBLUE", new Color(0x87CEEBFF) },
+        { "SLATEBLUE", new Color(0x6A5ACDFF) },
+        { "SLATEGRAY", new Color(0x708090FF) },
+        { "SNOW", new Color(0xFFFAFAFF) },
+        { "SPRINGGREEN", new Color(0x00FF7FFF) },
+        { "STEELBLUE", new Color(0x4682B4FF) },
+        { "TAN", new Color(0xD2B48CFF) },
+        { "TEAL", new Color(0x008080FF) },
+        { "THISTLE", new Color(0xD8BFD8FF) },
+        { "TOMATO", new Color(0xFF6347FF) },
+        { "TRANSPARENT", new Color(0xFFFFFF00) },
+        { "TURQUOISE", new Color(0x40E0D0FF) },
+        { "VIOLET", new Color(0xEE82EEFF) },
+        { "WEBGRAY", new Color(0x808080FF) },
+        { "WEBGREEN", new Color(0x008000FF) },
+        { "WEBMAROON", new Color(0x800000FF) },
+        { "WEBPURPLE", new Color(0x800080FF) },
+        { "WHEAT", new Color(0xF5DEB3FF) },
+        { "WHITE", new Color(0xFFFFFFFF) },
+        { "WHITESMOKE", new Color(0xF5F5F5FF) },
+        { "YELLOW", new Color(0xFFFF00FF) },
+        { "YELLOWGREEN", new Color(0x9ACD32FF) },
+    };
 
 #pragma warning disable CS1591 // Disable warning: "Missing XML comment for publicly visible type or member"
-        public static Color AliceBlue { get { return namedColors["ALICEBLUE"]; } }
-        public static Color AntiqueWhite { get { return namedColors["ANTIQUEWHITE"]; } }
-        public static Color Aqua { get { return namedColors["AQUA"]; } }
-        public static Color Aquamarine { get { return namedColors["AQUAMARINE"]; } }
-        public static Color Azure { get { return namedColors["AZURE"]; } }
-        public static Color Beige { get { return namedColors["BEIGE"]; } }
-        public static Color Bisque { get { return namedColors["BISQUE"]; } }
-        public static Color Black { get { return namedColors["BLACK"]; } }
-        public static Color BlanchedAlmond { get { return namedColors["BLANCHEDALMOND"]; } }
-        public static Color Blue { get { return namedColors["BLUE"]; } }
-        public static Color BlueViolet { get { return namedColors["BLUEVIOLET"]; } }
-        public static Color Brown { get { return namedColors["BROWN"]; } }
-        public static Color Burlywood { get { return namedColors["BURLYWOOD"]; } }
-        public static Color CadetBlue { get { return namedColors["CADETBLUE"]; } }
-        public static Color Chartreuse { get { return namedColors["CHARTREUSE"]; } }
-        public static Color Chocolate { get { return namedColors["CHOCOLATE"]; } }
-        public static Color Coral { get { return namedColors["CORAL"]; } }
-        public static Color CornflowerBlue { get { return namedColors["CORNFLOWERBLUE"]; } }
-        public static Color Cornsilk { get { return namedColors["CORNSILK"]; } }
-        public static Color Crimson { get { return namedColors["CRIMSON"]; } }
-        public static Color Cyan { get { return namedColors["CYAN"]; } }
-        public static Color DarkBlue { get { return namedColors["DARKBLUE"]; } }
-        public static Color DarkCyan { get { return namedColors["DARKCYAN"]; } }
-        public static Color DarkGoldenrod { get { return namedColors["DARKGOLDENROD"]; } }
-        public static Color DarkGray { get { return namedColors["DARKGRAY"]; } }
-        public static Color DarkGreen { get { return namedColors["DARKGREEN"]; } }
-        public static Color DarkKhaki { get { return namedColors["DARKKHAKI"]; } }
-        public static Color DarkMagenta { get { return namedColors["DARKMAGENTA"]; } }
-        public static Color DarkOliveGreen { get { return namedColors["DARKOLIVEGREEN"]; } }
-        public static Color DarkOrange { get { return namedColors["DARKORANGE"]; } }
-        public static Color DarkOrchid { get { return namedColors["DARKORCHID"]; } }
-        public static Color DarkRed { get { return namedColors["DARKRED"]; } }
-        public static Color DarkSalmon { get { return namedColors["DARKSALMON"]; } }
-        public static Color DarkSeaGreen { get { return namedColors["DARKSEAGREEN"]; } }
-        public static Color DarkSlateBlue { get { return namedColors["DARKSLATEBLUE"]; } }
-        public static Color DarkSlateGray { get { return namedColors["DARKSLATEGRAY"]; } }
-        public static Color DarkTurquoise { get { return namedColors["DARKTURQUOISE"]; } }
-        public static Color DarkViolet { get { return namedColors["DARKVIOLET"]; } }
-        public static Color DeepPink { get { return namedColors["DEEPPINK"]; } }
-        public static Color DeepSkyBlue { get { return namedColors["DEEPSKYBLUE"]; } }
-        public static Color DimGray { get { return namedColors["DIMGRAY"]; } }
-        public static Color DodgerBlue { get { return namedColors["DODGERBLUE"]; } }
-        public static Color Firebrick { get { return namedColors["FIREBRICK"]; } }
-        public static Color FloralWhite { get { return namedColors["FLORALWHITE"]; } }
-        public static Color ForestGreen { get { return namedColors["FORESTGREEN"]; } }
-        public static Color Fuchsia { get { return namedColors["FUCHSIA"]; } }
-        public static Color Gainsboro { get { return namedColors["GAINSBORO"]; } }
-        public static Color GhostWhite { get { return namedColors["GHOSTWHITE"]; } }
-        public static Color Gold { get { return namedColors["GOLD"]; } }
-        public static Color Goldenrod { get { return namedColors["GOLDENROD"]; } }
-        public static Color Gray { get { return namedColors["GRAY"]; } }
-        public static Color Green { get { return namedColors["GREEN"]; } }
-        public static Color GreenYellow { get { return namedColors["GREENYELLOW"]; } }
-        public static Color Honeydew { get { return namedColors["HONEYDEW"]; } }
-        public static Color HotPink { get { return namedColors["HOTPINK"]; } }
-        public static Color IndianRed { get { return namedColors["INDIANRED"]; } }
-        public static Color Indigo { get { return namedColors["INDIGO"]; } }
-        public static Color Ivory { get { return namedColors["IVORY"]; } }
-        public static Color Khaki { get { return namedColors["KHAKI"]; } }
-        public static Color Lavender { get { return namedColors["LAVENDER"]; } }
-        public static Color LavenderBlush { get { return namedColors["LAVENDERBLUSH"]; } }
-        public static Color LawnGreen { get { return namedColors["LAWNGREEN"]; } }
-        public static Color LemonChiffon { get { return namedColors["LEMONCHIFFON"]; } }
-        public static Color LightBlue { get { return namedColors["LIGHTBLUE"]; } }
-        public static Color LightCoral { get { return namedColors["LIGHTCORAL"]; } }
-        public static Color LightCyan { get { return namedColors["LIGHTCYAN"]; } }
-        public static Color LightGoldenrod { get { return namedColors["LIGHTGOLDENROD"]; } }
-        public static Color LightGray { get { return namedColors["LIGHTGRAY"]; } }
-        public static Color LightGreen { get { return namedColors["LIGHTGREEN"]; } }
-        public static Color LightPink { get { return namedColors["LIGHTPINK"]; } }
-        public static Color LightSalmon { get { return namedColors["LIGHTSALMON"]; } }
-        public static Color LightSeaGreen { get { return namedColors["LIGHTSEAGREEN"]; } }
-        public static Color LightSkyBlue { get { return namedColors["LIGHTSKYBLUE"]; } }
-        public static Color LightSlateGray { get { return namedColors["LIGHTSLATEGRAY"]; } }
-        public static Color LightSteelBlue { get { return namedColors["LIGHTSTEELBLUE"]; } }
-        public static Color LightYellow { get { return namedColors["LIGHTYELLOW"]; } }
-        public static Color Lime { get { return namedColors["LIME"]; } }
-        public static Color LimeGreen { get { return namedColors["LIMEGREEN"]; } }
-        public static Color Linen { get { return namedColors["LINEN"]; } }
-        public static Color Magenta { get { return namedColors["MAGENTA"]; } }
-        public static Color Maroon { get { return namedColors["MAROON"]; } }
-        public static Color MediumAquamarine { get { return namedColors["MEDIUMAQUAMARINE"]; } }
-        public static Color MediumBlue { get { return namedColors["MEDIUMBLUE"]; } }
-        public static Color MediumOrchid { get { return namedColors["MEDIUMORCHID"]; } }
-        public static Color MediumPurple { get { return namedColors["MEDIUMPURPLE"]; } }
-        public static Color MediumSeaGreen { get { return namedColors["MEDIUMSEAGREEN"]; } }
-        public static Color MediumSlateBlue { get { return namedColors["MEDIUMSLATEBLUE"]; } }
-        public static Color MediumSpringGreen { get { return namedColors["MEDIUMSPRINGGREEN"]; } }
-        public static Color MediumTurquoise { get { return namedColors["MEDIUMTURQUOISE"]; } }
-        public static Color MediumVioletRed { get { return namedColors["MEDIUMVIOLETRED"]; } }
-        public static Color MidnightBlue { get { return namedColors["MIDNIGHTBLUE"]; } }
-        public static Color MintCream { get { return namedColors["MINTCREAM"]; } }
-        public static Color MistyRose { get { return namedColors["MISTYROSE"]; } }
-        public static Color Moccasin { get { return namedColors["MOCCASIN"]; } }
-        public static Color NavajoWhite { get { return namedColors["NAVAJOWHITE"]; } }
-        public static Color NavyBlue { get { return namedColors["NAVYBLUE"]; } }
-        public static Color OldLace { get { return namedColors["OLDLACE"]; } }
-        public static Color Olive { get { return namedColors["OLIVE"]; } }
-        public static Color OliveDrab { get { return namedColors["OLIVEDRAB"]; } }
-        public static Color Orange { get { return namedColors["ORANGE"]; } }
-        public static Color OrangeRed { get { return namedColors["ORANGERED"]; } }
-        public static Color Orchid { get { return namedColors["ORCHID"]; } }
-        public static Color PaleGoldenrod { get { return namedColors["PALEGOLDENROD"]; } }
-        public static Color PaleGreen { get { return namedColors["PALEGREEN"]; } }
-        public static Color PaleTurquoise { get { return namedColors["PALETURQUOISE"]; } }
-        public static Color PaleVioletRed { get { return namedColors["PALEVIOLETRED"]; } }
-        public static Color PapayaWhip { get { return namedColors["PAPAYAWHIP"]; } }
-        public static Color PeachPuff { get { return namedColors["PEACHPUFF"]; } }
-        public static Color Peru { get { return namedColors["PERU"]; } }
-        public static Color Pink { get { return namedColors["PINK"]; } }
-        public static Color Plum { get { return namedColors["PLUM"]; } }
-        public static Color PowderBlue { get { return namedColors["POWDERBLUE"]; } }
-        public static Color Purple { get { return namedColors["PURPLE"]; } }
-        public static Color RebeccaPurple { get { return namedColors["REBECCAPURPLE"]; } }
-        public static Color Red { get { return namedColors["RED"]; } }
-        public static Color RosyBrown { get { return namedColors["ROSYBROWN"]; } }
-        public static Color RoyalBlue { get { return namedColors["ROYALBLUE"]; } }
-        public static Color SaddleBrown { get { return namedColors["SADDLEBROWN"]; } }
-        public static Color Salmon { get { return namedColors["SALMON"]; } }
-        public static Color SandyBrown { get { return namedColors["SANDYBROWN"]; } }
-        public static Color SeaGreen { get { return namedColors["SEAGREEN"]; } }
-        public static Color Seashell { get { return namedColors["SEASHELL"]; } }
-        public static Color Sienna { get { return namedColors["SIENNA"]; } }
-        public static Color Silver { get { return namedColors["SILVER"]; } }
-        public static Color SkyBlue { get { return namedColors["SKYBLUE"]; } }
-        public static Color SlateBlue { get { return namedColors["SLATEBLUE"]; } }
-        public static Color SlateGray { get { return namedColors["SLATEGRAY"]; } }
-        public static Color Snow { get { return namedColors["SNOW"]; } }
-        public static Color SpringGreen { get { return namedColors["SPRINGGREEN"]; } }
-        public static Color SteelBlue { get { return namedColors["STEELBLUE"]; } }
-        public static Color Tan { get { return namedColors["TAN"]; } }
-        public static Color Teal { get { return namedColors["TEAL"]; } }
-        public static Color Thistle { get { return namedColors["THISTLE"]; } }
-        public static Color Tomato { get { return namedColors["TOMATO"]; } }
-        public static Color Transparent { get { return namedColors["TRANSPARENT"]; } }
-        public static Color Turquoise { get { return namedColors["TURQUOISE"]; } }
-        public static Color Violet { get { return namedColors["VIOLET"]; } }
-        public static Color WebGray { get { return namedColors["WEBGRAY"]; } }
-        public static Color WebGreen { get { return namedColors["WEBGREEN"]; } }
-        public static Color WebMaroon { get { return namedColors["WEBMAROON"]; } }
-        public static Color WebPurple { get { return namedColors["WEBPURPLE"]; } }
-        public static Color Wheat { get { return namedColors["WHEAT"]; } }
-        public static Color White { get { return namedColors["WHITE"]; } }
-        public static Color WhiteSmoke { get { return namedColors["WHITESMOKE"]; } }
-        public static Color Yellow { get { return namedColors["YELLOW"]; } }
-        public static Color YellowGreen { get { return namedColors["YELLOWGREEN"]; } }
+    public static Color AliceBlue { get { return namedColors["ALICEBLUE"]; } }
+    public static Color AntiqueWhite { get { return namedColors["ANTIQUEWHITE"]; } }
+    public static Color Aqua { get { return namedColors["AQUA"]; } }
+    public static Color Aquamarine { get { return namedColors["AQUAMARINE"]; } }
+    public static Color Azure { get { return namedColors["AZURE"]; } }
+    public static Color Beige { get { return namedColors["BEIGE"]; } }
+    public static Color Bisque { get { return namedColors["BISQUE"]; } }
+    public static Color Black { get { return namedColors["BLACK"]; } }
+    public static Color BlanchedAlmond { get { return namedColors["BLANCHEDALMOND"]; } }
+    public static Color Blue { get { return namedColors["BLUE"]; } }
+    public static Color BlueViolet { get { return namedColors["BLUEVIOLET"]; } }
+    public static Color Brown { get { return namedColors["BROWN"]; } }
+    public static Color Burlywood { get { return namedColors["BURLYWOOD"]; } }
+    public static Color CadetBlue { get { return namedColors["CADETBLUE"]; } }
+    public static Color Chartreuse { get { return namedColors["CHARTREUSE"]; } }
+    public static Color Chocolate { get { return namedColors["CHOCOLATE"]; } }
+    public static Color Coral { get { return namedColors["CORAL"]; } }
+    public static Color CornflowerBlue { get { return namedColors["CORNFLOWERBLUE"]; } }
+    public static Color Cornsilk { get { return namedColors["CORNSILK"]; } }
+    public static Color Crimson { get { return namedColors["CRIMSON"]; } }
+    public static Color Cyan { get { return namedColors["CYAN"]; } }
+    public static Color DarkBlue { get { return namedColors["DARKBLUE"]; } }
+    public static Color DarkCyan { get { return namedColors["DARKCYAN"]; } }
+    public static Color DarkGoldenrod { get { return namedColors["DARKGOLDENROD"]; } }
+    public static Color DarkGray { get { return namedColors["DARKGRAY"]; } }
+    public static Color DarkGreen { get { return namedColors["DARKGREEN"]; } }
+    public static Color DarkKhaki { get { return namedColors["DARKKHAKI"]; } }
+    public static Color DarkMagenta { get { return namedColors["DARKMAGENTA"]; } }
+    public static Color DarkOliveGreen { get { return namedColors["DARKOLIVEGREEN"]; } }
+    public static Color DarkOrange { get { return namedColors["DARKORANGE"]; } }
+    public static Color DarkOrchid { get { return namedColors["DARKORCHID"]; } }
+    public static Color DarkRed { get { return namedColors["DARKRED"]; } }
+    public static Color DarkSalmon { get { return namedColors["DARKSALMON"]; } }
+    public static Color DarkSeaGreen { get { return namedColors["DARKSEAGREEN"]; } }
+    public static Color DarkSlateBlue { get { return namedColors["DARKSLATEBLUE"]; } }
+    public static Color DarkSlateGray { get { return namedColors["DARKSLATEGRAY"]; } }
+    public static Color DarkTurquoise { get { return namedColors["DARKTURQUOISE"]; } }
+    public static Color DarkViolet { get { return namedColors["DARKVIOLET"]; } }
+    public static Color DeepPink { get { return namedColors["DEEPPINK"]; } }
+    public static Color DeepSkyBlue { get { return namedColors["DEEPSKYBLUE"]; } }
+    public static Color DimGray { get { return namedColors["DIMGRAY"]; } }
+    public static Color DodgerBlue { get { return namedColors["DODGERBLUE"]; } }
+    public static Color Firebrick { get { return namedColors["FIREBRICK"]; } }
+    public static Color FloralWhite { get { return namedColors["FLORALWHITE"]; } }
+    public static Color ForestGreen { get { return namedColors["FORESTGREEN"]; } }
+    public static Color Fuchsia { get { return namedColors["FUCHSIA"]; } }
+    public static Color Gainsboro { get { return namedColors["GAINSBORO"]; } }
+    public static Color GhostWhite { get { return namedColors["GHOSTWHITE"]; } }
+    public static Color Gold { get { return namedColors["GOLD"]; } }
+    public static Color Goldenrod { get { return namedColors["GOLDENROD"]; } }
+    public static Color Gray { get { return namedColors["GRAY"]; } }
+    public static Color Green { get { return namedColors["GREEN"]; } }
+    public static Color GreenYellow { get { return namedColors["GREENYELLOW"]; } }
+    public static Color Honeydew { get { return namedColors["HONEYDEW"]; } }
+    public static Color HotPink { get { return namedColors["HOTPINK"]; } }
+    public static Color IndianRed { get { return namedColors["INDIANRED"]; } }
+    public static Color Indigo { get { return namedColors["INDIGO"]; } }
+    public static Color Ivory { get { return namedColors["IVORY"]; } }
+    public static Color Khaki { get { return namedColors["KHAKI"]; } }
+    public static Color Lavender { get { return namedColors["LAVENDER"]; } }
+    public static Color LavenderBlush { get { return namedColors["LAVENDERBLUSH"]; } }
+    public static Color LawnGreen { get { return namedColors["LAWNGREEN"]; } }
+    public static Color LemonChiffon { get { return namedColors["LEMONCHIFFON"]; } }
+    public static Color LightBlue { get { return namedColors["LIGHTBLUE"]; } }
+    public static Color LightCoral { get { return namedColors["LIGHTCORAL"]; } }
+    public static Color LightCyan { get { return namedColors["LIGHTCYAN"]; } }
+    public static Color LightGoldenrod { get { return namedColors["LIGHTGOLDENROD"]; } }
+    public static Color LightGray { get { return namedColors["LIGHTGRAY"]; } }
+    public static Color LightGreen { get { return namedColors["LIGHTGREEN"]; } }
+    public static Color LightPink { get { return namedColors["LIGHTPINK"]; } }
+    public static Color LightSalmon { get { return namedColors["LIGHTSALMON"]; } }
+    public static Color LightSeaGreen { get { return namedColors["LIGHTSEAGREEN"]; } }
+    public static Color LightSkyBlue { get { return namedColors["LIGHTSKYBLUE"]; } }
+    public static Color LightSlateGray { get { return namedColors["LIGHTSLATEGRAY"]; } }
+    public static Color LightSteelBlue { get { return namedColors["LIGHTSTEELBLUE"]; } }
+    public static Color LightYellow { get { return namedColors["LIGHTYELLOW"]; } }
+    public static Color Lime { get { return namedColors["LIME"]; } }
+    public static Color LimeGreen { get { return namedColors["LIMEGREEN"]; } }
+    public static Color Linen { get { return namedColors["LINEN"]; } }
+    public static Color Magenta { get { return namedColors["MAGENTA"]; } }
+    public static Color Maroon { get { return namedColors["MAROON"]; } }
+    public static Color MediumAquamarine { get { return namedColors["MEDIUMAQUAMARINE"]; } }
+    public static Color MediumBlue { get { return namedColors["MEDIUMBLUE"]; } }
+    public static Color MediumOrchid { get { return namedColors["MEDIUMORCHID"]; } }
+    public static Color MediumPurple { get { return namedColors["MEDIUMPURPLE"]; } }
+    public static Color MediumSeaGreen { get { return namedColors["MEDIUMSEAGREEN"]; } }
+    public static Color MediumSlateBlue { get { return namedColors["MEDIUMSLATEBLUE"]; } }
+    public static Color MediumSpringGreen { get { return namedColors["MEDIUMSPRINGGREEN"]; } }
+    public static Color MediumTurquoise { get { return namedColors["MEDIUMTURQUOISE"]; } }
+    public static Color MediumVioletRed { get { return namedColors["MEDIUMVIOLETRED"]; } }
+    public static Color MidnightBlue { get { return namedColors["MIDNIGHTBLUE"]; } }
+    public static Color MintCream { get { return namedColors["MINTCREAM"]; } }
+    public static Color MistyRose { get { return namedColors["MISTYROSE"]; } }
+    public static Color Moccasin { get { return namedColors["MOCCASIN"]; } }
+    public static Color NavajoWhite { get { return namedColors["NAVAJOWHITE"]; } }
+    public static Color NavyBlue { get { return namedColors["NAVYBLUE"]; } }
+    public static Color OldLace { get { return namedColors["OLDLACE"]; } }
+    public static Color Olive { get { return namedColors["OLIVE"]; } }
+    public static Color OliveDrab { get { return namedColors["OLIVEDRAB"]; } }
+    public static Color Orange { get { return namedColors["ORANGE"]; } }
+    public static Color OrangeRed { get { return namedColors["ORANGERED"]; } }
+    public static Color Orchid { get { return namedColors["ORCHID"]; } }
+    public static Color PaleGoldenrod { get { return namedColors["PALEGOLDENROD"]; } }
+    public static Color PaleGreen { get { return namedColors["PALEGREEN"]; } }
+    public static Color PaleTurquoise { get { return namedColors["PALETURQUOISE"]; } }
+    public static Color PaleVioletRed { get { return namedColors["PALEVIOLETRED"]; } }
+    public static Color PapayaWhip { get { return namedColors["PAPAYAWHIP"]; } }
+    public static Color PeachPuff { get { return namedColors["PEACHPUFF"]; } }
+    public static Color Peru { get { return namedColors["PERU"]; } }
+    public static Color Pink { get { return namedColors["PINK"]; } }
+    public static Color Plum { get { return namedColors["PLUM"]; } }
+    public static Color PowderBlue { get { return namedColors["POWDERBLUE"]; } }
+    public static Color Purple { get { return namedColors["PURPLE"]; } }
+    public static Color RebeccaPurple { get { return namedColors["REBECCAPURPLE"]; } }
+    public static Color Red { get { return namedColors["RED"]; } }
+    public static Color RosyBrown { get { return namedColors["ROSYBROWN"]; } }
+    public static Color RoyalBlue { get { return namedColors["ROYALBLUE"]; } }
+    public static Color SaddleBrown { get { return namedColors["SADDLEBROWN"]; } }
+    public static Color Salmon { get { return namedColors["SALMON"]; } }
+    public static Color SandyBrown { get { return namedColors["SANDYBROWN"]; } }
+    public static Color SeaGreen { get { return namedColors["SEAGREEN"]; } }
+    public static Color Seashell { get { return namedColors["SEASHELL"]; } }
+    public static Color Sienna { get { return namedColors["SIENNA"]; } }
+    public static Color Silver { get { return namedColors["SILVER"]; } }
+    public static Color SkyBlue { get { return namedColors["SKYBLUE"]; } }
+    public static Color SlateBlue { get { return namedColors["SLATEBLUE"]; } }
+    public static Color SlateGray { get { return namedColors["SLATEGRAY"]; } }
+    public static Color Snow { get { return namedColors["SNOW"]; } }
+    public static Color SpringGreen { get { return namedColors["SPRINGGREEN"]; } }
+    public static Color SteelBlue { get { return namedColors["STEELBLUE"]; } }
+    public static Color Tan { get { return namedColors["TAN"]; } }
+    public static Color Teal { get { return namedColors["TEAL"]; } }
+    public static Color Thistle { get { return namedColors["THISTLE"]; } }
+    public static Color Tomato { get { return namedColors["TOMATO"]; } }
+    public static Color Transparent { get { return namedColors["TRANSPARENT"]; } }
+    public static Color Turquoise { get { return namedColors["TURQUOISE"]; } }
+    public static Color Violet { get { return namedColors["VIOLET"]; } }
+    public static Color WebGray { get { return namedColors["WEBGRAY"]; } }
+    public static Color WebGreen { get { return namedColors["WEBGREEN"]; } }
+    public static Color WebMaroon { get { return namedColors["WEBMAROON"]; } }
+    public static Color WebPurple { get { return namedColors["WEBPURPLE"]; } }
+    public static Color Wheat { get { return namedColors["WHEAT"]; } }
+    public static Color White { get { return namedColors["WHITE"]; } }
+    public static Color WhiteSmoke { get { return namedColors["WHITESMOKE"]; } }
+    public static Color Yellow { get { return namedColors["YELLOW"]; } }
+    public static Color YellowGreen { get { return namedColors["YELLOWGREEN"]; } }
 #pragma warning restore CS1591
-    }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DebuggingUtils.cs
@@ -8,163 +8,162 @@ using Godot.NativeInterop;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+internal static class DebuggingUtils
 {
-    internal static class DebuggingUtils
+    private static void AppendTypeName(this StringBuilder sb, Type type)
     {
-        private static void AppendTypeName(this StringBuilder sb, Type type)
-        {
-            if (type.IsPrimitive)
-                sb.Append(type.Name);
-            else if (type == typeof(void))
-                sb.Append("void");
-            else
-                sb.Append(type);
+        if (type.IsPrimitive)
+            sb.Append(type.Name);
+        else if (type == typeof(void))
+            sb.Append("void");
+        else
+            sb.Append(type);
 
-            sb.Append(' ');
+        sb.Append(' ');
+    }
+
+    internal static void InstallTraceListener()
+    {
+        Trace.Listeners.Clear();
+        Trace.Listeners.Add(new GodotTraceListener());
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    // ReSharper disable once InconsistentNaming
+    internal ref struct godot_stack_info
+    {
+        public godot_string File;
+        public godot_string Func;
+        public int Line;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    // ReSharper disable once InconsistentNaming
+    internal ref struct godot_stack_info_vector
+    {
+        private IntPtr _writeProxy;
+        private unsafe godot_stack_info* _ptr;
+
+        public readonly unsafe godot_stack_info* Elements
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _ptr;
         }
 
-        internal static void InstallTraceListener()
+        public void Resize(int size)
         {
-            Trace.Listeners.Clear();
-            Trace.Listeners.Add(new GodotTraceListener());
+            if (size < 0)
+                throw new ArgumentOutOfRangeException(nameof(size));
+            var err = NativeFuncs.godotsharp_stack_info_vector_resize(ref this, size);
+            if (err != Error.Ok)
+                throw new InvalidOperationException("Failed to resize vector. Error code is: " + err.ToString());
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal ref struct godot_stack_info
+        public unsafe void Dispose()
         {
-            public godot_string File;
-            public godot_string Func;
-            public int Line;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal ref struct godot_stack_info_vector
-        {
-            private IntPtr _writeProxy;
-            private unsafe godot_stack_info* _ptr;
-
-            public readonly unsafe godot_stack_info* Elements
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _ptr;
-            }
-
-            public void Resize(int size)
-            {
-                if (size < 0)
-                    throw new ArgumentOutOfRangeException(nameof(size));
-                var err = NativeFuncs.godotsharp_stack_info_vector_resize(ref this, size);
-                if (err != Error.Ok)
-                    throw new InvalidOperationException("Failed to resize vector. Error code is: " + err.ToString());
-            }
-
-            public unsafe void Dispose()
-            {
-                if (_ptr == null)
-                    return;
-                NativeFuncs.godotsharp_stack_info_vector_destroy(ref this);
-                _ptr = null;
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void GetCurrentStackInfo(void* destVector)
-        {
-            try
-            {
-                var vector = (godot_stack_info_vector*)destVector;
-                var stackTrace = new StackTrace(skipFrames: 1, fNeedFileInfo: true);
-                int frameCount = stackTrace.FrameCount;
-
-                if (frameCount == 0)
-                    return;
-
-                vector->Resize(frameCount);
-
-                int i = 0;
-                foreach (StackFrame frame in stackTrace.GetFrames())
-                {
-                    string? fileName = frame.GetFileName();
-                    int fileLineNumber = frame.GetFileLineNumber();
-
-                    GetStackFrameMethodDecl(frame, out string methodDecl);
-
-                    godot_stack_info* stackInfo = &vector->Elements[i];
-
-                    // Assign directly to element in Vector. This way we don't need to worry
-                    // about disposal if an exception is thrown. The Vector takes care of it.
-                    stackInfo->File = Marshaling.ConvertStringToNative(fileName);
-                    stackInfo->Func = Marshaling.ConvertStringToNative(methodDecl);
-                    stackInfo->Line = fileLineNumber;
-
-                    i++;
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
-        }
-
-        internal static void GetStackFrameMethodDecl(StackFrame frame, out string methodDecl)
-        {
-            MethodBase? methodBase = frame.GetMethod();
-
-            if (methodBase == null)
-            {
-                methodDecl = string.Empty;
+            if (_ptr == null)
                 return;
-            }
+            NativeFuncs.godotsharp_stack_info_vector_destroy(ref this);
+            _ptr = null;
+        }
+    }
 
-            var sb = new StringBuilder();
+    [UnmanagedCallersOnly]
+    internal static unsafe void GetCurrentStackInfo(void* destVector)
+    {
+        try
+        {
+            var vector = (godot_stack_info_vector*)destVector;
+            var stackTrace = new StackTrace(skipFrames: 1, fNeedFileInfo: true);
+            int frameCount = stackTrace.FrameCount;
 
-            if (methodBase is MethodInfo methodInfo)
-                sb.AppendTypeName(methodInfo.ReturnType);
+            if (frameCount == 0)
+                return;
 
-            sb.Append(methodBase.DeclaringType?.FullName ?? "<unknown>");
-            sb.Append('.');
-            sb.Append(methodBase.Name);
+            vector->Resize(frameCount);
 
-            if (methodBase.IsGenericMethod)
+            int i = 0;
+            foreach (StackFrame frame in stackTrace.GetFrames())
             {
-                Type[] genericParams = methodBase.GetGenericArguments();
+                string? fileName = frame.GetFileName();
+                int fileLineNumber = frame.GetFileLineNumber();
 
-                sb.Append('<');
+                GetStackFrameMethodDecl(frame, out string methodDecl);
 
-                for (int j = 0; j < genericParams.Length; j++)
-                {
-                    if (j > 0)
-                        sb.Append(", ");
+                godot_stack_info* stackInfo = &vector->Elements[i];
 
-                    sb.AppendTypeName(genericParams[j]);
-                }
+                // Assign directly to element in Vector. This way we don't need to worry
+                // about disposal if an exception is thrown. The Vector takes care of it.
+                stackInfo->File = Marshaling.ConvertStringToNative(fileName);
+                stackInfo->Func = Marshaling.ConvertStringToNative(methodDecl);
+                stackInfo->Line = fileLineNumber;
 
-                sb.Append('>');
+                i++;
             }
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
 
-            sb.Append('(');
+    internal static void GetStackFrameMethodDecl(StackFrame frame, out string methodDecl)
+    {
+        MethodBase? methodBase = frame.GetMethod();
 
-            bool varArgs = (methodBase.CallingConvention & CallingConventions.VarArgs) != 0;
+        if (methodBase == null)
+        {
+            methodDecl = string.Empty;
+            return;
+        }
 
-            ParameterInfo[] parameter = methodBase.GetParameters();
+        var sb = new StringBuilder();
 
-            for (int i = 0; i < parameter.Length; i++)
+        if (methodBase is MethodInfo methodInfo)
+            sb.AppendTypeName(methodInfo.ReturnType);
+
+        sb.Append(methodBase.DeclaringType?.FullName ?? "<unknown>");
+        sb.Append('.');
+        sb.Append(methodBase.Name);
+
+        if (methodBase.IsGenericMethod)
+        {
+            Type[] genericParams = methodBase.GetGenericArguments();
+
+            sb.Append('<');
+
+            for (int j = 0; j < genericParams.Length; j++)
             {
-                if (i > 0)
+                if (j > 0)
                     sb.Append(", ");
 
-                if (i == parameter.Length - 1 && varArgs)
-                    sb.Append("params ");
-
-                sb.AppendTypeName(parameter[i].ParameterType);
+                sb.AppendTypeName(genericParams[j]);
             }
 
-            sb.Append(')');
-
-            methodDecl = sb.ToString();
+            sb.Append('>');
         }
+
+        sb.Append('(');
+
+        bool varArgs = (methodBase.CallingConvention & CallingConventions.VarArgs) != 0;
+
+        ParameterInfo[] parameter = methodBase.GetParameters();
+
+        for (int i = 0; i < parameter.Length; i++)
+        {
+            if (i > 0)
+                sb.Append(", ");
+
+            if (i == parameter.Length - 1 && varArgs)
+                sb.Append("params ");
+
+            sb.AppendTypeName(parameter[i].ParameterType);
+        }
+
+        sb.Append(')');
+
+        methodDecl = sb.ToString();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -9,864 +9,863 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+internal static class DelegateUtils
 {
-    internal static class DelegateUtils
+    [UnmanagedCallersOnly]
+    internal static godot_bool DelegateEquals(IntPtr delegateGCHandleA, IntPtr delegateGCHandleB)
     {
-        [UnmanagedCallersOnly]
-        internal static godot_bool DelegateEquals(IntPtr delegateGCHandleA, IntPtr delegateGCHandleB)
+        try
         {
-            try
+            var @delegateA = (Delegate?)GCHandle.FromIntPtr(delegateGCHandleA).Target;
+            var @delegateB = (Delegate?)GCHandle.FromIntPtr(delegateGCHandleB).Target;
+            return (@delegateA! == @delegateB!).ToGodotBool();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static int DelegateHash(IntPtr delegateGCHandle)
+    {
+        try
+        {
+            var @delegate = (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target;
+            return @delegate?.GetHashCode() ?? 0;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return 0;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void InvokeWithVariantArgs(IntPtr delegateGCHandle, void* trampoline,
+        godot_variant** args, int argc, godot_variant* outRet)
+    {
+        try
+        {
+            if (trampoline == null)
             {
-                var @delegateA = (Delegate?)GCHandle.FromIntPtr(delegateGCHandleA).Target;
-                var @delegateB = (Delegate?)GCHandle.FromIntPtr(delegateGCHandleB).Target;
-                return (@delegateA! == @delegateB!).ToGodotBool();
+                throw new ArgumentNullException(nameof(trampoline),
+                    "Cannot dynamically invoke delegate because the trampoline is null.");
             }
-            catch (Exception e)
+
+            var @delegate = (Delegate)GCHandle.FromIntPtr(delegateGCHandle).Target!;
+            var trampolineFn = (delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void>)trampoline;
+
+            trampolineFn(@delegate, new NativeVariantPtrArgs(args, argc), out godot_variant ret);
+
+            *outRet = ret;
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            *outRet = default;
+        }
+    }
+
+    // TODO: Check if we should be using BindingFlags.DeclaredOnly (would give better reflection performance).
+
+    private enum TargetKind : uint
+    {
+        Static,
+        GodotObject,
+        CompilerGenerated
+    }
+
+    internal static bool TrySerializeDelegate(Delegate @delegate, Collections.Array serializedData)
+    {
+        if (@delegate is null)
+        {
+            return false;
+        }
+
+        if (@delegate is MulticastDelegate multicastDelegate)
+        {
+            bool someDelegatesSerialized = false;
+
+            Delegate[] invocationList = multicastDelegate.GetInvocationList();
+
+            if (invocationList.Length > 1)
             {
-                ExceptionUtils.LogException(e);
-                return godot_bool.False;
+                var multiCastData = new Collections.Array();
+
+                foreach (Delegate oneDelegate in invocationList)
+                    someDelegatesSerialized |= TrySerializeDelegate(oneDelegate, multiCastData);
+
+                if (!someDelegatesSerialized)
+                    return false;
+
+                serializedData.Add(multiCastData);
+                return true;
             }
         }
 
-        [UnmanagedCallersOnly]
-        internal static int DelegateHash(IntPtr delegateGCHandle)
+        if (TrySerializeSingleDelegate(@delegate, out byte[]? buffer))
         {
-            try
-            {
-                var @delegate = (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target;
-                return @delegate?.GetHashCode() ?? 0;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                return 0;
-            }
+            serializedData.Add((Span<byte>)buffer);
+            return true;
         }
 
-        [UnmanagedCallersOnly]
-        internal static unsafe void InvokeWithVariantArgs(IntPtr delegateGCHandle, void* trampoline,
-            godot_variant** args, int argc, godot_variant* outRet)
+        return false;
+    }
+
+    private static bool TrySerializeSingleDelegate(Delegate @delegate, [MaybeNullWhen(false)] out byte[] buffer)
+    {
+        buffer = null;
+
+        object? target = @delegate.Target;
+
+        switch (target)
         {
-            try
+            case null:
             {
-                if (trampoline == null)
+                using (var stream = new MemoryStream())
+                using (var writer = new BinaryWriter(stream))
                 {
-                    throw new ArgumentNullException(nameof(trampoline),
-                        "Cannot dynamically invoke delegate because the trampoline is null.");
-                }
+                    writer.Write((ulong)TargetKind.Static);
 
-                var @delegate = (Delegate)GCHandle.FromIntPtr(delegateGCHandle).Target!;
-                var trampolineFn = (delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void>)trampoline;
+                    SerializeType(writer, @delegate.GetType());
 
-                trampolineFn(@delegate, new NativeVariantPtrArgs(args, argc), out godot_variant ret);
-
-                *outRet = ret;
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                *outRet = default;
-            }
-        }
-
-        // TODO: Check if we should be using BindingFlags.DeclaredOnly (would give better reflection performance).
-
-        private enum TargetKind : uint
-        {
-            Static,
-            GodotObject,
-            CompilerGenerated
-        }
-
-        internal static bool TrySerializeDelegate(Delegate @delegate, Collections.Array serializedData)
-        {
-            if (@delegate is null)
-            {
-                return false;
-            }
-
-            if (@delegate is MulticastDelegate multicastDelegate)
-            {
-                bool someDelegatesSerialized = false;
-
-                Delegate[] invocationList = multicastDelegate.GetInvocationList();
-
-                if (invocationList.Length > 1)
-                {
-                    var multiCastData = new Collections.Array();
-
-                    foreach (Delegate oneDelegate in invocationList)
-                        someDelegatesSerialized |= TrySerializeDelegate(oneDelegate, multiCastData);
-
-                    if (!someDelegatesSerialized)
+                    if (!TrySerializeMethodInfo(writer, @delegate.Method))
                         return false;
 
-                    serializedData.Add(multiCastData);
+                    buffer = stream.ToArray();
                     return true;
                 }
             }
-
-            if (TrySerializeSingleDelegate(@delegate, out byte[]? buffer))
+            // ReSharper disable once RedundantNameQualifier
+            case GodotObject godotObject:
             {
-                serializedData.Add((Span<byte>)buffer);
-                return true;
+                using (var stream = new MemoryStream())
+                using (var writer = new BinaryWriter(stream))
+                {
+                    writer.Write((ulong)TargetKind.GodotObject);
+                    // ReSharper disable once RedundantCast
+                    writer.Write((ulong)godotObject.GetInstanceId());
+
+                    SerializeType(writer, @delegate.GetType());
+
+                    if (!TrySerializeMethodInfo(writer, @delegate.Method))
+                        return false;
+
+                    buffer = stream.ToArray();
+                    return true;
+                }
             }
-
-            return false;
-        }
-
-        private static bool TrySerializeSingleDelegate(Delegate @delegate, [MaybeNullWhen(false)] out byte[] buffer)
-        {
-            buffer = null;
-
-            object? target = @delegate.Target;
-
-            switch (target)
+            default:
             {
-                case null:
+                Type targetType = target.GetType();
+
+                if (targetType.IsDefined(typeof(CompilerGeneratedAttribute), true))
                 {
+                    // Compiler generated. Probably a closure. Try to serialize it.
+
                     using (var stream = new MemoryStream())
                     using (var writer = new BinaryWriter(stream))
                     {
-                        writer.Write((ulong)TargetKind.Static);
+                        writer.Write((ulong)TargetKind.CompilerGenerated);
+                        SerializeType(writer, targetType);
 
                         SerializeType(writer, @delegate.GetType());
 
                         if (!TrySerializeMethodInfo(writer, @delegate.Method))
                             return false;
 
-                        buffer = stream.ToArray();
-                        return true;
-                    }
-                }
-                // ReSharper disable once RedundantNameQualifier
-                case GodotObject godotObject:
-                {
-                    using (var stream = new MemoryStream())
-                    using (var writer = new BinaryWriter(stream))
-                    {
-                        writer.Write((ulong)TargetKind.GodotObject);
-                        // ReSharper disable once RedundantCast
-                        writer.Write((ulong)godotObject.GetInstanceId());
+                        FieldInfo[] fields = targetType.GetFields(BindingFlags.Instance | BindingFlags.Public);
 
-                        SerializeType(writer, @delegate.GetType());
+                        writer.Write(fields.Length);
 
-                        if (!TrySerializeMethodInfo(writer, @delegate.Method))
-                            return false;
-
-                        buffer = stream.ToArray();
-                        return true;
-                    }
-                }
-                default:
-                {
-                    Type targetType = target.GetType();
-
-                    if (targetType.IsDefined(typeof(CompilerGeneratedAttribute), true))
-                    {
-                        // Compiler generated. Probably a closure. Try to serialize it.
-
-                        using (var stream = new MemoryStream())
-                        using (var writer = new BinaryWriter(stream))
+                        foreach (FieldInfo field in fields)
                         {
-                            writer.Write((ulong)TargetKind.CompilerGenerated);
-                            SerializeType(writer, targetType);
+                            Type fieldType = field.GetType();
 
-                            SerializeType(writer, @delegate.GetType());
+                            Variant.Type variantType = GD.TypeToVariantType(fieldType);
 
-                            if (!TrySerializeMethodInfo(writer, @delegate.Method))
+                            if (variantType == Variant.Type.Nil)
                                 return false;
 
-                            FieldInfo[] fields = targetType.GetFields(BindingFlags.Instance | BindingFlags.Public);
-
-                            writer.Write(fields.Length);
-
-                            foreach (FieldInfo field in fields)
+                            static byte[] VarToBytes(in godot_variant var)
                             {
-                                Type fieldType = field.GetType();
-
-                                Variant.Type variantType = GD.TypeToVariantType(fieldType);
-
-                                if (variantType == Variant.Type.Nil)
-                                    return false;
-
-                                static byte[] VarToBytes(in godot_variant var)
-                                {
-                                    NativeFuncs.godotsharp_var_to_bytes(var, false.ToGodotBool(), out var varBytes);
-                                    using (varBytes)
-                                        return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
-                                }
-
-                                writer.Write(field.Name);
-
-                                var fieldValue = field.GetValue(target);
-                                using var fieldValueVariant = RuntimeTypeConversionHelper.ConvertToVariant(fieldValue);
-                                byte[] valueBuffer = VarToBytes(fieldValueVariant);
-                                writer.Write(valueBuffer.Length);
-                                writer.Write(valueBuffer);
+                                NativeFuncs.godotsharp_var_to_bytes(var, false.ToGodotBool(), out var varBytes);
+                                using (varBytes)
+                                    return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
                             }
 
-                            buffer = stream.ToArray();
-                            return true;
+                            writer.Write(field.Name);
+
+                            var fieldValue = field.GetValue(target);
+                            using var fieldValueVariant = RuntimeTypeConversionHelper.ConvertToVariant(fieldValue);
+                            byte[] valueBuffer = VarToBytes(fieldValueVariant);
+                            writer.Write(valueBuffer.Length);
+                            writer.Write(valueBuffer);
                         }
+
+                        buffer = stream.ToArray();
+                        return true;
                     }
-
-                    return false;
                 }
+
+                return false;
             }
         }
+    }
 
-        private static bool TrySerializeMethodInfo(BinaryWriter writer, MethodInfo methodInfo)
+    private static bool TrySerializeMethodInfo(BinaryWriter writer, MethodInfo methodInfo)
+    {
+        SerializeType(writer, methodInfo.DeclaringType);
+
+        writer.Write(methodInfo.Name);
+
+        int flags = 0;
+
+        if (methodInfo.IsPublic)
+            flags |= (int)BindingFlags.Public;
+        else
+            flags |= (int)BindingFlags.NonPublic;
+
+        if (methodInfo.IsStatic)
+            flags |= (int)BindingFlags.Static;
+        else
+            flags |= (int)BindingFlags.Instance;
+
+        writer.Write(flags);
+
+        Type returnType = methodInfo.ReturnType;
+        bool hasReturn = methodInfo.ReturnType != typeof(void);
+
+        writer.Write(hasReturn);
+        if (hasReturn)
+            SerializeType(writer, returnType);
+
+        ParameterInfo[] parameters = methodInfo.GetParameters();
+
+        writer.Write(parameters.Length);
+
+        if (parameters.Length > 0)
         {
-            SerializeType(writer, methodInfo.DeclaringType);
-
-            writer.Write(methodInfo.Name);
-
-            int flags = 0;
-
-            if (methodInfo.IsPublic)
-                flags |= (int)BindingFlags.Public;
-            else
-                flags |= (int)BindingFlags.NonPublic;
-
-            if (methodInfo.IsStatic)
-                flags |= (int)BindingFlags.Static;
-            else
-                flags |= (int)BindingFlags.Instance;
-
-            writer.Write(flags);
-
-            Type returnType = methodInfo.ReturnType;
-            bool hasReturn = methodInfo.ReturnType != typeof(void);
-
-            writer.Write(hasReturn);
-            if (hasReturn)
-                SerializeType(writer, returnType);
-
-            ParameterInfo[] parameters = methodInfo.GetParameters();
-
-            writer.Write(parameters.Length);
-
-            if (parameters.Length > 0)
-            {
-                for (int i = 0; i < parameters.Length; i++)
-                    SerializeType(writer, parameters[i].ParameterType);
-            }
-
-            return true;
+            for (int i = 0; i < parameters.Length; i++)
+                SerializeType(writer, parameters[i].ParameterType);
         }
 
-        private static void SerializeType(BinaryWriter writer, Type? type)
+        return true;
+    }
+
+    private static void SerializeType(BinaryWriter writer, Type? type)
+    {
+        if (type == null)
         {
-            if (type == null)
+            int genericArgumentsCount = -1;
+            writer.Write(genericArgumentsCount);
+        }
+        else if (type.IsGenericType)
+        {
+            Type genericTypeDef = type.GetGenericTypeDefinition();
+            Type[] genericArgs = type.GetGenericArguments();
+
+            int genericArgumentsCount = genericArgs.Length;
+            writer.Write(genericArgumentsCount);
+
+            writer.Write(genericTypeDef.Assembly.GetName().Name ?? "");
+            writer.Write(genericTypeDef.FullName ?? genericTypeDef.ToString());
+
+            for (int i = 0; i < genericArgs.Length; i++)
+                SerializeType(writer, genericArgs[i]);
+        }
+        else
+        {
+            int genericArgumentsCount = 0;
+            writer.Write(genericArgumentsCount);
+
+            writer.Write(type.Assembly.GetName().Name ?? "");
+            writer.Write(type.FullName ?? type.ToString());
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool TrySerializeDelegateWithGCHandle(IntPtr delegateGCHandle,
+        godot_array* nSerializedData)
+    {
+        try
+        {
+            var serializedData = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+                NativeFuncs.godotsharp_array_new_copy(*nSerializedData));
+
+            var @delegate = (Delegate)GCHandle.FromIntPtr(delegateGCHandle).Target!;
+
+            return TrySerializeDelegate(@delegate, serializedData)
+                .ToGodotBool();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            return godot_bool.False;
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    internal static unsafe godot_bool TryDeserializeDelegateWithGCHandle(godot_array* nSerializedData,
+        IntPtr* delegateGCHandle)
+    {
+        try
+        {
+            var serializedData = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+                NativeFuncs.godotsharp_array_new_copy(*nSerializedData));
+
+            if (TryDeserializeDelegate(serializedData, out Delegate? @delegate))
             {
-                int genericArgumentsCount = -1;
-                writer.Write(genericArgumentsCount);
-            }
-            else if (type.IsGenericType)
-            {
-                Type genericTypeDef = type.GetGenericTypeDefinition();
-                Type[] genericArgs = type.GetGenericArguments();
-
-                int genericArgumentsCount = genericArgs.Length;
-                writer.Write(genericArgumentsCount);
-
-                writer.Write(genericTypeDef.Assembly.GetName().Name ?? "");
-                writer.Write(genericTypeDef.FullName ?? genericTypeDef.ToString());
-
-                for (int i = 0; i < genericArgs.Length; i++)
-                    SerializeType(writer, genericArgs[i]);
+                *delegateGCHandle = GCHandle.ToIntPtr(CustomGCHandle.AllocStrong(@delegate));
+                return godot_bool.True;
             }
             else
             {
-                int genericArgumentsCount = 0;
-                writer.Write(genericArgumentsCount);
-
-                writer.Write(type.Assembly.GetName().Name ?? "");
-                writer.Write(type.FullName ?? type.ToString());
-            }
-        }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool TrySerializeDelegateWithGCHandle(IntPtr delegateGCHandle,
-            godot_array* nSerializedData)
-        {
-            try
-            {
-                var serializedData = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_array_new_copy(*nSerializedData));
-
-                var @delegate = (Delegate)GCHandle.FromIntPtr(delegateGCHandle).Target!;
-
-                return TrySerializeDelegate(@delegate, serializedData)
-                    .ToGodotBool();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
+                *delegateGCHandle = IntPtr.Zero;
                 return godot_bool.False;
             }
         }
-
-        [UnmanagedCallersOnly]
-        internal static unsafe godot_bool TryDeserializeDelegateWithGCHandle(godot_array* nSerializedData,
-            IntPtr* delegateGCHandle)
+        catch (Exception e)
         {
-            try
-            {
-                var serializedData = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                    NativeFuncs.godotsharp_array_new_copy(*nSerializedData));
-
-                if (TryDeserializeDelegate(serializedData, out Delegate? @delegate))
-                {
-                    *delegateGCHandle = GCHandle.ToIntPtr(CustomGCHandle.AllocStrong(@delegate));
-                    return godot_bool.True;
-                }
-                else
-                {
-                    *delegateGCHandle = IntPtr.Zero;
-                    return godot_bool.False;
-                }
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                *delegateGCHandle = default;
-                return godot_bool.False;
-            }
+            ExceptionUtils.LogException(e);
+            *delegateGCHandle = default;
+            return godot_bool.False;
         }
+    }
 
-        internal static bool TryDeserializeDelegate(Collections.Array serializedData,
-            [MaybeNullWhen(false)] out Delegate @delegate)
+    internal static bool TryDeserializeDelegate(Collections.Array serializedData,
+        [MaybeNullWhen(false)] out Delegate @delegate)
+    {
+        @delegate = null;
+
+        if (serializedData.Count == 1)
         {
-            @delegate = null;
+            var elem = serializedData[0].Obj;
 
-            if (serializedData.Count == 1)
-            {
-                var elem = serializedData[0].Obj;
-
-                if (elem == null)
-                    return false;
-
-                if (elem is Collections.Array multiCastData)
-                    return TryDeserializeDelegate(multiCastData, out @delegate);
-
-                return TryDeserializeSingleDelegate((byte[])elem, out @delegate);
-            }
-
-            var delegates = new List<Delegate>(serializedData.Count);
-
-            foreach (Variant variantElem in serializedData)
-            {
-                var elem = variantElem.Obj;
-
-                if (elem == null)
-                    continue;
-
-                if (elem is Collections.Array multiCastData)
-                {
-                    if (TryDeserializeDelegate(multiCastData, out Delegate? oneDelegate))
-                        delegates.Add(oneDelegate);
-                }
-                else
-                {
-                    if (TryDeserializeSingleDelegate((byte[])elem, out Delegate? oneDelegate))
-                        delegates.Add(oneDelegate);
-                }
-            }
-
-            if (delegates.Count <= 0)
+            if (elem == null)
                 return false;
 
-            @delegate = delegates.Count == 1 ? delegates[0] : Delegate.Combine(delegates.ToArray())!;
-            return true;
+            if (elem is Collections.Array multiCastData)
+                return TryDeserializeDelegate(multiCastData, out @delegate);
+
+            return TryDeserializeSingleDelegate((byte[])elem, out @delegate);
         }
 
-        private static bool TryDeserializeSingleDelegate(byte[] buffer, [MaybeNullWhen(false)] out Delegate @delegate)
+        var delegates = new List<Delegate>(serializedData.Count);
+
+        foreach (Variant variantElem in serializedData)
         {
-            @delegate = null;
+            var elem = variantElem.Obj;
 
-            using (var stream = new MemoryStream(buffer, writable: false))
-            using (var reader = new BinaryReader(stream))
+            if (elem == null)
+                continue;
+
+            if (elem is Collections.Array multiCastData)
             {
-                var targetKind = (TargetKind)reader.ReadUInt64();
-
-                switch (targetKind)
-                {
-                    case TargetKind.Static:
-                    {
-                        Type? delegateType = DeserializeType(reader);
-                        if (delegateType == null)
-                            return false;
-
-                        if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
-                            return false;
-
-                        @delegate = Delegate.CreateDelegate(delegateType, null, methodInfo, throwOnBindFailure: false);
-
-                        if (@delegate == null)
-                            return false;
-
-                        return true;
-                    }
-                    case TargetKind.GodotObject:
-                    {
-                        ulong objectId = reader.ReadUInt64();
-                        // ReSharper disable once RedundantNameQualifier
-                        GodotObject godotObject = GodotObject.InstanceFromId(objectId);
-                        if (godotObject == null)
-                            return false;
-
-                        Type? delegateType = DeserializeType(reader);
-                        if (delegateType == null)
-                            return false;
-
-                        if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
-                            return false;
-
-                        @delegate = Delegate.CreateDelegate(delegateType, godotObject, methodInfo,
-                            throwOnBindFailure: false);
-
-                        if (@delegate == null)
-                            return false;
-
-                        return true;
-                    }
-                    case TargetKind.CompilerGenerated:
-                    {
-                        Type? targetType = DeserializeType(reader);
-                        if (targetType == null)
-                            return false;
-
-                        Type? delegateType = DeserializeType(reader);
-                        if (delegateType == null)
-                            return false;
-
-                        if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
-                            return false;
-
-                        int fieldCount = reader.ReadInt32();
-
-                        object recreatedTarget = Activator.CreateInstance(targetType)!;
-
-                        for (int i = 0; i < fieldCount; i++)
-                        {
-                            string name = reader.ReadString();
-                            int valueBufferLength = reader.ReadInt32();
-                            byte[] valueBuffer = reader.ReadBytes(valueBufferLength);
-
-                            FieldInfo? fieldInfo = targetType.GetField(name,
-                                BindingFlags.Instance | BindingFlags.Public);
-
-                            if (fieldInfo != null)
-                            {
-                                var variantValue = GD.BytesToVar(valueBuffer);
-                                object? managedValue = RuntimeTypeConversionHelper.ConvertToObjectOfType(
-                                    (godot_variant)variantValue.NativeVar, fieldInfo.FieldType);
-                                fieldInfo.SetValue(recreatedTarget, managedValue);
-                            }
-                        }
-
-                        @delegate = Delegate.CreateDelegate(delegateType, recreatedTarget, methodInfo,
-                            throwOnBindFailure: false);
-
-                        if (@delegate == null)
-                            return false;
-
-                        return true;
-                    }
-                    default:
-                        return false;
-                }
+                if (TryDeserializeDelegate(multiCastData, out Delegate? oneDelegate))
+                    delegates.Add(oneDelegate);
+            }
+            else
+            {
+                if (TryDeserializeSingleDelegate((byte[])elem, out Delegate? oneDelegate))
+                    delegates.Add(oneDelegate);
             }
         }
 
-        private static bool TryDeserializeMethodInfo(BinaryReader reader,
-            [MaybeNullWhen(false)] out MethodInfo methodInfo)
-        {
-            methodInfo = null;
-
-            Type? declaringType = DeserializeType(reader);
-
-            if (declaringType == null)
-                return false;
-
-            string methodName = reader.ReadString();
-
-            int flags = reader.ReadInt32();
-
-            bool hasReturn = reader.ReadBoolean();
-            Type? returnType = hasReturn ? DeserializeType(reader) : typeof(void);
-
-            int parametersCount = reader.ReadInt32();
-            var parameterTypes = parametersCount == 0 ? Type.EmptyTypes : new Type[parametersCount];
-
-            for (int i = 0; i < parametersCount; i++)
-            {
-                Type? parameterType = DeserializeType(reader);
-                if (parameterType == null)
-                    return false;
-                parameterTypes[i] = parameterType;
-            }
-
-            methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
-            return methodInfo != null && methodInfo.ReturnType == returnType;
-        }
-
-        private static Type? DeserializeType(BinaryReader reader)
-        {
-            int genericArgumentsCount = reader.ReadInt32();
-
-            if (genericArgumentsCount == -1)
-                return null;
-
-            string assemblyName = reader.ReadString();
-
-            if (assemblyName.Length == 0)
-            {
-                GD.PushError($"Missing assembly name of type when attempting to deserialize delegate");
-                return null;
-            }
-
-            string typeFullName = reader.ReadString();
-            var type = ReflectionUtils.FindTypeInLoadedAssemblies(assemblyName, typeFullName);
-
-            if (type == null)
-                return null; // Type not found
-
-            if (genericArgumentsCount != 0)
-            {
-                var genericArgumentTypes = new Type[genericArgumentsCount];
-
-                for (int i = 0; i < genericArgumentsCount; i++)
-                {
-                    Type? genericArgumentType = DeserializeType(reader);
-                    if (genericArgumentType == null)
-                        return null;
-                    genericArgumentTypes[i] = genericArgumentType;
-                }
-
-                type = type.MakeGenericType(genericArgumentTypes);
-            }
-
-            return type;
-        }
-
-        // Returns true, if unloading the delegate is necessary for assembly unloading to succeed.
-        // This check is not perfect and only intended to prevent things in GodotTools from being reloaded.
-        internal static bool IsDelegateCollectible(Delegate @delegate)
-        {
-            if (@delegate.GetType().IsCollectible)
-                return true;
-
-            if (@delegate is MulticastDelegate multicastDelegate)
-            {
-                Delegate[] invocationList = multicastDelegate.GetInvocationList();
-
-                if (invocationList.Length > 1)
-                {
-                    foreach (Delegate oneDelegate in invocationList)
-                        if (IsDelegateCollectible(oneDelegate))
-                            return true;
-
-                    return false;
-                }
-            }
-
-            if (@delegate.Method.IsCollectible)
-                return true;
-
-            object? target = @delegate.Target;
-
-            if (target is not null && target.GetType().IsCollectible)
-                return true;
-
+        if (delegates.Count <= 0)
             return false;
-        }
 
-        internal static class RuntimeTypeConversionHelper
+        @delegate = delegates.Count == 1 ? delegates[0] : Delegate.Combine(delegates.ToArray())!;
+        return true;
+    }
+
+    private static bool TryDeserializeSingleDelegate(byte[] buffer, [MaybeNullWhen(false)] out Delegate @delegate)
+    {
+        @delegate = null;
+
+        using (var stream = new MemoryStream(buffer, writable: false))
+        using (var reader = new BinaryReader(stream))
         {
-            [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-            public static godot_variant ConvertToVariant(object? obj)
+            var targetKind = (TargetKind)reader.ReadUInt64();
+
+            switch (targetKind)
             {
-                if (obj == null)
-                    return default;
-
-                switch (obj)
+                case TargetKind.Static:
                 {
-                    case bool @bool:
-                        return VariantUtils.CreateFrom(@bool);
-                    case char @char:
-                        return VariantUtils.CreateFrom(@char);
-                    case sbyte int8:
-                        return VariantUtils.CreateFrom(int8);
-                    case short int16:
-                        return VariantUtils.CreateFrom(int16);
-                    case int int32:
-                        return VariantUtils.CreateFrom(int32);
-                    case long int64:
-                        return VariantUtils.CreateFrom(int64);
-                    case byte uint8:
-                        return VariantUtils.CreateFrom(uint8);
-                    case ushort uint16:
-                        return VariantUtils.CreateFrom(uint16);
-                    case uint uint32:
-                        return VariantUtils.CreateFrom(uint32);
-                    case ulong uint64:
-                        return VariantUtils.CreateFrom(uint64);
-                    case float @float:
-                        return VariantUtils.CreateFrom(@float);
-                    case double @double:
-                        return VariantUtils.CreateFrom(@double);
-                    case Vector2 vector2:
-                        return VariantUtils.CreateFrom(vector2);
-                    case Vector2I vector2I:
-                        return VariantUtils.CreateFrom(vector2I);
-                    case Rect2 rect2:
-                        return VariantUtils.CreateFrom(rect2);
-                    case Rect2I rect2I:
-                        return VariantUtils.CreateFrom(rect2I);
-                    case Transform2D transform2D:
-                        return VariantUtils.CreateFrom(transform2D);
-                    case Vector3 vector3:
-                        return VariantUtils.CreateFrom(vector3);
-                    case Vector3I vector3I:
-                        return VariantUtils.CreateFrom(vector3I);
-                    case Vector4 vector4:
-                        return VariantUtils.CreateFrom(vector4);
-                    case Vector4I vector4I:
-                        return VariantUtils.CreateFrom(vector4I);
-                    case Basis basis:
-                        return VariantUtils.CreateFrom(basis);
-                    case Quaternion quaternion:
-                        return VariantUtils.CreateFrom(quaternion);
-                    case Transform3D transform3D:
-                        return VariantUtils.CreateFrom(transform3D);
-                    case Projection projection:
-                        return VariantUtils.CreateFrom(projection);
-                    case Aabb aabb:
-                        return VariantUtils.CreateFrom(aabb);
-                    case Color color:
-                        return VariantUtils.CreateFrom(color);
-                    case Plane plane:
-                        return VariantUtils.CreateFrom(plane);
-                    case Callable callable:
-                        return VariantUtils.CreateFrom(callable);
-                    case Signal signal:
-                        return VariantUtils.CreateFrom(signal);
-                    case string @string:
-                        return VariantUtils.CreateFrom(@string);
-                    case byte[] byteArray:
-                        return VariantUtils.CreateFrom(byteArray);
-                    case int[] int32Array:
-                        return VariantUtils.CreateFrom(int32Array);
-                    case long[] int64Array:
-                        return VariantUtils.CreateFrom(int64Array);
-                    case float[] floatArray:
-                        return VariantUtils.CreateFrom(floatArray);
-                    case double[] doubleArray:
-                        return VariantUtils.CreateFrom(doubleArray);
-                    case string[] stringArray:
-                        return VariantUtils.CreateFrom(stringArray);
-                    case Vector2[] vector2Array:
-                        return VariantUtils.CreateFrom(vector2Array);
-                    case Vector3[] vector3Array:
-                        return VariantUtils.CreateFrom(vector3Array);
-                    case Color[] colorArray:
-                        return VariantUtils.CreateFrom(colorArray);
-                    case StringName[] stringNameArray:
-                        return VariantUtils.CreateFrom(stringNameArray);
-                    case NodePath[] nodePathArray:
-                        return VariantUtils.CreateFrom(nodePathArray);
-                    case Rid[] ridArray:
-                        return VariantUtils.CreateFrom(ridArray);
-                    case GodotObject[] godotObjectArray:
-                        return VariantUtils.CreateFrom(godotObjectArray);
-                    case StringName stringName:
-                        return VariantUtils.CreateFrom(stringName);
-                    case NodePath nodePath:
-                        return VariantUtils.CreateFrom(nodePath);
-                    case Rid rid:
-                        return VariantUtils.CreateFrom(rid);
-                    case Collections.Dictionary godotDictionary:
-                        return VariantUtils.CreateFrom(godotDictionary);
-                    case Collections.Array godotArray:
-                        return VariantUtils.CreateFrom(godotArray);
-                    case Variant variant:
-                        return VariantUtils.CreateFrom(variant);
-                    case GodotObject godotObject:
-                        return VariantUtils.CreateFrom(godotObject);
-                    case Enum @enum:
-                        return VariantUtils.CreateFrom(Convert.ToInt64(@enum));
-                    case Collections.IGenericGodotDictionary godotDictionary:
-                        return VariantUtils.CreateFrom(godotDictionary.UnderlyingDictionary);
-                    case Collections.IGenericGodotArray godotArray:
-                        return VariantUtils.CreateFrom(godotArray.UnderlyingArray);
+                    Type? delegateType = DeserializeType(reader);
+                    if (delegateType == null)
+                        return false;
+
+                    if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
+                        return false;
+
+                    @delegate = Delegate.CreateDelegate(delegateType, null, methodInfo, throwOnBindFailure: false);
+
+                    if (@delegate == null)
+                        return false;
+
+                    return true;
                 }
-
-                GD.PushError("Attempted to convert an unmarshallable managed type to Variant. Name: '" +
-                             obj.GetType().FullName + ".");
-                return new godot_variant();
-            }
-
-            private delegate object? ConvertToSystemObjectFunc(in godot_variant managed);
-
-            [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-            // ReSharper disable once RedundantNameQualifier
-            private static readonly System.Collections.Generic.Dictionary<Type, ConvertToSystemObjectFunc>
-                ToSystemObjectFuncByType = new()
+                case TargetKind.GodotObject:
                 {
-                    [typeof(bool)] = (in godot_variant variant) => VariantUtils.ConvertTo<bool>(variant),
-                    [typeof(char)] = (in godot_variant variant) => VariantUtils.ConvertTo<char>(variant),
-                    [typeof(sbyte)] = (in godot_variant variant) => VariantUtils.ConvertTo<sbyte>(variant),
-                    [typeof(short)] = (in godot_variant variant) => VariantUtils.ConvertTo<short>(variant),
-                    [typeof(int)] = (in godot_variant variant) => VariantUtils.ConvertTo<int>(variant),
-                    [typeof(long)] = (in godot_variant variant) => VariantUtils.ConvertTo<long>(variant),
-                    [typeof(byte)] = (in godot_variant variant) => VariantUtils.ConvertTo<byte>(variant),
-                    [typeof(ushort)] = (in godot_variant variant) => VariantUtils.ConvertTo<ushort>(variant),
-                    [typeof(uint)] = (in godot_variant variant) => VariantUtils.ConvertTo<uint>(variant),
-                    [typeof(ulong)] = (in godot_variant variant) => VariantUtils.ConvertTo<ulong>(variant),
-                    [typeof(float)] = (in godot_variant variant) => VariantUtils.ConvertTo<float>(variant),
-                    [typeof(double)] = (in godot_variant variant) => VariantUtils.ConvertTo<double>(variant),
-                    [typeof(Vector2)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2>(variant),
-                    [typeof(Vector2I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2I>(variant),
-                    [typeof(Rect2)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rect2>(variant),
-                    [typeof(Rect2I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rect2I>(variant),
-                    [typeof(Transform2D)] = (in godot_variant variant) => VariantUtils.ConvertTo<Transform2D>(variant),
-                    [typeof(Vector3)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3>(variant),
-                    [typeof(Vector3I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3I>(variant),
-                    [typeof(Basis)] = (in godot_variant variant) => VariantUtils.ConvertTo<Basis>(variant),
-                    [typeof(Quaternion)] = (in godot_variant variant) => VariantUtils.ConvertTo<Quaternion>(variant),
-                    [typeof(Transform3D)] = (in godot_variant variant) => VariantUtils.ConvertTo<Transform3D>(variant),
-                    [typeof(Vector4)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector4>(variant),
-                    [typeof(Vector4I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector4I>(variant),
-                    [typeof(Aabb)] = (in godot_variant variant) => VariantUtils.ConvertTo<Aabb>(variant),
-                    [typeof(Color)] = (in godot_variant variant) => VariantUtils.ConvertTo<Color>(variant),
-                    [typeof(Plane)] = (in godot_variant variant) => VariantUtils.ConvertTo<Plane>(variant),
-                    [typeof(Callable)] = (in godot_variant variant) => VariantUtils.ConvertTo<Callable>(variant),
-                    [typeof(Signal)] = (in godot_variant variant) => VariantUtils.ConvertTo<Signal>(variant),
-                    [typeof(string)] = (in godot_variant variant) => VariantUtils.ConvertTo<string>(variant),
-                    [typeof(byte[])] = (in godot_variant variant) => VariantUtils.ConvertTo<byte[]>(variant),
-                    [typeof(int[])] = (in godot_variant variant) => VariantUtils.ConvertTo<int[]>(variant),
-                    [typeof(long[])] = (in godot_variant variant) => VariantUtils.ConvertTo<long[]>(variant),
-                    [typeof(float[])] = (in godot_variant variant) => VariantUtils.ConvertTo<float[]>(variant),
-                    [typeof(double[])] = (in godot_variant variant) => VariantUtils.ConvertTo<double[]>(variant),
-                    [typeof(string[])] = (in godot_variant variant) => VariantUtils.ConvertTo<string[]>(variant),
-                    [typeof(Vector2[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2[]>(variant),
-                    [typeof(Vector3[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3[]>(variant),
-                    [typeof(Color[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Color[]>(variant),
-                    [typeof(StringName[])] =
-                        (in godot_variant variant) => VariantUtils.ConvertTo<StringName[]>(variant),
-                    [typeof(NodePath[])] = (in godot_variant variant) => VariantUtils.ConvertTo<NodePath[]>(variant),
-                    [typeof(Rid[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Rid[]>(variant),
-                    [typeof(StringName)] = (in godot_variant variant) => VariantUtils.ConvertTo<StringName>(variant),
-                    [typeof(NodePath)] = (in godot_variant variant) => VariantUtils.ConvertTo<NodePath>(variant),
-                    [typeof(Rid)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rid>(variant),
-                    [typeof(Godot.Collections.Dictionary)] = (in godot_variant variant) =>
-                        VariantUtils.ConvertTo<Godot.Collections.Dictionary>(variant),
-                    [typeof(Godot.Collections.Array)] =
-                        (in godot_variant variant) => VariantUtils.ConvertTo<Godot.Collections.Array>(variant),
-                    [typeof(Variant)] = (in godot_variant variant) => VariantUtils.ConvertTo<Variant>(variant),
-                };
+                    ulong objectId = reader.ReadUInt64();
+                    // ReSharper disable once RedundantNameQualifier
+                    GodotObject godotObject = GodotObject.InstanceFromId(objectId);
+                    if (godotObject == null)
+                        return false;
 
-            [SuppressMessage("ReSharper", "RedundantNameQualifier")]
-            public static object? ConvertToObjectOfType(in godot_variant variant, Type type)
-            {
-                if (ToSystemObjectFuncByType.TryGetValue(type, out var func))
-                    return func(variant);
+                    Type? delegateType = DeserializeType(reader);
+                    if (delegateType == null)
+                        return false;
 
-                if (typeof(GodotObject).IsAssignableFrom(type))
-                    return Convert.ChangeType(VariantUtils.ConvertTo<GodotObject>(variant), type);
+                    if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
+                        return false;
 
-                if (typeof(GodotObject[]).IsAssignableFrom(type))
-                {
-                    static GodotObject[] ConvertToSystemArrayOfGodotObject(in godot_array nativeArray, Type type)
-                    {
-                        var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                            NativeFuncs.godotsharp_array_new_copy(nativeArray));
+                    @delegate = Delegate.CreateDelegate(delegateType, godotObject, methodInfo,
+                        throwOnBindFailure: false);
 
-                        int length = array.Count;
-                        var ret = (GodotObject[])Activator.CreateInstance(type, length)!;
+                    if (@delegate == null)
+                        return false;
 
-                        for (int i = 0; i < length; i++)
-                            ret[i] = array[i].AsGodotObject();
-
-                        return ret;
-                    }
-
-                    using var godotArray = NativeFuncs.godotsharp_variant_as_array(variant);
-                    return Convert.ChangeType(ConvertToSystemArrayOfGodotObject(godotArray, type), type);
+                    return true;
                 }
-
-                if (type.IsEnum)
+                case TargetKind.CompilerGenerated:
                 {
-                    var enumUnderlyingType = type.GetEnumUnderlyingType();
+                    Type? targetType = DeserializeType(reader);
+                    if (targetType == null)
+                        return false;
 
-                    switch (Type.GetTypeCode(enumUnderlyingType))
+                    Type? delegateType = DeserializeType(reader);
+                    if (delegateType == null)
+                        return false;
+
+                    if (!TryDeserializeMethodInfo(reader, out MethodInfo? methodInfo))
+                        return false;
+
+                    int fieldCount = reader.ReadInt32();
+
+                    object recreatedTarget = Activator.CreateInstance(targetType)!;
+
+                    for (int i = 0; i < fieldCount; i++)
                     {
-                        case TypeCode.SByte:
-                            return Enum.ToObject(type, VariantUtils.ConvertToInt8(variant));
-                        case TypeCode.Int16:
-                            return Enum.ToObject(type, VariantUtils.ConvertToInt16(variant));
-                        case TypeCode.Int32:
-                            return Enum.ToObject(type, VariantUtils.ConvertToInt32(variant));
-                        case TypeCode.Int64:
-                            return Enum.ToObject(type, VariantUtils.ConvertToInt64(variant));
-                        case TypeCode.Byte:
-                            return Enum.ToObject(type, VariantUtils.ConvertToUInt8(variant));
-                        case TypeCode.UInt16:
-                            return Enum.ToObject(type, VariantUtils.ConvertToUInt16(variant));
-                        case TypeCode.UInt32:
-                            return Enum.ToObject(type, VariantUtils.ConvertToUInt32(variant));
-                        case TypeCode.UInt64:
-                            return Enum.ToObject(type, VariantUtils.ConvertToUInt64(variant));
-                        default:
+                        string name = reader.ReadString();
+                        int valueBufferLength = reader.ReadInt32();
+                        byte[] valueBuffer = reader.ReadBytes(valueBufferLength);
+
+                        FieldInfo? fieldInfo = targetType.GetField(name,
+                            BindingFlags.Instance | BindingFlags.Public);
+
+                        if (fieldInfo != null)
                         {
-                            GD.PushError(
-                                "Attempted to convert Variant to enum value of unsupported underlying type. Name: " +
-                                type.FullName + " : " + enumUnderlyingType.FullName + ".");
-                            return null;
+                            var variantValue = GD.BytesToVar(valueBuffer);
+                            object? managedValue = RuntimeTypeConversionHelper.ConvertToObjectOfType(
+                                (godot_variant)variantValue.NativeVar, fieldInfo.FieldType);
+                            fieldInfo.SetValue(recreatedTarget, managedValue);
                         }
                     }
+
+                    @delegate = Delegate.CreateDelegate(delegateType, recreatedTarget, methodInfo,
+                        throwOnBindFailure: false);
+
+                    if (@delegate == null)
+                        return false;
+
+                    return true;
                 }
-
-                if (type.IsGenericType)
-                {
-                    var genericTypeDef = type.GetGenericTypeDefinition();
-
-                    if (genericTypeDef == typeof(Godot.Collections.Dictionary<,>))
-                    {
-                        var ctor = type.GetConstructor(BindingFlags.Default,
-                            new[] { typeof(Godot.Collections.Dictionary) });
-
-                        if (ctor == null)
-                            throw new InvalidOperationException("Dictionary constructor not found");
-
-                        return ctor.Invoke(new object?[]
-                        {
-                            VariantUtils.ConvertTo<Godot.Collections.Dictionary>(variant)
-                        });
-                    }
-
-                    if (genericTypeDef == typeof(Godot.Collections.Array<>))
-                    {
-                        var ctor = type.GetConstructor(BindingFlags.Default,
-                            new[] { typeof(Godot.Collections.Array) });
-
-                        if (ctor == null)
-                            throw new InvalidOperationException("Array constructor not found");
-
-                        return ctor.Invoke(new object?[]
-                        {
-                            VariantUtils.ConvertTo<Godot.Collections.Array>(variant)
-                        });
-                    }
-                }
-
-                GD.PushError($"Attempted to convert Variant to unsupported type. Name: {type.FullName}.");
-                return null;
+                default:
+                    return false;
             }
+        }
+    }
+
+    private static bool TryDeserializeMethodInfo(BinaryReader reader,
+        [MaybeNullWhen(false)] out MethodInfo methodInfo)
+    {
+        methodInfo = null;
+
+        Type? declaringType = DeserializeType(reader);
+
+        if (declaringType == null)
+            return false;
+
+        string methodName = reader.ReadString();
+
+        int flags = reader.ReadInt32();
+
+        bool hasReturn = reader.ReadBoolean();
+        Type? returnType = hasReturn ? DeserializeType(reader) : typeof(void);
+
+        int parametersCount = reader.ReadInt32();
+        var parameterTypes = parametersCount == 0 ? Type.EmptyTypes : new Type[parametersCount];
+
+        for (int i = 0; i < parametersCount; i++)
+        {
+            Type? parameterType = DeserializeType(reader);
+            if (parameterType == null)
+                return false;
+            parameterTypes[i] = parameterType;
+        }
+
+        methodInfo = declaringType.GetMethod(methodName, (BindingFlags)flags, null, parameterTypes, null);
+        return methodInfo != null && methodInfo.ReturnType == returnType;
+    }
+
+    private static Type? DeserializeType(BinaryReader reader)
+    {
+        int genericArgumentsCount = reader.ReadInt32();
+
+        if (genericArgumentsCount == -1)
+            return null;
+
+        string assemblyName = reader.ReadString();
+
+        if (assemblyName.Length == 0)
+        {
+            GD.PushError($"Missing assembly name of type when attempting to deserialize delegate");
+            return null;
+        }
+
+        string typeFullName = reader.ReadString();
+        var type = ReflectionUtils.FindTypeInLoadedAssemblies(assemblyName, typeFullName);
+
+        if (type == null)
+            return null; // Type not found
+
+        if (genericArgumentsCount != 0)
+        {
+            var genericArgumentTypes = new Type[genericArgumentsCount];
+
+            for (int i = 0; i < genericArgumentsCount; i++)
+            {
+                Type? genericArgumentType = DeserializeType(reader);
+                if (genericArgumentType == null)
+                    return null;
+                genericArgumentTypes[i] = genericArgumentType;
+            }
+
+            type = type.MakeGenericType(genericArgumentTypes);
+        }
+
+        return type;
+    }
+
+    // Returns true, if unloading the delegate is necessary for assembly unloading to succeed.
+    // This check is not perfect and only intended to prevent things in GodotTools from being reloaded.
+    internal static bool IsDelegateCollectible(Delegate @delegate)
+    {
+        if (@delegate.GetType().IsCollectible)
+            return true;
+
+        if (@delegate is MulticastDelegate multicastDelegate)
+        {
+            Delegate[] invocationList = multicastDelegate.GetInvocationList();
+
+            if (invocationList.Length > 1)
+            {
+                foreach (Delegate oneDelegate in invocationList)
+                    if (IsDelegateCollectible(oneDelegate))
+                        return true;
+
+                return false;
+            }
+        }
+
+        if (@delegate.Method.IsCollectible)
+            return true;
+
+        object? target = @delegate.Target;
+
+        if (target is not null && target.GetType().IsCollectible)
+            return true;
+
+        return false;
+    }
+
+    internal static class RuntimeTypeConversionHelper
+    {
+        [SuppressMessage("ReSharper", "RedundantNameQualifier")]
+        public static godot_variant ConvertToVariant(object? obj)
+        {
+            if (obj == null)
+                return default;
+
+            switch (obj)
+            {
+                case bool @bool:
+                    return VariantUtils.CreateFrom(@bool);
+                case char @char:
+                    return VariantUtils.CreateFrom(@char);
+                case sbyte int8:
+                    return VariantUtils.CreateFrom(int8);
+                case short int16:
+                    return VariantUtils.CreateFrom(int16);
+                case int int32:
+                    return VariantUtils.CreateFrom(int32);
+                case long int64:
+                    return VariantUtils.CreateFrom(int64);
+                case byte uint8:
+                    return VariantUtils.CreateFrom(uint8);
+                case ushort uint16:
+                    return VariantUtils.CreateFrom(uint16);
+                case uint uint32:
+                    return VariantUtils.CreateFrom(uint32);
+                case ulong uint64:
+                    return VariantUtils.CreateFrom(uint64);
+                case float @float:
+                    return VariantUtils.CreateFrom(@float);
+                case double @double:
+                    return VariantUtils.CreateFrom(@double);
+                case Vector2 vector2:
+                    return VariantUtils.CreateFrom(vector2);
+                case Vector2I vector2I:
+                    return VariantUtils.CreateFrom(vector2I);
+                case Rect2 rect2:
+                    return VariantUtils.CreateFrom(rect2);
+                case Rect2I rect2I:
+                    return VariantUtils.CreateFrom(rect2I);
+                case Transform2D transform2D:
+                    return VariantUtils.CreateFrom(transform2D);
+                case Vector3 vector3:
+                    return VariantUtils.CreateFrom(vector3);
+                case Vector3I vector3I:
+                    return VariantUtils.CreateFrom(vector3I);
+                case Vector4 vector4:
+                    return VariantUtils.CreateFrom(vector4);
+                case Vector4I vector4I:
+                    return VariantUtils.CreateFrom(vector4I);
+                case Basis basis:
+                    return VariantUtils.CreateFrom(basis);
+                case Quaternion quaternion:
+                    return VariantUtils.CreateFrom(quaternion);
+                case Transform3D transform3D:
+                    return VariantUtils.CreateFrom(transform3D);
+                case Projection projection:
+                    return VariantUtils.CreateFrom(projection);
+                case Aabb aabb:
+                    return VariantUtils.CreateFrom(aabb);
+                case Color color:
+                    return VariantUtils.CreateFrom(color);
+                case Plane plane:
+                    return VariantUtils.CreateFrom(plane);
+                case Callable callable:
+                    return VariantUtils.CreateFrom(callable);
+                case Signal signal:
+                    return VariantUtils.CreateFrom(signal);
+                case string @string:
+                    return VariantUtils.CreateFrom(@string);
+                case byte[] byteArray:
+                    return VariantUtils.CreateFrom(byteArray);
+                case int[] int32Array:
+                    return VariantUtils.CreateFrom(int32Array);
+                case long[] int64Array:
+                    return VariantUtils.CreateFrom(int64Array);
+                case float[] floatArray:
+                    return VariantUtils.CreateFrom(floatArray);
+                case double[] doubleArray:
+                    return VariantUtils.CreateFrom(doubleArray);
+                case string[] stringArray:
+                    return VariantUtils.CreateFrom(stringArray);
+                case Vector2[] vector2Array:
+                    return VariantUtils.CreateFrom(vector2Array);
+                case Vector3[] vector3Array:
+                    return VariantUtils.CreateFrom(vector3Array);
+                case Color[] colorArray:
+                    return VariantUtils.CreateFrom(colorArray);
+                case StringName[] stringNameArray:
+                    return VariantUtils.CreateFrom(stringNameArray);
+                case NodePath[] nodePathArray:
+                    return VariantUtils.CreateFrom(nodePathArray);
+                case Rid[] ridArray:
+                    return VariantUtils.CreateFrom(ridArray);
+                case GodotObject[] godotObjectArray:
+                    return VariantUtils.CreateFrom(godotObjectArray);
+                case StringName stringName:
+                    return VariantUtils.CreateFrom(stringName);
+                case NodePath nodePath:
+                    return VariantUtils.CreateFrom(nodePath);
+                case Rid rid:
+                    return VariantUtils.CreateFrom(rid);
+                case Collections.Dictionary godotDictionary:
+                    return VariantUtils.CreateFrom(godotDictionary);
+                case Collections.Array godotArray:
+                    return VariantUtils.CreateFrom(godotArray);
+                case Variant variant:
+                    return VariantUtils.CreateFrom(variant);
+                case GodotObject godotObject:
+                    return VariantUtils.CreateFrom(godotObject);
+                case Enum @enum:
+                    return VariantUtils.CreateFrom(Convert.ToInt64(@enum));
+                case Collections.IGenericGodotDictionary godotDictionary:
+                    return VariantUtils.CreateFrom(godotDictionary.UnderlyingDictionary);
+                case Collections.IGenericGodotArray godotArray:
+                    return VariantUtils.CreateFrom(godotArray.UnderlyingArray);
+            }
+
+            GD.PushError("Attempted to convert an unmarshallable managed type to Variant. Name: '" +
+                         obj.GetType().FullName + ".");
+            return new godot_variant();
+        }
+
+        private delegate object? ConvertToSystemObjectFunc(in godot_variant managed);
+
+        [SuppressMessage("ReSharper", "RedundantNameQualifier")]
+        // ReSharper disable once RedundantNameQualifier
+        private static readonly System.Collections.Generic.Dictionary<Type, ConvertToSystemObjectFunc>
+            ToSystemObjectFuncByType = new()
+            {
+                [typeof(bool)] = (in godot_variant variant) => VariantUtils.ConvertTo<bool>(variant),
+                [typeof(char)] = (in godot_variant variant) => VariantUtils.ConvertTo<char>(variant),
+                [typeof(sbyte)] = (in godot_variant variant) => VariantUtils.ConvertTo<sbyte>(variant),
+                [typeof(short)] = (in godot_variant variant) => VariantUtils.ConvertTo<short>(variant),
+                [typeof(int)] = (in godot_variant variant) => VariantUtils.ConvertTo<int>(variant),
+                [typeof(long)] = (in godot_variant variant) => VariantUtils.ConvertTo<long>(variant),
+                [typeof(byte)] = (in godot_variant variant) => VariantUtils.ConvertTo<byte>(variant),
+                [typeof(ushort)] = (in godot_variant variant) => VariantUtils.ConvertTo<ushort>(variant),
+                [typeof(uint)] = (in godot_variant variant) => VariantUtils.ConvertTo<uint>(variant),
+                [typeof(ulong)] = (in godot_variant variant) => VariantUtils.ConvertTo<ulong>(variant),
+                [typeof(float)] = (in godot_variant variant) => VariantUtils.ConvertTo<float>(variant),
+                [typeof(double)] = (in godot_variant variant) => VariantUtils.ConvertTo<double>(variant),
+                [typeof(Vector2)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2>(variant),
+                [typeof(Vector2I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2I>(variant),
+                [typeof(Rect2)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rect2>(variant),
+                [typeof(Rect2I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rect2I>(variant),
+                [typeof(Transform2D)] = (in godot_variant variant) => VariantUtils.ConvertTo<Transform2D>(variant),
+                [typeof(Vector3)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3>(variant),
+                [typeof(Vector3I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3I>(variant),
+                [typeof(Basis)] = (in godot_variant variant) => VariantUtils.ConvertTo<Basis>(variant),
+                [typeof(Quaternion)] = (in godot_variant variant) => VariantUtils.ConvertTo<Quaternion>(variant),
+                [typeof(Transform3D)] = (in godot_variant variant) => VariantUtils.ConvertTo<Transform3D>(variant),
+                [typeof(Vector4)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector4>(variant),
+                [typeof(Vector4I)] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector4I>(variant),
+                [typeof(Aabb)] = (in godot_variant variant) => VariantUtils.ConvertTo<Aabb>(variant),
+                [typeof(Color)] = (in godot_variant variant) => VariantUtils.ConvertTo<Color>(variant),
+                [typeof(Plane)] = (in godot_variant variant) => VariantUtils.ConvertTo<Plane>(variant),
+                [typeof(Callable)] = (in godot_variant variant) => VariantUtils.ConvertTo<Callable>(variant),
+                [typeof(Signal)] = (in godot_variant variant) => VariantUtils.ConvertTo<Signal>(variant),
+                [typeof(string)] = (in godot_variant variant) => VariantUtils.ConvertTo<string>(variant),
+                [typeof(byte[])] = (in godot_variant variant) => VariantUtils.ConvertTo<byte[]>(variant),
+                [typeof(int[])] = (in godot_variant variant) => VariantUtils.ConvertTo<int[]>(variant),
+                [typeof(long[])] = (in godot_variant variant) => VariantUtils.ConvertTo<long[]>(variant),
+                [typeof(float[])] = (in godot_variant variant) => VariantUtils.ConvertTo<float[]>(variant),
+                [typeof(double[])] = (in godot_variant variant) => VariantUtils.ConvertTo<double[]>(variant),
+                [typeof(string[])] = (in godot_variant variant) => VariantUtils.ConvertTo<string[]>(variant),
+                [typeof(Vector2[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector2[]>(variant),
+                [typeof(Vector3[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Vector3[]>(variant),
+                [typeof(Color[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Color[]>(variant),
+                [typeof(StringName[])] =
+                    (in godot_variant variant) => VariantUtils.ConvertTo<StringName[]>(variant),
+                [typeof(NodePath[])] = (in godot_variant variant) => VariantUtils.ConvertTo<NodePath[]>(variant),
+                [typeof(Rid[])] = (in godot_variant variant) => VariantUtils.ConvertTo<Rid[]>(variant),
+                [typeof(StringName)] = (in godot_variant variant) => VariantUtils.ConvertTo<StringName>(variant),
+                [typeof(NodePath)] = (in godot_variant variant) => VariantUtils.ConvertTo<NodePath>(variant),
+                [typeof(Rid)] = (in godot_variant variant) => VariantUtils.ConvertTo<Rid>(variant),
+                [typeof(Godot.Collections.Dictionary)] = (in godot_variant variant) =>
+                    VariantUtils.ConvertTo<Godot.Collections.Dictionary>(variant),
+                [typeof(Godot.Collections.Array)] =
+                    (in godot_variant variant) => VariantUtils.ConvertTo<Godot.Collections.Array>(variant),
+                [typeof(Variant)] = (in godot_variant variant) => VariantUtils.ConvertTo<Variant>(variant),
+            };
+
+        [SuppressMessage("ReSharper", "RedundantNameQualifier")]
+        public static object? ConvertToObjectOfType(in godot_variant variant, Type type)
+        {
+            if (ToSystemObjectFuncByType.TryGetValue(type, out var func))
+                return func(variant);
+
+            if (typeof(GodotObject).IsAssignableFrom(type))
+                return Convert.ChangeType(VariantUtils.ConvertTo<GodotObject>(variant), type);
+
+            if (typeof(GodotObject[]).IsAssignableFrom(type))
+            {
+                static GodotObject[] ConvertToSystemArrayOfGodotObject(in godot_array nativeArray, Type type)
+                {
+                    var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+                        NativeFuncs.godotsharp_array_new_copy(nativeArray));
+
+                    int length = array.Count;
+                    var ret = (GodotObject[])Activator.CreateInstance(type, length)!;
+
+                    for (int i = 0; i < length; i++)
+                        ret[i] = array[i].AsGodotObject();
+
+                    return ret;
+                }
+
+                using var godotArray = NativeFuncs.godotsharp_variant_as_array(variant);
+                return Convert.ChangeType(ConvertToSystemArrayOfGodotObject(godotArray, type), type);
+            }
+
+            if (type.IsEnum)
+            {
+                var enumUnderlyingType = type.GetEnumUnderlyingType();
+
+                switch (Type.GetTypeCode(enumUnderlyingType))
+                {
+                    case TypeCode.SByte:
+                        return Enum.ToObject(type, VariantUtils.ConvertToInt8(variant));
+                    case TypeCode.Int16:
+                        return Enum.ToObject(type, VariantUtils.ConvertToInt16(variant));
+                    case TypeCode.Int32:
+                        return Enum.ToObject(type, VariantUtils.ConvertToInt32(variant));
+                    case TypeCode.Int64:
+                        return Enum.ToObject(type, VariantUtils.ConvertToInt64(variant));
+                    case TypeCode.Byte:
+                        return Enum.ToObject(type, VariantUtils.ConvertToUInt8(variant));
+                    case TypeCode.UInt16:
+                        return Enum.ToObject(type, VariantUtils.ConvertToUInt16(variant));
+                    case TypeCode.UInt32:
+                        return Enum.ToObject(type, VariantUtils.ConvertToUInt32(variant));
+                    case TypeCode.UInt64:
+                        return Enum.ToObject(type, VariantUtils.ConvertToUInt64(variant));
+                    default:
+                    {
+                        GD.PushError(
+                            "Attempted to convert Variant to enum value of unsupported underlying type. Name: " +
+                            type.FullName + " : " + enumUnderlyingType.FullName + ".");
+                        return null;
+                    }
+                }
+            }
+
+            if (type.IsGenericType)
+            {
+                var genericTypeDef = type.GetGenericTypeDefinition();
+
+                if (genericTypeDef == typeof(Godot.Collections.Dictionary<,>))
+                {
+                    var ctor = type.GetConstructor(BindingFlags.Default,
+                        new[] { typeof(Godot.Collections.Dictionary) });
+
+                    if (ctor == null)
+                        throw new InvalidOperationException("Dictionary constructor not found");
+
+                    return ctor.Invoke(new object?[]
+                    {
+                            VariantUtils.ConvertTo<Godot.Collections.Dictionary>(variant)
+                    });
+                }
+
+                if (genericTypeDef == typeof(Godot.Collections.Array<>))
+                {
+                    var ctor = type.GetConstructor(BindingFlags.Default,
+                        new[] { typeof(Godot.Collections.Array) });
+
+                    if (ctor == null)
+                        throw new InvalidOperationException("Array constructor not found");
+
+                    return ctor.Invoke(new object?[]
+                    {
+                            VariantUtils.ConvertTo<Godot.Collections.Array>(variant)
+                    });
+                }
+            }
+
+            GD.PushError($"Attempted to convert Variant to unsupported type. Name: {type.FullName}.");
+            return null;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -5,895 +5,894 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Godot.NativeInterop;
 
-namespace Godot.Collections
+namespace Godot.Collections;
+
+/// <summary>
+/// Wrapper around Godot's Dictionary class, a dictionary of Variant
+/// typed elements allocated in the engine in C++. Useful when
+/// interfacing with the engine.
+/// </summary>
+public sealed class Dictionary :
+    IDictionary<Variant, Variant>,
+    IReadOnlyDictionary<Variant, Variant>,
+    IDisposable
 {
+    internal godot_dictionary.movable NativeValue;
+
+    private WeakReference<IDisposable> _weakReferenceToSelf;
+
     /// <summary>
-    /// Wrapper around Godot's Dictionary class, a dictionary of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine.
+    /// Constructs a new empty <see cref="Dictionary"/>.
     /// </summary>
-    public sealed class Dictionary :
-        IDictionary<Variant, Variant>,
-        IReadOnlyDictionary<Variant, Variant>,
-        IDisposable
+    public Dictionary()
     {
-        internal godot_dictionary.movable NativeValue;
+        NativeValue = (godot_dictionary.movable)NativeFuncs.godotsharp_dictionary_new();
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+    }
 
-        private WeakReference<IDisposable> _weakReferenceToSelf;
+    private Dictionary(godot_dictionary nativeValueToOwn)
+    {
+        NativeValue = (godot_dictionary.movable)(nativeValueToOwn.IsAllocated ?
+            nativeValueToOwn :
+            NativeFuncs.godotsharp_dictionary_new());
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+    }
 
-        /// <summary>
-        /// Constructs a new empty <see cref="Dictionary"/>.
-        /// </summary>
-        public Dictionary()
+    // Explicit name to make it very clear
+    internal static Dictionary CreateTakingOwnershipOfDisposableValue(godot_dictionary nativeValueToOwn)
+        => new Dictionary(nativeValueToOwn);
+
+    ~Dictionary()
+    {
+        Dispose(false);
+    }
+
+    /// <summary>
+    /// Disposes of this <see cref="Dictionary"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public void Dispose(bool disposing)
+    {
+        // Always dispose `NativeValue` even if disposing is true
+        NativeValue.DangerousSelfRef.Dispose();
+
+        if (_weakReferenceToSelf != null)
         {
-            NativeValue = (godot_dictionary.movable)NativeFuncs.godotsharp_dictionary_new();
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+            DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
         }
+    }
 
-        private Dictionary(godot_dictionary nativeValueToOwn)
+    /// <summary>
+    /// Returns a copy of the <see cref="Dictionary"/>.
+    /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy is performed:
+    /// all nested arrays and dictionaries are duplicated and will not be shared with
+    /// the original dictionary. If <see langword="false"/>, a shallow copy is made and
+    /// references to the original nested arrays and dictionaries are kept, so that
+    /// modifying a sub-array or dictionary in the copy will also impact those
+    /// referenced in the source dictionary. Note that any <see cref="GodotObject"/> derived
+    /// elements will be shallow copied regardless of the <paramref name="deep"/>
+    /// setting.
+    /// </summary>
+    /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
+    /// <returns>A new Godot Dictionary.</returns>
+    public Dictionary Duplicate(bool deep = false)
+    {
+        godot_dictionary newDictionary;
+        var self = (godot_dictionary)NativeValue;
+        NativeFuncs.godotsharp_dictionary_duplicate(ref self, deep.ToGodotBool(), out newDictionary);
+        return CreateTakingOwnershipOfDisposableValue(newDictionary);
+    }
+
+    /// <summary>
+    /// Adds entries from <paramref name="dictionary"/> to this dictionary.
+    /// By default, duplicate keys are not copied over, unless <paramref name="overwrite"/>
+    /// is <see langword="true"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <param name="dictionary">Dictionary to copy entries from.</param>
+    /// <param name="overwrite">If duplicate keys should be copied over as well.</param>
+    public void Merge(Dictionary dictionary, bool overwrite = false)
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_dictionary)NativeValue;
+        var other = (godot_dictionary)dictionary.NativeValue;
+        NativeFuncs.godotsharp_dictionary_merge(ref self, in other, overwrite.ToGodotBool());
+    }
+
+    /// <summary>
+    /// Compares this <see cref="Dictionary"/> against the <paramref name="other"/>
+    /// <see cref="Dictionary"/> recursively. Returns <see langword="true"/> if the
+    /// two dictionaries contain the same keys and values. The order of the entries
+    /// does not matter.
+    /// otherwise.
+    /// </summary>
+    /// <param name="other">The other dictionary to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if the dictionaries contain the same keys and values,
+    /// <see langword="false"/> otherwise.
+    /// </returns>
+    public bool RecursiveEqual(Dictionary other)
+    {
+        var self = (godot_dictionary)NativeValue;
+        var otherVariant = (godot_dictionary)other.NativeValue;
+        return NativeFuncs.godotsharp_dictionary_recursive_equal(ref self, otherVariant).ToBool();
+    }
+
+    // IDictionary
+
+    /// <summary>
+    /// Gets the collection of keys in this <see cref="Dictionary"/>.
+    /// </summary>
+    public ICollection<Variant> Keys
+    {
+        get
         {
-            NativeValue = (godot_dictionary.movable)(nativeValueToOwn.IsAllocated ?
-                nativeValueToOwn :
-                NativeFuncs.godotsharp_dictionary_new());
-            _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-        }
-
-        // Explicit name to make it very clear
-        internal static Dictionary CreateTakingOwnershipOfDisposableValue(godot_dictionary nativeValueToOwn)
-            => new Dictionary(nativeValueToOwn);
-
-        ~Dictionary()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Disposes of this <see cref="Dictionary"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public void Dispose(bool disposing)
-        {
-            // Always dispose `NativeValue` even if disposing is true
-            NativeValue.DangerousSelfRef.Dispose();
-
-            if (_weakReferenceToSelf != null)
-            {
-                DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
-            }
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Dictionary"/>.
-        /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy is performed:
-        /// all nested arrays and dictionaries are duplicated and will not be shared with
-        /// the original dictionary. If <see langword="false"/>, a shallow copy is made and
-        /// references to the original nested arrays and dictionaries are kept, so that
-        /// modifying a sub-array or dictionary in the copy will also impact those
-        /// referenced in the source dictionary. Note that any <see cref="GodotObject"/> derived
-        /// elements will be shallow copied regardless of the <paramref name="deep"/>
-        /// setting.
-        /// </summary>
-        /// <param name="deep">If <see langword="true"/>, performs a deep copy.</param>
-        /// <returns>A new Godot Dictionary.</returns>
-        public Dictionary Duplicate(bool deep = false)
-        {
-            godot_dictionary newDictionary;
-            var self = (godot_dictionary)NativeValue;
-            NativeFuncs.godotsharp_dictionary_duplicate(ref self, deep.ToGodotBool(), out newDictionary);
-            return CreateTakingOwnershipOfDisposableValue(newDictionary);
-        }
-
-        /// <summary>
-        /// Adds entries from <paramref name="dictionary"/> to this dictionary.
-        /// By default, duplicate keys are not copied over, unless <paramref name="overwrite"/>
-        /// is <see langword="true"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <param name="dictionary">Dictionary to copy entries from.</param>
-        /// <param name="overwrite">If duplicate keys should be copied over as well.</param>
-        public void Merge(Dictionary dictionary, bool overwrite = false)
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_dictionary)NativeValue;
-            var other = (godot_dictionary)dictionary.NativeValue;
-            NativeFuncs.godotsharp_dictionary_merge(ref self, in other, overwrite.ToGodotBool());
-        }
-
-        /// <summary>
-        /// Compares this <see cref="Dictionary"/> against the <paramref name="other"/>
-        /// <see cref="Dictionary"/> recursively. Returns <see langword="true"/> if the
-        /// two dictionaries contain the same keys and values. The order of the entries
-        /// does not matter.
-        /// otherwise.
-        /// </summary>
-        /// <param name="other">The other dictionary to compare against.</param>
-        /// <returns>
-        /// <see langword="true"/> if the dictionaries contain the same keys and values,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool RecursiveEqual(Dictionary other)
-        {
-            var self = (godot_dictionary)NativeValue;
-            var otherVariant = (godot_dictionary)other.NativeValue;
-            return NativeFuncs.godotsharp_dictionary_recursive_equal(ref self, otherVariant).ToBool();
-        }
-
-        // IDictionary
-
-        /// <summary>
-        /// Gets the collection of keys in this <see cref="Dictionary"/>.
-        /// </summary>
-        public ICollection<Variant> Keys
-        {
-            get
-            {
-                godot_array keysArray;
-                var self = (godot_dictionary)NativeValue;
-                NativeFuncs.godotsharp_dictionary_keys(ref self, out keysArray);
-                return Array.CreateTakingOwnershipOfDisposableValue(keysArray);
-            }
-        }
-
-        /// <summary>
-        /// Gets the collection of elements in this <see cref="Dictionary"/>.
-        /// </summary>
-        public ICollection<Variant> Values
-        {
-            get
-            {
-                godot_array valuesArray;
-                var self = (godot_dictionary)NativeValue;
-                NativeFuncs.godotsharp_dictionary_values(ref self, out valuesArray);
-                return Array.CreateTakingOwnershipOfDisposableValue(valuesArray);
-            }
-        }
-
-        IEnumerable<Variant> IReadOnlyDictionary<Variant, Variant>.Keys => Keys;
-
-        IEnumerable<Variant> IReadOnlyDictionary<Variant, Variant>.Values => Values;
-
-        private (Array keys, Array values, int count) GetKeyValuePairs()
-        {
-            var self = (godot_dictionary)NativeValue;
-
             godot_array keysArray;
+            var self = (godot_dictionary)NativeValue;
             NativeFuncs.godotsharp_dictionary_keys(ref self, out keysArray);
-            var keys = Array.CreateTakingOwnershipOfDisposableValue(keysArray);
-
-            godot_array valuesArray;
-            NativeFuncs.godotsharp_dictionary_keys(ref self, out valuesArray);
-            var values = Array.CreateTakingOwnershipOfDisposableValue(valuesArray);
-
-            int count = NativeFuncs.godotsharp_dictionary_count(ref self);
-
-            return (keys, values, count);
+            return Array.CreateTakingOwnershipOfDisposableValue(keysArray);
         }
-
-        /// <summary>
-        /// Returns the value at the given <paramref name="key"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The property is assigned and the dictionary is read-only.
-        /// </exception>
-        /// <exception cref="KeyNotFoundException">
-        /// The property is retrieved and an entry for <paramref name="key"/>
-        /// does not exist in the dictionary.
-        /// </exception>
-        /// <value>The value at the given <paramref name="key"/>.</value>
-        public Variant this[Variant key]
-        {
-            get
-            {
-                var self = (godot_dictionary)NativeValue;
-
-                if (NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                        (godot_variant)key.NativeVar, out godot_variant value).ToBool())
-                {
-                    return Variant.CreateTakingOwnershipOfDisposableValue(value);
-                }
-                else
-                {
-                    throw new KeyNotFoundException();
-                }
-            }
-            set
-            {
-                ThrowIfReadOnly();
-
-                var self = (godot_dictionary)NativeValue;
-                NativeFuncs.godotsharp_dictionary_set_value(ref self,
-                    (godot_variant)key.NativeVar, (godot_variant)value.NativeVar);
-            }
-        }
-
-        /// <summary>
-        /// Adds an value <paramref name="value"/> at key <paramref name="key"/>
-        /// to this <see cref="Dictionary"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// An entry for <paramref name="key"/> already exists in the dictionary.
-        /// </exception>
-        /// <param name="key">The key at which to add the value.</param>
-        /// <param name="value">The value to add.</param>
-        public void Add(Variant key, Variant value)
-        {
-            ThrowIfReadOnly();
-
-            var variantKey = (godot_variant)key.NativeVar;
-            var self = (godot_dictionary)NativeValue;
-
-            if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
-                throw new ArgumentException("An element with the same key already exists.", nameof(key));
-
-            godot_variant variantValue = (godot_variant)value.NativeVar;
-            NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);
-        }
-
-        void ICollection<KeyValuePair<Variant, Variant>>.Add(KeyValuePair<Variant, Variant> item)
-            => Add(item.Key, item.Value);
-
-        /// <summary>
-        /// Clears the dictionary, removing all entries from it.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        public void Clear()
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_dictionary)NativeValue;
-            NativeFuncs.godotsharp_dictionary_clear(ref self);
-        }
-
-        /// <summary>
-        /// Checks if this <see cref="Dictionary"/> contains the given key.
-        /// </summary>
-        /// <param name="key">The key to look for.</param>
-        /// <returns>Whether or not this dictionary contains the given key.</returns>
-        public bool ContainsKey(Variant key)
-        {
-            var self = (godot_dictionary)NativeValue;
-            return NativeFuncs.godotsharp_dictionary_contains_key(ref self, (godot_variant)key.NativeVar).ToBool();
-        }
-
-        bool ICollection<KeyValuePair<Variant, Variant>>.Contains(KeyValuePair<Variant, Variant> item)
-        {
-            godot_variant variantKey = (godot_variant)item.Key.NativeVar;
-            var self = (godot_dictionary)NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                variantKey, out godot_variant retValue).ToBool();
-
-            using (retValue)
-            {
-                if (!found)
-                    return false;
-
-                godot_variant variantValue = (godot_variant)item.Value.NativeVar;
-                return NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool();
-            }
-        }
-
-        /// <summary>
-        /// Removes an element from this <see cref="Dictionary"/> by key.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <param name="key">The key of the element to remove.</param>
-        public bool Remove(Variant key)
-        {
-            ThrowIfReadOnly();
-
-            var self = (godot_dictionary)NativeValue;
-            return NativeFuncs.godotsharp_dictionary_remove_key(ref self, (godot_variant)key.NativeVar).ToBool();
-        }
-
-        bool ICollection<KeyValuePair<Variant, Variant>>.Remove(KeyValuePair<Variant, Variant> item)
-        {
-            ThrowIfReadOnly();
-
-            godot_variant variantKey = (godot_variant)item.Key.NativeVar;
-            var self = (godot_dictionary)NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                variantKey, out godot_variant retValue).ToBool();
-
-            using (retValue)
-            {
-                if (!found)
-                    return false;
-
-                godot_variant variantValue = (godot_variant)item.Value.NativeVar;
-                if (NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool())
-                {
-                    return NativeFuncs.godotsharp_dictionary_remove_key(
-                        ref self, variantKey).ToBool();
-                }
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of elements in this <see cref="Dictionary"/>.
-        /// This is also known as the size or length of the dictionary.
-        /// </summary>
-        /// <returns>The number of elements.</returns>
-        public int Count
-        {
-            get
-            {
-                var self = (godot_dictionary)NativeValue;
-                return NativeFuncs.godotsharp_dictionary_count(ref self);
-            }
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the dictionary is read-only.
-        /// See <see cref="MakeReadOnly"/>.
-        /// </summary>
-        public bool IsReadOnly => NativeValue.DangerousSelfRef.IsReadOnly;
-
-        /// <summary>
-        /// Makes the <see cref="Dictionary"/> read-only, i.e. disabled modying of the
-        /// dictionary's elements. Does not apply to nested content, e.g. content of
-        /// nested dictionaries.
-        /// </summary>
-        public void MakeReadOnly()
-        {
-            if (IsReadOnly)
-            {
-                // Avoid interop call when the dictionary is already read-only.
-                return;
-            }
-
-            var self = (godot_dictionary)NativeValue;
-            NativeFuncs.godotsharp_dictionary_make_read_only(ref self);
-        }
-
-        /// <summary>
-        /// Gets the value for the given <paramref name="key"/> in the dictionary.
-        /// Returns <see langword="true"/> if an entry for the given key exists in
-        /// the dictionary; otherwise, returns <see langword="false"/>.
-        /// </summary>
-        /// <param name="key">The key of the element to get.</param>
-        /// <param name="value">The value at the given <paramref name="key"/>.</param>
-        /// <returns>If an entry was found for the given <paramref name="key"/>.</returns>
-        public bool TryGetValue(Variant key, out Variant value)
-        {
-            var self = (godot_dictionary)NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                (godot_variant)key.NativeVar, out godot_variant retValue).ToBool();
-
-            value = found ? Variant.CreateTakingOwnershipOfDisposableValue(retValue) : default;
-
-            return found;
-        }
-
-        /// <summary>
-        /// Copies the elements of this <see cref="Dictionary"/> to the given untyped
-        /// <see cref="KeyValuePair{TKey, TValue}"/> array, starting at the given index.
-        /// </summary>
-        /// <param name="array">The array to copy to.</param>
-        /// <param name="arrayIndex">The index to start at.</param>
-        void ICollection<KeyValuePair<Variant, Variant>>.CopyTo(KeyValuePair<Variant, Variant>[] array, int arrayIndex)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array), "Value cannot be null.");
-
-            if (arrayIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex),
-                    "Number was less than the array's lower bound in the first dimension.");
-
-            var (keys, values, count) = GetKeyValuePairs();
-
-            if (array.Length < (arrayIndex + count))
-                throw new ArgumentException(
-                    "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
-
-            for (int i = 0; i < count; i++)
-            {
-                array[arrayIndex] = new(keys[i], values[i]);
-                arrayIndex++;
-            }
-        }
-
-        // IEnumerable
-
-        /// <summary>
-        /// Gets an enumerator for this <see cref="Dictionary"/>.
-        /// </summary>
-        /// <returns>An enumerator.</returns>
-        public IEnumerator<KeyValuePair<Variant, Variant>> GetEnumerator()
-        {
-            for (int i = 0; i < Count; i++)
-            {
-                yield return GetKeyValuePair(i);
-            }
-        }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        private KeyValuePair<Variant, Variant> GetKeyValuePair(int index)
-        {
-            var self = (godot_dictionary)NativeValue;
-            NativeFuncs.godotsharp_dictionary_key_value_pair_at(ref self, index,
-                out godot_variant key,
-                out godot_variant value);
-            return new KeyValuePair<Variant, Variant>(Variant.CreateTakingOwnershipOfDisposableValue(key),
-                Variant.CreateTakingOwnershipOfDisposableValue(value));
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Dictionary"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this dictionary.</returns>
-        public override string ToString()
-        {
-            var self = (godot_dictionary)NativeValue;
-            NativeFuncs.godotsharp_dictionary_to_string(ref self, out godot_string str);
-            using (str)
-                return Marshaling.ConvertStringToManaged(str);
-        }
-
-        private void ThrowIfReadOnly()
-        {
-            if (IsReadOnly)
-            {
-                throw new InvalidOperationException("Dictionary instance is read-only.");
-            }
-        }
-    }
-
-    internal interface IGenericGodotDictionary
-    {
-        public Dictionary UnderlyingDictionary { get; }
     }
 
     /// <summary>
-    /// Typed wrapper around Godot's Dictionary class, a dictionary of Variant
-    /// typed elements allocated in the engine in C++. Useful when
-    /// interfacing with the engine. Otherwise prefer .NET collections
-    /// such as <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>.
+    /// Gets the collection of elements in this <see cref="Dictionary"/>.
     /// </summary>
-    /// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
-    /// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
-    public class Dictionary<[MustBeVariant] TKey, [MustBeVariant] TValue> :
-        IDictionary<TKey, TValue>,
-        IReadOnlyDictionary<TKey, TValue>,
-        IGenericGodotDictionary
+    public ICollection<Variant> Values
     {
-        private static godot_variant ToVariantFunc(in Dictionary<TKey, TValue> godotDictionary) =>
-            VariantUtils.CreateFromDictionary(godotDictionary);
-
-        private static Dictionary<TKey, TValue> FromVariantFunc(in godot_variant variant) =>
-            VariantUtils.ConvertToDictionary<TKey, TValue>(variant);
-
-        static unsafe Dictionary()
+        get
         {
-            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.ToVariantCb = &ToVariantFunc;
-            VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.FromVariantCb = &FromVariantFunc;
+            godot_array valuesArray;
+            var self = (godot_dictionary)NativeValue;
+            NativeFuncs.godotsharp_dictionary_values(ref self, out valuesArray);
+            return Array.CreateTakingOwnershipOfDisposableValue(valuesArray);
         }
+    }
 
-        private readonly Dictionary _underlyingDict;
+    IEnumerable<Variant> IReadOnlyDictionary<Variant, Variant>.Keys => Keys;
 
-        Dictionary IGenericGodotDictionary.UnderlyingDictionary => _underlyingDict;
+    IEnumerable<Variant> IReadOnlyDictionary<Variant, Variant>.Values => Values;
 
-        internal ref godot_dictionary.movable NativeValue
+    private (Array keys, Array values, int count) GetKeyValuePairs()
+    {
+        var self = (godot_dictionary)NativeValue;
+
+        godot_array keysArray;
+        NativeFuncs.godotsharp_dictionary_keys(ref self, out keysArray);
+        var keys = Array.CreateTakingOwnershipOfDisposableValue(keysArray);
+
+        godot_array valuesArray;
+        NativeFuncs.godotsharp_dictionary_keys(ref self, out valuesArray);
+        var values = Array.CreateTakingOwnershipOfDisposableValue(valuesArray);
+
+        int count = NativeFuncs.godotsharp_dictionary_count(ref self);
+
+        return (keys, values, count);
+    }
+
+    /// <summary>
+    /// Returns the value at the given <paramref name="key"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The property is assigned and the dictionary is read-only.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">
+    /// The property is retrieved and an entry for <paramref name="key"/>
+    /// does not exist in the dictionary.
+    /// </exception>
+    /// <value>The value at the given <paramref name="key"/>.</value>
+    public Variant this[Variant key]
+    {
+        get
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref _underlyingDict.NativeValue;
-        }
+            var self = (godot_dictionary)NativeValue;
 
-        /// <summary>
-        /// Constructs a new empty <see cref="Dictionary{TKey, TValue}"/>.
-        /// </summary>
-        public Dictionary()
-        {
-            _underlyingDict = new Dictionary();
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
-        /// </summary>
-        /// <param name="dictionary">The dictionary to construct from.</param>
-        /// <returns>A new Godot Dictionary.</returns>
-        public Dictionary(IDictionary<TKey, TValue> dictionary)
-        {
-            if (dictionary == null)
-                throw new ArgumentNullException(nameof(dictionary));
-
-            _underlyingDict = new Dictionary();
-
-            foreach (KeyValuePair<TKey, TValue> entry in dictionary)
-                Add(entry.Key, entry.Value);
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
-        /// </summary>
-        /// <param name="dictionary">The dictionary to construct from.</param>
-        /// <returns>A new Godot Dictionary.</returns>
-        public Dictionary(Dictionary dictionary)
-        {
-            _underlyingDict = dictionary;
-        }
-
-        // Explicit name to make it very clear
-        internal static Dictionary<TKey, TValue> CreateTakingOwnershipOfDisposableValue(
-            godot_dictionary nativeValueToOwn)
-            => new Dictionary<TKey, TValue>(Dictionary.CreateTakingOwnershipOfDisposableValue(nativeValueToOwn));
-
-        /// <summary>
-        /// Converts this typed <see cref="Dictionary{TKey, TValue}"/> to an untyped <see cref="Dictionary"/>.
-        /// </summary>
-        /// <param name="from">The typed dictionary to convert.</param>
-        public static explicit operator Dictionary(Dictionary<TKey, TValue> from)
-        {
-            return from?._underlyingDict;
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Dictionary{TKey, TValue}"/>.
-        /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy is performed:
-        /// all nested arrays and dictionaries are duplicated and will not be shared with
-        /// the original dictionary. If <see langword="false"/>, a shallow copy is made and
-        /// references to the original nested arrays and dictionaries are kept, so that
-        /// modifying a sub-array or dictionary in the copy will also impact those
-        /// referenced in the source dictionary. Note that any <see cref="GodotObject"/> derived
-        /// elements will be shallow copied regardless of the <paramref name="deep"/>
-        /// setting.
-        /// </summary>
-        public Dictionary<TKey, TValue> Duplicate(bool deep = false)
-        {
-            return new Dictionary<TKey, TValue>(_underlyingDict.Duplicate(deep));
-        }
-
-        /// <summary>
-        /// Adds entries from <paramref name="dictionary"/> to this dictionary.
-        /// By default, duplicate keys are not copied over, unless <paramref name="overwrite"/>
-        /// is <see langword="true"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <param name="dictionary">Dictionary to copy entries from.</param>
-        /// <param name="overwrite">If duplicate keys should be copied over as well.</param>
-        public void Merge(Dictionary<TKey, TValue> dictionary, bool overwrite = false)
-        {
-            _underlyingDict.Merge(dictionary._underlyingDict, overwrite);
-        }
-
-        /// <summary>
-        /// Compares this <see cref="Dictionary{TKey, TValue}"/> against the <paramref name="other"/>
-        /// <see cref="Dictionary{TKey, TValue}"/> recursively. Returns <see langword="true"/> if the
-        /// two dictionaries contain the same keys and values. The order of the entries does not matter.
-        /// otherwise.
-        /// </summary>
-        /// <param name="other">The other dictionary to compare against.</param>
-        /// <returns>
-        /// <see langword="true"/> if the dictionaries contain the same keys and values,
-        /// <see langword="false"/> otherwise.
-        /// </returns>
-        public bool RecursiveEqual(Dictionary<TKey, TValue> other)
-        {
-            return _underlyingDict.RecursiveEqual(other._underlyingDict);
-        }
-
-        // IDictionary<TKey, TValue>
-
-        /// <summary>
-        /// Returns the value at the given <paramref name="key"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The property is assigned and the dictionary is read-only.
-        /// </exception>
-        /// <exception cref="KeyNotFoundException">
-        /// The property is retrieved and an entry for <paramref name="key"/>
-        /// does not exist in the dictionary.
-        /// </exception>
-        /// <value>The value at the given <paramref name="key"/>.</value>
-        public TValue this[TKey key]
-        {
-            get
+            if (NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+                    (godot_variant)key.NativeVar, out godot_variant value).ToBool())
             {
-                using var variantKey = VariantUtils.CreateFrom(key);
-                var self = (godot_dictionary)_underlyingDict.NativeValue;
-
-                if (NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                        variantKey, out godot_variant value).ToBool())
-                {
-                    using (value)
-                        return VariantUtils.ConvertTo<TValue>(value);
-                }
-                else
-                {
-                    throw new KeyNotFoundException();
-                }
+                return Variant.CreateTakingOwnershipOfDisposableValue(value);
             }
-            set
+            else
             {
-                ThrowIfReadOnly();
-
-                using var variantKey = VariantUtils.CreateFrom(key);
-                using var variantValue = VariantUtils.CreateFrom(value);
-                var self = (godot_dictionary)_underlyingDict.NativeValue;
-                NativeFuncs.godotsharp_dictionary_set_value(ref self,
-                    variantKey, variantValue);
+                throw new KeyNotFoundException();
             }
         }
-
-        /// <summary>
-        /// Gets the collection of keys in this <see cref="Dictionary{TKey, TValue}"/>.
-        /// </summary>
-        public ICollection<TKey> Keys
-        {
-            get
-            {
-                godot_array keyArray;
-                var self = (godot_dictionary)_underlyingDict.NativeValue;
-                NativeFuncs.godotsharp_dictionary_keys(ref self, out keyArray);
-                return Array<TKey>.CreateTakingOwnershipOfDisposableValue(keyArray);
-            }
-        }
-
-        /// <summary>
-        /// Gets the collection of elements in this <see cref="Dictionary{TKey, TValue}"/>.
-        /// </summary>
-        public ICollection<TValue> Values
-        {
-            get
-            {
-                godot_array valuesArray;
-                var self = (godot_dictionary)_underlyingDict.NativeValue;
-                NativeFuncs.godotsharp_dictionary_values(ref self, out valuesArray);
-                return Array<TValue>.CreateTakingOwnershipOfDisposableValue(valuesArray);
-            }
-        }
-
-        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
-
-        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
-
-        private KeyValuePair<TKey, TValue> GetKeyValuePair(int index)
-        {
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            NativeFuncs.godotsharp_dictionary_key_value_pair_at(ref self, index,
-                out godot_variant key,
-                out godot_variant value);
-            using (key)
-            using (value)
-            {
-                return new KeyValuePair<TKey, TValue>(
-                    VariantUtils.ConvertTo<TKey>(key),
-                    VariantUtils.ConvertTo<TValue>(value));
-            }
-        }
-
-        /// <summary>
-        /// Adds an object <paramref name="value"/> at key <paramref name="key"/>
-        /// to this <see cref="Dictionary{TKey, TValue}"/>.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <param name="key">The key at which to add the object.</param>
-        /// <param name="value">The object to add.</param>
-        public void Add(TKey key, TValue value)
+        set
         {
             ThrowIfReadOnly();
 
-            using var variantKey = VariantUtils.CreateFrom(key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-
-            if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
-                throw new ArgumentException("An element with the same key already exists.", nameof(key));
-
-            using var variantValue = VariantUtils.CreateFrom(value);
-            NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);
+            var self = (godot_dictionary)NativeValue;
+            NativeFuncs.godotsharp_dictionary_set_value(ref self,
+                (godot_variant)key.NativeVar, (godot_variant)value.NativeVar);
         }
+    }
 
-        /// <summary>
-        /// Checks if this <see cref="Dictionary{TKey, TValue}"/> contains the given key.
-        /// </summary>
-        /// <param name="key">The key to look for.</param>
-        /// <returns>Whether or not this dictionary contains the given key.</returns>
-        public bool ContainsKey(TKey key)
+    /// <summary>
+    /// Adds an value <paramref name="value"/> at key <paramref name="key"/>
+    /// to this <see cref="Dictionary"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// An entry for <paramref name="key"/> already exists in the dictionary.
+    /// </exception>
+    /// <param name="key">The key at which to add the value.</param>
+    /// <param name="value">The value to add.</param>
+    public void Add(Variant key, Variant value)
+    {
+        ThrowIfReadOnly();
+
+        var variantKey = (godot_variant)key.NativeVar;
+        var self = (godot_dictionary)NativeValue;
+
+        if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
+            throw new ArgumentException("An element with the same key already exists.", nameof(key));
+
+        godot_variant variantValue = (godot_variant)value.NativeVar;
+        NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);
+    }
+
+    void ICollection<KeyValuePair<Variant, Variant>>.Add(KeyValuePair<Variant, Variant> item)
+        => Add(item.Key, item.Value);
+
+    /// <summary>
+    /// Clears the dictionary, removing all entries from it.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    public void Clear()
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_dictionary)NativeValue;
+        NativeFuncs.godotsharp_dictionary_clear(ref self);
+    }
+
+    /// <summary>
+    /// Checks if this <see cref="Dictionary"/> contains the given key.
+    /// </summary>
+    /// <param name="key">The key to look for.</param>
+    /// <returns>Whether or not this dictionary contains the given key.</returns>
+    public bool ContainsKey(Variant key)
+    {
+        var self = (godot_dictionary)NativeValue;
+        return NativeFuncs.godotsharp_dictionary_contains_key(ref self, (godot_variant)key.NativeVar).ToBool();
+    }
+
+    bool ICollection<KeyValuePair<Variant, Variant>>.Contains(KeyValuePair<Variant, Variant> item)
+    {
+        godot_variant variantKey = (godot_variant)item.Key.NativeVar;
+        var self = (godot_dictionary)NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            variantKey, out godot_variant retValue).ToBool();
+
+        using (retValue)
         {
-            using var variantKey = VariantUtils.CreateFrom(key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            return NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool();
-        }
-
-        /// <summary>
-        /// Removes an element from this <see cref="Dictionary{TKey, TValue}"/> by key.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        /// <param name="key">The key of the element to remove.</param>
-        public bool Remove(TKey key)
-        {
-            ThrowIfReadOnly();
-
-            using var variantKey = VariantUtils.CreateFrom(key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            return NativeFuncs.godotsharp_dictionary_remove_key(ref self, variantKey).ToBool();
-        }
-
-        /// <summary>
-        /// Gets the value for the given <paramref name="key"/> in the dictionary.
-        /// Returns <see langword="true"/> if an entry for the given key exists in
-        /// the dictionary; otherwise, returns <see langword="false"/>.
-        /// </summary>
-        /// <param name="key">The key of the element to get.</param>
-        /// <param name="value">The value at the given <paramref name="key"/>.</param>
-        /// <returns>If an entry was found for the given <paramref name="key"/>.</returns>
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
-        {
-            using var variantKey = VariantUtils.CreateFrom(key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                variantKey, out godot_variant retValue).ToBool();
-
-            using (retValue)
-                value = found ? VariantUtils.ConvertTo<TValue>(retValue) : default;
-
-            return found;
-        }
-
-        // ICollection<KeyValuePair<TKey, TValue>>
-
-        /// <summary>
-        /// Returns the number of elements in this <see cref="Dictionary{TKey, TValue}"/>.
-        /// This is also known as the size or length of the dictionary.
-        /// </summary>
-        /// <returns>The number of elements.</returns>
-        public int Count => _underlyingDict.Count;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the dictionary is read-only.
-        /// See <see cref="MakeReadOnly"/>.
-        /// </summary>
-        public bool IsReadOnly => _underlyingDict.IsReadOnly;
-
-        /// <summary>
-        /// Makes the <see cref="Dictionary{TKey, TValue}"/> read-only, i.e. disabled
-        /// modying of the dictionary's elements. Does not apply to nested content,
-        /// e.g. content of nested dictionaries.
-        /// </summary>
-        public void MakeReadOnly()
-        {
-            _underlyingDict.MakeReadOnly();
-        }
-
-        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
-            => Add(item.Key, item.Value);
-
-        /// <summary>
-        /// Clears the dictionary, removing all entries from it.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">
-        /// The dictionary is read-only.
-        /// </exception>
-        public void Clear() => _underlyingDict.Clear();
-
-        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
-        {
-            using var variantKey = VariantUtils.CreateFrom(item.Key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                variantKey, out godot_variant retValue).ToBool();
-
-            using (retValue)
-            {
-                if (!found)
-                    return false;
-
-                using var variantValue = VariantUtils.CreateFrom(item.Value);
-                return NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool();
-            }
-        }
-
-        /// <summary>
-        /// Copies the elements of this <see cref="Dictionary{TKey, TValue}"/> to the given
-        /// untyped C# array, starting at the given index.
-        /// </summary>
-        /// <param name="array">The array to copy to.</param>
-        /// <param name="arrayIndex">The index to start at.</param>
-        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
-        {
-            if (array == null)
-                throw new ArgumentNullException(nameof(array), "Value cannot be null.");
-
-            if (arrayIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex),
-                    "Number was less than the array's lower bound in the first dimension.");
-
-            int count = Count;
-
-            if (array.Length < (arrayIndex + count))
-                throw new ArgumentException(
-                    "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
-
-            for (int i = 0; i < count; i++)
-            {
-                array[arrayIndex] = GetKeyValuePair(i);
-                arrayIndex++;
-            }
-        }
-
-        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
-        {
-            ThrowIfReadOnly();
-
-            using var variantKey = VariantUtils.CreateFrom(item.Key);
-            var self = (godot_dictionary)_underlyingDict.NativeValue;
-            bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
-                variantKey, out godot_variant retValue).ToBool();
-
-            using (retValue)
-            {
-                if (!found)
-                    return false;
-
-                using var variantValue = VariantUtils.CreateFrom(item.Value);
-                if (NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool())
-                {
-                    return NativeFuncs.godotsharp_dictionary_remove_key(
-                        ref self, variantKey).ToBool();
-                }
-
+            if (!found)
                 return false;
+
+            godot_variant variantValue = (godot_variant)item.Value.NativeVar;
+            return NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool();
+        }
+    }
+
+    /// <summary>
+    /// Removes an element from this <see cref="Dictionary"/> by key.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <param name="key">The key of the element to remove.</param>
+    public bool Remove(Variant key)
+    {
+        ThrowIfReadOnly();
+
+        var self = (godot_dictionary)NativeValue;
+        return NativeFuncs.godotsharp_dictionary_remove_key(ref self, (godot_variant)key.NativeVar).ToBool();
+    }
+
+    bool ICollection<KeyValuePair<Variant, Variant>>.Remove(KeyValuePair<Variant, Variant> item)
+    {
+        ThrowIfReadOnly();
+
+        godot_variant variantKey = (godot_variant)item.Key.NativeVar;
+        var self = (godot_dictionary)NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            variantKey, out godot_variant retValue).ToBool();
+
+        using (retValue)
+        {
+            if (!found)
+                return false;
+
+            godot_variant variantValue = (godot_variant)item.Value.NativeVar;
+            if (NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool())
+            {
+                return NativeFuncs.godotsharp_dictionary_remove_key(
+                    ref self, variantKey).ToBool();
             }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of elements in this <see cref="Dictionary"/>.
+    /// This is also known as the size or length of the dictionary.
+    /// </summary>
+    /// <returns>The number of elements.</returns>
+    public int Count
+    {
+        get
+        {
+            var self = (godot_dictionary)NativeValue;
+            return NativeFuncs.godotsharp_dictionary_count(ref self);
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the dictionary is read-only.
+    /// See <see cref="MakeReadOnly"/>.
+    /// </summary>
+    public bool IsReadOnly => NativeValue.DangerousSelfRef.IsReadOnly;
+
+    /// <summary>
+    /// Makes the <see cref="Dictionary"/> read-only, i.e. disabled modying of the
+    /// dictionary's elements. Does not apply to nested content, e.g. content of
+    /// nested dictionaries.
+    /// </summary>
+    public void MakeReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            // Avoid interop call when the dictionary is already read-only.
+            return;
         }
 
-        // IEnumerable<KeyValuePair<TKey, TValue>>
+        var self = (godot_dictionary)NativeValue;
+        NativeFuncs.godotsharp_dictionary_make_read_only(ref self);
+    }
 
-        /// <summary>
-        /// Gets an enumerator for this <see cref="Dictionary{TKey, TValue}"/>.
-        /// </summary>
-        /// <returns>An enumerator.</returns>
-        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    /// <summary>
+    /// Gets the value for the given <paramref name="key"/> in the dictionary.
+    /// Returns <see langword="true"/> if an entry for the given key exists in
+    /// the dictionary; otherwise, returns <see langword="false"/>.
+    /// </summary>
+    /// <param name="key">The key of the element to get.</param>
+    /// <param name="value">The value at the given <paramref name="key"/>.</param>
+    /// <returns>If an entry was found for the given <paramref name="key"/>.</returns>
+    public bool TryGetValue(Variant key, out Variant value)
+    {
+        var self = (godot_dictionary)NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            (godot_variant)key.NativeVar, out godot_variant retValue).ToBool();
+
+        value = found ? Variant.CreateTakingOwnershipOfDisposableValue(retValue) : default;
+
+        return found;
+    }
+
+    /// <summary>
+    /// Copies the elements of this <see cref="Dictionary"/> to the given untyped
+    /// <see cref="KeyValuePair{TKey, TValue}"/> array, starting at the given index.
+    /// </summary>
+    /// <param name="array">The array to copy to.</param>
+    /// <param name="arrayIndex">The index to start at.</param>
+    void ICollection<KeyValuePair<Variant, Variant>>.CopyTo(KeyValuePair<Variant, Variant>[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array), "Value cannot be null.");
+
+        if (arrayIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex),
+                "Number was less than the array's lower bound in the first dimension.");
+
+        var (keys, values, count) = GetKeyValuePairs();
+
+        if (array.Length < (arrayIndex + count))
+            throw new ArgumentException(
+                "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
+
+        for (int i = 0; i < count; i++)
         {
-            for (int i = 0; i < Count; i++)
+            array[arrayIndex] = new(keys[i], values[i]);
+            arrayIndex++;
+        }
+    }
+
+    // IEnumerable
+
+    /// <summary>
+    /// Gets an enumerator for this <see cref="Dictionary"/>.
+    /// </summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<KeyValuePair<Variant, Variant>> GetEnumerator()
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            yield return GetKeyValuePair(i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private KeyValuePair<Variant, Variant> GetKeyValuePair(int index)
+    {
+        var self = (godot_dictionary)NativeValue;
+        NativeFuncs.godotsharp_dictionary_key_value_pair_at(ref self, index,
+            out godot_variant key,
+            out godot_variant value);
+        return new KeyValuePair<Variant, Variant>(Variant.CreateTakingOwnershipOfDisposableValue(key),
+            Variant.CreateTakingOwnershipOfDisposableValue(value));
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Dictionary"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this dictionary.</returns>
+    public override string ToString()
+    {
+        var self = (godot_dictionary)NativeValue;
+        NativeFuncs.godotsharp_dictionary_to_string(ref self, out godot_string str);
+        using (str)
+            return Marshaling.ConvertStringToManaged(str);
+    }
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Dictionary instance is read-only.");
+        }
+    }
+}
+
+internal interface IGenericGodotDictionary
+{
+    public Dictionary UnderlyingDictionary { get; }
+}
+
+/// <summary>
+/// Typed wrapper around Godot's Dictionary class, a dictionary of Variant
+/// typed elements allocated in the engine in C++. Useful when
+/// interfacing with the engine. Otherwise prefer .NET collections
+/// such as <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of the dictionary's keys.</typeparam>
+/// <typeparam name="TValue">The type of the dictionary's values.</typeparam>
+public class Dictionary<[MustBeVariant] TKey, [MustBeVariant] TValue> :
+    IDictionary<TKey, TValue>,
+    IReadOnlyDictionary<TKey, TValue>,
+    IGenericGodotDictionary
+{
+    private static godot_variant ToVariantFunc(in Dictionary<TKey, TValue> godotDictionary) =>
+        VariantUtils.CreateFromDictionary(godotDictionary);
+
+    private static Dictionary<TKey, TValue> FromVariantFunc(in godot_variant variant) =>
+        VariantUtils.ConvertToDictionary<TKey, TValue>(variant);
+
+    static unsafe Dictionary()
+    {
+        VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.ToVariantCb = &ToVariantFunc;
+        VariantUtils.GenericConversion<Dictionary<TKey, TValue>>.FromVariantCb = &FromVariantFunc;
+    }
+
+    private readonly Dictionary _underlyingDict;
+
+    Dictionary IGenericGodotDictionary.UnderlyingDictionary => _underlyingDict;
+
+    internal ref godot_dictionary.movable NativeValue
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref _underlyingDict.NativeValue;
+    }
+
+    /// <summary>
+    /// Constructs a new empty <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    public Dictionary()
+    {
+        _underlyingDict = new Dictionary();
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
+    /// </summary>
+    /// <param name="dictionary">The dictionary to construct from.</param>
+    /// <returns>A new Godot Dictionary.</returns>
+    public Dictionary(IDictionary<TKey, TValue> dictionary)
+    {
+        if (dictionary == null)
+            throw new ArgumentNullException(nameof(dictionary));
+
+        _underlyingDict = new Dictionary();
+
+        foreach (KeyValuePair<TKey, TValue> entry in dictionary)
+            Add(entry.Key, entry.Value);
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Dictionary{TKey, TValue}"/> from the given dictionary's elements.
+    /// </summary>
+    /// <param name="dictionary">The dictionary to construct from.</param>
+    /// <returns>A new Godot Dictionary.</returns>
+    public Dictionary(Dictionary dictionary)
+    {
+        _underlyingDict = dictionary;
+    }
+
+    // Explicit name to make it very clear
+    internal static Dictionary<TKey, TValue> CreateTakingOwnershipOfDisposableValue(
+        godot_dictionary nativeValueToOwn)
+        => new Dictionary<TKey, TValue>(Dictionary.CreateTakingOwnershipOfDisposableValue(nativeValueToOwn));
+
+    /// <summary>
+    /// Converts this typed <see cref="Dictionary{TKey, TValue}"/> to an untyped <see cref="Dictionary"/>.
+    /// </summary>
+    /// <param name="from">The typed dictionary to convert.</param>
+    public static explicit operator Dictionary(Dictionary<TKey, TValue> from)
+    {
+        return from?._underlyingDict;
+    }
+
+    /// <summary>
+    /// Returns a copy of the <see cref="Dictionary{TKey, TValue}"/>.
+    /// If <paramref name="deep"/> is <see langword="true"/>, a deep copy is performed:
+    /// all nested arrays and dictionaries are duplicated and will not be shared with
+    /// the original dictionary. If <see langword="false"/>, a shallow copy is made and
+    /// references to the original nested arrays and dictionaries are kept, so that
+    /// modifying a sub-array or dictionary in the copy will also impact those
+    /// referenced in the source dictionary. Note that any <see cref="GodotObject"/> derived
+    /// elements will be shallow copied regardless of the <paramref name="deep"/>
+    /// setting.
+    /// </summary>
+    public Dictionary<TKey, TValue> Duplicate(bool deep = false)
+    {
+        return new Dictionary<TKey, TValue>(_underlyingDict.Duplicate(deep));
+    }
+
+    /// <summary>
+    /// Adds entries from <paramref name="dictionary"/> to this dictionary.
+    /// By default, duplicate keys are not copied over, unless <paramref name="overwrite"/>
+    /// is <see langword="true"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <param name="dictionary">Dictionary to copy entries from.</param>
+    /// <param name="overwrite">If duplicate keys should be copied over as well.</param>
+    public void Merge(Dictionary<TKey, TValue> dictionary, bool overwrite = false)
+    {
+        _underlyingDict.Merge(dictionary._underlyingDict, overwrite);
+    }
+
+    /// <summary>
+    /// Compares this <see cref="Dictionary{TKey, TValue}"/> against the <paramref name="other"/>
+    /// <see cref="Dictionary{TKey, TValue}"/> recursively. Returns <see langword="true"/> if the
+    /// two dictionaries contain the same keys and values. The order of the entries does not matter.
+    /// otherwise.
+    /// </summary>
+    /// <param name="other">The other dictionary to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if the dictionaries contain the same keys and values,
+    /// <see langword="false"/> otherwise.
+    /// </returns>
+    public bool RecursiveEqual(Dictionary<TKey, TValue> other)
+    {
+        return _underlyingDict.RecursiveEqual(other._underlyingDict);
+    }
+
+    // IDictionary<TKey, TValue>
+
+    /// <summary>
+    /// Returns the value at the given <paramref name="key"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The property is assigned and the dictionary is read-only.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">
+    /// The property is retrieved and an entry for <paramref name="key"/>
+    /// does not exist in the dictionary.
+    /// </exception>
+    /// <value>The value at the given <paramref name="key"/>.</value>
+    public TValue this[TKey key]
+    {
+        get
+        {
+            using var variantKey = VariantUtils.CreateFrom(key);
+            var self = (godot_dictionary)_underlyingDict.NativeValue;
+
+            if (NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+                    variantKey, out godot_variant value).ToBool())
             {
-                yield return GetKeyValuePair(i);
+                using (value)
+                    return VariantUtils.ConvertTo<TValue>(value);
+            }
+            else
+            {
+                throw new KeyNotFoundException();
             }
         }
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        /// <summary>
-        /// Converts this <see cref="Dictionary{TKey, TValue}"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this dictionary.</returns>
-        public override string ToString() => _underlyingDict.ToString();
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Variant(Dictionary<TKey, TValue> from) => Variant.CreateFrom(from);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator Dictionary<TKey, TValue>(Variant from) =>
-            from.AsGodotDictionary<TKey, TValue>();
-
-        private void ThrowIfReadOnly()
+        set
         {
-            if (IsReadOnly)
+            ThrowIfReadOnly();
+
+            using var variantKey = VariantUtils.CreateFrom(key);
+            using var variantValue = VariantUtils.CreateFrom(value);
+            var self = (godot_dictionary)_underlyingDict.NativeValue;
+            NativeFuncs.godotsharp_dictionary_set_value(ref self,
+                variantKey, variantValue);
+        }
+    }
+
+    /// <summary>
+    /// Gets the collection of keys in this <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    public ICollection<TKey> Keys
+    {
+        get
+        {
+            godot_array keyArray;
+            var self = (godot_dictionary)_underlyingDict.NativeValue;
+            NativeFuncs.godotsharp_dictionary_keys(ref self, out keyArray);
+            return Array<TKey>.CreateTakingOwnershipOfDisposableValue(keyArray);
+        }
+    }
+
+    /// <summary>
+    /// Gets the collection of elements in this <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    public ICollection<TValue> Values
+    {
+        get
+        {
+            godot_array valuesArray;
+            var self = (godot_dictionary)_underlyingDict.NativeValue;
+            NativeFuncs.godotsharp_dictionary_values(ref self, out valuesArray);
+            return Array<TValue>.CreateTakingOwnershipOfDisposableValue(valuesArray);
+        }
+    }
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+    private KeyValuePair<TKey, TValue> GetKeyValuePair(int index)
+    {
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        NativeFuncs.godotsharp_dictionary_key_value_pair_at(ref self, index,
+            out godot_variant key,
+            out godot_variant value);
+        using (key)
+        using (value)
+        {
+            return new KeyValuePair<TKey, TValue>(
+                VariantUtils.ConvertTo<TKey>(key),
+                VariantUtils.ConvertTo<TValue>(value));
+        }
+    }
+
+    /// <summary>
+    /// Adds an object <paramref name="value"/> at key <paramref name="key"/>
+    /// to this <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <param name="key">The key at which to add the object.</param>
+    /// <param name="value">The object to add.</param>
+    public void Add(TKey key, TValue value)
+    {
+        ThrowIfReadOnly();
+
+        using var variantKey = VariantUtils.CreateFrom(key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+
+        if (NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool())
+            throw new ArgumentException("An element with the same key already exists.", nameof(key));
+
+        using var variantValue = VariantUtils.CreateFrom(value);
+        NativeFuncs.godotsharp_dictionary_add(ref self, variantKey, variantValue);
+    }
+
+    /// <summary>
+    /// Checks if this <see cref="Dictionary{TKey, TValue}"/> contains the given key.
+    /// </summary>
+    /// <param name="key">The key to look for.</param>
+    /// <returns>Whether or not this dictionary contains the given key.</returns>
+    public bool ContainsKey(TKey key)
+    {
+        using var variantKey = VariantUtils.CreateFrom(key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        return NativeFuncs.godotsharp_dictionary_contains_key(ref self, variantKey).ToBool();
+    }
+
+    /// <summary>
+    /// Removes an element from this <see cref="Dictionary{TKey, TValue}"/> by key.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    /// <param name="key">The key of the element to remove.</param>
+    public bool Remove(TKey key)
+    {
+        ThrowIfReadOnly();
+
+        using var variantKey = VariantUtils.CreateFrom(key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        return NativeFuncs.godotsharp_dictionary_remove_key(ref self, variantKey).ToBool();
+    }
+
+    /// <summary>
+    /// Gets the value for the given <paramref name="key"/> in the dictionary.
+    /// Returns <see langword="true"/> if an entry for the given key exists in
+    /// the dictionary; otherwise, returns <see langword="false"/>.
+    /// </summary>
+    /// <param name="key">The key of the element to get.</param>
+    /// <param name="value">The value at the given <paramref name="key"/>.</param>
+    /// <returns>If an entry was found for the given <paramref name="key"/>.</returns>
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+    {
+        using var variantKey = VariantUtils.CreateFrom(key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            variantKey, out godot_variant retValue).ToBool();
+
+        using (retValue)
+            value = found ? VariantUtils.ConvertTo<TValue>(retValue) : default;
+
+        return found;
+    }
+
+    // ICollection<KeyValuePair<TKey, TValue>>
+
+    /// <summary>
+    /// Returns the number of elements in this <see cref="Dictionary{TKey, TValue}"/>.
+    /// This is also known as the size or length of the dictionary.
+    /// </summary>
+    /// <returns>The number of elements.</returns>
+    public int Count => _underlyingDict.Count;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the dictionary is read-only.
+    /// See <see cref="MakeReadOnly"/>.
+    /// </summary>
+    public bool IsReadOnly => _underlyingDict.IsReadOnly;
+
+    /// <summary>
+    /// Makes the <see cref="Dictionary{TKey, TValue}"/> read-only, i.e. disabled
+    /// modying of the dictionary's elements. Does not apply to nested content,
+    /// e.g. content of nested dictionaries.
+    /// </summary>
+    public void MakeReadOnly()
+    {
+        _underlyingDict.MakeReadOnly();
+    }
+
+    void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+        => Add(item.Key, item.Value);
+
+    /// <summary>
+    /// Clears the dictionary, removing all entries from it.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The dictionary is read-only.
+    /// </exception>
+    public void Clear() => _underlyingDict.Clear();
+
+    bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+    {
+        using var variantKey = VariantUtils.CreateFrom(item.Key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            variantKey, out godot_variant retValue).ToBool();
+
+        using (retValue)
+        {
+            if (!found)
+                return false;
+
+            using var variantValue = VariantUtils.CreateFrom(item.Value);
+            return NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool();
+        }
+    }
+
+    /// <summary>
+    /// Copies the elements of this <see cref="Dictionary{TKey, TValue}"/> to the given
+    /// untyped C# array, starting at the given index.
+    /// </summary>
+    /// <param name="array">The array to copy to.</param>
+    /// <param name="arrayIndex">The index to start at.</param>
+    void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array), "Value cannot be null.");
+
+        if (arrayIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex),
+                "Number was less than the array's lower bound in the first dimension.");
+
+        int count = Count;
+
+        if (array.Length < (arrayIndex + count))
+            throw new ArgumentException(
+                "Destination array was not long enough. Check destIndex and length, and the array's lower bounds.");
+
+        for (int i = 0; i < count; i++)
+        {
+            array[arrayIndex] = GetKeyValuePair(i);
+            arrayIndex++;
+        }
+    }
+
+    bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+    {
+        ThrowIfReadOnly();
+
+        using var variantKey = VariantUtils.CreateFrom(item.Key);
+        var self = (godot_dictionary)_underlyingDict.NativeValue;
+        bool found = NativeFuncs.godotsharp_dictionary_try_get_value(ref self,
+            variantKey, out godot_variant retValue).ToBool();
+
+        using (retValue)
+        {
+            if (!found)
+                return false;
+
+            using var variantValue = VariantUtils.CreateFrom(item.Value);
+            if (NativeFuncs.godotsharp_variant_equals(variantValue, retValue).ToBool())
             {
-                throw new InvalidOperationException("Dictionary instance is read-only.");
+                return NativeFuncs.godotsharp_dictionary_remove_key(
+                    ref self, variantKey).ToBool();
             }
+
+            return false;
+        }
+    }
+
+    // IEnumerable<KeyValuePair<TKey, TValue>>
+
+    /// <summary>
+    /// Gets an enumerator for this <see cref="Dictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>An enumerator.</returns>
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            yield return GetKeyValuePair(i);
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Converts this <see cref="Dictionary{TKey, TValue}"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this dictionary.</returns>
+    public override string ToString() => _underlyingDict.ToString();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator Variant(Dictionary<TKey, TValue> from) => Variant.CreateFrom(from);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Dictionary<TKey, TValue>(Variant from) =>
+        from.AsGodotDictionary<TKey, TValue>();
+
+    private void ThrowIfReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Dictionary instance is read-only.");
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
@@ -2,18 +2,17 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+public static class Dispatcher
 {
-    public static class Dispatcher
+    internal static GodotTaskScheduler DefaultGodotTaskScheduler;
+
+    internal static void InitializeDefaultGodotTaskScheduler()
     {
-        internal static GodotTaskScheduler DefaultGodotTaskScheduler;
-
-        internal static void InitializeDefaultGodotTaskScheduler()
-        {
-            DefaultGodotTaskScheduler?.Dispose();
-            DefaultGodotTaskScheduler = new GodotTaskScheduler();
-        }
-
-        public static GodotSynchronizationContext SynchronizationContext => DefaultGodotTaskScheduler.Context;
+        DefaultGodotTaskScheduler?.Dispose();
+        DefaultGodotTaskScheduler = new GodotTaskScheduler();
     }
+
+    public static GodotSynchronizationContext SynchronizationContext => DefaultGodotTaskScheduler.Context;
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DisposablesTracker.cs
@@ -5,91 +5,90 @@ using Godot.NativeInterop;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+internal static class DisposablesTracker
 {
-    internal static class DisposablesTracker
+    [UnmanagedCallersOnly]
+    internal static void OnGodotShuttingDown()
     {
-        [UnmanagedCallersOnly]
-        internal static void OnGodotShuttingDown()
+        try
         {
-            try
-            {
-                OnGodotShuttingDownImpl();
-            }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+            OnGodotShuttingDownImpl();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+        }
+    }
+
+    private static void OnGodotShuttingDownImpl()
+    {
+        bool isStdoutVerbose;
+
+        try
+        {
+            isStdoutVerbose = OS.IsStdOutVerbose();
+        }
+        catch (ObjectDisposedException)
+        {
+            // OS singleton already disposed. Maybe OnUnloading was called twice.
+            isStdoutVerbose = false;
         }
 
-        private static void OnGodotShuttingDownImpl()
+        if (isStdoutVerbose)
+            GD.Print("Unloading: Disposing tracked instances...");
+
+        // Dispose Godot Objects first, and only then dispose other disposables
+        // like StringName, NodePath, Godot.Collections.Array/Dictionary, etc.
+        // The Godot Object Dispose() method may need any of the later instances.
+
+        foreach (WeakReference<GodotObject> item in GodotObjectInstances.Keys)
         {
-            bool isStdoutVerbose;
-
-            try
-            {
-                isStdoutVerbose = OS.IsStdOutVerbose();
-            }
-            catch (ObjectDisposedException)
-            {
-                // OS singleton already disposed. Maybe OnUnloading was called twice.
-                isStdoutVerbose = false;
-            }
-
-            if (isStdoutVerbose)
-                GD.Print("Unloading: Disposing tracked instances...");
-
-            // Dispose Godot Objects first, and only then dispose other disposables
-            // like StringName, NodePath, Godot.Collections.Array/Dictionary, etc.
-            // The Godot Object Dispose() method may need any of the later instances.
-
-            foreach (WeakReference<GodotObject> item in GodotObjectInstances.Keys)
-            {
-                if (item.TryGetTarget(out GodotObject? self))
-                    self.Dispose();
-            }
-
-            foreach (WeakReference<IDisposable> item in OtherInstances.Keys)
-            {
-                if (item.TryGetTarget(out IDisposable? self))
-                    self.Dispose();
-            }
-
-            if (isStdoutVerbose)
-                GD.Print("Unloading: Finished disposing tracked instances.");
+            if (item.TryGetTarget(out GodotObject? self))
+                self.Dispose();
         }
 
-        // ReSharper disable once RedundantNameQualifier
-        private static ConcurrentDictionary<WeakReference<GodotObject>, byte> GodotObjectInstances { get; } =
-            new();
-
-        private static ConcurrentDictionary<WeakReference<IDisposable>, byte> OtherInstances { get; } =
-            new();
-
-        public static WeakReference<GodotObject> RegisterGodotObject(GodotObject godotObject)
+        foreach (WeakReference<IDisposable> item in OtherInstances.Keys)
         {
-            var weakReferenceToSelf = new WeakReference<GodotObject>(godotObject);
-            GodotObjectInstances.TryAdd(weakReferenceToSelf, 0);
-            return weakReferenceToSelf;
+            if (item.TryGetTarget(out IDisposable? self))
+                self.Dispose();
         }
 
-        public static WeakReference<IDisposable> RegisterDisposable(IDisposable disposable)
-        {
-            var weakReferenceToSelf = new WeakReference<IDisposable>(disposable);
-            OtherInstances.TryAdd(weakReferenceToSelf, 0);
-            return weakReferenceToSelf;
-        }
+        if (isStdoutVerbose)
+            GD.Print("Unloading: Finished disposing tracked instances.");
+    }
 
-        public static void UnregisterGodotObject(GodotObject godotObject, WeakReference<GodotObject> weakReferenceToSelf)
-        {
-            if (!GodotObjectInstances.TryRemove(weakReferenceToSelf, out _))
-                throw new ArgumentException("Godot Object not registered.", nameof(weakReferenceToSelf));
-        }
+    // ReSharper disable once RedundantNameQualifier
+    private static ConcurrentDictionary<WeakReference<GodotObject>, byte> GodotObjectInstances { get; } =
+        new();
 
-        public static void UnregisterDisposable(WeakReference<IDisposable> weakReference)
-        {
-            if (!OtherInstances.TryRemove(weakReference, out _))
-                throw new ArgumentException("Disposable not registered.", nameof(weakReference));
-        }
+    private static ConcurrentDictionary<WeakReference<IDisposable>, byte> OtherInstances { get; } =
+        new();
+
+    public static WeakReference<GodotObject> RegisterGodotObject(GodotObject godotObject)
+    {
+        var weakReferenceToSelf = new WeakReference<GodotObject>(godotObject);
+        GodotObjectInstances.TryAdd(weakReferenceToSelf, 0);
+        return weakReferenceToSelf;
+    }
+
+    public static WeakReference<IDisposable> RegisterDisposable(IDisposable disposable)
+    {
+        var weakReferenceToSelf = new WeakReference<IDisposable>(disposable);
+        OtherInstances.TryAdd(weakReferenceToSelf, 0);
+        return weakReferenceToSelf;
+    }
+
+    public static void UnregisterGodotObject(GodotObject godotObject, WeakReference<GodotObject> weakReferenceToSelf)
+    {
+        if (!GodotObjectInstances.TryRemove(weakReferenceToSelf, out _))
+            throw new ArgumentException("Godot Object not registered.", nameof(weakReferenceToSelf));
+    }
+
+    public static void UnregisterDisposable(WeakReference<IDisposable> weakReference)
+    {
+        if (!OtherInstances.TryRemove(weakReference, out _))
+            throw new ArgumentException("Disposable not registered.", nameof(weakReference));
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/GodotObjectExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/GodotObjectExtensions.cs
@@ -1,86 +1,85 @@
 using System;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+public partial class GodotObject
 {
-    public partial class GodotObject
+    /// <summary>
+    /// Returns the <see cref="GodotObject"/> that corresponds to <paramref name="instanceId"/>.
+    /// All Objects have a unique instance ID. See also <see cref="GetInstanceId"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// public partial class MyNode : Node
+    /// {
+    ///     public string Foo { get; set; } = "bar";
+    ///
+    ///     public override void _Ready()
+    ///     {
+    ///         ulong id = GetInstanceId();
+    ///         var inst = (MyNode)InstanceFromId(Id);
+    ///         GD.Print(inst.Foo); // Prints bar
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    /// <param name="instanceId">Instance ID of the Object to retrieve.</param>
+    /// <returns>The <see cref="GodotObject"/> instance.</returns>
+    public static GodotObject InstanceFromId(ulong instanceId)
     {
-        /// <summary>
-        /// Returns the <see cref="GodotObject"/> that corresponds to <paramref name="instanceId"/>.
-        /// All Objects have a unique instance ID. See also <see cref="GetInstanceId"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// public partial class MyNode : Node
-        /// {
-        ///     public string Foo { get; set; } = "bar";
-        ///
-        ///     public override void _Ready()
-        ///     {
-        ///         ulong id = GetInstanceId();
-        ///         var inst = (MyNode)InstanceFromId(Id);
-        ///         GD.Print(inst.Foo); // Prints bar
-        ///     }
-        /// }
-        /// </code>
-        /// </example>
-        /// <param name="instanceId">Instance ID of the Object to retrieve.</param>
-        /// <returns>The <see cref="GodotObject"/> instance.</returns>
-        public static GodotObject InstanceFromId(ulong instanceId)
-        {
-            return InteropUtils.UnmanagedGetManaged(NativeFuncs.godotsharp_instance_from_id(instanceId));
-        }
+        return InteropUtils.UnmanagedGetManaged(NativeFuncs.godotsharp_instance_from_id(instanceId));
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="GodotObject"/> that corresponds
-        /// to <paramref name="id"/> is a valid object (e.g. has not been deleted from
-        /// memory). All Objects have a unique instance ID.
-        /// </summary>
-        /// <param name="id">The Object ID to check.</param>
-        /// <returns>If the instance with the given ID is a valid object.</returns>
-        public static bool IsInstanceIdValid(ulong id)
-        {
-            return IsInstanceValid(InstanceFromId(id));
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="GodotObject"/> that corresponds
+    /// to <paramref name="id"/> is a valid object (e.g. has not been deleted from
+    /// memory). All Objects have a unique instance ID.
+    /// </summary>
+    /// <param name="id">The Object ID to check.</param>
+    /// <returns>If the instance with the given ID is a valid object.</returns>
+    public static bool IsInstanceIdValid(ulong id)
+    {
+        return IsInstanceValid(InstanceFromId(id));
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="instance"/> is a
-        /// valid <see cref="GodotObject"/> (e.g. has not been deleted from memory).
-        /// </summary>
-        /// <param name="instance">The instance to check.</param>
-        /// <returns>If the instance is a valid object.</returns>
-        public static bool IsInstanceValid(GodotObject instance)
-        {
-            return instance != null && instance.NativeInstance != IntPtr.Zero;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="instance"/> is a
+    /// valid <see cref="GodotObject"/> (e.g. has not been deleted from memory).
+    /// </summary>
+    /// <param name="instance">The instance to check.</param>
+    /// <returns>If the instance is a valid object.</returns>
+    public static bool IsInstanceValid(GodotObject instance)
+    {
+        return instance != null && instance.NativeInstance != IntPtr.Zero;
+    }
 
-        /// <summary>
-        /// Returns a weak reference to an object, or <see langword="null"/>
-        /// if the argument is invalid.
-        /// A weak reference to an object is not enough to keep the object alive:
-        /// when the only remaining references to a referent are weak references,
-        /// garbage collection is free to destroy the referent and reuse its memory
-        /// for something else. However, until the object is actually destroyed the
-        /// weak reference may return the object even if there are no strong references
-        /// to it.
-        /// </summary>
-        /// <param name="obj">The object.</param>
-        /// <returns>
-        /// The <see cref="WeakRef"/> reference to the object or <see langword="null"/>.
-        /// </returns>
-        public static WeakRef WeakRef(GodotObject obj)
+    /// <summary>
+    /// Returns a weak reference to an object, or <see langword="null"/>
+    /// if the argument is invalid.
+    /// A weak reference to an object is not enough to keep the object alive:
+    /// when the only remaining references to a referent are weak references,
+    /// garbage collection is free to destroy the referent and reuse its memory
+    /// for something else. However, until the object is actually destroyed the
+    /// weak reference may return the object even if there are no strong references
+    /// to it.
+    /// </summary>
+    /// <param name="obj">The object.</param>
+    /// <returns>
+    /// The <see cref="WeakRef"/> reference to the object or <see langword="null"/>.
+    /// </returns>
+    public static WeakRef WeakRef(GodotObject obj)
+    {
+        if (!IsInstanceValid(obj))
+            return null;
+
+        NativeFuncs.godotsharp_weakref(GetPtr(obj), out godot_ref weakRef);
+        using (weakRef)
         {
-            if (!IsInstanceValid(obj))
+            if (weakRef.IsNull)
                 return null;
 
-            NativeFuncs.godotsharp_weakref(GetPtr(obj), out godot_ref weakRef);
-            using (weakRef)
-            {
-                if (weakRef.IsNull)
-                    return null;
-
-                return (WeakRef)InteropUtils.UnmanagedGetManaged(weakRef.Reference);
-            }
+            return (WeakRef)InteropUtils.UnmanagedGetManaged(weakRef.Reference);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -1,199 +1,198 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+public partial class Node
 {
-    public partial class Node
+    /// <summary>
+    /// Fetches a node. The <see cref="NodePath"/> can be either a relative path (from
+    /// the current node) or an absolute path (in the scene tree) to a node. If the path
+    /// does not exist, a <see langword="null"/> instance is returned and an error
+    /// is logged. Attempts to access methods on the return value will result in an
+    /// "Attempt to call &lt;method&gt; on a null instance." error.
+    /// Note: Fetching absolute paths only works when the node is inside the scene tree
+    /// (see <see cref="IsInsideTree"/>).
+    /// </summary>
+    /// <example>
+    /// Example: Assume your current node is Character and the following tree:
+    /// <code>
+    /// /root
+    /// /root/Character
+    /// /root/Character/Sword
+    /// /root/Character/Backpack/Dagger
+    /// /root/MyGame
+    /// /root/Swamp/Alligator
+    /// /root/Swamp/Mosquito
+    /// /root/Swamp/Goblin
+    /// </code>
+    /// Possible paths are:
+    /// <code>
+    /// GetNode("Sword");
+    /// GetNode("Backpack/Dagger");
+    /// GetNode("../Swamp/Alligator");
+    /// GetNode("/root/MyGame");
+    /// </code>
+    /// </example>
+    /// <seealso cref="GetNodeOrNull{T}(NodePath)"/>
+    /// <param name="path">The path to the node to fetch.</param>
+    /// <exception cref="InvalidCastException">
+    /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The <see cref="Node"/> at the given <paramref name="path"/>.
+    /// </returns>
+    public T GetNode<T>(NodePath path) where T : class
     {
-        /// <summary>
-        /// Fetches a node. The <see cref="NodePath"/> can be either a relative path (from
-        /// the current node) or an absolute path (in the scene tree) to a node. If the path
-        /// does not exist, a <see langword="null"/> instance is returned and an error
-        /// is logged. Attempts to access methods on the return value will result in an
-        /// "Attempt to call &lt;method&gt; on a null instance." error.
-        /// Note: Fetching absolute paths only works when the node is inside the scene tree
-        /// (see <see cref="IsInsideTree"/>).
-        /// </summary>
-        /// <example>
-        /// Example: Assume your current node is Character and the following tree:
-        /// <code>
-        /// /root
-        /// /root/Character
-        /// /root/Character/Sword
-        /// /root/Character/Backpack/Dagger
-        /// /root/MyGame
-        /// /root/Swamp/Alligator
-        /// /root/Swamp/Mosquito
-        /// /root/Swamp/Goblin
-        /// </code>
-        /// Possible paths are:
-        /// <code>
-        /// GetNode("Sword");
-        /// GetNode("Backpack/Dagger");
-        /// GetNode("../Swamp/Alligator");
-        /// GetNode("/root/MyGame");
-        /// </code>
-        /// </example>
-        /// <seealso cref="GetNodeOrNull{T}(NodePath)"/>
-        /// <param name="path">The path to the node to fetch.</param>
-        /// <exception cref="InvalidCastException">
-        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The <see cref="Node"/> at the given <paramref name="path"/>.
-        /// </returns>
-        public T GetNode<T>(NodePath path) where T : class
-        {
-            return (T)(object)GetNode(path);
-        }
+        return (T)(object)GetNode(path);
+    }
 
-        /// <summary>
-        /// Similar to <see cref="GetNode"/>, but does not log an error if <paramref name="path"/>
-        /// does not point to a valid <see cref="Node"/>.
-        /// </summary>
-        /// <example>
-        /// Example: Assume your current node is Character and the following tree:
-        /// <code>
-        /// /root
-        /// /root/Character
-        /// /root/Character/Sword
-        /// /root/Character/Backpack/Dagger
-        /// /root/MyGame
-        /// /root/Swamp/Alligator
-        /// /root/Swamp/Mosquito
-        /// /root/Swamp/Goblin
-        /// </code>
-        /// Possible paths are:
-        /// <code>
-        /// GetNode("Sword");
-        /// GetNode("Backpack/Dagger");
-        /// GetNode("../Swamp/Alligator");
-        /// GetNode("/root/MyGame");
-        /// </code>
-        /// </example>
-        /// <seealso cref="GetNode{T}(NodePath)"/>
-        /// <param name="path">The path to the node to fetch.</param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The <see cref="Node"/> at the given <paramref name="path"/>, or <see langword="null"/> if not found.
-        /// </returns>
-        public T GetNodeOrNull<T>(NodePath path) where T : class
-        {
-            return GetNodeOrNull(path) as T;
-        }
+    /// <summary>
+    /// Similar to <see cref="GetNode"/>, but does not log an error if <paramref name="path"/>
+    /// does not point to a valid <see cref="Node"/>.
+    /// </summary>
+    /// <example>
+    /// Example: Assume your current node is Character and the following tree:
+    /// <code>
+    /// /root
+    /// /root/Character
+    /// /root/Character/Sword
+    /// /root/Character/Backpack/Dagger
+    /// /root/MyGame
+    /// /root/Swamp/Alligator
+    /// /root/Swamp/Mosquito
+    /// /root/Swamp/Goblin
+    /// </code>
+    /// Possible paths are:
+    /// <code>
+    /// GetNode("Sword");
+    /// GetNode("Backpack/Dagger");
+    /// GetNode("../Swamp/Alligator");
+    /// GetNode("/root/MyGame");
+    /// </code>
+    /// </example>
+    /// <seealso cref="GetNode{T}(NodePath)"/>
+    /// <param name="path">The path to the node to fetch.</param>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The <see cref="Node"/> at the given <paramref name="path"/>, or <see langword="null"/> if not found.
+    /// </returns>
+    public T GetNodeOrNull<T>(NodePath path) where T : class
+    {
+        return GetNodeOrNull(path) as T;
+    }
 
-        /// <summary>
-        /// Returns a child node by its index (see <see cref="GetChildCount"/>).
-        /// This method is often used for iterating all children of a node.
-        /// Negative indices access the children from the last one.
-        /// To access a child node via its name, use <see cref="GetNode"/>.
-        /// </summary>
-        /// <seealso cref="GetChildOrNull{T}(int, bool)"/>
-        /// <param name="idx">Child index.</param>
-        /// <param name="includeInternal">
-        /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
-        /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
-        /// </param>
-        /// <exception cref="InvalidCastException">
-        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
-        /// </returns>
-        public T GetChild<T>(int idx, bool includeInternal = false) where T : class
-        {
-            return (T)(object)GetChild(idx, includeInternal);
-        }
+    /// <summary>
+    /// Returns a child node by its index (see <see cref="GetChildCount"/>).
+    /// This method is often used for iterating all children of a node.
+    /// Negative indices access the children from the last one.
+    /// To access a child node via its name, use <see cref="GetNode"/>.
+    /// </summary>
+    /// <seealso cref="GetChildOrNull{T}(int, bool)"/>
+    /// <param name="idx">Child index.</param>
+    /// <param name="includeInternal">
+    /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
+    /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
+    /// </param>
+    /// <exception cref="InvalidCastException">
+    /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The child <see cref="Node"/> at the given index <paramref name="idx"/>.
+    /// </returns>
+    public T GetChild<T>(int idx, bool includeInternal = false) where T : class
+    {
+        return (T)(object)GetChild(idx, includeInternal);
+    }
 
-        /// <summary>
-        /// Returns a child node by its index (see <see cref="GetChildCount"/>).
-        /// This method is often used for iterating all children of a node.
-        /// Negative indices access the children from the last one.
-        /// To access a child node via its name, use <see cref="GetNode"/>.
-        /// </summary>
-        /// <seealso cref="GetChild{T}(int, bool)"/>
-        /// <param name="idx">Child index.</param>
-        /// <param name="includeInternal">
-        /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
-        /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
-        /// </param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The child <see cref="Node"/> at the given index <paramref name="idx"/>, or <see langword="null"/> if not found.
-        /// </returns>
-        public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
-        {
-            int count = GetChildCount(includeInternal);
-            return idx >= -count && idx < count ? GetChild(idx, includeInternal) as T : null;
-        }
+    /// <summary>
+    /// Returns a child node by its index (see <see cref="GetChildCount"/>).
+    /// This method is often used for iterating all children of a node.
+    /// Negative indices access the children from the last one.
+    /// To access a child node via its name, use <see cref="GetNode"/>.
+    /// </summary>
+    /// <seealso cref="GetChild{T}(int, bool)"/>
+    /// <param name="idx">Child index.</param>
+    /// <param name="includeInternal">
+    /// If <see langword="false"/>, internal children are skipped (see <c>internal</c>
+    /// parameter in <see cref="AddChild(Node, bool, InternalMode)"/>).
+    /// </param>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The child <see cref="Node"/> at the given index <paramref name="idx"/>, or <see langword="null"/> if not found.
+    /// </returns>
+    public T GetChildOrNull<T>(int idx, bool includeInternal = false) where T : class
+    {
+        int count = GetChildCount(includeInternal);
+        return idx >= -count && idx < count ? GetChild(idx, includeInternal) as T : null;
+    }
 
-        /// <summary>
-        /// The node owner. A node can have any other node as owner (as long as it is
-        /// a valid parent, grandparent, etc. ascending in the tree). When saving a
-        /// node (using <see cref="PackedScene"/>), all the nodes it owns will be saved
-        /// with it. This allows for the creation of complex <see cref="SceneTree"/>s,
-        /// with instancing and subinstancing.
-        /// </summary>
-        /// <seealso cref="GetOwnerOrNull{T}"/>
-        /// <exception cref="InvalidCastException">
-        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The owner <see cref="Node"/>.
-        /// </returns>
-        public T GetOwner<T>() where T : class
-        {
-            return (T)(object)Owner;
-        }
+    /// <summary>
+    /// The node owner. A node can have any other node as owner (as long as it is
+    /// a valid parent, grandparent, etc. ascending in the tree). When saving a
+    /// node (using <see cref="PackedScene"/>), all the nodes it owns will be saved
+    /// with it. This allows for the creation of complex <see cref="SceneTree"/>s,
+    /// with instancing and subinstancing.
+    /// </summary>
+    /// <seealso cref="GetOwnerOrNull{T}"/>
+    /// <exception cref="InvalidCastException">
+    /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The owner <see cref="Node"/>.
+    /// </returns>
+    public T GetOwner<T>() where T : class
+    {
+        return (T)(object)Owner;
+    }
 
-        /// <summary>
-        /// The node owner. A node can have any other node as owner (as long as it is
-        /// a valid parent, grandparent, etc. ascending in the tree). When saving a
-        /// node (using <see cref="PackedScene"/>), all the nodes it owns will be saved
-        /// with it. This allows for the creation of complex <see cref="SceneTree"/>s,
-        /// with instancing and subinstancing.
-        /// </summary>
-        /// <seealso cref="GetOwner{T}"/>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The owner <see cref="Node"/>, or <see langword="null"/> if there is no owner.
-        /// </returns>
-        public T GetOwnerOrNull<T>() where T : class
-        {
-            return Owner as T;
-        }
+    /// <summary>
+    /// The node owner. A node can have any other node as owner (as long as it is
+    /// a valid parent, grandparent, etc. ascending in the tree). When saving a
+    /// node (using <see cref="PackedScene"/>), all the nodes it owns will be saved
+    /// with it. This allows for the creation of complex <see cref="SceneTree"/>s,
+    /// with instancing and subinstancing.
+    /// </summary>
+    /// <seealso cref="GetOwner{T}"/>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The owner <see cref="Node"/>, or <see langword="null"/> if there is no owner.
+    /// </returns>
+    public T GetOwnerOrNull<T>() where T : class
+    {
+        return Owner as T;
+    }
 
-        /// <summary>
-        /// Returns the parent node of the current node, or a <see langword="null"/> instance
-        /// if the node lacks a parent.
-        /// </summary>
-        /// <seealso cref="GetParentOrNull{T}"/>
-        /// <exception cref="InvalidCastException">
-        /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The parent <see cref="Node"/>.
-        /// </returns>
-        public T GetParent<T>() where T : class
-        {
-            return (T)(object)GetParent();
-        }
+    /// <summary>
+    /// Returns the parent node of the current node, or a <see langword="null"/> instance
+    /// if the node lacks a parent.
+    /// </summary>
+    /// <seealso cref="GetParentOrNull{T}"/>
+    /// <exception cref="InvalidCastException">
+    /// The fetched node can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The parent <see cref="Node"/>.
+    /// </returns>
+    public T GetParent<T>() where T : class
+    {
+        return (T)(object)GetParent();
+    }
 
-        /// <summary>
-        /// Returns the parent node of the current node, or a <see langword="null"/> instance
-        /// if the node lacks a parent.
-        /// </summary>
-        /// <seealso cref="GetParent{T}"/>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>
-        /// The parent <see cref="Node"/>, or <see langword="null"/> if the node has no parent.
-        /// </returns>
-        public T GetParentOrNull<T>() where T : class
-        {
-            return GetParent() as T;
-        }
+    /// <summary>
+    /// Returns the parent node of the current node, or a <see langword="null"/> instance
+    /// if the node lacks a parent.
+    /// </summary>
+    /// <seealso cref="GetParent{T}"/>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>
+    /// The parent <see cref="Node"/>, or <see langword="null"/> if the node has no parent.
+    /// </returns>
+    public T GetParentOrNull<T>() where T : class
+    {
+        return GetParent() as T;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/PackedSceneExtensions.cs
@@ -1,36 +1,35 @@
 using System;
 
-namespace Godot
-{
-    public partial class PackedScene
-    {
-        /// <summary>
-        /// Instantiates the scene's node hierarchy, erroring on failure.
-        /// Triggers child scene instantiation(s). Triggers a
-        /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
-        /// </summary>
-        /// <seealso cref="InstantiateOrNull{T}(GenEditState)"/>
-        /// <exception cref="InvalidCastException">
-        /// The instantiated node can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>The instantiated scene.</returns>
-        public T Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
-        {
-            return (T)(object)Instantiate(editState);
-        }
+namespace Godot;
 
-        /// <summary>
-        /// Instantiates the scene's node hierarchy, returning <see langword="null"/> on failure.
-        /// Triggers child scene instantiation(s). Triggers a
-        /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
-        /// </summary>
-        /// <seealso cref="Instantiate{T}(GenEditState)"/>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
-        /// <returns>The instantiated scene.</returns>
-        public T InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
-        {
-            return Instantiate(editState) as T;
-        }
+public partial class PackedScene
+{
+    /// <summary>
+    /// Instantiates the scene's node hierarchy, erroring on failure.
+    /// Triggers child scene instantiation(s). Triggers a
+    /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
+    /// </summary>
+    /// <seealso cref="InstantiateOrNull{T}(GenEditState)"/>
+    /// <exception cref="InvalidCastException">
+    /// The instantiated node can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>The instantiated scene.</returns>
+    public T Instantiate<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+    {
+        return (T)(object)Instantiate(editState);
+    }
+
+    /// <summary>
+    /// Instantiates the scene's node hierarchy, returning <see langword="null"/> on failure.
+    /// Triggers child scene instantiation(s). Triggers a
+    /// <see cref="Node.NotificationSceneInstantiated"/> notification on the root node.
+    /// </summary>
+    /// <seealso cref="Instantiate{T}(GenEditState)"/>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Node"/>.</typeparam>
+    /// <returns>The instantiated scene.</returns>
+    public T InstantiateOrNull<T>(PackedScene.GenEditState editState = (PackedScene.GenEditState)0) where T : class
+    {
+        return Instantiate(editState) as T;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -1,30 +1,29 @@
 using System;
 
-namespace Godot
+namespace Godot;
+
+public static partial class ResourceLoader
 {
-    public static partial class ResourceLoader
+    /// <summary>
+    /// Loads a resource at the given <paramref name="path"/>, caching the result
+    /// for further access.
+    /// The registered <see cref="ResourceFormatLoader"/> instances are queried sequentially
+    /// to find the first one which can handle the file's extension, and then attempt
+    /// loading. If loading fails, the remaining ResourceFormatLoaders are also attempted.
+    /// An optional <paramref name="typeHint"/> can be used to further specify the
+    /// <see cref="Resource"/> type that should be handled by the <see cref="ResourceFormatLoader"/>.
+    /// Anything that inherits from <see cref="Resource"/> can be used as a type hint,
+    /// for example <see cref="Image"/>.
+    /// The <paramref name="cacheMode"/> property defines whether and how the cache should
+    /// be used or updated when loading the resource. See <see cref="CacheMode"/> for details.
+    /// Returns an empty resource if no <see cref="ResourceFormatLoader"/> could handle the file.
+    /// </summary>
+    /// <exception cref="InvalidCastException">
+    /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
+    /// </exception>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
+    public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
     {
-        /// <summary>
-        /// Loads a resource at the given <paramref name="path"/>, caching the result
-        /// for further access.
-        /// The registered <see cref="ResourceFormatLoader"/> instances are queried sequentially
-        /// to find the first one which can handle the file's extension, and then attempt
-        /// loading. If loading fails, the remaining ResourceFormatLoaders are also attempted.
-        /// An optional <paramref name="typeHint"/> can be used to further specify the
-        /// <see cref="Resource"/> type that should be handled by the <see cref="ResourceFormatLoader"/>.
-        /// Anything that inherits from <see cref="Resource"/> can be used as a type hint,
-        /// for example <see cref="Image"/>.
-        /// The <paramref name="cacheMode"/> property defines whether and how the cache should
-        /// be used or updated when loading the resource. See <see cref="CacheMode"/> for details.
-        /// Returns an empty resource if no <see cref="ResourceFormatLoader"/> could handle the file.
-        /// </summary>
-        /// <exception cref="InvalidCastException">
-        /// The loaded resource can't be casted to the given type <typeparamref name="T"/>.
-        /// </exception>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
-        {
-            return (T)(object)Load(path, typeHint, cacheMode);
-        }
+        return (T)(object)Load(path, typeHint, cacheMode);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -3,670 +3,669 @@ using System.Collections.Generic;
 using System.Text;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Godot's global functions.
+/// </summary>
+public static partial class GD
 {
     /// <summary>
-    /// Godot's global functions.
+    /// Decodes a byte array back to a <see cref="Variant"/> value, without decoding objects.
+    /// Note: If you need object deserialization, see <see cref="BytesToVarWithObjects"/>.
     /// </summary>
-    public static partial class GD
+    /// <param name="bytes">Byte array that will be decoded to a <see cref="Variant"/>.</param>
+    /// <returns>The decoded <see cref="Variant"/>.</returns>
+    public static Variant BytesToVar(Span<byte> bytes)
     {
-        /// <summary>
-        /// Decodes a byte array back to a <see cref="Variant"/> value, without decoding objects.
-        /// Note: If you need object deserialization, see <see cref="BytesToVarWithObjects"/>.
-        /// </summary>
-        /// <param name="bytes">Byte array that will be decoded to a <see cref="Variant"/>.</param>
-        /// <returns>The decoded <see cref="Variant"/>.</returns>
-        public static Variant BytesToVar(Span<byte> bytes)
+        using var varBytes = Marshaling.ConvertSystemArrayToNativePackedByteArray(bytes);
+        NativeFuncs.godotsharp_bytes_to_var(varBytes, godot_bool.False, out godot_variant ret);
+        return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+    }
+
+    /// <summary>
+    /// Decodes a byte array back to a <see cref="Variant"/> value. Decoding objects is allowed.
+    /// Warning: Deserialized object can contain code which gets executed. Do not use this
+    /// option if the serialized object comes from untrusted sources to avoid potential security
+    /// threats (remote code execution).
+    /// </summary>
+    /// <param name="bytes">Byte array that will be decoded to a <see cref="Variant"/>.</param>
+    /// <returns>The decoded <see cref="Variant"/>.</returns>
+    public static Variant BytesToVarWithObjects(Span<byte> bytes)
+    {
+        using var varBytes = Marshaling.ConvertSystemArrayToNativePackedByteArray(bytes);
+        NativeFuncs.godotsharp_bytes_to_var(varBytes, godot_bool.True, out godot_variant ret);
+        return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+    }
+
+    /// <summary>
+    /// Converts <paramref name="what"/> to <paramref name="type"/> in the best way possible.
+    /// The <paramref name="type"/> parameter uses the <see cref="Variant.Type"/> values.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// Variant a = new Godot.Collections.Array { 4, 2.5, 1.2 };
+    /// GD.Print(a.VariantType == Variant.Type.Array); // Prints true
+    ///
+    /// var b = GD.Convert(a, Variant.Type.PackedByteArray);
+    /// GD.Print(b); // Prints [4, 2, 1]
+    /// GD.Print(b.VariantType == Variant.Type.Array); // Prints false
+    /// </code>
+    /// </example>
+    /// <returns>The <c>Variant</c> converted to the given <paramref name="type"/>.</returns>
+    public static Variant Convert(Variant what, Variant.Type type)
+    {
+        NativeFuncs.godotsharp_convert((godot_variant)what.NativeVar, (int)type, out godot_variant ret);
+        return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+    }
+
+    /// <summary>
+    /// Returns the integer hash of the passed <paramref name="var"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(GD.Hash("a")); // Prints 177670
+    /// </code>
+    /// </example>
+    /// <param name="var">Variable that will be hashed.</param>
+    /// <returns>Hash of the variable passed.</returns>
+    public static int Hash(Variant var)
+    {
+        return NativeFuncs.godotsharp_hash((godot_variant)var.NativeVar);
+    }
+
+    /// <summary>
+    /// Loads a resource from the filesystem located at <paramref name="path"/>.
+    /// The resource is loaded on the method call (unless it's referenced already
+    /// elsewhere, e.g. in another script or in the scene), which might cause slight delay,
+    /// especially when loading scenes. To avoid unnecessary delays when loading something
+    /// multiple times, either store the resource in a variable.
+    ///
+    /// Note: Resource paths can be obtained by right-clicking on a resource in the FileSystem
+    /// dock and choosing "Copy Path" or by dragging the file from the FileSystem dock into the script.
+    ///
+    /// Important: The path must be absolute, a local path will just return <see langword="null"/>.
+    /// This method is a simplified version of <see cref="ResourceLoader.Load"/>, which can be used
+    /// for more advanced scenarios.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Load a scene called main located in the root of the project directory and cache it in a variable.
+    /// var main = GD.Load("res://main.tscn"); // main will contain a PackedScene resource.
+    /// </code>
+    /// </example>
+    /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
+    /// <returns>The loaded <see cref="Resource"/>.</returns>
+    public static Resource Load(string path)
+    {
+        return ResourceLoader.Load(path);
+    }
+
+    /// <summary>
+    /// Loads a resource from the filesystem located at <paramref name="path"/>.
+    /// The resource is loaded on the method call (unless it's referenced already
+    /// elsewhere, e.g. in another script or in the scene), which might cause slight delay,
+    /// especially when loading scenes. To avoid unnecessary delays when loading something
+    /// multiple times, either store the resource in a variable.
+    ///
+    /// Note: Resource paths can be obtained by right-clicking on a resource in the FileSystem
+    /// dock and choosing "Copy Path" or by dragging the file from the FileSystem dock into the script.
+    ///
+    /// Important: The path must be absolute, a local path will just return <see langword="null"/>.
+    /// This method is a simplified version of <see cref="ResourceLoader.Load"/>, which can be used
+    /// for more advanced scenarios.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Load a scene called main located in the root of the project directory and cache it in a variable.
+    /// var main = GD.Load&lt;PackedScene&gt;("res://main.tscn"); // main will contain a PackedScene resource.
+    /// </code>
+    /// </example>
+    /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
+    /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
+    public static T Load<T>(string path) where T : class
+    {
+        return ResourceLoader.Load<T>(path);
+    }
+
+    private static string AppendPrintParams(object[] parameters)
+    {
+        if (parameters == null)
         {
-            using var varBytes = Marshaling.ConvertSystemArrayToNativePackedByteArray(bytes);
-            NativeFuncs.godotsharp_bytes_to_var(varBytes, godot_bool.False, out godot_variant ret);
-            return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+            return "null";
         }
 
-        /// <summary>
-        /// Decodes a byte array back to a <see cref="Variant"/> value. Decoding objects is allowed.
-        /// Warning: Deserialized object can contain code which gets executed. Do not use this
-        /// option if the serialized object comes from untrusted sources to avoid potential security
-        /// threats (remote code execution).
-        /// </summary>
-        /// <param name="bytes">Byte array that will be decoded to a <see cref="Variant"/>.</param>
-        /// <returns>The decoded <see cref="Variant"/>.</returns>
-        public static Variant BytesToVarWithObjects(Span<byte> bytes)
+        var sb = new StringBuilder();
+        for (int i = 0; i < parameters.Length; i++)
         {
-            using var varBytes = Marshaling.ConvertSystemArrayToNativePackedByteArray(bytes);
-            NativeFuncs.godotsharp_bytes_to_var(varBytes, godot_bool.True, out godot_variant ret);
-            return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+            sb.Append(parameters[i]?.ToString() ?? "null");
+        }
+        return sb.ToString();
+    }
+
+    private static string AppendPrintParams(char separator, object[] parameters)
+    {
+        if (parameters == null)
+        {
+            return "null";
         }
 
-        /// <summary>
-        /// Converts <paramref name="what"/> to <paramref name="type"/> in the best way possible.
-        /// The <paramref name="type"/> parameter uses the <see cref="Variant.Type"/> values.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// Variant a = new Godot.Collections.Array { 4, 2.5, 1.2 };
-        /// GD.Print(a.VariantType == Variant.Type.Array); // Prints true
-        ///
-        /// var b = GD.Convert(a, Variant.Type.PackedByteArray);
-        /// GD.Print(b); // Prints [4, 2, 1]
-        /// GD.Print(b.VariantType == Variant.Type.Array); // Prints false
-        /// </code>
-        /// </example>
-        /// <returns>The <c>Variant</c> converted to the given <paramref name="type"/>.</returns>
-        public static Variant Convert(Variant what, Variant.Type type)
+        var sb = new StringBuilder();
+        for (int i = 0; i < parameters.Length; i++)
         {
-            NativeFuncs.godotsharp_convert((godot_variant)what.NativeVar, (int)type, out godot_variant ret);
-            return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+            if (i != 0)
+                sb.Append(separator);
+            sb.Append(parameters[i]?.ToString() ?? "null");
         }
+        return sb.ToString();
+    }
 
-        /// <summary>
-        /// Returns the integer hash of the passed <paramref name="var"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(GD.Hash("a")); // Prints 177670
-        /// </code>
-        /// </example>
-        /// <param name="var">Variable that will be hashed.</param>
-        /// <returns>Hash of the variable passed.</returns>
-        public static int Hash(Variant var)
+    /// <summary>
+    /// Prints a message to the console.
+    ///
+    /// Note: Consider using <see cref="PushError(string)"/> and <see cref="PushWarning(string)"/>
+    /// to print error and warning messages instead of <see cref="Print(string)"/>.
+    /// This distinguishes them from print messages used for debugging purposes,
+    /// while also displaying a stack trace when an error or warning is printed.
+    /// </summary>
+    /// <param name="what">Message that will be printed.</param>
+    public static void Print(string what)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(what);
+        NativeFuncs.godotsharp_print(godotStr);
+    }
+
+    /// <summary>
+    /// Converts one or more arguments of any type to string in the best way possible
+    /// and prints them to the console.
+    ///
+    /// Note: Consider using <see cref="PushError(object[])"/> and <see cref="PushWarning(object[])"/>
+    /// to print error and warning messages instead of <see cref="Print(object[])"/>.
+    /// This distinguishes them from print messages used for debugging purposes,
+    /// while also displaying a stack trace when an error or warning is printed.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var a = new Godot.Collections.Array { 1, 2, 3 };
+    /// GD.Print("a", "b", a); // Prints ab[1, 2, 3]
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void Print(params object[] what)
+    {
+        Print(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Prints a message to the console.
+    /// The following BBCode tags are supported: b, i, u, s, indent, code, url, center,
+    /// right, color, bgcolor, fgcolor.
+    /// Color tags only support named colors such as <c>red</c>, not hexadecimal color codes.
+    /// Unsupported tags will be left as-is in standard output.
+    /// When printing to standard output, the supported subset of BBCode is converted to
+    /// ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes
+    /// is currently only supported on Linux and macOS. Support for ANSI escape codes may vary
+    /// across terminal emulators, especially for italic and strikethrough.
+    ///
+    /// Note: Consider using <see cref="PushError(string)"/> and <see cref="PushWarning(string)"/>
+    /// to print error and warning messages instead of <see cref="Print(string)"/> or
+    /// <see cref="PrintRich(string)"/>.
+    /// This distinguishes them from print messages used for debugging purposes,
+    /// while also displaying a stack trace when an error or warning is printed.
+    /// </summary>
+    /// <param name="what">Message that will be printed.</param>
+    public static void PrintRich(string what)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(what);
+        NativeFuncs.godotsharp_print_rich(godotStr);
+    }
+
+    /// <summary>
+    /// Converts one or more arguments of any type to string in the best way possible
+    /// and prints them to the console.
+    /// The following BBCode tags are supported: b, i, u, s, indent, code, url, center,
+    /// right, color, bgcolor, fgcolor.
+    /// Color tags only support named colors such as <c>red</c>, not hexadecimal color codes.
+    /// Unsupported tags will be left as-is in standard output.
+    /// When printing to standard output, the supported subset of BBCode is converted to
+    /// ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes
+    /// is currently only supported on Linux and macOS. Support for ANSI escape codes may vary
+    /// across terminal emulators, especially for italic and strikethrough.
+    ///
+    /// Note: Consider using <see cref="PushError(object[])"/> and <see cref="PushWarning(object[])"/>
+    /// to print error and warning messages instead of <see cref="Print(object[])"/> or
+    /// <see cref="PrintRich(object[])"/>.
+    /// This distinguishes them from print messages used for debugging purposes,
+    /// while also displaying a stack trace when an error or warning is printed.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PrintRich("[code][b]Hello world![/b][/code]"); // Prints out: [b]Hello world![/b]
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void PrintRich(params object[] what)
+    {
+        PrintRich(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Prints a message to standard error line.
+    /// </summary>
+    /// <param name="what">Message that will be printed.</param>
+    public static void PrintErr(string what)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(what);
+        NativeFuncs.godotsharp_printerr(godotStr);
+    }
+
+    /// <summary>
+    /// Prints one or more arguments to strings in the best way possible to standard error line.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PrintErr("prints to stderr");
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void PrintErr(params object[] what)
+    {
+        PrintErr(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Prints a message to the OS terminal.
+    /// Unlike <see cref="Print(string)"/>, no newline is added at the end.
+    /// </summary>
+    /// <param name="what">Message that will be printed.</param>
+    public static void PrintRaw(string what)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(what);
+        NativeFuncs.godotsharp_printraw(godotStr);
+    }
+
+    /// <summary>
+    /// Prints one or more arguments to strings in the best way possible to the OS terminal.
+    /// Unlike <see cref="Print(object[])"/>, no newline is added at the end.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PrintRaw("A");
+    /// GD.PrintRaw("B");
+    /// GD.PrintRaw("C");
+    /// // Prints ABC to terminal
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void PrintRaw(params object[] what)
+    {
+        PrintRaw(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Prints one or more arguments to the console with a space between each argument.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PrintS("A", "B", "C"); // Prints A B C
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void PrintS(params object[] what)
+    {
+        string message = AppendPrintParams(' ', what);
+        using var godotStr = Marshaling.ConvertStringToNative(message);
+        NativeFuncs.godotsharp_prints(godotStr);
+    }
+
+    /// <summary>
+    /// Prints one or more arguments to the console with a tab between each argument.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PrintT("A", "B", "C"); // Prints A       B       C
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that will be printed.</param>
+    public static void PrintT(params object[] what)
+    {
+        string message = AppendPrintParams('\t', what);
+        using var godotStr = Marshaling.ConvertStringToNative(message);
+        NativeFuncs.godotsharp_printt(godotStr);
+    }
+
+    /// <summary>
+    /// Pushes an error message to Godot's built-in debugger and to the OS terminal.
+    ///
+    /// Note: Errors printed this way will not pause project execution.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PushError("test error"); // Prints "test error" to debugger and terminal as error call
+    /// </code>
+    /// </example>
+    /// <param name="message">Error message.</param>
+    public static void PushError(string message)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(message);
+        NativeFuncs.godotsharp_pusherror(godotStr);
+    }
+
+    /// <summary>
+    /// Pushes an error message to Godot's built-in debugger and to the OS terminal.
+    ///
+    /// Note: Errors printed this way will not pause project execution.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PushError("test_error"); // Prints "test error" to debugger and terminal as error call
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that form the error message.</param>
+    public static void PushError(params object[] what)
+    {
+        PushError(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as warning call
+    /// </code>
+    /// </example>
+    /// <param name="message">Warning message.</param>
+    public static void PushWarning(string message)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(message);
+        NativeFuncs.godotsharp_pushwarning(godotStr);
+    }
+
+    /// <summary>
+    /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as warning call
+    /// </code>
+    /// </example>
+    /// <param name="what">Arguments that form the warning message.</param>
+    public static void PushWarning(params object[] what)
+    {
+        PushWarning(AppendPrintParams(what));
+    }
+
+    /// <summary>
+    /// Returns a random floating point value between <c>0.0</c> and <c>1.0</c> (inclusive).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Randf(); // Returns e.g. 0.375671
+    /// </code>
+    /// </example>
+    /// <returns>A random <see langword="float"/> number.</returns>
+    public static float Randf()
+    {
+        return NativeFuncs.godotsharp_randf();
+    }
+
+    /// <summary>
+    /// Returns a normally-distributed pseudo-random floating point value
+    /// using Box-Muller transform with the specified <pararmref name="mean"/>
+    /// and a standard <paramref name="deviation"/>.
+    /// This is also called Gaussian distribution.
+    /// </summary>
+    /// <returns>A random normally-distributed <see langword="float"/> number.</returns>
+    public static double Randfn(double mean, double deviation)
+    {
+        return NativeFuncs.godotsharp_randfn(mean, deviation);
+    }
+
+    /// <summary>
+    /// Returns a random unsigned 32-bit integer.
+    /// Use remainder to obtain a random value in the interval <c>[0, N - 1]</c>
+    /// (where N is smaller than 2^32).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Randi();           // Returns random integer between 0 and 2^32 - 1
+    /// GD.Randi() % 20;      // Returns random integer between 0 and 19
+    /// GD.Randi() % 100;     // Returns random integer between 0 and 99
+    /// GD.Randi() % 100 + 1; // Returns random integer between 1 and 100
+    /// </code>
+    /// </example>
+    /// <returns>A random <see langword="uint"/> number.</returns>
+    public static uint Randi()
+    {
+        return NativeFuncs.godotsharp_randi();
+    }
+
+    /// <summary>
+    /// Randomizes the seed (or the internal state) of the random number generator.
+    /// The current implementation uses a number based on the device's time.
+    ///
+    /// Note: This method is called automatically when the project is run.
+    /// If you need to fix the seed to have consistent, reproducible results,
+    /// use <see cref="Seed(ulong)"/> to initialize the random number generator.
+    /// </summary>
+    public static void Randomize()
+    {
+        NativeFuncs.godotsharp_randomize();
+    }
+
+    /// <summary>
+    /// Returns a random floating point value between <paramref name="from"/>
+    /// and <paramref name="to"/> (inclusive).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.RandRange(0.0, 20.5);   // Returns e.g. 7.45315
+    /// GD.RandRange(-10.0, 10.0); // Returns e.g. -3.844535
+    /// </code>
+    /// </example>
+    /// <returns>A random <see langword="double"/> number inside the given range.</returns>
+    public static double RandRange(double from, double to)
+    {
+        return NativeFuncs.godotsharp_randf_range(from, to);
+    }
+
+    /// <summary>
+    /// Returns a random signed 32-bit integer between <paramref name="from"/>
+    /// and <paramref name="to"/> (inclusive). If <paramref name="to"/> is lesser than
+    /// <paramref name="from"/>, they are swapped.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.RandRange(0, 1);      // Returns either 0 or 1
+    /// GD.RandRange(-10, 1000); // Returns random integer between -10 and 1000
+    /// </code>
+    /// </example>
+    /// <returns>A random <see langword="int"/> number inside the given range.</returns>
+    public static int RandRange(int from, int to)
+    {
+        return NativeFuncs.godotsharp_randi_range(from, to);
+    }
+
+    /// <summary>
+    /// Given a <paramref name="seed"/>, returns a randomized <see langword="uint"/>
+    /// value. The <paramref name="seed"/> may be modified.
+    /// Passing the same <paramref name="seed"/> consistently returns the same value.
+    ///
+    /// Note: "Seed" here refers to the internal state of the pseudo random number
+    /// generator, currently implemented as a 64 bit integer.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var a = GD.RandFromSeed(4);
+    /// </code>
+    /// </example>
+    /// <param name="seed">
+    /// Seed to use to generate the random number.
+    /// If a different seed is used, its value will be modified.
+    /// </param>
+    /// <returns>A random <see langword="uint"/> number.</returns>
+    public static uint RandFromSeed(ref ulong seed)
+    {
+        return NativeFuncs.godotsharp_rand_from_seed(seed, out seed);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="IEnumerable{T}"/> that iterates from
+    /// <c>0</c> (inclusive) to <paramref name="end"/> (exclusive)
+    /// in steps of <c>1</c>.
+    /// </summary>
+    /// <param name="end">The last index.</param>
+    public static IEnumerable<int> Range(int end)
+    {
+        return Range(0, end, 1);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="IEnumerable{T}"/> that iterates from
+    /// <paramref name="start"/> (inclusive) to <paramref name="end"/> (exclusive)
+    /// in steps of <c>1</c>.
+    /// </summary>
+    /// <param name="start">The first index.</param>
+    /// <param name="end">The last index.</param>
+    public static IEnumerable<int> Range(int start, int end)
+    {
+        return Range(start, end, 1);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="IEnumerable{T}"/> that iterates from
+    /// <paramref name="start"/> (inclusive) to <paramref name="end"/> (exclusive)
+    /// in steps of <paramref name="step"/>.
+    /// The argument <paramref name="step"/> can be negative, but not <c>0</c>.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="step"/> is 0.
+    /// </exception>
+    /// <param name="start">The first index.</param>
+    /// <param name="end">The last index.</param>
+    /// <param name="step">The amount by which to increment the index on each iteration.</param>
+    public static IEnumerable<int> Range(int start, int end, int step)
+    {
+        if (step == 0)
+            throw new ArgumentException("step cannot be 0.", nameof(step));
+
+        if (end < start && step > 0)
+            yield break;
+
+        if (end > start && step < 0)
+            yield break;
+
+        if (step > 0)
         {
-            return NativeFuncs.godotsharp_hash((godot_variant)var.NativeVar);
+            for (int i = start; i < end; i += step)
+                yield return i;
         }
-
-        /// <summary>
-        /// Loads a resource from the filesystem located at <paramref name="path"/>.
-        /// The resource is loaded on the method call (unless it's referenced already
-        /// elsewhere, e.g. in another script or in the scene), which might cause slight delay,
-        /// especially when loading scenes. To avoid unnecessary delays when loading something
-        /// multiple times, either store the resource in a variable.
-        ///
-        /// Note: Resource paths can be obtained by right-clicking on a resource in the FileSystem
-        /// dock and choosing "Copy Path" or by dragging the file from the FileSystem dock into the script.
-        ///
-        /// Important: The path must be absolute, a local path will just return <see langword="null"/>.
-        /// This method is a simplified version of <see cref="ResourceLoader.Load"/>, which can be used
-        /// for more advanced scenarios.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// // Load a scene called main located in the root of the project directory and cache it in a variable.
-        /// var main = GD.Load("res://main.tscn"); // main will contain a PackedScene resource.
-        /// </code>
-        /// </example>
-        /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
-        /// <returns>The loaded <see cref="Resource"/>.</returns>
-        public static Resource Load(string path)
+        else
         {
-            return ResourceLoader.Load(path);
+            for (int i = start; i > end; i += step)
+                yield return i;
         }
+    }
 
-        /// <summary>
-        /// Loads a resource from the filesystem located at <paramref name="path"/>.
-        /// The resource is loaded on the method call (unless it's referenced already
-        /// elsewhere, e.g. in another script or in the scene), which might cause slight delay,
-        /// especially when loading scenes. To avoid unnecessary delays when loading something
-        /// multiple times, either store the resource in a variable.
-        ///
-        /// Note: Resource paths can be obtained by right-clicking on a resource in the FileSystem
-        /// dock and choosing "Copy Path" or by dragging the file from the FileSystem dock into the script.
-        ///
-        /// Important: The path must be absolute, a local path will just return <see langword="null"/>.
-        /// This method is a simplified version of <see cref="ResourceLoader.Load"/>, which can be used
-        /// for more advanced scenarios.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// // Load a scene called main located in the root of the project directory and cache it in a variable.
-        /// var main = GD.Load&lt;PackedScene&gt;("res://main.tscn"); // main will contain a PackedScene resource.
-        /// </code>
-        /// </example>
-        /// <param name="path">Path of the <see cref="Resource"/> to load.</param>
-        /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path) where T : class
-        {
-            return ResourceLoader.Load<T>(path);
-        }
+    /// <summary>
+    /// Sets seed for the random number generator to <paramref name="seed"/>.
+    /// Setting the seed manually can ensure consistent, repeatable results for
+    /// most random functions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// ulong mySeed = (ulong)GD.Hash("Godot Rocks");
+    /// GD.Seed(mySeed);
+    /// var a = GD.Randf() + GD.Randi();
+    /// GD.Seed(mySeed);
+    /// var b = GD.Randf() + GD.Randi();
+    /// // a and b are now identical
+    /// </code>
+    /// </example>
+    /// <param name="seed">Seed that will be used.</param>
+    public static void Seed(ulong seed)
+    {
+        NativeFuncs.godotsharp_seed(seed);
+    }
 
-        private static string AppendPrintParams(object[] parameters)
-        {
-            if (parameters == null)
-            {
-                return "null";
-            }
+    /// <summary>
+    /// Converts a formatted string that was returned by <see cref="VarToStr(Variant)"/>
+    /// to the original value.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string a = "{ \"a\": 1, \"b\": 2 }";        // a is a string
+    /// var b = GD.StrToVar(a).AsGodotDictionary(); // b is a Dictionary
+    /// GD.Print(b["a"]);                           // Prints 1
+    /// </code>
+    /// </example>
+    /// <param name="str">String that will be converted to Variant.</param>
+    /// <returns>The decoded <c>Variant</c>.</returns>
+    public static Variant StrToVar(string str)
+    {
+        using var godotStr = Marshaling.ConvertStringToNative(str);
+        NativeFuncs.godotsharp_str_to_var(godotStr, out godot_variant ret);
+        return Variant.CreateTakingOwnershipOfDisposableValue(ret);
+    }
 
-            var sb = new StringBuilder();
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                sb.Append(parameters[i]?.ToString() ?? "null");
-            }
-            return sb.ToString();
-        }
+    /// <summary>
+    /// Encodes a <see cref="Variant"/> value to a byte array, without encoding objects.
+    /// Deserialization can be done with <see cref="BytesToVar"/>.
+    /// Note: If you need object serialization, see <see cref="VarToBytesWithObjects"/>.
+    /// </summary>
+    /// <param name="var"><see cref="Variant"/> that will be encoded.</param>
+    /// <returns>The <see cref="Variant"/> encoded as an array of bytes.</returns>
+    public static byte[] VarToBytes(Variant var)
+    {
+        NativeFuncs.godotsharp_var_to_bytes((godot_variant)var.NativeVar, godot_bool.False, out var varBytes);
+        using (varBytes)
+            return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
+    }
 
-        private static string AppendPrintParams(char separator, object[] parameters)
-        {
-            if (parameters == null)
-            {
-                return "null";
-            }
+    /// <summary>
+    /// Encodes a <see cref="Variant"/>. Encoding objects is allowed (and can potentially
+    /// include executable code). Deserialization can be done with <see cref="BytesToVarWithObjects"/>.
+    /// </summary>
+    /// <param name="var"><see cref="Variant"/> that will be encoded.</param>
+    /// <returns>The <see cref="Variant"/> encoded as an array of bytes.</returns>
+    public static byte[] VarToBytesWithObjects(Variant var)
+    {
+        NativeFuncs.godotsharp_var_to_bytes((godot_variant)var.NativeVar, godot_bool.True, out var varBytes);
+        using (varBytes)
+            return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
+    }
 
-            var sb = new StringBuilder();
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                if (i != 0)
-                    sb.Append(separator);
-                sb.Append(parameters[i]?.ToString() ?? "null");
-            }
-            return sb.ToString();
-        }
+    /// <summary>
+    /// Converts a <see cref="Variant"/> <paramref name="var"/> to a formatted string that
+    /// can later be parsed using <see cref="StrToVar(string)"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var a = new Godot.Collections.Dictionary { ["a"] = 1, ["b"] = 2 };
+    /// GD.Print(GD.VarToStr(a));
+    /// // Prints:
+    /// // {
+    /// //     "a": 1,
+    /// //     "b": 2
+    /// // }
+    /// </code>
+    /// </example>
+    /// <param name="var">Variant that will be converted to string.</param>
+    /// <returns>The <see cref="Variant"/> encoded as a string.</returns>
+    public static string VarToStr(Variant var)
+    {
+        NativeFuncs.godotsharp_var_to_str((godot_variant)var.NativeVar, out godot_string ret);
+        using (ret)
+            return Marshaling.ConvertStringToManaged(ret);
+    }
 
-        /// <summary>
-        /// Prints a message to the console.
-        ///
-        /// Note: Consider using <see cref="PushError(string)"/> and <see cref="PushWarning(string)"/>
-        /// to print error and warning messages instead of <see cref="Print(string)"/>.
-        /// This distinguishes them from print messages used for debugging purposes,
-        /// while also displaying a stack trace when an error or warning is printed.
-        /// </summary>
-        /// <param name="what">Message that will be printed.</param>
-        public static void Print(string what)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(what);
-            NativeFuncs.godotsharp_print(godotStr);
-        }
-
-        /// <summary>
-        /// Converts one or more arguments of any type to string in the best way possible
-        /// and prints them to the console.
-        ///
-        /// Note: Consider using <see cref="PushError(object[])"/> and <see cref="PushWarning(object[])"/>
-        /// to print error and warning messages instead of <see cref="Print(object[])"/>.
-        /// This distinguishes them from print messages used for debugging purposes,
-        /// while also displaying a stack trace when an error or warning is printed.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var a = new Godot.Collections.Array { 1, 2, 3 };
-        /// GD.Print("a", "b", a); // Prints ab[1, 2, 3]
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void Print(params object[] what)
-        {
-            Print(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Prints a message to the console.
-        /// The following BBCode tags are supported: b, i, u, s, indent, code, url, center,
-        /// right, color, bgcolor, fgcolor.
-        /// Color tags only support named colors such as <c>red</c>, not hexadecimal color codes.
-        /// Unsupported tags will be left as-is in standard output.
-        /// When printing to standard output, the supported subset of BBCode is converted to
-        /// ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes
-        /// is currently only supported on Linux and macOS. Support for ANSI escape codes may vary
-        /// across terminal emulators, especially for italic and strikethrough.
-        ///
-        /// Note: Consider using <see cref="PushError(string)"/> and <see cref="PushWarning(string)"/>
-        /// to print error and warning messages instead of <see cref="Print(string)"/> or
-        /// <see cref="PrintRich(string)"/>.
-        /// This distinguishes them from print messages used for debugging purposes,
-        /// while also displaying a stack trace when an error or warning is printed.
-        /// </summary>
-        /// <param name="what">Message that will be printed.</param>
-        public static void PrintRich(string what)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(what);
-            NativeFuncs.godotsharp_print_rich(godotStr);
-        }
-
-        /// <summary>
-        /// Converts one or more arguments of any type to string in the best way possible
-        /// and prints them to the console.
-        /// The following BBCode tags are supported: b, i, u, s, indent, code, url, center,
-        /// right, color, bgcolor, fgcolor.
-        /// Color tags only support named colors such as <c>red</c>, not hexadecimal color codes.
-        /// Unsupported tags will be left as-is in standard output.
-        /// When printing to standard output, the supported subset of BBCode is converted to
-        /// ANSI escape codes for the terminal emulator to display. Displaying ANSI escape codes
-        /// is currently only supported on Linux and macOS. Support for ANSI escape codes may vary
-        /// across terminal emulators, especially for italic and strikethrough.
-        ///
-        /// Note: Consider using <see cref="PushError(object[])"/> and <see cref="PushWarning(object[])"/>
-        /// to print error and warning messages instead of <see cref="Print(object[])"/> or
-        /// <see cref="PrintRich(object[])"/>.
-        /// This distinguishes them from print messages used for debugging purposes,
-        /// while also displaying a stack trace when an error or warning is printed.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PrintRich("[code][b]Hello world![/b][/code]"); // Prints out: [b]Hello world![/b]
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintRich(params object[] what)
-        {
-            PrintRich(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Prints a message to standard error line.
-        /// </summary>
-        /// <param name="what">Message that will be printed.</param>
-        public static void PrintErr(string what)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(what);
-            NativeFuncs.godotsharp_printerr(godotStr);
-        }
-
-        /// <summary>
-        /// Prints one or more arguments to strings in the best way possible to standard error line.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PrintErr("prints to stderr");
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintErr(params object[] what)
-        {
-            PrintErr(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Prints a message to the OS terminal.
-        /// Unlike <see cref="Print(string)"/>, no newline is added at the end.
-        /// </summary>
-        /// <param name="what">Message that will be printed.</param>
-        public static void PrintRaw(string what)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(what);
-            NativeFuncs.godotsharp_printraw(godotStr);
-        }
-
-        /// <summary>
-        /// Prints one or more arguments to strings in the best way possible to the OS terminal.
-        /// Unlike <see cref="Print(object[])"/>, no newline is added at the end.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PrintRaw("A");
-        /// GD.PrintRaw("B");
-        /// GD.PrintRaw("C");
-        /// // Prints ABC to terminal
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintRaw(params object[] what)
-        {
-            PrintRaw(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Prints one or more arguments to the console with a space between each argument.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PrintS("A", "B", "C"); // Prints A B C
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintS(params object[] what)
-        {
-            string message = AppendPrintParams(' ', what);
-            using var godotStr = Marshaling.ConvertStringToNative(message);
-            NativeFuncs.godotsharp_prints(godotStr);
-        }
-
-        /// <summary>
-        /// Prints one or more arguments to the console with a tab between each argument.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PrintT("A", "B", "C"); // Prints A       B       C
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that will be printed.</param>
-        public static void PrintT(params object[] what)
-        {
-            string message = AppendPrintParams('\t', what);
-            using var godotStr = Marshaling.ConvertStringToNative(message);
-            NativeFuncs.godotsharp_printt(godotStr);
-        }
-
-        /// <summary>
-        /// Pushes an error message to Godot's built-in debugger and to the OS terminal.
-        ///
-        /// Note: Errors printed this way will not pause project execution.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PushError("test error"); // Prints "test error" to debugger and terminal as error call
-        /// </code>
-        /// </example>
-        /// <param name="message">Error message.</param>
-        public static void PushError(string message)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(message);
-            NativeFuncs.godotsharp_pusherror(godotStr);
-        }
-
-        /// <summary>
-        /// Pushes an error message to Godot's built-in debugger and to the OS terminal.
-        ///
-        /// Note: Errors printed this way will not pause project execution.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PushError("test_error"); // Prints "test error" to debugger and terminal as error call
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that form the error message.</param>
-        public static void PushError(params object[] what)
-        {
-            PushError(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as warning call
-        /// </code>
-        /// </example>
-        /// <param name="message">Warning message.</param>
-        public static void PushWarning(string message)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(message);
-            NativeFuncs.godotsharp_pushwarning(godotStr);
-        }
-
-        /// <summary>
-        /// Pushes a warning message to Godot's built-in debugger and to the OS terminal.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as warning call
-        /// </code>
-        /// </example>
-        /// <param name="what">Arguments that form the warning message.</param>
-        public static void PushWarning(params object[] what)
-        {
-            PushWarning(AppendPrintParams(what));
-        }
-
-        /// <summary>
-        /// Returns a random floating point value between <c>0.0</c> and <c>1.0</c> (inclusive).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Randf(); // Returns e.g. 0.375671
-        /// </code>
-        /// </example>
-        /// <returns>A random <see langword="float"/> number.</returns>
-        public static float Randf()
-        {
-            return NativeFuncs.godotsharp_randf();
-        }
-
-        /// <summary>
-        /// Returns a normally-distributed pseudo-random floating point value
-        /// using Box-Muller transform with the specified <pararmref name="mean"/>
-        /// and a standard <paramref name="deviation"/>.
-        /// This is also called Gaussian distribution.
-        /// </summary>
-        /// <returns>A random normally-distributed <see langword="float"/> number.</returns>
-        public static double Randfn(double mean, double deviation)
-        {
-            return NativeFuncs.godotsharp_randfn(mean, deviation);
-        }
-
-        /// <summary>
-        /// Returns a random unsigned 32-bit integer.
-        /// Use remainder to obtain a random value in the interval <c>[0, N - 1]</c>
-        /// (where N is smaller than 2^32).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Randi();           // Returns random integer between 0 and 2^32 - 1
-        /// GD.Randi() % 20;      // Returns random integer between 0 and 19
-        /// GD.Randi() % 100;     // Returns random integer between 0 and 99
-        /// GD.Randi() % 100 + 1; // Returns random integer between 1 and 100
-        /// </code>
-        /// </example>
-        /// <returns>A random <see langword="uint"/> number.</returns>
-        public static uint Randi()
-        {
-            return NativeFuncs.godotsharp_randi();
-        }
-
-        /// <summary>
-        /// Randomizes the seed (or the internal state) of the random number generator.
-        /// The current implementation uses a number based on the device's time.
-        ///
-        /// Note: This method is called automatically when the project is run.
-        /// If you need to fix the seed to have consistent, reproducible results,
-        /// use <see cref="Seed(ulong)"/> to initialize the random number generator.
-        /// </summary>
-        public static void Randomize()
-        {
-            NativeFuncs.godotsharp_randomize();
-        }
-
-        /// <summary>
-        /// Returns a random floating point value between <paramref name="from"/>
-        /// and <paramref name="to"/> (inclusive).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.RandRange(0.0, 20.5);   // Returns e.g. 7.45315
-        /// GD.RandRange(-10.0, 10.0); // Returns e.g. -3.844535
-        /// </code>
-        /// </example>
-        /// <returns>A random <see langword="double"/> number inside the given range.</returns>
-        public static double RandRange(double from, double to)
-        {
-            return NativeFuncs.godotsharp_randf_range(from, to);
-        }
-
-        /// <summary>
-        /// Returns a random signed 32-bit integer between <paramref name="from"/>
-        /// and <paramref name="to"/> (inclusive). If <paramref name="to"/> is lesser than
-        /// <paramref name="from"/>, they are swapped.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.RandRange(0, 1);      // Returns either 0 or 1
-        /// GD.RandRange(-10, 1000); // Returns random integer between -10 and 1000
-        /// </code>
-        /// </example>
-        /// <returns>A random <see langword="int"/> number inside the given range.</returns>
-        public static int RandRange(int from, int to)
-        {
-            return NativeFuncs.godotsharp_randi_range(from, to);
-        }
-
-        /// <summary>
-        /// Given a <paramref name="seed"/>, returns a randomized <see langword="uint"/>
-        /// value. The <paramref name="seed"/> may be modified.
-        /// Passing the same <paramref name="seed"/> consistently returns the same value.
-        ///
-        /// Note: "Seed" here refers to the internal state of the pseudo random number
-        /// generator, currently implemented as a 64 bit integer.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var a = GD.RandFromSeed(4);
-        /// </code>
-        /// </example>
-        /// <param name="seed">
-        /// Seed to use to generate the random number.
-        /// If a different seed is used, its value will be modified.
-        /// </param>
-        /// <returns>A random <see langword="uint"/> number.</returns>
-        public static uint RandFromSeed(ref ulong seed)
-        {
-            return NativeFuncs.godotsharp_rand_from_seed(seed, out seed);
-        }
-
-        /// <summary>
-        /// Returns a <see cref="IEnumerable{T}"/> that iterates from
-        /// <c>0</c> (inclusive) to <paramref name="end"/> (exclusive)
-        /// in steps of <c>1</c>.
-        /// </summary>
-        /// <param name="end">The last index.</param>
-        public static IEnumerable<int> Range(int end)
-        {
-            return Range(0, end, 1);
-        }
-
-        /// <summary>
-        /// Returns a <see cref="IEnumerable{T}"/> that iterates from
-        /// <paramref name="start"/> (inclusive) to <paramref name="end"/> (exclusive)
-        /// in steps of <c>1</c>.
-        /// </summary>
-        /// <param name="start">The first index.</param>
-        /// <param name="end">The last index.</param>
-        public static IEnumerable<int> Range(int start, int end)
-        {
-            return Range(start, end, 1);
-        }
-
-        /// <summary>
-        /// Returns a <see cref="IEnumerable{T}"/> that iterates from
-        /// <paramref name="start"/> (inclusive) to <paramref name="end"/> (exclusive)
-        /// in steps of <paramref name="step"/>.
-        /// The argument <paramref name="step"/> can be negative, but not <c>0</c>.
-        /// </summary>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="step"/> is 0.
-        /// </exception>
-        /// <param name="start">The first index.</param>
-        /// <param name="end">The last index.</param>
-        /// <param name="step">The amount by which to increment the index on each iteration.</param>
-        public static IEnumerable<int> Range(int start, int end, int step)
-        {
-            if (step == 0)
-                throw new ArgumentException("step cannot be 0.", nameof(step));
-
-            if (end < start && step > 0)
-                yield break;
-
-            if (end > start && step < 0)
-                yield break;
-
-            if (step > 0)
-            {
-                for (int i = start; i < end; i += step)
-                    yield return i;
-            }
-            else
-            {
-                for (int i = start; i > end; i += step)
-                    yield return i;
-            }
-        }
-
-        /// <summary>
-        /// Sets seed for the random number generator to <paramref name="seed"/>.
-        /// Setting the seed manually can ensure consistent, repeatable results for
-        /// most random functions.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// ulong mySeed = (ulong)GD.Hash("Godot Rocks");
-        /// GD.Seed(mySeed);
-        /// var a = GD.Randf() + GD.Randi();
-        /// GD.Seed(mySeed);
-        /// var b = GD.Randf() + GD.Randi();
-        /// // a and b are now identical
-        /// </code>
-        /// </example>
-        /// <param name="seed">Seed that will be used.</param>
-        public static void Seed(ulong seed)
-        {
-            NativeFuncs.godotsharp_seed(seed);
-        }
-
-        /// <summary>
-        /// Converts a formatted string that was returned by <see cref="VarToStr(Variant)"/>
-        /// to the original value.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string a = "{ \"a\": 1, \"b\": 2 }";        // a is a string
-        /// var b = GD.StrToVar(a).AsGodotDictionary(); // b is a Dictionary
-        /// GD.Print(b["a"]);                           // Prints 1
-        /// </code>
-        /// </example>
-        /// <param name="str">String that will be converted to Variant.</param>
-        /// <returns>The decoded <c>Variant</c>.</returns>
-        public static Variant StrToVar(string str)
-        {
-            using var godotStr = Marshaling.ConvertStringToNative(str);
-            NativeFuncs.godotsharp_str_to_var(godotStr, out godot_variant ret);
-            return Variant.CreateTakingOwnershipOfDisposableValue(ret);
-        }
-
-        /// <summary>
-        /// Encodes a <see cref="Variant"/> value to a byte array, without encoding objects.
-        /// Deserialization can be done with <see cref="BytesToVar"/>.
-        /// Note: If you need object serialization, see <see cref="VarToBytesWithObjects"/>.
-        /// </summary>
-        /// <param name="var"><see cref="Variant"/> that will be encoded.</param>
-        /// <returns>The <see cref="Variant"/> encoded as an array of bytes.</returns>
-        public static byte[] VarToBytes(Variant var)
-        {
-            NativeFuncs.godotsharp_var_to_bytes((godot_variant)var.NativeVar, godot_bool.False, out var varBytes);
-            using (varBytes)
-                return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
-        }
-
-        /// <summary>
-        /// Encodes a <see cref="Variant"/>. Encoding objects is allowed (and can potentially
-        /// include executable code). Deserialization can be done with <see cref="BytesToVarWithObjects"/>.
-        /// </summary>
-        /// <param name="var"><see cref="Variant"/> that will be encoded.</param>
-        /// <returns>The <see cref="Variant"/> encoded as an array of bytes.</returns>
-        public static byte[] VarToBytesWithObjects(Variant var)
-        {
-            NativeFuncs.godotsharp_var_to_bytes((godot_variant)var.NativeVar, godot_bool.True, out var varBytes);
-            using (varBytes)
-                return Marshaling.ConvertNativePackedByteArrayToSystemArray(varBytes);
-        }
-
-        /// <summary>
-        /// Converts a <see cref="Variant"/> <paramref name="var"/> to a formatted string that
-        /// can later be parsed using <see cref="StrToVar(string)"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var a = new Godot.Collections.Dictionary { ["a"] = 1, ["b"] = 2 };
-        /// GD.Print(GD.VarToStr(a));
-        /// // Prints:
-        /// // {
-        /// //     "a": 1,
-        /// //     "b": 2
-        /// // }
-        /// </code>
-        /// </example>
-        /// <param name="var">Variant that will be converted to string.</param>
-        /// <returns>The <see cref="Variant"/> encoded as a string.</returns>
-        public static string VarToStr(Variant var)
-        {
-            NativeFuncs.godotsharp_var_to_str((godot_variant)var.NativeVar, out godot_string ret);
-            using (ret)
-                return Marshaling.ConvertStringToManaged(ret);
-        }
-
-        /// <summary>
-        /// Get the <see cref="Variant.Type"/> that corresponds for the given <see cref="Type"/>.
-        /// </summary>
-        /// <returns>The <see cref="Variant.Type"/> for the given <paramref name="type"/>.</returns>
-        public static Variant.Type TypeToVariantType(Type type)
-        {
-            return Marshaling.ConvertManagedTypeToVariantType(type, out bool _);
-        }
+    /// <summary>
+    /// Get the <see cref="Variant.Type"/> that corresponds for the given <see cref="Type"/>.
+    /// </summary>
+    /// <returns>The <see cref="Variant.Type"/> for the given <paramref name="type"/>.</returns>
+    public static Variant.Type TypeToVariantType(Type type)
+    {
+        return Marshaling.ConvertManagedTypeToVariantType(type, out bool _);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.base.cs
@@ -3,243 +3,242 @@ using System.Runtime.InteropServices;
 using Godot.Bridge;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+public partial class GodotObject : IDisposable
 {
-    public partial class GodotObject : IDisposable
+    private bool _disposed = false;
+    private static readonly Type CachedType = typeof(GodotObject);
+
+    internal IntPtr NativePtr;
+    private bool _memoryOwn;
+
+    private WeakReference<GodotObject> _weakReferenceToSelf;
+
+    /// <summary>
+    /// Constructs a new <see cref="GodotObject"/>.
+    /// </summary>
+    public GodotObject() : this(false)
     {
-        private bool _disposed = false;
-        private static readonly Type CachedType = typeof(GodotObject);
-
-        internal IntPtr NativePtr;
-        private bool _memoryOwn;
-
-        private WeakReference<GodotObject> _weakReferenceToSelf;
-
-        /// <summary>
-        /// Constructs a new <see cref="GodotObject"/>.
-        /// </summary>
-        public GodotObject() : this(false)
+        unsafe
         {
-            unsafe
-            {
-                _ConstructAndInitialize(NativeCtor, NativeName, CachedType, refCounted: false);
-            }
+            _ConstructAndInitialize(NativeCtor, NativeName, CachedType, refCounted: false);
+        }
+    }
+
+    internal unsafe void _ConstructAndInitialize(
+        delegate* unmanaged<IntPtr> nativeCtor,
+        StringName nativeName,
+        Type cachedType,
+        bool refCounted
+    )
+    {
+        if (NativePtr == IntPtr.Zero)
+        {
+            NativePtr = nativeCtor();
+
+            InteropUtils.TieManagedToUnmanaged(this, NativePtr,
+                nativeName, refCounted, GetType(), cachedType);
+        }
+        else
+        {
+            InteropUtils.TieManagedToUnmanagedWithPreSetup(this, NativePtr,
+                GetType(), cachedType);
         }
 
-        internal unsafe void _ConstructAndInitialize(
-            delegate* unmanaged<IntPtr> nativeCtor,
-            StringName nativeName,
-            Type cachedType,
-            bool refCounted
-        )
-        {
-            if (NativePtr == IntPtr.Zero)
-            {
-                NativePtr = nativeCtor();
+        _weakReferenceToSelf = DisposablesTracker.RegisterGodotObject(this);
+    }
 
-                InteropUtils.TieManagedToUnmanaged(this, NativePtr,
-                    nativeName, refCounted, GetType(), cachedType);
+    internal GodotObject(bool memoryOwn)
+    {
+        _memoryOwn = memoryOwn;
+    }
+
+    /// <summary>
+    /// The pointer to the native instance of this <see cref="GodotObject"/>.
+    /// </summary>
+    public IntPtr NativeInstance => NativePtr;
+
+    internal static IntPtr GetPtr(GodotObject instance)
+    {
+        if (instance == null)
+            return IntPtr.Zero;
+
+        // We check if NativePtr is null because this may be called by the debugger.
+        // If the debugger puts a breakpoint in one of the base constructors, before
+        // NativePtr is assigned, that would result in UB or crashes when calling
+        // native functions that receive the pointer, which can happen because the
+        // debugger calls ToString() and tries to get the value of properties.
+        if (instance._disposed || instance.NativePtr == IntPtr.Zero)
+            throw new ObjectDisposedException(instance.GetType().FullName);
+
+        return instance.NativePtr;
+    }
+
+    ~GodotObject()
+    {
+        Dispose(false);
+    }
+
+    /// <summary>
+    /// Disposes of this <see cref="GodotObject"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes implementation of this <see cref="GodotObject"/>.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        if (NativePtr != IntPtr.Zero)
+        {
+            IntPtr gcHandleToFree = NativeFuncs.godotsharp_internal_object_get_associated_gchandle(NativePtr);
+
+            if (gcHandleToFree != IntPtr.Zero)
+            {
+                object target = GCHandle.FromIntPtr(gcHandleToFree).Target;
+                // The GC handle may have been replaced in another thread. Release it only if
+                // it's associated to this managed instance, or if the target is no longer alive.
+                if (target != this && target != null)
+                    gcHandleToFree = IntPtr.Zero;
+            }
+
+            if (_memoryOwn)
+            {
+                NativeFuncs.godotsharp_internal_refcounted_disposed(NativePtr, gcHandleToFree,
+                    (!disposing).ToGodotBool());
             }
             else
             {
-                InteropUtils.TieManagedToUnmanagedWithPreSetup(this, NativePtr,
-                    GetType(), cachedType);
+                NativeFuncs.godotsharp_internal_object_disposed(NativePtr, gcHandleToFree);
             }
 
-            _weakReferenceToSelf = DisposablesTracker.RegisterGodotObject(this);
+            NativePtr = IntPtr.Zero;
         }
 
-        internal GodotObject(bool memoryOwn)
+        if (_weakReferenceToSelf != null)
         {
-            _memoryOwn = memoryOwn;
+            DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
         }
+    }
 
-        /// <summary>
-        /// The pointer to the native instance of this <see cref="GodotObject"/>.
-        /// </summary>
-        public IntPtr NativeInstance => NativePtr;
+    /// <summary>
+    /// Converts this <see cref="GodotObject"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this object.</returns>
+    public override string ToString()
+    {
+        NativeFuncs.godotsharp_object_to_string(GetPtr(this), out godot_string str);
+        using (str)
+            return Marshaling.ConvertStringToManaged(str);
+    }
 
-        internal static IntPtr GetPtr(GodotObject instance)
+    /// <summary>
+    /// Returns a new <see cref="SignalAwaiter"/> awaiter configured to complete when the instance
+    /// <paramref name="source"/> emits the signal specified by the <paramref name="signal"/> parameter.
+    /// </summary>
+    /// <param name="source">
+    /// The instance the awaiter will be listening to.
+    /// </param>
+    /// <param name="signal">
+    /// The signal the awaiter will be waiting for.
+    /// </param>
+    /// <example>
+    /// This sample prints a message once every frame up to 100 times.
+    /// <code>
+    /// public override void _Ready()
+    /// {
+    ///     for (int i = 0; i &lt; 100; i++)
+    ///     {
+    ///         await ToSignal(GetTree(), "process_frame");
+    ///         GD.Print($"Frame {i}");
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    /// <returns>
+    /// A <see cref="SignalAwaiter"/> that completes when
+    /// <paramref name="source"/> emits the <paramref name="signal"/>.
+    /// </returns>
+    public SignalAwaiter ToSignal(GodotObject source, StringName signal)
+    {
+        return new SignalAwaiter(source, signal, this);
+    }
+
+    internal static Type InternalGetClassNativeBase(Type t)
+    {
+        do
         {
-            if (instance == null)
-                return IntPtr.Zero;
+            var assemblyName = t.Assembly.GetName();
 
-            // We check if NativePtr is null because this may be called by the debugger.
-            // If the debugger puts a breakpoint in one of the base constructors, before
-            // NativePtr is assigned, that would result in UB or crashes when calling
-            // native functions that receive the pointer, which can happen because the
-            // debugger calls ToString() and tries to get the value of properties.
-            if (instance._disposed || instance.NativePtr == IntPtr.Zero)
-                throw new ObjectDisposedException(instance.GetType().FullName);
+            if (assemblyName.Name == "GodotSharp")
+                return t;
 
-            return instance.NativePtr;
-        }
+            if (assemblyName.Name == "GodotSharpEditor")
+                return t;
+        } while ((t = t.BaseType) != null);
 
-        ~GodotObject()
-        {
-            Dispose(false);
-        }
+        return null;
+    }
 
-        /// <summary>
-        /// Disposes of this <see cref="GodotObject"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+    // ReSharper disable once VirtualMemberNeverOverridden.Global
+    protected internal virtual bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
+    {
+        return false;
+    }
 
-        /// <summary>
-        /// Disposes implementation of this <see cref="GodotObject"/>.
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed)
-                return;
+    // ReSharper disable once VirtualMemberNeverOverridden.Global
+    protected internal virtual bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
+    {
+        value = default;
+        return false;
+    }
 
-            _disposed = true;
+    // ReSharper disable once VirtualMemberNeverOverridden.Global
+    protected internal virtual void RaiseGodotClassSignalCallbacks(in godot_string_name signal,
+        NativeVariantPtrArgs args)
+    {
+    }
 
-            if (NativePtr != IntPtr.Zero)
-            {
-                IntPtr gcHandleToFree = NativeFuncs.godotsharp_internal_object_get_associated_gchandle(NativePtr);
+    internal static IntPtr ClassDB_get_method(StringName type, StringName method)
+    {
+        var typeSelf = (godot_string_name)type.NativeValue;
+        var methodSelf = (godot_string_name)method.NativeValue;
+        IntPtr methodBind = NativeFuncs.godotsharp_method_bind_get_method(typeSelf, methodSelf);
 
-                if (gcHandleToFree != IntPtr.Zero)
-                {
-                    object target = GCHandle.FromIntPtr(gcHandleToFree).Target;
-                    // The GC handle may have been replaced in another thread. Release it only if
-                    // it's associated to this managed instance, or if the target is no longer alive.
-                    if (target != this && target != null)
-                        gcHandleToFree = IntPtr.Zero;
-                }
+        if (methodBind == IntPtr.Zero)
+            throw new NativeMethodBindNotFoundException(type + "." + method);
 
-                if (_memoryOwn)
-                {
-                    NativeFuncs.godotsharp_internal_refcounted_disposed(NativePtr, gcHandleToFree,
-                        (!disposing).ToGodotBool());
-                }
-                else
-                {
-                    NativeFuncs.godotsharp_internal_object_disposed(NativePtr, gcHandleToFree);
-                }
+        return methodBind;
+    }
 
-                NativePtr = IntPtr.Zero;
-            }
+    internal static unsafe delegate* unmanaged<IntPtr> ClassDB_get_constructor(StringName type)
+    {
+        // for some reason the '??' operator doesn't support 'delegate*'
+        var typeSelf = (godot_string_name)type.NativeValue;
+        var nativeConstructor = NativeFuncs.godotsharp_get_class_constructor(typeSelf);
 
-            if (_weakReferenceToSelf != null)
-            {
-                DisposablesTracker.UnregisterGodotObject(this, _weakReferenceToSelf);
-            }
-        }
+        if (nativeConstructor == null)
+            throw new NativeConstructorNotFoundException(type);
 
-        /// <summary>
-        /// Converts this <see cref="GodotObject"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this object.</returns>
-        public override string ToString()
-        {
-            NativeFuncs.godotsharp_object_to_string(GetPtr(this), out godot_string str);
-            using (str)
-                return Marshaling.ConvertStringToManaged(str);
-        }
+        return nativeConstructor;
+    }
 
-        /// <summary>
-        /// Returns a new <see cref="SignalAwaiter"/> awaiter configured to complete when the instance
-        /// <paramref name="source"/> emits the signal specified by the <paramref name="signal"/> parameter.
-        /// </summary>
-        /// <param name="source">
-        /// The instance the awaiter will be listening to.
-        /// </param>
-        /// <param name="signal">
-        /// The signal the awaiter will be waiting for.
-        /// </param>
-        /// <example>
-        /// This sample prints a message once every frame up to 100 times.
-        /// <code>
-        /// public override void _Ready()
-        /// {
-        ///     for (int i = 0; i &lt; 100; i++)
-        ///     {
-        ///         await ToSignal(GetTree(), "process_frame");
-        ///         GD.Print($"Frame {i}");
-        ///     }
-        /// }
-        /// </code>
-        /// </example>
-        /// <returns>
-        /// A <see cref="SignalAwaiter"/> that completes when
-        /// <paramref name="source"/> emits the <paramref name="signal"/>.
-        /// </returns>
-        public SignalAwaiter ToSignal(GodotObject source, StringName signal)
-        {
-            return new SignalAwaiter(source, signal, this);
-        }
+    protected internal virtual void SaveGodotObjectData(GodotSerializationInfo info)
+    {
+    }
 
-        internal static Type InternalGetClassNativeBase(Type t)
-        {
-            do
-            {
-                var assemblyName = t.Assembly.GetName();
-
-                if (assemblyName.Name == "GodotSharp")
-                    return t;
-
-                if (assemblyName.Name == "GodotSharpEditor")
-                    return t;
-            } while ((t = t.BaseType) != null);
-
-            return null;
-        }
-
-        // ReSharper disable once VirtualMemberNeverOverridden.Global
-        protected internal virtual bool SetGodotClassPropertyValue(in godot_string_name name, in godot_variant value)
-        {
-            return false;
-        }
-
-        // ReSharper disable once VirtualMemberNeverOverridden.Global
-        protected internal virtual bool GetGodotClassPropertyValue(in godot_string_name name, out godot_variant value)
-        {
-            value = default;
-            return false;
-        }
-
-        // ReSharper disable once VirtualMemberNeverOverridden.Global
-        protected internal virtual void RaiseGodotClassSignalCallbacks(in godot_string_name signal,
-            NativeVariantPtrArgs args)
-        {
-        }
-
-        internal static IntPtr ClassDB_get_method(StringName type, StringName method)
-        {
-            var typeSelf = (godot_string_name)type.NativeValue;
-            var methodSelf = (godot_string_name)method.NativeValue;
-            IntPtr methodBind = NativeFuncs.godotsharp_method_bind_get_method(typeSelf, methodSelf);
-
-            if (methodBind == IntPtr.Zero)
-                throw new NativeMethodBindNotFoundException(type + "." + method);
-
-            return methodBind;
-        }
-
-        internal static unsafe delegate* unmanaged<IntPtr> ClassDB_get_constructor(StringName type)
-        {
-            // for some reason the '??' operator doesn't support 'delegate*'
-            var typeSelf = (godot_string_name)type.NativeValue;
-            var nativeConstructor = NativeFuncs.godotsharp_get_class_constructor(typeSelf);
-
-            if (nativeConstructor == null)
-                throw new NativeConstructorNotFoundException(type);
-
-            return nativeConstructor;
-        }
-
-        protected internal virtual void SaveGodotObjectData(GodotSerializationInfo info)
-        {
-        }
-
-        // TODO: Should this be a constructor overload?
-        protected internal virtual void RestoreGodotObjectData(GodotSerializationInfo info)
-        {
-        }
+    // TODO: Should this be a constructor overload?
+    protected internal virtual void RestoreGodotObjectData(GodotSerializationInfo info)
+    {
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotObject.exceptions.cs
@@ -3,139 +3,138 @@ using System.Text;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+public partial class GodotObject
 {
-    public partial class GodotObject
+    public class NativeMemberNotFoundException : Exception
     {
-        public class NativeMemberNotFoundException : Exception
+        public NativeMemberNotFoundException()
         {
-            public NativeMemberNotFoundException()
-            {
-            }
-
-            public NativeMemberNotFoundException(string? message) : base(message)
-            {
-            }
-
-            public NativeMemberNotFoundException(string? message, Exception? innerException)
-                : base(message, innerException)
-            {
-            }
         }
 
-        public class NativeConstructorNotFoundException : NativeMemberNotFoundException
+        public NativeMemberNotFoundException(string? message) : base(message)
         {
-            private readonly string? _nativeClassName;
-
-            // ReSharper disable once InconsistentNaming
-            private const string Arg_NativeConstructorNotFoundException = "Unable to find the native constructor.";
-
-            public NativeConstructorNotFoundException()
-                : base(Arg_NativeConstructorNotFoundException)
-            {
-            }
-
-            public NativeConstructorNotFoundException(string? nativeClassName)
-                : this(Arg_NativeConstructorNotFoundException, nativeClassName)
-            {
-            }
-
-            public NativeConstructorNotFoundException(string? message, Exception? innerException)
-                : base(message, innerException)
-            {
-            }
-
-            public NativeConstructorNotFoundException(string? message, string? nativeClassName)
-                : base(message)
-            {
-                _nativeClassName = nativeClassName;
-            }
-
-            public NativeConstructorNotFoundException(string? message, string? nativeClassName, Exception? innerException)
-                : base(message, innerException)
-            {
-                _nativeClassName = nativeClassName;
-            }
-
-            public override string Message
-            {
-                get
-                {
-                    StringBuilder sb;
-                    if (string.IsNullOrEmpty(base.Message))
-                    {
-                        sb = new(Arg_NativeConstructorNotFoundException);
-                    }
-                    else
-                    {
-                        sb = new(base.Message);
-                    }
-
-                    if (!string.IsNullOrEmpty(_nativeClassName))
-                    {
-                        sb.Append($" (Method '{_nativeClassName}')");
-                    }
-
-                    return sb.ToString();
-                }
-            }
         }
 
-        public class NativeMethodBindNotFoundException : NativeMemberNotFoundException
+        public NativeMemberNotFoundException(string? message, Exception? innerException)
+            : base(message, innerException)
         {
-            private readonly string? _nativeMethodName;
+        }
+    }
 
-            // ReSharper disable once InconsistentNaming
-            private const string Arg_NativeMethodBindNotFoundException = "Unable to find the native method bind.";
+    public class NativeConstructorNotFoundException : NativeMemberNotFoundException
+    {
+        private readonly string? _nativeClassName;
 
-            public NativeMethodBindNotFoundException()
-                : base(Arg_NativeMethodBindNotFoundException)
+        // ReSharper disable once InconsistentNaming
+        private const string Arg_NativeConstructorNotFoundException = "Unable to find the native constructor.";
+
+        public NativeConstructorNotFoundException()
+            : base(Arg_NativeConstructorNotFoundException)
+        {
+        }
+
+        public NativeConstructorNotFoundException(string? nativeClassName)
+            : this(Arg_NativeConstructorNotFoundException, nativeClassName)
+        {
+        }
+
+        public NativeConstructorNotFoundException(string? message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public NativeConstructorNotFoundException(string? message, string? nativeClassName)
+            : base(message)
+        {
+            _nativeClassName = nativeClassName;
+        }
+
+        public NativeConstructorNotFoundException(string? message, string? nativeClassName, Exception? innerException)
+            : base(message, innerException)
+        {
+            _nativeClassName = nativeClassName;
+        }
+
+        public override string Message
+        {
+            get
             {
-            }
-
-            public NativeMethodBindNotFoundException(string? nativeMethodName)
-                : this(Arg_NativeMethodBindNotFoundException, nativeMethodName)
-            {
-            }
-
-            public NativeMethodBindNotFoundException(string? message, Exception? innerException)
-                : base(message, innerException)
-            {
-            }
-
-            public NativeMethodBindNotFoundException(string? message, string? nativeMethodName)
-                : base(message)
-            {
-                _nativeMethodName = nativeMethodName;
-            }
-
-            public NativeMethodBindNotFoundException(string? message, string? nativeMethodName, Exception? innerException)
-                : base(message, innerException)
-            {
-                _nativeMethodName = nativeMethodName;
-            }
-
-            public override string Message
-            {
-                get
+                StringBuilder sb;
+                if (string.IsNullOrEmpty(base.Message))
                 {
-                    StringBuilder sb;
-                    if (string.IsNullOrEmpty(base.Message))
-                    {
-                        sb = new(Arg_NativeMethodBindNotFoundException);
-                    }
-                    else
-                    {
-                        sb = new(base.Message);
-                    }
-
-                    if (!string.IsNullOrEmpty(_nativeMethodName))
-                    {
-                        sb.Append($" (Method '{_nativeMethodName}')");
-                    }
-
-                    return sb.ToString();
+                    sb = new(Arg_NativeConstructorNotFoundException);
                 }
+                else
+                {
+                    sb = new(base.Message);
+                }
+
+                if (!string.IsNullOrEmpty(_nativeClassName))
+                {
+                    sb.Append($" (Method '{_nativeClassName}')");
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+
+    public class NativeMethodBindNotFoundException : NativeMemberNotFoundException
+    {
+        private readonly string? _nativeMethodName;
+
+        // ReSharper disable once InconsistentNaming
+        private const string Arg_NativeMethodBindNotFoundException = "Unable to find the native method bind.";
+
+        public NativeMethodBindNotFoundException()
+            : base(Arg_NativeMethodBindNotFoundException)
+        {
+        }
+
+        public NativeMethodBindNotFoundException(string? nativeMethodName)
+            : this(Arg_NativeMethodBindNotFoundException, nativeMethodName)
+        {
+        }
+
+        public NativeMethodBindNotFoundException(string? message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public NativeMethodBindNotFoundException(string? message, string? nativeMethodName)
+            : base(message)
+        {
+            _nativeMethodName = nativeMethodName;
+        }
+
+        public NativeMethodBindNotFoundException(string? message, string? nativeMethodName, Exception? innerException)
+            : base(message, innerException)
+        {
+            _nativeMethodName = nativeMethodName;
+        }
+
+        public override string Message
+        {
+            get
+            {
+                StringBuilder sb;
+                if (string.IsNullOrEmpty(base.Message))
+                {
+                    sb = new(Arg_NativeMethodBindNotFoundException);
+                }
+                else
+                {
+                    sb = new(base.Message);
+                }
+
+                if (!string.IsNullOrEmpty(_nativeMethodName))
+                {
+                    sb.Append($" (Method '{_nativeMethodName}')");
+                }
+
+                return sb.ToString();
             }
         }
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -3,58 +3,57 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Godot
+namespace Godot;
+
+public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
 {
-    public sealed class GodotSynchronizationContext : SynchronizationContext, IDisposable
+    private readonly BlockingCollection<(SendOrPostCallback Callback, object State)> _queue = new();
+
+    public override void Send(SendOrPostCallback d, object state)
     {
-        private readonly BlockingCollection<(SendOrPostCallback Callback, object State)> _queue = new();
-
-        public override void Send(SendOrPostCallback d, object state)
+        // Shortcut if we're already on this context
+        // Also necessary to avoid a deadlock, since Send is blocking
+        if (Current == this)
         {
-            // Shortcut if we're already on this context
-            // Also necessary to avoid a deadlock, since Send is blocking
-            if (Current == this)
+            d(state);
+            return;
+        }
+
+        var source = new TaskCompletionSource();
+
+        _queue.Add((st =>
+        {
+            try
             {
-                d(state);
-                return;
+                d(st);
             }
-
-            var source = new TaskCompletionSource();
-
-            _queue.Add((st =>
+            finally
             {
-                try
-                {
-                    d(st);
-                }
-                finally
-                {
-                    source.SetResult();
-                }
-            }, state));
-
-            source.Task.Wait();
-        }
-
-        public override void Post(SendOrPostCallback d, object state)
-        {
-            _queue.Add((d, state));
-        }
-
-        /// <summary>
-        /// Calls the Key method on each workItem object in the _queue to activate their callbacks.
-        /// </summary>
-        public void ExecutePendingContinuations()
-        {
-            while (_queue.TryTake(out var workItem))
-            {
-                workItem.Callback(workItem.State);
+                source.SetResult();
             }
-        }
+        }, state));
 
-        public void Dispose()
+        source.Task.Wait();
+    }
+
+    public override void Post(SendOrPostCallback d, object state)
+    {
+        _queue.Add((d, state));
+    }
+
+    /// <summary>
+    /// Calls the Key method on each workItem object in the _queue to activate their callbacks.
+    /// </summary>
+    public void ExecutePendingContinuations()
+    {
+        while (_queue.TryTake(out var workItem))
         {
-            _queue.Dispose();
+            workItem.Callback(workItem.State);
         }
+    }
+
+    public void Dispose()
+    {
+        _queue.Dispose();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -4,114 +4,113 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// GodotTaskScheduler contains a linked list of tasks to perform as a queue. Methods
+/// within the class are used to control the queue and perform the contained tasks.
+/// </summary>
+public sealed class GodotTaskScheduler : TaskScheduler, IDisposable
 {
     /// <summary>
-    /// GodotTaskScheduler contains a linked list of tasks to perform as a queue. Methods
-    /// within the class are used to control the queue and perform the contained tasks.
+    /// The current synchronization context.
     /// </summary>
-    public sealed class GodotTaskScheduler : TaskScheduler, IDisposable
+    internal GodotSynchronizationContext Context { get; }
+
+    /// <summary>
+    /// The queue of tasks for the task scheduler.
+    /// </summary>
+    private readonly LinkedList<Task> _tasks = new LinkedList<Task>();
+
+    /// <summary>
+    /// Constructs a new GodotTaskScheduler instance.
+    /// </summary>
+    public GodotTaskScheduler()
     {
-        /// <summary>
-        /// The current synchronization context.
-        /// </summary>
-        internal GodotSynchronizationContext Context { get; }
+        Context = new GodotSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(Context);
+    }
 
-        /// <summary>
-        /// The queue of tasks for the task scheduler.
-        /// </summary>
-        private readonly LinkedList<Task> _tasks = new LinkedList<Task>();
-
-        /// <summary>
-        /// Constructs a new GodotTaskScheduler instance.
-        /// </summary>
-        public GodotTaskScheduler()
+    protected sealed override void QueueTask(Task task)
+    {
+        lock (_tasks)
         {
-            Context = new GodotSynchronizationContext();
-            SynchronizationContext.SetSynchronizationContext(Context);
+            _tasks.AddLast(task);
         }
+    }
 
-        protected sealed override void QueueTask(Task task)
+    protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+    {
+        if (SynchronizationContext.Current != Context)
+            return false;
+
+        if (taskWasPreviouslyQueued)
+            TryDequeue(task);
+
+        return TryExecuteTask(task);
+    }
+
+    protected sealed override bool TryDequeue(Task task)
+    {
+        lock (_tasks)
         {
+            return _tasks.Remove(task);
+        }
+    }
+
+    protected sealed override IEnumerable<Task> GetScheduledTasks()
+    {
+        lock (_tasks)
+        {
+            foreach (Task task in _tasks)
+                yield return task;
+        }
+    }
+
+    /// <summary>
+    /// Executes all queued tasks and pending tasks from the current context.
+    /// </summary>
+    public void Activate()
+    {
+        ExecuteQueuedTasks();
+        Context.ExecutePendingContinuations();
+    }
+
+    /// <summary>
+    /// Loops through and attempts to execute each task in _tasks.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    private void ExecuteQueuedTasks()
+    {
+        while (true)
+        {
+            Task task;
+
             lock (_tasks)
             {
-                _tasks.AddLast(task);
-            }
-        }
-
-        protected sealed override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
-        {
-            if (SynchronizationContext.Current != Context)
-                return false;
-
-            if (taskWasPreviouslyQueued)
-                TryDequeue(task);
-
-            return TryExecuteTask(task);
-        }
-
-        protected sealed override bool TryDequeue(Task task)
-        {
-            lock (_tasks)
-            {
-                return _tasks.Remove(task);
-            }
-        }
-
-        protected sealed override IEnumerable<Task> GetScheduledTasks()
-        {
-            lock (_tasks)
-            {
-                foreach (Task task in _tasks)
-                    yield return task;
-            }
-        }
-
-        /// <summary>
-        /// Executes all queued tasks and pending tasks from the current context.
-        /// </summary>
-        public void Activate()
-        {
-            ExecuteQueuedTasks();
-            Context.ExecutePendingContinuations();
-        }
-
-        /// <summary>
-        /// Loops through and attempts to execute each task in _tasks.
-        /// </summary>
-        /// <exception cref="InvalidOperationException"></exception>
-        private void ExecuteQueuedTasks()
-        {
-            while (true)
-            {
-                Task task;
-
-                lock (_tasks)
+                if (_tasks.Any())
                 {
-                    if (_tasks.Any())
-                    {
-                        task = _tasks.First.Value;
-                        _tasks.RemoveFirst();
-                    }
-                    else
-                    {
-                        break;
-                    }
+                    task = _tasks.First.Value;
+                    _tasks.RemoveFirst();
                 }
-
-                if (task != null)
+                else
                 {
-                    if (!TryExecuteTask(task))
-                    {
-                        throw new InvalidOperationException();
-                    }
+                    break;
+                }
+            }
+
+            if (task != null)
+            {
+                if (!TryExecuteTask(task))
+                {
+                    throw new InvalidOperationException();
                 }
             }
         }
+    }
 
-        public void Dispose()
-        {
-            Context.Dispose();
-        }
+    public void Dispose()
+    {
+        Context.Dispose();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTraceListener.cs
@@ -1,33 +1,32 @@
 using System.Diagnostics;
 
-namespace Godot
+namespace Godot;
+
+internal class GodotTraceListener : TraceListener
 {
-    internal class GodotTraceListener : TraceListener
+    public override void Write(string message)
     {
-        public override void Write(string message)
+        GD.PrintRaw(message);
+    }
+
+    public override void WriteLine(string message)
+    {
+        GD.Print(message);
+    }
+
+    public override void Fail(string message, string detailMessage)
+    {
+        GD.PrintErr("Assertion failed: ", message);
+        GD.PrintErr("  Details: ", detailMessage);
+
+        try
         {
-            GD.PrintRaw(message);
+            string stackTrace = new StackTrace(true).ToString();
+            GD.PrintErr(stackTrace);
         }
-
-        public override void WriteLine(string message)
+        catch
         {
-            GD.Print(message);
-        }
-
-        public override void Fail(string message, string detailMessage)
-        {
-            GD.PrintErr("Assertion failed: ", message);
-            GD.PrintErr("  Details: ", detailMessage);
-
-            try
-            {
-                string stackTrace = new StackTrace(true).ToString();
-                GD.PrintErr(stackTrace);
-            }
-            catch
-            {
-                // ignored
-            }
+            // ignored
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotUnhandledExceptionEvent.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotUnhandledExceptionEvent.cs
@@ -2,32 +2,31 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+public static partial class GD
 {
-    public static partial class GD
+    [UnmanagedCallersOnly]
+    internal static void OnCoreApiAssemblyLoaded(godot_bool isDebug)
     {
-        [UnmanagedCallersOnly]
-        internal static void OnCoreApiAssemblyLoaded(godot_bool isDebug)
+        try
         {
-            try
-            {
-                Dispatcher.InitializeDefaultGodotTaskScheduler();
+            Dispatcher.InitializeDefaultGodotTaskScheduler();
 
-                if (isDebug.ToBool())
+            if (isDebug.ToBool())
+            {
+                DebuggingUtils.InstallTraceListener();
+
+                AppDomain.CurrentDomain.UnhandledException += (_, e) =>
                 {
-                    DebuggingUtils.InstallTraceListener();
-
-                    AppDomain.CurrentDomain.UnhandledException += (_, e) =>
-                    {
-                        // Exception.ToString() includes the inner exception
-                        ExceptionUtils.LogUnhandledException((Exception)e.ExceptionObject);
-                    };
-                }
+                    // Exception.ToString() includes the inner exception
+                    ExceptionUtils.LogUnhandledException((Exception)e.ExceptionObject);
+                };
             }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-            }
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -1,19 +1,18 @@
-namespace Godot
-{
-    /// <summary>
-    /// An interface that requires a GetAwaiter() method to get a reference to the Awaiter.
-    /// </summary>
-    public interface IAwaitable
-    {
-        IAwaiter GetAwaiter();
-    }
+namespace Godot;
 
-    /// <summary>
-    /// A templated interface that requires a GetAwaiter() method to get a reference to the Awaiter.
-    /// </summary>
-    /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
-    public interface IAwaitable<out TResult>
-    {
-        IAwaiter<TResult> GetAwaiter();
-    }
+/// <summary>
+/// An interface that requires a GetAwaiter() method to get a reference to the Awaiter.
+/// </summary>
+public interface IAwaitable
+{
+    IAwaiter GetAwaiter();
+}
+
+/// <summary>
+/// A templated interface that requires a GetAwaiter() method to get a reference to the Awaiter.
+/// </summary>
+/// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
+public interface IAwaitable<out TResult>
+{
+    IAwaiter<TResult> GetAwaiter();
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -1,25 +1,24 @@
 using System.Runtime.CompilerServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// An interface that requires a boolean for completion status and a method that gets the result of completion.
+/// </summary>
+public interface IAwaiter : INotifyCompletion
 {
-    /// <summary>
-    /// An interface that requires a boolean for completion status and a method that gets the result of completion.
-    /// </summary>
-    public interface IAwaiter : INotifyCompletion
-    {
-        bool IsCompleted { get; }
+    bool IsCompleted { get; }
 
-        void GetResult();
-    }
+    void GetResult();
+}
 
-    /// <summary>
-    /// A templated interface that requires a boolean for completion status and a method that gets the result of completion and returns it.
-    /// </summary>
-    /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
-    public interface IAwaiter<out TResult> : INotifyCompletion
-    {
-        bool IsCompleted { get; }
+/// <summary>
+/// A templated interface that requires a boolean for completion status and a method that gets the result of completion and returns it.
+/// </summary>
+/// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
+public interface IAwaiter<out TResult> : INotifyCompletion
+{
+    bool IsCompleted { get; }
 
-        TResult GetResult();
-    }
+    TResult GetResult();
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
@@ -1,11 +1,10 @@
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// An interface that requires methods for before and after serialization.
+/// </summary>
+public interface ISerializationListener
 {
-    /// <summary>
-    /// An interface that requires methods for before and after serialization.
-    /// </summary>
-    public interface ISerializationListener
-    {
-        void OnBeforeSerialize();
-        void OnAfterDeserialize();
-    }
+    void OnBeforeSerialize();
+    void OnAfterDeserialize();
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -1,1522 +1,1522 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Provides constants and static methods for common mathematical functions.
+/// </summary>
+public static partial class Mathf
 {
+    // Define constants with Decimal precision and cast down to double or float.
+
     /// <summary>
-    /// Provides constants and static methods for common mathematical functions.
+    /// The circle constant, the circumference of the unit circle in radians.
     /// </summary>
-    public static partial class Mathf
+    // 6.2831855f and 6.28318530717959
+    public const real_t Tau = (real_t)6.2831853071795864769252867666M;
+
+    /// <summary>
+    /// Constant that represents how many times the diameter of a circle
+    /// fits around its perimeter. This is equivalent to <c>Mathf.Tau / 2</c>.
+    /// </summary>
+    // 3.1415927f and 3.14159265358979
+    public const real_t Pi = (real_t)3.1415926535897932384626433833M;
+
+    /// <summary>
+    /// Positive infinity. For negative infinity, use <c>-Mathf.Inf</c>.
+    /// </summary>
+    public const real_t Inf = real_t.PositiveInfinity;
+
+    /// <summary>
+    /// "Not a Number", an invalid value. <c>NaN</c> has special properties, including
+    /// that it is not equal to itself. It is output by some invalid operations,
+    /// such as dividing zero by zero.
+    /// </summary>
+    public const real_t NaN = real_t.NaN;
+
+    // 0.0174532924f and 0.0174532925199433
+    private const float _degToRadConstF = (float)0.0174532925199432957692369077M;
+    private const double _degToRadConstD = (double)0.0174532925199432957692369077M;
+    // 57.29578f and 57.2957795130823
+    private const float _radToDegConstF = (float)57.295779513082320876798154814M;
+    private const double _radToDegConstD = (double)57.295779513082320876798154814M;
+
+    /// <summary>
+    /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>The absolute value of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Abs(int s)
     {
-        // Define constants with Decimal precision and cast down to double or float.
+        return Math.Abs(s);
+    }
 
-        /// <summary>
-        /// The circle constant, the circumference of the unit circle in radians.
-        /// </summary>
-        // 6.2831855f and 6.28318530717959
-        public const real_t Tau = (real_t)6.2831853071795864769252867666M;
+    /// <summary>
+    /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>The absolute value of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Abs(float s)
+    {
+        return Math.Abs(s);
+    }
 
-        /// <summary>
-        /// Constant that represents how many times the diameter of a circle
-        /// fits around its perimeter. This is equivalent to <c>Mathf.Tau / 2</c>.
-        /// </summary>
-        // 3.1415927f and 3.14159265358979
-        public const real_t Pi = (real_t)3.1415926535897932384626433833M;
+    /// <summary>
+    /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>The absolute value of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Abs(double s)
+    {
+        return Math.Abs(s);
+    }
 
-        /// <summary>
-        /// Positive infinity. For negative infinity, use <c>-Mathf.Inf</c>.
-        /// </summary>
-        public const real_t Inf = real_t.PositiveInfinity;
+    /// <summary>
+    /// Returns the arc cosine of <paramref name="s"/> in radians.
+    /// Use to get the angle of cosine <paramref name="s"/>.
+    /// </summary>
+    /// <param name="s">The input cosine value. Must be on the range of -1.0 to 1.0.</param>
+    /// <returns>
+    /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Acos(float s)
+    {
+        return MathF.Acos(s);
+    }
 
-        /// <summary>
-        /// "Not a Number", an invalid value. <c>NaN</c> has special properties, including
-        /// that it is not equal to itself. It is output by some invalid operations,
-        /// such as dividing zero by zero.
-        /// </summary>
-        public const real_t NaN = real_t.NaN;
+    /// <summary>
+    /// Returns the arc cosine of <paramref name="s"/> in radians.
+    /// Use to get the angle of cosine <paramref name="s"/>.
+    /// </summary>
+    /// <param name="s">The input cosine value. Must be on the range of -1.0 to 1.0.</param>
+    /// <returns>
+    /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Acos(double s)
+    {
+        return Math.Acos(s);
+    }
 
-        // 0.0174532924f and 0.0174532925199433
-        private const float _degToRadConstF = (float)0.0174532925199432957692369077M;
-        private const double _degToRadConstD = (double)0.0174532925199432957692369077M;
-        // 57.29578f and 57.2957795130823
-        private const float _radToDegConstF = (float)57.295779513082320876798154814M;
-        private const double _radToDegConstD = (double)57.295779513082320876798154814M;
+    /// <summary>
+    /// Returns the arc sine of <paramref name="s"/> in radians.
+    /// Use to get the angle of sine <paramref name="s"/>.
+    /// </summary>
+    /// <param name="s">The input sine value. Must be on the range of -1.0 to 1.0.</param>
+    /// <returns>
+    /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Asin(float s)
+    {
+        return MathF.Asin(s);
+    }
 
-        /// <summary>
-        /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>The absolute value of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Abs(int s)
+    /// <summary>
+    /// Returns the arc sine of <paramref name="s"/> in radians.
+    /// Use to get the angle of sine <paramref name="s"/>.
+    /// </summary>
+    /// <param name="s">The input sine value. Must be on the range of -1.0 to 1.0.</param>
+    /// <returns>
+    /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Asin(double s)
+    {
+        return Math.Asin(s);
+    }
+
+    /// <summary>
+    /// Returns the arc tangent of <paramref name="s"/> in radians.
+    /// Use to get the angle of tangent <paramref name="s"/>.
+    ///
+    /// The method cannot know in which quadrant the angle should fall.
+    /// See <see cref="Atan2(float, float)"/> if you have both <c>y</c> and <c>x</c>.
+    /// </summary>
+    /// <param name="s">The input tangent value.</param>
+    /// <returns>
+    /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Atan(float s)
+    {
+        return MathF.Atan(s);
+    }
+
+    /// <summary>
+    /// Returns the arc tangent of <paramref name="s"/> in radians.
+    /// Use to get the angle of tangent <paramref name="s"/>.
+    ///
+    /// The method cannot know in which quadrant the angle should fall.
+    /// See <see cref="Atan2(double, double)"/> if you have both <c>y</c> and <c>x</c>.
+    /// </summary>
+    /// <param name="s">The input tangent value.</param>
+    /// <returns>
+    /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Atan(double s)
+    {
+        return Math.Atan(s);
+    }
+
+    /// <summary>
+    /// Returns the arc tangent of <paramref name="y"/> and <paramref name="x"/> in radians.
+    /// Use to get the angle of the tangent of <c>y/x</c>. To compute the value, the method takes into
+    /// account the sign of both arguments in order to determine the quadrant.
+    ///
+    /// Important note: The Y coordinate comes first, by convention.
+    /// </summary>
+    /// <param name="y">The Y coordinate of the point to find the angle to.</param>
+    /// <param name="x">The X coordinate of the point to find the angle to.</param>
+    /// <returns>
+    /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Atan2(float y, float x)
+    {
+        return MathF.Atan2(y, x);
+    }
+
+    /// <summary>
+    /// Returns the arc tangent of <paramref name="y"/> and <paramref name="x"/> in radians.
+    /// Use to get the angle of the tangent of <c>y/x</c>. To compute the value, the method takes into
+    /// account the sign of both arguments in order to determine the quadrant.
+    ///
+    /// Important note: The Y coordinate comes first, by convention.
+    /// </summary>
+    /// <param name="y">The Y coordinate of the point to find the angle to.</param>
+    /// <param name="x">The X coordinate of the point to find the angle to.</param>
+    /// <returns>
+    /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Atan2(double y, double x)
+    {
+        return Math.Atan2(y, x);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> upward (towards positive infinity).
+    /// </summary>
+    /// <param name="s">The number to ceil.</param>
+    /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Ceil(float s)
+    {
+        return MathF.Ceiling(s);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> upward (towards positive infinity).
+    /// </summary>
+    /// <param name="s">The number to ceil.</param>
+    /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Ceil(double s)
+    {
+        return Math.Ceiling(s);
+    }
+
+    /// <summary>
+    /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
+    /// and not more than <paramref name="max"/>.
+    /// </summary>
+    /// <param name="value">The value to clamp.</param>
+    /// <param name="min">The minimum allowed value.</param>
+    /// <param name="max">The maximum allowed value.</param>
+    /// <returns>The clamped value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Clamp(int value, int min, int max)
+    {
+        return Math.Clamp(value, min, max);
+    }
+
+    /// <summary>
+    /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
+    /// and not more than <paramref name="max"/>.
+    /// </summary>
+    /// <param name="value">The value to clamp.</param>
+    /// <param name="min">The minimum allowed value.</param>
+    /// <param name="max">The maximum allowed value.</param>
+    /// <returns>The clamped value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Clamp(float value, float min, float max)
+    {
+        return Math.Clamp(value, min, max);
+    }
+
+    /// <summary>
+    /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
+    /// and not more than <paramref name="max"/>.
+    /// </summary>
+    /// <param name="value">The value to clamp.</param>
+    /// <param name="min">The minimum allowed value.</param>
+    /// <param name="max">The maximum allowed value.</param>
+    /// <returns>The clamped value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Clamp(double value, double min, double max)
+    {
+        return Math.Clamp(value, min, max);
+    }
+
+    /// <summary>
+    /// Returns the cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The cosine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Cos(float s)
+    {
+        return MathF.Cos(s);
+    }
+
+    /// <summary>
+    /// Returns the cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The cosine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Cos(double s)
+    {
+        return Math.Cos(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic cosine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Cosh(float s)
+    {
+        return MathF.Cosh(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic cosine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Cosh(double s)
+    {
+        return Math.Cosh(s);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+    /// with pre and post values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float CubicInterpolate(float from, float to, float pre, float post, float weight)
+    {
+        return 0.5f *
+                ((from * 2.0f) +
+                        (-pre + to) * weight +
+                        (2.0f * pre - 5.0f * from + 4.0f * to - post) * (weight * weight) +
+                        (-pre + 3.0f * from - 3.0f * to + post) * (weight * weight * weight));
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+    /// with pre and post values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double CubicInterpolate(double from, double to, double pre, double post, double weight)
+    {
+        return 0.5 *
+                ((from * 2.0) +
+                        (-pre + to) * weight +
+                        (2.0 * pre - 5.0 * from + 4.0 * to - post) * (weight * weight) +
+                        (-pre + 3.0 * from - 3.0 * to + post) * (weight * weight * weight));
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two rotation values with shortest path
+    /// by the factor defined in <paramref name="weight"/> with pre and post values.
+    /// See also <see cref="LerpAngle(float, float, float)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float CubicInterpolateAngle(float from, float to, float pre, float post, float weight)
+    {
+        float fromRot = from % MathF.Tau;
+
+        float preDiff = (pre - fromRot) % MathF.Tau;
+        float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
+
+        float toDiff = (to - fromRot) % MathF.Tau;
+        float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
+
+        float postDiff = (post - toRot) % MathF.Tau;
+        float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
+
+        return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two rotation values with shortest path
+    /// by the factor defined in <paramref name="weight"/> with pre and post values.
+    /// See also <see cref="LerpAngle(double, double, double)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double CubicInterpolateAngle(double from, double to, double pre, double post, double weight)
+    {
+        double fromRot = from % Math.Tau;
+
+        double preDiff = (pre - fromRot) % Math.Tau;
+        double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
+
+        double toDiff = (to - fromRot) % Math.Tau;
+        double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
+
+        double postDiff = (post - toRot) % Math.Tau;
+        double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
+
+        return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+    /// with pre and post values.
+    /// It can perform smoother interpolation than
+    /// <see cref="CubicInterpolate(float, float, float, float, float)"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="toT"></param>
+    /// <param name="preT"></param>
+    /// <param name="postT"></param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float CubicInterpolateInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
+    {
+        /* Barry-Goldman method */
+        float t = Lerp(0.0f, toT, weight);
+        float a1 = Lerp(pre, from, preT == 0 ? 0.0f : (t - preT) / -preT);
+        float a2 = Lerp(from, to, toT == 0 ? 0.5f : t / toT);
+        float a3 = Lerp(to, post, postT - toT == 0 ? 1.0f : (t - toT) / (postT - toT));
+        float b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
+        float b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
+        return Lerp(b1, b2, toT == 0 ? 0.5f : t / toT);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
+    /// with pre and post values.
+    /// It can perform smoother interpolation than
+    /// <see cref="CubicInterpolate(double, double, double, double, double)"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="toT"></param>
+    /// <param name="preT"></param>
+    /// <param name="postT"></param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double CubicInterpolateInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
+    {
+        /* Barry-Goldman method */
+        double t = Lerp(0.0, toT, weight);
+        double a1 = Lerp(pre, from, preT == 0 ? 0.0 : (t - preT) / -preT);
+        double a2 = Lerp(from, to, toT == 0 ? 0.5 : t / toT);
+        double a3 = Lerp(to, post, postT - toT == 0 ? 1.0 : (t - toT) / (postT - toT));
+        double b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0 : (t - preT) / (toT - preT));
+        double b2 = Lerp(a2, a3, postT == 0 ? 1.0 : t / postT);
+        return Lerp(b1, b2, toT == 0 ? 0.5 : t / toT);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two rotation values with shortest path
+    /// by the factor defined in <paramref name="weight"/> with pre and post values.
+    /// See also <see cref="LerpAngle(float, float, float)"/>.
+    /// It can perform smoother interpolation than
+    /// <see cref="CubicInterpolateAngle(float, float, float, float, float)"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="toT"></param>
+    /// <param name="preT"></param>
+    /// <param name="postT"></param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float CubicInterpolateAngleInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
+    {
+        float fromRot = from % MathF.Tau;
+
+        float preDiff = (pre - fromRot) % MathF.Tau;
+        float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
+
+        float toDiff = (to - fromRot) % MathF.Tau;
+        float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
+
+        float postDiff = (post - toRot) % MathF.Tau;
+        float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
+
+        return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
+    }
+
+    /// <summary>
+    /// Cubic interpolates between two rotation values with shortest path
+    /// by the factor defined in <paramref name="weight"/> with pre and post values.
+    /// See also <see cref="LerpAngle(double, double, double)"/>.
+    /// It can perform smoother interpolation than
+    /// <see cref="CubicInterpolateAngle(double, double, double, double, double)"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="pre">The value which before "from" value for interpolation.</param>
+    /// <param name="post">The value which after "to" value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="toT"></param>
+    /// <param name="preT"></param>
+    /// <param name="postT"></param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double CubicInterpolateAngleInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
+    {
+        double fromRot = from % Math.Tau;
+
+        double preDiff = (pre - fromRot) % Math.Tau;
+        double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
+
+        double toDiff = (to - fromRot) % Math.Tau;
+        double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
+
+        double postDiff = (post - toRot) % Math.Tau;
+        double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
+
+        return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
+    }
+
+    /// <summary>
+    /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by
+    /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="start">The start value for the interpolation.</param>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float BezierInterpolate(float start, float control1, float control2, float end, float t)
+    {
+        // Formula from Wikipedia article on Bezier curves
+        float omt = 1.0f - t;
+        float omt2 = omt * omt;
+        float omt3 = omt2 * omt;
+        float t2 = t * t;
+        float t3 = t2 * t;
+
+        return start * omt3 + control1 * omt2 * t * 3.0f + control2 * omt * t2 * 3.0f + end * t3;
+    }
+
+    /// <summary>
+    /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by
+    /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="start">The start value for the interpolation.</param>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double BezierInterpolate(double start, double control1, double control2, double end, double t)
+    {
+        // Formula from Wikipedia article on Bezier curves
+        double omt = 1.0 - t;
+        double omt2 = omt * omt;
+        double omt3 = omt2 * omt;
+        double t2 = t * t;
+        double t3 = t2 * t;
+
+        return start * omt3 + control1 * omt2 * t * 3.0 + control2 * omt * t2 * 3.0 + end * t3;
+    }
+
+    /// <summary>
+    /// Returns the derivative at the given <paramref name="t"/> on a one dimensional Bezier curve defined by
+    /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="start">The start value for the interpolation.</param>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float BezierDerivative(float start, float control1, float control2, float end, float t)
+    {
+        // Formula from Wikipedia article on Bezier curves
+        float omt = 1.0f - t;
+        float omt2 = omt * omt;
+        float t2 = t * t;
+
+        float d = (control1 - start) * 3.0f * omt2 + (control2 - control1) * 6.0f * omt * t + (end - control2) * 3.0f * t2;
+        return d;
+    }
+
+    /// <summary>
+    /// Returns the derivative at the given <paramref name="t"/> on a one dimensional Bezier curve defined by
+    /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="start">The start value for the interpolation.</param>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double BezierDerivative(double start, double control1, double control2, double end, double t)
+    {
+        // Formula from Wikipedia article on Bezier curves
+        double omt = 1.0 - t;
+        double omt2 = omt * omt;
+        double t2 = t * t;
+
+        double d = (control1 - start) * 3.0 * omt2 + (control2 - control1) * 6.0 * omt * t + (end - control2) * 3.0 * t2;
+        return d;
+    }
+
+    /// <summary>
+    /// Converts from decibels to linear energy (audio).
+    /// </summary>
+    /// <seealso cref="LinearToDb(float)"/>
+    /// <param name="db">Decibels to convert.</param>
+    /// <returns>Audio volume as linear energy.</returns>
+    public static float DbToLinear(float db)
+    {
+        return MathF.Exp(db * 0.11512925464970228420089957273422f);
+    }
+
+    /// <summary>
+    /// Converts from decibels to linear energy (audio).
+    /// </summary>
+    /// <seealso cref="LinearToDb(double)"/>
+    /// <param name="db">Decibels to convert.</param>
+    /// <returns>Audio volume as linear energy.</returns>
+    public static double DbToLinear(double db)
+    {
+        return Math.Exp(db * 0.11512925464970228420089957273422);
+    }
+
+    /// <summary>
+    /// Converts an angle expressed in degrees to radians.
+    /// </summary>
+    /// <param name="deg">An angle expressed in degrees.</param>
+    /// <returns>The same angle expressed in radians.</returns>
+    public static float DegToRad(float deg)
+    {
+        return deg * _degToRadConstF;
+    }
+
+    /// <summary>
+    /// Converts an angle expressed in degrees to radians.
+    /// </summary>
+    /// <param name="deg">An angle expressed in degrees.</param>
+    /// <returns>The same angle expressed in radians.</returns>
+    public static double DegToRad(double deg)
+    {
+        return deg * _degToRadConstD;
+    }
+
+    /// <summary>
+    /// Easing function, based on exponent. The <paramref name="curve"/> values are:
+    /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+    /// Negative values are in-out/out-in.
+    /// </summary>
+    /// <param name="s">The value to ease.</param>
+    /// <param name="curve">
+    /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+    /// </param>
+    /// <returns>The eased value.</returns>
+    public static float Ease(float s, float curve)
+    {
+        if (s < 0.0f)
         {
-            return Math.Abs(s);
+            s = 0.0f;
+        }
+        else if (s > 1.0f)
+        {
+            s = 1.0f;
         }
 
-        /// <summary>
-        /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>The absolute value of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Abs(float s)
+        if (curve > 0.0f)
         {
-            return Math.Abs(s);
-        }
-
-        /// <summary>
-        /// Returns the absolute value of <paramref name="s"/> (i.e. positive value).
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>The absolute value of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Abs(double s)
-        {
-            return Math.Abs(s);
-        }
-
-        /// <summary>
-        /// Returns the arc cosine of <paramref name="s"/> in radians.
-        /// Use to get the angle of cosine <paramref name="s"/>.
-        /// </summary>
-        /// <param name="s">The input cosine value. Must be on the range of -1.0 to 1.0.</param>
-        /// <returns>
-        /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Acos(float s)
-        {
-            return MathF.Acos(s);
-        }
-
-        /// <summary>
-        /// Returns the arc cosine of <paramref name="s"/> in radians.
-        /// Use to get the angle of cosine <paramref name="s"/>.
-        /// </summary>
-        /// <param name="s">The input cosine value. Must be on the range of -1.0 to 1.0.</param>
-        /// <returns>
-        /// An angle that would result in the given cosine value. On the range <c>0</c> to <c>Tau/2</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Acos(double s)
-        {
-            return Math.Acos(s);
-        }
-
-        /// <summary>
-        /// Returns the arc sine of <paramref name="s"/> in radians.
-        /// Use to get the angle of sine <paramref name="s"/>.
-        /// </summary>
-        /// <param name="s">The input sine value. Must be on the range of -1.0 to 1.0.</param>
-        /// <returns>
-        /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Asin(float s)
-        {
-            return MathF.Asin(s);
-        }
-
-        /// <summary>
-        /// Returns the arc sine of <paramref name="s"/> in radians.
-        /// Use to get the angle of sine <paramref name="s"/>.
-        /// </summary>
-        /// <param name="s">The input sine value. Must be on the range of -1.0 to 1.0.</param>
-        /// <returns>
-        /// An angle that would result in the given sine value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Asin(double s)
-        {
-            return Math.Asin(s);
-        }
-
-        /// <summary>
-        /// Returns the arc tangent of <paramref name="s"/> in radians.
-        /// Use to get the angle of tangent <paramref name="s"/>.
-        ///
-        /// The method cannot know in which quadrant the angle should fall.
-        /// See <see cref="Atan2(float, float)"/> if you have both <c>y</c> and <c>x</c>.
-        /// </summary>
-        /// <param name="s">The input tangent value.</param>
-        /// <returns>
-        /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Atan(float s)
-        {
-            return MathF.Atan(s);
-        }
-
-        /// <summary>
-        /// Returns the arc tangent of <paramref name="s"/> in radians.
-        /// Use to get the angle of tangent <paramref name="s"/>.
-        ///
-        /// The method cannot know in which quadrant the angle should fall.
-        /// See <see cref="Atan2(double, double)"/> if you have both <c>y</c> and <c>x</c>.
-        /// </summary>
-        /// <param name="s">The input tangent value.</param>
-        /// <returns>
-        /// An angle that would result in the given tangent value. On the range <c>-Tau/4</c> to <c>Tau/4</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Atan(double s)
-        {
-            return Math.Atan(s);
-        }
-
-        /// <summary>
-        /// Returns the arc tangent of <paramref name="y"/> and <paramref name="x"/> in radians.
-        /// Use to get the angle of the tangent of <c>y/x</c>. To compute the value, the method takes into
-        /// account the sign of both arguments in order to determine the quadrant.
-        ///
-        /// Important note: The Y coordinate comes first, by convention.
-        /// </summary>
-        /// <param name="y">The Y coordinate of the point to find the angle to.</param>
-        /// <param name="x">The X coordinate of the point to find the angle to.</param>
-        /// <returns>
-        /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Atan2(float y, float x)
-        {
-            return MathF.Atan2(y, x);
-        }
-
-        /// <summary>
-        /// Returns the arc tangent of <paramref name="y"/> and <paramref name="x"/> in radians.
-        /// Use to get the angle of the tangent of <c>y/x</c>. To compute the value, the method takes into
-        /// account the sign of both arguments in order to determine the quadrant.
-        ///
-        /// Important note: The Y coordinate comes first, by convention.
-        /// </summary>
-        /// <param name="y">The Y coordinate of the point to find the angle to.</param>
-        /// <param name="x">The X coordinate of the point to find the angle to.</param>
-        /// <returns>
-        /// An angle that would result in the given tangent value. On the range <c>-Tau/2</c> to <c>Tau/2</c>.
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Atan2(double y, double x)
-        {
-            return Math.Atan2(y, x);
-        }
-
-        /// <summary>
-        /// Rounds <paramref name="s"/> upward (towards positive infinity).
-        /// </summary>
-        /// <param name="s">The number to ceil.</param>
-        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Ceil(float s)
-        {
-            return MathF.Ceiling(s);
-        }
-
-        /// <summary>
-        /// Rounds <paramref name="s"/> upward (towards positive infinity).
-        /// </summary>
-        /// <param name="s">The number to ceil.</param>
-        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Ceil(double s)
-        {
-            return Math.Ceiling(s);
-        }
-
-        /// <summary>
-        /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
-        /// and not more than <paramref name="max"/>.
-        /// </summary>
-        /// <param name="value">The value to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>The clamped value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Clamp(int value, int min, int max)
-        {
-            return Math.Clamp(value, min, max);
-        }
-
-        /// <summary>
-        /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
-        /// and not more than <paramref name="max"/>.
-        /// </summary>
-        /// <param name="value">The value to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>The clamped value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Clamp(float value, float min, float max)
-        {
-            return Math.Clamp(value, min, max);
-        }
-
-        /// <summary>
-        /// Clamps a <paramref name="value"/> so that it is not less than <paramref name="min"/>
-        /// and not more than <paramref name="max"/>.
-        /// </summary>
-        /// <param name="value">The value to clamp.</param>
-        /// <param name="min">The minimum allowed value.</param>
-        /// <param name="max">The maximum allowed value.</param>
-        /// <returns>The clamped value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Clamp(double value, double min, double max)
-        {
-            return Math.Clamp(value, min, max);
-        }
-
-        /// <summary>
-        /// Returns the cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The cosine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Cos(float s)
-        {
-            return MathF.Cos(s);
-        }
-
-        /// <summary>
-        /// Returns the cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The cosine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Cos(double s)
-        {
-            return Math.Cos(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic cosine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Cosh(float s)
-        {
-            return MathF.Cosh(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic cosine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Cosh(double s)
-        {
-            return Math.Cosh(s);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
-        /// with pre and post values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float CubicInterpolate(float from, float to, float pre, float post, float weight)
-        {
-            return 0.5f *
-                    ((from * 2.0f) +
-                            (-pre + to) * weight +
-                            (2.0f * pre - 5.0f * from + 4.0f * to - post) * (weight * weight) +
-                            (-pre + 3.0f * from - 3.0f * to + post) * (weight * weight * weight));
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
-        /// with pre and post values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double CubicInterpolate(double from, double to, double pre, double post, double weight)
-        {
-            return 0.5 *
-                    ((from * 2.0) +
-                            (-pre + to) * weight +
-                            (2.0 * pre - 5.0 * from + 4.0 * to - post) * (weight * weight) +
-                            (-pre + 3.0 * from - 3.0 * to + post) * (weight * weight * weight));
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two rotation values with shortest path
-        /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle(float, float, float)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float CubicInterpolateAngle(float from, float to, float pre, float post, float weight)
-        {
-            float fromRot = from % MathF.Tau;
-
-            float preDiff = (pre - fromRot) % MathF.Tau;
-            float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
-
-            float toDiff = (to - fromRot) % MathF.Tau;
-            float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
-
-            float postDiff = (post - toRot) % MathF.Tau;
-            float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
-
-            return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two rotation values with shortest path
-        /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle(double, double, double)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double CubicInterpolateAngle(double from, double to, double pre, double post, double weight)
-        {
-            double fromRot = from % Math.Tau;
-
-            double preDiff = (pre - fromRot) % Math.Tau;
-            double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
-
-            double toDiff = (to - fromRot) % Math.Tau;
-            double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
-
-            double postDiff = (post - toRot) % Math.Tau;
-            double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
-
-            return CubicInterpolate(fromRot, toRot, preRot, postRot, weight);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
-        /// with pre and post values.
-        /// It can perform smoother interpolation than
-        /// <see cref="CubicInterpolate(float, float, float, float, float)"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="toT"></param>
-        /// <param name="preT"></param>
-        /// <param name="postT"></param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float CubicInterpolateInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
-        {
-            /* Barry-Goldman method */
-            float t = Lerp(0.0f, toT, weight);
-            float a1 = Lerp(pre, from, preT == 0 ? 0.0f : (t - preT) / -preT);
-            float a2 = Lerp(from, to, toT == 0 ? 0.5f : t / toT);
-            float a3 = Lerp(to, post, postT - toT == 0 ? 1.0f : (t - toT) / (postT - toT));
-            float b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0f : (t - preT) / (toT - preT));
-            float b2 = Lerp(a2, a3, postT == 0 ? 1.0f : t / postT);
-            return Lerp(b1, b2, toT == 0 ? 0.5f : t / toT);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two values by the factor defined in <paramref name="weight"/>
-        /// with pre and post values.
-        /// It can perform smoother interpolation than
-        /// <see cref="CubicInterpolate(double, double, double, double, double)"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="toT"></param>
-        /// <param name="preT"></param>
-        /// <param name="postT"></param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double CubicInterpolateInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
-        {
-            /* Barry-Goldman method */
-            double t = Lerp(0.0, toT, weight);
-            double a1 = Lerp(pre, from, preT == 0 ? 0.0 : (t - preT) / -preT);
-            double a2 = Lerp(from, to, toT == 0 ? 0.5 : t / toT);
-            double a3 = Lerp(to, post, postT - toT == 0 ? 1.0 : (t - toT) / (postT - toT));
-            double b1 = Lerp(a1, a2, toT - preT == 0 ? 0.0 : (t - preT) / (toT - preT));
-            double b2 = Lerp(a2, a3, postT == 0 ? 1.0 : t / postT);
-            return Lerp(b1, b2, toT == 0 ? 0.5 : t / toT);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two rotation values with shortest path
-        /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle(float, float, float)"/>.
-        /// It can perform smoother interpolation than
-        /// <see cref="CubicInterpolateAngle(float, float, float, float, float)"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="toT"></param>
-        /// <param name="preT"></param>
-        /// <param name="postT"></param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float CubicInterpolateAngleInTime(float from, float to, float pre, float post, float weight, float toT, float preT, float postT)
-        {
-            float fromRot = from % MathF.Tau;
-
-            float preDiff = (pre - fromRot) % MathF.Tau;
-            float preRot = fromRot + (2.0f * preDiff) % MathF.Tau - preDiff;
-
-            float toDiff = (to - fromRot) % MathF.Tau;
-            float toRot = fromRot + (2.0f * toDiff) % MathF.Tau - toDiff;
-
-            float postDiff = (post - toRot) % MathF.Tau;
-            float postRot = toRot + (2.0f * postDiff) % MathF.Tau - postDiff;
-
-            return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
-        }
-
-        /// <summary>
-        /// Cubic interpolates between two rotation values with shortest path
-        /// by the factor defined in <paramref name="weight"/> with pre and post values.
-        /// See also <see cref="LerpAngle(double, double, double)"/>.
-        /// It can perform smoother interpolation than
-        /// <see cref="CubicInterpolateAngle(double, double, double, double, double)"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="pre">The value which before "from" value for interpolation.</param>
-        /// <param name="post">The value which after "to" value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="toT"></param>
-        /// <param name="preT"></param>
-        /// <param name="postT"></param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double CubicInterpolateAngleInTime(double from, double to, double pre, double post, double weight, double toT, double preT, double postT)
-        {
-            double fromRot = from % Math.Tau;
-
-            double preDiff = (pre - fromRot) % Math.Tau;
-            double preRot = fromRot + (2.0 * preDiff) % Math.Tau - preDiff;
-
-            double toDiff = (to - fromRot) % Math.Tau;
-            double toRot = fromRot + (2.0 * toDiff) % Math.Tau - toDiff;
-
-            double postDiff = (post - toRot) % Math.Tau;
-            double postRot = toRot + (2.0 * postDiff) % Math.Tau - postDiff;
-
-            return CubicInterpolateInTime(fromRot, toRot, preRot, postRot, weight, toT, preT, postT);
-        }
-
-        /// <summary>
-        /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by
-        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="start">The start value for the interpolation.</param>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float BezierInterpolate(float start, float control1, float control2, float end, float t)
-        {
-            // Formula from Wikipedia article on Bezier curves
-            float omt = 1.0f - t;
-            float omt2 = omt * omt;
-            float omt3 = omt2 * omt;
-            float t2 = t * t;
-            float t3 = t2 * t;
-
-            return start * omt3 + control1 * omt2 * t * 3.0f + control2 * omt * t2 * 3.0f + end * t3;
-        }
-
-        /// <summary>
-        /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by
-        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="start">The start value for the interpolation.</param>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double BezierInterpolate(double start, double control1, double control2, double end, double t)
-        {
-            // Formula from Wikipedia article on Bezier curves
-            double omt = 1.0 - t;
-            double omt2 = omt * omt;
-            double omt3 = omt2 * omt;
-            double t2 = t * t;
-            double t3 = t2 * t;
-
-            return start * omt3 + control1 * omt2 * t * 3.0 + control2 * omt * t2 * 3.0 + end * t3;
-        }
-
-        /// <summary>
-        /// Returns the derivative at the given <paramref name="t"/> on a one dimensional Bezier curve defined by
-        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="start">The start value for the interpolation.</param>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float BezierDerivative(float start, float control1, float control2, float end, float t)
-        {
-            // Formula from Wikipedia article on Bezier curves
-            float omt = 1.0f - t;
-            float omt2 = omt * omt;
-            float t2 = t * t;
-
-            float d = (control1 - start) * 3.0f * omt2 + (control2 - control1) * 6.0f * omt * t + (end - control2) * 3.0f * t2;
-            return d;
-        }
-
-        /// <summary>
-        /// Returns the derivative at the given <paramref name="t"/> on a one dimensional Bezier curve defined by
-        /// the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="start">The start value for the interpolation.</param>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double BezierDerivative(double start, double control1, double control2, double end, double t)
-        {
-            // Formula from Wikipedia article on Bezier curves
-            double omt = 1.0 - t;
-            double omt2 = omt * omt;
-            double t2 = t * t;
-
-            double d = (control1 - start) * 3.0 * omt2 + (control2 - control1) * 6.0 * omt * t + (end - control2) * 3.0 * t2;
-            return d;
-        }
-
-        /// <summary>
-        /// Converts from decibels to linear energy (audio).
-        /// </summary>
-        /// <seealso cref="LinearToDb(float)"/>
-        /// <param name="db">Decibels to convert.</param>
-        /// <returns>Audio volume as linear energy.</returns>
-        public static float DbToLinear(float db)
-        {
-            return MathF.Exp(db * 0.11512925464970228420089957273422f);
-        }
-
-        /// <summary>
-        /// Converts from decibels to linear energy (audio).
-        /// </summary>
-        /// <seealso cref="LinearToDb(double)"/>
-        /// <param name="db">Decibels to convert.</param>
-        /// <returns>Audio volume as linear energy.</returns>
-        public static double DbToLinear(double db)
-        {
-            return Math.Exp(db * 0.11512925464970228420089957273422);
-        }
-
-        /// <summary>
-        /// Converts an angle expressed in degrees to radians.
-        /// </summary>
-        /// <param name="deg">An angle expressed in degrees.</param>
-        /// <returns>The same angle expressed in radians.</returns>
-        public static float DegToRad(float deg)
-        {
-            return deg * _degToRadConstF;
-        }
-
-        /// <summary>
-        /// Converts an angle expressed in degrees to radians.
-        /// </summary>
-        /// <param name="deg">An angle expressed in degrees.</param>
-        /// <returns>The same angle expressed in radians.</returns>
-        public static double DegToRad(double deg)
-        {
-            return deg * _degToRadConstD;
-        }
-
-        /// <summary>
-        /// Easing function, based on exponent. The <paramref name="curve"/> values are:
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// Negative values are in-out/out-in.
-        /// </summary>
-        /// <param name="s">The value to ease.</param>
-        /// <param name="curve">
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// </param>
-        /// <returns>The eased value.</returns>
-        public static float Ease(float s, float curve)
-        {
-            if (s < 0.0f)
+            if (curve < 1.0f)
             {
-                s = 0.0f;
-            }
-            else if (s > 1.0f)
-            {
-                s = 1.0f;
+                return 1.0f - MathF.Pow(1.0f - s, 1.0f / curve);
             }
 
-            if (curve > 0.0f)
-            {
-                if (curve < 1.0f)
-                {
-                    return 1.0f - MathF.Pow(1.0f - s, 1.0f / curve);
-                }
+            return MathF.Pow(s, curve);
+        }
 
-                return MathF.Pow(s, curve);
+        if (curve < 0.0f)
+        {
+            if (s < 0.5f)
+            {
+                return MathF.Pow(s * 2.0f, -curve) * 0.5f;
             }
 
-            if (curve < 0.0f)
-            {
-                if (s < 0.5f)
-                {
-                    return MathF.Pow(s * 2.0f, -curve) * 0.5f;
-                }
+            return ((1.0f - MathF.Pow(1.0f - ((s - 0.5f) * 2.0f), -curve)) * 0.5f) + 0.5f;
+        }
 
-                return ((1.0f - MathF.Pow(1.0f - ((s - 0.5f) * 2.0f), -curve)) * 0.5f) + 0.5f;
+        return 0.0f;
+    }
+
+    /// <summary>
+    /// Easing function, based on exponent. The <paramref name="curve"/> values are:
+    /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+    /// Negative values are in-out/out-in.
+    /// </summary>
+    /// <param name="s">The value to ease.</param>
+    /// <param name="curve">
+    /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
+    /// </param>
+    /// <returns>The eased value.</returns>
+    public static double Ease(double s, double curve)
+    {
+        if (s < 0.0)
+        {
+            s = 0.0;
+        }
+        else if (s > 1.0)
+        {
+            s = 1.0;
+        }
+
+        if (curve > 0)
+        {
+            if (curve < 1.0)
+            {
+                return 1.0 - Math.Pow(1.0 - s, 1.0 / curve);
             }
 
-            return 0.0f;
+            return Math.Pow(s, curve);
         }
 
-        /// <summary>
-        /// Easing function, based on exponent. The <paramref name="curve"/> values are:
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// Negative values are in-out/out-in.
-        /// </summary>
-        /// <param name="s">The value to ease.</param>
-        /// <param name="curve">
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// </param>
-        /// <returns>The eased value.</returns>
-        public static double Ease(double s, double curve)
+        if (curve < 0.0)
         {
-            if (s < 0.0)
+            if (s < 0.5)
             {
-                s = 0.0;
-            }
-            else if (s > 1.0)
-            {
-                s = 1.0;
+                return Math.Pow(s * 2.0, -curve) * 0.5;
             }
 
-            if (curve > 0)
-            {
-                if (curve < 1.0)
-                {
-                    return 1.0 - Math.Pow(1.0 - s, 1.0 / curve);
-                }
-
-                return Math.Pow(s, curve);
-            }
-
-            if (curve < 0.0)
-            {
-                if (s < 0.5)
-                {
-                    return Math.Pow(s * 2.0, -curve) * 0.5;
-                }
-
-                return ((1.0 - Math.Pow(1.0 - ((s - 0.5) * 2.0), -curve)) * 0.5) + 0.5;
-            }
-
-            return 0.0;
+            return ((1.0 - Math.Pow(1.0 - ((s - 0.5) * 2.0), -curve)) * 0.5) + 0.5;
         }
 
-        /// <summary>
-        /// The natural exponential function. It raises the mathematical
-        /// constant <c>e</c> to the power of <paramref name="s"/> and returns it.
-        /// </summary>
-        /// <param name="s">The exponent to raise <c>e</c> to.</param>
-        /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Exp(float s)
+        return 0.0;
+    }
+
+    /// <summary>
+    /// The natural exponential function. It raises the mathematical
+    /// constant <c>e</c> to the power of <paramref name="s"/> and returns it.
+    /// </summary>
+    /// <param name="s">The exponent to raise <c>e</c> to.</param>
+    /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Exp(float s)
+    {
+        return MathF.Exp(s);
+    }
+
+    /// <summary>
+    /// The natural exponential function. It raises the mathematical
+    /// constant <c>e</c> to the power of <paramref name="s"/> and returns it.
+    /// </summary>
+    /// <param name="s">The exponent to raise <c>e</c> to.</param>
+    /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Exp(double s)
+    {
+        return Math.Exp(s);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> downward (towards negative infinity).
+    /// </summary>
+    /// <param name="s">The number to floor.</param>
+    /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Floor(float s)
+    {
+        return MathF.Floor(s);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> downward (towards negative infinity).
+    /// </summary>
+    /// <param name="s">The number to floor.</param>
+    /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Floor(double s)
+    {
+        return Math.Floor(s);
+    }
+
+    /// <summary>
+    /// Returns a normalized value considering the given range.
+    /// This is the opposite of <see cref="Lerp(float, float, float)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">The interpolated value.</param>
+    /// <returns>
+    /// The resulting value of the inverse interpolation.
+    /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
+    /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
+    /// </returns>
+    public static float InverseLerp(float from, float to, float weight)
+    {
+        return (weight - from) / (to - from);
+    }
+
+    /// <summary>
+    /// Returns a normalized value considering the given range.
+    /// This is the opposite of <see cref="Lerp(double, double, double)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">The interpolated value.</param>
+    /// <returns>
+    /// The resulting value of the inverse interpolation.
+    /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
+    /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
+    /// </returns>
+    public static double InverseLerp(double from, double to, double weight)
+    {
+        return (weight - from) / (to - from);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately equal
+    /// to each other.
+    /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
+    public static bool IsEqualApprox(float a, float b)
+    {
+        // Check for exact equality first, required to handle "infinity" values.
+        if (a == b)
         {
-            return MathF.Exp(s);
+            return true;
         }
-
-        /// <summary>
-        /// The natural exponential function. It raises the mathematical
-        /// constant <c>e</c> to the power of <paramref name="s"/> and returns it.
-        /// </summary>
-        /// <param name="s">The exponent to raise <c>e</c> to.</param>
-        /// <returns><c>e</c> raised to the power of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Exp(double s)
+        // Then check for approximate equality.
+        float tolerance = _epsilonF * Math.Abs(a);
+        if (tolerance < _epsilonF)
         {
-            return Math.Exp(s);
+            tolerance = _epsilonF;
         }
+        return Math.Abs(a - b) < tolerance;
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> downward (towards negative infinity).
-        /// </summary>
-        /// <param name="s">The number to floor.</param>
-        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Floor(float s)
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately equal
+    /// to each other.
+    /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
+    public static bool IsEqualApprox(double a, double b)
+    {
+        // Check for exact equality first, required to handle "infinity" values.
+        if (a == b)
         {
-            return MathF.Floor(s);
+            return true;
         }
-
-        /// <summary>
-        /// Rounds <paramref name="s"/> downward (towards negative infinity).
-        /// </summary>
-        /// <param name="s">The number to floor.</param>
-        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Floor(double s)
+        // Then check for approximate equality.
+        double tolerance = _epsilonD * Math.Abs(a);
+        if (tolerance < _epsilonD)
         {
-            return Math.Floor(s);
+            tolerance = _epsilonD;
         }
+        return Math.Abs(a - b) < tolerance;
+    }
 
-        /// <summary>
-        /// Returns a normalized value considering the given range.
-        /// This is the opposite of <see cref="Lerp(float, float, float)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">The interpolated value.</param>
-        /// <returns>
-        /// The resulting value of the inverse interpolation.
-        /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
-        /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
-        /// </returns>
-        public static float InverseLerp(float from, float to, float weight)
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is a finite value, i.e. it is not
+    /// <see cref="NaN"/>, positive infinite, or negative infinity.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsFinite(float s)
+    {
+        return float.IsFinite(s);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is a finite value, i.e. it is not
+    /// <see cref="NaN"/>, positive infinite, or negative infinity.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsFinite(double s)
+    {
+        return double.IsFinite(s);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is an infinity value (either positive infinity or negative infinity).
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsInf(float s)
+    {
+        return float.IsInfinity(s);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is an infinity value (either positive infinity or negative infinity).
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsInf(double s)
+    {
+        return double.IsInfinity(s);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is a <c>NaN</c> ("Not a Number" or invalid) value.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNaN(float s)
+    {
+        return float.IsNaN(s);
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="s"/> is a <c>NaN</c> ("Not a Number" or invalid) value.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNaN(double s)
+    {
+        return double.IsNaN(s);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
+    /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+    ///
+    /// This method is faster than using <see cref="IsEqualApprox(float, float)"/> with
+    /// one value as zero.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsZeroApprox(float s)
+    {
+        return Math.Abs(s) < _epsilonF;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
+    /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
+    ///
+    /// This method is faster than using <see cref="IsEqualApprox(double, double)"/> with
+    /// one value as zero.
+    /// </summary>
+    /// <param name="s">The value to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsZeroApprox(double s)
+    {
+        return Math.Abs(s) < _epsilonD;
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values by a normalized value.
+    /// This is the opposite <see cref="InverseLerp(float, float, float)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float Lerp(float from, float to, float weight)
+    {
+        return from + ((to - from) * weight);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two values by a normalized value.
+    /// This is the opposite <see cref="InverseLerp(double, double, double)"/>.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double Lerp(double from, double to, double weight)
+    {
+        return from + ((to - from) * weight);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two angles (in radians) by a normalized value.
+    ///
+    /// Similar to <see cref="Lerp(float, float, float)"/>,
+    /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
+    /// </summary>
+    /// <param name="from">The start angle for interpolation.</param>
+    /// <param name="to">The destination angle for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting angle of the interpolation.</returns>
+    public static float LerpAngle(float from, float to, float weight)
+    {
+        float difference = (to - from) % MathF.Tau;
+        float distance = ((2 * difference) % MathF.Tau) - difference;
+        return from + (distance * weight);
+    }
+
+    /// <summary>
+    /// Linearly interpolates between two angles (in radians) by a normalized value.
+    ///
+    /// Similar to <see cref="Lerp(double, double, double)"/>,
+    /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
+    /// </summary>
+    /// <param name="from">The start angle for interpolation.</param>
+    /// <param name="to">The destination angle for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting angle of the interpolation.</returns>
+    public static double LerpAngle(double from, double to, double weight)
+    {
+        double difference = (to - from) % Math.Tau;
+        double distance = ((2 * difference) % Math.Tau) - difference;
+        return from + (distance * weight);
+    }
+
+    /// <summary>
+    /// Converts from linear energy to decibels (audio).
+    /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
+    /// </summary>
+    /// <seealso cref="DbToLinear(float)"/>
+    /// <example>
+    /// <code>
+    /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
+    /// // Its range must be configured to go from 0 to 1.
+    /// // Change the bus name if you'd like to change the volume of a specific bus only.
+    /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
+    /// </code>
+    /// </example>
+    /// <param name="linear">The linear energy to convert.</param>
+    /// <returns>Audio as decibels.</returns>
+    public static float LinearToDb(float linear)
+    {
+        return MathF.Log(linear) * 8.6858896380650365530225783783321f;
+    }
+
+    /// <summary>
+    /// Converts from linear energy to decibels (audio).
+    /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
+    /// </summary>
+    /// <seealso cref="DbToLinear(double)"/>
+    /// <example>
+    /// <code>
+    /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
+    /// // Its range must be configured to go from 0 to 1.
+    /// // Change the bus name if you'd like to change the volume of a specific bus only.
+    /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
+    /// </code>
+    /// </example>
+    /// <param name="linear">The linear energy to convert.</param>
+    /// <returns>Audio as decibels.</returns>
+    public static double LinearToDb(double linear)
+    {
+        return Math.Log(linear) * 8.6858896380650365530225783783321;
+    }
+
+    /// <summary>
+    /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
+    ///
+    /// Note: This is not the same as the "log" function on most calculators, which uses a base 10 logarithm.
+    /// </summary>
+    /// <param name="s">The input value.</param>
+    /// <returns>The natural log of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Log(float s)
+    {
+        return MathF.Log(s);
+    }
+
+    /// <summary>
+    /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
+    ///
+    /// Note: This is not the same as the "log" function on most calculators, which uses a base 10 logarithm.
+    /// </summary>
+    /// <param name="s">The input value.</param>
+    /// <returns>The natural log of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Log(double s)
+    {
+        return Math.Log(s);
+    }
+
+    /// <summary>
+    /// Returns the maximum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is higher.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Max(int a, int b)
+    {
+        return Math.Max(a, b);
+    }
+
+    /// <summary>
+    /// Returns the maximum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is higher.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Max(float a, float b)
+    {
+        return Math.Max(a, b);
+    }
+
+    /// <summary>
+    /// Returns the maximum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is higher.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Max(double a, double b)
+    {
+        return Math.Max(a, b);
+    }
+
+    /// <summary>
+    /// Returns the minimum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is lower.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Min(int a, int b)
+    {
+        return Math.Min(a, b);
+    }
+
+    /// <summary>
+    /// Returns the minimum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is lower.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Min(float a, float b)
+    {
+        return Math.Min(a, b);
+    }
+
+    /// <summary>
+    /// Returns the minimum of two values.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <returns>Whichever of the two values is lower.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Min(double a, double b)
+    {
+        return Math.Min(a, b);
+    }
+
+    /// <summary>
+    /// Moves <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> value.
+    ///
+    /// Use a negative <paramref name="delta"/> value to move away.
+    /// </summary>
+    /// <param name="from">The start value.</param>
+    /// <param name="to">The value to move towards.</param>
+    /// <param name="delta">The amount to move by.</param>
+    /// <returns>The value after moving.</returns>
+    public static float MoveToward(float from, float to, float delta)
+    {
+        if (Math.Abs(to - from) <= delta)
+            return to;
+
+        return from + (Math.Sign(to - from) * delta);
+    }
+
+    /// <summary>
+    /// Moves <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> value.
+    ///
+    /// Use a negative <paramref name="delta"/> value to move away.
+    /// </summary>
+    /// <param name="from">The start value.</param>
+    /// <param name="to">The value to move towards.</param>
+    /// <param name="delta">The amount to move by.</param>
+    /// <returns>The value after moving.</returns>
+    public static double MoveToward(double from, double to, double delta)
+    {
+        if (Math.Abs(to - from) <= delta)
+            return to;
+
+        return from + (Math.Sign(to - from) * delta);
+    }
+
+    /// <summary>
+    /// Returns the nearest larger power of 2 for the integer <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The input value.</param>
+    /// <returns>The nearest larger power of 2.</returns>
+    public static int NearestPo2(int value)
+    {
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        value++;
+        return value;
+    }
+
+    /// <summary>
+    /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
+    /// </summary>
+    /// <param name="a">The dividend, the primary input.</param>
+    /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
+    /// <returns>The resulting output.</returns>
+    public static int PosMod(int a, int b)
+    {
+        int c = a % b;
+        if ((c < 0 && b > 0) || (c > 0 && b < 0))
         {
-            return (weight - from) / (to - from);
+            c += b;
         }
+        return c;
+    }
 
-        /// <summary>
-        /// Returns a normalized value considering the given range.
-        /// This is the opposite of <see cref="Lerp(double, double, double)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">The interpolated value.</param>
-        /// <returns>
-        /// The resulting value of the inverse interpolation.
-        /// The returned value will be between 0.0 and 1.0 if <paramref name="weight"/> is
-        /// between <paramref name="from"/> and <paramref name="to"/> (inclusive).
-        /// </returns>
-        public static double InverseLerp(double from, double to, double weight)
+    /// <summary>
+    /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
+    /// </summary>
+    /// <param name="a">The dividend, the primary input.</param>
+    /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
+    /// <returns>The resulting output.</returns>
+    public static float PosMod(float a, float b)
+    {
+        float c = a % b;
+        if ((c < 0 && b > 0) || (c > 0 && b < 0))
         {
-            return (weight - from) / (to - from);
+            c += b;
         }
+        return c;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately equal
-        /// to each other.
-        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
-        public static bool IsEqualApprox(float a, float b)
+    /// <summary>
+    /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
+    /// </summary>
+    /// <param name="a">The dividend, the primary input.</param>
+    /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
+    /// <returns>The resulting output.</returns>
+    public static double PosMod(double a, double b)
+    {
+        double c = a % b;
+        if ((c < 0 && b > 0) || (c > 0 && b < 0))
         {
-            // Check for exact equality first, required to handle "infinity" values.
-            if (a == b)
-            {
-                return true;
-            }
-            // Then check for approximate equality.
-            float tolerance = _epsilonF * Math.Abs(a);
-            if (tolerance < _epsilonF)
-            {
-                tolerance = _epsilonF;
-            }
-            return Math.Abs(a - b) < tolerance;
+            c += b;
         }
+        return c;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately equal
-        /// to each other.
-        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the two values are approximately equal.</returns>
-        public static bool IsEqualApprox(double a, double b)
+    /// <summary>
+    /// Returns the result of <paramref name="x"/> raised to the power of <paramref name="y"/>.
+    /// </summary>
+    /// <param name="x">The base.</param>
+    /// <param name="y">The exponent.</param>
+    /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Pow(float x, float y)
+    {
+        return MathF.Pow(x, y);
+    }
+
+    /// <summary>
+    /// Returns the result of <paramref name="x"/> raised to the power of <paramref name="y"/>.
+    /// </summary>
+    /// <param name="x">The base.</param>
+    /// <param name="y">The exponent.</param>
+    /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Pow(double x, double y)
+    {
+        return Math.Pow(x, y);
+    }
+
+    /// <summary>
+    /// Converts an angle expressed in radians to degrees.
+    /// </summary>
+    /// <param name="rad">An angle expressed in radians.</param>
+    /// <returns>The same angle expressed in degrees.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float RadToDeg(float rad)
+    {
+        return rad * _radToDegConstF;
+    }
+
+    /// <summary>
+    /// Converts an angle expressed in radians to degrees.
+    /// </summary>
+    /// <param name="rad">An angle expressed in radians.</param>
+    /// <returns>The same angle expressed in degrees.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double RadToDeg(double rad)
+    {
+        return rad * _radToDegConstD;
+    }
+
+    /// <summary>
+    /// Maps a <paramref name="value"/> from [<paramref name="inFrom"/>, <paramref name="inTo"/>]
+    /// to [<paramref name="outFrom"/>, <paramref name="outTo"/>].
+    /// </summary>
+    /// <param name="value">The value to map.</param>
+    /// <param name="inFrom">The start value for the input interpolation.</param>
+    /// <param name="inTo">The destination value for the input interpolation.</param>
+    /// <param name="outFrom">The start value for the output interpolation.</param>
+    /// <param name="outTo">The destination value for the output interpolation.</param>
+    /// <returns>The resulting mapped value mapped.</returns>
+    public static float Remap(float value, float inFrom, float inTo, float outFrom, float outTo)
+    {
+        return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
+    }
+
+    /// <summary>
+    /// Maps a <paramref name="value"/> from [<paramref name="inFrom"/>, <paramref name="inTo"/>]
+    /// to [<paramref name="outFrom"/>, <paramref name="outTo"/>].
+    /// </summary>
+    /// <param name="value">The value to map.</param>
+    /// <param name="inFrom">The start value for the input interpolation.</param>
+    /// <param name="inTo">The destination value for the input interpolation.</param>
+    /// <param name="outFrom">The start value for the output interpolation.</param>
+    /// <param name="outTo">The destination value for the output interpolation.</param>
+    /// <returns>The resulting mapped value mapped.</returns>
+    public static double Remap(double value, double inFrom, double inTo, double outFrom, double outTo)
+    {
+        return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> to the nearest whole number,
+    /// with halfway cases rounded towards the nearest multiple of two.
+    /// </summary>
+    /// <param name="s">The number to round.</param>
+    /// <returns>The rounded number.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Round(float s)
+    {
+        return MathF.Round(s);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="s"/> to the nearest whole number,
+    /// with halfway cases rounded towards the nearest multiple of two.
+    /// </summary>
+    /// <param name="s">The number to round.</param>
+    /// <returns>The rounded number.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Round(double s)
+    {
+        return Math.Round(s);
+    }
+
+    /// <summary>
+    /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
+    /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Sign(int s)
+    {
+        return Math.Sign(s);
+    }
+
+    /// <summary>
+    /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
+    /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Sign(float s)
+    {
+        return Math.Sign(s);
+    }
+
+    /// <summary>
+    /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
+    /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
+    /// </summary>
+    /// <param name="s">The input number.</param>
+    /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Sign(double s)
+    {
+        return Math.Sign(s);
+    }
+
+    /// <summary>
+    /// Returns the sine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The sine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Sin(float s)
+    {
+        return MathF.Sin(s);
+    }
+
+    /// <summary>
+    /// Returns the sine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The sine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Sin(double s)
+    {
+        return Math.Sin(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic sine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic sine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Sinh(float s)
+    {
+        return MathF.Sinh(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic sine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic sine of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Sinh(double s)
+    {
+        return Math.Sinh(s);
+    }
+
+    /// <summary>
+    /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
+    /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(float, float, float)"/>,
+    /// but interpolates faster at the beginning and slower at the end.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">A value representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static float SmoothStep(float from, float to, float weight)
+    {
+        if (IsEqualApprox(from, to))
         {
-            // Check for exact equality first, required to handle "infinity" values.
-            if (a == b)
-            {
-                return true;
-            }
-            // Then check for approximate equality.
-            double tolerance = _epsilonD * Math.Abs(a);
-            if (tolerance < _epsilonD)
-            {
-                tolerance = _epsilonD;
-            }
-            return Math.Abs(a - b) < tolerance;
+            return from;
         }
+        float x = Math.Clamp((weight - from) / (to - from), 0.0f, 1.0f);
+        return x * x * (3 - (2 * x));
+    }
 
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is a finite value, i.e. it is not
-        /// <see cref="NaN"/>, positive infinite, or negative infinity.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsFinite(float s)
+    /// <summary>
+    /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
+    /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(double, double, double)"/>,
+    /// but interpolates faster at the beginning and slower at the end.
+    /// </summary>
+    /// <param name="from">The start value for interpolation.</param>
+    /// <param name="to">The destination value for interpolation.</param>
+    /// <param name="weight">A value representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public static double SmoothStep(double from, double to, double weight)
+    {
+        if (IsEqualApprox(from, to))
         {
-            return float.IsFinite(s);
+            return from;
         }
+        double x = Math.Clamp((weight - from) / (to - from), 0.0, 1.0);
+        return x * x * (3 - (2 * x));
+    }
 
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is a finite value, i.e. it is not
-        /// <see cref="NaN"/>, positive infinite, or negative infinity.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is a finite value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsFinite(double s)
+    /// <summary>
+    /// Returns the square root of <paramref name="s"/>, where <paramref name="s"/> is a non-negative number.
+    ///
+    /// If you need negative inputs, use <see cref="System.Numerics.Complex"/>.
+    /// </summary>
+    /// <param name="s">The input number. Must not be negative.</param>
+    /// <returns>The square root of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Sqrt(float s)
+    {
+        return MathF.Sqrt(s);
+    }
+
+    /// <summary>
+    /// Returns the square root of <paramref name="s"/>, where <paramref name="s"/> is a non-negative number.
+    ///
+    /// If you need negative inputs, use <see cref="System.Numerics.Complex"/>.
+    /// </summary>
+    /// <param name="s">The input number. Must not be negative.</param>
+    /// <returns>The square root of <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Sqrt(double s)
+    {
+        return Math.Sqrt(s);
+    }
+
+    /// <summary>
+    /// Returns the position of the first non-zero digit, after the
+    /// decimal point. Note that the maximum return value is 10,
+    /// which is a design decision in the implementation.
+    /// </summary>
+    /// <param name="step">The input value.</param>
+    /// <returns>The position of the first non-zero digit.</returns>
+    public static int StepDecimals(double step)
+    {
+        double[] sd = new double[]
         {
-            return double.IsFinite(s);
-        }
-
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is an infinity value (either positive infinity or negative infinity).
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsInf(float s)
-        {
-            return float.IsInfinity(s);
-        }
-
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is an infinity value (either positive infinity or negative infinity).
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is an infinity value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsInf(double s)
-        {
-            return double.IsInfinity(s);
-        }
-
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is a <c>NaN</c> ("Not a Number" or invalid) value.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNaN(float s)
-        {
-            return float.IsNaN(s);
-        }
-
-        /// <summary>
-        /// Returns whether <paramref name="s"/> is a <c>NaN</c> ("Not a Number" or invalid) value.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is a <c>NaN</c> value.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNaN(double s)
-        {
-            return double.IsNaN(s);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
-        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
-        ///
-        /// This method is faster than using <see cref="IsEqualApprox(float, float)"/> with
-        /// one value as zero.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsZeroApprox(float s)
-        {
-            return Math.Abs(s) < _epsilonF;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="s"/> is zero or almost zero.
-        /// The comparison is done using a tolerance calculation with <see cref="Epsilon"/>.
-        ///
-        /// This method is faster than using <see cref="IsEqualApprox(double, double)"/> with
-        /// one value as zero.
-        /// </summary>
-        /// <param name="s">The value to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the value is nearly zero.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsZeroApprox(double s)
-        {
-            return Math.Abs(s) < _epsilonD;
-        }
-
-        /// <summary>
-        /// Linearly interpolates between two values by a normalized value.
-        /// This is the opposite <see cref="InverseLerp(float, float, float)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float Lerp(float from, float to, float weight)
-        {
-            return from + ((to - from) * weight);
-        }
-
-        /// <summary>
-        /// Linearly interpolates between two values by a normalized value.
-        /// This is the opposite <see cref="InverseLerp(double, double, double)"/>.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double Lerp(double from, double to, double weight)
-        {
-            return from + ((to - from) * weight);
-        }
-
-        /// <summary>
-        /// Linearly interpolates between two angles (in radians) by a normalized value.
-        ///
-        /// Similar to <see cref="Lerp(float, float, float)"/>,
-        /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
-        /// </summary>
-        /// <param name="from">The start angle for interpolation.</param>
-        /// <param name="to">The destination angle for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting angle of the interpolation.</returns>
-        public static float LerpAngle(float from, float to, float weight)
-        {
-            float difference = (to - from) % MathF.Tau;
-            float distance = ((2 * difference) % MathF.Tau) - difference;
-            return from + (distance * weight);
-        }
-
-        /// <summary>
-        /// Linearly interpolates between two angles (in radians) by a normalized value.
-        ///
-        /// Similar to <see cref="Lerp(double, double, double)"/>,
-        /// but interpolates correctly when the angles wrap around <see cref="Tau"/>.
-        /// </summary>
-        /// <param name="from">The start angle for interpolation.</param>
-        /// <param name="to">The destination angle for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting angle of the interpolation.</returns>
-        public static double LerpAngle(double from, double to, double weight)
-        {
-            double difference = (to - from) % Math.Tau;
-            double distance = ((2 * difference) % Math.Tau) - difference;
-            return from + (distance * weight);
-        }
-
-        /// <summary>
-        /// Converts from linear energy to decibels (audio).
-        /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
-        /// </summary>
-        /// <seealso cref="DbToLinear(float)"/>
-        /// <example>
-        /// <code>
-        /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
-        /// // Its range must be configured to go from 0 to 1.
-        /// // Change the bus name if you'd like to change the volume of a specific bus only.
-        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
-        /// </code>
-        /// </example>
-        /// <param name="linear">The linear energy to convert.</param>
-        /// <returns>Audio as decibels.</returns>
-        public static float LinearToDb(float linear)
-        {
-            return MathF.Log(linear) * 8.6858896380650365530225783783321f;
-        }
-
-        /// <summary>
-        /// Converts from linear energy to decibels (audio).
-        /// This can be used to implement volume sliders that behave as expected (since volume isn't linear).
-        /// </summary>
-        /// <seealso cref="DbToLinear(double)"/>
-        /// <example>
-        /// <code>
-        /// // "slider" refers to a node that inherits Range such as HSlider or VSlider.
-        /// // Its range must be configured to go from 0 to 1.
-        /// // Change the bus name if you'd like to change the volume of a specific bus only.
-        /// AudioServer.SetBusVolumeDb(AudioServer.GetBusIndex("Master"), GD.LinearToDb(slider.value));
-        /// </code>
-        /// </example>
-        /// <param name="linear">The linear energy to convert.</param>
-        /// <returns>Audio as decibels.</returns>
-        public static double LinearToDb(double linear)
-        {
-            return Math.Log(linear) * 8.6858896380650365530225783783321;
-        }
-
-        /// <summary>
-        /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
-        ///
-        /// Note: This is not the same as the "log" function on most calculators, which uses a base 10 logarithm.
-        /// </summary>
-        /// <param name="s">The input value.</param>
-        /// <returns>The natural log of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Log(float s)
-        {
-            return MathF.Log(s);
-        }
-
-        /// <summary>
-        /// Natural logarithm. The amount of time needed to reach a certain level of continuous growth.
-        ///
-        /// Note: This is not the same as the "log" function on most calculators, which uses a base 10 logarithm.
-        /// </summary>
-        /// <param name="s">The input value.</param>
-        /// <returns>The natural log of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Log(double s)
-        {
-            return Math.Log(s);
-        }
-
-        /// <summary>
-        /// Returns the maximum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is higher.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Max(int a, int b)
-        {
-            return Math.Max(a, b);
-        }
-
-        /// <summary>
-        /// Returns the maximum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is higher.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Max(float a, float b)
-        {
-            return Math.Max(a, b);
-        }
-
-        /// <summary>
-        /// Returns the maximum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is higher.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Max(double a, double b)
-        {
-            return Math.Max(a, b);
-        }
-
-        /// <summary>
-        /// Returns the minimum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is lower.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Min(int a, int b)
-        {
-            return Math.Min(a, b);
-        }
-
-        /// <summary>
-        /// Returns the minimum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is lower.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Min(float a, float b)
-        {
-            return Math.Min(a, b);
-        }
-
-        /// <summary>
-        /// Returns the minimum of two values.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <returns>Whichever of the two values is lower.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Min(double a, double b)
-        {
-            return Math.Min(a, b);
-        }
-
-        /// <summary>
-        /// Moves <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> value.
-        ///
-        /// Use a negative <paramref name="delta"/> value to move away.
-        /// </summary>
-        /// <param name="from">The start value.</param>
-        /// <param name="to">The value to move towards.</param>
-        /// <param name="delta">The amount to move by.</param>
-        /// <returns>The value after moving.</returns>
-        public static float MoveToward(float from, float to, float delta)
-        {
-            if (Math.Abs(to - from) <= delta)
-                return to;
-
-            return from + (Math.Sign(to - from) * delta);
-        }
-
-        /// <summary>
-        /// Moves <paramref name="from"/> toward <paramref name="to"/> by the <paramref name="delta"/> value.
-        ///
-        /// Use a negative <paramref name="delta"/> value to move away.
-        /// </summary>
-        /// <param name="from">The start value.</param>
-        /// <param name="to">The value to move towards.</param>
-        /// <param name="delta">The amount to move by.</param>
-        /// <returns>The value after moving.</returns>
-        public static double MoveToward(double from, double to, double delta)
-        {
-            if (Math.Abs(to - from) <= delta)
-                return to;
-
-            return from + (Math.Sign(to - from) * delta);
-        }
-
-        /// <summary>
-        /// Returns the nearest larger power of 2 for the integer <paramref name="value"/>.
-        /// </summary>
-        /// <param name="value">The input value.</param>
-        /// <returns>The nearest larger power of 2.</returns>
-        public static int NearestPo2(int value)
-        {
-            value--;
-            value |= value >> 1;
-            value |= value >> 2;
-            value |= value >> 4;
-            value |= value >> 8;
-            value |= value >> 16;
-            value++;
-            return value;
-        }
-
-        /// <summary>
-        /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
-        /// </summary>
-        /// <param name="a">The dividend, the primary input.</param>
-        /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
-        /// <returns>The resulting output.</returns>
-        public static int PosMod(int a, int b)
-        {
-            int c = a % b;
-            if ((c < 0 && b > 0) || (c > 0 && b < 0))
-            {
-                c += b;
-            }
-            return c;
-        }
-
-        /// <summary>
-        /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
-        /// </summary>
-        /// <param name="a">The dividend, the primary input.</param>
-        /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
-        /// <returns>The resulting output.</returns>
-        public static float PosMod(float a, float b)
-        {
-            float c = a % b;
-            if ((c < 0 && b > 0) || (c > 0 && b < 0))
-            {
-                c += b;
-            }
-            return c;
-        }
-
-        /// <summary>
-        /// Performs a canonical Modulus operation, where the output is on the range [0, <paramref name="b"/>).
-        /// </summary>
-        /// <param name="a">The dividend, the primary input.</param>
-        /// <param name="b">The divisor. The output is on the range [0, <paramref name="b"/>).</param>
-        /// <returns>The resulting output.</returns>
-        public static double PosMod(double a, double b)
-        {
-            double c = a % b;
-            if ((c < 0 && b > 0) || (c > 0 && b < 0))
-            {
-                c += b;
-            }
-            return c;
-        }
-
-        /// <summary>
-        /// Returns the result of <paramref name="x"/> raised to the power of <paramref name="y"/>.
-        /// </summary>
-        /// <param name="x">The base.</param>
-        /// <param name="y">The exponent.</param>
-        /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Pow(float x, float y)
-        {
-            return MathF.Pow(x, y);
-        }
-
-        /// <summary>
-        /// Returns the result of <paramref name="x"/> raised to the power of <paramref name="y"/>.
-        /// </summary>
-        /// <param name="x">The base.</param>
-        /// <param name="y">The exponent.</param>
-        /// <returns><paramref name="x"/> raised to the power of <paramref name="y"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Pow(double x, double y)
-        {
-            return Math.Pow(x, y);
-        }
-
-        /// <summary>
-        /// Converts an angle expressed in radians to degrees.
-        /// </summary>
-        /// <param name="rad">An angle expressed in radians.</param>
-        /// <returns>The same angle expressed in degrees.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float RadToDeg(float rad)
-        {
-            return rad * _radToDegConstF;
-        }
-
-        /// <summary>
-        /// Converts an angle expressed in radians to degrees.
-        /// </summary>
-        /// <param name="rad">An angle expressed in radians.</param>
-        /// <returns>The same angle expressed in degrees.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double RadToDeg(double rad)
-        {
-            return rad * _radToDegConstD;
-        }
-
-        /// <summary>
-        /// Maps a <paramref name="value"/> from [<paramref name="inFrom"/>, <paramref name="inTo"/>]
-        /// to [<paramref name="outFrom"/>, <paramref name="outTo"/>].
-        /// </summary>
-        /// <param name="value">The value to map.</param>
-        /// <param name="inFrom">The start value for the input interpolation.</param>
-        /// <param name="inTo">The destination value for the input interpolation.</param>
-        /// <param name="outFrom">The start value for the output interpolation.</param>
-        /// <param name="outTo">The destination value for the output interpolation.</param>
-        /// <returns>The resulting mapped value mapped.</returns>
-        public static float Remap(float value, float inFrom, float inTo, float outFrom, float outTo)
-        {
-            return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
-        }
-
-        /// <summary>
-        /// Maps a <paramref name="value"/> from [<paramref name="inFrom"/>, <paramref name="inTo"/>]
-        /// to [<paramref name="outFrom"/>, <paramref name="outTo"/>].
-        /// </summary>
-        /// <param name="value">The value to map.</param>
-        /// <param name="inFrom">The start value for the input interpolation.</param>
-        /// <param name="inTo">The destination value for the input interpolation.</param>
-        /// <param name="outFrom">The start value for the output interpolation.</param>
-        /// <param name="outTo">The destination value for the output interpolation.</param>
-        /// <returns>The resulting mapped value mapped.</returns>
-        public static double Remap(double value, double inFrom, double inTo, double outFrom, double outTo)
-        {
-            return Lerp(outFrom, outTo, InverseLerp(inFrom, inTo, value));
-        }
-
-        /// <summary>
-        /// Rounds <paramref name="s"/> to the nearest whole number,
-        /// with halfway cases rounded towards the nearest multiple of two.
-        /// </summary>
-        /// <param name="s">The number to round.</param>
-        /// <returns>The rounded number.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Round(float s)
-        {
-            return MathF.Round(s);
-        }
-
-        /// <summary>
-        /// Rounds <paramref name="s"/> to the nearest whole number,
-        /// with halfway cases rounded towards the nearest multiple of two.
-        /// </summary>
-        /// <param name="s">The number to round.</param>
-        /// <returns>The rounded number.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Round(double s)
-        {
-            return Math.Round(s);
-        }
-
-        /// <summary>
-        /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
-        /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Sign(int s)
-        {
-            return Math.Sign(s);
-        }
-
-        /// <summary>
-        /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
-        /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Sign(float s)
-        {
-            return Math.Sign(s);
-        }
-
-        /// <summary>
-        /// Returns the sign of <paramref name="s"/>: <c>-1</c> or <c>1</c>.
-        /// Returns <c>0</c> if <paramref name="s"/> is <c>0</c>.
-        /// </summary>
-        /// <param name="s">The input number.</param>
-        /// <returns>One of three possible values: <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Sign(double s)
-        {
-            return Math.Sign(s);
-        }
-
-        /// <summary>
-        /// Returns the sine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The sine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Sin(float s)
-        {
-            return MathF.Sin(s);
-        }
-
-        /// <summary>
-        /// Returns the sine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The sine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Sin(double s)
-        {
-            return Math.Sin(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic sine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic sine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Sinh(float s)
-        {
-            return MathF.Sinh(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic sine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic sine of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Sinh(double s)
-        {
-            return Math.Sinh(s);
-        }
-
-        /// <summary>
-        /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
-        /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(float, float, float)"/>,
-        /// but interpolates faster at the beginning and slower at the end.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">A value representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static float SmoothStep(float from, float to, float weight)
-        {
-            if (IsEqualApprox(from, to))
-            {
-                return from;
-            }
-            float x = Math.Clamp((weight - from) / (to - from), 0.0f, 1.0f);
-            return x * x * (3 - (2 * x));
-        }
-
-        /// <summary>
-        /// Returns a number smoothly interpolated between <paramref name="from"/> and <paramref name="to"/>,
-        /// based on the <paramref name="weight"/>. Similar to <see cref="Lerp(double, double, double)"/>,
-        /// but interpolates faster at the beginning and slower at the end.
-        /// </summary>
-        /// <param name="from">The start value for interpolation.</param>
-        /// <param name="to">The destination value for interpolation.</param>
-        /// <param name="weight">A value representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public static double SmoothStep(double from, double to, double weight)
-        {
-            if (IsEqualApprox(from, to))
-            {
-                return from;
-            }
-            double x = Math.Clamp((weight - from) / (to - from), 0.0, 1.0);
-            return x * x * (3 - (2 * x));
-        }
-
-        /// <summary>
-        /// Returns the square root of <paramref name="s"/>, where <paramref name="s"/> is a non-negative number.
-        ///
-        /// If you need negative inputs, use <see cref="System.Numerics.Complex"/>.
-        /// </summary>
-        /// <param name="s">The input number. Must not be negative.</param>
-        /// <returns>The square root of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Sqrt(float s)
-        {
-            return MathF.Sqrt(s);
-        }
-
-        /// <summary>
-        /// Returns the square root of <paramref name="s"/>, where <paramref name="s"/> is a non-negative number.
-        ///
-        /// If you need negative inputs, use <see cref="System.Numerics.Complex"/>.
-        /// </summary>
-        /// <param name="s">The input number. Must not be negative.</param>
-        /// <returns>The square root of <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Sqrt(double s)
-        {
-            return Math.Sqrt(s);
-        }
-
-        /// <summary>
-        /// Returns the position of the first non-zero digit, after the
-        /// decimal point. Note that the maximum return value is 10,
-        /// which is a design decision in the implementation.
-        /// </summary>
-        /// <param name="step">The input value.</param>
-        /// <returns>The position of the first non-zero digit.</returns>
-        public static int StepDecimals(double step)
-        {
-            double[] sd = new double[]
-            {
                 0.9999,
                 0.09999,
                 0.009999,
@@ -1526,192 +1526,191 @@ namespace Godot
                 0.0000009999,
                 0.00000009999,
                 0.000000009999,
-            };
-            double abs = Math.Abs(step);
-            double decs = abs - (int)abs; // Strip away integer part
-            for (int i = 0; i < sd.Length; i++)
+        };
+        double abs = Math.Abs(step);
+        double decs = abs - (int)abs; // Strip away integer part
+        for (int i = 0; i < sd.Length; i++)
+        {
+            if (decs >= sd[i])
             {
-                if (decs >= sd[i])
-                {
-                    return i;
-                }
-            }
-            return 0;
-        }
-
-        /// <summary>
-        /// Snaps float value <paramref name="s"/> to a given <paramref name="step"/>.
-        /// This can also be used to round a floating point number to an arbitrary number of decimals.
-        /// </summary>
-        /// <param name="s">The value to snap.</param>
-        /// <param name="step">The step size to snap to.</param>
-        /// <returns>The snapped value.</returns>
-        public static float Snapped(float s, float step)
-        {
-            if (step != 0f)
-            {
-                return MathF.Floor((s / step) + 0.5f) * step;
-            }
-
-            return s;
-        }
-
-        /// <summary>
-        /// Snaps float value <paramref name="s"/> to a given <paramref name="step"/>.
-        /// This can also be used to round a floating point number to an arbitrary number of decimals.
-        /// </summary>
-        /// <param name="s">The value to snap.</param>
-        /// <param name="step">The step size to snap to.</param>
-        /// <returns>The snapped value.</returns>
-        public static double Snapped(double s, double step)
-        {
-            if (step != 0f)
-            {
-                return Math.Floor((s / step) + 0.5f) * step;
-            }
-
-            return s;
-        }
-
-        /// <summary>
-        /// Returns the tangent of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The tangent of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Tan(float s)
-        {
-            return MathF.Tan(s);
-        }
-
-        /// <summary>
-        /// Returns the tangent of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The tangent of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Tan(double s)
-        {
-            return Math.Tan(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic tangent of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic tangent of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Tanh(float s)
-        {
-            return MathF.Tanh(s);
-        }
-
-        /// <summary>
-        /// Returns the hyperbolic tangent of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The hyperbolic tangent of that angle.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static double Tanh(double s)
-        {
-            return Math.Tanh(s);
-        }
-
-        /// <summary>
-        /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
-        /// Usable for creating loop-alike behavior or infinite surfaces.
-        /// If <paramref name="min"/> is <c>0</c>, this is equivalent
-        /// to <see cref="PosMod(int, int)"/>, so prefer using that instead.
-        /// </summary>
-        /// <param name="value">The value to wrap.</param>
-        /// <param name="min">The minimum allowed value and lower bound of the range.</param>
-        /// <param name="max">The maximum allowed value and upper bound of the range.</param>
-        /// <returns>The wrapped value.</returns>
-        public static int Wrap(int value, int min, int max)
-        {
-            int range = max - min;
-            if (range == 0)
-                return min;
-
-            return min + ((((value - min) % range) + range) % range);
-        }
-
-        /// <summary>
-        /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
-        /// Usable for creating loop-alike behavior or infinite surfaces.
-        /// If <paramref name="min"/> is <c>0</c>, this is equivalent
-        /// to <see cref="PosMod(float, float)"/>, so prefer using that instead.
-        /// </summary>
-        /// <param name="value">The value to wrap.</param>
-        /// <param name="min">The minimum allowed value and lower bound of the range.</param>
-        /// <param name="max">The maximum allowed value and upper bound of the range.</param>
-        /// <returns>The wrapped value.</returns>
-        public static float Wrap(float value, float min, float max)
-        {
-            float range = max - min;
-            if (IsZeroApprox(range))
-            {
-                return min;
-            }
-            return min + ((((value - min) % range) + range) % range);
-        }
-
-        /// <summary>
-        /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
-        /// Usable for creating loop-alike behavior or infinite surfaces.
-        /// If <paramref name="min"/> is <c>0</c>, this is equivalent
-        /// to <see cref="PosMod(double, double)"/>, so prefer using that instead.
-        /// </summary>
-        /// <param name="value">The value to wrap.</param>
-        /// <param name="min">The minimum allowed value and lower bound of the range.</param>
-        /// <param name="max">The maximum allowed value and upper bound of the range.</param>
-        /// <returns>The wrapped value.</returns>
-        public static double Wrap(double value, double min, double max)
-        {
-            double range = max - min;
-            if (IsZeroApprox(range))
-            {
-                return min;
-            }
-            return min + ((((value - min) % range) + range) % range);
-        }
-
-        /// <summary>
-        /// Returns the <paramref name="value"/> wrapped between <c>0</c> and the <paramref name="length"/>.
-        /// If the limit is reached, the next value the function returned is decreased to the <c>0</c> side
-        /// or increased to the <paramref name="length"/> side (like a triangle wave).
-        /// If <paramref name="length"/> is less than zero, it becomes positive.
-        /// </summary>
-        /// <param name="value">The value to pingpong.</param>
-        /// <param name="length">The maximum value of the function.</param>
-        /// <returns>The ping-ponged value.</returns>
-        public static float PingPong(float value, float length)
-        {
-            return (length != 0.0f) ? Math.Abs(Fract((value - length) / (length * 2.0f)) * length * 2.0f - length) : 0.0f;
-
-            static float Fract(float value)
-            {
-                return value - MathF.Floor(value);
+                return i;
             }
         }
+        return 0;
+    }
 
-        /// <summary>
-        /// Returns the <paramref name="value"/> wrapped between <c>0</c> and the <paramref name="length"/>.
-        /// If the limit is reached, the next value the function returned is decreased to the <c>0</c> side
-        /// or increased to the <paramref name="length"/> side (like a triangle wave).
-        /// If <paramref name="length"/> is less than zero, it becomes positive.
-        /// </summary>
-        /// <param name="value">The value to pingpong.</param>
-        /// <param name="length">The maximum value of the function.</param>
-        /// <returns>The ping-ponged value.</returns>
-        public static double PingPong(double value, double length)
+    /// <summary>
+    /// Snaps float value <paramref name="s"/> to a given <paramref name="step"/>.
+    /// This can also be used to round a floating point number to an arbitrary number of decimals.
+    /// </summary>
+    /// <param name="s">The value to snap.</param>
+    /// <param name="step">The step size to snap to.</param>
+    /// <returns>The snapped value.</returns>
+    public static float Snapped(float s, float step)
+    {
+        if (step != 0f)
         {
-            return (length != 0.0) ? Math.Abs(Fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
+            return MathF.Floor((s / step) + 0.5f) * step;
+        }
 
-            static double Fract(double value)
-            {
-                return value - Math.Floor(value);
-            }
+        return s;
+    }
+
+    /// <summary>
+    /// Snaps float value <paramref name="s"/> to a given <paramref name="step"/>.
+    /// This can also be used to round a floating point number to an arbitrary number of decimals.
+    /// </summary>
+    /// <param name="s">The value to snap.</param>
+    /// <param name="step">The step size to snap to.</param>
+    /// <returns>The snapped value.</returns>
+    public static double Snapped(double s, double step)
+    {
+        if (step != 0f)
+        {
+            return Math.Floor((s / step) + 0.5f) * step;
+        }
+
+        return s;
+    }
+
+    /// <summary>
+    /// Returns the tangent of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The tangent of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Tan(float s)
+    {
+        return MathF.Tan(s);
+    }
+
+    /// <summary>
+    /// Returns the tangent of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The tangent of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Tan(double s)
+    {
+        return Math.Tan(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic tangent of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic tangent of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float Tanh(float s)
+    {
+        return MathF.Tanh(s);
+    }
+
+    /// <summary>
+    /// Returns the hyperbolic tangent of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The hyperbolic tangent of that angle.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Tanh(double s)
+    {
+        return Math.Tanh(s);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
+    /// Usable for creating loop-alike behavior or infinite surfaces.
+    /// If <paramref name="min"/> is <c>0</c>, this is equivalent
+    /// to <see cref="PosMod(int, int)"/>, so prefer using that instead.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <param name="min">The minimum allowed value and lower bound of the range.</param>
+    /// <param name="max">The maximum allowed value and upper bound of the range.</param>
+    /// <returns>The wrapped value.</returns>
+    public static int Wrap(int value, int min, int max)
+    {
+        int range = max - min;
+        if (range == 0)
+            return min;
+
+        return min + ((((value - min) % range) + range) % range);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
+    /// Usable for creating loop-alike behavior or infinite surfaces.
+    /// If <paramref name="min"/> is <c>0</c>, this is equivalent
+    /// to <see cref="PosMod(float, float)"/>, so prefer using that instead.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <param name="min">The minimum allowed value and lower bound of the range.</param>
+    /// <param name="max">The maximum allowed value and upper bound of the range.</param>
+    /// <returns>The wrapped value.</returns>
+    public static float Wrap(float value, float min, float max)
+    {
+        float range = max - min;
+        if (IsZeroApprox(range))
+        {
+            return min;
+        }
+        return min + ((((value - min) % range) + range) % range);
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="value"/> between <paramref name="min"/> and <paramref name="max"/>.
+    /// Usable for creating loop-alike behavior or infinite surfaces.
+    /// If <paramref name="min"/> is <c>0</c>, this is equivalent
+    /// to <see cref="PosMod(double, double)"/>, so prefer using that instead.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <param name="min">The minimum allowed value and lower bound of the range.</param>
+    /// <param name="max">The maximum allowed value and upper bound of the range.</param>
+    /// <returns>The wrapped value.</returns>
+    public static double Wrap(double value, double min, double max)
+    {
+        double range = max - min;
+        if (IsZeroApprox(range))
+        {
+            return min;
+        }
+        return min + ((((value - min) % range) + range) % range);
+    }
+
+    /// <summary>
+    /// Returns the <paramref name="value"/> wrapped between <c>0</c> and the <paramref name="length"/>.
+    /// If the limit is reached, the next value the function returned is decreased to the <c>0</c> side
+    /// or increased to the <paramref name="length"/> side (like a triangle wave).
+    /// If <paramref name="length"/> is less than zero, it becomes positive.
+    /// </summary>
+    /// <param name="value">The value to pingpong.</param>
+    /// <param name="length">The maximum value of the function.</param>
+    /// <returns>The ping-ponged value.</returns>
+    public static float PingPong(float value, float length)
+    {
+        return (length != 0.0f) ? Math.Abs(Fract((value - length) / (length * 2.0f)) * length * 2.0f - length) : 0.0f;
+
+        static float Fract(float value)
+        {
+            return value - MathF.Floor(value);
+        }
+    }
+
+    /// <summary>
+    /// Returns the <paramref name="value"/> wrapped between <c>0</c> and the <paramref name="length"/>.
+    /// If the limit is reached, the next value the function returned is decreased to the <c>0</c> side
+    /// or increased to the <paramref name="length"/> side (like a triangle wave).
+    /// If <paramref name="length"/> is less than zero, it becomes positive.
+    /// </summary>
+    /// <param name="value">The value to pingpong.</param>
+    /// <param name="length">The maximum value of the function.</param>
+    /// <returns>The ping-ponged value.</returns>
+    public static double PingPong(double value, double length)
+    {
+        return (length != 0.0) ? Math.Abs(Fract((value - length) / (length * 2.0)) * length * 2.0 - length) : 0.0;
+
+        static double Fract(double value)
+        {
+            return value - Math.Floor(value);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/MathfEx.cs
@@ -4,196 +4,195 @@ using System.Runtime.CompilerServices;
 // This file contains extra members for the Mathf class that aren't part of Godot's Core API.
 // Math API that is also part of Core should go into Mathf.cs.
 
-namespace Godot
+namespace Godot;
+
+public static partial class Mathf
 {
-    public static partial class Mathf
-    {
-        // Define constants with Decimal precision and cast down to double or float.
+    // Define constants with Decimal precision and cast down to double or float.
 
-        /// <summary>
-        /// The natural number <c>e</c>.
-        /// </summary>
-        public const real_t E = (real_t)2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
+    /// <summary>
+    /// The natural number <c>e</c>.
+    /// </summary>
+    public const real_t E = (real_t)2.7182818284590452353602874714M; // 2.7182817f and 2.718281828459045
 
-        /// <summary>
-        /// The square root of 2.
-        /// </summary>
-        public const real_t Sqrt2 = (real_t)1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
+    /// <summary>
+    /// The square root of 2.
+    /// </summary>
+    public const real_t Sqrt2 = (real_t)1.4142135623730950488016887242M; // 1.4142136f and 1.414213562373095
 
-        // Epsilon size should depend on the precision used.
-        private const float _epsilonF = 1e-06f;
-        private const double _epsilonD = 1e-14;
+    // Epsilon size should depend on the precision used.
+    private const float _epsilonF = 1e-06f;
+    private const double _epsilonD = 1e-14;
 
-        /// <summary>
-        /// A very small number used for float comparison with error tolerance.
-        /// 1e-06 with single-precision floats, but 1e-14 if <c>REAL_T_IS_DOUBLE</c>.
-        /// </summary>
+    /// <summary>
+    /// A very small number used for float comparison with error tolerance.
+    /// 1e-06 with single-precision floats, but 1e-14 if <c>REAL_T_IS_DOUBLE</c>.
+    /// </summary>
 #if REAL_T_IS_DOUBLE
-        public const real_t Epsilon = _epsilonD;
+    public const real_t Epsilon = _epsilonD;
 #else
-        public const real_t Epsilon = _epsilonF;
+    public const real_t Epsilon = _epsilonF;
 #endif
 
-        /// <summary>
-        /// Returns the amount of digits after the decimal place.
-        /// </summary>
-        /// <param name="s">The input value.</param>
-        /// <returns>The amount of digits.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int DecimalCount(double s)
-        {
-            return DecimalCount((decimal)s);
-        }
+    /// <summary>
+    /// Returns the amount of digits after the decimal place.
+    /// </summary>
+    /// <param name="s">The input value.</param>
+    /// <returns>The amount of digits.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int DecimalCount(double s)
+    {
+        return DecimalCount((decimal)s);
+    }
 
-        /// <summary>
-        /// Returns the amount of digits after the decimal place.
-        /// </summary>
-        /// <param name="s">The input <see langword="decimal"/> value.</param>
-        /// <returns>The amount of digits.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int DecimalCount(decimal s)
-        {
-            return BitConverter.GetBytes(decimal.GetBits(s)[3])[2];
-        }
+    /// <summary>
+    /// Returns the amount of digits after the decimal place.
+    /// </summary>
+    /// <param name="s">The input <see langword="decimal"/> value.</param>
+    /// <returns>The amount of digits.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int DecimalCount(decimal s)
+    {
+        return BitConverter.GetBytes(decimal.GetBits(s)[3])[2];
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> upward (towards positive infinity).
-        ///
-        /// This is the same as <see cref="Ceil(float)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to ceil.</param>
-        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int CeilToInt(float s)
-        {
-            return (int)MathF.Ceiling(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> upward (towards positive infinity).
+    ///
+    /// This is the same as <see cref="Ceil(float)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to ceil.</param>
+    /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CeilToInt(float s)
+    {
+        return (int)MathF.Ceiling(s);
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> upward (towards positive infinity).
-        ///
-        /// This is the same as <see cref="Ceil(double)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to ceil.</param>
-        /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int CeilToInt(double s)
-        {
-            return (int)Math.Ceiling(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> upward (towards positive infinity).
+    ///
+    /// This is the same as <see cref="Ceil(double)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to ceil.</param>
+    /// <returns>The smallest whole number that is not less than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CeilToInt(double s)
+    {
+        return (int)Math.Ceiling(s);
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> downward (towards negative infinity).
-        ///
-        /// This is the same as <see cref="Floor(float)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to floor.</param>
-        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int FloorToInt(float s)
-        {
-            return (int)MathF.Floor(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> downward (towards negative infinity).
+    ///
+    /// This is the same as <see cref="Floor(float)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to floor.</param>
+    /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FloorToInt(float s)
+    {
+        return (int)MathF.Floor(s);
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> downward (towards negative infinity).
-        ///
-        /// This is the same as <see cref="Floor(double)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to floor.</param>
-        /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int FloorToInt(double s)
-        {
-            return (int)Math.Floor(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> downward (towards negative infinity).
+    ///
+    /// This is the same as <see cref="Floor(double)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to floor.</param>
+    /// <returns>The largest whole number that is not more than <paramref name="s"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FloorToInt(double s)
+    {
+        return (int)Math.Floor(s);
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> to the nearest whole number.
-        ///
-        /// This is the same as <see cref="Round(float)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to round.</param>
-        /// <returns>The rounded number.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int RoundToInt(float s)
-        {
-            return (int)MathF.Round(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> to the nearest whole number.
+    ///
+    /// This is the same as <see cref="Round(float)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to round.</param>
+    /// <returns>The rounded number.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int RoundToInt(float s)
+    {
+        return (int)MathF.Round(s);
+    }
 
-        /// <summary>
-        /// Rounds <paramref name="s"/> to the nearest whole number.
-        ///
-        /// This is the same as <see cref="Round(double)"/>, but returns an <see langword="int"/>.
-        /// </summary>
-        /// <param name="s">The number to round.</param>
-        /// <returns>The rounded number.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int RoundToInt(double s)
-        {
-            return (int)Math.Round(s);
-        }
+    /// <summary>
+    /// Rounds <paramref name="s"/> to the nearest whole number.
+    ///
+    /// This is the same as <see cref="Round(double)"/>, but returns an <see langword="int"/>.
+    /// </summary>
+    /// <param name="s">The number to round.</param>
+    /// <returns>The rounded number.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int RoundToInt(double s)
+    {
+        return (int)Math.Round(s);
+    }
 
-        /// <summary>
-        /// Returns the sine and cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The sine and cosine of that angle.</returns>
-        public static (float Sin, float Cos) SinCos(float s)
-        {
-            return MathF.SinCos(s);
-        }
+    /// <summary>
+    /// Returns the sine and cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The sine and cosine of that angle.</returns>
+    public static (float Sin, float Cos) SinCos(float s)
+    {
+        return MathF.SinCos(s);
+    }
 
-        /// <summary>
-        /// Returns the sine and cosine of angle <paramref name="s"/> in radians.
-        /// </summary>
-        /// <param name="s">The angle in radians.</param>
-        /// <returns>The sine and cosine of that angle.</returns>
-        public static (double Sin, double Cos) SinCos(double s)
-        {
-            return Math.SinCos(s);
-        }
+    /// <summary>
+    /// Returns the sine and cosine of angle <paramref name="s"/> in radians.
+    /// </summary>
+    /// <param name="s">The angle in radians.</param>
+    /// <returns>The sine and cosine of that angle.</returns>
+    public static (double Sin, double Cos) SinCos(double s)
+    {
+        return Math.SinCos(s);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
-        /// equal to each other.
-        /// The comparison is done using the provided tolerance value.
-        /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(float, float)"/>.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <param name="tolerance">The pre-calculated tolerance value.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
-        public static bool IsEqualApprox(float a, float b, float tolerance)
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
+    /// equal to each other.
+    /// The comparison is done using the provided tolerance value.
+    /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(float, float)"/>.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <param name="tolerance">The pre-calculated tolerance value.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
+    public static bool IsEqualApprox(float a, float b, float tolerance)
+    {
+        // Check for exact equality first, required to handle "infinity" values.
+        if (a == b)
         {
-            // Check for exact equality first, required to handle "infinity" values.
-            if (a == b)
-            {
-                return true;
-            }
-            // Then check for approximate equality.
-            return Math.Abs(a - b) < tolerance;
+            return true;
         }
+        // Then check for approximate equality.
+        return Math.Abs(a - b) < tolerance;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
-        /// equal to each other.
-        /// The comparison is done using the provided tolerance value.
-        /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(double, double)"/>.
-        /// </summary>
-        /// <param name="a">One of the values.</param>
-        /// <param name="b">The other value.</param>
-        /// <param name="tolerance">The pre-calculated tolerance value.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
-        public static bool IsEqualApprox(double a, double b, double tolerance)
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/> are approximately
+    /// equal to each other.
+    /// The comparison is done using the provided tolerance value.
+    /// If you want the tolerance to be calculated for you, use <see cref="IsEqualApprox(double, double)"/>.
+    /// </summary>
+    /// <param name="a">One of the values.</param>
+    /// <param name="b">The other value.</param>
+    /// <param name="tolerance">The pre-calculated tolerance value.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the two values are equal.</returns>
+    public static bool IsEqualApprox(double a, double b, double tolerance)
+    {
+        // Check for exact equality first, required to handle "infinity" values.
+        if (a == b)
         {
-            // Check for exact equality first, required to handle "infinity" values.
-            if (a == b)
-            {
-                return true;
-            }
-            // Then check for approximate equality.
-            return Math.Abs(a - b) < tolerance;
+            return true;
         }
+        // Then check for approximate equality.
+        return Math.Abs(a - b) < tolerance;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs
@@ -5,135 +5,134 @@ using System.Text;
 
 #nullable enable
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+internal static class ExceptionUtils
 {
-    internal static class ExceptionUtils
+    public static void PushError(string message)
     {
-        public static void PushError(string message)
+        GD.PushError(message);
+    }
+
+    private static void OnExceptionLoggerException(Exception loggerException, Exception exceptionToLog)
+    {
+        try
         {
-            GD.PushError(message);
+            // This better not throw
+            PushError(string.Concat("Exception thrown while trying to log another exception...",
+                "\n### Exception ###\n", exceptionToLog.ToString(),
+                "\n### Logger exception ###\n", loggerException.ToString()));
+        }
+        catch (Exception)
+        {
+            // Well, too bad...
+        }
+    }
+
+    private record struct StackInfoTuple(string? File, string Func, int Line);
+
+    private static void CollectExceptionInfo(Exception exception, List<StackInfoTuple> globalFrames,
+        StringBuilder excMsg)
+    {
+        if (excMsg.Length > 0)
+            excMsg.Append(" ---> ");
+        excMsg.Append(exception.GetType().FullName);
+        excMsg.Append(": ");
+        excMsg.Append(exception.Message);
+
+        var innerExc = exception.InnerException;
+
+        if (innerExc != null)
+        {
+            CollectExceptionInfo(innerExc, globalFrames, excMsg);
+            globalFrames.Add(new("", "--- End of inner exception stack trace ---", 0));
         }
 
-        private static void OnExceptionLoggerException(Exception loggerException, Exception exceptionToLog)
+        var stackTrace = new StackTrace(exception, fNeedFileInfo: true);
+
+        foreach (StackFrame frame in stackTrace.GetFrames())
         {
-            try
+            DebuggingUtils.GetStackFrameMethodDecl(frame, out string methodDecl);
+            globalFrames.Add(new(frame.GetFileName(), methodDecl, frame.GetFileLineNumber()));
+        }
+    }
+
+    private static void SendToScriptDebugger(Exception e)
+    {
+        var globalFrames = new List<StackInfoTuple>();
+
+        var excMsg = new StringBuilder();
+
+        CollectExceptionInfo(e, globalFrames, excMsg);
+
+        string file = globalFrames.Count > 0 ? globalFrames[0].File ?? "" : "";
+        string func = globalFrames.Count > 0 ? globalFrames[0].Func : "";
+        int line = globalFrames.Count > 0 ? globalFrames[0].Line : 0;
+        string errorMsg = e.GetType().FullName ?? "";
+
+        using godot_string nFile = Marshaling.ConvertStringToNative(file);
+        using godot_string nFunc = Marshaling.ConvertStringToNative(func);
+        using godot_string nErrorMsg = Marshaling.ConvertStringToNative(errorMsg);
+        using godot_string nExcMsg = Marshaling.ConvertStringToNative(excMsg.ToString());
+
+        using DebuggingUtils.godot_stack_info_vector stackInfoVector = default;
+
+        stackInfoVector.Resize(globalFrames.Count);
+
+        unsafe
+        {
+            for (int i = 0; i < globalFrames.Count; i++)
             {
-                // This better not throw
-                PushError(string.Concat("Exception thrown while trying to log another exception...",
-                    "\n### Exception ###\n", exceptionToLog.ToString(),
-                    "\n### Logger exception ###\n", loggerException.ToString()));
+                DebuggingUtils.godot_stack_info* stackInfo = &stackInfoVector.Elements[i];
+
+                var globalFrame = globalFrames[i];
+
+                // Assign directly to element in Vector. This way we don't need to worry
+                // about disposal if an exception is thrown. The Vector takes care of it.
+                stackInfo->File = Marshaling.ConvertStringToNative(globalFrame.File);
+                stackInfo->Func = Marshaling.ConvertStringToNative(globalFrame.Func);
+                stackInfo->Line = globalFrame.Line;
             }
-            catch (Exception)
+
+            NativeFuncs.godotsharp_internal_script_debugger_send_error(nFunc, nFile, line,
+                nErrorMsg, nExcMsg, p_warning: godot_bool.False, stackInfoVector);
+        }
+    }
+
+    public static void LogException(Exception e)
+    {
+        try
+        {
+            if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
             {
-                // Well, too bad...
+                SendToScriptDebugger(e);
+            }
+            else
+            {
+                GD.PushError(e.ToString());
             }
         }
-
-        private record struct StackInfoTuple(string? File, string Func, int Line);
-
-        private static void CollectExceptionInfo(Exception exception, List<StackInfoTuple> globalFrames,
-            StringBuilder excMsg)
+        catch (Exception unexpected)
         {
-            if (excMsg.Length > 0)
-                excMsg.Append(" ---> ");
-            excMsg.Append(exception.GetType().FullName);
-            excMsg.Append(": ");
-            excMsg.Append(exception.Message);
-
-            var innerExc = exception.InnerException;
-
-            if (innerExc != null)
-            {
-                CollectExceptionInfo(innerExc, globalFrames, excMsg);
-                globalFrames.Add(new("", "--- End of inner exception stack trace ---", 0));
-            }
-
-            var stackTrace = new StackTrace(exception, fNeedFileInfo: true);
-
-            foreach (StackFrame frame in stackTrace.GetFrames())
-            {
-                DebuggingUtils.GetStackFrameMethodDecl(frame, out string methodDecl);
-                globalFrames.Add(new(frame.GetFileName(), methodDecl, frame.GetFileLineNumber()));
-            }
+            OnExceptionLoggerException(unexpected, e);
         }
+    }
 
-        private static void SendToScriptDebugger(Exception e)
+    public static void LogUnhandledException(Exception e)
+    {
+        try
         {
-            var globalFrames = new List<StackInfoTuple>();
-
-            var excMsg = new StringBuilder();
-
-            CollectExceptionInfo(e, globalFrames, excMsg);
-
-            string file = globalFrames.Count > 0 ? globalFrames[0].File ?? "" : "";
-            string func = globalFrames.Count > 0 ? globalFrames[0].Func : "";
-            int line = globalFrames.Count > 0 ? globalFrames[0].Line : 0;
-            string errorMsg = e.GetType().FullName ?? "";
-
-            using godot_string nFile = Marshaling.ConvertStringToNative(file);
-            using godot_string nFunc = Marshaling.ConvertStringToNative(func);
-            using godot_string nErrorMsg = Marshaling.ConvertStringToNative(errorMsg);
-            using godot_string nExcMsg = Marshaling.ConvertStringToNative(excMsg.ToString());
-
-            using DebuggingUtils.godot_stack_info_vector stackInfoVector = default;
-
-            stackInfoVector.Resize(globalFrames.Count);
-
-            unsafe
+            if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
             {
-                for (int i = 0; i < globalFrames.Count; i++)
-                {
-                    DebuggingUtils.godot_stack_info* stackInfo = &stackInfoVector.Elements[i];
-
-                    var globalFrame = globalFrames[i];
-
-                    // Assign directly to element in Vector. This way we don't need to worry
-                    // about disposal if an exception is thrown. The Vector takes care of it.
-                    stackInfo->File = Marshaling.ConvertStringToNative(globalFrame.File);
-                    stackInfo->Func = Marshaling.ConvertStringToNative(globalFrame.Func);
-                    stackInfo->Line = globalFrame.Line;
-                }
-
-                NativeFuncs.godotsharp_internal_script_debugger_send_error(nFunc, nFile, line,
-                    nErrorMsg, nExcMsg, p_warning: godot_bool.False, stackInfoVector);
+                SendToScriptDebugger(e);
             }
+
+            // In this case, print it as well in addition to sending it to the script debugger
+            GD.PushError("Unhandled exception\n" + e);
         }
-
-        public static void LogException(Exception e)
+        catch (Exception unexpected)
         {
-            try
-            {
-                if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
-                {
-                    SendToScriptDebugger(e);
-                }
-                else
-                {
-                    GD.PushError(e.ToString());
-                }
-            }
-            catch (Exception unexpected)
-            {
-                OnExceptionLoggerException(unexpected, e);
-            }
-        }
-
-        public static void LogUnhandledException(Exception e)
-        {
-            try
-            {
-                if (NativeFuncs.godotsharp_internal_script_debugger_is_active().ToBool())
-                {
-                    SendToScriptDebugger(e);
-                }
-
-                // In this case, print it as well in addition to sending it to the script debugger
-                GD.PushError("Unhandled exception\n" + e);
-            }
-            catch (Exception unexpected)
-            {
-                OnExceptionLoggerException(unexpected, e);
-            }
+            OnExceptionLoggerException(unexpected, e);
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/GodotDllImportResolver.cs
@@ -4,56 +4,55 @@ using System.Runtime.InteropServices;
 
 #nullable enable
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+public class GodotDllImportResolver
 {
-    public class GodotDllImportResolver
+    private IntPtr _internalHandle;
+
+    public GodotDllImportResolver(IntPtr internalHandle)
     {
-        private IntPtr _internalHandle;
-
-        public GodotDllImportResolver(IntPtr internalHandle)
-        {
-            _internalHandle = internalHandle;
-        }
-
-        public IntPtr OnResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
-        {
-            if (libraryName == "__Internal")
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    return Win32.GetModuleHandle(IntPtr.Zero);
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    return _internalHandle;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return MacOS.dlopen(IntPtr.Zero, MacOS.RTLD_LAZY);
-                }
-            }
-
-            return IntPtr.Zero;
-        }
-
-        // ReSharper disable InconsistentNaming
-        private static class MacOS
-        {
-            private const string SystemLibrary = "/usr/lib/libSystem.dylib";
-
-            public const int RTLD_LAZY = 1;
-
-            [DllImport(SystemLibrary)]
-            public static extern IntPtr dlopen(IntPtr path, int mode);
-        }
-
-        private static class Win32
-        {
-            private const string SystemLibrary = "Kernel32.dll";
-
-            [DllImport(SystemLibrary)]
-            public static extern IntPtr GetModuleHandle(IntPtr lpModuleName);
-        }
-        // ReSharper restore InconsistentNaming
+        _internalHandle = internalHandle;
     }
+
+    public IntPtr OnResolveDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName == "__Internal")
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Win32.GetModuleHandle(IntPtr.Zero);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return _internalHandle;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MacOS.dlopen(IntPtr.Zero, MacOS.RTLD_LAZY);
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    // ReSharper disable InconsistentNaming
+    private static class MacOS
+    {
+        private const string SystemLibrary = "/usr/lib/libSystem.dylib";
+
+        public const int RTLD_LAZY = 1;
+
+        [DllImport(SystemLibrary)]
+        public static extern IntPtr dlopen(IntPtr path, int mode);
+    }
+
+    private static class Win32
+    {
+        private const string SystemLibrary = "Kernel32.dll";
+
+        [DllImport(SystemLibrary)]
+        public static extern IntPtr GetModuleHandle(IntPtr lpModuleName);
+    }
+    // ReSharper restore InconsistentNaming
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -3,1134 +3,1133 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+// NOTES:
+// ref structs cannot implement interfaces, but they still work in `using` directives if they declare Dispose()
+
+public static class GodotBoolExtensions
 {
-    // NOTES:
-    // ref structs cannot implement interfaces, but they still work in `using` directives if they declare Dispose()
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe godot_bool ToGodotBool(this bool @bool)
+    {
+        return *(godot_bool*)&@bool;
+    }
 
-    public static class GodotBoolExtensions
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe bool ToBool(this godot_bool godotBool)
+    {
+        return *(bool*)&godotBool;
+    }
+}
+
+// Apparently a struct with a byte is not blittable? It crashes when calling a UnmanagedCallersOnly function ptr.
+// ReSharper disable once InconsistentNaming
+public enum godot_bool : byte
+{
+    True = 1,
+    False = 0
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_ref
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_ref* GetUnsafeAddress()
+        => (godot_ref*)Unsafe.AsPointer(ref Unsafe.AsRef(in _reference));
+
+    private IntPtr _reference;
+
+    public void Dispose()
+    {
+        if (_reference == IntPtr.Zero)
+            return;
+        NativeFuncs.godotsharp_ref_destroy(ref this);
+        _reference = IntPtr.Zero;
+    }
+
+    public readonly IntPtr Reference
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe godot_bool ToGodotBool(this bool @bool)
+        get => _reference;
+    }
+
+    public readonly bool IsNull
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _reference == IntPtr.Zero;
+    }
+}
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public enum godot_variant_call_error_error
+{
+    GODOT_CALL_ERROR_CALL_OK = 0,
+    GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD,
+    GODOT_CALL_ERROR_CALL_ERROR_INVALID_ARGUMENT,
+    GODOT_CALL_ERROR_CALL_ERROR_TOO_MANY_ARGUMENTS,
+    GODOT_CALL_ERROR_CALL_ERROR_TOO_FEW_ARGUMENTS,
+    GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL,
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_variant_call_error
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_variant_call_error* GetUnsafeAddress()
+        => (godot_variant_call_error*)Unsafe.AsPointer(ref Unsafe.AsRef(in error));
+
+    private godot_variant_call_error_error error;
+    private int argument;
+    private int expected;
+
+    public godot_variant_call_error_error Error
+    {
+        readonly get => error;
+        set => error = value;
+    }
+
+    public int Argument
+    {
+        readonly get => argument;
+        set => argument = value;
+    }
+
+    public Godot.Variant.Type Expected
+    {
+        readonly get => (Godot.Variant.Type)expected;
+        set => expected = (int)value;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_variant
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_variant* GetUnsafeAddress()
+        => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
+
+    // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
+    private int _typeField;
+
+    // There's padding here
+
+    private godot_variant_data _data;
+
+    [StructLayout(LayoutKind.Explicit)]
+    // ReSharper disable once InconsistentNaming
+    private unsafe ref struct godot_variant_data
+    {
+        [FieldOffset(0)] public godot_bool _bool;
+        [FieldOffset(0)] public long _int;
+        [FieldOffset(0)] public double _float;
+        [FieldOffset(0)] public Transform2D* _transform2d;
+        [FieldOffset(0)] public Aabb* _aabb;
+        [FieldOffset(0)] public Basis* _basis;
+        [FieldOffset(0)] public Transform3D* _transform3d;
+        [FieldOffset(0)] public Projection* _projection;
+        [FieldOffset(0)] private godot_variant_data_mem _mem;
+
+        // The following fields are not in the C++ union, but this is how they're stored in _mem.
+        [FieldOffset(0)] public godot_string_name _m_string_name;
+        [FieldOffset(0)] public godot_string _m_string;
+        [FieldOffset(0)] public Vector4 _m_vector4;
+        [FieldOffset(0)] public Vector4I _m_vector4i;
+        [FieldOffset(0)] public Vector3 _m_vector3;
+        [FieldOffset(0)] public Vector3I _m_vector3i;
+        [FieldOffset(0)] public Vector2 _m_vector2;
+        [FieldOffset(0)] public Vector2I _m_vector2i;
+        [FieldOffset(0)] public Rect2 _m_rect2;
+        [FieldOffset(0)] public Rect2I _m_rect2i;
+        [FieldOffset(0)] public Plane _m_plane;
+        [FieldOffset(0)] public Quaternion _m_quaternion;
+        [FieldOffset(0)] public Color _m_color;
+        [FieldOffset(0)] public godot_node_path _m_node_path;
+        [FieldOffset(0)] public Rid _m_rid;
+        [FieldOffset(0)] public godot_variant_obj_data _m_obj_data;
+        [FieldOffset(0)] public godot_callable _m_callable;
+        [FieldOffset(0)] public godot_signal _m_signal;
+        [FieldOffset(0)] public godot_dictionary _m_dictionary;
+        [FieldOffset(0)] public godot_array _m_array;
+
+        [StructLayout(LayoutKind.Sequential)]
+        // ReSharper disable once InconsistentNaming
+        public struct godot_variant_obj_data
         {
-            return *(godot_bool*)&@bool;
+            public ulong id;
+            public IntPtr obj;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool ToBool(this godot_bool godotBool)
+        [StructLayout(LayoutKind.Sequential)]
+        // ReSharper disable once InconsistentNaming
+        public struct godot_variant_data_mem
         {
-            return *(bool*)&godotBool;
+#pragma warning disable 169
+            private real_t _mem0;
+            private real_t _mem1;
+            private real_t _mem2;
+            private real_t _mem3;
+#pragma warning restore 169
         }
     }
 
-    // Apparently a struct with a byte is not blittable? It crashes when calling a UnmanagedCallersOnly function ptr.
-    // ReSharper disable once InconsistentNaming
-    public enum godot_bool : byte
-    {
-        True = 1,
-        False = 0
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_ref
+    public Variant.Type Type
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_ref* GetUnsafeAddress()
-            => (godot_ref*)Unsafe.AsPointer(ref Unsafe.AsRef(in _reference));
+        readonly get => (Variant.Type)_typeField;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _typeField = (int)value;
+    }
 
-        private IntPtr _reference;
+    public godot_bool Bool
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._bool;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._bool = value;
+    }
 
-        public void Dispose()
+    public long Int
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._int;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._int = value;
+    }
+
+    public double Float
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._float;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._float = value;
+    }
+
+    public readonly unsafe Transform2D* Transform2D
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._transform2d;
+    }
+
+    public readonly unsafe Aabb* Aabb
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._aabb;
+    }
+
+    public readonly unsafe Basis* Basis
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._basis;
+    }
+
+    public readonly unsafe Transform3D* Transform3D
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._transform3d;
+    }
+
+    public readonly unsafe Projection* Projection
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._projection;
+    }
+
+    public godot_string_name StringName
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_string_name;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_string_name = value;
+    }
+
+    public godot_string String
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_string;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_string = value;
+    }
+
+    public Vector4 Vector4
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector4;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector4 = value;
+    }
+
+    public Vector4I Vector4I
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector4i;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector4i = value;
+    }
+
+    public Vector3 Vector3
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector3;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector3 = value;
+    }
+
+    public Vector3I Vector3I
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector3i;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector3i = value;
+    }
+
+    public Vector2 Vector2
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector2;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector2 = value;
+    }
+
+    public Vector2I Vector2I
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_vector2i;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_vector2i = value;
+    }
+
+    public Rect2 Rect2
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_rect2;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_rect2 = value;
+    }
+
+    public Rect2I Rect2I
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_rect2i;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_rect2i = value;
+    }
+
+    public Plane Plane
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_plane;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_plane = value;
+    }
+
+    public Quaternion Quaternion
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_quaternion;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_quaternion = value;
+    }
+
+    public Color Color
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_color;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_color = value;
+    }
+
+    public godot_node_path NodePath
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_node_path;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_node_path = value;
+    }
+
+    public Rid Rid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_rid;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_rid = value;
+    }
+
+    public godot_callable Callable
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_callable;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_callable = value;
+    }
+
+    public godot_signal Signal
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_signal;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_signal = value;
+    }
+
+    public godot_dictionary Dictionary
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_dictionary;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_dictionary = value;
+    }
+
+    public godot_array Array
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _data._m_array;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _data._m_array = value;
+    }
+
+    public readonly IntPtr Object
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data._m_obj_data.obj;
+    }
+
+    public void Dispose()
+    {
+        switch (Type)
         {
-            if (_reference == IntPtr.Zero)
+            case Variant.Type.Nil:
+            case Variant.Type.Bool:
+            case Variant.Type.Int:
+            case Variant.Type.Float:
+            case Variant.Type.Vector2:
+            case Variant.Type.Vector2I:
+            case Variant.Type.Rect2:
+            case Variant.Type.Rect2I:
+            case Variant.Type.Vector3:
+            case Variant.Type.Vector3I:
+            case Variant.Type.Vector4:
+            case Variant.Type.Vector4I:
+            case Variant.Type.Plane:
+            case Variant.Type.Quaternion:
+            case Variant.Type.Color:
+            case Variant.Type.Rid:
                 return;
-            NativeFuncs.godotsharp_ref_destroy(ref this);
-            _reference = IntPtr.Zero;
         }
 
-        public readonly IntPtr Reference
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _reference;
-        }
-
-        public readonly bool IsNull
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _reference == IntPtr.Zero;
-        }
+        NativeFuncs.godotsharp_variant_destroy(ref this);
+        Type = Variant.Type.Nil;
     }
 
-    [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public enum godot_variant_call_error_error
-    {
-        GODOT_CALL_ERROR_CALL_OK = 0,
-        GODOT_CALL_ERROR_CALL_ERROR_INVALID_METHOD,
-        GODOT_CALL_ERROR_CALL_ERROR_INVALID_ARGUMENT,
-        GODOT_CALL_ERROR_CALL_ERROR_TOO_MANY_ARGUMENTS,
-        GODOT_CALL_ERROR_CALL_ERROR_TOO_FEW_ARGUMENTS,
-        GODOT_CALL_ERROR_CALL_ERROR_INSTANCE_IS_NULL,
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Explicit)]
     // ReSharper disable once InconsistentNaming
-    public ref struct godot_variant_call_error
+    internal struct movable
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_variant_call_error* GetUnsafeAddress()
-            => (godot_variant_call_error*)Unsafe.AsPointer(ref Unsafe.AsRef(in error));
-
-        private godot_variant_call_error_error error;
-        private int argument;
-        private int expected;
-
-        public godot_variant_call_error_error Error
-        {
-            readonly get => error;
-            set => error = value;
-        }
-
-        public int Argument
-        {
-            readonly get => argument;
-            set => argument = value;
-        }
-
-        public Godot.Variant.Type Expected
-        {
-            readonly get => (Godot.Variant.Type)expected;
-            set => expected = (int)value;
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_variant
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_variant* GetUnsafeAddress()
-            => (godot_variant*)Unsafe.AsPointer(ref Unsafe.AsRef(in _typeField));
-
         // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
-        private int _typeField;
+        [FieldOffset(0)] private int _typeField;
 
         // There's padding here
 
-        private godot_variant_data _data;
+        [FieldOffset(8)] private godot_variant_data.godot_variant_data_mem _data;
 
-        [StructLayout(LayoutKind.Explicit)]
-        // ReSharper disable once InconsistentNaming
-        private unsafe ref struct godot_variant_data
-        {
-            [FieldOffset(0)] public godot_bool _bool;
-            [FieldOffset(0)] public long _int;
-            [FieldOffset(0)] public double _float;
-            [FieldOffset(0)] public Transform2D* _transform2d;
-            [FieldOffset(0)] public Aabb* _aabb;
-            [FieldOffset(0)] public Basis* _basis;
-            [FieldOffset(0)] public Transform3D* _transform3d;
-            [FieldOffset(0)] public Projection* _projection;
-            [FieldOffset(0)] private godot_variant_data_mem _mem;
+        public static unsafe explicit operator movable(in godot_variant value)
+            => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
 
-            // The following fields are not in the C++ union, but this is how they're stored in _mem.
-            [FieldOffset(0)] public godot_string_name _m_string_name;
-            [FieldOffset(0)] public godot_string _m_string;
-            [FieldOffset(0)] public Vector4 _m_vector4;
-            [FieldOffset(0)] public Vector4I _m_vector4i;
-            [FieldOffset(0)] public Vector3 _m_vector3;
-            [FieldOffset(0)] public Vector3I _m_vector3i;
-            [FieldOffset(0)] public Vector2 _m_vector2;
-            [FieldOffset(0)] public Vector2I _m_vector2i;
-            [FieldOffset(0)] public Rect2 _m_rect2;
-            [FieldOffset(0)] public Rect2I _m_rect2i;
-            [FieldOffset(0)] public Plane _m_plane;
-            [FieldOffset(0)] public Quaternion _m_quaternion;
-            [FieldOffset(0)] public Color _m_color;
-            [FieldOffset(0)] public godot_node_path _m_node_path;
-            [FieldOffset(0)] public Rid _m_rid;
-            [FieldOffset(0)] public godot_variant_obj_data _m_obj_data;
-            [FieldOffset(0)] public godot_callable _m_callable;
-            [FieldOffset(0)] public godot_signal _m_signal;
-            [FieldOffset(0)] public godot_dictionary _m_dictionary;
-            [FieldOffset(0)] public godot_array _m_array;
+        public static unsafe explicit operator godot_variant(movable value)
+            => *(godot_variant*)Unsafe.AsPointer(ref value);
 
-            [StructLayout(LayoutKind.Sequential)]
-            // ReSharper disable once InconsistentNaming
-            public struct godot_variant_obj_data
-            {
-                public ulong id;
-                public IntPtr obj;
-            }
+        public unsafe ref godot_variant DangerousSelfRef =>
+            ref CustomUnsafe.AsRef((godot_variant*)Unsafe.AsPointer(ref this));
+    }
+}
 
-            [StructLayout(LayoutKind.Sequential)]
-            // ReSharper disable once InconsistentNaming
-            public struct godot_variant_data_mem
-            {
-#pragma warning disable 169
-                private real_t _mem0;
-                private real_t _mem1;
-                private real_t _mem2;
-                private real_t _mem3;
-#pragma warning restore 169
-            }
-        }
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_string
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_string* GetUnsafeAddress()
+        => (godot_string*)Unsafe.AsPointer(ref Unsafe.AsRef(in _ptr));
 
-        public Variant.Type Type
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => (Variant.Type)_typeField;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _typeField = (int)value;
-        }
+    private IntPtr _ptr;
 
-        public godot_bool Bool
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._bool;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._bool = value;
-        }
+    public void Dispose()
+    {
+        if (_ptr == IntPtr.Zero)
+            return;
+        NativeFuncs.godotsharp_string_destroy(ref this);
+        _ptr = IntPtr.Zero;
+    }
 
-        public long Int
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._int;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._int = value;
-        }
+    public readonly IntPtr Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
 
-        public double Float
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._float;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._float = value;
-        }
+    // Size including the null termination character
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != IntPtr.Zero ? *((int*)_ptr - 1) : 0;
+    }
+}
 
-        public readonly unsafe Transform2D* Transform2D
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._transform2d;
-        }
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_string_name
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_string_name* GetUnsafeAddress()
+        => (godot_string_name*)Unsafe.AsPointer(ref Unsafe.AsRef(in _data));
 
-        public readonly unsafe Aabb* Aabb
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._aabb;
-        }
+    private IntPtr _data;
 
-        public readonly unsafe Basis* Basis
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._basis;
-        }
+    public void Dispose()
+    {
+        if (_data == IntPtr.Zero)
+            return;
+        NativeFuncs.godotsharp_string_name_destroy(ref this);
+        _data = IntPtr.Zero;
+    }
 
-        public readonly unsafe Transform3D* Transform3D
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._transform3d;
-        }
+    public readonly bool IsAllocated
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data != IntPtr.Zero;
+    }
 
-        public readonly unsafe Projection* Projection
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._projection;
-        }
+    public readonly bool IsEmpty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // This is all that's needed to check if it's empty. Equivalent to `== StringName()` in C++.
+        get => _data == IntPtr.Zero;
+    }
 
-        public godot_string_name StringName
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_string_name;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_string_name = value;
-        }
+    public static bool operator ==(godot_string_name left, godot_string_name right)
+    {
+        return left._data == right._data;
+    }
 
-        public godot_string String
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_string;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_string = value;
-        }
+    public static bool operator !=(godot_string_name left, godot_string_name right)
+    {
+        return !(left == right);
+    }
 
-        public Vector4 Vector4
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector4;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector4 = value;
-        }
+    public bool Equals(godot_string_name other)
+    {
+        return _data == other._data;
+    }
 
-        public Vector4I Vector4I
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector4i;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector4i = value;
-        }
+    public override bool Equals(object obj)
+    {
+        return obj is StringName s && s.Equals(this);
+    }
 
-        public Vector3 Vector3
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector3;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector3 = value;
-        }
-
-        public Vector3I Vector3I
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector3i;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector3i = value;
-        }
-
-        public Vector2 Vector2
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector2;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector2 = value;
-        }
-
-        public Vector2I Vector2I
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_vector2i;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_vector2i = value;
-        }
-
-        public Rect2 Rect2
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_rect2;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_rect2 = value;
-        }
-
-        public Rect2I Rect2I
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_rect2i;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_rect2i = value;
-        }
-
-        public Plane Plane
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_plane;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_plane = value;
-        }
-
-        public Quaternion Quaternion
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_quaternion;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_quaternion = value;
-        }
-
-        public Color Color
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_color;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_color = value;
-        }
-
-        public godot_node_path NodePath
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_node_path;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_node_path = value;
-        }
-
-        public Rid Rid
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_rid;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_rid = value;
-        }
-
-        public godot_callable Callable
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_callable;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_callable = value;
-        }
-
-        public godot_signal Signal
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_signal;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_signal = value;
-        }
-
-        public godot_dictionary Dictionary
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_dictionary;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_dictionary = value;
-        }
-
-        public godot_array Array
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            readonly get => _data._m_array;
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            set => _data._m_array = value;
-        }
-
-        public readonly IntPtr Object
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data._m_obj_data.obj;
-        }
-
-        public void Dispose()
-        {
-            switch (Type)
-            {
-                case Variant.Type.Nil:
-                case Variant.Type.Bool:
-                case Variant.Type.Int:
-                case Variant.Type.Float:
-                case Variant.Type.Vector2:
-                case Variant.Type.Vector2I:
-                case Variant.Type.Rect2:
-                case Variant.Type.Rect2I:
-                case Variant.Type.Vector3:
-                case Variant.Type.Vector3I:
-                case Variant.Type.Vector4:
-                case Variant.Type.Vector4I:
-                case Variant.Type.Plane:
-                case Variant.Type.Quaternion:
-                case Variant.Type.Color:
-                case Variant.Type.Rid:
-                    return;
-            }
-
-            NativeFuncs.godotsharp_variant_destroy(ref this);
-            Type = Variant.Type.Nil;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        // ReSharper disable once InconsistentNaming
-        internal struct movable
-        {
-            // Variant.Type is generated as an enum of type long, so we can't use for the field as it must only take 32-bits.
-            [FieldOffset(0)] private int _typeField;
-
-            // There's padding here
-
-            [FieldOffset(8)] private godot_variant_data.godot_variant_data_mem _data;
-
-            public static unsafe explicit operator movable(in godot_variant value)
-                => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
-
-            public static unsafe explicit operator godot_variant(movable value)
-                => *(godot_variant*)Unsafe.AsPointer(ref value);
-
-            public unsafe ref godot_variant DangerousSelfRef =>
-                ref CustomUnsafe.AsRef((godot_variant*)Unsafe.AsPointer(ref this));
-        }
+    public override int GetHashCode()
+    {
+        return _data.GetHashCode();
     }
 
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
-    public ref struct godot_string
+    internal struct movable
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_string* GetUnsafeAddress()
-            => (godot_string*)Unsafe.AsPointer(ref Unsafe.AsRef(in _ptr));
-
-        private IntPtr _ptr;
-
-        public void Dispose()
-        {
-            if (_ptr == IntPtr.Zero)
-                return;
-            NativeFuncs.godotsharp_string_destroy(ref this);
-            _ptr = IntPtr.Zero;
-        }
-
-        public readonly IntPtr Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        // Size including the null termination character
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != IntPtr.Zero ? *((int*)_ptr - 1) : 0;
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_string_name
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_string_name* GetUnsafeAddress()
-            => (godot_string_name*)Unsafe.AsPointer(ref Unsafe.AsRef(in _data));
-
         private IntPtr _data;
 
-        public void Dispose()
-        {
-            if (_data == IntPtr.Zero)
-                return;
-            NativeFuncs.godotsharp_string_name_destroy(ref this);
-            _data = IntPtr.Zero;
-        }
+        public static unsafe explicit operator movable(in godot_string_name value)
+            => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
 
-        public readonly bool IsAllocated
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data != IntPtr.Zero;
-        }
+        public static unsafe explicit operator godot_string_name(movable value)
+            => *(godot_string_name*)Unsafe.AsPointer(ref value);
 
-        public readonly bool IsEmpty
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            // This is all that's needed to check if it's empty. Equivalent to `== StringName()` in C++.
-            get => _data == IntPtr.Zero;
-        }
+        public unsafe ref godot_string_name DangerousSelfRef =>
+            ref CustomUnsafe.AsRef((godot_string_name*)Unsafe.AsPointer(ref this));
+    }
+}
 
-        public static bool operator ==(godot_string_name left, godot_string_name right)
-        {
-            return left._data == right._data;
-        }
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_node_path
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_node_path* GetUnsafeAddress()
+        => (godot_node_path*)Unsafe.AsPointer(ref Unsafe.AsRef(in _data));
 
-        public static bool operator !=(godot_string_name left, godot_string_name right)
-        {
-            return !(left == right);
-        }
+    private IntPtr _data;
 
-        public bool Equals(godot_string_name other)
-        {
-            return _data == other._data;
-        }
+    public void Dispose()
+    {
+        if (_data == IntPtr.Zero)
+            return;
+        NativeFuncs.godotsharp_node_path_destroy(ref this);
+        _data = IntPtr.Zero;
+    }
 
-        public override bool Equals(object obj)
-        {
-            return obj is StringName s && s.Equals(this);
-        }
+    public readonly bool IsAllocated
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _data != IntPtr.Zero;
+    }
 
-        public override int GetHashCode()
-        {
-            return _data.GetHashCode();
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal struct movable
-        {
-            private IntPtr _data;
-
-            public static unsafe explicit operator movable(in godot_string_name value)
-                => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
-
-            public static unsafe explicit operator godot_string_name(movable value)
-                => *(godot_string_name*)Unsafe.AsPointer(ref value);
-
-            public unsafe ref godot_string_name DangerousSelfRef =>
-                ref CustomUnsafe.AsRef((godot_string_name*)Unsafe.AsPointer(ref this));
-        }
+    public readonly bool IsEmpty
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // This is all that's needed to check if it's empty. It's what the `is_empty()` C++ method does.
+        get => _data == IntPtr.Zero;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
-    public ref struct godot_node_path
+    internal struct movable
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_node_path* GetUnsafeAddress()
-            => (godot_node_path*)Unsafe.AsPointer(ref Unsafe.AsRef(in _data));
-
         private IntPtr _data;
 
-        public void Dispose()
-        {
-            if (_data == IntPtr.Zero)
-                return;
-            NativeFuncs.godotsharp_node_path_destroy(ref this);
-            _data = IntPtr.Zero;
-        }
+        public static unsafe explicit operator movable(in godot_node_path value)
+            => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
 
-        public readonly bool IsAllocated
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _data != IntPtr.Zero;
-        }
+        public static unsafe explicit operator godot_node_path(movable value)
+            => *(godot_node_path*)Unsafe.AsPointer(ref value);
 
-        public readonly bool IsEmpty
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            // This is all that's needed to check if it's empty. It's what the `is_empty()` C++ method does.
-            get => _data == IntPtr.Zero;
-        }
+        public unsafe ref godot_node_path DangerousSelfRef =>
+            ref CustomUnsafe.AsRef((godot_node_path*)Unsafe.AsPointer(ref this));
+    }
+}
 
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal struct movable
-        {
-            private IntPtr _data;
+[StructLayout(LayoutKind.Explicit)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_signal
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_signal* GetUnsafeAddress()
+        => (godot_signal*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
 
-            public static unsafe explicit operator movable(in godot_node_path value)
-                => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
+    [FieldOffset(0)] private byte _getUnsafeAddressHelper;
 
-            public static unsafe explicit operator godot_node_path(movable value)
-                => *(godot_node_path*)Unsafe.AsPointer(ref value);
+    [FieldOffset(0)] private godot_string_name _name;
 
-            public unsafe ref godot_node_path DangerousSelfRef =>
-                ref CustomUnsafe.AsRef((godot_node_path*)Unsafe.AsPointer(ref this));
-        }
+    // There's padding here on 32-bit
+
+    [FieldOffset(8)] private ulong _objectId;
+
+    public godot_signal(godot_string_name name, ulong objectId) : this()
+    {
+        _name = name;
+        _objectId = objectId;
     }
 
-    [StructLayout(LayoutKind.Explicit)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_signal
+    public godot_string_name Name
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_signal* GetUnsafeAddress()
-            => (godot_signal*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
-
-        [FieldOffset(0)] private byte _getUnsafeAddressHelper;
-
-        [FieldOffset(0)] private godot_string_name _name;
-
-        // There's padding here on 32-bit
-
-        [FieldOffset(8)] private ulong _objectId;
-
-        public godot_signal(godot_string_name name, ulong objectId) : this()
-        {
-            _name = name;
-            _objectId = objectId;
-        }
-
-        public godot_string_name Name
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _name;
-        }
-
-        public ulong ObjectId
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _objectId;
-        }
-
-        public void Dispose()
-        {
-            if (!_name.IsAllocated)
-                return;
-            NativeFuncs.godotsharp_signal_destroy(ref this);
-            _name = default;
-        }
+        get => _name;
     }
 
-    [StructLayout(LayoutKind.Explicit)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_callable
+    public ulong ObjectId
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_callable* GetUnsafeAddress()
-            => (godot_callable*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
-
-        [FieldOffset(0)] private byte _getUnsafeAddressHelper;
-
-        [FieldOffset(0)] private godot_string_name _method;
-
-        // There's padding here on 32-bit
-
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        [FieldOffset(8)] private ulong _objectId;
-        [FieldOffset(8)] private IntPtr _custom;
-
-        public godot_callable(godot_string_name method, ulong objectId) : this()
-        {
-            _method = method;
-            _objectId = objectId;
-        }
-
-        public void Dispose()
-        {
-            // _custom needs freeing as well
-            if (!_method.IsAllocated && _custom == IntPtr.Zero)
-                return;
-            NativeFuncs.godotsharp_callable_destroy(ref this);
-            _method = default;
-            _custom = IntPtr.Zero;
-        }
+        get => _objectId;
     }
 
-    // A correctly constructed value needs to call the native default constructor to allocate `_p`.
-    // Don't pass a C# default constructed `godot_array` to native code, unless it's going to
-    // be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
-    [StructLayout(LayoutKind.Explicit)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_array
+    public void Dispose()
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_array* GetUnsafeAddress()
-            => (godot_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
+        if (!_name.IsAllocated)
+            return;
+        NativeFuncs.godotsharp_signal_destroy(ref this);
+        _name = default;
+    }
+}
 
-        [FieldOffset(0)] private byte _getUnsafeAddressHelper;
+[StructLayout(LayoutKind.Explicit)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_callable
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_callable* GetUnsafeAddress()
+        => (godot_callable*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
 
-        [FieldOffset(0)] private unsafe ArrayPrivate* _p;
+    [FieldOffset(0)] private byte _getUnsafeAddressHelper;
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ArrayPrivate
-        {
-            private uint _safeRefCount;
+    [FieldOffset(0)] private godot_string_name _method;
 
-            public VariantVector _arrayVector;
+    // There's padding here on 32-bit
 
-            private unsafe godot_variant* _readOnly;
+    // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+    [FieldOffset(8)] private ulong _objectId;
+    [FieldOffset(8)] private IntPtr _custom;
 
-            // There are more fields here, but we don't care as we never store this in C#
+    public godot_callable(godot_string_name method, ulong objectId) : this()
+    {
+        _method = method;
+        _objectId = objectId;
+    }
 
-            public readonly int Size
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _arrayVector.Size;
-            }
+    public void Dispose()
+    {
+        // _custom needs freeing as well
+        if (!_method.IsAllocated && _custom == IntPtr.Zero)
+            return;
+        NativeFuncs.godotsharp_callable_destroy(ref this);
+        _method = default;
+        _custom = IntPtr.Zero;
+    }
+}
 
-            public readonly unsafe bool IsReadOnly
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _readOnly != null;
-            }
-        }
+// A correctly constructed value needs to call the native default constructor to allocate `_p`.
+// Don't pass a C# default constructed `godot_array` to native code, unless it's going to
+// be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
+[StructLayout(LayoutKind.Explicit)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_array* GetUnsafeAddress()
+        => (godot_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct VariantVector
-        {
-            private IntPtr _writeProxy;
-            public unsafe godot_variant* _ptr;
+    [FieldOffset(0)] private byte _getUnsafeAddressHelper;
 
-            public readonly unsafe int Size
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _ptr != null ? *((int*)_ptr - 1) : 0;
-            }
-        }
+    [FieldOffset(0)] private unsafe ArrayPrivate* _p;
 
-        public readonly unsafe godot_variant* Elements
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ArrayPrivate
+    {
+        private uint _safeRefCount;
+
+        public VariantVector _arrayVector;
+
+        private unsafe godot_variant* _readOnly;
+
+        // There are more fields here, but we don't care as we never store this in C#
+
+        public readonly int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p->_arrayVector._ptr;
-        }
-
-        public readonly unsafe bool IsAllocated
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p != null;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p != null ? _p->Size : 0;
+            get => _arrayVector.Size;
         }
 
         public readonly unsafe bool IsReadOnly
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p != null && _p->IsReadOnly;
-        }
-
-        public unsafe void Dispose()
-        {
-            if (_p == null)
-                return;
-            NativeFuncs.godotsharp_array_destroy(ref this);
-            _p = null;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal struct movable
-        {
-            private unsafe ArrayPrivate* _p;
-
-            public static unsafe explicit operator movable(in godot_array value)
-                => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
-
-            public static unsafe explicit operator godot_array(movable value)
-                => *(godot_array*)Unsafe.AsPointer(ref value);
-
-            public unsafe ref godot_array DangerousSelfRef =>
-                ref CustomUnsafe.AsRef((godot_array*)Unsafe.AsPointer(ref this));
+            get => _readOnly != null;
         }
     }
 
-    // IMPORTANT:
-    // A correctly constructed value needs to call the native default constructor to allocate `_p`.
-    // Don't pass a C# default constructed `godot_dictionary` to native code, unless it's going to
-    // be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
-    [StructLayout(LayoutKind.Explicit)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_dictionary
+    [StructLayout(LayoutKind.Sequential)]
+    private struct VariantVector
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_dictionary* GetUnsafeAddress()
-            => (godot_dictionary*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
+        private IntPtr _writeProxy;
+        public unsafe godot_variant* _ptr;
 
-        [FieldOffset(0)] private byte _getUnsafeAddressHelper;
-
-        [FieldOffset(0)] private unsafe DictionaryPrivate* _p;
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct DictionaryPrivate
-        {
-            private uint _safeRefCount;
-
-            private unsafe godot_variant* _readOnly;
-
-            // There are more fields here, but we don't care as we never store this in C#
-
-            public readonly unsafe bool IsReadOnly
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => _readOnly != null;
-            }
-        }
-
-        public readonly unsafe bool IsAllocated
+        public readonly unsafe int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p != null;
+            get => _ptr != null ? *((int*)_ptr - 1) : 0;
         }
+    }
+
+    public readonly unsafe godot_variant* Elements
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p->_arrayVector._ptr;
+    }
+
+    public readonly unsafe bool IsAllocated
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p != null;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p != null ? _p->Size : 0;
+    }
+
+    public readonly unsafe bool IsReadOnly
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p != null && _p->IsReadOnly;
+    }
+
+    public unsafe void Dispose()
+    {
+        if (_p == null)
+            return;
+        NativeFuncs.godotsharp_array_destroy(ref this);
+        _p = null;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    // ReSharper disable once InconsistentNaming
+    internal struct movable
+    {
+        private unsafe ArrayPrivate* _p;
+
+        public static unsafe explicit operator movable(in godot_array value)
+            => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
+
+        public static unsafe explicit operator godot_array(movable value)
+            => *(godot_array*)Unsafe.AsPointer(ref value);
+
+        public unsafe ref godot_array DangerousSelfRef =>
+            ref CustomUnsafe.AsRef((godot_array*)Unsafe.AsPointer(ref this));
+    }
+}
+
+// IMPORTANT:
+// A correctly constructed value needs to call the native default constructor to allocate `_p`.
+// Don't pass a C# default constructed `godot_dictionary` to native code, unless it's going to
+// be re-assigned a new value (the copy constructor checks if `_p` is null so that's fine).
+[StructLayout(LayoutKind.Explicit)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_dictionary
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_dictionary* GetUnsafeAddress()
+        => (godot_dictionary*)Unsafe.AsPointer(ref Unsafe.AsRef(in _getUnsafeAddressHelper));
+
+    [FieldOffset(0)] private byte _getUnsafeAddressHelper;
+
+    [FieldOffset(0)] private unsafe DictionaryPrivate* _p;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DictionaryPrivate
+    {
+        private uint _safeRefCount;
+
+        private unsafe godot_variant* _readOnly;
+
+        // There are more fields here, but we don't care as we never store this in C#
 
         public readonly unsafe bool IsReadOnly
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _p != null && _p->IsReadOnly;
+            get => _readOnly != null;
         }
+    }
 
-        public unsafe void Dispose()
-        {
-            if (_p == null)
-                return;
-            NativeFuncs.godotsharp_dictionary_destroy(ref this);
-            _p = null;
-        }
+    public readonly unsafe bool IsAllocated
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p != null;
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        // ReSharper disable once InconsistentNaming
-        internal struct movable
-        {
-            private unsafe DictionaryPrivate* _p;
+    public readonly unsafe bool IsReadOnly
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _p != null && _p->IsReadOnly;
+    }
 
-            public static unsafe explicit operator movable(in godot_dictionary value)
-                => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
-
-            public static unsafe explicit operator godot_dictionary(movable value)
-                => *(godot_dictionary*)Unsafe.AsPointer(ref value);
-
-            public unsafe ref godot_dictionary DangerousSelfRef =>
-                ref CustomUnsafe.AsRef((godot_dictionary*)Unsafe.AsPointer(ref this));
-        }
+    public unsafe void Dispose()
+    {
+        if (_p == null)
+            return;
+        NativeFuncs.godotsharp_dictionary_destroy(ref this);
+        _p = null;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_byte_array
+    internal struct movable
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_byte_array* GetUnsafeAddress()
-            => (godot_packed_byte_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+        private unsafe DictionaryPrivate* _p;
 
-        private IntPtr _writeProxy;
-        private unsafe byte* _ptr;
+        public static unsafe explicit operator movable(in godot_dictionary value)
+            => *(movable*)CustomUnsafe.AsPointer(ref CustomUnsafe.AsRef(value));
 
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_byte_array_destroy(ref this);
-            _ptr = null;
-        }
+        public static unsafe explicit operator godot_dictionary(movable value)
+            => *(godot_dictionary*)Unsafe.AsPointer(ref value);
 
-        public readonly unsafe byte* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
+        public unsafe ref godot_dictionary DangerousSelfRef =>
+            ref CustomUnsafe.AsRef((godot_dictionary*)Unsafe.AsPointer(ref this));
+    }
+}
 
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_byte_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_byte_array* GetUnsafeAddress()
+        => (godot_packed_byte_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+
+    private IntPtr _writeProxy;
+    private unsafe byte* _ptr;
+
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_byte_array_destroy(ref this);
+        _ptr = null;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_int32_array
+    public readonly unsafe byte* Buffer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_int32_array* GetUnsafeAddress()
-            => (godot_packed_int32_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
-
-        private IntPtr _writeProxy;
-        private unsafe int* _ptr;
-
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_int32_array_destroy(ref this);
-            _ptr = null;
-        }
-
-        public readonly unsafe int* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *(_ptr - 1) : 0;
-        }
+        get => _ptr;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_int64_array
+    public readonly unsafe int Size
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_int64_array* GetUnsafeAddress()
-            => (godot_packed_int64_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
 
-        private IntPtr _writeProxy;
-        private unsafe long* _ptr;
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_int32_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_int32_array* GetUnsafeAddress()
+        => (godot_packed_int32_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
 
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_int64_array_destroy(ref this);
-            _ptr = null;
-        }
+    private IntPtr _writeProxy;
+    private unsafe int* _ptr;
 
-        public readonly unsafe long* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_int32_array_destroy(ref this);
+        _ptr = null;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_float32_array
+    public readonly unsafe int* Buffer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_float32_array* GetUnsafeAddress()
-            => (godot_packed_float32_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
-
-        private IntPtr _writeProxy;
-        private unsafe float* _ptr;
-
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_float32_array_destroy(ref this);
-            _ptr = null;
-        }
-
-        public readonly unsafe float* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+        get => _ptr;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_float64_array
+    public readonly unsafe int Size
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_float64_array* GetUnsafeAddress()
-            => (godot_packed_float64_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+        get => _ptr != null ? *(_ptr - 1) : 0;
+    }
+}
 
-        private IntPtr _writeProxy;
-        private unsafe double* _ptr;
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_int64_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_int64_array* GetUnsafeAddress()
+        => (godot_packed_int64_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
 
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_float64_array_destroy(ref this);
-            _ptr = null;
-        }
+    private IntPtr _writeProxy;
+    private unsafe long* _ptr;
 
-        public readonly unsafe double* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_int64_array_destroy(ref this);
+        _ptr = null;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_string_array
+    public readonly unsafe long* Buffer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_string_array* GetUnsafeAddress()
-            => (godot_packed_string_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
-
-        private IntPtr _writeProxy;
-        private unsafe godot_string* _ptr;
-
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_string_array_destroy(ref this);
-            _ptr = null;
-        }
-
-        public readonly unsafe godot_string* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+        get => _ptr;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_vector2_array
+    public readonly unsafe int Size
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_vector2_array* GetUnsafeAddress()
-            => (godot_packed_vector2_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
 
-        private IntPtr _writeProxy;
-        private unsafe Vector2* _ptr;
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_float32_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_float32_array* GetUnsafeAddress()
+        => (godot_packed_float32_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
 
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_vector2_array_destroy(ref this);
-            _ptr = null;
-        }
+    private IntPtr _writeProxy;
+    private unsafe float* _ptr;
 
-        public readonly unsafe Vector2* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_float32_array_destroy(ref this);
+        _ptr = null;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_vector3_array
+    public readonly unsafe float* Buffer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_vector3_array* GetUnsafeAddress()
-            => (godot_packed_vector3_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
-
-        private IntPtr _writeProxy;
-        private unsafe Vector3* _ptr;
-
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_vector3_array_destroy(ref this);
-            _ptr = null;
-        }
-
-        public readonly unsafe Vector3* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
-
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+        get => _ptr;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    // ReSharper disable once InconsistentNaming
-    public ref struct godot_packed_color_array
+    public readonly unsafe int Size
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly unsafe godot_packed_color_array* GetUnsafeAddress()
-            => (godot_packed_color_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
 
-        private IntPtr _writeProxy;
-        private unsafe Color* _ptr;
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_float64_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_float64_array* GetUnsafeAddress()
+        => (godot_packed_float64_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
 
-        public unsafe void Dispose()
-        {
-            if (_ptr == null)
-                return;
-            NativeFuncs.godotsharp_packed_color_array_destroy(ref this);
-            _ptr = null;
-        }
+    private IntPtr _writeProxy;
+    private unsafe double* _ptr;
 
-        public readonly unsafe Color* Buffer
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr;
-        }
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_float64_array_destroy(ref this);
+        _ptr = null;
+    }
 
-        public readonly unsafe int Size
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _ptr != null ? *((int*)_ptr - 1) : 0;
-        }
+    public readonly unsafe double* Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_string_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_string_array* GetUnsafeAddress()
+        => (godot_packed_string_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+
+    private IntPtr _writeProxy;
+    private unsafe godot_string* _ptr;
+
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_string_array_destroy(ref this);
+        _ptr = null;
+    }
+
+    public readonly unsafe godot_string* Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_vector2_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_vector2_array* GetUnsafeAddress()
+        => (godot_packed_vector2_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+
+    private IntPtr _writeProxy;
+    private unsafe Vector2* _ptr;
+
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_vector2_array_destroy(ref this);
+        _ptr = null;
+    }
+
+    public readonly unsafe Vector2* Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_vector3_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_vector3_array* GetUnsafeAddress()
+        => (godot_packed_vector3_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+
+    private IntPtr _writeProxy;
+    private unsafe Vector3* _ptr;
+
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_vector3_array_destroy(ref this);
+        _ptr = null;
+    }
+
+    public readonly unsafe Vector3* Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+// ReSharper disable once InconsistentNaming
+public ref struct godot_packed_color_array
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal readonly unsafe godot_packed_color_array* GetUnsafeAddress()
+        => (godot_packed_color_array*)Unsafe.AsPointer(ref Unsafe.AsRef(in _writeProxy));
+
+    private IntPtr _writeProxy;
+    private unsafe Color* _ptr;
+
+    public unsafe void Dispose()
+    {
+        if (_ptr == null)
+            return;
+        NativeFuncs.godotsharp_packed_color_array_destroy(ref this);
+        _ptr = null;
+    }
+
+    public readonly unsafe Color* Buffer
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr;
+    }
+
+    public readonly unsafe int Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _ptr != null ? *((int*)_ptr - 1) : 0;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropUtils.cs
@@ -4,93 +4,92 @@ using Godot.Bridge;
 
 // ReSharper disable InconsistentNaming
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+internal static class InteropUtils
 {
-    internal static class InteropUtils
+    public static GodotObject UnmanagedGetManaged(IntPtr unmanaged)
     {
-        public static GodotObject UnmanagedGetManaged(IntPtr unmanaged)
+        // The native pointer may be null
+        if (unmanaged == IntPtr.Zero)
+            return null;
+
+        IntPtr gcHandlePtr;
+        godot_bool hasCsScriptInstance;
+
+        // First try to get the tied managed instance from a CSharpInstance script instance
+
+        gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_get_script_instance_managed(
+            unmanaged, out hasCsScriptInstance);
+
+        if (gcHandlePtr != IntPtr.Zero)
+            return (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target;
+
+        // Otherwise, if the object has a CSharpInstance script instance, return null
+
+        if (hasCsScriptInstance.ToBool())
+            return null;
+
+        // If it doesn't have a CSharpInstance script instance, try with native instance bindings
+
+        gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_get_instance_binding_managed(unmanaged);
+
+        object target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+
+        if (target != null)
+            return (GodotObject)target;
+
+        // If the native instance binding GC handle target was collected, create a new one
+
+        gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_instance_binding_create_managed(
+            unmanaged, gcHandlePtr);
+
+        return gcHandlePtr != IntPtr.Zero ? (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+    }
+
+    public static void TieManagedToUnmanaged(GodotObject managed, IntPtr unmanaged,
+        StringName nativeName, bool refCounted, Type type, Type nativeType)
+    {
+        var gcHandle = refCounted ?
+            CustomGCHandle.AllocWeak(managed) :
+            CustomGCHandle.AllocStrong(managed, type);
+
+        if (type == nativeType)
         {
-            // The native pointer may be null
-            if (unmanaged == IntPtr.Zero)
-                return null;
-
-            IntPtr gcHandlePtr;
-            godot_bool hasCsScriptInstance;
-
-            // First try to get the tied managed instance from a CSharpInstance script instance
-
-            gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_get_script_instance_managed(
-                unmanaged, out hasCsScriptInstance);
-
-            if (gcHandlePtr != IntPtr.Zero)
-                return (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target;
-
-            // Otherwise, if the object has a CSharpInstance script instance, return null
-
-            if (hasCsScriptInstance.ToBool())
-                return null;
-
-            // If it doesn't have a CSharpInstance script instance, try with native instance bindings
-
-            gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_get_instance_binding_managed(unmanaged);
-
-            object target = gcHandlePtr != IntPtr.Zero ? GCHandle.FromIntPtr(gcHandlePtr).Target : null;
-
-            if (target != null)
-                return (GodotObject)target;
-
-            // If the native instance binding GC handle target was collected, create a new one
-
-            gcHandlePtr = NativeFuncs.godotsharp_internal_unmanaged_instance_binding_create_managed(
-                unmanaged, gcHandlePtr);
-
-            return gcHandlePtr != IntPtr.Zero ? (GodotObject)GCHandle.FromIntPtr(gcHandlePtr).Target : null;
+            var nativeNameSelf = (godot_string_name)nativeName.NativeValue;
+            NativeFuncs.godotsharp_internal_tie_native_managed_to_unmanaged(
+                GCHandle.ToIntPtr(gcHandle), unmanaged, nativeNameSelf, refCounted.ToGodotBool());
         }
-
-        public static void TieManagedToUnmanaged(GodotObject managed, IntPtr unmanaged,
-            StringName nativeName, bool refCounted, Type type, Type nativeType)
+        else
         {
-            var gcHandle = refCounted ?
-                CustomGCHandle.AllocWeak(managed) :
-                CustomGCHandle.AllocStrong(managed, type);
-
-            if (type == nativeType)
+            unsafe
             {
-                var nativeNameSelf = (godot_string_name)nativeName.NativeValue;
-                NativeFuncs.godotsharp_internal_tie_native_managed_to_unmanaged(
-                    GCHandle.ToIntPtr(gcHandle), unmanaged, nativeNameSelf, refCounted.ToGodotBool());
-            }
-            else
-            {
-                unsafe
-                {
-                    // We don't dispose `script` ourselves here.
-                    // `tie_user_managed_to_unmanaged` does it for us to avoid another P/Invoke call.
-                    godot_ref script;
-                    ScriptManagerBridge.GetOrLoadOrCreateScriptForType(type, &script);
+                // We don't dispose `script` ourselves here.
+                // `tie_user_managed_to_unmanaged` does it for us to avoid another P/Invoke call.
+                godot_ref script;
+                ScriptManagerBridge.GetOrLoadOrCreateScriptForType(type, &script);
 
-                    // IMPORTANT: This must be called after GetOrCreateScriptBridgeForType
-                    NativeFuncs.godotsharp_internal_tie_user_managed_to_unmanaged(
-                        GCHandle.ToIntPtr(gcHandle), unmanaged, &script, refCounted.ToGodotBool());
-                }
+                // IMPORTANT: This must be called after GetOrCreateScriptBridgeForType
+                NativeFuncs.godotsharp_internal_tie_user_managed_to_unmanaged(
+                    GCHandle.ToIntPtr(gcHandle), unmanaged, &script, refCounted.ToGodotBool());
             }
         }
+    }
 
-        public static void TieManagedToUnmanagedWithPreSetup(GodotObject managed, IntPtr unmanaged,
-            Type type, Type nativeType)
-        {
-            if (type == nativeType)
-                return;
+    public static void TieManagedToUnmanagedWithPreSetup(GodotObject managed, IntPtr unmanaged,
+        Type type, Type nativeType)
+    {
+        if (type == nativeType)
+            return;
 
-            var strongGCHandle = CustomGCHandle.AllocStrong(managed);
-            NativeFuncs.godotsharp_internal_tie_managed_to_unmanaged_with_pre_setup(
-                GCHandle.ToIntPtr(strongGCHandle), unmanaged);
-        }
+        var strongGCHandle = CustomGCHandle.AllocStrong(managed);
+        NativeFuncs.godotsharp_internal_tie_managed_to_unmanaged_with_pre_setup(
+            GCHandle.ToIntPtr(strongGCHandle), unmanaged);
+    }
 
-        public static GodotObject EngineGetSingleton(string name)
-        {
-            using godot_string src = Marshaling.ConvertStringToNative(name);
-            return UnmanagedGetManaged(NativeFuncs.godotsharp_engine_get_singleton(src));
-        }
+    public static GodotObject EngineGetSingleton(string name)
+    {
+        using godot_string src = Marshaling.ConvertStringToNative(name);
+        return UnmanagedGetManaged(NativeFuncs.godotsharp_engine_get_singleton(src));
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/Marshaling.cs
@@ -10,589 +10,588 @@ using Array = System.Array;
 
 #nullable enable
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+public static class Marshaling
 {
-    public static class Marshaling
+    internal static Variant.Type ConvertManagedTypeToVariantType(Type type, out bool r_nil_is_variant)
     {
-        internal static Variant.Type ConvertManagedTypeToVariantType(Type type, out bool r_nil_is_variant)
+        r_nil_is_variant = false;
+
+        switch (Type.GetTypeCode(type))
         {
-            r_nil_is_variant = false;
-
-            switch (Type.GetTypeCode(type))
+            case TypeCode.Boolean:
+                return Variant.Type.Bool;
+            case TypeCode.Char:
+                return Variant.Type.Int;
+            case TypeCode.SByte:
+                return Variant.Type.Int;
+            case TypeCode.Int16:
+                return Variant.Type.Int;
+            case TypeCode.Int32:
+                return Variant.Type.Int;
+            case TypeCode.Int64:
+                return Variant.Type.Int;
+            case TypeCode.Byte:
+                return Variant.Type.Int;
+            case TypeCode.UInt16:
+                return Variant.Type.Int;
+            case TypeCode.UInt32:
+                return Variant.Type.Int;
+            case TypeCode.UInt64:
+                return Variant.Type.Int;
+            case TypeCode.Single:
+                return Variant.Type.Float;
+            case TypeCode.Double:
+                return Variant.Type.Float;
+            case TypeCode.String:
+                return Variant.Type.String;
+            default:
             {
-                case TypeCode.Boolean:
-                    return Variant.Type.Bool;
-                case TypeCode.Char:
+                if (type == typeof(Vector2))
+                    return Variant.Type.Vector2;
+
+                if (type == typeof(Vector2I))
+                    return Variant.Type.Vector2I;
+
+                if (type == typeof(Rect2))
+                    return Variant.Type.Rect2;
+
+                if (type == typeof(Rect2I))
+                    return Variant.Type.Rect2I;
+
+                if (type == typeof(Transform2D))
+                    return Variant.Type.Transform2D;
+
+                if (type == typeof(Vector3))
+                    return Variant.Type.Vector3;
+
+                if (type == typeof(Vector3I))
+                    return Variant.Type.Vector3I;
+
+                if (type == typeof(Vector4))
+                    return Variant.Type.Vector4;
+
+                if (type == typeof(Vector4I))
+                    return Variant.Type.Vector4I;
+
+                if (type == typeof(Basis))
+                    return Variant.Type.Basis;
+
+                if (type == typeof(Quaternion))
+                    return Variant.Type.Quaternion;
+
+                if (type == typeof(Transform3D))
+                    return Variant.Type.Transform3D;
+
+                if (type == typeof(Projection))
+                    return Variant.Type.Projection;
+
+                if (type == typeof(Aabb))
+                    return Variant.Type.Aabb;
+
+                if (type == typeof(Color))
+                    return Variant.Type.Color;
+
+                if (type == typeof(Plane))
+                    return Variant.Type.Plane;
+
+                if (type == typeof(Callable))
+                    return Variant.Type.Callable;
+
+                if (type == typeof(Signal))
+                    return Variant.Type.Signal;
+
+                if (type.IsEnum)
                     return Variant.Type.Int;
-                case TypeCode.SByte:
-                    return Variant.Type.Int;
-                case TypeCode.Int16:
-                    return Variant.Type.Int;
-                case TypeCode.Int32:
-                    return Variant.Type.Int;
-                case TypeCode.Int64:
-                    return Variant.Type.Int;
-                case TypeCode.Byte:
-                    return Variant.Type.Int;
-                case TypeCode.UInt16:
-                    return Variant.Type.Int;
-                case TypeCode.UInt32:
-                    return Variant.Type.Int;
-                case TypeCode.UInt64:
-                    return Variant.Type.Int;
-                case TypeCode.Single:
-                    return Variant.Type.Float;
-                case TypeCode.Double:
-                    return Variant.Type.Float;
-                case TypeCode.String:
-                    return Variant.Type.String;
-                default:
+
+                if (type.IsArray || type.IsSZArray)
                 {
-                    if (type == typeof(Vector2))
-                        return Variant.Type.Vector2;
+                    if (type == typeof(byte[]))
+                        return Variant.Type.PackedByteArray;
 
-                    if (type == typeof(Vector2I))
-                        return Variant.Type.Vector2I;
+                    if (type == typeof(int[]))
+                        return Variant.Type.PackedInt32Array;
 
-                    if (type == typeof(Rect2))
-                        return Variant.Type.Rect2;
+                    if (type == typeof(long[]))
+                        return Variant.Type.PackedInt64Array;
 
-                    if (type == typeof(Rect2I))
-                        return Variant.Type.Rect2I;
+                    if (type == typeof(float[]))
+                        return Variant.Type.PackedFloat32Array;
 
-                    if (type == typeof(Transform2D))
-                        return Variant.Type.Transform2D;
+                    if (type == typeof(double[]))
+                        return Variant.Type.PackedFloat64Array;
 
-                    if (type == typeof(Vector3))
-                        return Variant.Type.Vector3;
+                    if (type == typeof(string[]))
+                        return Variant.Type.PackedStringArray;
 
-                    if (type == typeof(Vector3I))
-                        return Variant.Type.Vector3I;
+                    if (type == typeof(Vector2[]))
+                        return Variant.Type.PackedVector2Array;
 
-                    if (type == typeof(Vector4))
-                        return Variant.Type.Vector4;
+                    if (type == typeof(Vector3[]))
+                        return Variant.Type.PackedVector3Array;
 
-                    if (type == typeof(Vector4I))
-                        return Variant.Type.Vector4I;
+                    if (type == typeof(Color[]))
+                        return Variant.Type.PackedColorArray;
 
-                    if (type == typeof(Basis))
-                        return Variant.Type.Basis;
+                    if (type == typeof(StringName[]))
+                        return Variant.Type.Array;
 
-                    if (type == typeof(Quaternion))
-                        return Variant.Type.Quaternion;
+                    if (type == typeof(NodePath[]))
+                        return Variant.Type.Array;
 
-                    if (type == typeof(Transform3D))
-                        return Variant.Type.Transform3D;
+                    if (type == typeof(Rid[]))
+                        return Variant.Type.Array;
 
-                    if (type == typeof(Projection))
-                        return Variant.Type.Projection;
-
-                    if (type == typeof(Aabb))
-                        return Variant.Type.Aabb;
-
-                    if (type == typeof(Color))
-                        return Variant.Type.Color;
-
-                    if (type == typeof(Plane))
-                        return Variant.Type.Plane;
-
-                    if (type == typeof(Callable))
-                        return Variant.Type.Callable;
-
-                    if (type == typeof(Signal))
-                        return Variant.Type.Signal;
-
-                    if (type.IsEnum)
-                        return Variant.Type.Int;
-
-                    if (type.IsArray || type.IsSZArray)
-                    {
-                        if (type == typeof(byte[]))
-                            return Variant.Type.PackedByteArray;
-
-                        if (type == typeof(int[]))
-                            return Variant.Type.PackedInt32Array;
-
-                        if (type == typeof(long[]))
-                            return Variant.Type.PackedInt64Array;
-
-                        if (type == typeof(float[]))
-                            return Variant.Type.PackedFloat32Array;
-
-                        if (type == typeof(double[]))
-                            return Variant.Type.PackedFloat64Array;
-
-                        if (type == typeof(string[]))
-                            return Variant.Type.PackedStringArray;
-
-                        if (type == typeof(Vector2[]))
-                            return Variant.Type.PackedVector2Array;
-
-                        if (type == typeof(Vector3[]))
-                            return Variant.Type.PackedVector3Array;
-
-                        if (type == typeof(Color[]))
-                            return Variant.Type.PackedColorArray;
-
-                        if (type == typeof(StringName[]))
-                            return Variant.Type.Array;
-
-                        if (type == typeof(NodePath[]))
-                            return Variant.Type.Array;
-
-                        if (type == typeof(Rid[]))
-                            return Variant.Type.Array;
-
-                        if (typeof(GodotObject[]).IsAssignableFrom(type))
-                            return Variant.Type.Array;
-                    }
-                    else if (type.IsGenericType)
-                    {
-                        if (typeof(GodotObject).IsAssignableFrom(type))
-                            return Variant.Type.Object;
-
-                        // We use `IsAssignableFrom` with our helper interfaces to detect generic Godot collections
-                        // because `GetGenericTypeDefinition` is not supported in NativeAOT reflection-free mode.
-
-                        if (typeof(IGenericGodotDictionary).IsAssignableFrom(type))
-                            return Variant.Type.Dictionary;
-
-                        if (typeof(IGenericGodotArray).IsAssignableFrom(type))
-                            return Variant.Type.Array;
-                    }
-                    else if (type == typeof(Variant))
-                    {
-                        r_nil_is_variant = true;
-                        return Variant.Type.Nil;
-                    }
-                    else
-                    {
-                        if (typeof(GodotObject).IsAssignableFrom(type))
-                            return Variant.Type.Object;
-
-                        if (typeof(StringName) == type)
-                            return Variant.Type.StringName;
-
-                        if (typeof(NodePath) == type)
-                            return Variant.Type.NodePath;
-
-                        if (typeof(Rid) == type)
-                            return Variant.Type.Rid;
-
-                        if (typeof(Collections.Dictionary) == type)
-                            return Variant.Type.Dictionary;
-
-                        if (typeof(Collections.Array) == type)
-                            return Variant.Type.Array;
-                    }
-
-                    break;
+                    if (typeof(GodotObject[]).IsAssignableFrom(type))
+                        return Variant.Type.Array;
                 }
-            }
-
-            // Unknown
-            return Variant.Type.Nil;
-        }
-
-        // String
-
-        public static unsafe godot_string ConvertStringToNative(string? p_mono_string)
-        {
-            if (p_mono_string == null)
-                return new godot_string();
-
-            fixed (char* methodChars = p_mono_string)
-            {
-                NativeFuncs.godotsharp_string_new_with_utf16_chars(out godot_string dest, methodChars);
-                return dest;
-            }
-        }
-
-        public static unsafe string ConvertStringToManaged(in godot_string p_string)
-        {
-            if (p_string.Buffer == IntPtr.Zero)
-                return string.Empty;
-
-            const int sizeOfChar32 = 4;
-            byte* bytes = (byte*)p_string.Buffer;
-            int size = p_string.Size;
-            if (size == 0)
-                return string.Empty;
-            size -= 1; // zero at the end
-            int sizeInBytes = size * sizeOfChar32;
-            return System.Text.Encoding.UTF32.GetString(bytes, sizeInBytes);
-        }
-
-        // Callable
-
-        public static godot_callable ConvertCallableToNative(in Callable p_managed_callable)
-        {
-            if (p_managed_callable.Delegate != null)
-            {
-                var gcHandle = CustomGCHandle.AllocStrong(p_managed_callable.Delegate);
-
-                IntPtr objectPtr = p_managed_callable.Target != null ?
-                    GodotObject.GetPtr(p_managed_callable.Target) :
-                    IntPtr.Zero;
-
-                unsafe
+                else if (type.IsGenericType)
                 {
-                    NativeFuncs.godotsharp_callable_new_with_delegate(
-                        GCHandle.ToIntPtr(gcHandle), (IntPtr)p_managed_callable.Trampoline,
-                        objectPtr, out godot_callable callable);
+                    if (typeof(GodotObject).IsAssignableFrom(type))
+                        return Variant.Type.Object;
 
-                    return callable;
+                    // We use `IsAssignableFrom` with our helper interfaces to detect generic Godot collections
+                    // because `GetGenericTypeDefinition` is not supported in NativeAOT reflection-free mode.
+
+                    if (typeof(IGenericGodotDictionary).IsAssignableFrom(type))
+                        return Variant.Type.Dictionary;
+
+                    if (typeof(IGenericGodotArray).IsAssignableFrom(type))
+                        return Variant.Type.Array;
                 }
-            }
-            else
-            {
-                godot_string_name method;
-
-                if (p_managed_callable.Method != null && !p_managed_callable.Method.IsEmpty)
+                else if (type == typeof(Variant))
                 {
-                    var src = (godot_string_name)p_managed_callable.Method.NativeValue;
-                    method = NativeFuncs.godotsharp_string_name_new_copy(src);
+                    r_nil_is_variant = true;
+                    return Variant.Type.Nil;
                 }
                 else
                 {
-                    method = default;
+                    if (typeof(GodotObject).IsAssignableFrom(type))
+                        return Variant.Type.Object;
+
+                    if (typeof(StringName) == type)
+                        return Variant.Type.StringName;
+
+                    if (typeof(NodePath) == type)
+                        return Variant.Type.NodePath;
+
+                    if (typeof(Rid) == type)
+                        return Variant.Type.Rid;
+
+                    if (typeof(Collections.Dictionary) == type)
+                        return Variant.Type.Dictionary;
+
+                    if (typeof(Collections.Array) == type)
+                        return Variant.Type.Array;
                 }
 
-                return new godot_callable(method /* Takes ownership of disposable */,
-                    p_managed_callable.Target.GetInstanceId());
+                break;
             }
         }
 
-        public static Callable ConvertCallableToManaged(in godot_callable p_callable)
+        // Unknown
+        return Variant.Type.Nil;
+    }
+
+    // String
+
+    public static unsafe godot_string ConvertStringToNative(string? p_mono_string)
+    {
+        if (p_mono_string == null)
+            return new godot_string();
+
+        fixed (char* methodChars = p_mono_string)
         {
-            if (NativeFuncs.godotsharp_callable_get_data_for_marshalling(p_callable,
-                    out IntPtr delegateGCHandle, out IntPtr trampoline,
-                    out IntPtr godotObject, out godot_string_name name).ToBool())
-            {
-                if (delegateGCHandle != IntPtr.Zero)
-                {
-                    unsafe
-                    {
-                        return Callable.CreateWithUnsafeTrampoline(
-                            (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target,
-                            (delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void>)trampoline);
-                    }
-                }
-
-                return new Callable(
-                    InteropUtils.UnmanagedGetManaged(godotObject),
-                    StringName.CreateTakingOwnershipOfDisposableValue(name));
-            }
-
-            // Some other unsupported callable
-            return new Callable();
+            NativeFuncs.godotsharp_string_new_with_utf16_chars(out godot_string dest, methodChars);
+            return dest;
         }
+    }
 
-        // Signal
+    public static unsafe string ConvertStringToManaged(in godot_string p_string)
+    {
+        if (p_string.Buffer == IntPtr.Zero)
+            return string.Empty;
 
-        public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
+        const int sizeOfChar32 = 4;
+        byte* bytes = (byte*)p_string.Buffer;
+        int size = p_string.Size;
+        if (size == 0)
+            return string.Empty;
+        size -= 1; // zero at the end
+        int sizeInBytes = size * sizeOfChar32;
+        return System.Text.Encoding.UTF32.GetString(bytes, sizeInBytes);
+    }
+
+    // Callable
+
+    public static godot_callable ConvertCallableToNative(in Callable p_managed_callable)
+    {
+        if (p_managed_callable.Delegate != null)
         {
-            ulong ownerId = p_managed_signal.Owner.GetInstanceId();
-            godot_string_name name;
+            var gcHandle = CustomGCHandle.AllocStrong(p_managed_callable.Delegate);
 
-            if (p_managed_signal.Name != null && !p_managed_signal.Name.IsEmpty)
+            IntPtr objectPtr = p_managed_callable.Target != null ?
+                GodotObject.GetPtr(p_managed_callable.Target) :
+                IntPtr.Zero;
+
+            unsafe
             {
-                var src = (godot_string_name)p_managed_signal.Name.NativeValue;
-                name = NativeFuncs.godotsharp_string_name_new_copy(src);
+                NativeFuncs.godotsharp_callable_new_with_delegate(
+                    GCHandle.ToIntPtr(gcHandle), (IntPtr)p_managed_callable.Trampoline,
+                    objectPtr, out godot_callable callable);
+
+                return callable;
+            }
+        }
+        else
+        {
+            godot_string_name method;
+
+            if (p_managed_callable.Method != null && !p_managed_callable.Method.IsEmpty)
+            {
+                var src = (godot_string_name)p_managed_callable.Method.NativeValue;
+                method = NativeFuncs.godotsharp_string_name_new_copy(src);
             }
             else
             {
-                name = default;
+                method = default;
             }
 
-            return new godot_signal(name, ownerId);
+            return new godot_callable(method /* Takes ownership of disposable */,
+                p_managed_callable.Target.GetInstanceId());
         }
+    }
 
-        public static Signal ConvertSignalToManaged(in godot_signal p_signal)
+    public static Callable ConvertCallableToManaged(in godot_callable p_callable)
+    {
+        if (NativeFuncs.godotsharp_callable_get_data_for_marshalling(p_callable,
+                out IntPtr delegateGCHandle, out IntPtr trampoline,
+                out IntPtr godotObject, out godot_string_name name).ToBool())
         {
-            var owner = GodotObject.InstanceFromId(p_signal.ObjectId);
-            var name = StringName.CreateTakingOwnershipOfDisposableValue(
-                NativeFuncs.godotsharp_string_name_new_copy(p_signal.Name));
-            return new Signal(owner, name);
-        }
-
-        // Array
-
-        internal static T[] ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(in godot_array p_array)
-            where T : GodotObject
-        {
-            var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                NativeFuncs.godotsharp_array_new_copy(p_array));
-
-            int length = array.Count;
-            var ret = new T[length];
-
-            for (int i = 0; i < length; i++)
-                ret[i] = (T)array[i].AsGodotObject();
-
-            return ret;
-        }
-
-        internal static StringName[] ConvertNativeGodotArrayToSystemArrayOfStringName(in godot_array p_array)
-        {
-            var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                NativeFuncs.godotsharp_array_new_copy(p_array));
-
-            int length = array.Count;
-            var ret = new StringName[length];
-
-            for (int i = 0; i < length; i++)
-                ret[i] = array[i].AsStringName();
-
-            return ret;
-        }
-
-        internal static NodePath[] ConvertNativeGodotArrayToSystemArrayOfNodePath(in godot_array p_array)
-        {
-            var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                NativeFuncs.godotsharp_array_new_copy(p_array));
-
-            int length = array.Count;
-            var ret = new NodePath[length];
-
-            for (int i = 0; i < length; i++)
-                ret[i] = array[i].AsNodePath();
-
-            return ret;
-        }
-
-        internal static Rid[] ConvertNativeGodotArrayToSystemArrayOfRid(in godot_array p_array)
-        {
-            var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
-                NativeFuncs.godotsharp_array_new_copy(p_array));
-
-            int length = array.Count;
-            var ret = new Rid[length];
-
-            for (int i = 0; i < length; i++)
-                ret[i] = array[i].AsRid();
-
-            return ret;
-        }
-
-        // PackedByteArray
-
-        public static unsafe byte[] ConvertNativePackedByteArrayToSystemArray(in godot_packed_byte_array p_array)
-        {
-            byte* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<byte>();
-            var array = new byte[size];
-            fixed (byte* dest = array)
-                Buffer.MemoryCopy(buffer, dest, size, size);
-            return array;
-        }
-
-        public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_byte_array();
-            fixed (byte* src = p_array)
-                return NativeFuncs.godotsharp_packed_byte_array_new_mem_copy(src, p_array.Length);
-        }
-
-        // PackedInt32Array
-
-        public static unsafe int[] ConvertNativePackedInt32ArrayToSystemArray(godot_packed_int32_array p_array)
-        {
-            int* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<int>();
-            int sizeInBytes = size * sizeof(int);
-            var array = new int[size];
-            fixed (int* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
-
-        public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_int32_array();
-            fixed (int* src = p_array)
-                return NativeFuncs.godotsharp_packed_int32_array_new_mem_copy(src, p_array.Length);
-        }
-
-        // PackedInt64Array
-
-        public static unsafe long[] ConvertNativePackedInt64ArrayToSystemArray(godot_packed_int64_array p_array)
-        {
-            long* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<long>();
-            int sizeInBytes = size * sizeof(long);
-            var array = new long[size];
-            fixed (long* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
-
-        public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_int64_array();
-            fixed (long* src = p_array)
-                return NativeFuncs.godotsharp_packed_int64_array_new_mem_copy(src, p_array.Length);
-        }
-
-        // PackedFloat32Array
-
-        public static unsafe float[] ConvertNativePackedFloat32ArrayToSystemArray(godot_packed_float32_array p_array)
-        {
-            float* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<float>();
-            int sizeInBytes = size * sizeof(float);
-            var array = new float[size];
-            fixed (float* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
-
-        public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
-            Span<float> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_float32_array();
-            fixed (float* src = p_array)
-                return NativeFuncs.godotsharp_packed_float32_array_new_mem_copy(src, p_array.Length);
-        }
-
-        // PackedFloat64Array
-
-        public static unsafe double[] ConvertNativePackedFloat64ArrayToSystemArray(godot_packed_float64_array p_array)
-        {
-            double* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<double>();
-            int sizeInBytes = size * sizeof(double);
-            var array = new double[size];
-            fixed (double* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
-
-        public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
-            Span<double> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_float64_array();
-            fixed (double* src = p_array)
-                return NativeFuncs.godotsharp_packed_float64_array_new_mem_copy(src, p_array.Length);
-        }
-
-        // PackedStringArray
-
-        public static unsafe string[] ConvertNativePackedStringArrayToSystemArray(godot_packed_string_array p_array)
-        {
-            godot_string* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<string>();
-            var array = new string[size];
-            for (int i = 0; i < size; i++)
-                array[i] = ConvertStringToManaged(buffer[i]);
-            return array;
-        }
-
-        public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
-        {
-            godot_packed_string_array dest = new godot_packed_string_array();
-
-            if (p_array.IsEmpty)
-                return dest;
-
-            /* TODO: Replace godotsharp_packed_string_array_add with a single internal call to
-             get the write address. We can't use `dest._ptr` directly for writing due to COW. */
-
-            for (int i = 0; i < p_array.Length; i++)
+            if (delegateGCHandle != IntPtr.Zero)
             {
-                using godot_string godotStrElem = ConvertStringToNative(p_array[i]);
-                NativeFuncs.godotsharp_packed_string_array_add(ref dest, godotStrElem);
+                unsafe
+                {
+                    return Callable.CreateWithUnsafeTrampoline(
+                        (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target,
+                        (delegate* managed<object, NativeVariantPtrArgs, out godot_variant, void>)trampoline);
+                }
             }
 
+            return new Callable(
+                InteropUtils.UnmanagedGetManaged(godotObject),
+                StringName.CreateTakingOwnershipOfDisposableValue(name));
+        }
+
+        // Some other unsupported callable
+        return new Callable();
+    }
+
+    // Signal
+
+    public static godot_signal ConvertSignalToNative(in Signal p_managed_signal)
+    {
+        ulong ownerId = p_managed_signal.Owner.GetInstanceId();
+        godot_string_name name;
+
+        if (p_managed_signal.Name != null && !p_managed_signal.Name.IsEmpty)
+        {
+            var src = (godot_string_name)p_managed_signal.Name.NativeValue;
+            name = NativeFuncs.godotsharp_string_name_new_copy(src);
+        }
+        else
+        {
+            name = default;
+        }
+
+        return new godot_signal(name, ownerId);
+    }
+
+    public static Signal ConvertSignalToManaged(in godot_signal p_signal)
+    {
+        var owner = GodotObject.InstanceFromId(p_signal.ObjectId);
+        var name = StringName.CreateTakingOwnershipOfDisposableValue(
+            NativeFuncs.godotsharp_string_name_new_copy(p_signal.Name));
+        return new Signal(owner, name);
+    }
+
+    // Array
+
+    internal static T[] ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(in godot_array p_array)
+        where T : GodotObject
+    {
+        var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+            NativeFuncs.godotsharp_array_new_copy(p_array));
+
+        int length = array.Count;
+        var ret = new T[length];
+
+        for (int i = 0; i < length; i++)
+            ret[i] = (T)array[i].AsGodotObject();
+
+        return ret;
+    }
+
+    internal static StringName[] ConvertNativeGodotArrayToSystemArrayOfStringName(in godot_array p_array)
+    {
+        var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+            NativeFuncs.godotsharp_array_new_copy(p_array));
+
+        int length = array.Count;
+        var ret = new StringName[length];
+
+        for (int i = 0; i < length; i++)
+            ret[i] = array[i].AsStringName();
+
+        return ret;
+    }
+
+    internal static NodePath[] ConvertNativeGodotArrayToSystemArrayOfNodePath(in godot_array p_array)
+    {
+        var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+            NativeFuncs.godotsharp_array_new_copy(p_array));
+
+        int length = array.Count;
+        var ret = new NodePath[length];
+
+        for (int i = 0; i < length; i++)
+            ret[i] = array[i].AsNodePath();
+
+        return ret;
+    }
+
+    internal static Rid[] ConvertNativeGodotArrayToSystemArrayOfRid(in godot_array p_array)
+    {
+        var array = Collections.Array.CreateTakingOwnershipOfDisposableValue(
+            NativeFuncs.godotsharp_array_new_copy(p_array));
+
+        int length = array.Count;
+        var ret = new Rid[length];
+
+        for (int i = 0; i < length; i++)
+            ret[i] = array[i].AsRid();
+
+        return ret;
+    }
+
+    // PackedByteArray
+
+    public static unsafe byte[] ConvertNativePackedByteArrayToSystemArray(in godot_packed_byte_array p_array)
+    {
+        byte* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<byte>();
+        var array = new byte[size];
+        fixed (byte* dest = array)
+            Buffer.MemoryCopy(buffer, dest, size, size);
+        return array;
+    }
+
+    public static unsafe godot_packed_byte_array ConvertSystemArrayToNativePackedByteArray(Span<byte> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_byte_array();
+        fixed (byte* src = p_array)
+            return NativeFuncs.godotsharp_packed_byte_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedInt32Array
+
+    public static unsafe int[] ConvertNativePackedInt32ArrayToSystemArray(godot_packed_int32_array p_array)
+    {
+        int* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<int>();
+        int sizeInBytes = size * sizeof(int);
+        var array = new int[size];
+        fixed (int* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
+
+    public static unsafe godot_packed_int32_array ConvertSystemArrayToNativePackedInt32Array(Span<int> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_int32_array();
+        fixed (int* src = p_array)
+            return NativeFuncs.godotsharp_packed_int32_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedInt64Array
+
+    public static unsafe long[] ConvertNativePackedInt64ArrayToSystemArray(godot_packed_int64_array p_array)
+    {
+        long* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<long>();
+        int sizeInBytes = size * sizeof(long);
+        var array = new long[size];
+        fixed (long* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
+
+    public static unsafe godot_packed_int64_array ConvertSystemArrayToNativePackedInt64Array(Span<long> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_int64_array();
+        fixed (long* src = p_array)
+            return NativeFuncs.godotsharp_packed_int64_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedFloat32Array
+
+    public static unsafe float[] ConvertNativePackedFloat32ArrayToSystemArray(godot_packed_float32_array p_array)
+    {
+        float* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<float>();
+        int sizeInBytes = size * sizeof(float);
+        var array = new float[size];
+        fixed (float* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
+
+    public static unsafe godot_packed_float32_array ConvertSystemArrayToNativePackedFloat32Array(
+        Span<float> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_float32_array();
+        fixed (float* src = p_array)
+            return NativeFuncs.godotsharp_packed_float32_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedFloat64Array
+
+    public static unsafe double[] ConvertNativePackedFloat64ArrayToSystemArray(godot_packed_float64_array p_array)
+    {
+        double* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<double>();
+        int sizeInBytes = size * sizeof(double);
+        var array = new double[size];
+        fixed (double* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
+
+    public static unsafe godot_packed_float64_array ConvertSystemArrayToNativePackedFloat64Array(
+        Span<double> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_float64_array();
+        fixed (double* src = p_array)
+            return NativeFuncs.godotsharp_packed_float64_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedStringArray
+
+    public static unsafe string[] ConvertNativePackedStringArrayToSystemArray(godot_packed_string_array p_array)
+    {
+        godot_string* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<string>();
+        var array = new string[size];
+        for (int i = 0; i < size; i++)
+            array[i] = ConvertStringToManaged(buffer[i]);
+        return array;
+    }
+
+    public static godot_packed_string_array ConvertSystemArrayToNativePackedStringArray(Span<string> p_array)
+    {
+        godot_packed_string_array dest = new godot_packed_string_array();
+
+        if (p_array.IsEmpty)
             return dest;
-        }
 
-        // PackedVector2Array
+        /* TODO: Replace godotsharp_packed_string_array_add with a single internal call to
+         get the write address. We can't use `dest._ptr` directly for writing due to COW. */
 
-        public static unsafe Vector2[] ConvertNativePackedVector2ArrayToSystemArray(godot_packed_vector2_array p_array)
+        for (int i = 0; i < p_array.Length; i++)
         {
-            Vector2* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<Vector2>();
-            int sizeInBytes = size * sizeof(Vector2);
-            var array = new Vector2[size];
-            fixed (Vector2* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
+            using godot_string godotStrElem = ConvertStringToNative(p_array[i]);
+            NativeFuncs.godotsharp_packed_string_array_add(ref dest, godotStrElem);
         }
 
-        public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
-            Span<Vector2> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_vector2_array();
-            fixed (Vector2* src = p_array)
-                return NativeFuncs.godotsharp_packed_vector2_array_new_mem_copy(src, p_array.Length);
-        }
+        return dest;
+    }
 
-        // PackedVector3Array
+    // PackedVector2Array
 
-        public static unsafe Vector3[] ConvertNativePackedVector3ArrayToSystemArray(godot_packed_vector3_array p_array)
-        {
-            Vector3* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<Vector3>();
-            int sizeInBytes = size * sizeof(Vector3);
-            var array = new Vector3[size];
-            fixed (Vector3* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
+    public static unsafe Vector2[] ConvertNativePackedVector2ArrayToSystemArray(godot_packed_vector2_array p_array)
+    {
+        Vector2* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<Vector2>();
+        int sizeInBytes = size * sizeof(Vector2);
+        var array = new Vector2[size];
+        fixed (Vector2* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
 
-        public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
-            Span<Vector3> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_vector3_array();
-            fixed (Vector3* src = p_array)
-                return NativeFuncs.godotsharp_packed_vector3_array_new_mem_copy(src, p_array.Length);
-        }
+    public static unsafe godot_packed_vector2_array ConvertSystemArrayToNativePackedVector2Array(
+        Span<Vector2> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_vector2_array();
+        fixed (Vector2* src = p_array)
+            return NativeFuncs.godotsharp_packed_vector2_array_new_mem_copy(src, p_array.Length);
+    }
 
-        // PackedColorArray
+    // PackedVector3Array
 
-        public static unsafe Color[] ConvertNativePackedColorArrayToSystemArray(godot_packed_color_array p_array)
-        {
-            Color* buffer = p_array.Buffer;
-            int size = p_array.Size;
-            if (size == 0)
-                return Array.Empty<Color>();
-            int sizeInBytes = size * sizeof(Color);
-            var array = new Color[size];
-            fixed (Color* dest = array)
-                Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
-            return array;
-        }
+    public static unsafe Vector3[] ConvertNativePackedVector3ArrayToSystemArray(godot_packed_vector3_array p_array)
+    {
+        Vector3* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<Vector3>();
+        int sizeInBytes = size * sizeof(Vector3);
+        var array = new Vector3[size];
+        fixed (Vector3* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
 
-        public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
-        {
-            if (p_array.IsEmpty)
-                return new godot_packed_color_array();
-            fixed (Color* src = p_array)
-                return NativeFuncs.godotsharp_packed_color_array_new_mem_copy(src, p_array.Length);
-        }
+    public static unsafe godot_packed_vector3_array ConvertSystemArrayToNativePackedVector3Array(
+        Span<Vector3> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_vector3_array();
+        fixed (Vector3* src = p_array)
+            return NativeFuncs.godotsharp_packed_vector3_array_new_mem_copy(src, p_array.Length);
+    }
+
+    // PackedColorArray
+
+    public static unsafe Color[] ConvertNativePackedColorArrayToSystemArray(godot_packed_color_array p_array)
+    {
+        Color* buffer = p_array.Buffer;
+        int size = p_array.Size;
+        if (size == 0)
+            return Array.Empty<Color>();
+        int sizeInBytes = size * sizeof(Color);
+        var array = new Color[size];
+        fixed (Color* dest = array)
+            Buffer.MemoryCopy(buffer, dest, sizeInBytes, sizeInBytes);
+        return array;
+    }
+
+    public static unsafe godot_packed_color_array ConvertSystemArrayToNativePackedColorArray(Span<Color> p_array)
+    {
+        if (p_array.IsEmpty)
+            return new godot_packed_color_array();
+        fixed (Color* src = p_array)
+            return NativeFuncs.godotsharp_packed_color_array_new_mem_copy(src, p_array.Length);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -5,547 +5,546 @@ using Godot.SourceGenerators.Internal;
 
 // ReSharper disable InconsistentNaming
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+/*
+ * IMPORTANT:
+ * The order of the methods defined in NativeFuncs must match the order
+ * in the array defined at the bottom of 'glue/runtime_interop.cpp'.
+ */
+
+[GenerateUnmanagedCallbacks(typeof(UnmanagedCallbacks))]
+public static unsafe partial class NativeFuncs
 {
-    /*
-     * IMPORTANT:
-     * The order of the methods defined in NativeFuncs must match the order
-     * in the array defined at the bottom of 'glue/runtime_interop.cpp'.
-     */
+    private static bool initialized = false;
 
-    [GenerateUnmanagedCallbacks(typeof(UnmanagedCallbacks))]
-    public static unsafe partial class NativeFuncs
+    // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Global
+    public static void Initialize(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
     {
-        private static bool initialized = false;
+        if (initialized)
+            throw new InvalidOperationException("Already initialized.");
+        initialized = true;
 
-        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Global
-        public static void Initialize(IntPtr unmanagedCallbacks, int unmanagedCallbacksSize)
-        {
-            if (initialized)
-                throw new InvalidOperationException("Already initialized.");
-            initialized = true;
+        if (unmanagedCallbacksSize != sizeof(UnmanagedCallbacks))
+            throw new ArgumentException("Unmanaged callbacks size mismatch.", nameof(unmanagedCallbacksSize));
 
-            if (unmanagedCallbacksSize != sizeof(UnmanagedCallbacks))
-                throw new ArgumentException("Unmanaged callbacks size mismatch.", nameof(unmanagedCallbacksSize));
-
-            _unmanagedCallbacks = Unsafe.AsRef<UnmanagedCallbacks>((void*)unmanagedCallbacks);
-        }
-
-        private partial struct UnmanagedCallbacks
-        {
-        }
-
-        // Custom functions
-
-        internal static partial godot_bool godotsharp_dotnet_module_is_initialized();
-
-        public static partial IntPtr godotsharp_method_bind_get_method(in godot_string_name p_classname,
-            in godot_string_name p_methodname);
-
-        public static partial delegate* unmanaged<IntPtr> godotsharp_get_class_constructor(
-            in godot_string_name p_classname);
-
-        public static partial IntPtr godotsharp_engine_get_singleton(in godot_string p_name);
-
-
-        internal static partial Error godotsharp_stack_info_vector_resize(
-            ref DebuggingUtils.godot_stack_info_vector p_stack_info_vector, int p_size);
-
-        internal static partial void godotsharp_stack_info_vector_destroy(
-            ref DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
-
-        internal static partial void godotsharp_internal_editor_file_system_update_file(in godot_string p_script_path);
-
-        internal static partial void godotsharp_internal_script_debugger_send_error(in godot_string p_func,
-            in godot_string p_file, int p_line, in godot_string p_err, in godot_string p_descr,
-            godot_bool p_warning, in DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
-
-        internal static partial godot_bool godotsharp_internal_script_debugger_is_active();
-
-        internal static partial IntPtr godotsharp_internal_object_get_associated_gchandle(IntPtr ptr);
-
-        internal static partial void godotsharp_internal_object_disposed(IntPtr ptr, IntPtr gcHandleToFree);
-
-        internal static partial void godotsharp_internal_refcounted_disposed(IntPtr ptr, IntPtr gcHandleToFree,
-            godot_bool isFinalizer);
-
-        internal static partial Error godotsharp_internal_signal_awaiter_connect(IntPtr source,
-            in godot_string_name signal,
-            IntPtr target, IntPtr awaiterHandlePtr);
-
-        internal static partial void godotsharp_internal_tie_native_managed_to_unmanaged(IntPtr gcHandleIntPtr,
-            IntPtr unmanaged, in godot_string_name nativeName, godot_bool refCounted);
-
-        internal static partial void godotsharp_internal_tie_user_managed_to_unmanaged(IntPtr gcHandleIntPtr,
-            IntPtr unmanaged, godot_ref* scriptPtr, godot_bool refCounted);
-
-        internal static partial void godotsharp_internal_tie_managed_to_unmanaged_with_pre_setup(
-            IntPtr gcHandleIntPtr, IntPtr unmanaged);
-
-        internal static partial IntPtr godotsharp_internal_unmanaged_get_script_instance_managed(IntPtr p_unmanaged,
-            out godot_bool r_has_cs_script_instance);
-
-        internal static partial IntPtr godotsharp_internal_unmanaged_get_instance_binding_managed(IntPtr p_unmanaged);
-
-        internal static partial IntPtr godotsharp_internal_unmanaged_instance_binding_create_managed(IntPtr p_unmanaged,
-            IntPtr oldGCHandlePtr);
-
-        internal static partial void godotsharp_internal_new_csharp_script(godot_ref* r_dest);
-
-        internal static partial godot_bool godotsharp_internal_script_load(in godot_string p_path, godot_ref* r_dest);
-
-        internal static partial void godotsharp_internal_reload_registered_script(IntPtr scriptPtr);
-
-        internal static partial void godotsharp_array_filter_godot_objects_by_native(in godot_string_name p_native_name,
-            in godot_array p_input, out godot_array r_output);
-
-        internal static partial void godotsharp_array_filter_godot_objects_by_non_native(in godot_array p_input,
-            out godot_array r_output);
-
-        public static partial void godotsharp_ref_new_from_ref_counted_ptr(out godot_ref r_dest,
-            IntPtr p_ref_counted_ptr);
-
-        public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
-
-        public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
-            in godot_string p_name);
-
-        public static partial void godotsharp_node_path_new_from_string(out godot_node_path r_dest,
-            in godot_string p_name);
-
-        public static partial void
-            godotsharp_string_name_as_string(out godot_string r_dest, in godot_string_name p_name);
-
-        public static partial void godotsharp_node_path_as_string(out godot_string r_dest, in godot_node_path p_np);
-
-        public static partial godot_packed_byte_array godotsharp_packed_byte_array_new_mem_copy(byte* p_src,
-            int p_length);
-
-        public static partial godot_packed_int32_array godotsharp_packed_int32_array_new_mem_copy(int* p_src,
-            int p_length);
-
-        public static partial godot_packed_int64_array godotsharp_packed_int64_array_new_mem_copy(long* p_src,
-            int p_length);
-
-        public static partial godot_packed_float32_array godotsharp_packed_float32_array_new_mem_copy(float* p_src,
-            int p_length);
-
-        public static partial godot_packed_float64_array godotsharp_packed_float64_array_new_mem_copy(double* p_src,
-            int p_length);
-
-        public static partial godot_packed_vector2_array godotsharp_packed_vector2_array_new_mem_copy(Vector2* p_src,
-            int p_length);
-
-        public static partial godot_packed_vector3_array godotsharp_packed_vector3_array_new_mem_copy(Vector3* p_src,
-            int p_length);
-
-        public static partial godot_packed_color_array godotsharp_packed_color_array_new_mem_copy(Color* p_src,
-            int p_length);
-
-        public static partial void godotsharp_packed_string_array_add(ref godot_packed_string_array r_dest,
-            in godot_string p_element);
-
-        public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
-            IntPtr p_object, out godot_callable r_callable);
-
-        internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(in godot_callable p_callable,
-            out IntPtr r_delegate_handle, out IntPtr r_trampoline, out IntPtr r_object, out godot_string_name r_name);
-
-        internal static partial godot_variant godotsharp_callable_call(in godot_callable p_callable,
-            godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
-
-        internal static partial void godotsharp_callable_call_deferred(in godot_callable p_callable,
-            godot_variant** p_args, int p_arg_count);
-
-        internal static partial Color godotsharp_color_from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha);
-
-        // GDNative functions
-
-        // gdnative.h
-
-        public static partial void godotsharp_method_bind_ptrcall(IntPtr p_method_bind, IntPtr p_instance, void** p_args,
-            void* p_ret);
-
-        public static partial godot_variant godotsharp_method_bind_call(IntPtr p_method_bind, IntPtr p_instance,
-            godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
-
-        // variant.h
-
-        public static partial void
-            godotsharp_variant_new_string_name(out godot_variant r_dest, in godot_string_name p_s);
-
-        public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, in godot_variant p_src);
-
-        public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, in godot_node_path p_np);
-
-        public static partial void godotsharp_variant_new_object(out godot_variant r_dest, IntPtr p_obj);
-
-        public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
-
-        public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
-
-        public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);
-
-        public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, in Projection p_proj);
-
-        public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, in Aabb p_aabb);
-
-        public static partial void godotsharp_variant_new_dictionary(out godot_variant r_dest,
-            in godot_dictionary p_dict);
-
-        public static partial void godotsharp_variant_new_array(out godot_variant r_dest, in godot_array p_arr);
-
-        public static partial void godotsharp_variant_new_packed_byte_array(out godot_variant r_dest,
-            in godot_packed_byte_array p_pba);
-
-        public static partial void godotsharp_variant_new_packed_int32_array(out godot_variant r_dest,
-            in godot_packed_int32_array p_pia);
-
-        public static partial void godotsharp_variant_new_packed_int64_array(out godot_variant r_dest,
-            in godot_packed_int64_array p_pia);
-
-        public static partial void godotsharp_variant_new_packed_float32_array(out godot_variant r_dest,
-            in godot_packed_float32_array p_pra);
-
-        public static partial void godotsharp_variant_new_packed_float64_array(out godot_variant r_dest,
-            in godot_packed_float64_array p_pra);
-
-        public static partial void godotsharp_variant_new_packed_string_array(out godot_variant r_dest,
-            in godot_packed_string_array p_psa);
-
-        public static partial void godotsharp_variant_new_packed_vector2_array(out godot_variant r_dest,
-            in godot_packed_vector2_array p_pv2a);
-
-        public static partial void godotsharp_variant_new_packed_vector3_array(out godot_variant r_dest,
-            in godot_packed_vector3_array p_pv3a);
-
-        public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
-            in godot_packed_color_array p_pca);
-
-        public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
-
-        public static partial Int64 godotsharp_variant_as_int(in godot_variant p_self);
-
-        public static partial double godotsharp_variant_as_float(in godot_variant p_self);
-
-        public static partial godot_string godotsharp_variant_as_string(in godot_variant p_self);
-
-        public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
-
-        public static partial Vector2I godotsharp_variant_as_vector2i(in godot_variant p_self);
-
-        public static partial Rect2 godotsharp_variant_as_rect2(in godot_variant p_self);
-
-        public static partial Rect2I godotsharp_variant_as_rect2i(in godot_variant p_self);
-
-        public static partial Vector3 godotsharp_variant_as_vector3(in godot_variant p_self);
-
-        public static partial Vector3I godotsharp_variant_as_vector3i(in godot_variant p_self);
-
-        public static partial Transform2D godotsharp_variant_as_transform2d(in godot_variant p_self);
-
-        public static partial Vector4 godotsharp_variant_as_vector4(in godot_variant p_self);
-
-        public static partial Vector4I godotsharp_variant_as_vector4i(in godot_variant p_self);
-
-        public static partial Plane godotsharp_variant_as_plane(in godot_variant p_self);
-
-        public static partial Quaternion godotsharp_variant_as_quaternion(in godot_variant p_self);
-
-        public static partial Aabb godotsharp_variant_as_aabb(in godot_variant p_self);
-
-        public static partial Basis godotsharp_variant_as_basis(in godot_variant p_self);
-
-        public static partial Transform3D godotsharp_variant_as_transform3d(in godot_variant p_self);
-
-        public static partial Projection godotsharp_variant_as_projection(in godot_variant p_self);
-
-        public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
-
-        public static partial godot_string_name godotsharp_variant_as_string_name(in godot_variant p_self);
-
-        public static partial godot_node_path godotsharp_variant_as_node_path(in godot_variant p_self);
-
-        public static partial Rid godotsharp_variant_as_rid(in godot_variant p_self);
-
-        public static partial godot_callable godotsharp_variant_as_callable(in godot_variant p_self);
-
-        public static partial godot_signal godotsharp_variant_as_signal(in godot_variant p_self);
-
-        public static partial godot_dictionary godotsharp_variant_as_dictionary(in godot_variant p_self);
-
-        public static partial godot_array godotsharp_variant_as_array(in godot_variant p_self);
-
-        public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(in godot_variant p_self);
-
-        public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(in godot_variant p_self);
-
-        public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(in godot_variant p_self);
-
-        public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
-            in godot_variant p_self);
-
-        public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
-            in godot_variant p_self);
-
-        public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
-            in godot_variant p_self);
-
-        public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
-            in godot_variant p_self);
-
-        public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
-            in godot_variant p_self);
-
-        public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(in godot_variant p_self);
-
-        public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
-
-        // string.h
-
-        public static partial void godotsharp_string_new_with_utf16_chars(out godot_string r_dest, char* p_contents);
-
-        // string_name.h
-
-        public static partial void godotsharp_string_name_new_copy(out godot_string_name r_dest,
-            in godot_string_name p_src);
-
-        // node_path.h
-
-        public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, in godot_node_path p_src);
-
-        // array.h
-
-        public static partial void godotsharp_array_new(out godot_array r_dest);
-
-        public static partial void godotsharp_array_new_copy(out godot_array r_dest, in godot_array p_src);
-
-        public static partial godot_variant* godotsharp_array_ptrw(ref godot_array p_self);
-
-        // dictionary.h
-
-        public static partial void godotsharp_dictionary_new(out godot_dictionary r_dest);
-
-        public static partial void godotsharp_dictionary_new_copy(out godot_dictionary r_dest,
-            in godot_dictionary p_src);
-
-        // destroy functions
-
-        public static partial void godotsharp_packed_byte_array_destroy(ref godot_packed_byte_array p_self);
-
-        public static partial void godotsharp_packed_int32_array_destroy(ref godot_packed_int32_array p_self);
-
-        public static partial void godotsharp_packed_int64_array_destroy(ref godot_packed_int64_array p_self);
-
-        public static partial void godotsharp_packed_float32_array_destroy(ref godot_packed_float32_array p_self);
-
-        public static partial void godotsharp_packed_float64_array_destroy(ref godot_packed_float64_array p_self);
-
-        public static partial void godotsharp_packed_string_array_destroy(ref godot_packed_string_array p_self);
-
-        public static partial void godotsharp_packed_vector2_array_destroy(ref godot_packed_vector2_array p_self);
-
-        public static partial void godotsharp_packed_vector3_array_destroy(ref godot_packed_vector3_array p_self);
-
-        public static partial void godotsharp_packed_color_array_destroy(ref godot_packed_color_array p_self);
-
-        public static partial void godotsharp_variant_destroy(ref godot_variant p_self);
-
-        public static partial void godotsharp_string_destroy(ref godot_string p_self);
-
-        public static partial void godotsharp_string_name_destroy(ref godot_string_name p_self);
-
-        public static partial void godotsharp_node_path_destroy(ref godot_node_path p_self);
-
-        public static partial void godotsharp_signal_destroy(ref godot_signal p_self);
-
-        public static partial void godotsharp_callable_destroy(ref godot_callable p_self);
-
-        public static partial void godotsharp_array_destroy(ref godot_array p_self);
-
-        public static partial void godotsharp_dictionary_destroy(ref godot_dictionary p_self);
-
-        // Array
-
-        public static partial int godotsharp_array_add(ref godot_array p_self, in godot_variant p_item);
-
-        public static partial int godotsharp_array_add_range(ref godot_array p_self, in godot_array p_collection);
-
-        public static partial int godotsharp_array_binary_search(ref godot_array p_self, int p_index, int p_count, in godot_variant p_value);
-
-        public static partial void
-            godotsharp_array_duplicate(ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
-
-        public static partial void godotsharp_array_fill(ref godot_array p_self, in godot_variant p_value);
-
-        public static partial int godotsharp_array_index_of(ref godot_array p_self, in godot_variant p_item, int p_index = 0);
-
-        public static partial void godotsharp_array_insert(ref godot_array p_self, int p_index, in godot_variant p_item);
-
-        public static partial int godotsharp_array_last_index_of(ref godot_array p_self, in godot_variant p_item, int p_index);
-
-        public static partial void godotsharp_array_make_read_only(ref godot_array p_self);
-
-        public static partial void godotsharp_array_max(ref godot_array p_self, out godot_variant r_value);
-
-        public static partial void godotsharp_array_min(ref godot_array p_self, out godot_variant r_value);
-
-        public static partial void godotsharp_array_pick_random(ref godot_array p_self, out godot_variant r_value);
-
-        public static partial godot_bool godotsharp_array_recursive_equal(ref godot_array p_self, in godot_array p_other);
-
-        public static partial void godotsharp_array_remove_at(ref godot_array p_self, int p_index);
-
-        public static partial Error godotsharp_array_resize(ref godot_array p_self, int p_new_size);
-
-        public static partial void godotsharp_array_reverse(ref godot_array p_self);
-
-        public static partial void godotsharp_array_shuffle(ref godot_array p_self);
-
-        public static partial void godotsharp_array_slice(ref godot_array p_self, int p_start, int p_end,
-            int p_step, godot_bool p_deep, out godot_array r_dest);
-
-        public static partial void godotsharp_array_sort(ref godot_array p_self);
-
-        public static partial void godotsharp_array_to_string(ref godot_array p_self, out godot_string r_str);
-
-        // Dictionary
-
-        public static partial godot_bool godotsharp_dictionary_try_get_value(ref godot_dictionary p_self,
-            in godot_variant p_key,
-            out godot_variant r_value);
-
-        public static partial void godotsharp_dictionary_set_value(ref godot_dictionary p_self, in godot_variant p_key,
-            in godot_variant p_value);
-
-        public static partial void godotsharp_dictionary_keys(ref godot_dictionary p_self, out godot_array r_dest);
-
-        public static partial void godotsharp_dictionary_values(ref godot_dictionary p_self, out godot_array r_dest);
-
-        public static partial int godotsharp_dictionary_count(ref godot_dictionary p_self);
-
-        public static partial void godotsharp_dictionary_key_value_pair_at(ref godot_dictionary p_self, int p_index,
-            out godot_variant r_key, out godot_variant r_value);
-
-        public static partial void godotsharp_dictionary_add(ref godot_dictionary p_self, in godot_variant p_key,
-            in godot_variant p_value);
-
-        public static partial void godotsharp_dictionary_clear(ref godot_dictionary p_self);
-
-        public static partial godot_bool godotsharp_dictionary_contains_key(ref godot_dictionary p_self,
-            in godot_variant p_key);
-
-        public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
-            out godot_dictionary r_dest);
-
-        public static partial void godotsharp_dictionary_merge(ref godot_dictionary p_self, in godot_dictionary p_dictionary, godot_bool p_overwrite);
-
-        public static partial godot_bool godotsharp_dictionary_recursive_equal(ref godot_dictionary p_self, in godot_dictionary p_other);
-
-        public static partial godot_bool godotsharp_dictionary_remove_key(ref godot_dictionary p_self,
-            in godot_variant p_key);
-
-        public static partial void godotsharp_dictionary_make_read_only(ref godot_dictionary p_self);
-
-        public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
-
-        // StringExtensions
-
-        public static partial void godotsharp_string_simplify_path(in godot_string p_self,
-            out godot_string r_simplified_path);
-
-        public static partial void godotsharp_string_to_camel_case(in godot_string p_self,
-            out godot_string r_camel_case);
-
-        public static partial void godotsharp_string_to_pascal_case(in godot_string p_self,
-            out godot_string r_pascal_case);
-
-        public static partial void godotsharp_string_to_snake_case(in godot_string p_self,
-            out godot_string r_snake_case);
-
-        // NodePath
-
-        public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,
-            ref godot_node_path r_dest);
-
-        public static partial void godotsharp_node_path_get_concatenated_names(in godot_node_path p_self,
-            out godot_string r_names);
-
-        public static partial void godotsharp_node_path_get_concatenated_subnames(in godot_node_path p_self,
-            out godot_string r_subnames);
-
-        public static partial void godotsharp_node_path_get_name(in godot_node_path p_self, int p_idx,
-            out godot_string r_name);
-
-        public static partial int godotsharp_node_path_get_name_count(in godot_node_path p_self);
-
-        public static partial void godotsharp_node_path_get_subname(in godot_node_path p_self, int p_idx,
-            out godot_string r_subname);
-
-        public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
-
-        public static partial godot_bool godotsharp_node_path_is_absolute(in godot_node_path p_self);
-
-        public static partial godot_bool godotsharp_node_path_equals(in godot_node_path p_self, in godot_node_path p_other);
-
-        public static partial int godotsharp_node_path_hash(in godot_node_path p_self);
-
-        // GD, etc
-
-        internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,
-            godot_bool p_allow_objects,
-            out godot_variant r_ret);
-
-        internal static partial void godotsharp_convert(in godot_variant p_what, int p_type,
-            out godot_variant r_ret);
-
-        internal static partial int godotsharp_hash(in godot_variant p_var);
-
-        internal static partial IntPtr godotsharp_instance_from_id(ulong p_instance_id);
-
-        internal static partial void godotsharp_print(in godot_string p_what);
-
-        public static partial void godotsharp_print_rich(in godot_string p_what);
-
-        internal static partial void godotsharp_printerr(in godot_string p_what);
-
-        internal static partial void godotsharp_printraw(in godot_string p_what);
-
-        internal static partial void godotsharp_prints(in godot_string p_what);
-
-        internal static partial void godotsharp_printt(in godot_string p_what);
-
-        internal static partial float godotsharp_randf();
-
-        internal static partial uint godotsharp_randi();
-
-        internal static partial void godotsharp_randomize();
-
-        internal static partial double godotsharp_randf_range(double from, double to);
-
-        internal static partial double godotsharp_randfn(double mean, double deviation);
-
-        internal static partial int godotsharp_randi_range(int from, int to);
-
-        internal static partial uint godotsharp_rand_from_seed(ulong seed, out ulong newSeed);
-
-        internal static partial void godotsharp_seed(ulong seed);
-
-        internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
-
-        internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
-
-        internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
-            out godot_packed_byte_array r_bytes);
-
-        internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
-
-        internal static partial void godotsharp_pusherror(in godot_string p_str);
-
-        internal static partial void godotsharp_pushwarning(in godot_string p_str);
-
-        // Object
-
-        public static partial void godotsharp_object_to_string(IntPtr ptr, out godot_string r_str);
+        _unmanagedCallbacks = Unsafe.AsRef<UnmanagedCallbacks>((void*)unmanagedCallbacks);
     }
+
+    private partial struct UnmanagedCallbacks
+    {
+    }
+
+    // Custom functions
+
+    internal static partial godot_bool godotsharp_dotnet_module_is_initialized();
+
+    public static partial IntPtr godotsharp_method_bind_get_method(in godot_string_name p_classname,
+        in godot_string_name p_methodname);
+
+    public static partial delegate* unmanaged<IntPtr> godotsharp_get_class_constructor(
+        in godot_string_name p_classname);
+
+    public static partial IntPtr godotsharp_engine_get_singleton(in godot_string p_name);
+
+
+    internal static partial Error godotsharp_stack_info_vector_resize(
+        ref DebuggingUtils.godot_stack_info_vector p_stack_info_vector, int p_size);
+
+    internal static partial void godotsharp_stack_info_vector_destroy(
+        ref DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
+
+    internal static partial void godotsharp_internal_editor_file_system_update_file(in godot_string p_script_path);
+
+    internal static partial void godotsharp_internal_script_debugger_send_error(in godot_string p_func,
+        in godot_string p_file, int p_line, in godot_string p_err, in godot_string p_descr,
+        godot_bool p_warning, in DebuggingUtils.godot_stack_info_vector p_stack_info_vector);
+
+    internal static partial godot_bool godotsharp_internal_script_debugger_is_active();
+
+    internal static partial IntPtr godotsharp_internal_object_get_associated_gchandle(IntPtr ptr);
+
+    internal static partial void godotsharp_internal_object_disposed(IntPtr ptr, IntPtr gcHandleToFree);
+
+    internal static partial void godotsharp_internal_refcounted_disposed(IntPtr ptr, IntPtr gcHandleToFree,
+        godot_bool isFinalizer);
+
+    internal static partial Error godotsharp_internal_signal_awaiter_connect(IntPtr source,
+        in godot_string_name signal,
+        IntPtr target, IntPtr awaiterHandlePtr);
+
+    internal static partial void godotsharp_internal_tie_native_managed_to_unmanaged(IntPtr gcHandleIntPtr,
+        IntPtr unmanaged, in godot_string_name nativeName, godot_bool refCounted);
+
+    internal static partial void godotsharp_internal_tie_user_managed_to_unmanaged(IntPtr gcHandleIntPtr,
+        IntPtr unmanaged, godot_ref* scriptPtr, godot_bool refCounted);
+
+    internal static partial void godotsharp_internal_tie_managed_to_unmanaged_with_pre_setup(
+        IntPtr gcHandleIntPtr, IntPtr unmanaged);
+
+    internal static partial IntPtr godotsharp_internal_unmanaged_get_script_instance_managed(IntPtr p_unmanaged,
+        out godot_bool r_has_cs_script_instance);
+
+    internal static partial IntPtr godotsharp_internal_unmanaged_get_instance_binding_managed(IntPtr p_unmanaged);
+
+    internal static partial IntPtr godotsharp_internal_unmanaged_instance_binding_create_managed(IntPtr p_unmanaged,
+        IntPtr oldGCHandlePtr);
+
+    internal static partial void godotsharp_internal_new_csharp_script(godot_ref* r_dest);
+
+    internal static partial godot_bool godotsharp_internal_script_load(in godot_string p_path, godot_ref* r_dest);
+
+    internal static partial void godotsharp_internal_reload_registered_script(IntPtr scriptPtr);
+
+    internal static partial void godotsharp_array_filter_godot_objects_by_native(in godot_string_name p_native_name,
+        in godot_array p_input, out godot_array r_output);
+
+    internal static partial void godotsharp_array_filter_godot_objects_by_non_native(in godot_array p_input,
+        out godot_array r_output);
+
+    public static partial void godotsharp_ref_new_from_ref_counted_ptr(out godot_ref r_dest,
+        IntPtr p_ref_counted_ptr);
+
+    public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
+
+    public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
+        in godot_string p_name);
+
+    public static partial void godotsharp_node_path_new_from_string(out godot_node_path r_dest,
+        in godot_string p_name);
+
+    public static partial void
+        godotsharp_string_name_as_string(out godot_string r_dest, in godot_string_name p_name);
+
+    public static partial void godotsharp_node_path_as_string(out godot_string r_dest, in godot_node_path p_np);
+
+    public static partial godot_packed_byte_array godotsharp_packed_byte_array_new_mem_copy(byte* p_src,
+        int p_length);
+
+    public static partial godot_packed_int32_array godotsharp_packed_int32_array_new_mem_copy(int* p_src,
+        int p_length);
+
+    public static partial godot_packed_int64_array godotsharp_packed_int64_array_new_mem_copy(long* p_src,
+        int p_length);
+
+    public static partial godot_packed_float32_array godotsharp_packed_float32_array_new_mem_copy(float* p_src,
+        int p_length);
+
+    public static partial godot_packed_float64_array godotsharp_packed_float64_array_new_mem_copy(double* p_src,
+        int p_length);
+
+    public static partial godot_packed_vector2_array godotsharp_packed_vector2_array_new_mem_copy(Vector2* p_src,
+        int p_length);
+
+    public static partial godot_packed_vector3_array godotsharp_packed_vector3_array_new_mem_copy(Vector3* p_src,
+        int p_length);
+
+    public static partial godot_packed_color_array godotsharp_packed_color_array_new_mem_copy(Color* p_src,
+        int p_length);
+
+    public static partial void godotsharp_packed_string_array_add(ref godot_packed_string_array r_dest,
+        in godot_string p_element);
+
+    public static partial void godotsharp_callable_new_with_delegate(IntPtr p_delegate_handle, IntPtr p_trampoline,
+        IntPtr p_object, out godot_callable r_callable);
+
+    internal static partial godot_bool godotsharp_callable_get_data_for_marshalling(in godot_callable p_callable,
+        out IntPtr r_delegate_handle, out IntPtr r_trampoline, out IntPtr r_object, out godot_string_name r_name);
+
+    internal static partial godot_variant godotsharp_callable_call(in godot_callable p_callable,
+        godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
+
+    internal static partial void godotsharp_callable_call_deferred(in godot_callable p_callable,
+        godot_variant** p_args, int p_arg_count);
+
+    internal static partial Color godotsharp_color_from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha);
+
+    // GDNative functions
+
+    // gdnative.h
+
+    public static partial void godotsharp_method_bind_ptrcall(IntPtr p_method_bind, IntPtr p_instance, void** p_args,
+        void* p_ret);
+
+    public static partial godot_variant godotsharp_method_bind_call(IntPtr p_method_bind, IntPtr p_instance,
+        godot_variant** p_args, int p_arg_count, out godot_variant_call_error p_call_error);
+
+    // variant.h
+
+    public static partial void
+        godotsharp_variant_new_string_name(out godot_variant r_dest, in godot_string_name p_s);
+
+    public static partial void godotsharp_variant_new_copy(out godot_variant r_dest, in godot_variant p_src);
+
+    public static partial void godotsharp_variant_new_node_path(out godot_variant r_dest, in godot_node_path p_np);
+
+    public static partial void godotsharp_variant_new_object(out godot_variant r_dest, IntPtr p_obj);
+
+    public static partial void godotsharp_variant_new_transform2d(out godot_variant r_dest, in Transform2D p_t2d);
+
+    public static partial void godotsharp_variant_new_basis(out godot_variant r_dest, in Basis p_basis);
+
+    public static partial void godotsharp_variant_new_transform3d(out godot_variant r_dest, in Transform3D p_trans);
+
+    public static partial void godotsharp_variant_new_projection(out godot_variant r_dest, in Projection p_proj);
+
+    public static partial void godotsharp_variant_new_aabb(out godot_variant r_dest, in Aabb p_aabb);
+
+    public static partial void godotsharp_variant_new_dictionary(out godot_variant r_dest,
+        in godot_dictionary p_dict);
+
+    public static partial void godotsharp_variant_new_array(out godot_variant r_dest, in godot_array p_arr);
+
+    public static partial void godotsharp_variant_new_packed_byte_array(out godot_variant r_dest,
+        in godot_packed_byte_array p_pba);
+
+    public static partial void godotsharp_variant_new_packed_int32_array(out godot_variant r_dest,
+        in godot_packed_int32_array p_pia);
+
+    public static partial void godotsharp_variant_new_packed_int64_array(out godot_variant r_dest,
+        in godot_packed_int64_array p_pia);
+
+    public static partial void godotsharp_variant_new_packed_float32_array(out godot_variant r_dest,
+        in godot_packed_float32_array p_pra);
+
+    public static partial void godotsharp_variant_new_packed_float64_array(out godot_variant r_dest,
+        in godot_packed_float64_array p_pra);
+
+    public static partial void godotsharp_variant_new_packed_string_array(out godot_variant r_dest,
+        in godot_packed_string_array p_psa);
+
+    public static partial void godotsharp_variant_new_packed_vector2_array(out godot_variant r_dest,
+        in godot_packed_vector2_array p_pv2a);
+
+    public static partial void godotsharp_variant_new_packed_vector3_array(out godot_variant r_dest,
+        in godot_packed_vector3_array p_pv3a);
+
+    public static partial void godotsharp_variant_new_packed_color_array(out godot_variant r_dest,
+        in godot_packed_color_array p_pca);
+
+    public static partial godot_bool godotsharp_variant_as_bool(in godot_variant p_self);
+
+    public static partial Int64 godotsharp_variant_as_int(in godot_variant p_self);
+
+    public static partial double godotsharp_variant_as_float(in godot_variant p_self);
+
+    public static partial godot_string godotsharp_variant_as_string(in godot_variant p_self);
+
+    public static partial Vector2 godotsharp_variant_as_vector2(in godot_variant p_self);
+
+    public static partial Vector2I godotsharp_variant_as_vector2i(in godot_variant p_self);
+
+    public static partial Rect2 godotsharp_variant_as_rect2(in godot_variant p_self);
+
+    public static partial Rect2I godotsharp_variant_as_rect2i(in godot_variant p_self);
+
+    public static partial Vector3 godotsharp_variant_as_vector3(in godot_variant p_self);
+
+    public static partial Vector3I godotsharp_variant_as_vector3i(in godot_variant p_self);
+
+    public static partial Transform2D godotsharp_variant_as_transform2d(in godot_variant p_self);
+
+    public static partial Vector4 godotsharp_variant_as_vector4(in godot_variant p_self);
+
+    public static partial Vector4I godotsharp_variant_as_vector4i(in godot_variant p_self);
+
+    public static partial Plane godotsharp_variant_as_plane(in godot_variant p_self);
+
+    public static partial Quaternion godotsharp_variant_as_quaternion(in godot_variant p_self);
+
+    public static partial Aabb godotsharp_variant_as_aabb(in godot_variant p_self);
+
+    public static partial Basis godotsharp_variant_as_basis(in godot_variant p_self);
+
+    public static partial Transform3D godotsharp_variant_as_transform3d(in godot_variant p_self);
+
+    public static partial Projection godotsharp_variant_as_projection(in godot_variant p_self);
+
+    public static partial Color godotsharp_variant_as_color(in godot_variant p_self);
+
+    public static partial godot_string_name godotsharp_variant_as_string_name(in godot_variant p_self);
+
+    public static partial godot_node_path godotsharp_variant_as_node_path(in godot_variant p_self);
+
+    public static partial Rid godotsharp_variant_as_rid(in godot_variant p_self);
+
+    public static partial godot_callable godotsharp_variant_as_callable(in godot_variant p_self);
+
+    public static partial godot_signal godotsharp_variant_as_signal(in godot_variant p_self);
+
+    public static partial godot_dictionary godotsharp_variant_as_dictionary(in godot_variant p_self);
+
+    public static partial godot_array godotsharp_variant_as_array(in godot_variant p_self);
+
+    public static partial godot_packed_byte_array godotsharp_variant_as_packed_byte_array(in godot_variant p_self);
+
+    public static partial godot_packed_int32_array godotsharp_variant_as_packed_int32_array(in godot_variant p_self);
+
+    public static partial godot_packed_int64_array godotsharp_variant_as_packed_int64_array(in godot_variant p_self);
+
+    public static partial godot_packed_float32_array godotsharp_variant_as_packed_float32_array(
+        in godot_variant p_self);
+
+    public static partial godot_packed_float64_array godotsharp_variant_as_packed_float64_array(
+        in godot_variant p_self);
+
+    public static partial godot_packed_string_array godotsharp_variant_as_packed_string_array(
+        in godot_variant p_self);
+
+    public static partial godot_packed_vector2_array godotsharp_variant_as_packed_vector2_array(
+        in godot_variant p_self);
+
+    public static partial godot_packed_vector3_array godotsharp_variant_as_packed_vector3_array(
+        in godot_variant p_self);
+
+    public static partial godot_packed_color_array godotsharp_variant_as_packed_color_array(in godot_variant p_self);
+
+    public static partial godot_bool godotsharp_variant_equals(in godot_variant p_a, in godot_variant p_b);
+
+    // string.h
+
+    public static partial void godotsharp_string_new_with_utf16_chars(out godot_string r_dest, char* p_contents);
+
+    // string_name.h
+
+    public static partial void godotsharp_string_name_new_copy(out godot_string_name r_dest,
+        in godot_string_name p_src);
+
+    // node_path.h
+
+    public static partial void godotsharp_node_path_new_copy(out godot_node_path r_dest, in godot_node_path p_src);
+
+    // array.h
+
+    public static partial void godotsharp_array_new(out godot_array r_dest);
+
+    public static partial void godotsharp_array_new_copy(out godot_array r_dest, in godot_array p_src);
+
+    public static partial godot_variant* godotsharp_array_ptrw(ref godot_array p_self);
+
+    // dictionary.h
+
+    public static partial void godotsharp_dictionary_new(out godot_dictionary r_dest);
+
+    public static partial void godotsharp_dictionary_new_copy(out godot_dictionary r_dest,
+        in godot_dictionary p_src);
+
+    // destroy functions
+
+    public static partial void godotsharp_packed_byte_array_destroy(ref godot_packed_byte_array p_self);
+
+    public static partial void godotsharp_packed_int32_array_destroy(ref godot_packed_int32_array p_self);
+
+    public static partial void godotsharp_packed_int64_array_destroy(ref godot_packed_int64_array p_self);
+
+    public static partial void godotsharp_packed_float32_array_destroy(ref godot_packed_float32_array p_self);
+
+    public static partial void godotsharp_packed_float64_array_destroy(ref godot_packed_float64_array p_self);
+
+    public static partial void godotsharp_packed_string_array_destroy(ref godot_packed_string_array p_self);
+
+    public static partial void godotsharp_packed_vector2_array_destroy(ref godot_packed_vector2_array p_self);
+
+    public static partial void godotsharp_packed_vector3_array_destroy(ref godot_packed_vector3_array p_self);
+
+    public static partial void godotsharp_packed_color_array_destroy(ref godot_packed_color_array p_self);
+
+    public static partial void godotsharp_variant_destroy(ref godot_variant p_self);
+
+    public static partial void godotsharp_string_destroy(ref godot_string p_self);
+
+    public static partial void godotsharp_string_name_destroy(ref godot_string_name p_self);
+
+    public static partial void godotsharp_node_path_destroy(ref godot_node_path p_self);
+
+    public static partial void godotsharp_signal_destroy(ref godot_signal p_self);
+
+    public static partial void godotsharp_callable_destroy(ref godot_callable p_self);
+
+    public static partial void godotsharp_array_destroy(ref godot_array p_self);
+
+    public static partial void godotsharp_dictionary_destroy(ref godot_dictionary p_self);
+
+    // Array
+
+    public static partial int godotsharp_array_add(ref godot_array p_self, in godot_variant p_item);
+
+    public static partial int godotsharp_array_add_range(ref godot_array p_self, in godot_array p_collection);
+
+    public static partial int godotsharp_array_binary_search(ref godot_array p_self, int p_index, int p_count, in godot_variant p_value);
+
+    public static partial void
+        godotsharp_array_duplicate(ref godot_array p_self, godot_bool p_deep, out godot_array r_dest);
+
+    public static partial void godotsharp_array_fill(ref godot_array p_self, in godot_variant p_value);
+
+    public static partial int godotsharp_array_index_of(ref godot_array p_self, in godot_variant p_item, int p_index = 0);
+
+    public static partial void godotsharp_array_insert(ref godot_array p_self, int p_index, in godot_variant p_item);
+
+    public static partial int godotsharp_array_last_index_of(ref godot_array p_self, in godot_variant p_item, int p_index);
+
+    public static partial void godotsharp_array_make_read_only(ref godot_array p_self);
+
+    public static partial void godotsharp_array_max(ref godot_array p_self, out godot_variant r_value);
+
+    public static partial void godotsharp_array_min(ref godot_array p_self, out godot_variant r_value);
+
+    public static partial void godotsharp_array_pick_random(ref godot_array p_self, out godot_variant r_value);
+
+    public static partial godot_bool godotsharp_array_recursive_equal(ref godot_array p_self, in godot_array p_other);
+
+    public static partial void godotsharp_array_remove_at(ref godot_array p_self, int p_index);
+
+    public static partial Error godotsharp_array_resize(ref godot_array p_self, int p_new_size);
+
+    public static partial void godotsharp_array_reverse(ref godot_array p_self);
+
+    public static partial void godotsharp_array_shuffle(ref godot_array p_self);
+
+    public static partial void godotsharp_array_slice(ref godot_array p_self, int p_start, int p_end,
+        int p_step, godot_bool p_deep, out godot_array r_dest);
+
+    public static partial void godotsharp_array_sort(ref godot_array p_self);
+
+    public static partial void godotsharp_array_to_string(ref godot_array p_self, out godot_string r_str);
+
+    // Dictionary
+
+    public static partial godot_bool godotsharp_dictionary_try_get_value(ref godot_dictionary p_self,
+        in godot_variant p_key,
+        out godot_variant r_value);
+
+    public static partial void godotsharp_dictionary_set_value(ref godot_dictionary p_self, in godot_variant p_key,
+        in godot_variant p_value);
+
+    public static partial void godotsharp_dictionary_keys(ref godot_dictionary p_self, out godot_array r_dest);
+
+    public static partial void godotsharp_dictionary_values(ref godot_dictionary p_self, out godot_array r_dest);
+
+    public static partial int godotsharp_dictionary_count(ref godot_dictionary p_self);
+
+    public static partial void godotsharp_dictionary_key_value_pair_at(ref godot_dictionary p_self, int p_index,
+        out godot_variant r_key, out godot_variant r_value);
+
+    public static partial void godotsharp_dictionary_add(ref godot_dictionary p_self, in godot_variant p_key,
+        in godot_variant p_value);
+
+    public static partial void godotsharp_dictionary_clear(ref godot_dictionary p_self);
+
+    public static partial godot_bool godotsharp_dictionary_contains_key(ref godot_dictionary p_self,
+        in godot_variant p_key);
+
+    public static partial void godotsharp_dictionary_duplicate(ref godot_dictionary p_self, godot_bool p_deep,
+        out godot_dictionary r_dest);
+
+    public static partial void godotsharp_dictionary_merge(ref godot_dictionary p_self, in godot_dictionary p_dictionary, godot_bool p_overwrite);
+
+    public static partial godot_bool godotsharp_dictionary_recursive_equal(ref godot_dictionary p_self, in godot_dictionary p_other);
+
+    public static partial godot_bool godotsharp_dictionary_remove_key(ref godot_dictionary p_self,
+        in godot_variant p_key);
+
+    public static partial void godotsharp_dictionary_make_read_only(ref godot_dictionary p_self);
+
+    public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
+
+    // StringExtensions
+
+    public static partial void godotsharp_string_simplify_path(in godot_string p_self,
+        out godot_string r_simplified_path);
+
+    public static partial void godotsharp_string_to_camel_case(in godot_string p_self,
+        out godot_string r_camel_case);
+
+    public static partial void godotsharp_string_to_pascal_case(in godot_string p_self,
+        out godot_string r_pascal_case);
+
+    public static partial void godotsharp_string_to_snake_case(in godot_string p_self,
+        out godot_string r_snake_case);
+
+    // NodePath
+
+    public static partial void godotsharp_node_path_get_as_property_path(in godot_node_path p_self,
+        ref godot_node_path r_dest);
+
+    public static partial void godotsharp_node_path_get_concatenated_names(in godot_node_path p_self,
+        out godot_string r_names);
+
+    public static partial void godotsharp_node_path_get_concatenated_subnames(in godot_node_path p_self,
+        out godot_string r_subnames);
+
+    public static partial void godotsharp_node_path_get_name(in godot_node_path p_self, int p_idx,
+        out godot_string r_name);
+
+    public static partial int godotsharp_node_path_get_name_count(in godot_node_path p_self);
+
+    public static partial void godotsharp_node_path_get_subname(in godot_node_path p_self, int p_idx,
+        out godot_string r_subname);
+
+    public static partial int godotsharp_node_path_get_subname_count(in godot_node_path p_self);
+
+    public static partial godot_bool godotsharp_node_path_is_absolute(in godot_node_path p_self);
+
+    public static partial godot_bool godotsharp_node_path_equals(in godot_node_path p_self, in godot_node_path p_other);
+
+    public static partial int godotsharp_node_path_hash(in godot_node_path p_self);
+
+    // GD, etc
+
+    internal static partial void godotsharp_bytes_to_var(in godot_packed_byte_array p_bytes,
+        godot_bool p_allow_objects,
+        out godot_variant r_ret);
+
+    internal static partial void godotsharp_convert(in godot_variant p_what, int p_type,
+        out godot_variant r_ret);
+
+    internal static partial int godotsharp_hash(in godot_variant p_var);
+
+    internal static partial IntPtr godotsharp_instance_from_id(ulong p_instance_id);
+
+    internal static partial void godotsharp_print(in godot_string p_what);
+
+    public static partial void godotsharp_print_rich(in godot_string p_what);
+
+    internal static partial void godotsharp_printerr(in godot_string p_what);
+
+    internal static partial void godotsharp_printraw(in godot_string p_what);
+
+    internal static partial void godotsharp_prints(in godot_string p_what);
+
+    internal static partial void godotsharp_printt(in godot_string p_what);
+
+    internal static partial float godotsharp_randf();
+
+    internal static partial uint godotsharp_randi();
+
+    internal static partial void godotsharp_randomize();
+
+    internal static partial double godotsharp_randf_range(double from, double to);
+
+    internal static partial double godotsharp_randfn(double mean, double deviation);
+
+    internal static partial int godotsharp_randi_range(int from, int to);
+
+    internal static partial uint godotsharp_rand_from_seed(ulong seed, out ulong newSeed);
+
+    internal static partial void godotsharp_seed(ulong seed);
+
+    internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
+
+    internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
+
+    internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
+        out godot_packed_byte_array r_bytes);
+
+    internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
+
+    internal static partial void godotsharp_pusherror(in godot_string p_str);
+
+    internal static partial void godotsharp_pushwarning(in godot_string p_str);
+
+    // Object
+
+    public static partial void godotsharp_object_to_string(IntPtr ptr, out godot_string r_str);
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.extended.cs
@@ -1,103 +1,102 @@
 // ReSharper disable InconsistentNaming
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+public static partial class NativeFuncs
 {
-    public static partial class NativeFuncs
+    public static godot_variant godotsharp_variant_new_copy(in godot_variant src)
     {
-        public static godot_variant godotsharp_variant_new_copy(in godot_variant src)
+        switch (src.Type)
         {
-            switch (src.Type)
-            {
-                case Variant.Type.Nil:
-                    return default;
-                case Variant.Type.Bool:
-                    return new godot_variant() { Bool = src.Bool, Type = Variant.Type.Bool };
-                case Variant.Type.Int:
-                    return new godot_variant() { Int = src.Int, Type = Variant.Type.Int };
-                case Variant.Type.Float:
-                    return new godot_variant() { Float = src.Float, Type = Variant.Type.Float };
-                case Variant.Type.Vector2:
-                    return new godot_variant() { Vector2 = src.Vector2, Type = Variant.Type.Vector2 };
-                case Variant.Type.Vector2I:
-                    return new godot_variant() { Vector2I = src.Vector2I, Type = Variant.Type.Vector2I };
-                case Variant.Type.Rect2:
-                    return new godot_variant() { Rect2 = src.Rect2, Type = Variant.Type.Rect2 };
-                case Variant.Type.Rect2I:
-                    return new godot_variant() { Rect2I = src.Rect2I, Type = Variant.Type.Rect2I };
-                case Variant.Type.Vector3:
-                    return new godot_variant() { Vector3 = src.Vector3, Type = Variant.Type.Vector3 };
-                case Variant.Type.Vector3I:
-                    return new godot_variant() { Vector3I = src.Vector3I, Type = Variant.Type.Vector3I };
-                case Variant.Type.Vector4:
-                    return new godot_variant() { Vector4 = src.Vector4, Type = Variant.Type.Vector4 };
-                case Variant.Type.Vector4I:
-                    return new godot_variant() { Vector4I = src.Vector4I, Type = Variant.Type.Vector4I };
-                case Variant.Type.Plane:
-                    return new godot_variant() { Plane = src.Plane, Type = Variant.Type.Plane };
-                case Variant.Type.Quaternion:
-                    return new godot_variant() { Quaternion = src.Quaternion, Type = Variant.Type.Quaternion };
-                case Variant.Type.Color:
-                    return new godot_variant() { Color = src.Color, Type = Variant.Type.Color };
-                case Variant.Type.Rid:
-                    return new godot_variant() { Rid = src.Rid, Type = Variant.Type.Rid };
-            }
-
-            godotsharp_variant_new_copy(out godot_variant ret, src);
-            return ret;
-        }
-
-        public static godot_string_name godotsharp_string_name_new_copy(in godot_string_name src)
-        {
-            if (src.IsEmpty)
+            case Variant.Type.Nil:
                 return default;
-            godotsharp_string_name_new_copy(out godot_string_name ret, src);
-            return ret;
+            case Variant.Type.Bool:
+                return new godot_variant() { Bool = src.Bool, Type = Variant.Type.Bool };
+            case Variant.Type.Int:
+                return new godot_variant() { Int = src.Int, Type = Variant.Type.Int };
+            case Variant.Type.Float:
+                return new godot_variant() { Float = src.Float, Type = Variant.Type.Float };
+            case Variant.Type.Vector2:
+                return new godot_variant() { Vector2 = src.Vector2, Type = Variant.Type.Vector2 };
+            case Variant.Type.Vector2I:
+                return new godot_variant() { Vector2I = src.Vector2I, Type = Variant.Type.Vector2I };
+            case Variant.Type.Rect2:
+                return new godot_variant() { Rect2 = src.Rect2, Type = Variant.Type.Rect2 };
+            case Variant.Type.Rect2I:
+                return new godot_variant() { Rect2I = src.Rect2I, Type = Variant.Type.Rect2I };
+            case Variant.Type.Vector3:
+                return new godot_variant() { Vector3 = src.Vector3, Type = Variant.Type.Vector3 };
+            case Variant.Type.Vector3I:
+                return new godot_variant() { Vector3I = src.Vector3I, Type = Variant.Type.Vector3I };
+            case Variant.Type.Vector4:
+                return new godot_variant() { Vector4 = src.Vector4, Type = Variant.Type.Vector4 };
+            case Variant.Type.Vector4I:
+                return new godot_variant() { Vector4I = src.Vector4I, Type = Variant.Type.Vector4I };
+            case Variant.Type.Plane:
+                return new godot_variant() { Plane = src.Plane, Type = Variant.Type.Plane };
+            case Variant.Type.Quaternion:
+                return new godot_variant() { Quaternion = src.Quaternion, Type = Variant.Type.Quaternion };
+            case Variant.Type.Color:
+                return new godot_variant() { Color = src.Color, Type = Variant.Type.Color };
+            case Variant.Type.Rid:
+                return new godot_variant() { Rid = src.Rid, Type = Variant.Type.Rid };
         }
 
-        public static godot_node_path godotsharp_node_path_new_copy(in godot_node_path src)
-        {
-            if (src.IsEmpty)
-                return default;
-            godotsharp_node_path_new_copy(out godot_node_path ret, src);
-            return ret;
-        }
+        godotsharp_variant_new_copy(out godot_variant ret, src);
+        return ret;
+    }
 
-        public static godot_array godotsharp_array_new()
-        {
-            godotsharp_array_new(out godot_array ret);
-            return ret;
-        }
+    public static godot_string_name godotsharp_string_name_new_copy(in godot_string_name src)
+    {
+        if (src.IsEmpty)
+            return default;
+        godotsharp_string_name_new_copy(out godot_string_name ret, src);
+        return ret;
+    }
 
-        public static godot_array godotsharp_array_new_copy(in godot_array src)
-        {
-            godotsharp_array_new_copy(out godot_array ret, src);
-            return ret;
-        }
+    public static godot_node_path godotsharp_node_path_new_copy(in godot_node_path src)
+    {
+        if (src.IsEmpty)
+            return default;
+        godotsharp_node_path_new_copy(out godot_node_path ret, src);
+        return ret;
+    }
 
-        public static godot_dictionary godotsharp_dictionary_new()
-        {
-            godotsharp_dictionary_new(out godot_dictionary ret);
-            return ret;
-        }
+    public static godot_array godotsharp_array_new()
+    {
+        godotsharp_array_new(out godot_array ret);
+        return ret;
+    }
 
-        public static godot_dictionary godotsharp_dictionary_new_copy(in godot_dictionary src)
-        {
-            godotsharp_dictionary_new_copy(out godot_dictionary ret, src);
-            return ret;
-        }
+    public static godot_array godotsharp_array_new_copy(in godot_array src)
+    {
+        godotsharp_array_new_copy(out godot_array ret, src);
+        return ret;
+    }
 
-        public static godot_string_name godotsharp_string_name_new_from_string(string name)
-        {
-            using godot_string src = Marshaling.ConvertStringToNative(name);
-            godotsharp_string_name_new_from_string(out godot_string_name ret, src);
-            return ret;
-        }
+    public static godot_dictionary godotsharp_dictionary_new()
+    {
+        godotsharp_dictionary_new(out godot_dictionary ret);
+        return ret;
+    }
 
-        public static godot_node_path godotsharp_node_path_new_from_string(string name)
-        {
-            using godot_string src = Marshaling.ConvertStringToNative(name);
-            godotsharp_node_path_new_from_string(out godot_node_path ret, src);
-            return ret;
-        }
+    public static godot_dictionary godotsharp_dictionary_new_copy(in godot_dictionary src)
+    {
+        godotsharp_dictionary_new_copy(out godot_dictionary ret, src);
+        return ret;
+    }
+
+    public static godot_string_name godotsharp_string_name_new_from_string(string name)
+    {
+        using godot_string src = Marshaling.ConvertStringToNative(name);
+        godotsharp_string_name_new_from_string(out godot_string_name ret, src);
+        return ret;
+    }
+
+    public static godot_node_path godotsharp_node_path_new_from_string(string name)
+    {
+        using godot_string src = Marshaling.ConvertStringToNative(name);
+        godotsharp_node_path_new_from_string(out godot_node_path ret, src);
+        return ret;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeVariantPtrArgs.cs
@@ -1,34 +1,33 @@
 using System.Runtime.CompilerServices;
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+// Our source generators will add trampolines methods that access variant arguments.
+// This struct makes that possible without having to enable `AllowUnsafeBlocks` in game projects.
+
+public unsafe ref struct NativeVariantPtrArgs
 {
-    // Our source generators will add trampolines methods that access variant arguments.
-    // This struct makes that possible without having to enable `AllowUnsafeBlocks` in game projects.
+    private godot_variant** _args;
+    private int _argc;
 
-    public unsafe ref struct NativeVariantPtrArgs
+    internal NativeVariantPtrArgs(godot_variant** args, int argc)
     {
-        private godot_variant** _args;
-        private int _argc;
+        _args = args;
+        _argc = argc;
+    }
 
-        internal NativeVariantPtrArgs(godot_variant** args, int argc)
-        {
-            _args = args;
-            _argc = argc;
-        }
+    /// <summary>
+    /// Returns the number of arguments.
+    /// </summary>
+    public int Count
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _argc;
+    }
 
-        /// <summary>
-        /// Returns the number of arguments.
-        /// </summary>
-        public int Count
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _argc;
-        }
-
-        public ref godot_variant this[int index]
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => ref *_args[index];
-        }
+    public ref godot_variant this[int index]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref *_args[index];
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -6,620 +6,619 @@ using Godot.Collections;
 
 #nullable enable
 
-namespace Godot.NativeInterop
+namespace Godot.NativeInterop;
+
+public static partial class VariantUtils
 {
-    public static partial class VariantUtils
+    public static godot_variant CreateFromRid(Rid from)
+        => new() { Type = Variant.Type.Rid, Rid = from };
+
+    public static godot_variant CreateFromBool(bool from)
+        => new() { Type = Variant.Type.Bool, Bool = from.ToGodotBool() };
+
+    public static godot_variant CreateFromInt(long from)
+        => new() { Type = Variant.Type.Int, Int = from };
+
+    public static godot_variant CreateFromInt(ulong from)
+        => new() { Type = Variant.Type.Int, Int = (long)from };
+
+    public static godot_variant CreateFromFloat(double from)
+        => new() { Type = Variant.Type.Float, Float = from };
+
+    public static godot_variant CreateFromVector2(Vector2 from)
+        => new() { Type = Variant.Type.Vector2, Vector2 = from };
+
+    public static godot_variant CreateFromVector2I(Vector2I from)
+        => new() { Type = Variant.Type.Vector2I, Vector2I = from };
+
+    public static godot_variant CreateFromVector3(Vector3 from)
+        => new() { Type = Variant.Type.Vector3, Vector3 = from };
+
+    public static godot_variant CreateFromVector3I(Vector3I from)
+        => new() { Type = Variant.Type.Vector3I, Vector3I = from };
+
+    public static godot_variant CreateFromVector4(Vector4 from)
+        => new() { Type = Variant.Type.Vector4, Vector4 = from };
+
+    public static godot_variant CreateFromVector4I(Vector4I from)
+        => new() { Type = Variant.Type.Vector4I, Vector4I = from };
+
+    public static godot_variant CreateFromRect2(Rect2 from)
+        => new() { Type = Variant.Type.Rect2, Rect2 = from };
+
+    public static godot_variant CreateFromRect2I(Rect2I from)
+        => new() { Type = Variant.Type.Rect2I, Rect2I = from };
+
+    public static godot_variant CreateFromQuaternion(Quaternion from)
+        => new() { Type = Variant.Type.Quaternion, Quaternion = from };
+
+    public static godot_variant CreateFromColor(Color from)
+        => new() { Type = Variant.Type.Color, Color = from };
+
+    public static godot_variant CreateFromPlane(Plane from)
+        => new() { Type = Variant.Type.Plane, Plane = from };
+
+    public static godot_variant CreateFromTransform2D(Transform2D from)
     {
-        public static godot_variant CreateFromRid(Rid from)
-            => new() { Type = Variant.Type.Rid, Rid = from };
+        NativeFuncs.godotsharp_variant_new_transform2d(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromBool(bool from)
-            => new() { Type = Variant.Type.Bool, Bool = from.ToGodotBool() };
+    public static godot_variant CreateFromBasis(Basis from)
+    {
+        NativeFuncs.godotsharp_variant_new_basis(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromInt(long from)
-            => new() { Type = Variant.Type.Int, Int = from };
+    public static godot_variant CreateFromTransform3D(Transform3D from)
+    {
+        NativeFuncs.godotsharp_variant_new_transform3d(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromInt(ulong from)
-            => new() { Type = Variant.Type.Int, Int = (long)from };
+    public static godot_variant CreateFromProjection(Projection from)
+    {
+        NativeFuncs.godotsharp_variant_new_projection(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromFloat(double from)
-            => new() { Type = Variant.Type.Float, Float = from };
+    public static godot_variant CreateFromAabb(Aabb from)
+    {
+        NativeFuncs.godotsharp_variant_new_aabb(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromVector2(Vector2 from)
-            => new() { Type = Variant.Type.Vector2, Vector2 = from };
+    // Explicit name to make it very clear
+    public static godot_variant CreateFromCallableTakingOwnershipOfDisposableValue(godot_callable from)
+        => new() { Type = Variant.Type.Callable, Callable = from };
 
-        public static godot_variant CreateFromVector2I(Vector2I from)
-            => new() { Type = Variant.Type.Vector2I, Vector2I = from };
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromCallable(Callable from)
+        => CreateFromCallableTakingOwnershipOfDisposableValue(
+            Marshaling.ConvertCallableToNative(from));
 
-        public static godot_variant CreateFromVector3(Vector3 from)
-            => new() { Type = Variant.Type.Vector3, Vector3 = from };
+    // Explicit name to make it very clear
+    public static godot_variant CreateFromSignalTakingOwnershipOfDisposableValue(godot_signal from)
+        => new() { Type = Variant.Type.Signal, Signal = from };
 
-        public static godot_variant CreateFromVector3I(Vector3I from)
-            => new() { Type = Variant.Type.Vector3I, Vector3I = from };
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromSignal(Signal from)
+        => CreateFromSignalTakingOwnershipOfDisposableValue(
+            Marshaling.ConvertSignalToNative(from));
 
-        public static godot_variant CreateFromVector4(Vector4 from)
-            => new() { Type = Variant.Type.Vector4, Vector4 = from };
+    // Explicit name to make it very clear
+    public static godot_variant CreateFromStringTakingOwnershipOfDisposableValue(godot_string from)
+        => new() { Type = Variant.Type.String, String = from };
 
-        public static godot_variant CreateFromVector4I(Vector4I from)
-            => new() { Type = Variant.Type.Vector4I, Vector4I = from };
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromString(string? from)
+        => CreateFromStringTakingOwnershipOfDisposableValue(Marshaling.ConvertStringToNative(from));
 
-        public static godot_variant CreateFromRect2(Rect2 from)
-            => new() { Type = Variant.Type.Rect2, Rect2 = from };
+    public static godot_variant CreateFromPackedByteArray(in godot_packed_byte_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_byte_array(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromRect2I(Rect2I from)
-            => new() { Type = Variant.Type.Rect2I, Rect2I = from };
+    public static godot_variant CreateFromPackedInt32Array(in godot_packed_int32_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_int32_array(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromQuaternion(Quaternion from)
-            => new() { Type = Variant.Type.Quaternion, Quaternion = from };
+    public static godot_variant CreateFromPackedInt64Array(in godot_packed_int64_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_int64_array(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromColor(Color from)
-            => new() { Type = Variant.Type.Color, Color = from };
+    public static godot_variant CreateFromPackedFloat32Array(in godot_packed_float32_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_float32_array(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromPlane(Plane from)
-            => new() { Type = Variant.Type.Plane, Plane = from };
+    public static godot_variant CreateFromPackedFloat64Array(in godot_packed_float64_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_float64_array(out godot_variant ret, from);
+        return ret;
+    }
 
-        public static godot_variant CreateFromTransform2D(Transform2D from)
+    public static godot_variant CreateFromPackedStringArray(in godot_packed_string_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_string_array(out godot_variant ret, from);
+        return ret;
+    }
+
+    public static godot_variant CreateFromPackedVector2Array(in godot_packed_vector2_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_vector2_array(out godot_variant ret, from);
+        return ret;
+    }
+
+    public static godot_variant CreateFromPackedVector3Array(in godot_packed_vector3_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_vector3_array(out godot_variant ret, from);
+        return ret;
+    }
+
+    public static godot_variant CreateFromPackedColorArray(in godot_packed_color_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_packed_color_array(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedByteArray(Span<byte> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedByteArray(from);
+        return CreateFromPackedByteArray(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedInt32Array(Span<int> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt32Array(from);
+        return CreateFromPackedInt32Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedInt64Array(Span<long> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt64Array(from);
+        return CreateFromPackedInt64Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedFloat32Array(Span<float> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat32Array(from);
+        return CreateFromPackedFloat32Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedFloat64Array(Span<double> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat64Array(from);
+        return CreateFromPackedFloat64Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedStringArray(Span<string> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedStringArray(from);
+        return CreateFromPackedStringArray(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedVector2Array(Span<Vector2> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector2Array(from);
+        return CreateFromPackedVector2Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedVector3Array(Span<Vector3> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector3Array(from);
+        return CreateFromPackedVector3Array(nativePackedArray);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromPackedColorArray(Span<Color> from)
+    {
+        using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedColorArray(from);
+        return CreateFromPackedColorArray(nativePackedArray);
+    }
+
+    public static godot_variant CreateFromSystemArrayOfStringName(Span<StringName> from)
+        => CreateFromArray(new Collections.Array(from));
+
+    public static godot_variant CreateFromSystemArrayOfNodePath(Span<NodePath> from)
+        => CreateFromArray(new Collections.Array(from));
+
+    public static godot_variant CreateFromSystemArrayOfRid(Span<Rid> from)
+        => CreateFromArray(new Collections.Array(from));
+
+    // ReSharper disable once RedundantNameQualifier
+    public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
+    {
+        if (from == null)
+            return default; // Nil
+        using var fromGodot = new Collections.Array(from);
+        return CreateFromArray((godot_array)fromGodot.NativeValue);
+    }
+
+    public static godot_variant CreateFromArray(godot_array from)
+    {
+        NativeFuncs.godotsharp_variant_new_array(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromArray(Collections.Array? from)
+        => from != null ? CreateFromArray((godot_array)from.NativeValue) : default;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromArray<[MustBeVariant] T>(Array<T>? from)
+        => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
+
+    public static godot_variant CreateFromDictionary(godot_dictionary from)
+    {
+        NativeFuncs.godotsharp_variant_new_dictionary(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromDictionary(Dictionary? from)
+        => from != null ? CreateFromDictionary((godot_dictionary)from.NativeValue) : default;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? from)
+        => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
+
+    public static godot_variant CreateFromStringName(godot_string_name from)
+    {
+        NativeFuncs.godotsharp_variant_new_string_name(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromStringName(StringName? from)
+        => from != null ? CreateFromStringName((godot_string_name)from.NativeValue) : default;
+
+    public static godot_variant CreateFromNodePath(godot_node_path from)
+    {
+        NativeFuncs.godotsharp_variant_new_node_path(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_variant CreateFromNodePath(NodePath? from)
+        => from != null ? CreateFromNodePath((godot_node_path)from.NativeValue) : default;
+
+    public static godot_variant CreateFromGodotObjectPtr(IntPtr from)
+    {
+        if (from == IntPtr.Zero)
+            return new godot_variant();
+        NativeFuncs.godotsharp_variant_new_object(out godot_variant ret, from);
+        return ret;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    // ReSharper disable once RedundantNameQualifier
+    public static godot_variant CreateFromGodotObject(GodotObject? from)
+        => from != null ? CreateFromGodotObjectPtr(GodotObject.GetPtr(from)) : default;
+
+    // We avoid the internal call if the stored type is the same we want.
+
+    public static bool ConvertToBool(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Bool ?
+            p_var.Bool.ToBool() :
+            NativeFuncs.godotsharp_variant_as_bool(p_var).ToBool();
+
+    public static char ConvertToChar(in godot_variant p_var)
+        => (char)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static sbyte ConvertToInt8(in godot_variant p_var)
+        => (sbyte)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static short ConvertToInt16(in godot_variant p_var)
+        => (short)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static int ConvertToInt32(in godot_variant p_var)
+        => (int)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static long ConvertToInt64(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Int ? p_var.Int : NativeFuncs.godotsharp_variant_as_int(p_var);
+
+    public static byte ConvertToUInt8(in godot_variant p_var)
+        => (byte)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static ushort ConvertToUInt16(in godot_variant p_var)
+        => (ushort)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static uint ConvertToUInt32(in godot_variant p_var)
+        => (uint)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static ulong ConvertToUInt64(in godot_variant p_var)
+        => (ulong)(p_var.Type == Variant.Type.Int ?
+            p_var.Int :
+            NativeFuncs.godotsharp_variant_as_int(p_var));
+
+    public static float ConvertToFloat32(in godot_variant p_var)
+        => (float)(p_var.Type == Variant.Type.Float ?
+            p_var.Float :
+            NativeFuncs.godotsharp_variant_as_float(p_var));
+
+    public static double ConvertToFloat64(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Float ?
+            p_var.Float :
+            NativeFuncs.godotsharp_variant_as_float(p_var);
+
+    public static Vector2 ConvertToVector2(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector2 ?
+            p_var.Vector2 :
+            NativeFuncs.godotsharp_variant_as_vector2(p_var);
+
+    public static Vector2I ConvertToVector2I(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector2I ?
+            p_var.Vector2I :
+            NativeFuncs.godotsharp_variant_as_vector2i(p_var);
+
+    public static Rect2 ConvertToRect2(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Rect2 ?
+            p_var.Rect2 :
+            NativeFuncs.godotsharp_variant_as_rect2(p_var);
+
+    public static Rect2I ConvertToRect2I(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Rect2I ?
+            p_var.Rect2I :
+            NativeFuncs.godotsharp_variant_as_rect2i(p_var);
+
+    public static unsafe Transform2D ConvertToTransform2D(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Transform2D ?
+            *p_var.Transform2D :
+            NativeFuncs.godotsharp_variant_as_transform2d(p_var);
+
+    public static Vector3 ConvertToVector3(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector3 ?
+            p_var.Vector3 :
+            NativeFuncs.godotsharp_variant_as_vector3(p_var);
+
+    public static Vector3I ConvertToVector3I(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector3I ?
+            p_var.Vector3I :
+            NativeFuncs.godotsharp_variant_as_vector3i(p_var);
+
+    public static unsafe Vector4 ConvertToVector4(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector4 ?
+            p_var.Vector4 :
+            NativeFuncs.godotsharp_variant_as_vector4(p_var);
+
+    public static unsafe Vector4I ConvertToVector4I(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Vector4I ?
+            p_var.Vector4I :
+            NativeFuncs.godotsharp_variant_as_vector4i(p_var);
+
+    public static unsafe Basis ConvertToBasis(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Basis ?
+            *p_var.Basis :
+            NativeFuncs.godotsharp_variant_as_basis(p_var);
+
+    public static Quaternion ConvertToQuaternion(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Quaternion ?
+            p_var.Quaternion :
+            NativeFuncs.godotsharp_variant_as_quaternion(p_var);
+
+    public static unsafe Transform3D ConvertToTransform3D(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Transform3D ?
+            *p_var.Transform3D :
+            NativeFuncs.godotsharp_variant_as_transform3d(p_var);
+
+    public static unsafe Projection ConvertToProjection(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Projection ?
+            *p_var.Projection :
+            NativeFuncs.godotsharp_variant_as_projection(p_var);
+
+    public static unsafe Aabb ConvertToAabb(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Aabb ?
+            *p_var.Aabb :
+            NativeFuncs.godotsharp_variant_as_aabb(p_var);
+
+    public static Color ConvertToColor(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Color ?
+            p_var.Color :
+            NativeFuncs.godotsharp_variant_as_color(p_var);
+
+    public static Plane ConvertToPlane(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Plane ?
+            p_var.Plane :
+            NativeFuncs.godotsharp_variant_as_plane(p_var);
+
+    public static Rid ConvertToRid(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Rid ?
+            p_var.Rid :
+            NativeFuncs.godotsharp_variant_as_rid(p_var);
+
+    public static IntPtr ConvertToGodotObjectPtr(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Object ? p_var.Object : IntPtr.Zero;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    // ReSharper disable once RedundantNameQualifier
+    public static GodotObject ConvertToGodotObject(in godot_variant p_var)
+        => InteropUtils.UnmanagedGetManaged(ConvertToGodotObjectPtr(p_var));
+
+    public static string ConvertToString(in godot_variant p_var)
+    {
+        switch (p_var.Type)
         {
-            NativeFuncs.godotsharp_variant_new_transform2d(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromBasis(Basis from)
-        {
-            NativeFuncs.godotsharp_variant_new_basis(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromTransform3D(Transform3D from)
-        {
-            NativeFuncs.godotsharp_variant_new_transform3d(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromProjection(Projection from)
-        {
-            NativeFuncs.godotsharp_variant_new_projection(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromAabb(Aabb from)
-        {
-            NativeFuncs.godotsharp_variant_new_aabb(out godot_variant ret, from);
-            return ret;
-        }
-
-        // Explicit name to make it very clear
-        public static godot_variant CreateFromCallableTakingOwnershipOfDisposableValue(godot_callable from)
-            => new() { Type = Variant.Type.Callable, Callable = from };
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromCallable(Callable from)
-            => CreateFromCallableTakingOwnershipOfDisposableValue(
-                Marshaling.ConvertCallableToNative(from));
-
-        // Explicit name to make it very clear
-        public static godot_variant CreateFromSignalTakingOwnershipOfDisposableValue(godot_signal from)
-            => new() { Type = Variant.Type.Signal, Signal = from };
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromSignal(Signal from)
-            => CreateFromSignalTakingOwnershipOfDisposableValue(
-                Marshaling.ConvertSignalToNative(from));
-
-        // Explicit name to make it very clear
-        public static godot_variant CreateFromStringTakingOwnershipOfDisposableValue(godot_string from)
-            => new() { Type = Variant.Type.String, String = from };
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromString(string? from)
-            => CreateFromStringTakingOwnershipOfDisposableValue(Marshaling.ConvertStringToNative(from));
-
-        public static godot_variant CreateFromPackedByteArray(in godot_packed_byte_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_byte_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedInt32Array(in godot_packed_int32_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_int32_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedInt64Array(in godot_packed_int64_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_int64_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedFloat32Array(in godot_packed_float32_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_float32_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedFloat64Array(in godot_packed_float64_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_float64_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedStringArray(in godot_packed_string_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_string_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedVector2Array(in godot_packed_vector2_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_vector2_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedVector3Array(in godot_packed_vector3_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_vector3_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        public static godot_variant CreateFromPackedColorArray(in godot_packed_color_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_packed_color_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedByteArray(Span<byte> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedByteArray(from);
-            return CreateFromPackedByteArray(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt32Array(Span<int> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt32Array(from);
-            return CreateFromPackedInt32Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedInt64Array(Span<long> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedInt64Array(from);
-            return CreateFromPackedInt64Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat32Array(Span<float> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat32Array(from);
-            return CreateFromPackedFloat32Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedFloat64Array(Span<double> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedFloat64Array(from);
-            return CreateFromPackedFloat64Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedStringArray(Span<string> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedStringArray(from);
-            return CreateFromPackedStringArray(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector2Array(Span<Vector2> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector2Array(from);
-            return CreateFromPackedVector2Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedVector3Array(Span<Vector3> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedVector3Array(from);
-            return CreateFromPackedVector3Array(nativePackedArray);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromPackedColorArray(Span<Color> from)
-        {
-            using var nativePackedArray = Marshaling.ConvertSystemArrayToNativePackedColorArray(from);
-            return CreateFromPackedColorArray(nativePackedArray);
-        }
-
-        public static godot_variant CreateFromSystemArrayOfStringName(Span<StringName> from)
-            => CreateFromArray(new Collections.Array(from));
-
-        public static godot_variant CreateFromSystemArrayOfNodePath(Span<NodePath> from)
-            => CreateFromArray(new Collections.Array(from));
-
-        public static godot_variant CreateFromSystemArrayOfRid(Span<Rid> from)
-            => CreateFromArray(new Collections.Array(from));
-
-        // ReSharper disable once RedundantNameQualifier
-        public static godot_variant CreateFromSystemArrayOfGodotObject(GodotObject[]? from)
-        {
-            if (from == null)
-                return default; // Nil
-            using var fromGodot = new Collections.Array(from);
-            return CreateFromArray((godot_array)fromGodot.NativeValue);
-        }
-
-        public static godot_variant CreateFromArray(godot_array from)
-        {
-            NativeFuncs.godotsharp_variant_new_array(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromArray(Collections.Array? from)
-            => from != null ? CreateFromArray((godot_array)from.NativeValue) : default;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromArray<[MustBeVariant] T>(Array<T>? from)
-            => from != null ? CreateFromArray((godot_array)((Collections.Array)from).NativeValue) : default;
-
-        public static godot_variant CreateFromDictionary(godot_dictionary from)
-        {
-            NativeFuncs.godotsharp_variant_new_dictionary(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromDictionary(Dictionary? from)
-            => from != null ? CreateFromDictionary((godot_dictionary)from.NativeValue) : default;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(Dictionary<TKey, TValue>? from)
-            => from != null ? CreateFromDictionary((godot_dictionary)((Dictionary)from).NativeValue) : default;
-
-        public static godot_variant CreateFromStringName(godot_string_name from)
-        {
-            NativeFuncs.godotsharp_variant_new_string_name(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromStringName(StringName? from)
-            => from != null ? CreateFromStringName((godot_string_name)from.NativeValue) : default;
-
-        public static godot_variant CreateFromNodePath(godot_node_path from)
-        {
-            NativeFuncs.godotsharp_variant_new_node_path(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_variant CreateFromNodePath(NodePath? from)
-            => from != null ? CreateFromNodePath((godot_node_path)from.NativeValue) : default;
-
-        public static godot_variant CreateFromGodotObjectPtr(IntPtr from)
-        {
-            if (from == IntPtr.Zero)
-                return new godot_variant();
-            NativeFuncs.godotsharp_variant_new_object(out godot_variant ret, from);
-            return ret;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        // ReSharper disable once RedundantNameQualifier
-        public static godot_variant CreateFromGodotObject(GodotObject? from)
-            => from != null ? CreateFromGodotObjectPtr(GodotObject.GetPtr(from)) : default;
-
-        // We avoid the internal call if the stored type is the same we want.
-
-        public static bool ConvertToBool(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Bool ?
-                p_var.Bool.ToBool() :
-                NativeFuncs.godotsharp_variant_as_bool(p_var).ToBool();
-
-        public static char ConvertToChar(in godot_variant p_var)
-            => (char)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static sbyte ConvertToInt8(in godot_variant p_var)
-            => (sbyte)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static short ConvertToInt16(in godot_variant p_var)
-            => (short)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static int ConvertToInt32(in godot_variant p_var)
-            => (int)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static long ConvertToInt64(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Int ? p_var.Int : NativeFuncs.godotsharp_variant_as_int(p_var);
-
-        public static byte ConvertToUInt8(in godot_variant p_var)
-            => (byte)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static ushort ConvertToUInt16(in godot_variant p_var)
-            => (ushort)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static uint ConvertToUInt32(in godot_variant p_var)
-            => (uint)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static ulong ConvertToUInt64(in godot_variant p_var)
-            => (ulong)(p_var.Type == Variant.Type.Int ?
-                p_var.Int :
-                NativeFuncs.godotsharp_variant_as_int(p_var));
-
-        public static float ConvertToFloat32(in godot_variant p_var)
-            => (float)(p_var.Type == Variant.Type.Float ?
-                p_var.Float :
-                NativeFuncs.godotsharp_variant_as_float(p_var));
-
-        public static double ConvertToFloat64(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Float ?
-                p_var.Float :
-                NativeFuncs.godotsharp_variant_as_float(p_var);
-
-        public static Vector2 ConvertToVector2(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector2 ?
-                p_var.Vector2 :
-                NativeFuncs.godotsharp_variant_as_vector2(p_var);
-
-        public static Vector2I ConvertToVector2I(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector2I ?
-                p_var.Vector2I :
-                NativeFuncs.godotsharp_variant_as_vector2i(p_var);
-
-        public static Rect2 ConvertToRect2(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Rect2 ?
-                p_var.Rect2 :
-                NativeFuncs.godotsharp_variant_as_rect2(p_var);
-
-        public static Rect2I ConvertToRect2I(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Rect2I ?
-                p_var.Rect2I :
-                NativeFuncs.godotsharp_variant_as_rect2i(p_var);
-
-        public static unsafe Transform2D ConvertToTransform2D(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Transform2D ?
-                *p_var.Transform2D :
-                NativeFuncs.godotsharp_variant_as_transform2d(p_var);
-
-        public static Vector3 ConvertToVector3(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector3 ?
-                p_var.Vector3 :
-                NativeFuncs.godotsharp_variant_as_vector3(p_var);
-
-        public static Vector3I ConvertToVector3I(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector3I ?
-                p_var.Vector3I :
-                NativeFuncs.godotsharp_variant_as_vector3i(p_var);
-
-        public static unsafe Vector4 ConvertToVector4(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector4 ?
-                p_var.Vector4 :
-                NativeFuncs.godotsharp_variant_as_vector4(p_var);
-
-        public static unsafe Vector4I ConvertToVector4I(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Vector4I ?
-                p_var.Vector4I :
-                NativeFuncs.godotsharp_variant_as_vector4i(p_var);
-
-        public static unsafe Basis ConvertToBasis(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Basis ?
-                *p_var.Basis :
-                NativeFuncs.godotsharp_variant_as_basis(p_var);
-
-        public static Quaternion ConvertToQuaternion(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Quaternion ?
-                p_var.Quaternion :
-                NativeFuncs.godotsharp_variant_as_quaternion(p_var);
-
-        public static unsafe Transform3D ConvertToTransform3D(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Transform3D ?
-                *p_var.Transform3D :
-                NativeFuncs.godotsharp_variant_as_transform3d(p_var);
-
-        public static unsafe Projection ConvertToProjection(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Projection ?
-                *p_var.Projection :
-                NativeFuncs.godotsharp_variant_as_projection(p_var);
-
-        public static unsafe Aabb ConvertToAabb(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Aabb ?
-                *p_var.Aabb :
-                NativeFuncs.godotsharp_variant_as_aabb(p_var);
-
-        public static Color ConvertToColor(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Color ?
-                p_var.Color :
-                NativeFuncs.godotsharp_variant_as_color(p_var);
-
-        public static Plane ConvertToPlane(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Plane ?
-                p_var.Plane :
-                NativeFuncs.godotsharp_variant_as_plane(p_var);
-
-        public static Rid ConvertToRid(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Rid ?
-                p_var.Rid :
-                NativeFuncs.godotsharp_variant_as_rid(p_var);
-
-        public static IntPtr ConvertToGodotObjectPtr(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Object ? p_var.Object : IntPtr.Zero;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        // ReSharper disable once RedundantNameQualifier
-        public static GodotObject ConvertToGodotObject(in godot_variant p_var)
-            => InteropUtils.UnmanagedGetManaged(ConvertToGodotObjectPtr(p_var));
-
-        public static string ConvertToString(in godot_variant p_var)
-        {
-            switch (p_var.Type)
+            case Variant.Type.Nil:
+                return ""; // Otherwise, Variant -> String would return the string "Null"
+            case Variant.Type.String:
             {
-                case Variant.Type.Nil:
-                    return ""; // Otherwise, Variant -> String would return the string "Null"
-                case Variant.Type.String:
-                {
-                    // We avoid the internal call if the stored type is the same we want.
-                    return Marshaling.ConvertStringToManaged(p_var.String);
-                }
-                default:
-                {
-                    using godot_string godotString = NativeFuncs.godotsharp_variant_as_string(p_var);
-                    return Marshaling.ConvertStringToManaged(godotString);
-                }
+                // We avoid the internal call if the stored type is the same we want.
+                return Marshaling.ConvertStringToManaged(p_var.String);
+            }
+            default:
+            {
+                using godot_string godotString = NativeFuncs.godotsharp_variant_as_string(p_var);
+                return Marshaling.ConvertStringToManaged(godotString);
             }
         }
+    }
 
-        public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
-            => p_var.Type == Variant.Type.StringName ?
-                NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
-                NativeFuncs.godotsharp_variant_as_string_name(p_var);
+    public static godot_string_name ConvertToNativeStringName(in godot_variant p_var)
+        => p_var.Type == Variant.Type.StringName ?
+            NativeFuncs.godotsharp_string_name_new_copy(p_var.StringName) :
+            NativeFuncs.godotsharp_variant_as_string_name(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static StringName ConvertToStringName(in godot_variant p_var)
-            => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StringName ConvertToStringName(in godot_variant p_var)
+        => StringName.CreateTakingOwnershipOfDisposableValue(ConvertToNativeStringName(p_var));
 
-        public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
-            => p_var.Type == Variant.Type.NodePath ?
-                NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
-                NativeFuncs.godotsharp_variant_as_node_path(p_var);
+    public static godot_node_path ConvertToNativeNodePath(in godot_variant p_var)
+        => p_var.Type == Variant.Type.NodePath ?
+            NativeFuncs.godotsharp_node_path_new_copy(p_var.NodePath) :
+            NativeFuncs.godotsharp_variant_as_node_path(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodePath ConvertToNodePath(in godot_variant p_var)
-            => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static NodePath ConvertToNodePath(in godot_variant p_var)
+        => NodePath.CreateTakingOwnershipOfDisposableValue(ConvertToNativeNodePath(p_var));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
-            => NativeFuncs.godotsharp_variant_as_callable(p_var);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_callable ConvertToNativeCallable(in godot_variant p_var)
+        => NativeFuncs.godotsharp_variant_as_callable(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Callable ConvertToCallable(in godot_variant p_var)
-            => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Callable ConvertToCallable(in godot_variant p_var)
+        => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
-            => NativeFuncs.godotsharp_variant_as_signal(p_var);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
+        => NativeFuncs.godotsharp_variant_as_signal(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Signal ConvertToSignal(in godot_variant p_var)
-            => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Signal ConvertToSignal(in godot_variant p_var)
+        => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
 
-        public static godot_array ConvertToNativeArray(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Array ?
-                NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
-                NativeFuncs.godotsharp_variant_as_array(p_var);
+    public static godot_array ConvertToNativeArray(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Array ?
+            NativeFuncs.godotsharp_array_new_copy(p_var.Array) :
+            NativeFuncs.godotsharp_variant_as_array(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Collections.Array ConvertToArray(in godot_variant p_var)
-            => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Collections.Array ConvertToArray(in godot_variant p_var)
+        => Collections.Array.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Array<T> ConvertToArray<[MustBeVariant] T>(in godot_variant p_var)
-            => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Array<T> ConvertToArray<[MustBeVariant] T>(in godot_variant p_var)
+        => Array<T>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeArray(p_var));
 
-        public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Dictionary ?
-                NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
-                NativeFuncs.godotsharp_variant_as_dictionary(p_var);
+    public static godot_dictionary ConvertToNativeDictionary(in godot_variant p_var)
+        => p_var.Type == Variant.Type.Dictionary ?
+            NativeFuncs.godotsharp_dictionary_new_copy(p_var.Dictionary) :
+            NativeFuncs.godotsharp_variant_as_dictionary(p_var);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Dictionary ConvertToDictionary(in godot_variant p_var)
-            => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Dictionary ConvertToDictionary(in godot_variant p_var)
+        => Dictionary.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Dictionary<TKey, TValue> ConvertToDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(in godot_variant p_var)
-            => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Dictionary<TKey, TValue> ConvertToDictionary<[MustBeVariant] TKey, [MustBeVariant] TValue>(in godot_variant p_var)
+        => Dictionary<TKey, TValue>.CreateTakingOwnershipOfDisposableValue(ConvertToNativeDictionary(p_var));
 
-        public static byte[] ConvertAsPackedByteArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_byte_array(p_var);
-            return Marshaling.ConvertNativePackedByteArrayToSystemArray(packedArray);
-        }
+    public static byte[] ConvertAsPackedByteArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_byte_array(p_var);
+        return Marshaling.ConvertNativePackedByteArrayToSystemArray(packedArray);
+    }
 
-        public static int[] ConvertAsPackedInt32ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int32_array(p_var);
-            return Marshaling.ConvertNativePackedInt32ArrayToSystemArray(packedArray);
-        }
+    public static int[] ConvertAsPackedInt32ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int32_array(p_var);
+        return Marshaling.ConvertNativePackedInt32ArrayToSystemArray(packedArray);
+    }
 
-        public static long[] ConvertAsPackedInt64ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int64_array(p_var);
-            return Marshaling.ConvertNativePackedInt64ArrayToSystemArray(packedArray);
-        }
+    public static long[] ConvertAsPackedInt64ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_int64_array(p_var);
+        return Marshaling.ConvertNativePackedInt64ArrayToSystemArray(packedArray);
+    }
 
-        public static float[] ConvertAsPackedFloat32ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float32_array(p_var);
-            return Marshaling.ConvertNativePackedFloat32ArrayToSystemArray(packedArray);
-        }
+    public static float[] ConvertAsPackedFloat32ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float32_array(p_var);
+        return Marshaling.ConvertNativePackedFloat32ArrayToSystemArray(packedArray);
+    }
 
-        public static double[] ConvertAsPackedFloat64ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float64_array(p_var);
-            return Marshaling.ConvertNativePackedFloat64ArrayToSystemArray(packedArray);
-        }
+    public static double[] ConvertAsPackedFloat64ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_float64_array(p_var);
+        return Marshaling.ConvertNativePackedFloat64ArrayToSystemArray(packedArray);
+    }
 
-        public static string[] ConvertAsPackedStringArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_string_array(p_var);
-            return Marshaling.ConvertNativePackedStringArrayToSystemArray(packedArray);
-        }
+    public static string[] ConvertAsPackedStringArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_string_array(p_var);
+        return Marshaling.ConvertNativePackedStringArrayToSystemArray(packedArray);
+    }
 
-        public static Vector2[] ConvertAsPackedVector2ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector2_array(p_var);
-            return Marshaling.ConvertNativePackedVector2ArrayToSystemArray(packedArray);
-        }
+    public static Vector2[] ConvertAsPackedVector2ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector2_array(p_var);
+        return Marshaling.ConvertNativePackedVector2ArrayToSystemArray(packedArray);
+    }
 
-        public static Vector3[] ConvertAsPackedVector3ArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector3_array(p_var);
-            return Marshaling.ConvertNativePackedVector3ArrayToSystemArray(packedArray);
-        }
+    public static Vector3[] ConvertAsPackedVector3ArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_vector3_array(p_var);
+        return Marshaling.ConvertNativePackedVector3ArrayToSystemArray(packedArray);
+    }
 
-        public static Color[] ConvertAsPackedColorArrayToSystemArray(in godot_variant p_var)
-        {
-            using var packedArray = NativeFuncs.godotsharp_variant_as_packed_color_array(p_var);
-            return Marshaling.ConvertNativePackedColorArrayToSystemArray(packedArray);
-        }
+    public static Color[] ConvertAsPackedColorArrayToSystemArray(in godot_variant p_var)
+    {
+        using var packedArray = NativeFuncs.godotsharp_variant_as_packed_color_array(p_var);
+        return Marshaling.ConvertNativePackedColorArrayToSystemArray(packedArray);
+    }
 
-        public static StringName[] ConvertToSystemArrayOfStringName(in godot_variant p_var)
-        {
-            using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
-            return Marshaling.ConvertNativeGodotArrayToSystemArrayOfStringName(godotArray);
-        }
+    public static StringName[] ConvertToSystemArrayOfStringName(in godot_variant p_var)
+    {
+        using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
+        return Marshaling.ConvertNativeGodotArrayToSystemArrayOfStringName(godotArray);
+    }
 
-        public static NodePath[] ConvertToSystemArrayOfNodePath(in godot_variant p_var)
-        {
-            using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
-            return Marshaling.ConvertNativeGodotArrayToSystemArrayOfNodePath(godotArray);
-        }
+    public static NodePath[] ConvertToSystemArrayOfNodePath(in godot_variant p_var)
+    {
+        using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
+        return Marshaling.ConvertNativeGodotArrayToSystemArrayOfNodePath(godotArray);
+    }
 
-        public static Rid[] ConvertToSystemArrayOfRid(in godot_variant p_var)
-        {
-            using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
-            return Marshaling.ConvertNativeGodotArrayToSystemArrayOfRid(godotArray);
-        }
+    public static Rid[] ConvertToSystemArrayOfRid(in godot_variant p_var)
+    {
+        using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
+        return Marshaling.ConvertNativeGodotArrayToSystemArrayOfRid(godotArray);
+    }
 
-        public static T[] ConvertToSystemArrayOfGodotObject<T>(in godot_variant p_var)
-            // ReSharper disable once RedundantNameQualifier
-            where T : GodotObject
-        {
-            using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
-            return Marshaling.ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(godotArray);
-        }
+    public static T[] ConvertToSystemArrayOfGodotObject<T>(in godot_variant p_var)
+        // ReSharper disable once RedundantNameQualifier
+        where T : GodotObject
+    {
+        using var godotArray = NativeFuncs.godotsharp_variant_as_array(p_var);
+        return Marshaling.ConvertNativeGodotArrayToSystemArrayOfGodotObjectType<T>(godotArray);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NodePath.cs
@@ -1,324 +1,323 @@
 using System;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// A pre-parsed relative or absolute path in a scene tree,
+/// for use with <see cref="Node.GetNode(NodePath)"/> and similar functions.
+/// It can reference a node, a resource within a node, or a property
+/// of a node or resource.
+/// For instance, <c>"Path2D/PathFollow2D/Sprite2D:texture:size"</c>
+/// would refer to the <c>size</c> property of the <c>texture</c>
+/// resource on the node named <c>"Sprite2D"</c> which is a child of
+/// the other named nodes in the path.
+/// You will usually just pass a string to <see cref="Node.GetNode(NodePath)"/>
+/// and it will be automatically converted, but you may occasionally
+/// want to parse a path ahead of time with NodePath.
+/// Exporting a NodePath variable will give you a node selection widget
+/// in the properties panel of the editor, which can often be useful.
+/// A NodePath is composed of a list of slash-separated node names
+/// (like a filesystem path) and an optional colon-separated list of
+/// "subnames" which can be resources or properties.
+///
+/// Note: In the editor, NodePath properties are automatically updated when moving,
+/// renaming or deleting a node in the scene tree, but they are never updated at runtime.
+/// </summary>
+/// <example>
+/// Some examples of NodePaths include the following:
+/// <code>
+/// // No leading slash means it is relative to the current node.
+/// new NodePath("A"); // Immediate child A.
+/// new NodePath("A/B"); // A's child B.
+/// new NodePath("."); // The current node.
+/// new NodePath(".."); // The parent node.
+/// new NodePath("../C"); // A sibling node C.
+/// // A leading slash means it is absolute from the SceneTree.
+/// new NodePath("/root"); // Equivalent to GetTree().Root
+/// new NodePath("/root/Main"); // If your main scene's root node were named "Main".
+/// new NodePath("/root/MyAutoload"); // If you have an autoloaded node or scene.
+/// </code>
+/// </example>
+public sealed class NodePath : IDisposable, IEquatable<NodePath>
 {
+    internal godot_node_path.movable NativeValue;
+
+    private WeakReference<IDisposable> _weakReferenceToSelf;
+
+    ~NodePath()
+    {
+        Dispose(false);
+    }
+
     /// <summary>
-    /// A pre-parsed relative or absolute path in a scene tree,
-    /// for use with <see cref="Node.GetNode(NodePath)"/> and similar functions.
-    /// It can reference a node, a resource within a node, or a property
-    /// of a node or resource.
-    /// For instance, <c>"Path2D/PathFollow2D/Sprite2D:texture:size"</c>
-    /// would refer to the <c>size</c> property of the <c>texture</c>
-    /// resource on the node named <c>"Sprite2D"</c> which is a child of
-    /// the other named nodes in the path.
-    /// You will usually just pass a string to <see cref="Node.GetNode(NodePath)"/>
-    /// and it will be automatically converted, but you may occasionally
-    /// want to parse a path ahead of time with NodePath.
-    /// Exporting a NodePath variable will give you a node selection widget
-    /// in the properties panel of the editor, which can often be useful.
-    /// A NodePath is composed of a list of slash-separated node names
-    /// (like a filesystem path) and an optional colon-separated list of
-    /// "subnames" which can be resources or properties.
-    ///
-    /// Note: In the editor, NodePath properties are automatically updated when moving,
-    /// renaming or deleting a node in the scene tree, but they are never updated at runtime.
+    /// Disposes of this <see cref="NodePath"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public void Dispose(bool disposing)
+    {
+        // Always dispose `NativeValue` even if disposing is true
+        NativeValue.DangerousSelfRef.Dispose();
+
+        if (_weakReferenceToSelf != null)
+        {
+            DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
+        }
+    }
+
+    private NodePath(godot_node_path nativeValueToOwn)
+    {
+        NativeValue = (godot_node_path.movable)nativeValueToOwn;
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+    }
+
+    // Explicit name to make it very clear
+    internal static NodePath CreateTakingOwnershipOfDisposableValue(godot_node_path nativeValueToOwn)
+        => new NodePath(nativeValueToOwn);
+
+    /// <summary>
+    /// Constructs an empty <see cref="NodePath"/>.
+    /// </summary>
+    public NodePath()
+    {
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="NodePath"/> from a string <paramref name="path"/>,
+    /// e.g.: <c>"Path2D/PathFollow2D/Sprite2D:texture:size"</c>.
+    /// A path is absolute if it starts with a slash. Absolute paths
+    /// are only valid in the global scene tree, not within individual
+    /// scenes. In a relative path, <c>"."</c> and <c>".."</c> indicate
+    /// the current node and its parent.
+    /// The "subnames" optionally included after the path to the target
+    /// node can point to resources or properties, and can also be nested.
     /// </summary>
     /// <example>
-    /// Some examples of NodePaths include the following:
+    /// Examples of valid NodePaths (assuming that those nodes exist and
+    /// have the referenced resources or properties):
     /// <code>
-    /// // No leading slash means it is relative to the current node.
-    /// new NodePath("A"); // Immediate child A.
-    /// new NodePath("A/B"); // A's child B.
-    /// new NodePath("."); // The current node.
-    /// new NodePath(".."); // The parent node.
-    /// new NodePath("../C"); // A sibling node C.
-    /// // A leading slash means it is absolute from the SceneTree.
-    /// new NodePath("/root"); // Equivalent to GetTree().Root
-    /// new NodePath("/root/Main"); // If your main scene's root node were named "Main".
-    /// new NodePath("/root/MyAutoload"); // If you have an autoloaded node or scene.
+    /// // Points to the Sprite2D node.
+    /// "Path2D/PathFollow2D/Sprite2D"
+    /// // Points to the Sprite2D node and its "texture" resource.
+    /// // GetNode() would retrieve "Sprite2D", while GetNodeAndResource()
+    /// // would retrieve both the Sprite2D node and the "texture" resource.
+    /// "Path2D/PathFollow2D/Sprite2D:texture"
+    /// // Points to the Sprite2D node and its "position" property.
+    /// "Path2D/PathFollow2D/Sprite2D:position"
+    /// // Points to the Sprite2D node and the "x" component of its "position" property.
+    /// "Path2D/PathFollow2D/Sprite2D:position:x"
+    /// // Absolute path (from "root")
+    /// "/root/Level/Path2D"
     /// </code>
     /// </example>
-    public sealed class NodePath : IDisposable, IEquatable<NodePath>
+    /// <param name="path">A string that represents a path in a scene tree.</param>
+    public NodePath(string path)
     {
-        internal godot_node_path.movable NativeValue;
-
-        private WeakReference<IDisposable> _weakReferenceToSelf;
-
-        ~NodePath()
+        if (!string.IsNullOrEmpty(path))
         {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Disposes of this <see cref="NodePath"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public void Dispose(bool disposing)
-        {
-            // Always dispose `NativeValue` even if disposing is true
-            NativeValue.DangerousSelfRef.Dispose();
-
-            if (_weakReferenceToSelf != null)
-            {
-                DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
-            }
-        }
-
-        private NodePath(godot_node_path nativeValueToOwn)
-        {
-            NativeValue = (godot_node_path.movable)nativeValueToOwn;
+            NativeValue = (godot_node_path.movable)NativeFuncs.godotsharp_node_path_new_from_string(path);
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
         }
+    }
 
-        // Explicit name to make it very clear
-        internal static NodePath CreateTakingOwnershipOfDisposableValue(godot_node_path nativeValueToOwn)
-            => new NodePath(nativeValueToOwn);
+    /// <summary>
+    /// Converts a string to a <see cref="NodePath"/>.
+    /// </summary>
+    /// <param name="from">The string to convert.</param>
+    public static implicit operator NodePath(string from) => new NodePath(from);
 
-        /// <summary>
-        /// Constructs an empty <see cref="NodePath"/>.
-        /// </summary>
-        public NodePath()
-        {
-        }
+    /// <summary>
+    /// Converts this <see cref="NodePath"/> to a string.
+    /// </summary>
+    /// <param name="from">The <see cref="NodePath"/> to convert.</param>
+    public static implicit operator string(NodePath from) => from?.ToString();
 
-        /// <summary>
-        /// Constructs a <see cref="NodePath"/> from a string <paramref name="path"/>,
-        /// e.g.: <c>"Path2D/PathFollow2D/Sprite2D:texture:size"</c>.
-        /// A path is absolute if it starts with a slash. Absolute paths
-        /// are only valid in the global scene tree, not within individual
-        /// scenes. In a relative path, <c>"."</c> and <c>".."</c> indicate
-        /// the current node and its parent.
-        /// The "subnames" optionally included after the path to the target
-        /// node can point to resources or properties, and can also be nested.
-        /// </summary>
-        /// <example>
-        /// Examples of valid NodePaths (assuming that those nodes exist and
-        /// have the referenced resources or properties):
-        /// <code>
-        /// // Points to the Sprite2D node.
-        /// "Path2D/PathFollow2D/Sprite2D"
-        /// // Points to the Sprite2D node and its "texture" resource.
-        /// // GetNode() would retrieve "Sprite2D", while GetNodeAndResource()
-        /// // would retrieve both the Sprite2D node and the "texture" resource.
-        /// "Path2D/PathFollow2D/Sprite2D:texture"
-        /// // Points to the Sprite2D node and its "position" property.
-        /// "Path2D/PathFollow2D/Sprite2D:position"
-        /// // Points to the Sprite2D node and the "x" component of its "position" property.
-        /// "Path2D/PathFollow2D/Sprite2D:position:x"
-        /// // Absolute path (from "root")
-        /// "/root/Level/Path2D"
-        /// </code>
-        /// </example>
-        /// <param name="path">A string that represents a path in a scene tree.</param>
-        public NodePath(string path)
-        {
-            if (!string.IsNullOrEmpty(path))
-            {
-                NativeValue = (godot_node_path.movable)NativeFuncs.godotsharp_node_path_new_from_string(path);
-                _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-            }
-        }
+    /// <summary>
+    /// Converts this <see cref="NodePath"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this <see cref="NodePath"/>.</returns>
+    public override string ToString()
+    {
+        if (IsEmpty)
+            return string.Empty;
 
-        /// <summary>
-        /// Converts a string to a <see cref="NodePath"/>.
-        /// </summary>
-        /// <param name="from">The string to convert.</param>
-        public static implicit operator NodePath(string from) => new NodePath(from);
+        var src = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_as_string(out godot_string dest, src);
+        using (dest)
+            return Marshaling.ConvertStringToManaged(dest);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="NodePath"/> to a string.
-        /// </summary>
-        /// <param name="from">The <see cref="NodePath"/> to convert.</param>
-        public static implicit operator string(NodePath from) => from?.ToString();
+    /// <summary>
+    /// Returns a node path with a colon character (<c>:</c>) prepended,
+    /// transforming it to a pure property path with no node name (defaults
+    /// to resolving from the current node).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // This will be parsed as a node path to the "x" property in the "position" node.
+    /// var nodePath = new NodePath("position:x");
+    /// // This will be parsed as a node path to the "x" component of the "position" property in the current node.
+    /// NodePath propertyPath = nodePath.GetAsPropertyPath();
+    /// GD.Print(propertyPath); // :position:x
+    /// </code>
+    /// </example>
+    /// <returns>The <see cref="NodePath"/> as a pure property path.</returns>
+    public NodePath GetAsPropertyPath()
+    {
+        godot_node_path propertyPath = default;
+        var self = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_get_as_property_path(self, ref propertyPath);
+        return CreateTakingOwnershipOfDisposableValue(propertyPath);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="NodePath"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this <see cref="NodePath"/>.</returns>
-        public override string ToString()
-        {
-            if (IsEmpty)
-                return string.Empty;
+    /// <summary>
+    /// Returns all names concatenated with a slash character (<c>/</c>).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
+    /// GD.Print(nodepath.GetConcatenatedNames()); // Path2D/PathFollow2D/Sprite2D
+    /// </code>
+    /// </example>
+    /// <returns>The names concatenated with <c>/</c>.</returns>
+    public string GetConcatenatedNames()
+    {
+        var self = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_get_concatenated_names(self, out godot_string names);
+        using (names)
+            return Marshaling.ConvertStringToManaged(names);
+    }
 
-            var src = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_as_string(out godot_string dest, src);
-            using (dest)
-                return Marshaling.ConvertStringToManaged(dest);
-        }
+    /// <summary>
+    /// Returns all subnames concatenated with a colon character (<c>:</c>)
+    /// as separator, i.e. the right side of the first colon in a node path.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
+    /// GD.Print(nodepath.GetConcatenatedSubnames()); // texture:load_path
+    /// </code>
+    /// </example>
+    /// <returns>The subnames concatenated with <c>:</c>.</returns>
+    public string GetConcatenatedSubNames()
+    {
+        var self = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_get_concatenated_subnames(self, out godot_string subNames);
+        using (subNames)
+            return Marshaling.ConvertStringToManaged(subNames);
+    }
 
-        /// <summary>
-        /// Returns a node path with a colon character (<c>:</c>) prepended,
-        /// transforming it to a pure property path with no node name (defaults
-        /// to resolving from the current node).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// // This will be parsed as a node path to the "x" property in the "position" node.
-        /// var nodePath = new NodePath("position:x");
-        /// // This will be parsed as a node path to the "x" component of the "position" property in the current node.
-        /// NodePath propertyPath = nodePath.GetAsPropertyPath();
-        /// GD.Print(propertyPath); // :position:x
-        /// </code>
-        /// </example>
-        /// <returns>The <see cref="NodePath"/> as a pure property path.</returns>
-        public NodePath GetAsPropertyPath()
-        {
-            godot_node_path propertyPath = default;
-            var self = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_get_as_property_path(self, ref propertyPath);
-            return CreateTakingOwnershipOfDisposableValue(propertyPath);
-        }
+    /// <summary>
+    /// Gets the node name indicated by <paramref name="idx"/> (0 to <see cref="GetNameCount"/>).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D");
+    /// GD.Print(nodePath.GetName(0)); // Path2D
+    /// GD.Print(nodePath.GetName(1)); // PathFollow2D
+    /// GD.Print(nodePath.GetName(2)); // Sprite
+    /// </code>
+    /// </example>
+    /// <param name="idx">The name index.</param>
+    /// <returns>The name at the given index <paramref name="idx"/>.</returns>
+    public string GetName(int idx)
+    {
+        var self = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_get_name(self, idx, out godot_string name);
+        using (name)
+            return Marshaling.ConvertStringToManaged(name);
+    }
 
-        /// <summary>
-        /// Returns all names concatenated with a slash character (<c>/</c>).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
-        /// GD.Print(nodepath.GetConcatenatedNames()); // Path2D/PathFollow2D/Sprite2D
-        /// </code>
-        /// </example>
-        /// <returns>The names concatenated with <c>/</c>.</returns>
-        public string GetConcatenatedNames()
-        {
-            var self = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_get_concatenated_names(self, out godot_string names);
-            using (names)
-                return Marshaling.ConvertStringToManaged(names);
-        }
+    /// <summary>
+    /// Gets the number of node names which make up the path.
+    /// Subnames (see <see cref="GetSubNameCount"/>) are not included.
+    /// For example, <c>"Path2D/PathFollow2D/Sprite2D"</c> has 3 names.
+    /// </summary>
+    /// <returns>The number of node names which make up the path.</returns>
+    public int GetNameCount()
+    {
+        var self = (godot_node_path)NativeValue;
+        return NativeFuncs.godotsharp_node_path_get_name_count(self);
+    }
 
-        /// <summary>
-        /// Returns all subnames concatenated with a colon character (<c>:</c>)
-        /// as separator, i.e. the right side of the first colon in a node path.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
-        /// GD.Print(nodepath.GetConcatenatedSubnames()); // texture:load_path
-        /// </code>
-        /// </example>
-        /// <returns>The subnames concatenated with <c>:</c>.</returns>
-        public string GetConcatenatedSubNames()
-        {
-            var self = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_get_concatenated_subnames(self, out godot_string subNames);
-            using (subNames)
-                return Marshaling.ConvertStringToManaged(subNames);
-        }
+    /// <summary>
+    /// Gets the resource or property name indicated by <paramref name="idx"/> (0 to <see cref="GetSubNameCount"/>).
+    /// </summary>
+    /// <param name="idx">The subname index.</param>
+    /// <returns>The subname at the given index <paramref name="idx"/>.</returns>
+    public string GetSubName(int idx)
+    {
+        var self = (godot_node_path)NativeValue;
+        NativeFuncs.godotsharp_node_path_get_subname(self, idx, out godot_string subName);
+        using (subName)
+            return Marshaling.ConvertStringToManaged(subName);
+    }
 
-        /// <summary>
-        /// Gets the node name indicated by <paramref name="idx"/> (0 to <see cref="GetNameCount"/>).
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D");
-        /// GD.Print(nodePath.GetName(0)); // Path2D
-        /// GD.Print(nodePath.GetName(1)); // PathFollow2D
-        /// GD.Print(nodePath.GetName(2)); // Sprite
-        /// </code>
-        /// </example>
-        /// <param name="idx">The name index.</param>
-        /// <returns>The name at the given index <paramref name="idx"/>.</returns>
-        public string GetName(int idx)
-        {
-            var self = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_get_name(self, idx, out godot_string name);
-            using (name)
-                return Marshaling.ConvertStringToManaged(name);
-        }
+    /// <summary>
+    /// Gets the number of resource or property names ("subnames") in the path.
+    /// Each subname is listed after a colon character (<c>:</c>) in the node path.
+    /// For example, <c>"Path2D/PathFollow2D/Sprite2D:texture:load_path"</c> has 2 subnames.
+    /// </summary>
+    /// <returns>The number of subnames in the path.</returns>
+    public int GetSubNameCount()
+    {
+        var self = (godot_node_path)NativeValue;
+        return NativeFuncs.godotsharp_node_path_get_subname_count(self);
+    }
 
-        /// <summary>
-        /// Gets the number of node names which make up the path.
-        /// Subnames (see <see cref="GetSubNameCount"/>) are not included.
-        /// For example, <c>"Path2D/PathFollow2D/Sprite2D"</c> has 3 names.
-        /// </summary>
-        /// <returns>The number of node names which make up the path.</returns>
-        public int GetNameCount()
-        {
-            var self = (godot_node_path)NativeValue;
-            return NativeFuncs.godotsharp_node_path_get_name_count(self);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the node path is absolute (as opposed to relative),
+    /// which means that it starts with a slash character (<c>/</c>). Absolute node paths can
+    /// be used to access the root node (<c>"/root"</c>) or autoloads (e.g. <c>"/global"</c>
+    /// if a "global" autoload was registered).
+    /// </summary>
+    /// <returns>If the <see cref="NodePath"/> is an absolute path.</returns>
+    public bool IsAbsolute()
+    {
+        var self = (godot_node_path)NativeValue;
+        return NativeFuncs.godotsharp_node_path_is_absolute(self).ToBool();
+    }
 
-        /// <summary>
-        /// Gets the resource or property name indicated by <paramref name="idx"/> (0 to <see cref="GetSubNameCount"/>).
-        /// </summary>
-        /// <param name="idx">The subname index.</param>
-        /// <returns>The subname at the given index <paramref name="idx"/>.</returns>
-        public string GetSubName(int idx)
-        {
-            var self = (godot_node_path)NativeValue;
-            NativeFuncs.godotsharp_node_path_get_subname(self, idx, out godot_string subName);
-            using (subName)
-                return Marshaling.ConvertStringToManaged(subName);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the node path is empty.
+    /// </summary>
+    /// <returns>If the <see cref="NodePath"/> is empty.</returns>
+    public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
 
-        /// <summary>
-        /// Gets the number of resource or property names ("subnames") in the path.
-        /// Each subname is listed after a colon character (<c>:</c>) in the node path.
-        /// For example, <c>"Path2D/PathFollow2D/Sprite2D:texture:load_path"</c> has 2 subnames.
-        /// </summary>
-        /// <returns>The number of subnames in the path.</returns>
-        public int GetSubNameCount()
-        {
-            var self = (godot_node_path)NativeValue;
-            return NativeFuncs.godotsharp_node_path_get_subname_count(self);
-        }
+    public static bool operator ==(NodePath left, NodePath right)
+    {
+        if (left is null)
+            return right is null;
+        return left.Equals(right);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the node path is absolute (as opposed to relative),
-        /// which means that it starts with a slash character (<c>/</c>). Absolute node paths can
-        /// be used to access the root node (<c>"/root"</c>) or autoloads (e.g. <c>"/global"</c>
-        /// if a "global" autoload was registered).
-        /// </summary>
-        /// <returns>If the <see cref="NodePath"/> is an absolute path.</returns>
-        public bool IsAbsolute()
-        {
-            var self = (godot_node_path)NativeValue;
-            return NativeFuncs.godotsharp_node_path_is_absolute(self).ToBool();
-        }
+    public static bool operator !=(NodePath left, NodePath right)
+    {
+        return !(left == right);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the node path is empty.
-        /// </summary>
-        /// <returns>If the <see cref="NodePath"/> is empty.</returns>
-        public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
+    public bool Equals(NodePath other)
+    {
+        if (other is null)
+            return false;
+        var self = (godot_node_path)NativeValue;
+        var otherNative = (godot_node_path)other.NativeValue;
+        return NativeFuncs.godotsharp_node_path_equals(self, otherNative).ToBool();
+    }
 
-        public static bool operator ==(NodePath left, NodePath right)
-        {
-            if (left is null)
-                return right is null;
-            return left.Equals(right);
-        }
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || (obj is NodePath other && Equals(other));
+    }
 
-        public static bool operator !=(NodePath left, NodePath right)
-        {
-            return !(left == right);
-        }
-
-        public bool Equals(NodePath other)
-        {
-            if (other is null)
-                return false;
-            var self = (godot_node_path)NativeValue;
-            var otherNative = (godot_node_path)other.NativeValue;
-            return NativeFuncs.godotsharp_node_path_equals(self, otherNative).ToBool();
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || (obj is NodePath other && Equals(other));
-        }
-
-        public override int GetHashCode()
-        {
-            var self = (godot_node_path)NativeValue;
-            return NativeFuncs.godotsharp_node_path_hash(self);
-        }
+    public override int GetHashCode()
+    {
+        var self = (godot_node_path)NativeValue;
+        return NativeFuncs.godotsharp_node_path_hash(self);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Plane.cs
@@ -1,438 +1,437 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Plane represents a normalized plane equation.
+/// "Over" or "Above" the plane is considered the side of
+/// the plane towards where the normal is pointing.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Plane : IEquatable<Plane>
 {
+    private Vector3 _normal;
+    private real_t _d;
+
     /// <summary>
-    /// Plane represents a normalized plane equation.
-    /// "Over" or "Above" the plane is considered the side of
-    /// the plane towards where the normal is pointing.
+    /// The normal of the plane, which must be a unit vector.
+    /// In the scalar equation of the plane <c>ax + by + cz = d</c>, this is
+    /// the vector <c>(a, b, c)</c>, where <c>d</c> is the <see cref="D"/> property.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Plane : IEquatable<Plane>
+    /// <value>Equivalent to <see cref="X"/>, <see cref="Y"/>, and <see cref="Z"/>.</value>
+    public Vector3 Normal
     {
-        private Vector3 _normal;
-        private real_t _d;
+        readonly get { return _normal; }
+        set { _normal = value; }
+    }
 
-        /// <summary>
-        /// The normal of the plane, which must be a unit vector.
-        /// In the scalar equation of the plane <c>ax + by + cz = d</c>, this is
-        /// the vector <c>(a, b, c)</c>, where <c>d</c> is the <see cref="D"/> property.
-        /// </summary>
-        /// <value>Equivalent to <see cref="X"/>, <see cref="Y"/>, and <see cref="Z"/>.</value>
-        public Vector3 Normal
+    /// <summary>
+    /// The distance from the origin to the plane (in the direction of
+    /// <see cref="Normal"/>). This value is typically non-negative.
+    /// In the scalar equation of the plane <c>ax + by + cz = d</c>,
+    /// this is <c>d</c>, while the <c>(a, b, c)</c> coordinates are represented
+    /// by the <see cref="Normal"/> property.
+    /// </summary>
+    /// <value>The plane's distance from the origin.</value>
+    public real_t D
+    {
+        readonly get { return _d; }
+        set { _d = value; }
+    }
+
+    /// <summary>
+    /// The X component of the plane's normal vector.
+    /// </summary>
+    /// <value>Equivalent to <see cref="Normal"/>'s X value.</value>
+    public real_t X
+    {
+        readonly get
         {
-            readonly get { return _normal; }
-            set { _normal = value; }
+            return _normal.X;
+        }
+        set
+        {
+            _normal.X = value;
+        }
+    }
+
+    /// <summary>
+    /// The Y component of the plane's normal vector.
+    /// </summary>
+    /// <value>Equivalent to <see cref="Normal"/>'s Y value.</value>
+    public real_t Y
+    {
+        readonly get
+        {
+            return _normal.Y;
+        }
+        set
+        {
+            _normal.Y = value;
+        }
+    }
+
+    /// <summary>
+    /// The Z component of the plane's normal vector.
+    /// </summary>
+    /// <value>Equivalent to <see cref="Normal"/>'s Z value.</value>
+    public real_t Z
+    {
+        readonly get
+        {
+            return _normal.Z;
+        }
+        set
+        {
+            _normal.Z = value;
+        }
+    }
+
+    /// <summary>
+    /// Returns the shortest distance from this plane to the position <paramref name="point"/>.
+    /// </summary>
+    /// <param name="point">The position to use for the calculation.</param>
+    /// <returns>The shortest distance.</returns>
+    public readonly real_t DistanceTo(Vector3 point)
+    {
+        return _normal.Dot(point) - _d;
+    }
+
+    /// <summary>
+    /// Returns the center of the plane, the point on the plane closest to the origin.
+    /// The point where the normal line going through the origin intersects the plane.
+    /// </summary>
+    /// <value>Equivalent to <see cref="Normal"/> multiplied by <see cref="D"/>.</value>
+    public readonly Vector3 GetCenter()
+    {
+        return _normal * _d;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if point is inside the plane.
+    /// Comparison uses a custom minimum tolerance threshold.
+    /// </summary>
+    /// <param name="point">The point to check.</param>
+    /// <param name="tolerance">The tolerance threshold.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the plane has the point.</returns>
+    public readonly bool HasPoint(Vector3 point, real_t tolerance = Mathf.Epsilon)
+    {
+        real_t dist = _normal.Dot(point) - _d;
+        return Mathf.Abs(dist) <= tolerance;
+    }
+
+    /// <summary>
+    /// Returns the intersection point of the three planes: <paramref name="b"/>, <paramref name="c"/>,
+    /// and this plane. If no intersection is found, <see langword="null"/> is returned.
+    /// </summary>
+    /// <param name="b">One of the three planes to use in the calculation.</param>
+    /// <param name="c">One of the three planes to use in the calculation.</param>
+    /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
+    public readonly Vector3? Intersect3(Plane b, Plane c)
+    {
+        real_t denom = _normal.Cross(b._normal).Dot(c._normal);
+
+        if (Mathf.IsZeroApprox(denom))
+        {
+            return null;
         }
 
-        /// <summary>
-        /// The distance from the origin to the plane (in the direction of
-        /// <see cref="Normal"/>). This value is typically non-negative.
-        /// In the scalar equation of the plane <c>ax + by + cz = d</c>,
-        /// this is <c>d</c>, while the <c>(a, b, c)</c> coordinates are represented
-        /// by the <see cref="Normal"/> property.
-        /// </summary>
-        /// <value>The plane's distance from the origin.</value>
-        public real_t D
+        Vector3 result = (b._normal.Cross(c._normal) * _d) +
+                            (c._normal.Cross(_normal) * b._d) +
+                            (_normal.Cross(b._normal) * c._d);
+
+        return result / denom;
+    }
+
+    /// <summary>
+    /// Returns the intersection point of a ray consisting of the position <paramref name="from"/>
+    /// and the direction normal <paramref name="dir"/> with this plane.
+    /// If no intersection is found, <see langword="null"/> is returned.
+    /// </summary>
+    /// <param name="from">The start of the ray.</param>
+    /// <param name="dir">The direction of the ray, normalized.</param>
+    /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
+    public readonly Vector3? IntersectsRay(Vector3 from, Vector3 dir)
+    {
+        real_t den = _normal.Dot(dir);
+
+        if (Mathf.IsZeroApprox(den))
         {
-            readonly get { return _d; }
-            set { _d = value; }
+            return null;
         }
 
-        /// <summary>
-        /// The X component of the plane's normal vector.
-        /// </summary>
-        /// <value>Equivalent to <see cref="Normal"/>'s X value.</value>
-        public real_t X
+        real_t dist = (_normal.Dot(from) - _d) / den;
+
+        // This is a ray, before the emitting pos (from) does not exist
+        if (dist > Mathf.Epsilon)
         {
-            readonly get
-            {
-                return _normal.X;
-            }
-            set
-            {
-                _normal.X = value;
-            }
+            return null;
         }
 
-        /// <summary>
-        /// The Y component of the plane's normal vector.
-        /// </summary>
-        /// <value>Equivalent to <see cref="Normal"/>'s Y value.</value>
-        public real_t Y
+        return from - (dir * dist);
+    }
+
+    /// <summary>
+    /// Returns the intersection point of a line segment from
+    /// position <paramref name="begin"/> to position <paramref name="end"/> with this plane.
+    /// If no intersection is found, <see langword="null"/> is returned.
+    /// </summary>
+    /// <param name="begin">The start of the line segment.</param>
+    /// <param name="end">The end of the line segment.</param>
+    /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
+    public readonly Vector3? IntersectsSegment(Vector3 begin, Vector3 end)
+    {
+        Vector3 segment = begin - end;
+        real_t den = _normal.Dot(segment);
+
+        if (Mathf.IsZeroApprox(den))
         {
-            readonly get
-            {
-                return _normal.Y;
-            }
-            set
-            {
-                _normal.Y = value;
-            }
+            return null;
         }
 
-        /// <summary>
-        /// The Z component of the plane's normal vector.
-        /// </summary>
-        /// <value>Equivalent to <see cref="Normal"/>'s Z value.</value>
-        public real_t Z
+        real_t dist = (_normal.Dot(begin) - _d) / den;
+
+        // Only allow dist to be in the range of 0 to 1, with tolerance.
+        if (dist < -Mathf.Epsilon || dist > 1.0f + Mathf.Epsilon)
         {
-            readonly get
-            {
-                return _normal.Z;
-            }
-            set
-            {
-                _normal.Z = value;
-            }
+            return null;
         }
 
-        /// <summary>
-        /// Returns the shortest distance from this plane to the position <paramref name="point"/>.
-        /// </summary>
-        /// <param name="point">The position to use for the calculation.</param>
-        /// <returns>The shortest distance.</returns>
-        public readonly real_t DistanceTo(Vector3 point)
+        return begin - (segment * dist);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this plane is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return _normal.IsFinite() && Mathf.IsFinite(D);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="point"/> is located above the plane.
+    /// </summary>
+    /// <param name="point">The point to check.</param>
+    /// <returns>A <see langword="bool"/> for whether or not the point is above the plane.</returns>
+    public readonly bool IsPointOver(Vector3 point)
+    {
+        return _normal.Dot(point) > _d;
+    }
+
+    /// <summary>
+    /// Returns the plane scaled to unit length.
+    /// </summary>
+    /// <returns>A normalized version of the plane.</returns>
+    public readonly Plane Normalized()
+    {
+        real_t len = _normal.Length();
+
+        if (len == 0)
         {
-            return _normal.Dot(point) - _d;
+            return new Plane(0, 0, 0, 0);
         }
 
-        /// <summary>
-        /// Returns the center of the plane, the point on the plane closest to the origin.
-        /// The point where the normal line going through the origin intersects the plane.
-        /// </summary>
-        /// <value>Equivalent to <see cref="Normal"/> multiplied by <see cref="D"/>.</value>
-        public readonly Vector3 GetCenter()
-        {
-            return _normal * _d;
-        }
+        return new Plane(_normal / len, _d / len);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if point is inside the plane.
-        /// Comparison uses a custom minimum tolerance threshold.
-        /// </summary>
-        /// <param name="point">The point to check.</param>
-        /// <param name="tolerance">The tolerance threshold.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the plane has the point.</returns>
-        public readonly bool HasPoint(Vector3 point, real_t tolerance = Mathf.Epsilon)
-        {
-            real_t dist = _normal.Dot(point) - _d;
-            return Mathf.Abs(dist) <= tolerance;
-        }
+    /// <summary>
+    /// Returns the orthogonal projection of <paramref name="point"/> into the plane.
+    /// </summary>
+    /// <param name="point">The point to project.</param>
+    /// <returns>The projected point.</returns>
+    public readonly Vector3 Project(Vector3 point)
+    {
+        return point - (_normal * DistanceTo(point));
+    }
 
-        /// <summary>
-        /// Returns the intersection point of the three planes: <paramref name="b"/>, <paramref name="c"/>,
-        /// and this plane. If no intersection is found, <see langword="null"/> is returned.
-        /// </summary>
-        /// <param name="b">One of the three planes to use in the calculation.</param>
-        /// <param name="c">One of the three planes to use in the calculation.</param>
-        /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
-        public readonly Vector3? Intersect3(Plane b, Plane c)
-        {
-            real_t denom = _normal.Cross(b._normal).Dot(c._normal);
+    // Constants
+    private static readonly Plane _planeYZ = new Plane(1, 0, 0, 0);
+    private static readonly Plane _planeXZ = new Plane(0, 1, 0, 0);
+    private static readonly Plane _planeXY = new Plane(0, 0, 1, 0);
 
-            if (Mathf.IsZeroApprox(denom))
-            {
-                return null;
-            }
+    /// <summary>
+    /// A <see cref="Plane"/> that extends in the Y and Z axes (normal vector points +X).
+    /// </summary>
+    /// <value>Equivalent to <c>new Plane(1, 0, 0, 0)</c>.</value>
+    public static Plane PlaneYZ { get { return _planeYZ; } }
 
-            Vector3 result = (b._normal.Cross(c._normal) * _d) +
-                                (c._normal.Cross(_normal) * b._d) +
-                                (_normal.Cross(b._normal) * c._d);
+    /// <summary>
+    /// A <see cref="Plane"/> that extends in the X and Z axes (normal vector points +Y).
+    /// </summary>
+    /// <value>Equivalent to <c>new Plane(0, 1, 0, 0)</c>.</value>
+    public static Plane PlaneXZ { get { return _planeXZ; } }
 
-            return result / denom;
-        }
+    /// <summary>
+    /// A <see cref="Plane"/> that extends in the X and Y axes (normal vector points +Z).
+    /// </summary>
+    /// <value>Equivalent to <c>new Plane(0, 0, 1, 0)</c>.</value>
+    public static Plane PlaneXY { get { return _planeXY; } }
 
-        /// <summary>
-        /// Returns the intersection point of a ray consisting of the position <paramref name="from"/>
-        /// and the direction normal <paramref name="dir"/> with this plane.
-        /// If no intersection is found, <see langword="null"/> is returned.
-        /// </summary>
-        /// <param name="from">The start of the ray.</param>
-        /// <param name="dir">The direction of the ray, normalized.</param>
-        /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
-        public readonly Vector3? IntersectsRay(Vector3 from, Vector3 dir)
-        {
-            real_t den = _normal.Dot(dir);
+    /// <summary>
+    /// Constructs a <see cref="Plane"/> from four values.
+    /// <paramref name="a"/>, <paramref name="b"/> and <paramref name="c"/> become the
+    /// components of the resulting plane's <see cref="Normal"/> vector.
+    /// <paramref name="d"/> becomes the plane's distance from the origin.
+    /// </summary>
+    /// <param name="a">The X component of the plane's normal vector.</param>
+    /// <param name="b">The Y component of the plane's normal vector.</param>
+    /// <param name="c">The Z component of the plane's normal vector.</param>
+    /// <param name="d">The plane's distance from the origin. This value is typically non-negative.</param>
+    public Plane(real_t a, real_t b, real_t c, real_t d)
+    {
+        _normal = new Vector3(a, b, c);
+        _d = d;
+    }
 
-            if (Mathf.IsZeroApprox(den))
-            {
-                return null;
-            }
+    /// <summary>
+    /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector.
+    /// The plane will intersect the origin.
+    /// </summary>
+    /// <param name="normal">The normal of the plane, must be a unit vector.</param>
+    public Plane(Vector3 normal)
+    {
+        _normal = normal;
+        _d = 0;
+    }
 
-            real_t dist = (_normal.Dot(from) - _d) / den;
+    /// <summary>
+    /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector and
+    /// the plane's distance to the origin <paramref name="d"/>.
+    /// </summary>
+    /// <param name="normal">The normal of the plane, must be a unit vector.</param>
+    /// <param name="d">The plane's distance from the origin. This value is typically non-negative.</param>
+    public Plane(Vector3 normal, real_t d)
+    {
+        _normal = normal;
+        _d = d;
+    }
 
-            // This is a ray, before the emitting pos (from) does not exist
-            if (dist > Mathf.Epsilon)
-            {
-                return null;
-            }
+    /// <summary>
+    /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector and
+    /// a <paramref name="point"/> on the plane.
+    /// </summary>
+    /// <param name="normal">The normal of the plane, must be a unit vector.</param>
+    /// <param name="point">The point on the plane.</param>
+    public Plane(Vector3 normal, Vector3 point)
+    {
+        _normal = normal;
+        _d = _normal.Dot(point);
+    }
 
-            return from - (dir * dist);
-        }
+    /// <summary>
+    /// Constructs a <see cref="Plane"/> from the three points, given in clockwise order.
+    /// </summary>
+    /// <param name="v1">The first point.</param>
+    /// <param name="v2">The second point.</param>
+    /// <param name="v3">The third point.</param>
+    public Plane(Vector3 v1, Vector3 v2, Vector3 v3)
+    {
+        _normal = (v1 - v3).Cross(v1 - v2);
+        _normal.Normalize();
+        _d = _normal.Dot(v1);
+    }
 
-        /// <summary>
-        /// Returns the intersection point of a line segment from
-        /// position <paramref name="begin"/> to position <paramref name="end"/> with this plane.
-        /// If no intersection is found, <see langword="null"/> is returned.
-        /// </summary>
-        /// <param name="begin">The start of the line segment.</param>
-        /// <param name="end">The end of the line segment.</param>
-        /// <returns>The intersection, or <see langword="null"/> if none is found.</returns>
-        public readonly Vector3? IntersectsSegment(Vector3 begin, Vector3 end)
-        {
-            Vector3 segment = begin - end;
-            real_t den = _normal.Dot(segment);
+    /// <summary>
+    /// Returns the negative value of the <see cref="Plane"/>.
+    /// This is the same as writing <c>new Plane(-p.Normal, -p.D)</c>.
+    /// This operation flips the direction of the normal vector and
+    /// also flips the distance value, resulting in a Plane that is
+    /// in the same place, but facing the opposite direction.
+    /// </summary>
+    /// <param name="plane">The plane to negate/flip.</param>
+    /// <returns>The negated/flipped plane.</returns>
+    public static Plane operator -(Plane plane)
+    {
+        return new Plane(-plane._normal, -plane._d);
+    }
 
-            if (Mathf.IsZeroApprox(den))
-            {
-                return null;
-            }
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Plane"/>s are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the planes are exactly equal.</returns>
+    public static bool operator ==(Plane left, Plane right)
+    {
+        return left.Equals(right);
+    }
 
-            real_t dist = (_normal.Dot(begin) - _d) / den;
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Plane"/>s are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the planes are not equal.</returns>
+    public static bool operator !=(Plane left, Plane right)
+    {
+        return !left.Equals(right);
+    }
 
-            // Only allow dist to be in the range of 0 to 1, with tolerance.
-            if (dist < -Mathf.Epsilon || dist > 1.0f + Mathf.Epsilon)
-            {
-                return null;
-            }
+    /// <summary>
+    /// Returns <see langword="true"/> if this plane and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the plane and the other object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Plane other && Equals(other);
+    }
 
-            return begin - (segment * dist);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are equal.
+    /// </summary>
+    /// <param name="other">The other plane to compare.</param>
+    /// <returns>Whether or not the planes are exactly equal.</returns>
+    public readonly bool Equals(Plane other)
+    {
+        return _normal == other._normal && _d == other._d;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this plane is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return _normal.IsFinite() && Mathf.IsFinite(D);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are
+    /// approximately equal, by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other plane to compare.</param>
+    /// <returns>Whether or not the planes are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Plane other)
+    {
+        return _normal.IsEqualApprox(other._normal) && Mathf.IsEqualApprox(_d, other._d);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="point"/> is located above the plane.
-        /// </summary>
-        /// <param name="point">The point to check.</param>
-        /// <returns>A <see langword="bool"/> for whether or not the point is above the plane.</returns>
-        public readonly bool IsPointOver(Vector3 point)
-        {
-            return _normal.Dot(point) > _d;
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Plane"/>.
+    /// </summary>
+    /// <returns>A hash code for this plane.</returns>
+    public override readonly int GetHashCode()
+    {
+        return _normal.GetHashCode() ^ _d.GetHashCode();
+    }
 
-        /// <summary>
-        /// Returns the plane scaled to unit length.
-        /// </summary>
-        /// <returns>A normalized version of the plane.</returns>
-        public readonly Plane Normalized()
-        {
-            real_t len = _normal.Length();
+    /// <summary>
+    /// Converts this <see cref="Plane"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this plane.</returns>
+    public override readonly string ToString()
+    {
+        return $"{_normal}, {_d}";
+    }
 
-            if (len == 0)
-            {
-                return new Plane(0, 0, 0, 0);
-            }
-
-            return new Plane(_normal / len, _d / len);
-        }
-
-        /// <summary>
-        /// Returns the orthogonal projection of <paramref name="point"/> into the plane.
-        /// </summary>
-        /// <param name="point">The point to project.</param>
-        /// <returns>The projected point.</returns>
-        public readonly Vector3 Project(Vector3 point)
-        {
-            return point - (_normal * DistanceTo(point));
-        }
-
-        // Constants
-        private static readonly Plane _planeYZ = new Plane(1, 0, 0, 0);
-        private static readonly Plane _planeXZ = new Plane(0, 1, 0, 0);
-        private static readonly Plane _planeXY = new Plane(0, 0, 1, 0);
-
-        /// <summary>
-        /// A <see cref="Plane"/> that extends in the Y and Z axes (normal vector points +X).
-        /// </summary>
-        /// <value>Equivalent to <c>new Plane(1, 0, 0, 0)</c>.</value>
-        public static Plane PlaneYZ { get { return _planeYZ; } }
-
-        /// <summary>
-        /// A <see cref="Plane"/> that extends in the X and Z axes (normal vector points +Y).
-        /// </summary>
-        /// <value>Equivalent to <c>new Plane(0, 1, 0, 0)</c>.</value>
-        public static Plane PlaneXZ { get { return _planeXZ; } }
-
-        /// <summary>
-        /// A <see cref="Plane"/> that extends in the X and Y axes (normal vector points +Z).
-        /// </summary>
-        /// <value>Equivalent to <c>new Plane(0, 0, 1, 0)</c>.</value>
-        public static Plane PlaneXY { get { return _planeXY; } }
-
-        /// <summary>
-        /// Constructs a <see cref="Plane"/> from four values.
-        /// <paramref name="a"/>, <paramref name="b"/> and <paramref name="c"/> become the
-        /// components of the resulting plane's <see cref="Normal"/> vector.
-        /// <paramref name="d"/> becomes the plane's distance from the origin.
-        /// </summary>
-        /// <param name="a">The X component of the plane's normal vector.</param>
-        /// <param name="b">The Y component of the plane's normal vector.</param>
-        /// <param name="c">The Z component of the plane's normal vector.</param>
-        /// <param name="d">The plane's distance from the origin. This value is typically non-negative.</param>
-        public Plane(real_t a, real_t b, real_t c, real_t d)
-        {
-            _normal = new Vector3(a, b, c);
-            _d = d;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector.
-        /// The plane will intersect the origin.
-        /// </summary>
-        /// <param name="normal">The normal of the plane, must be a unit vector.</param>
-        public Plane(Vector3 normal)
-        {
-            _normal = normal;
-            _d = 0;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector and
-        /// the plane's distance to the origin <paramref name="d"/>.
-        /// </summary>
-        /// <param name="normal">The normal of the plane, must be a unit vector.</param>
-        /// <param name="d">The plane's distance from the origin. This value is typically non-negative.</param>
-        public Plane(Vector3 normal, real_t d)
-        {
-            _normal = normal;
-            _d = d;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Plane"/> from a <paramref name="normal"/> vector and
-        /// a <paramref name="point"/> on the plane.
-        /// </summary>
-        /// <param name="normal">The normal of the plane, must be a unit vector.</param>
-        /// <param name="point">The point on the plane.</param>
-        public Plane(Vector3 normal, Vector3 point)
-        {
-            _normal = normal;
-            _d = _normal.Dot(point);
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Plane"/> from the three points, given in clockwise order.
-        /// </summary>
-        /// <param name="v1">The first point.</param>
-        /// <param name="v2">The second point.</param>
-        /// <param name="v3">The third point.</param>
-        public Plane(Vector3 v1, Vector3 v2, Vector3 v3)
-        {
-            _normal = (v1 - v3).Cross(v1 - v2);
-            _normal.Normalize();
-            _d = _normal.Dot(v1);
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Plane"/>.
-        /// This is the same as writing <c>new Plane(-p.Normal, -p.D)</c>.
-        /// This operation flips the direction of the normal vector and
-        /// also flips the distance value, resulting in a Plane that is
-        /// in the same place, but facing the opposite direction.
-        /// </summary>
-        /// <param name="plane">The plane to negate/flip.</param>
-        /// <returns>The negated/flipped plane.</returns>
-        public static Plane operator -(Plane plane)
-        {
-            return new Plane(-plane._normal, -plane._d);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Plane"/>s are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the planes are exactly equal.</returns>
-        public static bool operator ==(Plane left, Plane right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Plane"/>s are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the planes are not equal.</returns>
-        public static bool operator !=(Plane left, Plane right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this plane and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the plane and the other object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Plane other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are equal.
-        /// </summary>
-        /// <param name="other">The other plane to compare.</param>
-        /// <returns>Whether or not the planes are exactly equal.</returns>
-        public readonly bool Equals(Plane other)
-        {
-            return _normal == other._normal && _d == other._d;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this plane and <paramref name="other"/> are
-        /// approximately equal, by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other plane to compare.</param>
-        /// <returns>Whether or not the planes are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Plane other)
-        {
-            return _normal.IsEqualApprox(other._normal) && Mathf.IsEqualApprox(_d, other._d);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Plane"/>.
-        /// </summary>
-        /// <returns>A hash code for this plane.</returns>
-        public override readonly int GetHashCode()
-        {
-            return _normal.GetHashCode() ^ _d.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Plane"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this plane.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_normal}, {_d}";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Plane"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this plane.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"{_normal.ToString(format)}, {_d.ToString(format)}";
-        }
+    /// <summary>
+    /// Converts this <see cref="Plane"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this plane.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"{_normal.ToString(format)}, {_d.ToString(format)}";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Projection.cs
@@ -1,1028 +1,1027 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// A 4x4 matrix used for 3D projective transformations. It can represent transformations such as
+/// translation, rotation, scaling, shearing, and perspective division. It consists of four
+/// <see cref="Vector4"/> columns.
+/// For purely linear transformations (translation, rotation, and scale), it is recommended to use
+/// <see cref="Transform3D"/>, as it is more performant and has a lower memory footprint.
+/// Used internally as <see cref="Camera3D"/>'s projection matrix.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Projection : IEquatable<Projection>
 {
     /// <summary>
-    /// A 4x4 matrix used for 3D projective transformations. It can represent transformations such as
-    /// translation, rotation, scaling, shearing, and perspective division. It consists of four
-    /// <see cref="Vector4"/> columns.
-    /// For purely linear transformations (translation, rotation, and scale), it is recommended to use
-    /// <see cref="Transform3D"/>, as it is more performant and has a lower memory footprint.
-    /// Used internally as <see cref="Camera3D"/>'s projection matrix.
+    /// Enumerated index values for the planes.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Projection : IEquatable<Projection>
+    public enum Planes
     {
         /// <summary>
-        /// Enumerated index values for the planes.
+        /// The projection's near plane.
         /// </summary>
-        public enum Planes
+        Near,
+        /// <summary>
+        /// The projection's far plane.
+        /// </summary>
+        Far,
+        /// <summary>
+        /// The projection's left plane.
+        /// </summary>
+        Left,
+        /// <summary>
+        /// The projection's top plane.
+        /// </summary>
+        Top,
+        /// <summary>
+        /// The projection's right plane.
+        /// </summary>
+        Right,
+        /// <summary>
+        /// The projection's bottom plane.
+        /// </summary>
+        Bottom,
+    }
+
+    /// <summary>
+    /// The projection's X column. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public Vector4 X;
+
+    /// <summary>
+    /// The projection's Y column. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public Vector4 Y;
+
+    /// <summary>
+    /// The projection's Z column. Also accessible by using the index position <c>[2]</c>.
+    /// </summary>
+    public Vector4 Z;
+
+    /// <summary>
+    /// The projection's W column. Also accessible by using the index position <c>[3]</c>.
+    /// </summary>
+    public Vector4 W;
+
+    /// <summary>
+    /// Access whole columns in the form of <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="column">Which column vector.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="column"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    public Vector4 this[int column]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The projection's near plane.
-            /// </summary>
-            Near,
-            /// <summary>
-            /// The projection's far plane.
-            /// </summary>
-            Far,
-            /// <summary>
-            /// The projection's left plane.
-            /// </summary>
-            Left,
-            /// <summary>
-            /// The projection's top plane.
-            /// </summary>
-            Top,
-            /// <summary>
-            /// The projection's right plane.
-            /// </summary>
-            Right,
-            /// <summary>
-            /// The projection's bottom plane.
-            /// </summary>
-            Bottom,
-        }
-
-        /// <summary>
-        /// The projection's X column. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public Vector4 X;
-
-        /// <summary>
-        /// The projection's Y column. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public Vector4 Y;
-
-        /// <summary>
-        /// The projection's Z column. Also accessible by using the index position <c>[2]</c>.
-        /// </summary>
-        public Vector4 Z;
-
-        /// <summary>
-        /// The projection's W column. Also accessible by using the index position <c>[3]</c>.
-        /// </summary>
-        public Vector4 W;
-
-        /// <summary>
-        /// Access whole columns in the form of <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="column">Which column vector.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="column"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        public Vector4 this[int column]
-        {
-            readonly get
+            switch (column)
             {
-                switch (column)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    case 3:
-                        return W;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-            set
-            {
-                switch (column)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Z = value;
-                        return;
-                    case 3:
-                        W = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Access single values.
-        /// </summary>
-        /// <param name="column">Which column vector.</param>
-        /// <param name="row">Which row of the column.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="column"/> or <paramref name="row"/> are not 0, 1, 2 or 3.
-        /// </exception>
-        public real_t this[int column, int row]
-        {
-            readonly get
-            {
-                switch (column)
-                {
-                    case 0:
-                        return X[row];
-                    case 1:
-                        return Y[row];
-                    case 2:
-                        return Z[row];
-                    case 3:
-                        return W[row];
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-            set
-            {
-                switch (column)
-                {
-                    case 0:
-                        X[row] = value;
-                        return;
-                    case 1:
-                        Y[row] = value;
-                        return;
-                    case 2:
-                        Z[row] = value;
-                        return;
-                    case 3:
-                        W[row] = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions from a depth range of
-        /// <c>-1</c> to <c>1</c> to one that ranges from <c>0</c> to <c>1</c>, and flips the projected
-        /// positions vertically, according to <paramref name="flipY"/>.
-        /// </summary>
-        /// <param name="flipY">If the projection should be flipped vertically.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateDepthCorrection(bool flipY)
-        {
-            return new Projection(
-                new Vector4(1, 0, 0, 0),
-                new Vector4(0, flipY ? -1 : 1, 0, 0),
-                new Vector4(0, 0, (real_t)0.5, 0),
-                new Vector4(0, 0, (real_t)0.5, 1)
-            );
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that scales a given projection to fit around
-        /// a given <see cref="Aabb"/> in projection space.
-        /// </summary>
-        /// <param name="aabb">The Aabb to fit the projection around.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateFitAabb(Aabb aabb)
-        {
-            Vector3 min = aabb.Position;
-            Vector3 max = aabb.Position + aabb.Size;
-
-            return new Projection(
-                new Vector4(2 / (max.X - min.X), 0, 0, 0),
-                new Vector4(0, 2 / (max.Y - min.Y), 0, 0),
-                new Vector4(0, 0, 2 / (max.Z - min.Z), 0),
-                new Vector4(-(max.X + min.X) / (max.X - min.X), -(max.Y + min.Y) / (max.Y - min.Y), -(max.Z + min.Z) / (max.Z - min.Z), 1)
-            );
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> for projecting positions onto a head-mounted display with
-        /// the given X:Y aspect ratio, distance between eyes, display width, distance to lens, oversampling factor,
-        /// and depth clipping planes.
-        /// <paramref name="eye"/> creates the projection for the left eye when set to 1,
-        /// or the right eye when set to 2.
-        /// </summary>
-        /// <param name="eye">
-        /// The eye to create the projection for.
-        /// The left eye when set to 1, the right eye when set to 2.
-        /// </param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <param name="intraocularDist">The distance between the eyes.</param>
-        /// <param name="displayWidth">The display width.</param>
-        /// <param name="displayToLens">The distance to the lens.</param>
-        /// <param name="oversample">The oversampling factor.</param>
-        /// <param name="zNear">The near clipping distance.</param>
-        /// <param name="zFar">The far clipping distance.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateForHmd(int eye, real_t aspect, real_t intraocularDist, real_t displayWidth, real_t displayToLens, real_t oversample, real_t zNear, real_t zFar)
-        {
-            real_t f1 = (intraocularDist * (real_t)0.5) / displayToLens;
-            real_t f2 = ((displayWidth - intraocularDist) * (real_t)0.5) / displayToLens;
-            real_t f3 = (displayWidth / (real_t)4.0) / displayToLens;
-
-            real_t add = ((f1 + f2) * (oversample - (real_t)1.0)) / (real_t)2.0;
-            f1 += add;
-            f2 += add;
-            f3 *= oversample;
-
-            f3 /= aspect;
-
-            switch (eye)
-            {
+                case 0:
+                    return X;
                 case 1:
-                    return CreateFrustum(-f2 * zNear, f1 * zNear, -f3 * zNear, f3 * zNear, zNear, zFar);
+                    return Y;
                 case 2:
-                    return CreateFrustum(-f1 * zNear, f2 * zNear, -f3 * zNear, f3 * zNear, zNear, zFar);
+                    return Z;
+                case 3:
+                    return W;
                 default:
-                    return Zero;
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions in a frustum with
-        /// the given clipping planes.
-        /// </summary>
-        /// <param name="left">The left clipping distance.</param>
-        /// <param name="right">The right clipping distance.</param>
-        /// <param name="bottom">The bottom clipping distance.</param>
-        /// <param name="top">The top clipping distance.</param>
-        /// <param name="near">The near clipping distance.</param>
-        /// <param name="far">The far clipping distance.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateFrustum(real_t left, real_t right, real_t bottom, real_t top, real_t near, real_t far)
+        set
         {
-            if (right <= left)
+            switch (column)
             {
-                throw new ArgumentException("right is less or equal to left.");
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Z = value;
+                    return;
+                case 3:
+                    W = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
-            if (top <= bottom)
+        }
+    }
+
+    /// <summary>
+    /// Access single values.
+    /// </summary>
+    /// <param name="column">Which column vector.</param>
+    /// <param name="row">Which row of the column.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="column"/> or <paramref name="row"/> are not 0, 1, 2 or 3.
+    /// </exception>
+    public real_t this[int column, int row]
+    {
+        readonly get
+        {
+            switch (column)
             {
-                throw new ArgumentException("top is less or equal to bottom.");
+                case 0:
+                    return X[row];
+                case 1:
+                    return Y[row];
+                case 2:
+                    return Z[row];
+                case 3:
+                    return W[row];
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
-            if (far <= near)
+        }
+        set
+        {
+            switch (column)
             {
-                throw new ArgumentException("far is less or equal to near.");
+                case 0:
+                    X[row] = value;
+                    return;
+                case 1:
+                    Y[row] = value;
+                    return;
+                case 2:
+                    Z[row] = value;
+                    return;
+                case 3:
+                    W[row] = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
+        }
+    }
 
-            real_t x = 2 * near / (right - left);
-            real_t y = 2 * near / (top - bottom);
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions from a depth range of
+    /// <c>-1</c> to <c>1</c> to one that ranges from <c>0</c> to <c>1</c>, and flips the projected
+    /// positions vertically, according to <paramref name="flipY"/>.
+    /// </summary>
+    /// <param name="flipY">If the projection should be flipped vertically.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateDepthCorrection(bool flipY)
+    {
+        return new Projection(
+            new Vector4(1, 0, 0, 0),
+            new Vector4(0, flipY ? -1 : 1, 0, 0),
+            new Vector4(0, 0, (real_t)0.5, 0),
+            new Vector4(0, 0, (real_t)0.5, 1)
+        );
+    }
 
-            real_t a = (right + left) / (right - left);
-            real_t b = (top + bottom) / (top - bottom);
-            real_t c = -(far + near) / (far - near);
-            real_t d = -2 * far * near / (far - near);
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that scales a given projection to fit around
+    /// a given <see cref="Aabb"/> in projection space.
+    /// </summary>
+    /// <param name="aabb">The Aabb to fit the projection around.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateFitAabb(Aabb aabb)
+    {
+        Vector3 min = aabb.Position;
+        Vector3 max = aabb.Position + aabb.Size;
 
-            return new Projection(
-                new Vector4(x, 0, 0, 0),
-                new Vector4(0, y, 0, 0),
-                new Vector4(a, b, c, -1),
-                new Vector4(0, 0, d, 0)
-            );
+        return new Projection(
+            new Vector4(2 / (max.X - min.X), 0, 0, 0),
+            new Vector4(0, 2 / (max.Y - min.Y), 0, 0),
+            new Vector4(0, 0, 2 / (max.Z - min.Z), 0),
+            new Vector4(-(max.X + min.X) / (max.X - min.X), -(max.Y + min.Y) / (max.Y - min.Y), -(max.Z + min.Z) / (max.Z - min.Z), 1)
+        );
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> for projecting positions onto a head-mounted display with
+    /// the given X:Y aspect ratio, distance between eyes, display width, distance to lens, oversampling factor,
+    /// and depth clipping planes.
+    /// <paramref name="eye"/> creates the projection for the left eye when set to 1,
+    /// or the right eye when set to 2.
+    /// </summary>
+    /// <param name="eye">
+    /// The eye to create the projection for.
+    /// The left eye when set to 1, the right eye when set to 2.
+    /// </param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <param name="intraocularDist">The distance between the eyes.</param>
+    /// <param name="displayWidth">The display width.</param>
+    /// <param name="displayToLens">The distance to the lens.</param>
+    /// <param name="oversample">The oversampling factor.</param>
+    /// <param name="zNear">The near clipping distance.</param>
+    /// <param name="zFar">The far clipping distance.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateForHmd(int eye, real_t aspect, real_t intraocularDist, real_t displayWidth, real_t displayToLens, real_t oversample, real_t zNear, real_t zFar)
+    {
+        real_t f1 = (intraocularDist * (real_t)0.5) / displayToLens;
+        real_t f2 = ((displayWidth - intraocularDist) * (real_t)0.5) / displayToLens;
+        real_t f3 = (displayWidth / (real_t)4.0) / displayToLens;
+
+        real_t add = ((f1 + f2) * (oversample - (real_t)1.0)) / (real_t)2.0;
+        f1 += add;
+        f2 += add;
+        f3 *= oversample;
+
+        f3 /= aspect;
+
+        switch (eye)
+        {
+            case 1:
+                return CreateFrustum(-f2 * zNear, f1 * zNear, -f3 * zNear, f3 * zNear, zNear, zFar);
+            case 2:
+                return CreateFrustum(-f1 * zNear, f2 * zNear, -f3 * zNear, f3 * zNear, zNear, zFar);
+            default:
+                return Zero;
+        }
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions in a frustum with
+    /// the given clipping planes.
+    /// </summary>
+    /// <param name="left">The left clipping distance.</param>
+    /// <param name="right">The right clipping distance.</param>
+    /// <param name="bottom">The bottom clipping distance.</param>
+    /// <param name="top">The top clipping distance.</param>
+    /// <param name="near">The near clipping distance.</param>
+    /// <param name="far">The far clipping distance.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateFrustum(real_t left, real_t right, real_t bottom, real_t top, real_t near, real_t far)
+    {
+        if (right <= left)
+        {
+            throw new ArgumentException("right is less or equal to left.");
+        }
+        if (top <= bottom)
+        {
+            throw new ArgumentException("top is less or equal to bottom.");
+        }
+        if (far <= near)
+        {
+            throw new ArgumentException("far is less or equal to near.");
         }
 
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions in a frustum with
-        /// the given size, X:Y aspect ratio, offset, and clipping planes.
-        /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
-        /// </summary>
-        /// <param name="size">The frustum size.</param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <param name="offset">The offset to apply.</param>
-        /// <param name="near">The near clipping distance.</param>
-        /// <param name="far">The far clipping distance.</param>
-        /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateFrustumAspect(real_t size, real_t aspect, Vector2 offset, real_t near, real_t far, bool flipFov)
+        real_t x = 2 * near / (right - left);
+        real_t y = 2 * near / (top - bottom);
+
+        real_t a = (right + left) / (right - left);
+        real_t b = (top + bottom) / (top - bottom);
+        real_t c = -(far + near) / (far - near);
+        real_t d = -2 * far * near / (far - near);
+
+        return new Projection(
+            new Vector4(x, 0, 0, 0),
+            new Vector4(0, y, 0, 0),
+            new Vector4(a, b, c, -1),
+            new Vector4(0, 0, d, 0)
+        );
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions in a frustum with
+    /// the given size, X:Y aspect ratio, offset, and clipping planes.
+    /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
+    /// </summary>
+    /// <param name="size">The frustum size.</param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <param name="offset">The offset to apply.</param>
+    /// <param name="near">The near clipping distance.</param>
+    /// <param name="far">The far clipping distance.</param>
+    /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateFrustumAspect(real_t size, real_t aspect, Vector2 offset, real_t near, real_t far, bool flipFov)
+    {
+        if (!flipFov)
         {
-            if (!flipFov)
+            size *= aspect;
+        }
+        return CreateFrustum(-size / 2 + offset.X, +size / 2 + offset.X, -size / aspect / 2 + offset.Y, +size / aspect / 2 + offset.Y, near, far);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions into the given <see cref="Rect2"/>.
+    /// </summary>
+    /// <param name="rect">The Rect2 to project positions into.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateLightAtlasRect(Rect2 rect)
+    {
+        return new Projection(
+            new Vector4(rect.Size.X, 0, 0, 0),
+            new Vector4(0, rect.Size.Y, 0, 0),
+            new Vector4(0, 0, 1, 0),
+            new Vector4(rect.Position.X, rect.Position.Y, 0, 1)
+        );
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions using an orthogonal projection with
+    /// the given clipping planes.
+    /// </summary>
+    /// <param name="left">The left clipping distance.</param>
+    /// <param name="right">The right clipping distance.</param>
+    /// <param name="bottom">The bottom clipping distance.</param>
+    /// <param name="top">The top clipping distance.</param>
+    /// <param name="zNear">The near clipping distance.</param>
+    /// <param name="zFar">The far clipping distance.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateOrthogonal(real_t left, real_t right, real_t bottom, real_t top, real_t zNear, real_t zFar)
+    {
+        Projection proj = Projection.Identity;
+        proj.X.X = (real_t)2.0 / (right - left);
+        proj.W.X = -((right + left) / (right - left));
+        proj.Y.Y = (real_t)2.0 / (top - bottom);
+        proj.W.Y = -((top + bottom) / (top - bottom));
+        proj.Z.Z = (real_t)(-2.0) / (zFar - zNear);
+        proj.W.Z = -((zFar + zNear) / (zFar - zNear));
+        proj.W.W = (real_t)1.0;
+        return proj;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions using an orthogonal projection with
+    /// the given size, X:Y aspect ratio, and clipping planes.
+    /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
+    /// </summary>
+    /// <param name="size">The frustum size.</param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <param name="zNear">The near clipping distance.</param>
+    /// <param name="zFar">The far clipping distance.</param>
+    /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreateOrthogonalAspect(real_t size, real_t aspect, real_t zNear, real_t zFar, bool flipFov)
+    {
+        if (!flipFov)
+        {
+            size *= aspect;
+        }
+        return CreateOrthogonal(-size / 2, +size / 2, -size / aspect / 2, +size / aspect / 2, zNear, zFar);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions using a perspective projection with
+    /// the given Y-axis field of view (in degrees), X:Y aspect ratio, and clipping planes.
+    /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
+    /// </summary>
+    /// <param name="fovyDegrees">The vertical field of view (in degrees).</param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <param name="zNear">The near clipping distance.</param>
+    /// <param name="zFar">The far clipping distance.</param>
+    /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreatePerspective(real_t fovyDegrees, real_t aspect, real_t zNear, real_t zFar, bool flipFov)
+    {
+        if (flipFov)
+        {
+            fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
+        }
+        real_t radians = Mathf.DegToRad(fovyDegrees / (real_t)2.0);
+        real_t deltaZ = zFar - zNear;
+        (real_t sin, real_t cos) = Mathf.SinCos(radians);
+
+        if ((deltaZ == 0) || (sin == 0) || (aspect == 0))
+        {
+            return Zero;
+        }
+
+        real_t cotangent = cos / sin;
+
+        Projection proj = Projection.Identity;
+
+        proj.X.X = cotangent / aspect;
+        proj.Y.Y = cotangent;
+        proj.Z.Z = -(zFar + zNear) / deltaZ;
+        proj.Z.W = -1;
+        proj.W.Z = -2 * zNear * zFar / deltaZ;
+        proj.W.W = 0;
+
+        return proj;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="Projection"/> that projects positions using a perspective projection with
+    /// the given Y-axis field of view (in degrees), X:Y aspect ratio, and clipping distances.
+    /// The projection is adjusted for a head-mounted display with the given distance between eyes and distance
+    /// to a point that can be focused on.
+    /// <paramref name="eye"/> creates the projection for the left eye when set to 1,
+    /// or the right eye when set to 2.
+    /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
+    /// </summary>
+    /// <param name="fovyDegrees">The vertical field of view (in degrees).</param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <param name="zNear">The near clipping distance.</param>
+    /// <param name="zFar">The far clipping distance.</param>
+    /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
+    /// <param name="eye">
+    /// The eye to create the projection for.
+    /// The left eye when set to 1, the right eye when set to 2.
+    /// </param>
+    /// <param name="intraocularDist">The distance between the eyes.</param>
+    /// <param name="convergenceDist">The distance to a point of convergence that can be focused on.</param>
+    /// <returns>The created projection.</returns>
+    public static Projection CreatePerspectiveHmd(real_t fovyDegrees, real_t aspect, real_t zNear, real_t zFar, bool flipFov, int eye, real_t intraocularDist, real_t convergenceDist)
+    {
+        if (flipFov)
+        {
+            fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
+        }
+
+        real_t ymax = zNear * Mathf.Tan(Mathf.DegToRad(fovyDegrees / (real_t)2.0));
+        real_t xmax = ymax * aspect;
+        real_t frustumshift = (intraocularDist / (real_t)2.0) * zNear / convergenceDist;
+        real_t left;
+        real_t right;
+        real_t modeltranslation;
+        switch (eye)
+        {
+            case 1:
+                left = -xmax + frustumshift;
+                right = xmax + frustumshift;
+                modeltranslation = intraocularDist / (real_t)2.0;
+                break;
+            case 2:
+                left = -xmax - frustumshift;
+                right = xmax - frustumshift;
+                modeltranslation = -intraocularDist / (real_t)2.0;
+                break;
+            default:
+                left = -xmax;
+                right = xmax;
+                modeltranslation = (real_t)0.0;
+                break;
+        }
+        Projection proj = CreateFrustum(left, right, -ymax, ymax, zNear, zFar);
+        Projection cm = Projection.Identity;
+        cm.W.X = modeltranslation;
+        return proj * cm;
+    }
+
+    /// <summary>
+    /// Returns a scalar value that is the signed factor by which areas are scaled by this matrix.
+    /// If the sign is negative, the matrix flips the orientation of the area.
+    /// The determinant can be used to calculate the invertibility of a matrix or solve linear systems
+    /// of equations involving the matrix, among other applications.
+    /// </summary>
+    /// <returns>The determinant calculated from this projection.</returns>
+    public readonly real_t Determinant()
+    {
+        return X.W * Y.Z * Z.Y * W.X - X.Z * Y.W * Z.Y * W.X -
+               X.W * Y.Y * Z.Z * W.X + X.Y * Y.W * Z.Z * W.X +
+               X.Z * Y.Y * Z.W * W.X - X.Y * Y.Z * Z.W * W.X -
+               X.W * Y.Z * Z.X * W.Y + X.Z * Y.W * Z.X * W.Y +
+               X.W * Y.X * Z.Z * W.Y - X.X * Y.W * Z.Z * W.Y -
+               X.Z * Y.X * Z.W * W.Y + X.X * Y.Z * Z.W * W.Y +
+               X.W * Y.Y * Z.X * W.Z - X.Y * Y.W * Z.X * W.Z -
+               X.W * Y.X * Z.Y * W.Z + X.X * Y.W * Z.Y * W.Z +
+               X.Y * Y.X * Z.W * W.Z - X.X * Y.Y * Z.W * W.Z -
+               X.Z * Y.Y * Z.X * W.W + X.Y * Y.Z * Z.X * W.W +
+               X.Z * Y.X * Z.Y * W.W - X.X * Y.Z * Z.Y * W.W -
+               X.Y * Y.X * Z.Z * W.W + X.X * Y.Y * Z.Z * W.W;
+    }
+
+    /// <summary>
+    /// Returns the X:Y aspect ratio of this <see cref="Projection"/>'s viewport.
+    /// </summary>
+    /// <returns>The aspect ratio from this projection's viewport.</returns>
+    public readonly real_t GetAspect()
+    {
+        Vector2 vpHe = GetViewportHalfExtents();
+        return vpHe.X / vpHe.Y;
+    }
+
+    /// <summary>
+    /// Returns the horizontal field of view of the projection (in degrees).
+    /// </summary>
+    /// <returns>The horizontal field of view of this projection.</returns>
+    public readonly real_t GetFov()
+    {
+        Plane rightPlane = new Plane(X.W - X.X, Y.W - Y.X, Z.W - Z.X, -W.W + W.X).Normalized();
+        if (Z.X == 0 && Z.Y == 0)
+        {
+            return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.X))) * (real_t)2.0;
+        }
+        else
+        {
+            Plane leftPlane = new Plane(X.W + X.X, Y.W + Y.X, Z.W + Z.X, W.W + W.X).Normalized();
+            return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(leftPlane.Normal.X))) + Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.X)));
+        }
+    }
+
+    /// <summary>
+    /// Returns the vertical field of view of the projection (in degrees) associated with
+    /// the given horizontal field of view (in degrees) and aspect ratio.
+    /// </summary>
+    /// <param name="fovx">The horizontal field of view (in degrees).</param>
+    /// <param name="aspect">The aspect ratio.</param>
+    /// <returns>The vertical field of view of this projection.</returns>
+    public static real_t GetFovy(real_t fovx, real_t aspect)
+    {
+        return Mathf.RadToDeg(Mathf.Atan(aspect * Mathf.Tan(Mathf.DegToRad(fovx) * (real_t)0.5)) * (real_t)2.0);
+    }
+
+    /// <summary>
+    /// Returns the factor by which the visible level of detail is scaled by this <see cref="Projection"/>.
+    /// </summary>
+    /// <returns>The level of detail factor for this projection.</returns>
+    public readonly real_t GetLodMultiplier()
+    {
+        if (IsOrthogonal())
+        {
+            return GetViewportHalfExtents().X;
+        }
+        else
+        {
+            real_t zn = GetZNear();
+            real_t width = GetViewportHalfExtents().X * (real_t)2.0;
+            return (real_t)1.0 / (zn / width);
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of pixels with the given pixel width displayed per meter, after
+    /// this <see cref="Projection"/> is applied.
+    /// </summary>
+    /// <param name="forPixelWidth">The width for each pixel (in meters).</param>
+    /// <returns>The number of pixels per meter.</returns>
+    public readonly int GetPixelsPerMeter(int forPixelWidth)
+    {
+        Vector3 result = this * new Vector3(1, 0, -1);
+
+        return (int)((result.X * (real_t)0.5 + (real_t)0.5) * forPixelWidth);
+    }
+
+    /// <summary>
+    /// Returns the clipping plane of this <see cref="Projection"/> whose index is given
+    /// by <paramref name="plane"/>.
+    /// <paramref name="plane"/> should be equal to one of <see cref="Planes.Near"/>,
+    /// <see cref="Planes.Far"/>, <see cref="Planes.Left"/>, <see cref="Planes.Top"/>,
+    /// <see cref="Planes.Right"/>, or <see cref="Planes.Bottom"/>.
+    /// </summary>
+    /// <param name="plane">The kind of clipping plane to get from the projection.</param>
+    /// <returns>The clipping plane of this projection.</returns>
+    public readonly Plane GetProjectionPlane(Planes plane)
+    {
+        Plane newPlane = plane switch
+        {
+            Planes.Near => new Plane(X.W + X.Z, Y.W + Y.Z, Z.W + Z.Z, W.W + W.Z),
+            Planes.Far => new Plane(X.W - X.Z, Y.W - Y.Z, Z.W - Z.Z, W.W - W.Z),
+            Planes.Left => new Plane(X.W + X.X, Y.W + Y.X, Z.W + Z.X, W.W + W.X),
+            Planes.Top => new Plane(X.W - X.Y, Y.W - Y.Y, Z.W - Z.Y, W.W - W.Y),
+            Planes.Right => new Plane(X.W - X.X, Y.W - Y.X, Z.W - Z.X, W.W - W.X),
+            Planes.Bottom => new Plane(X.W + X.Y, Y.W + Y.Y, Z.W + Z.Y, W.W + W.Y),
+            _ => new Plane(),
+        };
+        newPlane.Normal = -newPlane.Normal;
+        return newPlane.Normalized();
+    }
+
+    /// <summary>
+    /// Returns the dimensions of the far clipping plane of the projection, divided by two.
+    /// </summary>
+    /// <returns>The half extents for this projection's far plane.</returns>
+    public readonly Vector2 GetFarPlaneHalfExtents()
+    {
+        var res = GetProjectionPlane(Planes.Far).Intersect3(GetProjectionPlane(Planes.Right), GetProjectionPlane(Planes.Top));
+        return new Vector2(res.Value.X, res.Value.Y);
+    }
+
+    /// <summary>
+    /// Returns the dimensions of the viewport plane that this <see cref="Projection"/>
+    /// projects positions onto, divided by two.
+    /// </summary>
+    /// <returns>The half extents for this projection's viewport plane.</returns>
+    public readonly Vector2 GetViewportHalfExtents()
+    {
+        var res = GetProjectionPlane(Planes.Near).Intersect3(GetProjectionPlane(Planes.Right), GetProjectionPlane(Planes.Top));
+        return new Vector2(res.Value.X, res.Value.Y);
+    }
+
+    /// <summary>
+    /// Returns the distance for this <see cref="Projection"/> beyond which positions are clipped.
+    /// </summary>
+    /// <returns>The distance beyond which positions are clipped.</returns>
+    public readonly real_t GetZFar()
+    {
+        return GetProjectionPlane(Planes.Far).D;
+    }
+
+    /// <summary>
+    /// Returns the distance for this <see cref="Projection"/> before which positions are clipped.
+    /// </summary>
+    /// <returns>The distance before which positions are clipped.</returns>
+    public readonly real_t GetZNear()
+    {
+        return -GetProjectionPlane(Planes.Near).D;
+    }
+
+    /// <summary>
+    /// Returns a copy of this <see cref="Projection"/> with the signs of the values of the Y column flipped.
+    /// </summary>
+    /// <returns>The flipped projection.</returns>
+    public readonly Projection FlippedY()
+    {
+        Projection proj = this;
+        proj.Y = -proj.Y;
+        return proj;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Projection"/> with the near clipping distance adjusted to be
+    /// <paramref name="newZNear"/>.
+    /// Note: The original <see cref="Projection"/> must be a perspective projection.
+    /// </summary>
+    /// <param name="newZNear">The near clipping distance to adjust the projection to.</param>
+    /// <returns>The adjusted projection.</returns>
+    public readonly Projection PerspectiveZNearAdjusted(real_t newZNear)
+    {
+        Projection proj = this;
+        real_t zFar = GetZFar();
+        real_t zNear = newZNear;
+        real_t deltaZ = zFar - zNear;
+        proj.Z.Z = -(zFar + zNear) / deltaZ;
+        proj.W.Z = -2 * zNear * zFar / deltaZ;
+        return proj;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Projection"/> with the X and Y values from the given <see cref="Vector2"/>
+    /// added to the first and second values of the final column respectively.
+    /// </summary>
+    /// <param name="offset">The offset to apply to the projection.</param>
+    /// <returns>The offsetted projection.</returns>
+    public readonly Projection JitterOffseted(Vector2 offset)
+    {
+        Projection proj = this;
+        proj.W.X += offset.X;
+        proj.W.Y += offset.Y;
+        return proj;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Projection"/> that performs the inverse of this <see cref="Projection"/>'s
+    /// projective transformation.
+    /// </summary>
+    /// <returns>The inverted projection.</returns>
+    public readonly Projection Inverse()
+    {
+        Projection proj = this;
+        int i, j, k;
+        int[] pvt_i = new int[4];
+        int[] pvt_j = new int[4]; /* Locations of pivot matrix */
+        real_t pvt_val; /* Value of current pivot element */
+        real_t hold; /* Temporary storage */
+        real_t determinant = 1.0f;
+        for (k = 0; k < 4; k++)
+        {
+            /* Locate k'th pivot element */
+            pvt_val = proj[k][k]; /* Initialize for search */
+            pvt_i[k] = k;
+            pvt_j[k] = k;
+            for (i = k; i < 4; i++)
             {
-                size *= aspect;
+                for (j = k; j < 4; j++)
+                {
+                    if (Mathf.Abs(proj[i][j]) > Mathf.Abs(pvt_val))
+                    {
+                        pvt_i[k] = i;
+                        pvt_j[k] = j;
+                        pvt_val = proj[i][j];
+                    }
+                }
             }
-            return CreateFrustum(-size / 2 + offset.X, +size / 2 + offset.X, -size / aspect / 2 + offset.Y, +size / aspect / 2 + offset.Y, near, far);
-        }
 
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions into the given <see cref="Rect2"/>.
-        /// </summary>
-        /// <param name="rect">The Rect2 to project positions into.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateLightAtlasRect(Rect2 rect)
-        {
-            return new Projection(
-                new Vector4(rect.Size.X, 0, 0, 0),
-                new Vector4(0, rect.Size.Y, 0, 0),
-                new Vector4(0, 0, 1, 0),
-                new Vector4(rect.Position.X, rect.Position.Y, 0, 1)
-            );
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions using an orthogonal projection with
-        /// the given clipping planes.
-        /// </summary>
-        /// <param name="left">The left clipping distance.</param>
-        /// <param name="right">The right clipping distance.</param>
-        /// <param name="bottom">The bottom clipping distance.</param>
-        /// <param name="top">The top clipping distance.</param>
-        /// <param name="zNear">The near clipping distance.</param>
-        /// <param name="zFar">The far clipping distance.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateOrthogonal(real_t left, real_t right, real_t bottom, real_t top, real_t zNear, real_t zFar)
-        {
-            Projection proj = Projection.Identity;
-            proj.X.X = (real_t)2.0 / (right - left);
-            proj.W.X = -((right + left) / (right - left));
-            proj.Y.Y = (real_t)2.0 / (top - bottom);
-            proj.W.Y = -((top + bottom) / (top - bottom));
-            proj.Z.Z = (real_t)(-2.0) / (zFar - zNear);
-            proj.W.Z = -((zFar + zNear) / (zFar - zNear));
-            proj.W.W = (real_t)1.0;
-            return proj;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions using an orthogonal projection with
-        /// the given size, X:Y aspect ratio, and clipping planes.
-        /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
-        /// </summary>
-        /// <param name="size">The frustum size.</param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <param name="zNear">The near clipping distance.</param>
-        /// <param name="zFar">The far clipping distance.</param>
-        /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreateOrthogonalAspect(real_t size, real_t aspect, real_t zNear, real_t zFar, bool flipFov)
-        {
-            if (!flipFov)
-            {
-                size *= aspect;
-            }
-            return CreateOrthogonal(-size / 2, +size / 2, -size / aspect / 2, +size / aspect / 2, zNear, zFar);
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions using a perspective projection with
-        /// the given Y-axis field of view (in degrees), X:Y aspect ratio, and clipping planes.
-        /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
-        /// </summary>
-        /// <param name="fovyDegrees">The vertical field of view (in degrees).</param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <param name="zNear">The near clipping distance.</param>
-        /// <param name="zFar">The far clipping distance.</param>
-        /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreatePerspective(real_t fovyDegrees, real_t aspect, real_t zNear, real_t zFar, bool flipFov)
-        {
-            if (flipFov)
-            {
-                fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
-            }
-            real_t radians = Mathf.DegToRad(fovyDegrees / (real_t)2.0);
-            real_t deltaZ = zFar - zNear;
-            (real_t sin, real_t cos) = Mathf.SinCos(radians);
-
-            if ((deltaZ == 0) || (sin == 0) || (aspect == 0))
+            /* Product of pivots, gives determinant when finished */
+            determinant *= pvt_val;
+            if (Mathf.IsZeroApprox(determinant))
             {
                 return Zero;
             }
 
-            real_t cotangent = cos / sin;
-
-            Projection proj = Projection.Identity;
-
-            proj.X.X = cotangent / aspect;
-            proj.Y.Y = cotangent;
-            proj.Z.Z = -(zFar + zNear) / deltaZ;
-            proj.Z.W = -1;
-            proj.W.Z = -2 * zNear * zFar / deltaZ;
-            proj.W.W = 0;
-
-            return proj;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Projection"/> that projects positions using a perspective projection with
-        /// the given Y-axis field of view (in degrees), X:Y aspect ratio, and clipping distances.
-        /// The projection is adjusted for a head-mounted display with the given distance between eyes and distance
-        /// to a point that can be focused on.
-        /// <paramref name="eye"/> creates the projection for the left eye when set to 1,
-        /// or the right eye when set to 2.
-        /// <paramref name="flipFov"/> determines whether the projection's field of view is flipped over its diagonal.
-        /// </summary>
-        /// <param name="fovyDegrees">The vertical field of view (in degrees).</param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <param name="zNear">The near clipping distance.</param>
-        /// <param name="zFar">The far clipping distance.</param>
-        /// <param name="flipFov">If the field of view is flipped over the projection's diagonal.</param>
-        /// <param name="eye">
-        /// The eye to create the projection for.
-        /// The left eye when set to 1, the right eye when set to 2.
-        /// </param>
-        /// <param name="intraocularDist">The distance between the eyes.</param>
-        /// <param name="convergenceDist">The distance to a point of convergence that can be focused on.</param>
-        /// <returns>The created projection.</returns>
-        public static Projection CreatePerspectiveHmd(real_t fovyDegrees, real_t aspect, real_t zNear, real_t zFar, bool flipFov, int eye, real_t intraocularDist, real_t convergenceDist)
-        {
-            if (flipFov)
-            {
-                fovyDegrees = GetFovy(fovyDegrees, (real_t)1.0 / aspect);
-            }
-
-            real_t ymax = zNear * Mathf.Tan(Mathf.DegToRad(fovyDegrees / (real_t)2.0));
-            real_t xmax = ymax * aspect;
-            real_t frustumshift = (intraocularDist / (real_t)2.0) * zNear / convergenceDist;
-            real_t left;
-            real_t right;
-            real_t modeltranslation;
-            switch (eye)
-            {
-                case 1:
-                    left = -xmax + frustumshift;
-                    right = xmax + frustumshift;
-                    modeltranslation = intraocularDist / (real_t)2.0;
-                    break;
-                case 2:
-                    left = -xmax - frustumshift;
-                    right = xmax - frustumshift;
-                    modeltranslation = -intraocularDist / (real_t)2.0;
-                    break;
-                default:
-                    left = -xmax;
-                    right = xmax;
-                    modeltranslation = (real_t)0.0;
-                    break;
-            }
-            Projection proj = CreateFrustum(left, right, -ymax, ymax, zNear, zFar);
-            Projection cm = Projection.Identity;
-            cm.W.X = modeltranslation;
-            return proj * cm;
-        }
-
-        /// <summary>
-        /// Returns a scalar value that is the signed factor by which areas are scaled by this matrix.
-        /// If the sign is negative, the matrix flips the orientation of the area.
-        /// The determinant can be used to calculate the invertibility of a matrix or solve linear systems
-        /// of equations involving the matrix, among other applications.
-        /// </summary>
-        /// <returns>The determinant calculated from this projection.</returns>
-        public readonly real_t Determinant()
-        {
-            return X.W * Y.Z * Z.Y * W.X - X.Z * Y.W * Z.Y * W.X -
-                   X.W * Y.Y * Z.Z * W.X + X.Y * Y.W * Z.Z * W.X +
-                   X.Z * Y.Y * Z.W * W.X - X.Y * Y.Z * Z.W * W.X -
-                   X.W * Y.Z * Z.X * W.Y + X.Z * Y.W * Z.X * W.Y +
-                   X.W * Y.X * Z.Z * W.Y - X.X * Y.W * Z.Z * W.Y -
-                   X.Z * Y.X * Z.W * W.Y + X.X * Y.Z * Z.W * W.Y +
-                   X.W * Y.Y * Z.X * W.Z - X.Y * Y.W * Z.X * W.Z -
-                   X.W * Y.X * Z.Y * W.Z + X.X * Y.W * Z.Y * W.Z +
-                   X.Y * Y.X * Z.W * W.Z - X.X * Y.Y * Z.W * W.Z -
-                   X.Z * Y.Y * Z.X * W.W + X.Y * Y.Z * Z.X * W.W +
-                   X.Z * Y.X * Z.Y * W.W - X.X * Y.Z * Z.Y * W.W -
-                   X.Y * Y.X * Z.Z * W.W + X.X * Y.Y * Z.Z * W.W;
-        }
-
-        /// <summary>
-        /// Returns the X:Y aspect ratio of this <see cref="Projection"/>'s viewport.
-        /// </summary>
-        /// <returns>The aspect ratio from this projection's viewport.</returns>
-        public readonly real_t GetAspect()
-        {
-            Vector2 vpHe = GetViewportHalfExtents();
-            return vpHe.X / vpHe.Y;
-        }
-
-        /// <summary>
-        /// Returns the horizontal field of view of the projection (in degrees).
-        /// </summary>
-        /// <returns>The horizontal field of view of this projection.</returns>
-        public readonly real_t GetFov()
-        {
-            Plane rightPlane = new Plane(X.W - X.X, Y.W - Y.X, Z.W - Z.X, -W.W + W.X).Normalized();
-            if (Z.X == 0 && Z.Y == 0)
-            {
-                return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.X))) * (real_t)2.0;
-            }
-            else
-            {
-                Plane leftPlane = new Plane(X.W + X.X, Y.W + Y.X, Z.W + Z.X, W.W + W.X).Normalized();
-                return Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(leftPlane.Normal.X))) + Mathf.RadToDeg(Mathf.Acos(Mathf.Abs(rightPlane.Normal.X)));
-            }
-        }
-
-        /// <summary>
-        /// Returns the vertical field of view of the projection (in degrees) associated with
-        /// the given horizontal field of view (in degrees) and aspect ratio.
-        /// </summary>
-        /// <param name="fovx">The horizontal field of view (in degrees).</param>
-        /// <param name="aspect">The aspect ratio.</param>
-        /// <returns>The vertical field of view of this projection.</returns>
-        public static real_t GetFovy(real_t fovx, real_t aspect)
-        {
-            return Mathf.RadToDeg(Mathf.Atan(aspect * Mathf.Tan(Mathf.DegToRad(fovx) * (real_t)0.5)) * (real_t)2.0);
-        }
-
-        /// <summary>
-        /// Returns the factor by which the visible level of detail is scaled by this <see cref="Projection"/>.
-        /// </summary>
-        /// <returns>The level of detail factor for this projection.</returns>
-        public readonly real_t GetLodMultiplier()
-        {
-            if (IsOrthogonal())
-            {
-                return GetViewportHalfExtents().X;
-            }
-            else
-            {
-                real_t zn = GetZNear();
-                real_t width = GetViewportHalfExtents().X * (real_t)2.0;
-                return (real_t)1.0 / (zn / width);
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of pixels with the given pixel width displayed per meter, after
-        /// this <see cref="Projection"/> is applied.
-        /// </summary>
-        /// <param name="forPixelWidth">The width for each pixel (in meters).</param>
-        /// <returns>The number of pixels per meter.</returns>
-        public readonly int GetPixelsPerMeter(int forPixelWidth)
-        {
-            Vector3 result = this * new Vector3(1, 0, -1);
-
-            return (int)((result.X * (real_t)0.5 + (real_t)0.5) * forPixelWidth);
-        }
-
-        /// <summary>
-        /// Returns the clipping plane of this <see cref="Projection"/> whose index is given
-        /// by <paramref name="plane"/>.
-        /// <paramref name="plane"/> should be equal to one of <see cref="Planes.Near"/>,
-        /// <see cref="Planes.Far"/>, <see cref="Planes.Left"/>, <see cref="Planes.Top"/>,
-        /// <see cref="Planes.Right"/>, or <see cref="Planes.Bottom"/>.
-        /// </summary>
-        /// <param name="plane">The kind of clipping plane to get from the projection.</param>
-        /// <returns>The clipping plane of this projection.</returns>
-        public readonly Plane GetProjectionPlane(Planes plane)
-        {
-            Plane newPlane = plane switch
-            {
-                Planes.Near => new Plane(X.W + X.Z, Y.W + Y.Z, Z.W + Z.Z, W.W + W.Z),
-                Planes.Far => new Plane(X.W - X.Z, Y.W - Y.Z, Z.W - Z.Z, W.W - W.Z),
-                Planes.Left => new Plane(X.W + X.X, Y.W + Y.X, Z.W + Z.X, W.W + W.X),
-                Planes.Top => new Plane(X.W - X.Y, Y.W - Y.Y, Z.W - Z.Y, W.W - W.Y),
-                Planes.Right => new Plane(X.W - X.X, Y.W - Y.X, Z.W - Z.X, W.W - W.X),
-                Planes.Bottom => new Plane(X.W + X.Y, Y.W + Y.Y, Z.W + Z.Y, W.W + W.Y),
-                _ => new Plane(),
-            };
-            newPlane.Normal = -newPlane.Normal;
-            return newPlane.Normalized();
-        }
-
-        /// <summary>
-        /// Returns the dimensions of the far clipping plane of the projection, divided by two.
-        /// </summary>
-        /// <returns>The half extents for this projection's far plane.</returns>
-        public readonly Vector2 GetFarPlaneHalfExtents()
-        {
-            var res = GetProjectionPlane(Planes.Far).Intersect3(GetProjectionPlane(Planes.Right), GetProjectionPlane(Planes.Top));
-            return new Vector2(res.Value.X, res.Value.Y);
-        }
-
-        /// <summary>
-        /// Returns the dimensions of the viewport plane that this <see cref="Projection"/>
-        /// projects positions onto, divided by two.
-        /// </summary>
-        /// <returns>The half extents for this projection's viewport plane.</returns>
-        public readonly Vector2 GetViewportHalfExtents()
-        {
-            var res = GetProjectionPlane(Planes.Near).Intersect3(GetProjectionPlane(Planes.Right), GetProjectionPlane(Planes.Top));
-            return new Vector2(res.Value.X, res.Value.Y);
-        }
-
-        /// <summary>
-        /// Returns the distance for this <see cref="Projection"/> beyond which positions are clipped.
-        /// </summary>
-        /// <returns>The distance beyond which positions are clipped.</returns>
-        public readonly real_t GetZFar()
-        {
-            return GetProjectionPlane(Planes.Far).D;
-        }
-
-        /// <summary>
-        /// Returns the distance for this <see cref="Projection"/> before which positions are clipped.
-        /// </summary>
-        /// <returns>The distance before which positions are clipped.</returns>
-        public readonly real_t GetZNear()
-        {
-            return -GetProjectionPlane(Planes.Near).D;
-        }
-
-        /// <summary>
-        /// Returns a copy of this <see cref="Projection"/> with the signs of the values of the Y column flipped.
-        /// </summary>
-        /// <returns>The flipped projection.</returns>
-        public readonly Projection FlippedY()
-        {
-            Projection proj = this;
-            proj.Y = -proj.Y;
-            return proj;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="Projection"/> with the near clipping distance adjusted to be
-        /// <paramref name="newZNear"/>.
-        /// Note: The original <see cref="Projection"/> must be a perspective projection.
-        /// </summary>
-        /// <param name="newZNear">The near clipping distance to adjust the projection to.</param>
-        /// <returns>The adjusted projection.</returns>
-        public readonly Projection PerspectiveZNearAdjusted(real_t newZNear)
-        {
-            Projection proj = this;
-            real_t zFar = GetZFar();
-            real_t zNear = newZNear;
-            real_t deltaZ = zFar - zNear;
-            proj.Z.Z = -(zFar + zNear) / deltaZ;
-            proj.W.Z = -2 * zNear * zFar / deltaZ;
-            return proj;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="Projection"/> with the X and Y values from the given <see cref="Vector2"/>
-        /// added to the first and second values of the final column respectively.
-        /// </summary>
-        /// <param name="offset">The offset to apply to the projection.</param>
-        /// <returns>The offsetted projection.</returns>
-        public readonly Projection JitterOffseted(Vector2 offset)
-        {
-            Projection proj = this;
-            proj.W.X += offset.X;
-            proj.W.Y += offset.Y;
-            return proj;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="Projection"/> that performs the inverse of this <see cref="Projection"/>'s
-        /// projective transformation.
-        /// </summary>
-        /// <returns>The inverted projection.</returns>
-        public readonly Projection Inverse()
-        {
-            Projection proj = this;
-            int i, j, k;
-            int[] pvt_i = new int[4];
-            int[] pvt_j = new int[4]; /* Locations of pivot matrix */
-            real_t pvt_val; /* Value of current pivot element */
-            real_t hold; /* Temporary storage */
-            real_t determinant = 1.0f;
-            for (k = 0; k < 4; k++)
-            {
-                /* Locate k'th pivot element */
-                pvt_val = proj[k][k]; /* Initialize for search */
-                pvt_i[k] = k;
-                pvt_j[k] = k;
-                for (i = k; i < 4; i++)
+            /* "Interchange" rows (with sign change stuff) */
+            i = pvt_i[k];
+            if (i != k)
+            { /* If rows are different */
+                for (j = 0; j < 4; j++)
                 {
-                    for (j = k; j < 4; j++)
-                    {
-                        if (Mathf.Abs(proj[i][j]) > Mathf.Abs(pvt_val))
-                        {
-                            pvt_i[k] = i;
-                            pvt_j[k] = j;
-                            pvt_val = proj[i][j];
-                        }
-                    }
+                    hold = -proj[k][j];
+                    proj[k, j] = proj[i][j];
+                    proj[i, j] = hold;
                 }
+            }
 
-                /* Product of pivots, gives determinant when finished */
-                determinant *= pvt_val;
-                if (Mathf.IsZeroApprox(determinant))
-                {
-                    return Zero;
-                }
-
-                /* "Interchange" rows (with sign change stuff) */
-                i = pvt_i[k];
-                if (i != k)
-                { /* If rows are different */
-                    for (j = 0; j < 4; j++)
-                    {
-                        hold = -proj[k][j];
-                        proj[k, j] = proj[i][j];
-                        proj[i, j] = hold;
-                    }
-                }
-
-                /* "Interchange" columns */
-                j = pvt_j[k];
-                if (j != k)
-                { /* If columns are different */
-                    for (i = 0; i < 4; i++)
-                    {
-                        hold = -proj[i][k];
-                        proj[i, k] = proj[i][j];
-                        proj[i, j] = hold;
-                    }
-                }
-
-                /* Divide column by minus pivot value */
+            /* "Interchange" columns */
+            j = pvt_j[k];
+            if (j != k)
+            { /* If columns are different */
                 for (i = 0; i < 4; i++)
                 {
-                    if (i != k)
+                    hold = -proj[i][k];
+                    proj[i, k] = proj[i][j];
+                    proj[i, j] = hold;
+                }
+            }
+
+            /* Divide column by minus pivot value */
+            for (i = 0; i < 4; i++)
+            {
+                if (i != k)
+                {
+                    proj[i, k] /= (-pvt_val);
+                }
+            }
+
+            /* Reduce the matrix */
+            for (i = 0; i < 4; i++)
+            {
+                hold = proj[i][k];
+                for (j = 0; j < 4; j++)
+                {
+                    if (i != k && j != k)
                     {
-                        proj[i, k] /= (-pvt_val);
+                        proj[i, j] += hold * proj[k][j];
                     }
                 }
+            }
 
-                /* Reduce the matrix */
+            /* Divide row by pivot */
+            for (j = 0; j < 4; j++)
+            {
+                if (j != k)
+                {
+                    proj[k, j] /= pvt_val;
+                }
+            }
+
+            /* Replace pivot by reciprocal (at last we can touch it). */
+            proj[k, k] = (real_t)1.0 / pvt_val;
+        }
+
+        /* That was most of the work, one final pass of row/column interchange */
+        /* to finish */
+        for (k = 4 - 2; k >= 0; k--)
+        { /* Don't need to work with 1 by 1 corner*/
+            i = pvt_j[k]; /* Rows to swap correspond to pivot COLUMN */
+            if (i != k)
+            { /* If rows are different */
+                for (j = 0; j < 4; j++)
+                {
+                    hold = proj[k][j];
+                    proj[k, j] = -proj[i][j];
+                    proj[i, j] = hold;
+                }
+            }
+
+            j = pvt_i[k]; /* Columns to swap correspond to pivot ROW */
+            if (j != k)
+            { /* If columns are different */
                 for (i = 0; i < 4; i++)
                 {
                     hold = proj[i][k];
-                    for (j = 0; j < 4; j++)
-                    {
-                        if (i != k && j != k)
-                        {
-                            proj[i, j] += hold * proj[k][j];
-                        }
-                    }
-                }
-
-                /* Divide row by pivot */
-                for (j = 0; j < 4; j++)
-                {
-                    if (j != k)
-                    {
-                        proj[k, j] /= pvt_val;
-                    }
-                }
-
-                /* Replace pivot by reciprocal (at last we can touch it). */
-                proj[k, k] = (real_t)1.0 / pvt_val;
-            }
-
-            /* That was most of the work, one final pass of row/column interchange */
-            /* to finish */
-            for (k = 4 - 2; k >= 0; k--)
-            { /* Don't need to work with 1 by 1 corner*/
-                i = pvt_j[k]; /* Rows to swap correspond to pivot COLUMN */
-                if (i != k)
-                { /* If rows are different */
-                    for (j = 0; j < 4; j++)
-                    {
-                        hold = proj[k][j];
-                        proj[k, j] = -proj[i][j];
-                        proj[i, j] = hold;
-                    }
-                }
-
-                j = pvt_i[k]; /* Columns to swap correspond to pivot ROW */
-                if (j != k)
-                { /* If columns are different */
-                    for (i = 0; i < 4; i++)
-                    {
-                        hold = proj[i][k];
-                        proj[i, k] = -proj[i][j];
-                        proj[i, j] = hold;
-                    }
+                    proj[i, k] = -proj[i][j];
+                    proj[i, j] = hold;
                 }
             }
-            return proj;
         }
+        return proj;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Projection"/> performs an orthogonal projection.
-        /// </summary>
-        /// <returns>If the projection performs an orthogonal projection.</returns>
-        public readonly bool IsOrthogonal()
-        {
-            return W.W == (real_t)1.0;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Projection"/> performs an orthogonal projection.
+    /// </summary>
+    /// <returns>If the projection performs an orthogonal projection.</returns>
+    public readonly bool IsOrthogonal()
+    {
+        return W.W == (real_t)1.0;
+    }
 
-        // Constants
-        private static readonly Projection _zero = new Projection(
-            new Vector4(0, 0, 0, 0),
-            new Vector4(0, 0, 0, 0),
-            new Vector4(0, 0, 0, 0),
-            new Vector4(0, 0, 0, 0)
+    // Constants
+    private static readonly Projection _zero = new Projection(
+        new Vector4(0, 0, 0, 0),
+        new Vector4(0, 0, 0, 0),
+        new Vector4(0, 0, 0, 0),
+        new Vector4(0, 0, 0, 0)
+    );
+    private static readonly Projection _identity = new Projection(
+        new Vector4(1, 0, 0, 0),
+        new Vector4(0, 1, 0, 0),
+        new Vector4(0, 0, 1, 0),
+        new Vector4(0, 0, 0, 1)
+    );
+
+    /// <summary>
+    /// Zero projection, a projection with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Projection(Vector4.Zero, Vector4.Zero, Vector4.Zero, Vector4.Zero)</c>.</value>
+    public static Projection Zero { get { return _zero; } }
+
+    /// <summary>
+    /// The identity projection, with no distortion applied.
+    /// This is used as a replacement for <c>Projection()</c> in GDScript.
+    /// Do not use <c>new Projection()</c> with no arguments in C#, because it sets all values to zero.
+    /// </summary>
+    /// <value>Equivalent to <c>new Projection(new Vector4(1, 0, 0, 0), new Vector4(0, 1, 0, 0), new Vector4(0, 0, 1, 0), new Vector4(0, 0, 0, 1))</c>.</value>
+    public static Projection Identity { get { return _identity; } }
+
+    /// <summary>
+    /// Constructs a projection from 4 vectors (matrix columns).
+    /// </summary>
+    /// <param name="x">The X column, or column index 0.</param>
+    /// <param name="y">The Y column, or column index 1.</param>
+    /// <param name="z">The Z column, or column index 2.</param>
+    /// <param name="w">The W column, or column index 3.</param>
+    public Projection(Vector4 x, Vector4 y, Vector4 z, Vector4 w)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        W = w;
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="Projection"/> from a <see cref="Transform3D"/>.
+    /// </summary>
+    /// <param name="transform">The <see cref="Transform3D"/>.</param>
+    public Projection(Transform3D transform)
+    {
+        X = new Vector4(transform.Basis.Row0.X, transform.Basis.Row1.X, transform.Basis.Row2.X, 0);
+        Y = new Vector4(transform.Basis.Row0.Y, transform.Basis.Row1.Y, transform.Basis.Row2.Y, 0);
+        Z = new Vector4(transform.Basis.Row0.Z, transform.Basis.Row1.Z, transform.Basis.Row2.Z, 0);
+        W = new Vector4(transform.Origin.X, transform.Origin.Y, transform.Origin.Z, 1);
+    }
+
+    /// <summary>
+    /// Composes these two projections by multiplying them
+    /// together. This has the effect of applying the right
+    /// and then the left projection.
+    /// </summary>
+    /// <param name="left">The parent transform.</param>
+    /// <param name="right">The child transform.</param>
+    /// <returns>The composed projection.</returns>
+    public static Projection operator *(Projection left, Projection right)
+    {
+        return new Projection(
+            new Vector4(
+                left.X.X * right.X.X + left.Y.X * right.X.Y + left.Z.X * right.X.Z + left.W.X * right.X.W,
+                left.X.Y * right.X.X + left.Y.Y * right.X.Y + left.Z.Y * right.X.Z + left.W.Y * right.X.W,
+                left.X.Z * right.X.X + left.Y.Z * right.X.Y + left.Z.Z * right.X.Z + left.W.Z * right.X.W,
+                left.X.W * right.X.X + left.Y.W * right.X.Y + left.Z.W * right.X.Z + left.W.W * right.X.W
+            ), new Vector4(
+                left.X.X * right.Y.X + left.Y.X * right.Y.Y + left.Z.X * right.Y.Z + left.W.X * right.Y.W,
+                left.X.Y * right.Y.X + left.Y.Y * right.Y.Y + left.Z.Y * right.Y.Z + left.W.Y * right.Y.W,
+                left.X.Z * right.Y.X + left.Y.Z * right.Y.Y + left.Z.Z * right.Y.Z + left.W.Z * right.Y.W,
+                left.X.W * right.Y.X + left.Y.W * right.Y.Y + left.Z.W * right.Y.Z + left.W.W * right.Y.W
+            ), new Vector4(
+                left.X.X * right.Z.X + left.Y.X * right.Z.Y + left.Z.X * right.Z.Z + left.W.X * right.Z.W,
+                left.X.Y * right.Z.X + left.Y.Y * right.Z.Y + left.Z.Y * right.Z.Z + left.W.Y * right.Z.W,
+                left.X.Z * right.Z.X + left.Y.Z * right.Z.Y + left.Z.Z * right.Z.Z + left.W.Z * right.Z.W,
+                left.X.W * right.Z.X + left.Y.W * right.Z.Y + left.Z.W * right.Z.Z + left.W.W * right.Z.W
+            ), new Vector4(
+                left.X.X * right.W.X + left.Y.X * right.W.Y + left.Z.X * right.W.Z + left.W.X * right.W.W,
+                left.X.Y * right.W.X + left.Y.Y * right.W.Y + left.Z.Y * right.W.Z + left.W.Y * right.W.W,
+                left.X.Z * right.W.X + left.Y.Z * right.W.Y + left.Z.Z * right.W.Z + left.W.Z * right.W.W,
+                left.X.W * right.W.X + left.Y.W * right.W.Y + left.Z.W * right.W.Z + left.W.W * right.W.W
+            )
         );
-        private static readonly Projection _identity = new Projection(
-            new Vector4(1, 0, 0, 0),
-            new Vector4(0, 1, 0, 0),
-            new Vector4(0, 0, 1, 0),
-            new Vector4(0, 0, 0, 1)
+    }
+
+    /// <summary>
+    /// Returns a Vector4 transformed (multiplied) by the projection.
+    /// </summary>
+    /// <param name="proj">The projection to apply.</param>
+    /// <param name="vector">A Vector4 to transform.</param>
+    /// <returns>The transformed Vector4.</returns>
+    public static Vector4 operator *(Projection proj, Vector4 vector)
+    {
+        return new Vector4(
+            proj.X.X * vector.X + proj.Y.X * vector.Y + proj.Z.X * vector.Z + proj.W.X * vector.W,
+            proj.X.Y * vector.X + proj.Y.Y * vector.Y + proj.Z.Y * vector.Z + proj.W.Y * vector.W,
+            proj.X.Z * vector.X + proj.Y.Z * vector.Y + proj.Z.Z * vector.Z + proj.W.Z * vector.W,
+            proj.X.W * vector.X + proj.Y.W * vector.Y + proj.Z.W * vector.Z + proj.W.W * vector.W
         );
+    }
 
-        /// <summary>
-        /// Zero projection, a projection with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Projection(Vector4.Zero, Vector4.Zero, Vector4.Zero, Vector4.Zero)</c>.</value>
-        public static Projection Zero { get { return _zero; } }
+    /// <summary>
+    /// Returns a Vector4 transformed (multiplied) by the inverse projection.
+    /// </summary>
+    /// <param name="proj">The projection to apply.</param>
+    /// <param name="vector">A Vector4 to transform.</param>
+    /// <returns>The inversely transformed Vector4.</returns>
+    public static Vector4 operator *(Vector4 vector, Projection proj)
+    {
+        return new Vector4(
+            proj.X.X * vector.X + proj.X.Y * vector.Y + proj.X.Z * vector.Z + proj.X.W * vector.W,
+            proj.Y.X * vector.X + proj.Y.Y * vector.Y + proj.Y.Z * vector.Z + proj.Y.W * vector.W,
+            proj.Z.X * vector.X + proj.Z.Y * vector.Y + proj.Z.Z * vector.Z + proj.Z.W * vector.W,
+            proj.W.X * vector.X + proj.W.Y * vector.Y + proj.W.Z * vector.Z + proj.W.W * vector.W
+        );
+    }
 
-        /// <summary>
-        /// The identity projection, with no distortion applied.
-        /// This is used as a replacement for <c>Projection()</c> in GDScript.
-        /// Do not use <c>new Projection()</c> with no arguments in C#, because it sets all values to zero.
-        /// </summary>
-        /// <value>Equivalent to <c>new Projection(new Vector4(1, 0, 0, 0), new Vector4(0, 1, 0, 0), new Vector4(0, 0, 1, 0), new Vector4(0, 0, 0, 1))</c>.</value>
-        public static Projection Identity { get { return _identity; } }
+    /// <summary>
+    /// Returns a Vector3 transformed (multiplied) by the projection.
+    /// </summary>
+    /// <param name="proj">The projection to apply.</param>
+    /// <param name="vector">A Vector3 to transform.</param>
+    /// <returns>The transformed Vector3.</returns>
+    public static Vector3 operator *(Projection proj, Vector3 vector)
+    {
+        Vector3 ret = new Vector3(
+            proj.X.X * vector.X + proj.Y.X * vector.Y + proj.Z.X * vector.Z + proj.W.X,
+            proj.X.Y * vector.X + proj.Y.Y * vector.Y + proj.Z.Y * vector.Z + proj.W.Y,
+            proj.X.Z * vector.X + proj.Y.Z * vector.Y + proj.Z.Z * vector.Z + proj.W.Z
+        );
+        return ret / (proj.X.W * vector.X + proj.Y.W * vector.Y + proj.Z.W * vector.Z + proj.W.W);
+    }
 
-        /// <summary>
-        /// Constructs a projection from 4 vectors (matrix columns).
-        /// </summary>
-        /// <param name="x">The X column, or column index 0.</param>
-        /// <param name="y">The Y column, or column index 1.</param>
-        /// <param name="z">The Z column, or column index 2.</param>
-        /// <param name="w">The W column, or column index 3.</param>
-        public Projection(Vector4 x, Vector4 y, Vector4 z, Vector4 w)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-            W = w;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the projections are exactly equal.
+    /// </summary>
+    /// <param name="left">The left projection.</param>
+    /// <param name="right">The right projection.</param>
+    /// <returns>Whether or not the projections are exactly equal.</returns>
+    public static bool operator ==(Projection left, Projection right)
+    {
+        return left.Equals(right);
+    }
 
-        /// <summary>
-        /// Constructs a new <see cref="Projection"/> from a <see cref="Transform3D"/>.
-        /// </summary>
-        /// <param name="transform">The <see cref="Transform3D"/>.</param>
-        public Projection(Transform3D transform)
-        {
-            X = new Vector4(transform.Basis.Row0.X, transform.Basis.Row1.X, transform.Basis.Row2.X, 0);
-            Y = new Vector4(transform.Basis.Row0.Y, transform.Basis.Row1.Y, transform.Basis.Row2.Y, 0);
-            Z = new Vector4(transform.Basis.Row0.Z, transform.Basis.Row1.Z, transform.Basis.Row2.Z, 0);
-            W = new Vector4(transform.Origin.X, transform.Origin.Y, transform.Origin.Z, 1);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the projections are not exactly equal.
+    /// </summary>
+    /// <param name="left">The left projection.</param>
+    /// <param name="right">The right projection.</param>
+    /// <returns>Whether or not the projections are not exactly equal.</returns>
+    public static bool operator !=(Projection left, Projection right)
+    {
+        return !left.Equals(right);
+    }
 
-        /// <summary>
-        /// Composes these two projections by multiplying them
-        /// together. This has the effect of applying the right
-        /// and then the left projection.
-        /// </summary>
-        /// <param name="left">The parent transform.</param>
-        /// <param name="right">The child transform.</param>
-        /// <returns>The composed projection.</returns>
-        public static Projection operator *(Projection left, Projection right)
-        {
-            return new Projection(
-                new Vector4(
-                    left.X.X * right.X.X + left.Y.X * right.X.Y + left.Z.X * right.X.Z + left.W.X * right.X.W,
-                    left.X.Y * right.X.X + left.Y.Y * right.X.Y + left.Z.Y * right.X.Z + left.W.Y * right.X.W,
-                    left.X.Z * right.X.X + left.Y.Z * right.X.Y + left.Z.Z * right.X.Z + left.W.Z * right.X.W,
-                    left.X.W * right.X.X + left.Y.W * right.X.Y + left.Z.W * right.X.Z + left.W.W * right.X.W
-                ), new Vector4(
-                    left.X.X * right.Y.X + left.Y.X * right.Y.Y + left.Z.X * right.Y.Z + left.W.X * right.Y.W,
-                    left.X.Y * right.Y.X + left.Y.Y * right.Y.Y + left.Z.Y * right.Y.Z + left.W.Y * right.Y.W,
-                    left.X.Z * right.Y.X + left.Y.Z * right.Y.Y + left.Z.Z * right.Y.Z + left.W.Z * right.Y.W,
-                    left.X.W * right.Y.X + left.Y.W * right.Y.Y + left.Z.W * right.Y.Z + left.W.W * right.Y.W
-                ), new Vector4(
-                    left.X.X * right.Z.X + left.Y.X * right.Z.Y + left.Z.X * right.Z.Z + left.W.X * right.Z.W,
-                    left.X.Y * right.Z.X + left.Y.Y * right.Z.Y + left.Z.Y * right.Z.Z + left.W.Y * right.Z.W,
-                    left.X.Z * right.Z.X + left.Y.Z * right.Z.Y + left.Z.Z * right.Z.Z + left.W.Z * right.Z.W,
-                    left.X.W * right.Z.X + left.Y.W * right.Z.Y + left.Z.W * right.Z.Z + left.W.W * right.Z.W
-                ), new Vector4(
-                    left.X.X * right.W.X + left.Y.X * right.W.Y + left.Z.X * right.W.Z + left.W.X * right.W.W,
-                    left.X.Y * right.W.X + left.Y.Y * right.W.Y + left.Z.Y * right.W.Z + left.W.Y * right.W.W,
-                    left.X.Z * right.W.X + left.Y.Z * right.W.Y + left.Z.Z * right.W.Z + left.W.Z * right.W.W,
-                    left.X.W * right.W.X + left.Y.W * right.W.Y + left.Z.W * right.W.Z + left.W.W * right.W.W
-                )
-            );
-        }
+    /// <summary>
+    /// Constructs a new <see cref="Transform3D"/> from the <see cref="Projection"/>.
+    /// </summary>
+    /// <param name="proj">The <see cref="Projection"/>.</param>
+    public static explicit operator Transform3D(Projection proj)
+    {
+        return new Transform3D(
+            new Basis(
+                new Vector3(proj.X.X, proj.X.Y, proj.X.Z),
+                new Vector3(proj.Y.X, proj.Y.Y, proj.Y.Z),
+                new Vector3(proj.Z.X, proj.Z.Y, proj.Z.Z)
+            ),
+            new Vector3(proj.W.X, proj.W.Y, proj.W.Z)
+        );
+    }
 
-        /// <summary>
-        /// Returns a Vector4 transformed (multiplied) by the projection.
-        /// </summary>
-        /// <param name="proj">The projection to apply.</param>
-        /// <param name="vector">A Vector4 to transform.</param>
-        /// <returns>The transformed Vector4.</returns>
-        public static Vector4 operator *(Projection proj, Vector4 vector)
-        {
-            return new Vector4(
-                proj.X.X * vector.X + proj.Y.X * vector.Y + proj.Z.X * vector.Z + proj.W.X * vector.W,
-                proj.X.Y * vector.X + proj.Y.Y * vector.Y + proj.Z.Y * vector.Z + proj.W.Y * vector.W,
-                proj.X.Z * vector.X + proj.Y.Z * vector.Y + proj.Z.Z * vector.Z + proj.W.Z * vector.W,
-                proj.X.W * vector.X + proj.Y.W * vector.Y + proj.Z.W * vector.Z + proj.W.W * vector.W
-            );
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the projection is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Projection other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns a Vector4 transformed (multiplied) by the inverse projection.
-        /// </summary>
-        /// <param name="proj">The projection to apply.</param>
-        /// <param name="vector">A Vector4 to transform.</param>
-        /// <returns>The inversely transformed Vector4.</returns>
-        public static Vector4 operator *(Vector4 vector, Projection proj)
-        {
-            return new Vector4(
-                proj.X.X * vector.X + proj.X.Y * vector.Y + proj.X.Z * vector.Z + proj.X.W * vector.W,
-                proj.Y.X * vector.X + proj.Y.Y * vector.Y + proj.Y.Z * vector.Z + proj.Y.W * vector.W,
-                proj.Z.X * vector.X + proj.Z.Y * vector.Y + proj.Z.Z * vector.Z + proj.Z.W * vector.W,
-                proj.W.X * vector.X + proj.W.Y * vector.Y + proj.W.Z * vector.Z + proj.W.W * vector.W
-            );
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the projections are exactly equal.
+    /// </summary>
+    /// <param name="other">The other projection.</param>
+    /// <returns>Whether or not the projections are exactly equal.</returns>
+    public readonly bool Equals(Projection other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
+    }
 
-        /// <summary>
-        /// Returns a Vector3 transformed (multiplied) by the projection.
-        /// </summary>
-        /// <param name="proj">The projection to apply.</param>
-        /// <param name="vector">A Vector3 to transform.</param>
-        /// <returns>The transformed Vector3.</returns>
-        public static Vector3 operator *(Projection proj, Vector3 vector)
-        {
-            Vector3 ret = new Vector3(
-                proj.X.X * vector.X + proj.Y.X * vector.Y + proj.Z.X * vector.Z + proj.W.X,
-                proj.X.Y * vector.X + proj.Y.Y * vector.Y + proj.Z.Y * vector.Z + proj.W.Y,
-                proj.X.Z * vector.X + proj.Y.Z * vector.Y + proj.Z.Z * vector.Z + proj.W.Z
-            );
-            return ret / (proj.X.W * vector.X + proj.Y.W * vector.Y + proj.Z.W * vector.Z + proj.W.W);
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Projection"/>.
+    /// </summary>
+    /// <returns>A hash code for this projection.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the projections are exactly equal.
-        /// </summary>
-        /// <param name="left">The left projection.</param>
-        /// <param name="right">The right projection.</param>
-        /// <returns>Whether or not the projections are exactly equal.</returns>
-        public static bool operator ==(Projection left, Projection right)
-        {
-            return left.Equals(right);
-        }
+    /// <summary>
+    /// Converts this <see cref="Projection"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this projection.</returns>
+    public override readonly string ToString()
+    {
+        return $"{X.X}, {X.Y}, {X.Z}, {X.W}\n{Y.X}, {Y.Y}, {Y.Z}, {Y.W}\n{Z.X}, {Z.Y}, {Z.Z}, {Z.W}\n{W.X}, {W.Y}, {W.Z}, {W.W}\n";
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the projections are not exactly equal.
-        /// </summary>
-        /// <param name="left">The left projection.</param>
-        /// <param name="right">The right projection.</param>
-        /// <returns>Whether or not the projections are not exactly equal.</returns>
-        public static bool operator !=(Projection left, Projection right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Transform3D"/> from the <see cref="Projection"/>.
-        /// </summary>
-        /// <param name="proj">The <see cref="Projection"/>.</param>
-        public static explicit operator Transform3D(Projection proj)
-        {
-            return new Transform3D(
-                new Basis(
-                    new Vector3(proj.X.X, proj.X.Y, proj.X.Z),
-                    new Vector3(proj.Y.X, proj.Y.Y, proj.Y.Z),
-                    new Vector3(proj.Z.X, proj.Z.Y, proj.Z.Z)
-                ),
-                new Vector3(proj.W.X, proj.W.Y, proj.W.Z)
-            );
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the projection is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Projection other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the projections are exactly equal.
-        /// </summary>
-        /// <param name="other">The other projection.</param>
-        /// <returns>Whether or not the projections are exactly equal.</returns>
-        public readonly bool Equals(Projection other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Projection"/>.
-        /// </summary>
-        /// <returns>A hash code for this projection.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Projection"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this projection.</returns>
-        public override readonly string ToString()
-        {
-            return $"{X.X}, {X.Y}, {X.Z}, {X.W}\n{Y.X}, {Y.Y}, {Y.Z}, {Y.W}\n{Z.X}, {Z.Y}, {Z.Z}, {Z.W}\n{W.X}, {W.Y}, {W.Z}, {W.W}\n";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Projection"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this projection.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"{X.X.ToString(format)}, {X.Y.ToString(format)}, {X.Z.ToString(format)}, {X.W.ToString(format)}\n" +
-                $"{Y.X.ToString(format)}, {Y.Y.ToString(format)}, {Y.Z.ToString(format)}, {Y.W.ToString(format)}\n" +
-                $"{Z.X.ToString(format)}, {Z.Y.ToString(format)}, {Z.Z.ToString(format)}, {Z.W.ToString(format)}\n" +
-                $"{W.X.ToString(format)}, {W.Y.ToString(format)}, {W.Z.ToString(format)}, {W.W.ToString(format)}\n";
-        }
+    /// <summary>
+    /// Converts this <see cref="Projection"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this projection.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"{X.X.ToString(format)}, {X.Y.ToString(format)}, {X.Z.ToString(format)}, {X.W.ToString(format)}\n" +
+            $"{Y.X.ToString(format)}, {Y.Y.ToString(format)}, {Y.Z.ToString(format)}, {Y.W.ToString(format)}\n" +
+            $"{Z.X.ToString(format)}, {Z.Y.ToString(format)}, {Z.Z.ToString(format)}, {Z.W.ToString(format)}\n" +
+            $"{W.X.ToString(format)}, {W.Y.ToString(format)}, {W.Z.ToString(format)}, {W.W.ToString(format)}\n";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -1,824 +1,823 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// A unit quaternion used for representing 3D rotations.
+/// Quaternions need to be normalized to be used for rotation.
+///
+/// It is similar to <see cref="Basis"/>, which implements matrix
+/// representation of rotations, and can be parametrized using both
+/// an axis-angle pair or Euler angles. Basis stores rotation, scale,
+/// and shearing, while Quaternion only stores rotation.
+///
+/// Due to its compactness and the way it is stored in memory, certain
+/// operations (obtaining axis-angle and performing SLERP, in particular)
+/// are more efficient and robust against floating-point errors.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Quaternion : IEquatable<Quaternion>
 {
     /// <summary>
-    /// A unit quaternion used for representing 3D rotations.
-    /// Quaternions need to be normalized to be used for rotation.
-    ///
-    /// It is similar to <see cref="Basis"/>, which implements matrix
-    /// representation of rotations, and can be parametrized using both
-    /// an axis-angle pair or Euler angles. Basis stores rotation, scale,
-    /// and shearing, while Quaternion only stores rotation.
-    ///
-    /// Due to its compactness and the way it is stored in memory, certain
-    /// operations (obtaining axis-angle and performing SLERP, in particular)
-    /// are more efficient and robust against floating-point errors.
+    /// X component of the quaternion (imaginary <c>i</c> axis part).
+    /// Quaternion components should usually not be manipulated directly.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Quaternion : IEquatable<Quaternion>
+    public real_t X;
+
+    /// <summary>
+    /// Y component of the quaternion (imaginary <c>j</c> axis part).
+    /// Quaternion components should usually not be manipulated directly.
+    /// </summary>
+    public real_t Y;
+
+    /// <summary>
+    /// Z component of the quaternion (imaginary <c>k</c> axis part).
+    /// Quaternion components should usually not be manipulated directly.
+    /// </summary>
+    public real_t Z;
+
+    /// <summary>
+    /// W component of the quaternion (real part).
+    /// Quaternion components should usually not be manipulated directly.
+    /// </summary>
+    public real_t W;
+
+    /// <summary>
+    /// Access quaternion components using their index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>,
+    /// <c>[2]</c> is equivalent to <see cref="Z"/>,
+    /// <c>[3]</c> is equivalent to <see cref="W"/>.
+    /// </value>
+    public real_t this[int index]
     {
-        /// <summary>
-        /// X component of the quaternion (imaginary <c>i</c> axis part).
-        /// Quaternion components should usually not be manipulated directly.
-        /// </summary>
-        public real_t X;
-
-        /// <summary>
-        /// Y component of the quaternion (imaginary <c>j</c> axis part).
-        /// Quaternion components should usually not be manipulated directly.
-        /// </summary>
-        public real_t Y;
-
-        /// <summary>
-        /// Z component of the quaternion (imaginary <c>k</c> axis part).
-        /// Quaternion components should usually not be manipulated directly.
-        /// </summary>
-        public real_t Z;
-
-        /// <summary>
-        /// W component of the quaternion (real part).
-        /// Quaternion components should usually not be manipulated directly.
-        /// </summary>
-        public real_t W;
-
-        /// <summary>
-        /// Access quaternion components using their index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>,
-        /// <c>[2]</c> is equivalent to <see cref="Z"/>,
-        /// <c>[3]</c> is equivalent to <see cref="W"/>.
-        /// </value>
-        public real_t this[int index]
+        readonly get
         {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    case 3:
-                        return W;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        break;
-                    case 1:
-                        Y = value;
-                        break;
-                    case 2:
-                        Z = value;
-                        break;
-                    case 3:
-                        W = value;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Z;
+                case 3:
+                    return W;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Returns the angle between this quaternion and <paramref name="to"/>.
-        /// This is the magnitude of the angle you would need to rotate
-        /// by to get from one to the other.
-        ///
-        /// Note: This method has an abnormally high amount
-        /// of floating-point error, so methods such as
-        /// <see cref="Mathf.IsZeroApprox"/> will not work reliably.
-        /// </summary>
-        /// <param name="to">The other quaternion.</param>
-        /// <returns>The angle between the quaternions.</returns>
-        public readonly real_t AngleTo(Quaternion to)
+        set
         {
-            real_t dot = Dot(to);
-            return Mathf.Acos(Mathf.Clamp(dot * dot * 2 - 1, -1, 1));
+            switch (index)
+            {
+                case 0:
+                    X = value;
+                    break;
+                case 1:
+                    Y = value;
+                    break;
+                case 2:
+                    Z = value;
+                    break;
+                case 3:
+                    W = value;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
         }
+    }
 
-        /// <summary>
-        /// Performs a spherical cubic interpolation between quaternions <paramref name="preA"/>, this quaternion,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="b">The destination quaternion.</param>
-        /// <param name="preA">A quaternion before this quaternion.</param>
-        /// <param name="postB">A quaternion after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated quaternion.</returns>
-        public readonly Quaternion SphericalCubicInterpolate(Quaternion b, Quaternion preA, Quaternion postB, real_t weight)
-        {
+    /// <summary>
+    /// Returns the angle between this quaternion and <paramref name="to"/>.
+    /// This is the magnitude of the angle you would need to rotate
+    /// by to get from one to the other.
+    ///
+    /// Note: This method has an abnormally high amount
+    /// of floating-point error, so methods such as
+    /// <see cref="Mathf.IsZeroApprox"/> will not work reliably.
+    /// </summary>
+    /// <param name="to">The other quaternion.</param>
+    /// <returns>The angle between the quaternions.</returns>
+    public readonly real_t AngleTo(Quaternion to)
+    {
+        real_t dot = Dot(to);
+        return Mathf.Acos(Mathf.Clamp(dot * dot * 2 - 1, -1, 1));
+    }
+
+    /// <summary>
+    /// Performs a spherical cubic interpolation between quaternions <paramref name="preA"/>, this quaternion,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="b">The destination quaternion.</param>
+    /// <param name="preA">A quaternion before this quaternion.</param>
+    /// <param name="postB">A quaternion after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated quaternion.</returns>
+    public readonly Quaternion SphericalCubicInterpolate(Quaternion b, Quaternion preA, Quaternion postB, real_t weight)
+    {
 #if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized");
-            }
-            if (!b.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized", nameof(b));
-            }
+        if (!IsNormalized())
+        {
+            throw new InvalidOperationException("Quaternion is not normalized");
+        }
+        if (!b.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized", nameof(b));
+        }
 #endif
 
-            // Align flip phases.
-            Quaternion fromQ = new Basis(this).GetRotationQuaternion();
-            Quaternion preQ = new Basis(preA).GetRotationQuaternion();
-            Quaternion toQ = new Basis(b).GetRotationQuaternion();
-            Quaternion postQ = new Basis(postB).GetRotationQuaternion();
+        // Align flip phases.
+        Quaternion fromQ = new Basis(this).GetRotationQuaternion();
+        Quaternion preQ = new Basis(preA).GetRotationQuaternion();
+        Quaternion toQ = new Basis(b).GetRotationQuaternion();
+        Quaternion postQ = new Basis(postB).GetRotationQuaternion();
 
-            // Flip quaternions to shortest path if necessary.
-            bool flip1 = Math.Sign(fromQ.Dot(preQ)) < 0;
-            preQ = flip1 ? -preQ : preQ;
-            bool flip2 = Math.Sign(fromQ.Dot(toQ)) < 0;
-            toQ = flip2 ? -toQ : toQ;
-            bool flip3 = flip2 ? toQ.Dot(postQ) <= 0 : Math.Sign(toQ.Dot(postQ)) < 0;
-            postQ = flip3 ? -postQ : postQ;
+        // Flip quaternions to shortest path if necessary.
+        bool flip1 = Math.Sign(fromQ.Dot(preQ)) < 0;
+        preQ = flip1 ? -preQ : preQ;
+        bool flip2 = Math.Sign(fromQ.Dot(toQ)) < 0;
+        toQ = flip2 ? -toQ : toQ;
+        bool flip3 = flip2 ? toQ.Dot(postQ) <= 0 : Math.Sign(toQ.Dot(postQ)) < 0;
+        postQ = flip3 ? -postQ : postQ;
 
-            // Calc by Expmap in fromQ space.
-            Quaternion lnFrom = new Quaternion(0, 0, 0, 0);
-            Quaternion lnTo = (fromQ.Inverse() * toQ).Log();
-            Quaternion lnPre = (fromQ.Inverse() * preQ).Log();
-            Quaternion lnPost = (fromQ.Inverse() * postQ).Log();
-            Quaternion ln = new Quaternion(
-                Mathf.CubicInterpolate(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight),
-                Mathf.CubicInterpolate(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight),
-                Mathf.CubicInterpolate(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight),
-                0);
-            Quaternion q1 = fromQ * ln.Exp();
+        // Calc by Expmap in fromQ space.
+        Quaternion lnFrom = new Quaternion(0, 0, 0, 0);
+        Quaternion lnTo = (fromQ.Inverse() * toQ).Log();
+        Quaternion lnPre = (fromQ.Inverse() * preQ).Log();
+        Quaternion lnPost = (fromQ.Inverse() * postQ).Log();
+        Quaternion ln = new Quaternion(
+            Mathf.CubicInterpolate(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight),
+            Mathf.CubicInterpolate(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight),
+            Mathf.CubicInterpolate(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight),
+            0);
+        Quaternion q1 = fromQ * ln.Exp();
 
-            // Calc by Expmap in toQ space.
-            lnFrom = (toQ.Inverse() * fromQ).Log();
-            lnTo = new Quaternion(0, 0, 0, 0);
-            lnPre = (toQ.Inverse() * preQ).Log();
-            lnPost = (toQ.Inverse() * postQ).Log();
-            ln = new Quaternion(
-                Mathf.CubicInterpolate(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight),
-                Mathf.CubicInterpolate(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight),
-                Mathf.CubicInterpolate(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight),
-                0);
-            Quaternion q2 = toQ * ln.Exp();
+        // Calc by Expmap in toQ space.
+        lnFrom = (toQ.Inverse() * fromQ).Log();
+        lnTo = new Quaternion(0, 0, 0, 0);
+        lnPre = (toQ.Inverse() * preQ).Log();
+        lnPost = (toQ.Inverse() * postQ).Log();
+        ln = new Quaternion(
+            Mathf.CubicInterpolate(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight),
+            Mathf.CubicInterpolate(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight),
+            Mathf.CubicInterpolate(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight),
+            0);
+        Quaternion q2 = toQ * ln.Exp();
 
-            // To cancel error made by Expmap ambiguity, do blending.
-            return q1.Slerp(q2, weight);
-        }
+        // To cancel error made by Expmap ambiguity, do blending.
+        return q1.Slerp(q2, weight);
+    }
 
-        /// <summary>
-        /// Performs a spherical cubic interpolation between quaternions <paramref name="preA"/>, this quaternion,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// It can perform smoother interpolation than <see cref="SphericalCubicInterpolate"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="b">The destination quaternion.</param>
-        /// <param name="preA">A quaternion before this quaternion.</param>
-        /// <param name="postB">A quaternion after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="bT"></param>
-        /// <param name="preAT"></param>
-        /// <param name="postBT"></param>
-        /// <returns>The interpolated quaternion.</returns>
-        public readonly Quaternion SphericalCubicInterpolateInTime(Quaternion b, Quaternion preA, Quaternion postB, real_t weight, real_t bT, real_t preAT, real_t postBT)
-        {
+    /// <summary>
+    /// Performs a spherical cubic interpolation between quaternions <paramref name="preA"/>, this quaternion,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// It can perform smoother interpolation than <see cref="SphericalCubicInterpolate"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="b">The destination quaternion.</param>
+    /// <param name="preA">A quaternion before this quaternion.</param>
+    /// <param name="postB">A quaternion after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="bT"></param>
+    /// <param name="preAT"></param>
+    /// <param name="postBT"></param>
+    /// <returns>The interpolated quaternion.</returns>
+    public readonly Quaternion SphericalCubicInterpolateInTime(Quaternion b, Quaternion preA, Quaternion postB, real_t weight, real_t bT, real_t preAT, real_t postBT)
+    {
 #if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized");
-            }
-            if (!b.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized", nameof(b));
-            }
+        if (!IsNormalized())
+        {
+            throw new InvalidOperationException("Quaternion is not normalized");
+        }
+        if (!b.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized", nameof(b));
+        }
 #endif
 
-            // Align flip phases.
-            Quaternion fromQ = new Basis(this).GetRotationQuaternion();
-            Quaternion preQ = new Basis(preA).GetRotationQuaternion();
-            Quaternion toQ = new Basis(b).GetRotationQuaternion();
-            Quaternion postQ = new Basis(postB).GetRotationQuaternion();
+        // Align flip phases.
+        Quaternion fromQ = new Basis(this).GetRotationQuaternion();
+        Quaternion preQ = new Basis(preA).GetRotationQuaternion();
+        Quaternion toQ = new Basis(b).GetRotationQuaternion();
+        Quaternion postQ = new Basis(postB).GetRotationQuaternion();
 
-            // Flip quaternions to shortest path if necessary.
-            bool flip1 = Math.Sign(fromQ.Dot(preQ)) < 0;
-            preQ = flip1 ? -preQ : preQ;
-            bool flip2 = Math.Sign(fromQ.Dot(toQ)) < 0;
-            toQ = flip2 ? -toQ : toQ;
-            bool flip3 = flip2 ? toQ.Dot(postQ) <= 0 : Math.Sign(toQ.Dot(postQ)) < 0;
-            postQ = flip3 ? -postQ : postQ;
+        // Flip quaternions to shortest path if necessary.
+        bool flip1 = Math.Sign(fromQ.Dot(preQ)) < 0;
+        preQ = flip1 ? -preQ : preQ;
+        bool flip2 = Math.Sign(fromQ.Dot(toQ)) < 0;
+        toQ = flip2 ? -toQ : toQ;
+        bool flip3 = flip2 ? toQ.Dot(postQ) <= 0 : Math.Sign(toQ.Dot(postQ)) < 0;
+        postQ = flip3 ? -postQ : postQ;
 
-            // Calc by Expmap in fromQ space.
-            Quaternion lnFrom = new Quaternion(0, 0, 0, 0);
-            Quaternion lnTo = (fromQ.Inverse() * toQ).Log();
-            Quaternion lnPre = (fromQ.Inverse() * preQ).Log();
-            Quaternion lnPost = (fromQ.Inverse() * postQ).Log();
-            Quaternion ln = new Quaternion(
-                Mathf.CubicInterpolateInTime(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight, bT, preAT, postBT),
-                Mathf.CubicInterpolateInTime(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight, bT, preAT, postBT),
-                Mathf.CubicInterpolateInTime(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight, bT, preAT, postBT),
-                0);
-            Quaternion q1 = fromQ * ln.Exp();
+        // Calc by Expmap in fromQ space.
+        Quaternion lnFrom = new Quaternion(0, 0, 0, 0);
+        Quaternion lnTo = (fromQ.Inverse() * toQ).Log();
+        Quaternion lnPre = (fromQ.Inverse() * preQ).Log();
+        Quaternion lnPost = (fromQ.Inverse() * postQ).Log();
+        Quaternion ln = new Quaternion(
+            Mathf.CubicInterpolateInTime(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight, bT, preAT, postBT),
+            Mathf.CubicInterpolateInTime(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight, bT, preAT, postBT),
+            Mathf.CubicInterpolateInTime(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight, bT, preAT, postBT),
+            0);
+        Quaternion q1 = fromQ * ln.Exp();
 
-            // Calc by Expmap in toQ space.
-            lnFrom = (toQ.Inverse() * fromQ).Log();
-            lnTo = new Quaternion(0, 0, 0, 0);
-            lnPre = (toQ.Inverse() * preQ).Log();
-            lnPost = (toQ.Inverse() * postQ).Log();
-            ln = new Quaternion(
-                Mathf.CubicInterpolateInTime(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight, bT, preAT, postBT),
-                Mathf.CubicInterpolateInTime(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight, bT, preAT, postBT),
-                Mathf.CubicInterpolateInTime(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight, bT, preAT, postBT),
-                0);
-            Quaternion q2 = toQ * ln.Exp();
+        // Calc by Expmap in toQ space.
+        lnFrom = (toQ.Inverse() * fromQ).Log();
+        lnTo = new Quaternion(0, 0, 0, 0);
+        lnPre = (toQ.Inverse() * preQ).Log();
+        lnPost = (toQ.Inverse() * postQ).Log();
+        ln = new Quaternion(
+            Mathf.CubicInterpolateInTime(lnFrom.X, lnTo.X, lnPre.X, lnPost.X, weight, bT, preAT, postBT),
+            Mathf.CubicInterpolateInTime(lnFrom.Y, lnTo.Y, lnPre.Y, lnPost.Y, weight, bT, preAT, postBT),
+            Mathf.CubicInterpolateInTime(lnFrom.Z, lnTo.Z, lnPre.Z, lnPost.Z, weight, bT, preAT, postBT),
+            0);
+        Quaternion q2 = toQ * ln.Exp();
 
-            // To cancel error made by Expmap ambiguity, do blending.
-            return q1.Slerp(q2, weight);
+        // To cancel error made by Expmap ambiguity, do blending.
+        return q1.Slerp(q2, weight);
+    }
+
+    /// <summary>
+    /// Returns the dot product of two quaternions.
+    /// </summary>
+    /// <param name="b">The other quaternion.</param>
+    /// <returns>The dot product.</returns>
+    public readonly real_t Dot(Quaternion b)
+    {
+        return (X * b.X) + (Y * b.Y) + (Z * b.Z) + (W * b.W);
+    }
+
+    public readonly Quaternion Exp()
+    {
+        Vector3 v = new Vector3(X, Y, Z);
+        real_t theta = v.Length();
+        v = v.Normalized();
+        if (theta < Mathf.Epsilon || !v.IsNormalized())
+        {
+            return new Quaternion(0, 0, 0, 1);
+        }
+        return new Quaternion(v, theta);
+    }
+
+    public readonly real_t GetAngle()
+    {
+        return 2 * Mathf.Acos(W);
+    }
+
+    public readonly Vector3 GetAxis()
+    {
+        if (Mathf.Abs(W) > 1 - Mathf.Epsilon)
+        {
+            return new Vector3(X, Y, Z);
         }
 
-        /// <summary>
-        /// Returns the dot product of two quaternions.
-        /// </summary>
-        /// <param name="b">The other quaternion.</param>
-        /// <returns>The dot product.</returns>
-        public readonly real_t Dot(Quaternion b)
-        {
-            return (X * b.X) + (Y * b.Y) + (Z * b.Z) + (W * b.W);
-        }
+        real_t r = 1 / Mathf.Sqrt(1 - W * W);
+        return new Vector3(X * r, Y * r, Z * r);
+    }
 
-        public readonly Quaternion Exp()
-        {
-            Vector3 v = new Vector3(X, Y, Z);
-            real_t theta = v.Length();
-            v = v.Normalized();
-            if (theta < Mathf.Epsilon || !v.IsNormalized())
-            {
-                return new Quaternion(0, 0, 0, 1);
-            }
-            return new Quaternion(v, theta);
-        }
-
-        public readonly real_t GetAngle()
-        {
-            return 2 * Mathf.Acos(W);
-        }
-
-        public readonly Vector3 GetAxis()
-        {
-            if (Mathf.Abs(W) > 1 - Mathf.Epsilon)
-            {
-                return new Vector3(X, Y, Z);
-            }
-
-            real_t r = 1 / Mathf.Sqrt(1 - W * W);
-            return new Vector3(X * r, Y * r, Z * r);
-        }
-
-        /// <summary>
-        /// Returns Euler angles (in the YXZ convention: when decomposing,
-        /// first Z, then X, and Y last) corresponding to the rotation
-        /// represented by the unit quaternion. Returned vector contains
-        /// the rotation angles in the format (X angle, Y angle, Z angle).
-        /// </summary>
-        /// <returns>The Euler angle representation of this quaternion.</returns>
-        public readonly Vector3 GetEuler(EulerOrder order = EulerOrder.Yxz)
-        {
+    /// <summary>
+    /// Returns Euler angles (in the YXZ convention: when decomposing,
+    /// first Z, then X, and Y last) corresponding to the rotation
+    /// represented by the unit quaternion. Returned vector contains
+    /// the rotation angles in the format (X angle, Y angle, Z angle).
+    /// </summary>
+    /// <returns>The Euler angle representation of this quaternion.</returns>
+    public readonly Vector3 GetEuler(EulerOrder order = EulerOrder.Yxz)
+    {
 #if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized.");
-            }
+        if (!IsNormalized())
+        {
+            throw new InvalidOperationException("Quaternion is not normalized.");
+        }
 #endif
-            var basis = new Basis(this);
-            return basis.GetEuler(order);
-        }
+        var basis = new Basis(this);
+        return basis.GetEuler(order);
+    }
 
-        /// <summary>
-        /// Returns the inverse of the quaternion.
-        /// </summary>
-        /// <returns>The inverse quaternion.</returns>
-        public readonly Quaternion Inverse()
-        {
+    /// <summary>
+    /// Returns the inverse of the quaternion.
+    /// </summary>
+    /// <returns>The inverse quaternion.</returns>
+    public readonly Quaternion Inverse()
+    {
 #if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized.");
-            }
+        if (!IsNormalized())
+        {
+            throw new InvalidOperationException("Quaternion is not normalized.");
+        }
 #endif
-            return new Quaternion(-X, -Y, -Z, W);
-        }
+        return new Quaternion(-X, -Y, -Z, W);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this quaternion is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z) && Mathf.IsFinite(W);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this quaternion is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z) && Mathf.IsFinite(W);
+    }
 
-        /// <summary>
-        /// Returns whether the quaternion is normalized or not.
-        /// </summary>
-        /// <returns>A <see langword="bool"/> for whether the quaternion is normalized or not.</returns>
-        public readonly bool IsNormalized()
-        {
-            return Mathf.Abs(LengthSquared() - 1) <= Mathf.Epsilon;
-        }
+    /// <summary>
+    /// Returns whether the quaternion is normalized or not.
+    /// </summary>
+    /// <returns>A <see langword="bool"/> for whether the quaternion is normalized or not.</returns>
+    public readonly bool IsNormalized()
+    {
+        return Mathf.Abs(LengthSquared() - 1) <= Mathf.Epsilon;
+    }
 
-        public readonly Quaternion Log()
-        {
-            Vector3 v = GetAxis() * GetAngle();
-            return new Quaternion(v.X, v.Y, v.Z, 0);
-        }
+    public readonly Quaternion Log()
+    {
+        Vector3 v = GetAxis() * GetAngle();
+        return new Quaternion(v.X, v.Y, v.Z, 0);
+    }
 
-        /// <summary>
-        /// Returns the length (magnitude) of the quaternion.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <value>Equivalent to <c>Mathf.Sqrt(LengthSquared)</c>.</value>
-        public readonly real_t Length()
-        {
-            return Mathf.Sqrt(LengthSquared());
-        }
+    /// <summary>
+    /// Returns the length (magnitude) of the quaternion.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <value>Equivalent to <c>Mathf.Sqrt(LengthSquared)</c>.</value>
+    public readonly real_t Length()
+    {
+        return Mathf.Sqrt(LengthSquared());
+    }
 
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of the quaternion.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare quaternions or need the squared length for some formula.
-        /// </summary>
-        /// <value>Equivalent to <c>Dot(this)</c>.</value>
-        public readonly real_t LengthSquared()
-        {
-            return Dot(this);
-        }
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of the quaternion.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare quaternions or need the squared length for some formula.
+    /// </summary>
+    /// <value>Equivalent to <c>Dot(this)</c>.</value>
+    public readonly real_t LengthSquared()
+    {
+        return Dot(this);
+    }
 
-        /// <summary>
-        /// Returns a copy of the quaternion, normalized to unit length.
-        /// </summary>
-        /// <returns>The normalized quaternion.</returns>
-        public readonly Quaternion Normalized()
-        {
-            return this / Length();
-        }
+    /// <summary>
+    /// Returns a copy of the quaternion, normalized to unit length.
+    /// </summary>
+    /// <returns>The normalized quaternion.</returns>
+    public readonly Quaternion Normalized()
+    {
+        return this / Length();
+    }
 
-        /// <summary>
-        /// Returns the result of the spherical linear interpolation between
-        /// this quaternion and <paramref name="to"/> by amount <paramref name="weight"/>.
-        ///
-        /// Note: Both quaternions must be normalized.
-        /// </summary>
-        /// <param name="to">The destination quaternion for interpolation. Must be normalized.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting quaternion of the interpolation.</returns>
-        public readonly Quaternion Slerp(Quaternion to, real_t weight)
-        {
+    /// <summary>
+    /// Returns the result of the spherical linear interpolation between
+    /// this quaternion and <paramref name="to"/> by amount <paramref name="weight"/>.
+    ///
+    /// Note: Both quaternions must be normalized.
+    /// </summary>
+    /// <param name="to">The destination quaternion for interpolation. Must be normalized.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting quaternion of the interpolation.</returns>
+    public readonly Quaternion Slerp(Quaternion to, real_t weight)
+    {
 #if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized.");
-            }
-            if (!to.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized.", nameof(to));
-            }
-#endif
-
-            // Calculate cosine.
-            real_t cosom = Dot(to);
-
-            var to1 = new Quaternion();
-
-            // Adjust signs if necessary.
-            if (cosom < 0.0)
-            {
-                cosom = -cosom;
-                to1 = -to;
-            }
-            else
-            {
-                to1 = to;
-            }
-
-            real_t sinom, scale0, scale1;
-
-            // Calculate coefficients.
-            if (1.0 - cosom > Mathf.Epsilon)
-            {
-                // Standard case (Slerp).
-                real_t omega = Mathf.Acos(cosom);
-                sinom = Mathf.Sin(omega);
-                scale0 = Mathf.Sin((1.0f - weight) * omega) / sinom;
-                scale1 = Mathf.Sin(weight * omega) / sinom;
-            }
-            else
-            {
-                // Quaternions are very close so we can do a linear interpolation.
-                scale0 = 1.0f - weight;
-                scale1 = weight;
-            }
-
-            // Calculate final values.
-            return new Quaternion
-            (
-                (scale0 * X) + (scale1 * to1.X),
-                (scale0 * Y) + (scale1 * to1.Y),
-                (scale0 * Z) + (scale1 * to1.Z),
-                (scale0 * W) + (scale1 * to1.W)
-            );
-        }
-
-        /// <summary>
-        /// Returns the result of the spherical linear interpolation between
-        /// this quaternion and <paramref name="to"/> by amount <paramref name="weight"/>, but without
-        /// checking if the rotation path is not bigger than 90 degrees.
-        /// </summary>
-        /// <param name="to">The destination quaternion for interpolation. Must be normalized.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting quaternion of the interpolation.</returns>
-        public readonly Quaternion Slerpni(Quaternion to, real_t weight)
+        if (!IsNormalized())
         {
-#if DEBUG
-            if (!IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized");
-            }
-            if (!to.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized", nameof(to));
-            }
+            throw new InvalidOperationException("Quaternion is not normalized.");
+        }
+        if (!to.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized.", nameof(to));
+        }
 #endif
 
-            real_t dot = Dot(to);
+        // Calculate cosine.
+        real_t cosom = Dot(to);
 
-            if (Mathf.Abs(dot) > 0.9999f)
-            {
-                return this;
-            }
+        var to1 = new Quaternion();
 
-            real_t theta = Mathf.Acos(dot);
-            real_t sinT = 1.0f / Mathf.Sin(theta);
-            real_t newFactor = Mathf.Sin(weight * theta) * sinT;
-            real_t invFactor = Mathf.Sin((1.0f - weight) * theta) * sinT;
-
-            return new Quaternion
-            (
-                (invFactor * X) + (newFactor * to.X),
-                (invFactor * Y) + (newFactor * to.Y),
-                (invFactor * Z) + (newFactor * to.Z),
-                (invFactor * W) + (newFactor * to.W)
-            );
+        // Adjust signs if necessary.
+        if (cosom < 0.0)
+        {
+            cosom = -cosom;
+            to1 = -to;
+        }
+        else
+        {
+            to1 = to;
         }
 
-        // Constants
-        private static readonly Quaternion _identity = new Quaternion(0, 0, 0, 1);
+        real_t sinom, scale0, scale1;
 
-        /// <summary>
-        /// The identity quaternion, representing no rotation.
-        /// Equivalent to an identity <see cref="Basis"/> matrix. If a vector is transformed by
-        /// an identity quaternion, it will not change.
-        /// </summary>
-        /// <value>Equivalent to <c>new Quaternion(0, 0, 0, 1)</c>.</value>
-        public static Quaternion Identity { get { return _identity; } }
-
-        /// <summary>
-        /// Constructs a <see cref="Quaternion"/> defined by the given values.
-        /// </summary>
-        /// <param name="x">X component of the quaternion (imaginary <c>i</c> axis part).</param>
-        /// <param name="y">Y component of the quaternion (imaginary <c>j</c> axis part).</param>
-        /// <param name="z">Z component of the quaternion (imaginary <c>k</c> axis part).</param>
-        /// <param name="w">W component of the quaternion (real part).</param>
-        public Quaternion(real_t x, real_t y, real_t z, real_t w)
+        // Calculate coefficients.
+        if (1.0 - cosom > Mathf.Epsilon)
         {
-            X = x;
-            Y = y;
-            Z = z;
-            W = w;
+            // Standard case (Slerp).
+            real_t omega = Mathf.Acos(cosom);
+            sinom = Mathf.Sin(omega);
+            scale0 = Mathf.Sin((1.0f - weight) * omega) / sinom;
+            scale1 = Mathf.Sin(weight * omega) / sinom;
+        }
+        else
+        {
+            // Quaternions are very close so we can do a linear interpolation.
+            scale0 = 1.0f - weight;
+            scale1 = weight;
         }
 
-        /// <summary>
-        /// Constructs a <see cref="Quaternion"/> from the given <see cref="Basis"/>.
-        /// </summary>
-        /// <param name="basis">The <see cref="Basis"/> to construct from.</param>
-        public Quaternion(Basis basis)
-        {
-            this = basis.GetQuaternion();
-        }
+        // Calculate final values.
+        return new Quaternion
+        (
+            (scale0 * X) + (scale1 * to1.X),
+            (scale0 * Y) + (scale1 * to1.Y),
+            (scale0 * Z) + (scale1 * to1.Z),
+            (scale0 * W) + (scale1 * to1.W)
+        );
+    }
 
-        /// <summary>
-        /// Constructs a <see cref="Quaternion"/> that will rotate around the given axis
-        /// by the specified angle. The axis must be a normalized vector.
-        /// </summary>
-        /// <param name="axis">The axis to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        public Quaternion(Vector3 axis, real_t angle)
-        {
+    /// <summary>
+    /// Returns the result of the spherical linear interpolation between
+    /// this quaternion and <paramref name="to"/> by amount <paramref name="weight"/>, but without
+    /// checking if the rotation path is not bigger than 90 degrees.
+    /// </summary>
+    /// <param name="to">The destination quaternion for interpolation. Must be normalized.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting quaternion of the interpolation.</returns>
+    public readonly Quaternion Slerpni(Quaternion to, real_t weight)
+    {
 #if DEBUG
-            if (!axis.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized.", nameof(axis));
-            }
+        if (!IsNormalized())
+        {
+            throw new InvalidOperationException("Quaternion is not normalized");
+        }
+        if (!to.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized", nameof(to));
+        }
 #endif
 
-            real_t d = axis.Length();
+        real_t dot = Dot(to);
 
-            if (d == 0f)
-            {
-                X = 0f;
-                Y = 0f;
-                Z = 0f;
-                W = 0f;
-            }
-            else
-            {
-                (real_t sin, real_t cos) = Mathf.SinCos(angle * 0.5f);
-                real_t s = sin / d;
-
-                X = axis.X * s;
-                Y = axis.Y * s;
-                Z = axis.Z * s;
-                W = cos;
-            }
+        if (Mathf.Abs(dot) > 0.9999f)
+        {
+            return this;
         }
 
-        public Quaternion(Vector3 arcFrom, Vector3 arcTo)
-        {
-            Vector3 c = arcFrom.Cross(arcTo);
-            real_t d = arcFrom.Dot(arcTo);
+        real_t theta = Mathf.Acos(dot);
+        real_t sinT = 1.0f / Mathf.Sin(theta);
+        real_t newFactor = Mathf.Sin(weight * theta) * sinT;
+        real_t invFactor = Mathf.Sin((1.0f - weight) * theta) * sinT;
 
-            if (d < -1.0f + Mathf.Epsilon)
-            {
-                X = 0f;
-                Y = 1f;
-                Z = 0f;
-                W = 0f;
-            }
-            else
-            {
-                real_t s = Mathf.Sqrt((1.0f + d) * 2.0f);
-                real_t rs = 1.0f / s;
+        return new Quaternion
+        (
+            (invFactor * X) + (newFactor * to.X),
+            (invFactor * Y) + (newFactor * to.Y),
+            (invFactor * Z) + (newFactor * to.Z),
+            (invFactor * W) + (newFactor * to.W)
+        );
+    }
 
-                X = c.X * rs;
-                Y = c.Y * rs;
-                Z = c.Z * rs;
-                W = s * 0.5f;
-            }
-        }
+    // Constants
+    private static readonly Quaternion _identity = new Quaternion(0, 0, 0, 1);
 
-        /// <summary>
-        /// Constructs a <see cref="Quaternion"/> that will perform a rotation specified by
-        /// Euler angles (in the YXZ convention: when decomposing, first Z, then X, and Y last),
-        /// given in the vector format as (X angle, Y angle, Z angle).
-        /// </summary>
-        /// <param name="eulerYXZ">Euler angles that the quaternion will be rotated by.</param>
-        public static Quaternion FromEuler(Vector3 eulerYXZ)
-        {
-            real_t halfA1 = eulerYXZ.Y * 0.5f;
-            real_t halfA2 = eulerYXZ.X * 0.5f;
-            real_t halfA3 = eulerYXZ.Z * 0.5f;
+    /// <summary>
+    /// The identity quaternion, representing no rotation.
+    /// Equivalent to an identity <see cref="Basis"/> matrix. If a vector is transformed by
+    /// an identity quaternion, it will not change.
+    /// </summary>
+    /// <value>Equivalent to <c>new Quaternion(0, 0, 0, 1)</c>.</value>
+    public static Quaternion Identity { get { return _identity; } }
 
-            // R = Y(a1).X(a2).Z(a3) convention for Euler angles.
-            // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
-            // a3 is the angle of the first rotation, following the notation in this reference.
+    /// <summary>
+    /// Constructs a <see cref="Quaternion"/> defined by the given values.
+    /// </summary>
+    /// <param name="x">X component of the quaternion (imaginary <c>i</c> axis part).</param>
+    /// <param name="y">Y component of the quaternion (imaginary <c>j</c> axis part).</param>
+    /// <param name="z">Z component of the quaternion (imaginary <c>k</c> axis part).</param>
+    /// <param name="w">W component of the quaternion (real part).</param>
+    public Quaternion(real_t x, real_t y, real_t z, real_t w)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        W = w;
+    }
 
-            (real_t sinA1, real_t cosA1) = Mathf.SinCos(halfA1);
-            (real_t sinA2, real_t cosA2) = Mathf.SinCos(halfA2);
-            (real_t sinA3, real_t cosA3) = Mathf.SinCos(halfA3);
+    /// <summary>
+    /// Constructs a <see cref="Quaternion"/> from the given <see cref="Basis"/>.
+    /// </summary>
+    /// <param name="basis">The <see cref="Basis"/> to construct from.</param>
+    public Quaternion(Basis basis)
+    {
+        this = basis.GetQuaternion();
+    }
 
-            return new Quaternion(
-                (sinA1 * cosA2 * sinA3) + (cosA1 * sinA2 * cosA3),
-                (sinA1 * cosA2 * cosA3) - (cosA1 * sinA2 * sinA3),
-                (cosA1 * cosA2 * sinA3) - (sinA1 * sinA2 * cosA3),
-                (sinA1 * sinA2 * sinA3) + (cosA1 * cosA2 * cosA3)
-            );
-        }
-
-        /// <summary>
-        /// Composes these two quaternions by multiplying them together.
-        /// This has the effect of rotating the second quaternion
-        /// (the child) by the first quaternion (the parent).
-        /// </summary>
-        /// <param name="left">The parent quaternion.</param>
-        /// <param name="right">The child quaternion.</param>
-        /// <returns>The composed quaternion.</returns>
-        public static Quaternion operator *(Quaternion left, Quaternion right)
-        {
-            return new Quaternion
-            (
-                (left.W * right.X) + (left.X * right.W) + (left.Y * right.Z) - (left.Z * right.Y),
-                (left.W * right.Y) + (left.Y * right.W) + (left.Z * right.X) - (left.X * right.Z),
-                (left.W * right.Z) + (left.Z * right.W) + (left.X * right.Y) - (left.Y * right.X),
-                (left.W * right.W) - (left.X * right.X) - (left.Y * right.Y) - (left.Z * right.Z)
-            );
-        }
-
-        /// <summary>
-        /// Returns a Vector3 rotated (multiplied) by the quaternion.
-        /// </summary>
-        /// <param name="quaternion">The quaternion to rotate by.</param>
-        /// <param name="vector">A Vector3 to transform.</param>
-        /// <returns>The rotated Vector3.</returns>
-        public static Vector3 operator *(Quaternion quaternion, Vector3 vector)
-        {
+    /// <summary>
+    /// Constructs a <see cref="Quaternion"/> that will rotate around the given axis
+    /// by the specified angle. The axis must be a normalized vector.
+    /// </summary>
+    /// <param name="axis">The axis to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    public Quaternion(Vector3 axis, real_t angle)
+    {
 #if DEBUG
-            if (!quaternion.IsNormalized())
-            {
-                throw new InvalidOperationException("Quaternion is not normalized.");
-            }
+        if (!axis.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized.", nameof(axis));
+        }
 #endif
-            var u = new Vector3(quaternion.X, quaternion.Y, quaternion.Z);
-            Vector3 uv = u.Cross(vector);
-            return vector + (((uv * quaternion.W) + u.Cross(uv)) * 2);
-        }
 
-        /// <summary>
-        /// Returns a Vector3 rotated (multiplied) by the inverse quaternion.
-        /// </summary>
-        /// <param name="vector">A Vector3 to inversely rotate.</param>
-        /// <param name="quaternion">The quaternion to rotate by.</param>
-        /// <returns>The inversely rotated Vector3.</returns>
-        public static Vector3 operator *(Vector3 vector, Quaternion quaternion)
-        {
-            return quaternion.Inverse() * vector;
-        }
+        real_t d = axis.Length();
 
-        /// <summary>
-        /// Adds each component of the left <see cref="Quaternion"/>
-        /// to the right <see cref="Quaternion"/>. This operation is not
-        /// meaningful on its own, but it can be used as a part of a
-        /// larger expression, such as approximating an intermediate
-        /// rotation between two nearby rotations.
-        /// </summary>
-        /// <param name="left">The left quaternion to add.</param>
-        /// <param name="right">The right quaternion to add.</param>
-        /// <returns>The added quaternion.</returns>
-        public static Quaternion operator +(Quaternion left, Quaternion right)
+        if (d == 0f)
         {
-            return new Quaternion(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+            X = 0f;
+            Y = 0f;
+            Z = 0f;
+            W = 0f;
         }
+        else
+        {
+            (real_t sin, real_t cos) = Mathf.SinCos(angle * 0.5f);
+            real_t s = sin / d;
 
-        /// <summary>
-        /// Subtracts each component of the left <see cref="Quaternion"/>
-        /// by the right <see cref="Quaternion"/>. This operation is not
-        /// meaningful on its own, but it can be used as a part of a
-        /// larger expression.
-        /// </summary>
-        /// <param name="left">The left quaternion to subtract.</param>
-        /// <param name="right">The right quaternion to subtract.</param>
-        /// <returns>The subtracted quaternion.</returns>
-        public static Quaternion operator -(Quaternion left, Quaternion right)
-        {
-            return new Quaternion(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+            X = axis.X * s;
+            Y = axis.Y * s;
+            Z = axis.Z * s;
+            W = cos;
         }
+    }
 
-        /// <summary>
-        /// Returns the negative value of the <see cref="Quaternion"/>.
-        /// This is the same as writing
-        /// <c>new Quaternion(-q.X, -q.Y, -q.Z, -q.W)</c>. This operation
-        /// results in a quaternion that represents the same rotation.
-        /// </summary>
-        /// <param name="quat">The quaternion to negate.</param>
-        /// <returns>The negated quaternion.</returns>
-        public static Quaternion operator -(Quaternion quat)
-        {
-            return new Quaternion(-quat.X, -quat.Y, -quat.Z, -quat.W);
-        }
+    public Quaternion(Vector3 arcFrom, Vector3 arcTo)
+    {
+        Vector3 c = arcFrom.Cross(arcTo);
+        real_t d = arcFrom.Dot(arcTo);
 
-        /// <summary>
-        /// Multiplies each component of the <see cref="Quaternion"/>
-        /// by the given <see cref="real_t"/>. This operation is not
-        /// meaningful on its own, but it can be used as a part of a
-        /// larger expression.
-        /// </summary>
-        /// <param name="left">The quaternion to multiply.</param>
-        /// <param name="right">The value to multiply by.</param>
-        /// <returns>The multiplied quaternion.</returns>
-        public static Quaternion operator *(Quaternion left, real_t right)
+        if (d < -1.0f + Mathf.Epsilon)
         {
-            return new Quaternion(left.X * right, left.Y * right, left.Z * right, left.W * right);
+            X = 0f;
+            Y = 1f;
+            Z = 0f;
+            W = 0f;
         }
+        else
+        {
+            real_t s = Mathf.Sqrt((1.0f + d) * 2.0f);
+            real_t rs = 1.0f / s;
 
-        /// <summary>
-        /// Multiplies each component of the <see cref="Quaternion"/>
-        /// by the given <see cref="real_t"/>. This operation is not
-        /// meaningful on its own, but it can be used as a part of a
-        /// larger expression.
-        /// </summary>
-        /// <param name="left">The value to multiply by.</param>
-        /// <param name="right">The quaternion to multiply.</param>
-        /// <returns>The multiplied quaternion.</returns>
-        public static Quaternion operator *(real_t left, Quaternion right)
-        {
-            return new Quaternion(right.X * left, right.Y * left, right.Z * left, right.W * left);
+            X = c.X * rs;
+            Y = c.Y * rs;
+            Z = c.Z * rs;
+            W = s * 0.5f;
         }
+    }
 
-        /// <summary>
-        /// Divides each component of the <see cref="Quaternion"/>
-        /// by the given <see cref="real_t"/>. This operation is not
-        /// meaningful on its own, but it can be used as a part of a
-        /// larger expression.
-        /// </summary>
-        /// <param name="left">The quaternion to divide.</param>
-        /// <param name="right">The value to divide by.</param>
-        /// <returns>The divided quaternion.</returns>
-        public static Quaternion operator /(Quaternion left, real_t right)
-        {
-            return left * (1.0f / right);
-        }
+    /// <summary>
+    /// Constructs a <see cref="Quaternion"/> that will perform a rotation specified by
+    /// Euler angles (in the YXZ convention: when decomposing, first Z, then X, and Y last),
+    /// given in the vector format as (X angle, Y angle, Z angle).
+    /// </summary>
+    /// <param name="eulerYXZ">Euler angles that the quaternion will be rotated by.</param>
+    public static Quaternion FromEuler(Vector3 eulerYXZ)
+    {
+        real_t halfA1 = eulerYXZ.Y * 0.5f;
+        real_t halfA2 = eulerYXZ.X * 0.5f;
+        real_t halfA3 = eulerYXZ.Z * 0.5f;
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the quaternions are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left quaternion.</param>
-        /// <param name="right">The right quaternion.</param>
-        /// <returns>Whether or not the quaternions are exactly equal.</returns>
-        public static bool operator ==(Quaternion left, Quaternion right)
-        {
-            return left.Equals(right);
-        }
+        // R = Y(a1).X(a2).Z(a3) convention for Euler angles.
+        // Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
+        // a3 is the angle of the first rotation, following the notation in this reference.
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the quaternions are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left quaternion.</param>
-        /// <param name="right">The right quaternion.</param>
-        /// <returns>Whether or not the quaternions are not equal.</returns>
-        public static bool operator !=(Quaternion left, Quaternion right)
-        {
-            return !left.Equals(right);
-        }
+        (real_t sinA1, real_t cosA1) = Mathf.SinCos(halfA1);
+        (real_t sinA2, real_t cosA2) = Mathf.SinCos(halfA2);
+        (real_t sinA3, real_t cosA3) = Mathf.SinCos(halfA3);
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this quaternion and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the quaternion and the other object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Quaternion other && Equals(other);
-        }
+        return new Quaternion(
+            (sinA1 * cosA2 * sinA3) + (cosA1 * sinA2 * cosA3),
+            (sinA1 * cosA2 * cosA3) - (cosA1 * sinA2 * sinA3),
+            (cosA1 * cosA2 * sinA3) - (sinA1 * sinA2 * cosA3),
+            (sinA1 * sinA2 * sinA3) + (cosA1 * cosA2 * cosA3)
+        );
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are equal.
-        /// </summary>
-        /// <param name="other">The other quaternion to compare.</param>
-        /// <returns>Whether or not the quaternions are exactly equal.</returns>
-        public readonly bool Equals(Quaternion other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
-        }
+    /// <summary>
+    /// Composes these two quaternions by multiplying them together.
+    /// This has the effect of rotating the second quaternion
+    /// (the child) by the first quaternion (the parent).
+    /// </summary>
+    /// <param name="left">The parent quaternion.</param>
+    /// <param name="right">The child quaternion.</param>
+    /// <returns>The composed quaternion.</returns>
+    public static Quaternion operator *(Quaternion left, Quaternion right)
+    {
+        return new Quaternion
+        (
+            (left.W * right.X) + (left.X * right.W) + (left.Y * right.Z) - (left.Z * right.Y),
+            (left.W * right.Y) + (left.Y * right.W) + (left.Z * right.X) - (left.X * right.Z),
+            (left.W * right.Z) + (left.Z * right.W) + (left.X * right.Y) - (left.Y * right.X),
+            (left.W * right.W) - (left.X * right.X) - (left.Y * right.Y) - (left.Z * right.Z)
+        );
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other quaternion to compare.</param>
-        /// <returns>Whether or not the quaternions are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Quaternion other)
+    /// <summary>
+    /// Returns a Vector3 rotated (multiplied) by the quaternion.
+    /// </summary>
+    /// <param name="quaternion">The quaternion to rotate by.</param>
+    /// <param name="vector">A Vector3 to transform.</param>
+    /// <returns>The rotated Vector3.</returns>
+    public static Vector3 operator *(Quaternion quaternion, Vector3 vector)
+    {
+#if DEBUG
+        if (!quaternion.IsNormalized())
         {
-            return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z) && Mathf.IsEqualApprox(W, other.W);
+            throw new InvalidOperationException("Quaternion is not normalized.");
         }
+#endif
+        var u = new Vector3(quaternion.X, quaternion.Y, quaternion.Z);
+        Vector3 uv = u.Cross(vector);
+        return vector + (((uv * quaternion.W) + u.Cross(uv)) * 2);
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Quaternion"/>.
-        /// </summary>
-        /// <returns>A hash code for this quaternion.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
-        }
+    /// <summary>
+    /// Returns a Vector3 rotated (multiplied) by the inverse quaternion.
+    /// </summary>
+    /// <param name="vector">A Vector3 to inversely rotate.</param>
+    /// <param name="quaternion">The quaternion to rotate by.</param>
+    /// <returns>The inversely rotated Vector3.</returns>
+    public static Vector3 operator *(Vector3 vector, Quaternion quaternion)
+    {
+        return quaternion.Inverse() * vector;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Quaternion"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this quaternion.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
+    /// <summary>
+    /// Adds each component of the left <see cref="Quaternion"/>
+    /// to the right <see cref="Quaternion"/>. This operation is not
+    /// meaningful on its own, but it can be used as a part of a
+    /// larger expression, such as approximating an intermediate
+    /// rotation between two nearby rotations.
+    /// </summary>
+    /// <param name="left">The left quaternion to add.</param>
+    /// <param name="right">The right quaternion to add.</param>
+    /// <returns>The added quaternion.</returns>
+    public static Quaternion operator +(Quaternion left, Quaternion right)
+    {
+        return new Quaternion(left.X + right.X, left.Y + right.Y, left.Z + right.Z, left.W + right.W);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Quaternion"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this quaternion.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
-        }
+    /// <summary>
+    /// Subtracts each component of the left <see cref="Quaternion"/>
+    /// by the right <see cref="Quaternion"/>. This operation is not
+    /// meaningful on its own, but it can be used as a part of a
+    /// larger expression.
+    /// </summary>
+    /// <param name="left">The left quaternion to subtract.</param>
+    /// <param name="right">The right quaternion to subtract.</param>
+    /// <returns>The subtracted quaternion.</returns>
+    public static Quaternion operator -(Quaternion left, Quaternion right)
+    {
+        return new Quaternion(left.X - right.X, left.Y - right.Y, left.Z - right.Z, left.W - right.W);
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Quaternion"/>.
+    /// This is the same as writing
+    /// <c>new Quaternion(-q.X, -q.Y, -q.Z, -q.W)</c>. This operation
+    /// results in a quaternion that represents the same rotation.
+    /// </summary>
+    /// <param name="quat">The quaternion to negate.</param>
+    /// <returns>The negated quaternion.</returns>
+    public static Quaternion operator -(Quaternion quat)
+    {
+        return new Quaternion(-quat.X, -quat.Y, -quat.Z, -quat.W);
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Quaternion"/>
+    /// by the given <see cref="real_t"/>. This operation is not
+    /// meaningful on its own, but it can be used as a part of a
+    /// larger expression.
+    /// </summary>
+    /// <param name="left">The quaternion to multiply.</param>
+    /// <param name="right">The value to multiply by.</param>
+    /// <returns>The multiplied quaternion.</returns>
+    public static Quaternion operator *(Quaternion left, real_t right)
+    {
+        return new Quaternion(left.X * right, left.Y * right, left.Z * right, left.W * right);
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Quaternion"/>
+    /// by the given <see cref="real_t"/>. This operation is not
+    /// meaningful on its own, but it can be used as a part of a
+    /// larger expression.
+    /// </summary>
+    /// <param name="left">The value to multiply by.</param>
+    /// <param name="right">The quaternion to multiply.</param>
+    /// <returns>The multiplied quaternion.</returns>
+    public static Quaternion operator *(real_t left, Quaternion right)
+    {
+        return new Quaternion(right.X * left, right.Y * left, right.Z * left, right.W * left);
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Quaternion"/>
+    /// by the given <see cref="real_t"/>. This operation is not
+    /// meaningful on its own, but it can be used as a part of a
+    /// larger expression.
+    /// </summary>
+    /// <param name="left">The quaternion to divide.</param>
+    /// <param name="right">The value to divide by.</param>
+    /// <returns>The divided quaternion.</returns>
+    public static Quaternion operator /(Quaternion left, real_t right)
+    {
+        return left * (1.0f / right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the quaternions are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left quaternion.</param>
+    /// <param name="right">The right quaternion.</param>
+    /// <returns>Whether or not the quaternions are exactly equal.</returns>
+    public static bool operator ==(Quaternion left, Quaternion right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the quaternions are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left quaternion.</param>
+    /// <param name="right">The right quaternion.</param>
+    /// <returns>Whether or not the quaternions are not equal.</returns>
+    public static bool operator !=(Quaternion left, Quaternion right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this quaternion and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the quaternion and the other object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Quaternion other && Equals(other);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are equal.
+    /// </summary>
+    /// <param name="other">The other quaternion to compare.</param>
+    /// <returns>Whether or not the quaternions are exactly equal.</returns>
+    public readonly bool Equals(Quaternion other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this quaternion and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other quaternion to compare.</param>
+    /// <returns>Whether or not the quaternions are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Quaternion other)
+    {
+        return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z) && Mathf.IsEqualApprox(W, other.W);
+    }
+
+    /// <summary>
+    /// Serves as the hash function for <see cref="Quaternion"/>.
+    /// </summary>
+    /// <returns>A hash code for this quaternion.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Quaternion"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this quaternion.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y}, {Z}, {W})";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Quaternion"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this quaternion.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2.cs
@@ -1,483 +1,482 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 2D axis-aligned bounding box. Rect2 consists of a position, a size, and
+/// several utility functions. It is typically used for fast overlap tests.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Rect2 : IEquatable<Rect2>
 {
+    private Vector2 _position;
+    private Vector2 _size;
+
     /// <summary>
-    /// 2D axis-aligned bounding box. Rect2 consists of a position, a size, and
-    /// several utility functions. It is typically used for fast overlap tests.
+    /// Beginning corner. Typically has values lower than <see cref="End"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Rect2 : IEquatable<Rect2>
+    /// <value>Directly uses a private field.</value>
+    public Vector2 Position
     {
-        private Vector2 _position;
-        private Vector2 _size;
+        readonly get { return _position; }
+        set { _position = value; }
+    }
 
-        /// <summary>
-        /// Beginning corner. Typically has values lower than <see cref="End"/>.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector2 Position
+    /// <summary>
+    /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
+    /// If the size is negative, you can use <see cref="Abs"/> to fix it.
+    /// </summary>
+    /// <value>Directly uses a private field.</value>
+    public Vector2 Size
+    {
+        readonly get { return _size; }
+        set { _size = value; }
+    }
+
+    /// <summary>
+    /// Ending corner. This is calculated as <see cref="Position"/> plus <see cref="Size"/>.
+    /// Setting this value will change the size.
+    /// </summary>
+    /// <value>
+    /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
+    /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
+    /// </value>
+    public Vector2 End
+    {
+        readonly get { return _position + _size; }
+        set { _size = value - _position; }
+    }
+
+    /// <summary>
+    /// The area of this <see cref="Rect2"/>.
+    /// See also <see cref="HasArea"/>.
+    /// </summary>
+    public readonly real_t Area
+    {
+        get { return _size.X * _size.Y; }
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Rect2"/> with equivalent position and size, modified so that
+    /// the top-left corner is the origin and width and height are positive.
+    /// </summary>
+    /// <returns>The modified <see cref="Rect2"/>.</returns>
+    public readonly Rect2 Abs()
+    {
+        Vector2 end = End;
+        Vector2 topLeft = new Vector2(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y));
+        return new Rect2(topLeft, _size.Abs());
+    }
+
+    /// <summary>
+    /// Returns the intersection of this <see cref="Rect2"/> and <paramref name="b"/>.
+    /// If the rectangles do not intersect, an empty <see cref="Rect2"/> is returned.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2"/>.</param>
+    /// <returns>
+    /// The intersection of this <see cref="Rect2"/> and <paramref name="b"/>,
+    /// or an empty <see cref="Rect2"/> if they do not intersect.
+    /// </returns>
+    public readonly Rect2 Intersection(Rect2 b)
+    {
+        Rect2 newRect = b;
+
+        if (!Intersects(newRect))
         {
-            readonly get { return _position; }
-            set { _position = value; }
+            return new Rect2();
         }
 
-        /// <summary>
-        /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
-        /// If the size is negative, you can use <see cref="Abs"/> to fix it.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector2 Size
+        newRect._position.X = Mathf.Max(b._position.X, _position.X);
+        newRect._position.Y = Mathf.Max(b._position.Y, _position.Y);
+
+        Vector2 bEnd = b._position + b._size;
+        Vector2 end = _position + _size;
+
+        newRect._size.X = Mathf.Min(bEnd.X, end.X) - newRect._position.X;
+        newRect._size.Y = Mathf.Min(bEnd.Y, end.Y) - newRect._position.Y;
+
+        return newRect;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Rect2"/> is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public bool IsFinite()
+    {
+        return _position.IsFinite() && _size.IsFinite();
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Rect2"/> completely encloses another one.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2"/> that may be enclosed.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not this <see cref="Rect2"/> encloses <paramref name="b"/>.
+    /// </returns>
+    public readonly bool Encloses(Rect2 b)
+    {
+        return b._position.X >= _position.X && b._position.Y >= _position.Y &&
+           b._position.X + b._size.X < _position.X + _size.X &&
+           b._position.Y + b._size.Y < _position.Y + _size.Y;
+    }
+
+    /// <summary>
+    /// Returns this <see cref="Rect2"/> expanded to include a given point.
+    /// </summary>
+    /// <param name="to">The point to include.</param>
+    /// <returns>The expanded <see cref="Rect2"/>.</returns>
+    public readonly Rect2 Expand(Vector2 to)
+    {
+        Rect2 expanded = this;
+
+        Vector2 begin = expanded._position;
+        Vector2 end = expanded._position + expanded._size;
+
+        if (to.X < begin.X)
         {
-            readonly get { return _size; }
-            set { _size = value; }
+            begin.X = to.X;
+        }
+        if (to.Y < begin.Y)
+        {
+            begin.Y = to.Y;
         }
 
-        /// <summary>
-        /// Ending corner. This is calculated as <see cref="Position"/> plus <see cref="Size"/>.
-        /// Setting this value will change the size.
-        /// </summary>
-        /// <value>
-        /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
-        /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
-        /// </value>
-        public Vector2 End
+        if (to.X > end.X)
         {
-            readonly get { return _position + _size; }
-            set { _size = value - _position; }
+            end.X = to.X;
+        }
+        if (to.Y > end.Y)
+        {
+            end.Y = to.Y;
         }
 
-        /// <summary>
-        /// The area of this <see cref="Rect2"/>.
-        /// See also <see cref="HasArea"/>.
-        /// </summary>
-        public readonly real_t Area
-        {
-            get { return _size.X * _size.Y; }
-        }
+        expanded._position = begin;
+        expanded._size = end - begin;
 
-        /// <summary>
-        /// Returns a <see cref="Rect2"/> with equivalent position and size, modified so that
-        /// the top-left corner is the origin and width and height are positive.
-        /// </summary>
-        /// <returns>The modified <see cref="Rect2"/>.</returns>
-        public readonly Rect2 Abs()
-        {
-            Vector2 end = End;
-            Vector2 topLeft = new Vector2(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y));
-            return new Rect2(topLeft, _size.Abs());
-        }
+        return expanded;
+    }
 
-        /// <summary>
-        /// Returns the intersection of this <see cref="Rect2"/> and <paramref name="b"/>.
-        /// If the rectangles do not intersect, an empty <see cref="Rect2"/> is returned.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2"/>.</param>
-        /// <returns>
-        /// The intersection of this <see cref="Rect2"/> and <paramref name="b"/>,
-        /// or an empty <see cref="Rect2"/> if they do not intersect.
-        /// </returns>
-        public readonly Rect2 Intersection(Rect2 b)
-        {
-            Rect2 newRect = b;
+    /// <summary>
+    /// Returns the center of the <see cref="Rect2"/>, which is equal
+    /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
+    /// </summary>
+    /// <returns>The center.</returns>
+    public readonly Vector2 GetCenter()
+    {
+        return _position + (_size * 0.5f);
+    }
 
-            if (!Intersects(newRect))
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
+    /// on all sides.
+    /// </summary>
+    /// <seealso cref="GrowIndividual(real_t, real_t, real_t, real_t)"/>
+    /// <seealso cref="GrowSide(Side, real_t)"/>
+    /// <param name="by">The amount to grow by.</param>
+    /// <returns>The grown <see cref="Rect2"/>.</returns>
+    public readonly Rect2 Grow(real_t by)
+    {
+        Rect2 g = this;
+
+        g._position.X -= by;
+        g._position.Y -= by;
+        g._size.X += by * 2;
+        g._size.Y += by * 2;
+
+        return g;
+    }
+
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
+    /// on each side individually.
+    /// </summary>
+    /// <seealso cref="Grow(real_t)"/>
+    /// <seealso cref="GrowSide(Side, real_t)"/>
+    /// <param name="left">The amount to grow by on the left side.</param>
+    /// <param name="top">The amount to grow by on the top side.</param>
+    /// <param name="right">The amount to grow by on the right side.</param>
+    /// <param name="bottom">The amount to grow by on the bottom side.</param>
+    /// <returns>The grown <see cref="Rect2"/>.</returns>
+    public readonly Rect2 GrowIndividual(real_t left, real_t top, real_t right, real_t bottom)
+    {
+        Rect2 g = this;
+
+        g._position.X -= left;
+        g._position.Y -= top;
+        g._size.X += left + right;
+        g._size.Y += top + bottom;
+
+        return g;
+    }
+
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
+    /// on the specified <see cref="Side"/>.
+    /// </summary>
+    /// <seealso cref="Grow(real_t)"/>
+    /// <seealso cref="GrowIndividual(real_t, real_t, real_t, real_t)"/>
+    /// <param name="side">The side to grow.</param>
+    /// <param name="by">The amount to grow by.</param>
+    /// <returns>The grown <see cref="Rect2"/>.</returns>
+    public readonly Rect2 GrowSide(Side side, real_t by)
+    {
+        Rect2 g = this;
+
+        g = g.GrowIndividual(Side.Left == side ? by : 0,
+                Side.Top == side ? by : 0,
+                Side.Right == side ? by : 0,
+                Side.Bottom == side ? by : 0);
+
+        return g;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2"/> has
+    /// area, and <see langword="false"/> if the <see cref="Rect2"/>
+    /// is linear, empty, or has a negative <see cref="Size"/>.
+    /// See also <see cref="Area"/>.
+    /// </summary>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> has area.
+    /// </returns>
+    public readonly bool HasArea()
+    {
+        return _size.X > 0.0f && _size.Y > 0.0f;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2"/> contains a point,
+    /// or <see langword="false"/> otherwise.
+    /// </summary>
+    /// <param name="point">The point to check.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> contains <paramref name="point"/>.
+    /// </returns>
+    public readonly bool HasPoint(Vector2 point)
+    {
+        if (point.X < _position.X)
+            return false;
+        if (point.Y < _position.Y)
+            return false;
+
+        if (point.X >= _position.X + _size.X)
+            return false;
+        if (point.Y >= _position.Y + _size.Y)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2"/> overlaps with <paramref name="b"/>
+    /// (i.e. they have at least one point in common).
+    ///
+    /// If <paramref name="includeBorders"/> is <see langword="true"/>,
+    /// they will also be considered overlapping if their borders touch,
+    /// even without intersection.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2"/> to check for intersections with.</param>
+    /// <param name="includeBorders">Whether or not to consider borders.</param>
+    /// <returns>A <see langword="bool"/> for whether or not they are intersecting.</returns>
+    public readonly bool Intersects(Rect2 b, bool includeBorders = false)
+    {
+        if (includeBorders)
+        {
+            if (_position.X > b._position.X + b._size.X)
             {
-                return new Rect2();
-            }
-
-            newRect._position.X = Mathf.Max(b._position.X, _position.X);
-            newRect._position.Y = Mathf.Max(b._position.Y, _position.Y);
-
-            Vector2 bEnd = b._position + b._size;
-            Vector2 end = _position + _size;
-
-            newRect._size.X = Mathf.Min(bEnd.X, end.X) - newRect._position.X;
-            newRect._size.Y = Mathf.Min(bEnd.Y, end.Y) - newRect._position.Y;
-
-            return newRect;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Rect2"/> is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public bool IsFinite()
-        {
-            return _position.IsFinite() && _size.IsFinite();
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Rect2"/> completely encloses another one.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2"/> that may be enclosed.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not this <see cref="Rect2"/> encloses <paramref name="b"/>.
-        /// </returns>
-        public readonly bool Encloses(Rect2 b)
-        {
-            return b._position.X >= _position.X && b._position.Y >= _position.Y &&
-               b._position.X + b._size.X < _position.X + _size.X &&
-               b._position.Y + b._size.Y < _position.Y + _size.Y;
-        }
-
-        /// <summary>
-        /// Returns this <see cref="Rect2"/> expanded to include a given point.
-        /// </summary>
-        /// <param name="to">The point to include.</param>
-        /// <returns>The expanded <see cref="Rect2"/>.</returns>
-        public readonly Rect2 Expand(Vector2 to)
-        {
-            Rect2 expanded = this;
-
-            Vector2 begin = expanded._position;
-            Vector2 end = expanded._position + expanded._size;
-
-            if (to.X < begin.X)
-            {
-                begin.X = to.X;
-            }
-            if (to.Y < begin.Y)
-            {
-                begin.Y = to.Y;
-            }
-
-            if (to.X > end.X)
-            {
-                end.X = to.X;
-            }
-            if (to.Y > end.Y)
-            {
-                end.Y = to.Y;
-            }
-
-            expanded._position = begin;
-            expanded._size = end - begin;
-
-            return expanded;
-        }
-
-        /// <summary>
-        /// Returns the center of the <see cref="Rect2"/>, which is equal
-        /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
-        /// </summary>
-        /// <returns>The center.</returns>
-        public readonly Vector2 GetCenter()
-        {
-            return _position + (_size * 0.5f);
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
-        /// on all sides.
-        /// </summary>
-        /// <seealso cref="GrowIndividual(real_t, real_t, real_t, real_t)"/>
-        /// <seealso cref="GrowSide(Side, real_t)"/>
-        /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown <see cref="Rect2"/>.</returns>
-        public readonly Rect2 Grow(real_t by)
-        {
-            Rect2 g = this;
-
-            g._position.X -= by;
-            g._position.Y -= by;
-            g._size.X += by * 2;
-            g._size.Y += by * 2;
-
-            return g;
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
-        /// on each side individually.
-        /// </summary>
-        /// <seealso cref="Grow(real_t)"/>
-        /// <seealso cref="GrowSide(Side, real_t)"/>
-        /// <param name="left">The amount to grow by on the left side.</param>
-        /// <param name="top">The amount to grow by on the top side.</param>
-        /// <param name="right">The amount to grow by on the right side.</param>
-        /// <param name="bottom">The amount to grow by on the bottom side.</param>
-        /// <returns>The grown <see cref="Rect2"/>.</returns>
-        public readonly Rect2 GrowIndividual(real_t left, real_t top, real_t right, real_t bottom)
-        {
-            Rect2 g = this;
-
-            g._position.X -= left;
-            g._position.Y -= top;
-            g._size.X += left + right;
-            g._size.Y += top + bottom;
-
-            return g;
-        }
-
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2"/> grown by the specified amount
-        /// on the specified <see cref="Side"/>.
-        /// </summary>
-        /// <seealso cref="Grow(real_t)"/>
-        /// <seealso cref="GrowIndividual(real_t, real_t, real_t, real_t)"/>
-        /// <param name="side">The side to grow.</param>
-        /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown <see cref="Rect2"/>.</returns>
-        public readonly Rect2 GrowSide(Side side, real_t by)
-        {
-            Rect2 g = this;
-
-            g = g.GrowIndividual(Side.Left == side ? by : 0,
-                    Side.Top == side ? by : 0,
-                    Side.Right == side ? by : 0,
-                    Side.Bottom == side ? by : 0);
-
-            return g;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2"/> has
-        /// area, and <see langword="false"/> if the <see cref="Rect2"/>
-        /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="Area"/>.
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> has area.
-        /// </returns>
-        public readonly bool HasArea()
-        {
-            return _size.X > 0.0f && _size.Y > 0.0f;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2"/> contains a point,
-        /// or <see langword="false"/> otherwise.
-        /// </summary>
-        /// <param name="point">The point to check.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Rect2"/> contains <paramref name="point"/>.
-        /// </returns>
-        public readonly bool HasPoint(Vector2 point)
-        {
-            if (point.X < _position.X)
                 return false;
-            if (point.Y < _position.Y)
-                return false;
-
-            if (point.X >= _position.X + _size.X)
-                return false;
-            if (point.Y >= _position.Y + _size.Y)
-                return false;
-
-            return true;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2"/> overlaps with <paramref name="b"/>
-        /// (i.e. they have at least one point in common).
-        ///
-        /// If <paramref name="includeBorders"/> is <see langword="true"/>,
-        /// they will also be considered overlapping if their borders touch,
-        /// even without intersection.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2"/> to check for intersections with.</param>
-        /// <param name="includeBorders">Whether or not to consider borders.</param>
-        /// <returns>A <see langword="bool"/> for whether or not they are intersecting.</returns>
-        public readonly bool Intersects(Rect2 b, bool includeBorders = false)
-        {
-            if (includeBorders)
-            {
-                if (_position.X > b._position.X + b._size.X)
-                {
-                    return false;
-                }
-                if (_position.X + _size.X < b._position.X)
-                {
-                    return false;
-                }
-                if (_position.Y > b._position.Y + b._size.Y)
-                {
-                    return false;
-                }
-                if (_position.Y + _size.Y < b._position.Y)
-                {
-                    return false;
-                }
             }
-            else
+            if (_position.X + _size.X < b._position.X)
             {
-                if (_position.X >= b._position.X + b._size.X)
-                {
-                    return false;
-                }
-                if (_position.X + _size.X <= b._position.X)
-                {
-                    return false;
-                }
-                if (_position.Y >= b._position.Y + b._size.Y)
-                {
-                    return false;
-                }
-                if (_position.Y + _size.Y <= b._position.Y)
-                {
-                    return false;
-                }
+                return false;
             }
-
-            return true;
+            if (_position.Y > b._position.Y + b._size.Y)
+            {
+                return false;
+            }
+            if (_position.Y + _size.Y < b._position.Y)
+            {
+                return false;
+            }
         }
-
-        /// <summary>
-        /// Returns a larger <see cref="Rect2"/> that contains this <see cref="Rect2"/> and <paramref name="b"/>.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2"/>.</param>
-        /// <returns>The merged <see cref="Rect2"/>.</returns>
-        public readonly Rect2 Merge(Rect2 b)
+        else
         {
-            Rect2 newRect;
-
-            newRect._position.X = Mathf.Min(b._position.X, _position.X);
-            newRect._position.Y = Mathf.Min(b._position.Y, _position.Y);
-
-            newRect._size.X = Mathf.Max(b._position.X + b._size.X, _position.X + _size.X);
-            newRect._size.Y = Mathf.Max(b._position.Y + b._size.Y, _position.Y + _size.Y);
-
-            newRect._size -= newRect._position; // Make relative again
-
-            return newRect;
+            if (_position.X >= b._position.X + b._size.X)
+            {
+                return false;
+            }
+            if (_position.X + _size.X <= b._position.X)
+            {
+                return false;
+            }
+            if (_position.Y >= b._position.Y + b._size.Y)
+            {
+                return false;
+            }
+            if (_position.Y + _size.Y <= b._position.Y)
+            {
+                return false;
+            }
         }
 
-        /// <summary>
-        /// Constructs a <see cref="Rect2"/> from a position and size.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="size">The size.</param>
-        public Rect2(Vector2 position, Vector2 size)
-        {
-            _position = position;
-            _size = size;
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Constructs a <see cref="Rect2"/> from a position, width, and height.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        public Rect2(Vector2 position, real_t width, real_t height)
-        {
-            _position = position;
-            _size = new Vector2(width, height);
-        }
+    /// <summary>
+    /// Returns a larger <see cref="Rect2"/> that contains this <see cref="Rect2"/> and <paramref name="b"/>.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2"/>.</param>
+    /// <returns>The merged <see cref="Rect2"/>.</returns>
+    public readonly Rect2 Merge(Rect2 b)
+    {
+        Rect2 newRect;
 
-        /// <summary>
-        /// Constructs a <see cref="Rect2"/> from x, y, and size.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="size">The size.</param>
-        public Rect2(real_t x, real_t y, Vector2 size)
-        {
-            _position = new Vector2(x, y);
-            _size = size;
-        }
+        newRect._position.X = Mathf.Min(b._position.X, _position.X);
+        newRect._position.Y = Mathf.Min(b._position.Y, _position.Y);
 
-        /// <summary>
-        /// Constructs a <see cref="Rect2"/> from x, y, width, and height.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        public Rect2(real_t x, real_t y, real_t width, real_t height)
-        {
-            _position = new Vector2(x, y);
-            _size = new Vector2(width, height);
-        }
+        newRect._size.X = Mathf.Max(b._position.X + b._size.X, _position.X + _size.X);
+        newRect._size.Y = Mathf.Max(b._position.Y + b._size.Y, _position.Y + _size.Y);
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Rect2"/>s are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the rects are exactly equal.</returns>
-        public static bool operator ==(Rect2 left, Rect2 right)
-        {
-            return left.Equals(right);
-        }
+        newRect._size -= newRect._position; // Make relative again
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Rect2"/>s are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the rects are not equal.</returns>
-        public static bool operator !=(Rect2 left, Rect2 right)
-        {
-            return !left.Equals(right);
-        }
+        return newRect;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the rect and the other object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Rect2 other && Equals(other);
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2"/> from a position and size.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="size">The size.</param>
+    public Rect2(Vector2 position, Vector2 size)
+    {
+        _position = position;
+        _size = size;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
-        /// </summary>
-        /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are exactly equal.</returns>
-        public readonly bool Equals(Rect2 other)
-        {
-            return _position.Equals(other._position) && _size.Equals(other._size);
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2"/> from a position, width, and height.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    public Rect2(Vector2 position, real_t width, real_t height)
+    {
+        _position = position;
+        _size = new Vector2(width, height);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Vector2.IsEqualApprox(Vector2)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Rect2 other)
-        {
-            return _position.IsEqualApprox(other._position) && _size.IsEqualApprox(other.Size);
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2"/> from x, y, and size.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="size">The size.</param>
+    public Rect2(real_t x, real_t y, Vector2 size)
+    {
+        _position = new Vector2(x, y);
+        _size = size;
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Rect2"/>.
-        /// </summary>
-        /// <returns>A hash code for this rect.</returns>
-        public override readonly int GetHashCode()
-        {
-            return _position.GetHashCode() ^ _size.GetHashCode();
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2"/> from x, y, width, and height.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    public Rect2(real_t x, real_t y, real_t width, real_t height)
+    {
+        _position = new Vector2(x, y);
+        _size = new Vector2(width, height);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Rect2"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this rect.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Rect2"/>s are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the rects are exactly equal.</returns>
+    public static bool operator ==(Rect2 left, Rect2 right)
+    {
+        return left.Equals(right);
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Rect2"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this rect.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Rect2"/>s are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the rects are not equal.</returns>
+    public static bool operator !=(Rect2 left, Rect2 right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the rect and the other object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Rect2 other && Equals(other);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
+    /// </summary>
+    /// <param name="other">The other rect to compare.</param>
+    /// <returns>Whether or not the rects are exactly equal.</returns>
+    public readonly bool Equals(Rect2 other)
+    {
+        return _position.Equals(other._position) && _size.Equals(other._size);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Vector2.IsEqualApprox(Vector2)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other rect to compare.</param>
+    /// <returns>Whether or not the rects are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Rect2 other)
+    {
+        return _position.IsEqualApprox(other._position) && _size.IsEqualApprox(other.Size);
+    }
+
+    /// <summary>
+    /// Serves as the hash function for <see cref="Rect2"/>.
+    /// </summary>
+    /// <returns>A hash code for this rect.</returns>
+    public override readonly int GetHashCode()
+    {
+        return _position.GetHashCode() ^ _size.GetHashCode();
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Rect2"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this rect.</returns>
+    public override readonly string ToString()
+    {
+        return $"{_position}, {_size}";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Rect2"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this rect.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"{_position.ToString(format)}, {_size.ToString(format)}";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rect2I.cs
@@ -1,443 +1,442 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 2D axis-aligned bounding box using integers. Rect2I consists of a position, a size, and
+/// several utility functions. It is typically used for fast overlap tests.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Rect2I : IEquatable<Rect2I>
 {
+    private Vector2I _position;
+    private Vector2I _size;
+
     /// <summary>
-    /// 2D axis-aligned bounding box using integers. Rect2I consists of a position, a size, and
-    /// several utility functions. It is typically used for fast overlap tests.
+    /// Beginning corner. Typically has values lower than <see cref="End"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Rect2I : IEquatable<Rect2I>
+    /// <value>Directly uses a private field.</value>
+    public Vector2I Position
     {
-        private Vector2I _position;
-        private Vector2I _size;
+        readonly get { return _position; }
+        set { _position = value; }
+    }
 
-        /// <summary>
-        /// Beginning corner. Typically has values lower than <see cref="End"/>.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector2I Position
+    /// <summary>
+    /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
+    /// If the size is negative, you can use <see cref="Abs"/> to fix it.
+    /// </summary>
+    /// <value>Directly uses a private field.</value>
+    public Vector2I Size
+    {
+        readonly get { return _size; }
+        set { _size = value; }
+    }
+
+    /// <summary>
+    /// Ending corner. This is calculated as <see cref="Position"/> plus <see cref="Size"/>.
+    /// Setting this value will change the size.
+    /// </summary>
+    /// <value>
+    /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
+    /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
+    /// </value>
+    public Vector2I End
+    {
+        readonly get { return _position + _size; }
+        set { _size = value - _position; }
+    }
+
+    /// <summary>
+    /// The area of this <see cref="Rect2I"/>.
+    /// See also <see cref="HasArea"/>.
+    /// </summary>
+    public readonly int Area
+    {
+        get { return _size.X * _size.Y; }
+    }
+
+    /// <summary>
+    /// Returns a <see cref="Rect2I"/> with equivalent position and size, modified so that
+    /// the top-left corner is the origin and width and height are positive.
+    /// </summary>
+    /// <returns>The modified <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I Abs()
+    {
+        Vector2I end = End;
+        Vector2I topLeft = new Vector2I(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y));
+        return new Rect2I(topLeft, _size.Abs());
+    }
+
+    /// <summary>
+    /// Returns the intersection of this <see cref="Rect2I"/> and <paramref name="b"/>.
+    /// If the rectangles do not intersect, an empty <see cref="Rect2I"/> is returned.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2I"/>.</param>
+    /// <returns>
+    /// The intersection of this <see cref="Rect2I"/> and <paramref name="b"/>,
+    /// or an empty <see cref="Rect2I"/> if they do not intersect.
+    /// </returns>
+    public readonly Rect2I Intersection(Rect2I b)
+    {
+        Rect2I newRect = b;
+
+        if (!Intersects(newRect))
         {
-            readonly get { return _position; }
-            set { _position = value; }
+            return new Rect2I();
         }
 
-        /// <summary>
-        /// Size from <see cref="Position"/> to <see cref="End"/>. Typically all components are positive.
-        /// If the size is negative, you can use <see cref="Abs"/> to fix it.
-        /// </summary>
-        /// <value>Directly uses a private field.</value>
-        public Vector2I Size
+        newRect._position.X = Mathf.Max(b._position.X, _position.X);
+        newRect._position.Y = Mathf.Max(b._position.Y, _position.Y);
+
+        Vector2I bEnd = b._position + b._size;
+        Vector2I end = _position + _size;
+
+        newRect._size.X = Mathf.Min(bEnd.X, end.X) - newRect._position.X;
+        newRect._size.Y = Mathf.Min(bEnd.Y, end.Y) - newRect._position.Y;
+
+        return newRect;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="Rect2I"/> completely encloses another one.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2I"/> that may be enclosed.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not this <see cref="Rect2I"/> encloses <paramref name="b"/>.
+    /// </returns>
+    public readonly bool Encloses(Rect2I b)
+    {
+        return b._position.X >= _position.X && b._position.Y >= _position.Y &&
+           b._position.X + b._size.X < _position.X + _size.X &&
+           b._position.Y + b._size.Y < _position.Y + _size.Y;
+    }
+
+    /// <summary>
+    /// Returns this <see cref="Rect2I"/> expanded to include a given point.
+    /// </summary>
+    /// <param name="to">The point to include.</param>
+    /// <returns>The expanded <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I Expand(Vector2I to)
+    {
+        Rect2I expanded = this;
+
+        Vector2I begin = expanded._position;
+        Vector2I end = expanded._position + expanded._size;
+
+        if (to.X < begin.X)
         {
-            readonly get { return _size; }
-            set { _size = value; }
+            begin.X = to.X;
+        }
+        if (to.Y < begin.Y)
+        {
+            begin.Y = to.Y;
         }
 
-        /// <summary>
-        /// Ending corner. This is calculated as <see cref="Position"/> plus <see cref="Size"/>.
-        /// Setting this value will change the size.
-        /// </summary>
-        /// <value>
-        /// Getting is equivalent to <paramref name="value"/> = <see cref="Position"/> + <see cref="Size"/>,
-        /// setting is equivalent to <see cref="Size"/> = <paramref name="value"/> - <see cref="Position"/>
-        /// </value>
-        public Vector2I End
+        if (to.X > end.X)
         {
-            readonly get { return _position + _size; }
-            set { _size = value - _position; }
+            end.X = to.X;
+        }
+        if (to.Y > end.Y)
+        {
+            end.Y = to.Y;
         }
 
-        /// <summary>
-        /// The area of this <see cref="Rect2I"/>.
-        /// See also <see cref="HasArea"/>.
-        /// </summary>
-        public readonly int Area
-        {
-            get { return _size.X * _size.Y; }
-        }
+        expanded._position = begin;
+        expanded._size = end - begin;
 
-        /// <summary>
-        /// Returns a <see cref="Rect2I"/> with equivalent position and size, modified so that
-        /// the top-left corner is the origin and width and height are positive.
-        /// </summary>
-        /// <returns>The modified <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I Abs()
-        {
-            Vector2I end = End;
-            Vector2I topLeft = new Vector2I(Mathf.Min(_position.X, end.X), Mathf.Min(_position.Y, end.Y));
-            return new Rect2I(topLeft, _size.Abs());
-        }
+        return expanded;
+    }
 
-        /// <summary>
-        /// Returns the intersection of this <see cref="Rect2I"/> and <paramref name="b"/>.
-        /// If the rectangles do not intersect, an empty <see cref="Rect2I"/> is returned.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2I"/>.</param>
-        /// <returns>
-        /// The intersection of this <see cref="Rect2I"/> and <paramref name="b"/>,
-        /// or an empty <see cref="Rect2I"/> if they do not intersect.
-        /// </returns>
-        public readonly Rect2I Intersection(Rect2I b)
-        {
-            Rect2I newRect = b;
+    /// <summary>
+    /// Returns the center of the <see cref="Rect2I"/>, which is equal
+    /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
+    /// If <see cref="Size"/> is an odd number, the returned center
+    /// value will be rounded towards <see cref="Position"/>.
+    /// </summary>
+    /// <returns>The center.</returns>
+    public readonly Vector2I GetCenter()
+    {
+        return _position + (_size / 2);
+    }
 
-            if (!Intersects(newRect))
-            {
-                return new Rect2I();
-            }
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
+    /// on all sides.
+    /// </summary>
+    /// <seealso cref="GrowIndividual(int, int, int, int)"/>
+    /// <seealso cref="GrowSide(Side, int)"/>
+    /// <param name="by">The amount to grow by.</param>
+    /// <returns>The grown <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I Grow(int by)
+    {
+        Rect2I g = this;
 
-            newRect._position.X = Mathf.Max(b._position.X, _position.X);
-            newRect._position.Y = Mathf.Max(b._position.Y, _position.Y);
+        g._position.X -= by;
+        g._position.Y -= by;
+        g._size.X += by * 2;
+        g._size.Y += by * 2;
 
-            Vector2I bEnd = b._position + b._size;
-            Vector2I end = _position + _size;
+        return g;
+    }
 
-            newRect._size.X = Mathf.Min(bEnd.X, end.X) - newRect._position.X;
-            newRect._size.Y = Mathf.Min(bEnd.Y, end.Y) - newRect._position.Y;
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
+    /// on each side individually.
+    /// </summary>
+    /// <seealso cref="Grow(int)"/>
+    /// <seealso cref="GrowSide(Side, int)"/>
+    /// <param name="left">The amount to grow by on the left side.</param>
+    /// <param name="top">The amount to grow by on the top side.</param>
+    /// <param name="right">The amount to grow by on the right side.</param>
+    /// <param name="bottom">The amount to grow by on the bottom side.</param>
+    /// <returns>The grown <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I GrowIndividual(int left, int top, int right, int bottom)
+    {
+        Rect2I g = this;
 
-            return newRect;
-        }
+        g._position.X -= left;
+        g._position.Y -= top;
+        g._size.X += left + right;
+        g._size.Y += top + bottom;
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Rect2I"/> completely encloses another one.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2I"/> that may be enclosed.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not this <see cref="Rect2I"/> encloses <paramref name="b"/>.
-        /// </returns>
-        public readonly bool Encloses(Rect2I b)
-        {
-            return b._position.X >= _position.X && b._position.Y >= _position.Y &&
-               b._position.X + b._size.X < _position.X + _size.X &&
-               b._position.Y + b._size.Y < _position.Y + _size.Y;
-        }
+        return g;
+    }
 
-        /// <summary>
-        /// Returns this <see cref="Rect2I"/> expanded to include a given point.
-        /// </summary>
-        /// <param name="to">The point to include.</param>
-        /// <returns>The expanded <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I Expand(Vector2I to)
-        {
-            Rect2I expanded = this;
+    /// <summary>
+    /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
+    /// on the specified <see cref="Side"/>.
+    /// </summary>
+    /// <seealso cref="Grow(int)"/>
+    /// <seealso cref="GrowIndividual(int, int, int, int)"/>
+    /// <param name="side">The side to grow.</param>
+    /// <param name="by">The amount to grow by.</param>
+    /// <returns>The grown <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I GrowSide(Side side, int by)
+    {
+        Rect2I g = this;
 
-            Vector2I begin = expanded._position;
-            Vector2I end = expanded._position + expanded._size;
+        g = g.GrowIndividual(Side.Left == side ? by : 0,
+                Side.Top == side ? by : 0,
+                Side.Right == side ? by : 0,
+                Side.Bottom == side ? by : 0);
 
-            if (to.X < begin.X)
-            {
-                begin.X = to.X;
-            }
-            if (to.Y < begin.Y)
-            {
-                begin.Y = to.Y;
-            }
+        return g;
+    }
 
-            if (to.X > end.X)
-            {
-                end.X = to.X;
-            }
-            if (to.Y > end.Y)
-            {
-                end.Y = to.Y;
-            }
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2I"/> has
+    /// area, and <see langword="false"/> if the <see cref="Rect2I"/>
+    /// is linear, empty, or has a negative <see cref="Size"/>.
+    /// See also <see cref="Area"/>.
+    /// </summary>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Rect2I"/> has area.
+    /// </returns>
+    public readonly bool HasArea()
+    {
+        return _size.X > 0 && _size.Y > 0;
+    }
 
-            expanded._position = begin;
-            expanded._size = end - begin;
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2I"/> contains a point,
+    /// or <see langword="false"/> otherwise.
+    /// </summary>
+    /// <param name="point">The point to check.</param>
+    /// <returns>
+    /// A <see langword="bool"/> for whether or not the <see cref="Rect2I"/> contains <paramref name="point"/>.
+    /// </returns>
+    public readonly bool HasPoint(Vector2I point)
+    {
+        if (point.X < _position.X)
+            return false;
+        if (point.Y < _position.Y)
+            return false;
 
-            return expanded;
-        }
+        if (point.X >= _position.X + _size.X)
+            return false;
+        if (point.Y >= _position.Y + _size.Y)
+            return false;
 
-        /// <summary>
-        /// Returns the center of the <see cref="Rect2I"/>, which is equal
-        /// to <see cref="Position"/> + (<see cref="Size"/> / 2).
-        /// If <see cref="Size"/> is an odd number, the returned center
-        /// value will be rounded towards <see cref="Position"/>.
-        /// </summary>
-        /// <returns>The center.</returns>
-        public readonly Vector2I GetCenter()
-        {
-            return _position + (_size / 2);
-        }
+        return true;
+    }
 
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
-        /// on all sides.
-        /// </summary>
-        /// <seealso cref="GrowIndividual(int, int, int, int)"/>
-        /// <seealso cref="GrowSide(Side, int)"/>
-        /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I Grow(int by)
-        {
-            Rect2I g = this;
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rect2I"/> overlaps with <paramref name="b"/>
+    /// (i.e. they have at least one point in common).
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2I"/> to check for intersections with.</param>
+    /// <returns>A <see langword="bool"/> for whether or not they are intersecting.</returns>
+    public readonly bool Intersects(Rect2I b)
+    {
+        if (_position.X >= b._position.X + b._size.X)
+            return false;
+        if (_position.X + _size.X <= b._position.X)
+            return false;
+        if (_position.Y >= b._position.Y + b._size.Y)
+            return false;
+        if (_position.Y + _size.Y <= b._position.Y)
+            return false;
 
-            g._position.X -= by;
-            g._position.Y -= by;
-            g._size.X += by * 2;
-            g._size.Y += by * 2;
+        return true;
+    }
 
-            return g;
-        }
+    /// <summary>
+    /// Returns a larger <see cref="Rect2I"/> that contains this <see cref="Rect2I"/> and <paramref name="b"/>.
+    /// </summary>
+    /// <param name="b">The other <see cref="Rect2I"/>.</param>
+    /// <returns>The merged <see cref="Rect2I"/>.</returns>
+    public readonly Rect2I Merge(Rect2I b)
+    {
+        Rect2I newRect;
 
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
-        /// on each side individually.
-        /// </summary>
-        /// <seealso cref="Grow(int)"/>
-        /// <seealso cref="GrowSide(Side, int)"/>
-        /// <param name="left">The amount to grow by on the left side.</param>
-        /// <param name="top">The amount to grow by on the top side.</param>
-        /// <param name="right">The amount to grow by on the right side.</param>
-        /// <param name="bottom">The amount to grow by on the bottom side.</param>
-        /// <returns>The grown <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I GrowIndividual(int left, int top, int right, int bottom)
-        {
-            Rect2I g = this;
+        newRect._position.X = Mathf.Min(b._position.X, _position.X);
+        newRect._position.Y = Mathf.Min(b._position.Y, _position.Y);
 
-            g._position.X -= left;
-            g._position.Y -= top;
-            g._size.X += left + right;
-            g._size.Y += top + bottom;
+        newRect._size.X = Mathf.Max(b._position.X + b._size.X, _position.X + _size.X);
+        newRect._size.Y = Mathf.Max(b._position.Y + b._size.Y, _position.Y + _size.Y);
 
-            return g;
-        }
+        newRect._size -= newRect._position; // Make relative again
 
-        /// <summary>
-        /// Returns a copy of the <see cref="Rect2I"/> grown by the specified amount
-        /// on the specified <see cref="Side"/>.
-        /// </summary>
-        /// <seealso cref="Grow(int)"/>
-        /// <seealso cref="GrowIndividual(int, int, int, int)"/>
-        /// <param name="side">The side to grow.</param>
-        /// <param name="by">The amount to grow by.</param>
-        /// <returns>The grown <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I GrowSide(Side side, int by)
-        {
-            Rect2I g = this;
+        return newRect;
+    }
 
-            g = g.GrowIndividual(Side.Left == side ? by : 0,
-                    Side.Top == side ? by : 0,
-                    Side.Right == side ? by : 0,
-                    Side.Bottom == side ? by : 0);
+    /// <summary>
+    /// Constructs a <see cref="Rect2I"/> from a position and size.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="size">The size.</param>
+    public Rect2I(Vector2I position, Vector2I size)
+    {
+        _position = position;
+        _size = size;
+    }
 
-            return g;
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2I"/> from a position, width, and height.
+    /// </summary>
+    /// <param name="position">The position.</param>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    public Rect2I(Vector2I position, int width, int height)
+    {
+        _position = position;
+        _size = new Vector2I(width, height);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2I"/> has
-        /// area, and <see langword="false"/> if the <see cref="Rect2I"/>
-        /// is linear, empty, or has a negative <see cref="Size"/>.
-        /// See also <see cref="Area"/>.
-        /// </summary>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Rect2I"/> has area.
-        /// </returns>
-        public readonly bool HasArea()
-        {
-            return _size.X > 0 && _size.Y > 0;
-        }
+    /// <summary>
+    /// Constructs a <see cref="Rect2I"/> from x, y, and size.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="size">The size.</param>
+    public Rect2I(int x, int y, Vector2I size)
+    {
+        _position = new Vector2I(x, y);
+        _size = size;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2I"/> contains a point,
-        /// or <see langword="false"/> otherwise.
-        /// </summary>
-        /// <param name="point">The point to check.</param>
-        /// <returns>
-        /// A <see langword="bool"/> for whether or not the <see cref="Rect2I"/> contains <paramref name="point"/>.
-        /// </returns>
-        public readonly bool HasPoint(Vector2I point)
-        {
-            if (point.X < _position.X)
-                return false;
-            if (point.Y < _position.Y)
-                return false;
+    /// <summary>
+    /// Constructs a <see cref="Rect2I"/> from x, y, width, and height.
+    /// </summary>
+    /// <param name="x">The position's X coordinate.</param>
+    /// <param name="y">The position's Y coordinate.</param>
+    /// <param name="width">The width.</param>
+    /// <param name="height">The height.</param>
+    public Rect2I(int x, int y, int width, int height)
+    {
+        _position = new Vector2I(x, y);
+        _size = new Vector2I(width, height);
+    }
 
-            if (point.X >= _position.X + _size.X)
-                return false;
-            if (point.Y >= _position.Y + _size.Y)
-                return false;
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Rect2I"/>s are exactly equal.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the rects are equal.</returns>
+    public static bool operator ==(Rect2I left, Rect2I right)
+    {
+        return left.Equals(right);
+    }
 
-            return true;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the
+    /// <see cref="Rect2I"/>s are not equal.
+    /// </summary>
+    /// <param name="left">The left rect.</param>
+    /// <param name="right">The right rect.</param>
+    /// <returns>Whether or not the rects are not equal.</returns>
+    public static bool operator !=(Rect2I left, Rect2I right)
+    {
+        return !left.Equals(right);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rect2I"/> overlaps with <paramref name="b"/>
-        /// (i.e. they have at least one point in common).
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2I"/> to check for intersections with.</param>
-        /// <returns>A <see langword="bool"/> for whether or not they are intersecting.</returns>
-        public readonly bool Intersects(Rect2I b)
-        {
-            if (_position.X >= b._position.X + b._size.X)
-                return false;
-            if (_position.X + _size.X <= b._position.X)
-                return false;
-            if (_position.Y >= b._position.Y + b._size.Y)
-                return false;
-            if (_position.Y + _size.Y <= b._position.Y)
-                return false;
+    /// <summary>
+    /// Converts this <see cref="Rect2I"/> to a <see cref="Rect2"/>.
+    /// </summary>
+    /// <param name="value">The rect to convert.</param>
+    public static implicit operator Rect2(Rect2I value)
+    {
+        return new Rect2(value._position, value._size);
+    }
 
-            return true;
-        }
+    /// <summary>
+    /// Converts a <see cref="Rect2"/> to a <see cref="Rect2I"/>.
+    /// </summary>
+    /// <param name="value">The rect to convert.</param>
+    public static explicit operator Rect2I(Rect2 value)
+    {
+        return new Rect2I((Vector2I)value.Position, (Vector2I)value.Size);
+    }
 
-        /// <summary>
-        /// Returns a larger <see cref="Rect2I"/> that contains this <see cref="Rect2I"/> and <paramref name="b"/>.
-        /// </summary>
-        /// <param name="b">The other <see cref="Rect2I"/>.</param>
-        /// <returns>The merged <see cref="Rect2I"/>.</returns>
-        public readonly Rect2I Merge(Rect2I b)
-        {
-            Rect2I newRect;
+    /// <summary>
+    /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the rect and the other object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Rect2I other && Equals(other);
+    }
 
-            newRect._position.X = Mathf.Min(b._position.X, _position.X);
-            newRect._position.Y = Mathf.Min(b._position.Y, _position.Y);
+    /// <summary>
+    /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
+    /// </summary>
+    /// <param name="other">The other rect to compare.</param>
+    /// <returns>Whether or not the rects are equal.</returns>
+    public readonly bool Equals(Rect2I other)
+    {
+        return _position.Equals(other._position) && _size.Equals(other._size);
+    }
 
-            newRect._size.X = Mathf.Max(b._position.X + b._size.X, _position.X + _size.X);
-            newRect._size.Y = Mathf.Max(b._position.Y + b._size.Y, _position.Y + _size.Y);
+    /// <summary>
+    /// Serves as the hash function for <see cref="Rect2I"/>.
+    /// </summary>
+    /// <returns>A hash code for this rect.</returns>
+    public override readonly int GetHashCode()
+    {
+        return _position.GetHashCode() ^ _size.GetHashCode();
+    }
 
-            newRect._size -= newRect._position; // Make relative again
+    /// <summary>
+    /// Converts this <see cref="Rect2I"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this rect.</returns>
+    public override readonly string ToString()
+    {
+        return $"{_position}, {_size}";
+    }
 
-            return newRect;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Rect2I"/> from a position and size.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="size">The size.</param>
-        public Rect2I(Vector2I position, Vector2I size)
-        {
-            _position = position;
-            _size = size;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Rect2I"/> from a position, width, and height.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        public Rect2I(Vector2I position, int width, int height)
-        {
-            _position = position;
-            _size = new Vector2I(width, height);
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Rect2I"/> from x, y, and size.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="size">The size.</param>
-        public Rect2I(int x, int y, Vector2I size)
-        {
-            _position = new Vector2I(x, y);
-            _size = size;
-        }
-
-        /// <summary>
-        /// Constructs a <see cref="Rect2I"/> from x, y, width, and height.
-        /// </summary>
-        /// <param name="x">The position's X coordinate.</param>
-        /// <param name="y">The position's Y coordinate.</param>
-        /// <param name="width">The width.</param>
-        /// <param name="height">The height.</param>
-        public Rect2I(int x, int y, int width, int height)
-        {
-            _position = new Vector2I(x, y);
-            _size = new Vector2I(width, height);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Rect2I"/>s are exactly equal.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the rects are equal.</returns>
-        public static bool operator ==(Rect2I left, Rect2I right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the
-        /// <see cref="Rect2I"/>s are not equal.
-        /// </summary>
-        /// <param name="left">The left rect.</param>
-        /// <param name="right">The right rect.</param>
-        /// <returns>Whether or not the rects are not equal.</returns>
-        public static bool operator !=(Rect2I left, Rect2I right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Rect2I"/> to a <see cref="Rect2"/>.
-        /// </summary>
-        /// <param name="value">The rect to convert.</param>
-        public static implicit operator Rect2(Rect2I value)
-        {
-            return new Rect2(value._position, value._size);
-        }
-
-        /// <summary>
-        /// Converts a <see cref="Rect2"/> to a <see cref="Rect2I"/>.
-        /// </summary>
-        /// <param name="value">The rect to convert.</param>
-        public static explicit operator Rect2I(Rect2 value)
-        {
-            return new Rect2I((Vector2I)value.Position, (Vector2I)value.Size);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this rect and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the rect and the other object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Rect2I other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this rect and <paramref name="other"/> are equal.
-        /// </summary>
-        /// <param name="other">The other rect to compare.</param>
-        /// <returns>Whether or not the rects are equal.</returns>
-        public readonly bool Equals(Rect2I other)
-        {
-            return _position.Equals(other._position) && _size.Equals(other._size);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Rect2I"/>.
-        /// </summary>
-        /// <returns>A hash code for this rect.</returns>
-        public override readonly int GetHashCode()
-        {
-            return _position.GetHashCode() ^ _size.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Rect2I"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this rect.</returns>
-        public override readonly string ToString()
-        {
-            return $"{_position}, {_size}";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Rect2I"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this rect.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"{_position.ToString(format)}, {_size.ToString(format)}";
-        }
+    /// <summary>
+    /// Converts this <see cref="Rect2I"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this rect.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"{_position.ToString(format)}, {_size.ToString(format)}";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Rid.cs
@@ -3,102 +3,101 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// The RID type is used to access a low-level resource by its unique ID.
+/// RIDs are opaque, which means they do not grant access to the resource
+/// by themselves. They are used by the low-level server classes, such as
+/// <see cref="DisplayServer"/>, <see cref="RenderingServer"/>,
+/// <see cref="TextServer"/>, etc.
+///
+/// A low-level resource may correspond to a high-level <see cref="Resource"/>,
+/// such as <see cref="Texture"/> or <see cref="Mesh"/>
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct Rid : IEquatable<Rid>
 {
-    /// <summary>
-    /// The RID type is used to access a low-level resource by its unique ID.
-    /// RIDs are opaque, which means they do not grant access to the resource
-    /// by themselves. They are used by the low-level server classes, such as
-    /// <see cref="DisplayServer"/>, <see cref="RenderingServer"/>,
-    /// <see cref="TextServer"/>, etc.
-    ///
-    /// A low-level resource may correspond to a high-level <see cref="Resource"/>,
-    /// such as <see cref="Texture"/> or <see cref="Mesh"/>
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    public readonly struct Rid : IEquatable<Rid>
+    private readonly ulong _id; // Default is 0
+
+    internal Rid(ulong id)
     {
-        private readonly ulong _id; // Default is 0
-
-        internal Rid(ulong id)
-        {
-            _id = id;
-        }
-
-        /// <summary>
-        /// Constructs a new <see cref="Rid"/> for the given <see cref="GodotObject"/> <paramref name="from"/>.
-        /// </summary>
-        public Rid(GodotObject from)
-            => _id = from is Resource res ? res.GetRid()._id : default;
-
-        /// <summary>
-        /// Returns the ID of the referenced low-level resource.
-        /// </summary>
-        /// <returns>The ID of the referenced resource.</returns>
-        public ulong Id => _id;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rid"/> is not <c>0</c>.
-        /// </summary>
-        /// <returns>Whether or not the ID is valid.</returns>
-        public bool IsValid => _id != 0;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if both <see cref="Rid"/>s are equal,
-        /// which means they both refer to the same low-level resource.
-        /// </summary>
-        /// <param name="left">The left RID.</param>
-        /// <param name="right">The right RID.</param>
-        /// <returns>Whether or not the RIDs are equal.</returns>
-        public static bool operator ==(Rid left, Rid right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the <see cref="Rid"/>s are not equal.
-        /// </summary>
-        /// <param name="left">The left RID.</param>
-        /// <param name="right">The right RID.</param>
-        /// <returns>Whether or not the RIDs are equal.</returns>
-        public static bool operator !=(Rid left, Rid right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this RID and <paramref name="obj"/> are equal.
-        /// </summary>
-        /// <param name="obj">The other object to compare.</param>
-        /// <returns>Whether or not the color and the other object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Rid other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the RIDs are equal.
-        /// </summary>
-        /// <param name="other">The other RID.</param>
-        /// <returns>Whether or not the RIDs are equal.</returns>
-        public readonly bool Equals(Rid other)
-        {
-            return _id == other.Id;
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Rid"/>.
-        /// </summary>
-        /// <returns>A hash code for this RID.</returns>
-        public override readonly int GetHashCode()
-        {
-            return HashCode.Combine(_id);
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Rid"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this Rid.</returns>
-        public override string ToString() => $"RID({Id})";
+        _id = id;
     }
+
+    /// <summary>
+    /// Constructs a new <see cref="Rid"/> for the given <see cref="GodotObject"/> <paramref name="from"/>.
+    /// </summary>
+    public Rid(GodotObject from)
+        => _id = from is Resource res ? res.GetRid()._id : default;
+
+    /// <summary>
+    /// Returns the ID of the referenced low-level resource.
+    /// </summary>
+    /// <returns>The ID of the referenced resource.</returns>
+    public ulong Id => _id;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rid"/> is not <c>0</c>.
+    /// </summary>
+    /// <returns>Whether or not the ID is valid.</returns>
+    public bool IsValid => _id != 0;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if both <see cref="Rid"/>s are equal,
+    /// which means they both refer to the same low-level resource.
+    /// </summary>
+    /// <param name="left">The left RID.</param>
+    /// <param name="right">The right RID.</param>
+    /// <returns>Whether or not the RIDs are equal.</returns>
+    public static bool operator ==(Rid left, Rid right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the <see cref="Rid"/>s are not equal.
+    /// </summary>
+    /// <param name="left">The left RID.</param>
+    /// <param name="right">The right RID.</param>
+    /// <returns>Whether or not the RIDs are equal.</returns>
+    public static bool operator !=(Rid left, Rid right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this RID and <paramref name="obj"/> are equal.
+    /// </summary>
+    /// <param name="obj">The other object to compare.</param>
+    /// <returns>Whether or not the color and the other object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Rid other && Equals(other);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the RIDs are equal.
+    /// </summary>
+    /// <param name="other">The other RID.</param>
+    /// <returns>Whether or not the RIDs are equal.</returns>
+    public readonly bool Equals(Rid other)
+    {
+        return _id == other.Id;
+    }
+
+    /// <summary>
+    /// Serves as the hash function for <see cref="Rid"/>.
+    /// </summary>
+    /// <returns>A hash code for this RID.</returns>
+    public override readonly int GetHashCode()
+    {
+        return HashCode.Combine(_id);
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Rid"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this Rid.</returns>
+    public override string ToString() => $"RID({Id})";
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Signal.cs
@@ -1,38 +1,37 @@
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Represents a signal defined in an object.
+/// </summary>
+public readonly struct Signal : IAwaitable<Variant[]>
 {
+    private readonly GodotObject _owner;
+    private readonly StringName _signalName;
+
     /// <summary>
-    /// Represents a signal defined in an object.
+    /// Object that contains the signal.
     /// </summary>
-    public readonly struct Signal : IAwaitable<Variant[]>
+    public GodotObject Owner => _owner;
+
+    /// <summary>
+    /// Name of the signal.
+    /// </summary>
+    public StringName Name => _signalName;
+
+    /// <summary>
+    /// Creates a new <see cref="Signal"/> with the name <paramref name="name"/>
+    /// in the specified <paramref name="owner"/>.
+    /// </summary>
+    /// <param name="owner">Object that contains the signal.</param>
+    /// <param name="name">Name of the signal.</param>
+    public Signal(GodotObject owner, StringName name)
     {
-        private readonly GodotObject _owner;
-        private readonly StringName _signalName;
+        _owner = owner;
+        _signalName = name;
+    }
 
-        /// <summary>
-        /// Object that contains the signal.
-        /// </summary>
-        public GodotObject Owner => _owner;
-
-        /// <summary>
-        /// Name of the signal.
-        /// </summary>
-        public StringName Name => _signalName;
-
-        /// <summary>
-        /// Creates a new <see cref="Signal"/> with the name <paramref name="name"/>
-        /// in the specified <paramref name="owner"/>.
-        /// </summary>
-        /// <param name="owner">Object that contains the signal.</param>
-        /// <param name="name">Name of the signal.</param>
-        public Signal(GodotObject owner, StringName name)
-        {
-            _owner = owner;
-            _signalName = name;
-        }
-
-        public IAwaiter<Variant[]> GetAwaiter()
-        {
-            return new SignalAwaiter(_owner, _signalName, _owner);
-        }
+    public IAwaiter<Variant[]> GetAwaiter()
+    {
+        return new SignalAwaiter(_owner, _signalName, _owner);
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -2,66 +2,65 @@ using System;
 using System.Runtime.InteropServices;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+public class SignalAwaiter : IAwaiter<Variant[]>, IAwaitable<Variant[]>
 {
-    public class SignalAwaiter : IAwaiter<Variant[]>, IAwaitable<Variant[]>
+    private bool _completed;
+    private Variant[] _result;
+    private Action _continuation;
+
+    public SignalAwaiter(GodotObject source, StringName signal, GodotObject target)
     {
-        private bool _completed;
-        private Variant[] _result;
-        private Action _continuation;
+        var awaiterGcHandle = CustomGCHandle.AllocStrong(this);
+        using godot_string_name signalSrc = NativeFuncs.godotsharp_string_name_new_copy(
+            (godot_string_name)(signal?.NativeValue ?? default));
+        NativeFuncs.godotsharp_internal_signal_awaiter_connect(GodotObject.GetPtr(source), in signalSrc,
+            GodotObject.GetPtr(target), GCHandle.ToIntPtr(awaiterGcHandle));
+    }
 
-        public SignalAwaiter(GodotObject source, StringName signal, GodotObject target)
+    public bool IsCompleted => _completed;
+
+    public void OnCompleted(Action continuation)
+    {
+        _continuation = continuation;
+    }
+
+    public Variant[] GetResult() => _result;
+
+    public IAwaiter<Variant[]> GetAwaiter() => this;
+
+    [UnmanagedCallersOnly]
+    internal static unsafe void SignalCallback(IntPtr awaiterGCHandlePtr, godot_variant** args, int argCount,
+        godot_bool* outAwaiterIsNull)
+    {
+        try
         {
-            var awaiterGcHandle = CustomGCHandle.AllocStrong(this);
-            using godot_string_name signalSrc = NativeFuncs.godotsharp_string_name_new_copy(
-                (godot_string_name)(signal?.NativeValue ?? default));
-            NativeFuncs.godotsharp_internal_signal_awaiter_connect(GodotObject.GetPtr(source), in signalSrc,
-                GodotObject.GetPtr(target), GCHandle.ToIntPtr(awaiterGcHandle));
-        }
+            var awaiter = (SignalAwaiter)GCHandle.FromIntPtr(awaiterGCHandlePtr).Target;
 
-        public bool IsCompleted => _completed;
-
-        public void OnCompleted(Action continuation)
-        {
-            _continuation = continuation;
-        }
-
-        public Variant[] GetResult() => _result;
-
-        public IAwaiter<Variant[]> GetAwaiter() => this;
-
-        [UnmanagedCallersOnly]
-        internal static unsafe void SignalCallback(IntPtr awaiterGCHandlePtr, godot_variant** args, int argCount,
-            godot_bool* outAwaiterIsNull)
-        {
-            try
+            if (awaiter == null)
             {
-                var awaiter = (SignalAwaiter)GCHandle.FromIntPtr(awaiterGCHandlePtr).Target;
-
-                if (awaiter == null)
-                {
-                    *outAwaiterIsNull = godot_bool.True;
-                    return;
-                }
-
-                *outAwaiterIsNull = godot_bool.False;
-
-                awaiter._completed = true;
-
-                Variant[] signalArgs = new Variant[argCount];
-
-                for (int i = 0; i < argCount; i++)
-                    signalArgs[i] = Variant.CreateCopyingBorrowed(*args[i]);
-
-                awaiter._result = signalArgs;
-
-                awaiter._continuation?.Invoke();
+                *outAwaiterIsNull = godot_bool.True;
+                return;
             }
-            catch (Exception e)
-            {
-                ExceptionUtils.LogException(e);
-                *outAwaiterIsNull = godot_bool.False;
-            }
+
+            *outAwaiterIsNull = godot_bool.False;
+
+            awaiter._completed = true;
+
+            Variant[] signalArgs = new Variant[argCount];
+
+            for (int i = 0; i < argCount; i++)
+                signalArgs[i] = Variant.CreateCopyingBorrowed(*args[i]);
+
+            awaiter._result = signalArgs;
+
+            awaiter._continuation?.Invoke();
+        }
+        catch (Exception e)
+        {
+            ExceptionUtils.LogException(e);
+            *outAwaiterIsNull = godot_bool.False;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -10,1643 +10,1643 @@ using Godot.NativeInterop;
 
 #nullable enable
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// Extension methods to manipulate strings.
+/// </summary>
+public static class StringExtensions
 {
-    /// <summary>
-    /// Extension methods to manipulate strings.
-    /// </summary>
-    public static class StringExtensions
+    private static int GetSliceCount(this string instance, string splitter)
     {
-        private static int GetSliceCount(this string instance, string splitter)
+        if (string.IsNullOrEmpty(instance) || string.IsNullOrEmpty(splitter))
+            return 0;
+
+        int pos = 0;
+        int slices = 1;
+
+        while ((pos = instance.Find(splitter, pos, caseSensitive: true)) >= 0)
         {
-            if (string.IsNullOrEmpty(instance) || string.IsNullOrEmpty(splitter))
-                return 0;
-
-            int pos = 0;
-            int slices = 1;
-
-            while ((pos = instance.Find(splitter, pos, caseSensitive: true)) >= 0)
-            {
-                slices++;
-                pos += splitter.Length;
-            }
-
-            return slices;
+            slices++;
+            pos += splitter.Length;
         }
 
-        private static string GetSliceCharacter(this string instance, char splitter, int slice)
+        return slices;
+    }
+
+    private static string GetSliceCharacter(this string instance, char splitter, int slice)
+    {
+        if (!string.IsNullOrEmpty(instance) && slice >= 0)
         {
-            if (!string.IsNullOrEmpty(instance) && slice >= 0)
+            int i = 0;
+            int prev = 0;
+            int count = 0;
+
+            while (true)
             {
-                int i = 0;
-                int prev = 0;
-                int count = 0;
+                bool end = instance.Length <= i;
 
-                while (true)
+                if (end || instance[i] == splitter)
                 {
-                    bool end = instance.Length <= i;
-
-                    if (end || instance[i] == splitter)
+                    if (slice == count)
                     {
-                        if (slice == count)
-                        {
-                            return instance.Substring(prev, i - prev);
-                        }
-                        else if (end)
-                        {
-                            return string.Empty;
-                        }
-
-                        count++;
-                        prev = i + 1;
+                        return instance.Substring(prev, i - prev);
+                    }
+                    else if (end)
+                    {
+                        return string.Empty;
                     }
 
-                    i++;
+                    count++;
+                    prev = i + 1;
                 }
-            }
 
-            return string.Empty;
+                i++;
+            }
         }
 
-        /// <summary>
-        /// Returns the bigrams (pairs of consecutive letters) of this string.
-        /// </summary>
-        /// <param name="instance">The string that will be used.</param>
-        /// <returns>The bigrams of this string.</returns>
-        public static string[] Bigrams(this string instance)
-        {
-            string[] b = new string[instance.Length - 1];
+        return string.Empty;
+    }
 
-            for (int i = 0; i < b.Length; i++)
+    /// <summary>
+    /// Returns the bigrams (pairs of consecutive letters) of this string.
+    /// </summary>
+    /// <param name="instance">The string that will be used.</param>
+    /// <returns>The bigrams of this string.</returns>
+    public static string[] Bigrams(this string instance)
+    {
+        string[] b = new string[instance.Length - 1];
+
+        for (int i = 0; i < b.Length; i++)
+        {
+            b[i] = instance.Substring(i, 2);
+        }
+
+        return b;
+    }
+
+    /// <summary>
+    /// Converts a string containing a binary number into an integer.
+    /// Binary strings can either be prefixed with <c>0b</c> or not,
+    /// and they can also start with a <c>-</c> before the optional prefix.
+    /// </summary>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The converted string.</returns>
+    public static int BinToInt(this string instance)
+    {
+        if (instance.Length == 0)
+        {
+            return 0;
+        }
+
+        int sign = 1;
+
+        if (instance[0] == '-')
+        {
+            sign = -1;
+            instance = instance.Substring(1);
+        }
+
+        if (instance.StartsWith("0b"))
+        {
+            instance = instance.Substring(2);
+        }
+
+        return sign * Convert.ToInt32(instance, 2);
+    }
+
+    /// <summary>
+    /// Returns the number of occurrences of substring <paramref name="what"/> in the string.
+    /// </summary>
+    /// <param name="instance">The string where the substring will be searched.</param>
+    /// <param name="what">The substring that will be counted.</param>
+    /// <param name="from">Index to start searching from.</param>
+    /// <param name="to">Index to stop searching at.</param>
+    /// <param name="caseSensitive">If the search is case sensitive.</param>
+    /// <returns>Number of occurrences of the substring in the string.</returns>
+    public static int Count(this string instance, string what, int from = 0, int to = 0, bool caseSensitive = true)
+    {
+        if (what.Length == 0)
+        {
+            return 0;
+        }
+
+        int len = instance.Length;
+        int slen = what.Length;
+
+        if (len < slen)
+        {
+            return 0;
+        }
+
+        string str;
+
+        if (from >= 0 && to >= 0)
+        {
+            if (to == 0)
             {
-                b[i] = instance.Substring(i, 2);
+                to = len;
             }
-
-            return b;
-        }
-
-        /// <summary>
-        /// Converts a string containing a binary number into an integer.
-        /// Binary strings can either be prefixed with <c>0b</c> or not,
-        /// and they can also start with a <c>-</c> before the optional prefix.
-        /// </summary>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static int BinToInt(this string instance)
-        {
-            if (instance.Length == 0)
+            else if (from >= to)
             {
                 return 0;
             }
 
-            int sign = 1;
-
-            if (instance[0] == '-')
+            if (from == 0 && to == len)
             {
-                sign = -1;
-                instance = instance.Substring(1);
-            }
-
-            if (instance.StartsWith("0b"))
-            {
-                instance = instance.Substring(2);
-            }
-
-            return sign * Convert.ToInt32(instance, 2);
-        }
-
-        /// <summary>
-        /// Returns the number of occurrences of substring <paramref name="what"/> in the string.
-        /// </summary>
-        /// <param name="instance">The string where the substring will be searched.</param>
-        /// <param name="what">The substring that will be counted.</param>
-        /// <param name="from">Index to start searching from.</param>
-        /// <param name="to">Index to stop searching at.</param>
-        /// <param name="caseSensitive">If the search is case sensitive.</param>
-        /// <returns>Number of occurrences of the substring in the string.</returns>
-        public static int Count(this string instance, string what, int from = 0, int to = 0, bool caseSensitive = true)
-        {
-            if (what.Length == 0)
-            {
-                return 0;
-            }
-
-            int len = instance.Length;
-            int slen = what.Length;
-
-            if (len < slen)
-            {
-                return 0;
-            }
-
-            string str;
-
-            if (from >= 0 && to >= 0)
-            {
-                if (to == 0)
-                {
-                    to = len;
-                }
-                else if (from >= to)
-                {
-                    return 0;
-                }
-
-                if (from == 0 && to == len)
-                {
-                    str = instance;
-                }
-                else
-                {
-                    str = instance.Substring(from, to - from);
-                }
+                str = instance;
             }
             else
             {
-                return 0;
+                str = instance.Substring(from, to - from);
             }
-
-            int c = 0;
-            int idx;
-
-            do
-            {
-                idx = str.IndexOf(what, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
-                if (idx != -1)
-                {
-                    str = str.Substring(idx + slen);
-                    ++c;
-                }
-            } while (idx != -1);
-
-            return c;
+        }
+        else
+        {
+            return 0;
         }
 
-        /// <summary>
-        /// Returns the number of occurrences of substring <paramref name="what"/> (ignoring case)
-        /// between <paramref name="from"/> and <paramref name="to"/> positions. If <paramref name="from"/>
-        /// and <paramref name="to"/> equals 0 the whole string will be used. If only <paramref name="to"/>
-        /// equals 0 the remained substring will be used.
-        /// </summary>
-        /// <param name="instance">The string where the substring will be searched.</param>
-        /// <param name="what">The substring that will be counted.</param>
-        /// <param name="from">Index to start searching from.</param>
-        /// <param name="to">Index to stop searching at.</param>
-        /// <returns>Number of occurrences of the substring in the string.</returns>
-        public static int CountN(this string instance, string what, int from = 0, int to = 0)
-        {
-            return instance.Count(what, from, to, caseSensitive: false);
-        }
+        int c = 0;
+        int idx;
 
-        /// <summary>
-        /// Returns a copy of the string with indentation (leading tabs and spaces) removed.
-        /// See also <see cref="Indent"/> to add indentation.
-        /// </summary>
-        /// <param name="instance">The string to remove the indentation from.</param>
-        /// <returns>The string with the indentation removed.</returns>
-        public static string Dedent(this string instance)
+        do
         {
-            var sb = new StringBuilder();
-            string indent = "";
-            bool hasIndent = false;
-            bool hasText = false;
-            int lineStart = 0;
-            int indentStop = -1;
-
-            for (int i = 0; i < instance.Length; i++)
+            idx = str.IndexOf(what, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+            if (idx != -1)
             {
-                char c = instance[i];
-                if (c == '\n')
+                str = str.Substring(idx + slen);
+                ++c;
+            }
+        } while (idx != -1);
+
+        return c;
+    }
+
+    /// <summary>
+    /// Returns the number of occurrences of substring <paramref name="what"/> (ignoring case)
+    /// between <paramref name="from"/> and <paramref name="to"/> positions. If <paramref name="from"/>
+    /// and <paramref name="to"/> equals 0 the whole string will be used. If only <paramref name="to"/>
+    /// equals 0 the remained substring will be used.
+    /// </summary>
+    /// <param name="instance">The string where the substring will be searched.</param>
+    /// <param name="what">The substring that will be counted.</param>
+    /// <param name="from">Index to start searching from.</param>
+    /// <param name="to">Index to stop searching at.</param>
+    /// <returns>Number of occurrences of the substring in the string.</returns>
+    public static int CountN(this string instance, string what, int from = 0, int to = 0)
+    {
+        return instance.Count(what, from, to, caseSensitive: false);
+    }
+
+    /// <summary>
+    /// Returns a copy of the string with indentation (leading tabs and spaces) removed.
+    /// See also <see cref="Indent"/> to add indentation.
+    /// </summary>
+    /// <param name="instance">The string to remove the indentation from.</param>
+    /// <returns>The string with the indentation removed.</returns>
+    public static string Dedent(this string instance)
+    {
+        var sb = new StringBuilder();
+        string indent = "";
+        bool hasIndent = false;
+        bool hasText = false;
+        int lineStart = 0;
+        int indentStop = -1;
+
+        for (int i = 0; i < instance.Length; i++)
+        {
+            char c = instance[i];
+            if (c == '\n')
+            {
+                if (hasText)
                 {
-                    if (hasText)
-                    {
-                        sb.Append(instance.Substring(indentStop, i - indentStop));
-                    }
-                    sb.Append('\n');
-                    hasText = false;
-                    lineStart = i + 1;
-                    indentStop = -1;
+                    sb.Append(instance.Substring(indentStop, i - indentStop));
                 }
-                else if (!hasText)
+                sb.Append('\n');
+                hasText = false;
+                lineStart = i + 1;
+                indentStop = -1;
+            }
+            else if (!hasText)
+            {
+                if (c > 32)
                 {
-                    if (c > 32)
+                    hasText = true;
+                    if (!hasIndent)
                     {
-                        hasText = true;
-                        if (!hasIndent)
-                        {
-                            hasIndent = true;
-                            indent = instance.Substring(lineStart, i - lineStart);
-                            indentStop = i;
-                        }
-                    }
-                    if (hasIndent && indentStop < 0)
-                    {
-                        int j = i - lineStart;
-                        if (j >= indent.Length || c != indent[j])
-                        {
-                            indentStop = i;
-                        }
+                        hasIndent = true;
+                        indent = instance.Substring(lineStart, i - lineStart);
+                        indentStop = i;
                     }
                 }
+                if (hasIndent && indentStop < 0)
+                {
+                    int j = i - lineStart;
+                    if (j >= indent.Length || c != indent[j])
+                    {
+                        indentStop = i;
+                    }
+                }
             }
+        }
 
-            if (hasText)
+        if (hasText)
+        {
+            sb.Append(instance.Substring(indentStop, instance.Length - indentStop));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns a copy of the string with special characters escaped using the C language standard.
+    /// </summary>
+    /// <param name="instance">The string to escape.</param>
+    /// <returns>The escaped string.</returns>
+    public static string CEscape(this string instance)
+    {
+        var sb = new StringBuilder(instance);
+
+        sb.Replace("\\", "\\\\");
+        sb.Replace("\a", "\\a");
+        sb.Replace("\b", "\\b");
+        sb.Replace("\f", "\\f");
+        sb.Replace("\n", "\\n");
+        sb.Replace("\r", "\\r");
+        sb.Replace("\t", "\\t");
+        sb.Replace("\v", "\\v");
+        sb.Replace("\'", "\\'");
+        sb.Replace("\"", "\\\"");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns a copy of the string with escaped characters replaced by their meanings
+    /// according to the C language standard.
+    /// </summary>
+    /// <param name="instance">The string to unescape.</param>
+    /// <returns>The unescaped string.</returns>
+    public static string CUnescape(this string instance)
+    {
+        var sb = new StringBuilder(instance);
+
+        sb.Replace("\\a", "\a");
+        sb.Replace("\\b", "\b");
+        sb.Replace("\\f", "\f");
+        sb.Replace("\\n", "\n");
+        sb.Replace("\\r", "\r");
+        sb.Replace("\\t", "\t");
+        sb.Replace("\\v", "\v");
+        sb.Replace("\\'", "\'");
+        sb.Replace("\\\"", "\"");
+        sb.Replace("\\\\", "\\");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Changes the case of some letters. Replace underscores with spaces, convert all letters
+    /// to lowercase then capitalize first and every letter following the space character.
+    /// For <c>capitalize camelCase mixed_with_underscores</c> it will return
+    /// <c>Capitalize Camelcase Mixed With Underscores</c>.
+    /// </summary>
+    /// <param name="instance">The string to capitalize.</param>
+    /// <returns>The capitalized string.</returns>
+    public static string Capitalize(this string instance)
+    {
+        string aux = instance.CamelcaseToUnderscore(true).Replace("_", " ").Trim();
+        string cap = string.Empty;
+
+        for (int i = 0; i < aux.GetSliceCount(" "); i++)
+        {
+            string slice = aux.GetSliceCharacter(' ', i);
+            if (slice.Length > 0)
             {
-                sb.Append(instance.Substring(indentStop, instance.Length - indentStop));
+                slice = char.ToUpper(slice[0]) + slice.Substring(1);
+                if (i > 0)
+                    cap += " ";
+                cap += slice;
             }
-
-            return sb.ToString();
         }
 
-        /// <summary>
-        /// Returns a copy of the string with special characters escaped using the C language standard.
-        /// </summary>
-        /// <param name="instance">The string to escape.</param>
-        /// <returns>The escaped string.</returns>
-        public static string CEscape(this string instance)
+        return cap;
+    }
+
+    /// <summary>
+    /// Returns the string converted to <c>camelCase</c>.
+    /// </summary>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The converted string.</returns>
+    public static string ToCamelCase(this string instance)
+    {
+        using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+        NativeFuncs.godotsharp_string_to_camel_case(instanceStr, out godot_string camelCase);
+        using (camelCase)
+            return Marshaling.ConvertStringToManaged(camelCase);
+    }
+
+    /// <summary>
+    /// Returns the string converted to <c>PascalCase</c>.
+    /// </summary>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The converted string.</returns>
+    public static string ToPascalCase(this string instance)
+    {
+        using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+        NativeFuncs.godotsharp_string_to_pascal_case(instanceStr, out godot_string pascalCase);
+        using (pascalCase)
+            return Marshaling.ConvertStringToManaged(pascalCase);
+    }
+
+    /// <summary>
+    /// Returns the string converted to <c>snake_case</c>.
+    /// </summary>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The converted string.</returns>
+    public static string ToSnakeCase(this string instance)
+    {
+        using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+        NativeFuncs.godotsharp_string_to_snake_case(instanceStr, out godot_string snakeCase);
+        using (snakeCase)
+            return Marshaling.ConvertStringToManaged(snakeCase);
+    }
+
+    private static string CamelcaseToUnderscore(this string instance, bool lowerCase)
+    {
+        string newString = string.Empty;
+        int startIndex = 0;
+
+        for (int i = 1; i < instance.Length; i++)
         {
-            var sb = new StringBuilder(instance);
+            bool isUpper = char.IsUpper(instance[i]);
+            bool isNumber = char.IsDigit(instance[i]);
 
-            sb.Replace("\\", "\\\\");
-            sb.Replace("\a", "\\a");
-            sb.Replace("\b", "\\b");
-            sb.Replace("\f", "\\f");
-            sb.Replace("\n", "\\n");
-            sb.Replace("\r", "\\r");
-            sb.Replace("\t", "\\t");
-            sb.Replace("\v", "\\v");
-            sb.Replace("\'", "\\'");
-            sb.Replace("\"", "\\\"");
+            bool areNext2Lower = false;
+            bool isNextLower = false;
+            bool isNextNumber = false;
+            bool wasPrecedentUpper = char.IsUpper(instance[i - 1]);
+            bool wasPrecedentNumber = char.IsDigit(instance[i - 1]);
 
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Returns a copy of the string with escaped characters replaced by their meanings
-        /// according to the C language standard.
-        /// </summary>
-        /// <param name="instance">The string to unescape.</param>
-        /// <returns>The unescaped string.</returns>
-        public static string CUnescape(this string instance)
-        {
-            var sb = new StringBuilder(instance);
-
-            sb.Replace("\\a", "\a");
-            sb.Replace("\\b", "\b");
-            sb.Replace("\\f", "\f");
-            sb.Replace("\\n", "\n");
-            sb.Replace("\\r", "\r");
-            sb.Replace("\\t", "\t");
-            sb.Replace("\\v", "\v");
-            sb.Replace("\\'", "\'");
-            sb.Replace("\\\"", "\"");
-            sb.Replace("\\\\", "\\");
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Changes the case of some letters. Replace underscores with spaces, convert all letters
-        /// to lowercase then capitalize first and every letter following the space character.
-        /// For <c>capitalize camelCase mixed_with_underscores</c> it will return
-        /// <c>Capitalize Camelcase Mixed With Underscores</c>.
-        /// </summary>
-        /// <param name="instance">The string to capitalize.</param>
-        /// <returns>The capitalized string.</returns>
-        public static string Capitalize(this string instance)
-        {
-            string aux = instance.CamelcaseToUnderscore(true).Replace("_", " ").Trim();
-            string cap = string.Empty;
-
-            for (int i = 0; i < aux.GetSliceCount(" "); i++)
+            if (i + 2 < instance.Length)
             {
-                string slice = aux.GetSliceCharacter(' ', i);
-                if (slice.Length > 0)
-                {
-                    slice = char.ToUpper(slice[0]) + slice.Substring(1);
-                    if (i > 0)
-                        cap += " ";
-                    cap += slice;
-                }
+                areNext2Lower = char.IsLower(instance[i + 1]) && char.IsLower(instance[i + 2]);
             }
 
-            return cap;
-        }
-
-        /// <summary>
-        /// Returns the string converted to <c>camelCase</c>.
-        /// </summary>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static string ToCamelCase(this string instance)
-        {
-            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
-            NativeFuncs.godotsharp_string_to_camel_case(instanceStr, out godot_string camelCase);
-            using (camelCase)
-                return Marshaling.ConvertStringToManaged(camelCase);
-        }
-
-        /// <summary>
-        /// Returns the string converted to <c>PascalCase</c>.
-        /// </summary>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static string ToPascalCase(this string instance)
-        {
-            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
-            NativeFuncs.godotsharp_string_to_pascal_case(instanceStr, out godot_string pascalCase);
-            using (pascalCase)
-                return Marshaling.ConvertStringToManaged(pascalCase);
-        }
-
-        /// <summary>
-        /// Returns the string converted to <c>snake_case</c>.
-        /// </summary>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static string ToSnakeCase(this string instance)
-        {
-            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
-            NativeFuncs.godotsharp_string_to_snake_case(instanceStr, out godot_string snakeCase);
-            using (snakeCase)
-                return Marshaling.ConvertStringToManaged(snakeCase);
-        }
-
-        private static string CamelcaseToUnderscore(this string instance, bool lowerCase)
-        {
-            string newString = string.Empty;
-            int startIndex = 0;
-
-            for (int i = 1; i < instance.Length; i++)
+            if (i + 1 < instance.Length)
             {
-                bool isUpper = char.IsUpper(instance[i]);
-                bool isNumber = char.IsDigit(instance[i]);
-
-                bool areNext2Lower = false;
-                bool isNextLower = false;
-                bool isNextNumber = false;
-                bool wasPrecedentUpper = char.IsUpper(instance[i - 1]);
-                bool wasPrecedentNumber = char.IsDigit(instance[i - 1]);
-
-                if (i + 2 < instance.Length)
-                {
-                    areNext2Lower = char.IsLower(instance[i + 1]) && char.IsLower(instance[i + 2]);
-                }
-
-                if (i + 1 < instance.Length)
-                {
-                    isNextLower = char.IsLower(instance[i + 1]);
-                    isNextNumber = char.IsDigit(instance[i + 1]);
-                }
-
-                bool condA = isUpper && !wasPrecedentUpper && !wasPrecedentNumber;
-                bool condB = wasPrecedentUpper && isUpper && areNext2Lower;
-                bool condC = isNumber && !wasPrecedentNumber;
-                bool canBreakNumberLetter = isNumber && !wasPrecedentNumber && isNextLower;
-                bool canBreakLetterNumber = !isNumber && wasPrecedentNumber && (isNextLower || isNextNumber);
-
-                bool shouldSplit = condA || condB || condC || canBreakNumberLetter || canBreakLetterNumber;
-                if (shouldSplit)
-                {
-                    newString += instance.Substring(startIndex, i - startIndex) + "_";
-                    startIndex = i;
-                }
+                isNextLower = char.IsLower(instance[i + 1]);
+                isNextNumber = char.IsDigit(instance[i + 1]);
             }
 
-            newString += instance.Substring(startIndex, instance.Length - startIndex);
-            return lowerCase ? newString.ToLower() : newString;
-        }
+            bool condA = isUpper && !wasPrecedentUpper && !wasPrecedentNumber;
+            bool condB = wasPrecedentUpper && isUpper && areNext2Lower;
+            bool condC = isNumber && !wasPrecedentNumber;
+            bool canBreakNumberLetter = isNumber && !wasPrecedentNumber && isNextLower;
+            bool canBreakLetterNumber = !isNumber && wasPrecedentNumber && (isNextLower || isNextNumber);
 
-        /// <summary>
-        /// Performs a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        /// </summary>
-        /// <seealso cref="NocasecmpTo(string, string)"/>
-        /// <seealso cref="CompareTo(string, string, bool)"/>
-        /// <param name="instance">The string to compare.</param>
-        /// <param name="to">The other string to compare.</param>
-        /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
-        public static int CasecmpTo(this string instance, string to)
-        {
-            return instance.CompareTo(to, caseSensitive: true);
-        }
-
-        /// <summary>
-        /// Performs a comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        /// </summary>
-        /// <param name="instance">The string to compare.</param>
-        /// <param name="to">The other string to compare.</param>
-        /// <param name="caseSensitive">
-        /// If <see langword="true"/>, the comparison will be case sensitive.
-        /// </param>
-        /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
-        public static int CompareTo(this string instance, string to, bool caseSensitive = true)
-        {
-            if (string.IsNullOrEmpty(instance))
-                return string.IsNullOrEmpty(to) ? 0 : -1;
-
-            if (string.IsNullOrEmpty(to))
-                return 1;
-
-            int instanceIndex = 0;
-            int toIndex = 0;
-
-            if (caseSensitive) // Outside while loop to avoid checking multiple times, despite some code duplication.
+            bool shouldSplit = condA || condB || condC || canBreakNumberLetter || canBreakLetterNumber;
+            if (shouldSplit)
             {
-                while (true)
-                {
-                    if (to[toIndex] == 0 && instance[instanceIndex] == 0)
-                        return 0; // We're equal
-                    if (instance[instanceIndex] == 0)
-                        return -1; // If this is empty, and the other one is not, then we're less... I think?
-                    if (to[toIndex] == 0)
-                        return 1; // Otherwise the other one is smaller...
-                    if (instance[instanceIndex] < to[toIndex]) // More than
-                        return -1;
-                    if (instance[instanceIndex] > to[toIndex]) // Less than
-                        return 1;
-
-                    instanceIndex++;
-                    toIndex++;
-                }
+                newString += instance.Substring(startIndex, i - startIndex) + "_";
+                startIndex = i;
             }
-            else
+        }
+
+        newString += instance.Substring(startIndex, instance.Length - startIndex);
+        return lowerCase ? newString.ToLower() : newString;
+    }
+
+    /// <summary>
+    /// Performs a case-sensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+    /// </summary>
+    /// <seealso cref="NocasecmpTo(string, string)"/>
+    /// <seealso cref="CompareTo(string, string, bool)"/>
+    /// <param name="instance">The string to compare.</param>
+    /// <param name="to">The other string to compare.</param>
+    /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
+    public static int CasecmpTo(this string instance, string to)
+    {
+        return instance.CompareTo(to, caseSensitive: true);
+    }
+
+    /// <summary>
+    /// Performs a comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+    /// </summary>
+    /// <param name="instance">The string to compare.</param>
+    /// <param name="to">The other string to compare.</param>
+    /// <param name="caseSensitive">
+    /// If <see langword="true"/>, the comparison will be case sensitive.
+    /// </param>
+    /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
+    public static int CompareTo(this string instance, string to, bool caseSensitive = true)
+    {
+        if (string.IsNullOrEmpty(instance))
+            return string.IsNullOrEmpty(to) ? 0 : -1;
+
+        if (string.IsNullOrEmpty(to))
+            return 1;
+
+        int instanceIndex = 0;
+        int toIndex = 0;
+
+        if (caseSensitive) // Outside while loop to avoid checking multiple times, despite some code duplication.
+        {
+            while (true)
             {
-                while (true)
-                {
-                    if (to[toIndex] == 0 && instance[instanceIndex] == 0)
-                        return 0; // We're equal
-                    if (instance[instanceIndex] == 0)
-                        return -1; // If this is empty, and the other one is not, then we're less... I think?
-                    if (to[toIndex] == 0)
-                        return 1; // Otherwise the other one is smaller..
-                    if (char.ToUpper(instance[instanceIndex]) < char.ToUpper(to[toIndex])) // More than
-                        return -1;
-                    if (char.ToUpper(instance[instanceIndex]) > char.ToUpper(to[toIndex])) // Less than
-                        return 1;
+                if (to[toIndex] == 0 && instance[instanceIndex] == 0)
+                    return 0; // We're equal
+                if (instance[instanceIndex] == 0)
+                    return -1; // If this is empty, and the other one is not, then we're less... I think?
+                if (to[toIndex] == 0)
+                    return 1; // Otherwise the other one is smaller...
+                if (instance[instanceIndex] < to[toIndex]) // More than
+                    return -1;
+                if (instance[instanceIndex] > to[toIndex]) // Less than
+                    return 1;
 
-                    instanceIndex++;
-                    toIndex++;
-                }
+                instanceIndex++;
+                toIndex++;
             }
         }
-
-        /// <summary>
-        /// Returns the extension without the leading period character (<c>.</c>)
-        /// if the string is a valid file name or path. If the string does not contain
-        /// an extension, returns an empty string instead.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print("/path/to/file.txt".GetExtension())  // "txt"
-        /// GD.Print("file.txt".GetExtension())  // "txt"
-        /// GD.Print("file.sample.txt".GetExtension())  // "txt"
-        /// GD.Print(".txt".GetExtension())  // "txt"
-        /// GD.Print("file.txt.".GetExtension())  // "" (empty string)
-        /// GD.Print("file.txt..".GetExtension())  // "" (empty string)
-        /// GD.Print("txt".GetExtension())  // "" (empty string)
-        /// GD.Print("".GetExtension())  // "" (empty string)
-        /// </code>
-        /// </example>
-        /// <seealso cref="GetBaseName(string)"/>
-        /// <seealso cref="GetBaseDir(string)"/>
-        /// <seealso cref="GetFile(string)"/>
-        /// <param name="instance">The path to a file.</param>
-        /// <returns>The extension of the file or an empty string.</returns>
-        public static string GetExtension(this string instance)
+        else
         {
-            int pos = instance.RFind(".");
-
-            if (pos < 0)
-                return instance;
-
-            return instance.Substring(pos + 1);
-        }
-
-        /// <summary>
-        /// Returns the index of the first occurrence of the specified string in this instance,
-        /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing
-        /// to the end of the string.
-        /// Note: If you just want to know whether a string contains a substring, use the
-        /// <see cref="string.Contains(string)"/> method.
-        /// </summary>
-        /// <seealso cref="Find(string, char, int, bool)"/>
-        /// <seealso cref="FindN(string, string, int)"/>
-        /// <seealso cref="RFind(string, string, int, bool)"/>
-        /// <seealso cref="RFindN(string, string, int)"/>
-        /// <param name="instance">The string that will be searched.</param>
-        /// <param name="what">The substring to find.</param>
-        /// <param name="from">The search starting position.</param>
-        /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
-        /// <returns>The starting position of the substring, or -1 if not found.</returns>
-        public static int Find(this string instance, string what, int from = 0, bool caseSensitive = true)
-        {
-            return instance.IndexOf(what, from,
-                caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Find the first occurrence of a char. Optionally, the search starting position can be passed.
-        /// </summary>
-        /// <seealso cref="Find(string, string, int, bool)"/>
-        /// <seealso cref="FindN(string, string, int)"/>
-        /// <seealso cref="RFind(string, string, int, bool)"/>
-        /// <seealso cref="RFindN(string, string, int)"/>
-        /// <param name="instance">The string that will be searched.</param>
-        /// <param name="what">The substring to find.</param>
-        /// <param name="from">The search starting position.</param>
-        /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
-        /// <returns>The first instance of the char, or -1 if not found.</returns>
-        public static int Find(this string instance, char what, int from = 0, bool caseSensitive = true)
-        {
-            if (caseSensitive)
-                return instance.IndexOf(what, from);
-
-            return CultureInfo.InvariantCulture.CompareInfo.IndexOf(instance, what, from, CompareOptions.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Returns the index of the first case-insensitive occurrence of the specified string in this instance,
-        /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing
-        /// to the end of the string.
-        /// </summary>
-        /// <seealso cref="Find(string, string, int, bool)"/>
-        /// <seealso cref="Find(string, char, int, bool)"/>
-        /// <seealso cref="RFind(string, string, int, bool)"/>
-        /// <seealso cref="RFindN(string, string, int)"/>
-        /// <param name="instance">The string that will be searched.</param>
-        /// <param name="what">The substring to find.</param>
-        /// <param name="from">The search starting position.</param>
-        /// <returns>The starting position of the substring, or -1 if not found.</returns>
-        public static int FindN(this string instance, string what, int from = 0)
-        {
-            return instance.IndexOf(what, from, StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// If the string is a path to a file, return the base directory.
-        /// </summary>
-        /// <seealso cref="GetBaseName(string)"/>
-        /// <seealso cref="GetExtension(string)"/>
-        /// <seealso cref="GetFile(string)"/>
-        /// <param name="instance">The path to a file.</param>
-        /// <returns>The base directory.</returns>
-        public static string GetBaseDir(this string instance)
-        {
-            int basepos = instance.Find("://");
-
-            string rs;
-            string directory = string.Empty;
-
-            if (basepos != -1)
+            while (true)
             {
-                int end = basepos + 3;
-                rs = instance.Substring(end);
-                directory = instance.Substring(0, end);
+                if (to[toIndex] == 0 && instance[instanceIndex] == 0)
+                    return 0; // We're equal
+                if (instance[instanceIndex] == 0)
+                    return -1; // If this is empty, and the other one is not, then we're less... I think?
+                if (to[toIndex] == 0)
+                    return 1; // Otherwise the other one is smaller..
+                if (char.ToUpper(instance[instanceIndex]) < char.ToUpper(to[toIndex])) // More than
+                    return -1;
+                if (char.ToUpper(instance[instanceIndex]) > char.ToUpper(to[toIndex])) // Less than
+                    return 1;
+
+                instanceIndex++;
+                toIndex++;
             }
-            else
-            {
-                if (instance.StartsWith('/'))
-                {
-                    rs = instance.Substring(1);
-                    directory = "/";
-                }
-                else
-                {
-                    rs = instance;
-                }
-            }
-
-            int sep = Mathf.Max(rs.RFind("/"), rs.RFind("\\"));
-
-            if (sep == -1)
-                return directory;
-
-            return directory + rs.Substr(0, sep);
         }
+    }
 
-        /// <summary>
-        /// If the string is a path to a file, return the path to the file without the extension.
-        /// </summary>
-        /// <seealso cref="GetExtension(string)"/>
-        /// <seealso cref="GetBaseDir(string)"/>
-        /// <seealso cref="GetFile(string)"/>
-        /// <param name="instance">The path to a file.</param>
-        /// <returns>The path to the file without the extension.</returns>
-        public static string GetBaseName(this string instance)
-        {
-            int index = instance.RFind(".");
+    /// <summary>
+    /// Returns the extension without the leading period character (<c>.</c>)
+    /// if the string is a valid file name or path. If the string does not contain
+    /// an extension, returns an empty string instead.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print("/path/to/file.txt".GetExtension())  // "txt"
+    /// GD.Print("file.txt".GetExtension())  // "txt"
+    /// GD.Print("file.sample.txt".GetExtension())  // "txt"
+    /// GD.Print(".txt".GetExtension())  // "txt"
+    /// GD.Print("file.txt.".GetExtension())  // "" (empty string)
+    /// GD.Print("file.txt..".GetExtension())  // "" (empty string)
+    /// GD.Print("txt".GetExtension())  // "" (empty string)
+    /// GD.Print("".GetExtension())  // "" (empty string)
+    /// </code>
+    /// </example>
+    /// <seealso cref="GetBaseName(string)"/>
+    /// <seealso cref="GetBaseDir(string)"/>
+    /// <seealso cref="GetFile(string)"/>
+    /// <param name="instance">The path to a file.</param>
+    /// <returns>The extension of the file or an empty string.</returns>
+    public static string GetExtension(this string instance)
+    {
+        int pos = instance.RFind(".");
 
-            if (index > 0)
-                return instance.Substring(0, index);
-
+        if (pos < 0)
             return instance;
-        }
 
-        /// <summary>
-        /// If the string is a path to a file, return the file and ignore the base directory.
-        /// </summary>
-        /// <seealso cref="GetBaseName(string)"/>
-        /// <seealso cref="GetExtension(string)"/>
-        /// <seealso cref="GetBaseDir(string)"/>
-        /// <param name="instance">The path to a file.</param>
-        /// <returns>The file name.</returns>
-        public static string GetFile(this string instance)
+        return instance.Substring(pos + 1);
+    }
+
+    /// <summary>
+    /// Returns the index of the first occurrence of the specified string in this instance,
+    /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing
+    /// to the end of the string.
+    /// Note: If you just want to know whether a string contains a substring, use the
+    /// <see cref="string.Contains(string)"/> method.
+    /// </summary>
+    /// <seealso cref="Find(string, char, int, bool)"/>
+    /// <seealso cref="FindN(string, string, int)"/>
+    /// <seealso cref="RFind(string, string, int, bool)"/>
+    /// <seealso cref="RFindN(string, string, int)"/>
+    /// <param name="instance">The string that will be searched.</param>
+    /// <param name="what">The substring to find.</param>
+    /// <param name="from">The search starting position.</param>
+    /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
+    /// <returns>The starting position of the substring, or -1 if not found.</returns>
+    public static int Find(this string instance, string what, int from = 0, bool caseSensitive = true)
+    {
+        return instance.IndexOf(what, from,
+            caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Find the first occurrence of a char. Optionally, the search starting position can be passed.
+    /// </summary>
+    /// <seealso cref="Find(string, string, int, bool)"/>
+    /// <seealso cref="FindN(string, string, int)"/>
+    /// <seealso cref="RFind(string, string, int, bool)"/>
+    /// <seealso cref="RFindN(string, string, int)"/>
+    /// <param name="instance">The string that will be searched.</param>
+    /// <param name="what">The substring to find.</param>
+    /// <param name="from">The search starting position.</param>
+    /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
+    /// <returns>The first instance of the char, or -1 if not found.</returns>
+    public static int Find(this string instance, char what, int from = 0, bool caseSensitive = true)
+    {
+        if (caseSensitive)
+            return instance.IndexOf(what, from);
+
+        return CultureInfo.InvariantCulture.CompareInfo.IndexOf(instance, what, from, CompareOptions.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the index of the first case-insensitive occurrence of the specified string in this instance,
+    /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing
+    /// to the end of the string.
+    /// </summary>
+    /// <seealso cref="Find(string, string, int, bool)"/>
+    /// <seealso cref="Find(string, char, int, bool)"/>
+    /// <seealso cref="RFind(string, string, int, bool)"/>
+    /// <seealso cref="RFindN(string, string, int)"/>
+    /// <param name="instance">The string that will be searched.</param>
+    /// <param name="what">The substring to find.</param>
+    /// <param name="from">The search starting position.</param>
+    /// <returns>The starting position of the substring, or -1 if not found.</returns>
+    public static int FindN(this string instance, string what, int from = 0)
+    {
+        return instance.IndexOf(what, from, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// If the string is a path to a file, return the base directory.
+    /// </summary>
+    /// <seealso cref="GetBaseName(string)"/>
+    /// <seealso cref="GetExtension(string)"/>
+    /// <seealso cref="GetFile(string)"/>
+    /// <param name="instance">The path to a file.</param>
+    /// <returns>The base directory.</returns>
+    public static string GetBaseDir(this string instance)
+    {
+        int basepos = instance.Find("://");
+
+        string rs;
+        string directory = string.Empty;
+
+        if (basepos != -1)
         {
-            int sep = Mathf.Max(instance.RFind("/"), instance.RFind("\\"));
-
-            if (sep == -1)
-                return instance;
-
-            return instance.Substring(sep + 1);
+            int end = basepos + 3;
+            rs = instance.Substring(end);
+            directory = instance.Substring(0, end);
         }
-
-        /// <summary>
-        /// Converts ASCII encoded array to string.
-        /// Fast alternative to <see cref="GetStringFromUtf8"/> if the
-        /// content is ASCII-only. Unlike the UTF-8 function this function
-        /// maps every byte to a character in the array. Multibyte sequences
-        /// will not be interpreted correctly. For parsing user input always
-        /// use <see cref="GetStringFromUtf8"/>.
-        /// </summary>
-        /// <param name="bytes">A byte array of ASCII characters (on the range of 0-127).</param>
-        /// <returns>A string created from the bytes.</returns>
-        public static string GetStringFromAscii(this byte[] bytes)
+        else
         {
-            return Encoding.ASCII.GetString(bytes);
-        }
-
-        /// <summary>
-        /// Converts UTF-16 encoded array to string using the little endian byte order.
-        /// </summary>
-        /// <param name="bytes">A byte array of UTF-16 characters.</param>
-        /// <returns>A string created from the bytes.</returns>
-        public static string GetStringFromUtf16(this byte[] bytes)
-        {
-            return Encoding.Unicode.GetString(bytes);
-        }
-
-        /// <summary>
-        /// Converts UTF-32 encoded array to string using the little endian byte order.
-        /// </summary>
-        /// <param name="bytes">A byte array of UTF-32 characters.</param>
-        /// <returns>A string created from the bytes.</returns>
-        public static string GetStringFromUtf32(this byte[] bytes)
-        {
-            return Encoding.UTF32.GetString(bytes);
-        }
-
-        /// <summary>
-        /// Converts UTF-8 encoded array to string.
-        /// Slower than <see cref="GetStringFromAscii"/> but supports UTF-8
-        /// encoded data. Use this function if you are unsure about the
-        /// source of the data. For user input this function
-        /// should always be preferred.
-        /// </summary>
-        /// <param name="bytes">
-        /// A byte array of UTF-8 characters (a character may take up multiple bytes).
-        /// </param>
-        /// <returns>A string created from the bytes.</returns>
-        public static string GetStringFromUtf8(this byte[] bytes)
-        {
-            return Encoding.UTF8.GetString(bytes);
-        }
-
-        /// <summary>
-        /// Hash the string and return a 32 bits unsigned integer.
-        /// </summary>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The calculated hash of the string.</returns>
-        public static uint Hash(this string instance)
-        {
-            uint hash = 5381;
-
-            foreach (uint c in instance)
+            if (instance.StartsWith('/'))
             {
-                hash = (hash << 5) + hash + c; // hash * 33 + c
+                rs = instance.Substring(1);
+                directory = "/";
             }
-
-            return hash;
-        }
-
-        /// <summary>
-        /// Decodes a hexadecimal string.
-        /// </summary>
-        /// <param name="instance">The hexadecimal string.</param>
-        /// <returns>The byte array representation of this string.</returns>
-        public static byte[] HexDecode(this string instance)
-        {
-            if (instance.Length % 2 != 0)
-            {
-                throw new ArgumentException("Hexadecimal string of uneven length.", nameof(instance));
-            }
-            int len = instance.Length / 2;
-            byte[] ret = new byte[len];
-            for (int i = 0; i < len; i++)
-            {
-                ret[i] = (byte)int.Parse(instance.AsSpan(i * 2, 2), NumberStyles.AllowHexSpecifier);
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Returns a hexadecimal representation of this byte as a string.
-        /// </summary>
-        /// <param name="b">The byte to encode.</param>
-        /// <returns>The hexadecimal representation of this byte.</returns>
-        internal static string HexEncode(this byte b)
-        {
-            string ret = string.Empty;
-
-            for (int i = 0; i < 2; i++)
-            {
-                char c;
-                int lv = b & 0xF;
-
-                if (lv < 10)
-                {
-                    c = (char)('0' + lv);
-                }
-                else
-                {
-                    c = (char)('a' + lv - 10);
-                }
-
-                b >>= 4;
-                ret = c + ret;
-            }
-
-            return ret;
-        }
-
-        /// <summary>
-        /// Returns a hexadecimal representation of this byte array as a string.
-        /// </summary>
-        /// <param name="bytes">The byte array to encode.</param>
-        /// <returns>The hexadecimal representation of this byte array.</returns>
-        public static string HexEncode(this byte[] bytes)
-        {
-            string ret = string.Empty;
-
-            foreach (byte b in bytes)
-            {
-                ret += b.HexEncode();
-            }
-
-            return ret;
-        }
-
-        /// <summary>
-        /// Converts a string containing a hexadecimal number into an integer.
-        /// Hexadecimal strings can either be prefixed with <c>0x</c> or not,
-        /// and they can also start with a <c>-</c> before the optional prefix.
-        /// </summary>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The converted string.</returns>
-        public static int HexToInt(this string instance)
-        {
-            if (instance.Length == 0)
-            {
-                return 0;
-            }
-
-            int sign = 1;
-
-            if (instance[0] == '-')
-            {
-                sign = -1;
-                instance = instance.Substring(1);
-            }
-
-            if (instance.StartsWith("0x"))
-            {
-                instance = instance.Substring(2);
-            }
-
-            return sign * int.Parse(instance, NumberStyles.HexNumber);
-        }
-
-        /// <summary>
-        /// Returns a copy of the string with lines indented with <paramref name="prefix"/>.
-        /// For example, the string can be indented with two tabs using <c>"\t\t"</c>,
-        /// or four spaces using <c>"    "</c>. The prefix can be any string so it can
-        /// also be used to comment out strings with e.g. <c>"// </c>.
-        /// See also <see cref="Dedent"/> to remove indentation.
-        /// Note: Empty lines are kept empty.
-        /// </summary>
-        /// <param name="instance">The string to add indentation to.</param>
-        /// <param name="prefix">The string to use as indentation.</param>
-        /// <returns>The string with indentation added.</returns>
-        public static string Indent(this string instance, string prefix)
-        {
-            var sb = new StringBuilder();
-            int lineStart = 0;
-
-            for (int i = 0; i < instance.Length; i++)
-            {
-                char c = instance[i];
-                if (c == '\n')
-                {
-                    if (i == lineStart)
-                    {
-                        sb.Append(c); // Leave empty lines empty.
-                    }
-                    else
-                    {
-                        sb.Append(prefix);
-                        sb.Append(instance.Substring(lineStart, i - lineStart + 1));
-                    }
-                    lineStart = i + 1;
-                }
-            }
-            if (lineStart != instance.Length)
-            {
-                sb.Append(prefix);
-                sb.Append(instance.Substring(lineStart));
-            }
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the string is a path to a file or
-        /// directory and its starting point is explicitly defined. This includes
-        /// <c>res://</c>, <c>user://</c>, <c>C:\</c>, <c>/</c>, etc.
-        /// </summary>
-        /// <seealso cref="IsRelativePath(string)"/>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string is an absolute path.</returns>
-        public static bool IsAbsolutePath(this string instance)
-        {
-            if (string.IsNullOrEmpty(instance))
-                return false;
-            else if (instance.Length > 1)
-                return instance[0] == '/' || instance[0] == '\\' || instance.Contains(":/") || instance.Contains(":\\");
             else
-                return instance[0] == '/' || instance[0] == '\\';
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the string is a path to a file or
-        /// directory and its starting point is implicitly defined within the
-        /// context it is being used. The starting point may refer to the current
-        /// directory (<c>./</c>), or the current <see cref="Node"/>.
-        /// </summary>
-        /// <seealso cref="IsAbsolutePath(string)"/>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string is a relative path.</returns>
-        public static bool IsRelativePath(this string instance)
-        {
-            return !IsAbsolutePath(instance);
-        }
-
-        /// <summary>
-        /// Check whether this string is a subsequence of the given string.
-        /// </summary>
-        /// <seealso cref="IsSubsequenceOfN(string, string)"/>
-        /// <param name="instance">The subsequence to search.</param>
-        /// <param name="text">The string that contains the subsequence.</param>
-        /// <param name="caseSensitive">If <see langword="true"/>, the check is case sensitive.</param>
-        /// <returns>If the string is a subsequence of the given string.</returns>
-        public static bool IsSubsequenceOf(this string instance, string text, bool caseSensitive = true)
-        {
-            int len = instance.Length;
-
-            if (len == 0)
-                return true; // Technically an empty string is subsequence of any string
-
-            if (len > text.Length)
-                return false;
-
-            int source = 0;
-            int target = 0;
-
-            while (source < len && target < text.Length)
             {
-                bool match;
+                rs = instance;
+            }
+        }
 
-                if (!caseSensitive)
+        int sep = Mathf.Max(rs.RFind("/"), rs.RFind("\\"));
+
+        if (sep == -1)
+            return directory;
+
+        return directory + rs.Substr(0, sep);
+    }
+
+    /// <summary>
+    /// If the string is a path to a file, return the path to the file without the extension.
+    /// </summary>
+    /// <seealso cref="GetExtension(string)"/>
+    /// <seealso cref="GetBaseDir(string)"/>
+    /// <seealso cref="GetFile(string)"/>
+    /// <param name="instance">The path to a file.</param>
+    /// <returns>The path to the file without the extension.</returns>
+    public static string GetBaseName(this string instance)
+    {
+        int index = instance.RFind(".");
+
+        if (index > 0)
+            return instance.Substring(0, index);
+
+        return instance;
+    }
+
+    /// <summary>
+    /// If the string is a path to a file, return the file and ignore the base directory.
+    /// </summary>
+    /// <seealso cref="GetBaseName(string)"/>
+    /// <seealso cref="GetExtension(string)"/>
+    /// <seealso cref="GetBaseDir(string)"/>
+    /// <param name="instance">The path to a file.</param>
+    /// <returns>The file name.</returns>
+    public static string GetFile(this string instance)
+    {
+        int sep = Mathf.Max(instance.RFind("/"), instance.RFind("\\"));
+
+        if (sep == -1)
+            return instance;
+
+        return instance.Substring(sep + 1);
+    }
+
+    /// <summary>
+    /// Converts ASCII encoded array to string.
+    /// Fast alternative to <see cref="GetStringFromUtf8"/> if the
+    /// content is ASCII-only. Unlike the UTF-8 function this function
+    /// maps every byte to a character in the array. Multibyte sequences
+    /// will not be interpreted correctly. For parsing user input always
+    /// use <see cref="GetStringFromUtf8"/>.
+    /// </summary>
+    /// <param name="bytes">A byte array of ASCII characters (on the range of 0-127).</param>
+    /// <returns>A string created from the bytes.</returns>
+    public static string GetStringFromAscii(this byte[] bytes)
+    {
+        return Encoding.ASCII.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Converts UTF-16 encoded array to string using the little endian byte order.
+    /// </summary>
+    /// <param name="bytes">A byte array of UTF-16 characters.</param>
+    /// <returns>A string created from the bytes.</returns>
+    public static string GetStringFromUtf16(this byte[] bytes)
+    {
+        return Encoding.Unicode.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Converts UTF-32 encoded array to string using the little endian byte order.
+    /// </summary>
+    /// <param name="bytes">A byte array of UTF-32 characters.</param>
+    /// <returns>A string created from the bytes.</returns>
+    public static string GetStringFromUtf32(this byte[] bytes)
+    {
+        return Encoding.UTF32.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Converts UTF-8 encoded array to string.
+    /// Slower than <see cref="GetStringFromAscii"/> but supports UTF-8
+    /// encoded data. Use this function if you are unsure about the
+    /// source of the data. For user input this function
+    /// should always be preferred.
+    /// </summary>
+    /// <param name="bytes">
+    /// A byte array of UTF-8 characters (a character may take up multiple bytes).
+    /// </param>
+    /// <returns>A string created from the bytes.</returns>
+    public static string GetStringFromUtf8(this byte[] bytes)
+    {
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Hash the string and return a 32 bits unsigned integer.
+    /// </summary>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The calculated hash of the string.</returns>
+    public static uint Hash(this string instance)
+    {
+        uint hash = 5381;
+
+        foreach (uint c in instance)
+        {
+            hash = (hash << 5) + hash + c; // hash * 33 + c
+        }
+
+        return hash;
+    }
+
+    /// <summary>
+    /// Decodes a hexadecimal string.
+    /// </summary>
+    /// <param name="instance">The hexadecimal string.</param>
+    /// <returns>The byte array representation of this string.</returns>
+    public static byte[] HexDecode(this string instance)
+    {
+        if (instance.Length % 2 != 0)
+        {
+            throw new ArgumentException("Hexadecimal string of uneven length.", nameof(instance));
+        }
+        int len = instance.Length / 2;
+        byte[] ret = new byte[len];
+        for (int i = 0; i < len; i++)
+        {
+            ret[i] = (byte)int.Parse(instance.AsSpan(i * 2, 2), NumberStyles.AllowHexSpecifier);
+        }
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns a hexadecimal representation of this byte as a string.
+    /// </summary>
+    /// <param name="b">The byte to encode.</param>
+    /// <returns>The hexadecimal representation of this byte.</returns>
+    internal static string HexEncode(this byte b)
+    {
+        string ret = string.Empty;
+
+        for (int i = 0; i < 2; i++)
+        {
+            char c;
+            int lv = b & 0xF;
+
+            if (lv < 10)
+            {
+                c = (char)('0' + lv);
+            }
+            else
+            {
+                c = (char)('a' + lv - 10);
+            }
+
+            b >>= 4;
+            ret = c + ret;
+        }
+
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns a hexadecimal representation of this byte array as a string.
+    /// </summary>
+    /// <param name="bytes">The byte array to encode.</param>
+    /// <returns>The hexadecimal representation of this byte array.</returns>
+    public static string HexEncode(this byte[] bytes)
+    {
+        string ret = string.Empty;
+
+        foreach (byte b in bytes)
+        {
+            ret += b.HexEncode();
+        }
+
+        return ret;
+    }
+
+    /// <summary>
+    /// Converts a string containing a hexadecimal number into an integer.
+    /// Hexadecimal strings can either be prefixed with <c>0x</c> or not,
+    /// and they can also start with a <c>-</c> before the optional prefix.
+    /// </summary>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The converted string.</returns>
+    public static int HexToInt(this string instance)
+    {
+        if (instance.Length == 0)
+        {
+            return 0;
+        }
+
+        int sign = 1;
+
+        if (instance[0] == '-')
+        {
+            sign = -1;
+            instance = instance.Substring(1);
+        }
+
+        if (instance.StartsWith("0x"))
+        {
+            instance = instance.Substring(2);
+        }
+
+        return sign * int.Parse(instance, NumberStyles.HexNumber);
+    }
+
+    /// <summary>
+    /// Returns a copy of the string with lines indented with <paramref name="prefix"/>.
+    /// For example, the string can be indented with two tabs using <c>"\t\t"</c>,
+    /// or four spaces using <c>"    "</c>. The prefix can be any string so it can
+    /// also be used to comment out strings with e.g. <c>"// </c>.
+    /// See also <see cref="Dedent"/> to remove indentation.
+    /// Note: Empty lines are kept empty.
+    /// </summary>
+    /// <param name="instance">The string to add indentation to.</param>
+    /// <param name="prefix">The string to use as indentation.</param>
+    /// <returns>The string with indentation added.</returns>
+    public static string Indent(this string instance, string prefix)
+    {
+        var sb = new StringBuilder();
+        int lineStart = 0;
+
+        for (int i = 0; i < instance.Length; i++)
+        {
+            char c = instance[i];
+            if (c == '\n')
+            {
+                if (i == lineStart)
                 {
-                    char sourcec = char.ToLower(instance[source]);
-                    char targetc = char.ToLower(text[target]);
-                    match = sourcec == targetc;
+                    sb.Append(c); // Leave empty lines empty.
                 }
                 else
                 {
-                    match = instance[source] == text[target];
+                    sb.Append(prefix);
+                    sb.Append(instance.Substring(lineStart, i - lineStart + 1));
                 }
-
-                if (match)
-                {
-                    source++;
-                    if (source >= len)
-                        return true;
-                }
-
-                target++;
+                lineStart = i + 1;
             }
+        }
+        if (lineStart != instance.Length)
+        {
+            sb.Append(prefix);
+            sb.Append(instance.Substring(lineStart));
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the string is a path to a file or
+    /// directory and its starting point is explicitly defined. This includes
+    /// <c>res://</c>, <c>user://</c>, <c>C:\</c>, <c>/</c>, etc.
+    /// </summary>
+    /// <seealso cref="IsRelativePath(string)"/>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string is an absolute path.</returns>
+    public static bool IsAbsolutePath(this string instance)
+    {
+        if (string.IsNullOrEmpty(instance))
+            return false;
+        else if (instance.Length > 1)
+            return instance[0] == '/' || instance[0] == '\\' || instance.Contains(":/") || instance.Contains(":\\");
+        else
+            return instance[0] == '/' || instance[0] == '\\';
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the string is a path to a file or
+    /// directory and its starting point is implicitly defined within the
+    /// context it is being used. The starting point may refer to the current
+    /// directory (<c>./</c>), or the current <see cref="Node"/>.
+    /// </summary>
+    /// <seealso cref="IsAbsolutePath(string)"/>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string is a relative path.</returns>
+    public static bool IsRelativePath(this string instance)
+    {
+        return !IsAbsolutePath(instance);
+    }
+
+    /// <summary>
+    /// Check whether this string is a subsequence of the given string.
+    /// </summary>
+    /// <seealso cref="IsSubsequenceOfN(string, string)"/>
+    /// <param name="instance">The subsequence to search.</param>
+    /// <param name="text">The string that contains the subsequence.</param>
+    /// <param name="caseSensitive">If <see langword="true"/>, the check is case sensitive.</param>
+    /// <returns>If the string is a subsequence of the given string.</returns>
+    public static bool IsSubsequenceOf(this string instance, string text, bool caseSensitive = true)
+    {
+        int len = instance.Length;
+
+        if (len == 0)
+            return true; // Technically an empty string is subsequence of any string
+
+        if (len > text.Length)
+            return false;
+
+        int source = 0;
+        int target = 0;
+
+        while (source < len && target < text.Length)
+        {
+            bool match;
+
+            if (!caseSensitive)
+            {
+                char sourcec = char.ToLower(instance[source]);
+                char targetc = char.ToLower(text[target]);
+                match = sourcec == targetc;
+            }
+            else
+            {
+                match = instance[source] == text[target];
+            }
+
+            if (match)
+            {
+                source++;
+                if (source >= len)
+                    return true;
+            }
+
+            target++;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Check whether this string is a subsequence of the given string, ignoring case differences.
+    /// </summary>
+    /// <seealso cref="IsSubsequenceOf(string, string, bool)"/>
+    /// <param name="instance">The subsequence to search.</param>
+    /// <param name="text">The string that contains the subsequence.</param>
+    /// <returns>If the string is a subsequence of the given string.</returns>
+    public static bool IsSubsequenceOfN(this string instance, string text)
+    {
+        return instance.IsSubsequenceOf(text, caseSensitive: false);
+    }
+
+    private static readonly char[] _invalidFileNameCharacters = { ':', '/', '\\', '?', '*', '"', '|', '%', '<', '>' };
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string is free from characters that
+    /// aren't allowed in file names.
+    /// </summary>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid file name.</returns>
+    public static bool IsValidFileName(this string instance)
+    {
+        var stripped = instance.Trim();
+        if (instance != stripped)
+            return false;
+
+        if (string.IsNullOrEmpty(stripped))
+            return false;
+
+        return instance.IndexOfAny(_invalidFileNameCharacters) == -1;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string contains a valid <see langword="float"/>.
+    /// This is inclusive of integers, and also supports exponents.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print("1.7".IsValidFloat())  // Prints "True"
+    /// GD.Print("24".IsValidFloat())  // Prints "True"
+    /// GD.Print("7e3".IsValidFloat())  // Prints "True"
+    /// GD.Print("Hello".IsValidFloat())  // Prints "False"
+    /// </code>
+    /// </example>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid floating point number.</returns>
+    public static bool IsValidFloat(this string instance)
+    {
+        return float.TryParse(instance, out _);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string contains a valid hexadecimal number.
+    /// If <paramref name="withPrefix"/> is <see langword="true"/>, then a validity of the
+    /// hexadecimal number is determined by <c>0x</c> prefix, for instance: <c>0xDEADC0DE</c>.
+    /// </summary>
+    /// <param name="instance">The string to check.</param>
+    /// <param name="withPrefix">If the string must contain the <c>0x</c> prefix to be valid.</param>
+    /// <returns>If the string contains a valid hexadecimal number.</returns>
+    public static bool IsValidHexNumber(this string instance, bool withPrefix = false)
+    {
+        if (string.IsNullOrEmpty(instance))
+            return false;
+
+        int from = 0;
+        if (instance.Length != 1 && instance[0] == '+' || instance[0] == '-')
+        {
+            from++;
+        }
+
+        if (withPrefix)
+        {
+            if (instance.Length < 3)
+                return false;
+            if (instance[from] != '0' || instance[from + 1] != 'x')
+                return false;
+            from += 2;
+        }
+
+        for (int i = from; i < instance.Length; i++)
+        {
+            char c = instance[i];
+            if (IsHexDigit(c))
+                continue;
 
             return false;
         }
 
-        /// <summary>
-        /// Check whether this string is a subsequence of the given string, ignoring case differences.
-        /// </summary>
-        /// <seealso cref="IsSubsequenceOf(string, string, bool)"/>
-        /// <param name="instance">The subsequence to search.</param>
-        /// <param name="text">The string that contains the subsequence.</param>
-        /// <returns>If the string is a subsequence of the given string.</returns>
-        public static bool IsSubsequenceOfN(this string instance, string text)
+        return true;
+
+        static bool IsHexDigit(char c)
         {
-            return instance.IsSubsequenceOf(text, caseSensitive: false);
+            return char.IsDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string contains a valid color in hexadecimal
+    /// HTML notation. Other HTML notations such as named colors or <c>hsl()</c> aren't
+    /// considered valid by this method and will return <see langword="false"/>.
+    /// </summary>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid HTML color.</returns>
+    public static bool IsValidHtmlColor(this string instance)
+    {
+        return Color.HtmlIsValid(instance);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string is a valid identifier.
+    /// A valid identifier may contain only letters, digits and underscores (<c>_</c>)
+    /// and the first character may not be a digit.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print("good_ident_1".IsValidIdentifier())  // Prints "True"
+    /// GD.Print("1st_bad_ident".IsValidIdentifier())  // Prints "False"
+    /// GD.Print("bad_ident_#2".IsValidIdentifier())  // Prints "False"
+    /// </code>
+    /// </example>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid identifier.</returns>
+    public static bool IsValidIdentifier(this string instance)
+    {
+        int len = instance.Length;
+
+        if (len == 0)
+            return false;
+
+        if (instance[0] >= '0' && instance[0] <= '9')
+            return false; // Identifiers cannot start with numbers.
+
+        for (int i = 0; i < len; i++)
+        {
+            bool validChar = instance[i] == '_' ||
+                (instance[i] >= 'a' && instance[i] <= 'z') ||
+                (instance[i] >= 'A' && instance[i] <= 'Z') ||
+                (instance[i] >= '0' && instance[i] <= '9');
+
+            if (!validChar)
+                return false;
         }
 
-        private static readonly char[] _invalidFileNameCharacters = { ':', '/', '\\', '?', '*', '"', '|', '%', '<', '>' };
+        return true;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this string is free from characters that
-        /// aren't allowed in file names.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid file name.</returns>
-        public static bool IsValidFileName(this string instance)
+    /// <summary>
+    /// Returns <see langword="true"/> if this string contains a valid <see langword="int"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print("7".IsValidInt())  // Prints "True"
+    /// GD.Print("14.6".IsValidInt())  // Prints "False"
+    /// GD.Print("L".IsValidInt())  // Prints "False"
+    /// GD.Print("+3".IsValidInt())  // Prints "True"
+    /// GD.Print("-12".IsValidInt())  // Prints "True"
+    /// </code>
+    /// </example>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid integer.</returns>
+    public static bool IsValidInt(this string instance)
+    {
+        return int.TryParse(instance, out _);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this string contains only a well-formatted
+    /// IPv4 or IPv6 address. This method considers reserved IP addresses such as
+    /// <c>0.0.0.0</c> as valid.
+    /// </summary>
+    /// <param name="instance">The string to check.</param>
+    /// <returns>If the string contains a valid IP address.</returns>
+    public static bool IsValidIPAddress(this string instance)
+    {
+        if (instance.Contains(':'))
         {
-            var stripped = instance.Trim();
-            if (instance != stripped)
-                return false;
+            string[] ip = instance.Split(':');
 
-            if (string.IsNullOrEmpty(stripped))
-                return false;
-
-            return instance.IndexOfAny(_invalidFileNameCharacters) == -1;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this string contains a valid <see langword="float"/>.
-        /// This is inclusive of integers, and also supports exponents.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print("1.7".IsValidFloat())  // Prints "True"
-        /// GD.Print("24".IsValidFloat())  // Prints "True"
-        /// GD.Print("7e3".IsValidFloat())  // Prints "True"
-        /// GD.Print("Hello".IsValidFloat())  // Prints "False"
-        /// </code>
-        /// </example>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid floating point number.</returns>
-        public static bool IsValidFloat(this string instance)
-        {
-            return float.TryParse(instance, out _);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this string contains a valid hexadecimal number.
-        /// If <paramref name="withPrefix"/> is <see langword="true"/>, then a validity of the
-        /// hexadecimal number is determined by <c>0x</c> prefix, for instance: <c>0xDEADC0DE</c>.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="withPrefix">If the string must contain the <c>0x</c> prefix to be valid.</param>
-        /// <returns>If the string contains a valid hexadecimal number.</returns>
-        public static bool IsValidHexNumber(this string instance, bool withPrefix = false)
-        {
-            if (string.IsNullOrEmpty(instance))
-                return false;
-
-            int from = 0;
-            if (instance.Length != 1 && instance[0] == '+' || instance[0] == '-')
+            for (int i = 0; i < ip.Length; i++)
             {
-                from++;
-            }
-
-            if (withPrefix)
-            {
-                if (instance.Length < 3)
-                    return false;
-                if (instance[from] != '0' || instance[from + 1] != 'x')
-                    return false;
-                from += 2;
-            }
-
-            for (int i = from; i < instance.Length; i++)
-            {
-                char c = instance[i];
-                if (IsHexDigit(c))
+                string n = ip[i];
+                if (n.Length == 0)
                     continue;
 
-                return false;
-            }
+                if (n.IsValidHexNumber(withPrefix: false))
+                {
+                    long nint = n.HexToInt();
+                    if (nint < 0 || nint > 0xffff)
+                        return false;
 
-            return true;
+                    continue;
+                }
 
-            static bool IsHexDigit(char c)
-            {
-                return char.IsDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-            }
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this string contains a valid color in hexadecimal
-        /// HTML notation. Other HTML notations such as named colors or <c>hsl()</c> aren't
-        /// considered valid by this method and will return <see langword="false"/>.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid HTML color.</returns>
-        public static bool IsValidHtmlColor(this string instance)
-        {
-            return Color.HtmlIsValid(instance);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this string is a valid identifier.
-        /// A valid identifier may contain only letters, digits and underscores (<c>_</c>)
-        /// and the first character may not be a digit.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print("good_ident_1".IsValidIdentifier())  // Prints "True"
-        /// GD.Print("1st_bad_ident".IsValidIdentifier())  // Prints "False"
-        /// GD.Print("bad_ident_#2".IsValidIdentifier())  // Prints "False"
-        /// </code>
-        /// </example>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid identifier.</returns>
-        public static bool IsValidIdentifier(this string instance)
-        {
-            int len = instance.Length;
-
-            if (len == 0)
-                return false;
-
-            if (instance[0] >= '0' && instance[0] <= '9')
-                return false; // Identifiers cannot start with numbers.
-
-            for (int i = 0; i < len; i++)
-            {
-                bool validChar = instance[i] == '_' ||
-                    (instance[i] >= 'a' && instance[i] <= 'z') ||
-                    (instance[i] >= 'A' && instance[i] <= 'Z') ||
-                    (instance[i] >= '0' && instance[i] <= '9');
-
-                if (!validChar)
+                if (!n.IsValidIPAddress())
                     return false;
             }
-
-            return true;
         }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this string contains a valid <see langword="int"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print("7".IsValidInt())  // Prints "True"
-        /// GD.Print("14.6".IsValidInt())  // Prints "False"
-        /// GD.Print("L".IsValidInt())  // Prints "False"
-        /// GD.Print("+3".IsValidInt())  // Prints "True"
-        /// GD.Print("-12".IsValidInt())  // Prints "True"
-        /// </code>
-        /// </example>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid integer.</returns>
-        public static bool IsValidInt(this string instance)
+        else
         {
-            return int.TryParse(instance, out _);
-        }
+            string[] ip = instance.Split('.');
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this string contains only a well-formatted
-        /// IPv4 or IPv6 address. This method considers reserved IP addresses such as
-        /// <c>0.0.0.0</c> as valid.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <returns>If the string contains a valid IP address.</returns>
-        public static bool IsValidIPAddress(this string instance)
-        {
-            if (instance.Contains(':'))
+            if (ip.Length != 4)
+                return false;
+
+            for (int i = 0; i < ip.Length; i++)
             {
-                string[] ip = instance.Split(':');
-
-                for (int i = 0; i < ip.Length; i++)
-                {
-                    string n = ip[i];
-                    if (n.Length == 0)
-                        continue;
-
-                    if (n.IsValidHexNumber(withPrefix: false))
-                    {
-                        long nint = n.HexToInt();
-                        if (nint < 0 || nint > 0xffff)
-                            return false;
-
-                        continue;
-                    }
-
-                    if (!n.IsValidIPAddress())
-                        return false;
-                }
-            }
-            else
-            {
-                string[] ip = instance.Split('.');
-
-                if (ip.Length != 4)
+                string n = ip[i];
+                if (!n.IsValidInt())
                     return false;
 
-                for (int i = 0; i < ip.Length; i++)
-                {
-                    string n = ip[i];
-                    if (!n.IsValidInt())
-                        return false;
-
-                    int val = n.ToInt();
-                    if (val < 0 || val > 255)
-                        return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Returns a copy of the string with special characters escaped using the JSON standard.
-        /// </summary>
-        /// <param name="instance">The string to escape.</param>
-        /// <returns>The escaped string.</returns>
-        public static string JSONEscape(this string instance)
-        {
-            var sb = new StringBuilder(instance);
-
-            sb.Replace("\\", "\\\\");
-            sb.Replace("\b", "\\b");
-            sb.Replace("\f", "\\f");
-            sb.Replace("\n", "\\n");
-            sb.Replace("\r", "\\r");
-            sb.Replace("\t", "\\t");
-            sb.Replace("\v", "\\v");
-            sb.Replace("\"", "\\\"");
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Returns an amount of characters from the left of the string.
-        /// </summary>
-        /// <seealso cref="Right(string, int)"/>
-        /// <param name="instance">The original string.</param>
-        /// <param name="pos">The position in the string where the left side ends.</param>
-        /// <returns>The left side of the string from the given position.</returns>
-        public static string Left(this string instance, int pos)
-        {
-            if (pos <= 0)
-                return string.Empty;
-
-            if (pos >= instance.Length)
-                return instance;
-
-            return instance.Substring(0, pos);
-        }
-
-        /// <summary>
-        /// Do a simple expression match, where '*' matches zero or more
-        /// arbitrary characters and '?' matches any single character except '.'.
-        /// </summary>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="expr">Expression to check.</param>
-        /// <param name="caseSensitive">
-        /// If <see langword="true"/>, the check will be case sensitive.
-        /// </param>
-        /// <returns>If the expression has any matches.</returns>
-        private static bool ExprMatch(this string instance, string expr, bool caseSensitive)
-        {
-            // case '\0':
-            if (expr.Length == 0)
-                return instance.Length == 0;
-
-            switch (expr[0])
-            {
-                case '*':
-                    return ExprMatch(instance, expr.Substring(1), caseSensitive) || (instance.Length > 0 &&
-                        ExprMatch(instance.Substring(1), expr, caseSensitive));
-                case '?':
-                    return instance.Length > 0 && instance[0] != '.' &&
-                           ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
-                default:
-                    if (instance.Length == 0)
-                        return false;
-                    if (caseSensitive)
-                        return instance[0] == expr[0];
-                    return (char.ToUpper(instance[0]) == char.ToUpper(expr[0])) &&
-                           ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
+                int val = n.ToInt();
+                if (val < 0 || val > 255)
+                    return false;
             }
         }
 
-        /// <summary>
-        /// Do a simple case sensitive expression match, using ? and * wildcards
-        /// (see <see cref="ExprMatch(string, string, bool)"/>).
-        /// </summary>
-        /// <seealso cref="MatchN(string, string)"/>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="expr">Expression to check.</param>
-        /// <param name="caseSensitive">
-        /// If <see langword="true"/>, the check will be case sensitive.
-        /// </param>
-        /// <returns>If the expression has any matches.</returns>
-        public static bool Match(this string instance, string expr, bool caseSensitive = true)
-        {
-            if (instance.Length == 0 || expr.Length == 0)
-                return false;
+        return true;
+    }
 
-            return instance.ExprMatch(expr, caseSensitive);
-        }
+    /// <summary>
+    /// Returns a copy of the string with special characters escaped using the JSON standard.
+    /// </summary>
+    /// <param name="instance">The string to escape.</param>
+    /// <returns>The escaped string.</returns>
+    public static string JSONEscape(this string instance)
+    {
+        var sb = new StringBuilder(instance);
 
-        /// <summary>
-        /// Do a simple case insensitive expression match, using ? and * wildcards
-        /// (see <see cref="ExprMatch(string, string, bool)"/>).
-        /// </summary>
-        /// <seealso cref="Match(string, string, bool)"/>
-        /// <param name="instance">The string to check.</param>
-        /// <param name="expr">Expression to check.</param>
-        /// <returns>If the expression has any matches.</returns>
-        public static bool MatchN(this string instance, string expr)
-        {
-            if (instance.Length == 0 || expr.Length == 0)
-                return false;
+        sb.Replace("\\", "\\\\");
+        sb.Replace("\b", "\\b");
+        sb.Replace("\f", "\\f");
+        sb.Replace("\n", "\\n");
+        sb.Replace("\r", "\\r");
+        sb.Replace("\t", "\\t");
+        sb.Replace("\v", "\\v");
+        sb.Replace("\"", "\\\"");
 
-            return instance.ExprMatch(expr, caseSensitive: false);
-        }
+        return sb.ToString();
+    }
 
-        /// <summary>
-        /// Returns the MD5 hash of the string as an array of bytes.
-        /// </summary>
-        /// <seealso cref="Md5Text(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The MD5 hash of the string.</returns>
-        public static byte[] Md5Buffer(this string instance)
-        {
-#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
-            return MD5.HashData(Encoding.UTF8.GetBytes(instance));
-#pragma warning restore CA5351
-        }
+    /// <summary>
+    /// Returns an amount of characters from the left of the string.
+    /// </summary>
+    /// <seealso cref="Right(string, int)"/>
+    /// <param name="instance">The original string.</param>
+    /// <param name="pos">The position in the string where the left side ends.</param>
+    /// <returns>The left side of the string from the given position.</returns>
+    public static string Left(this string instance, int pos)
+    {
+        if (pos <= 0)
+            return string.Empty;
 
-        /// <summary>
-        /// Returns the MD5 hash of the string as a string.
-        /// </summary>
-        /// <seealso cref="Md5Buffer(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The MD5 hash of the string.</returns>
-        public static string Md5Text(this string instance)
-        {
-            return instance.Md5Buffer().HexEncode();
-        }
-
-        /// <summary>
-        /// Perform a case-insensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
-        /// </summary>
-        /// <seealso cref="CasecmpTo(string, string)"/>
-        /// <seealso cref="CompareTo(string, string, bool)"/>
-        /// <param name="instance">The string to compare.</param>
-        /// <param name="to">The other string to compare.</param>
-        /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
-        public static int NocasecmpTo(this string instance, string to)
-        {
-            return instance.CompareTo(to, caseSensitive: false);
-        }
-
-        /// <summary>
-        /// Format a number to have an exact number of <paramref name="digits"/>
-        /// after the decimal point.
-        /// </summary>
-        /// <seealso cref="PadZeros(string, int)"/>
-        /// <param name="instance">The string to pad.</param>
-        /// <param name="digits">Amount of digits after the decimal point.</param>
-        /// <returns>The string padded with zeroes.</returns>
-        public static string PadDecimals(this string instance, int digits)
-        {
-            int c = instance.Find(".");
-
-            if (c == -1)
-            {
-                if (digits <= 0)
-                    return instance;
-
-                instance += ".";
-                c = instance.Length - 1;
-            }
-            else
-            {
-                if (digits <= 0)
-                    return instance.Substring(0, c);
-            }
-
-            if (instance.Length - (c + 1) > digits)
-            {
-                instance = instance.Substring(0, c + digits + 1);
-            }
-            else
-            {
-                while (instance.Length - (c + 1) < digits)
-                {
-                    instance += "0";
-                }
-            }
-
+        if (pos >= instance.Length)
             return instance;
-        }
 
-        /// <summary>
-        /// Format a number to have an exact number of <paramref name="digits"/>
-        /// before the decimal point.
-        /// </summary>
-        /// <seealso cref="PadDecimals(string, int)"/>
-        /// <param name="instance">The string to pad.</param>
-        /// <param name="digits">Amount of digits before the decimal point.</param>
-        /// <returns>The string padded with zeroes.</returns>
-        public static string PadZeros(this string instance, int digits)
+        return instance.Substring(0, pos);
+    }
+
+    /// <summary>
+    /// Do a simple expression match, where '*' matches zero or more
+    /// arbitrary characters and '?' matches any single character except '.'.
+    /// </summary>
+    /// <param name="instance">The string to check.</param>
+    /// <param name="expr">Expression to check.</param>
+    /// <param name="caseSensitive">
+    /// If <see langword="true"/>, the check will be case sensitive.
+    /// </param>
+    /// <returns>If the expression has any matches.</returns>
+    private static bool ExprMatch(this string instance, string expr, bool caseSensitive)
+    {
+        // case '\0':
+        if (expr.Length == 0)
+            return instance.Length == 0;
+
+        switch (expr[0])
         {
-            string s = instance;
-            int end = s.Find(".");
-
-            if (end == -1)
-                end = s.Length;
-
-            if (end == 0)
-                return s;
-
-            int begin = 0;
-
-            while (begin < end && (s[begin] < '0' || s[begin] > '9'))
-            {
-                begin++;
-            }
-
-            if (begin >= end)
-                return s;
-
-            while (end - begin < digits)
-            {
-                s = s.Insert(begin, "0");
-                end++;
-            }
-
-            return s;
+            case '*':
+                return ExprMatch(instance, expr.Substring(1), caseSensitive) || (instance.Length > 0 &&
+                    ExprMatch(instance.Substring(1), expr, caseSensitive));
+            case '?':
+                return instance.Length > 0 && instance[0] != '.' &&
+                       ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
+            default:
+                if (instance.Length == 0)
+                    return false;
+                if (caseSensitive)
+                    return instance[0] == expr[0];
+                return (char.ToUpper(instance[0]) == char.ToUpper(expr[0])) &&
+                       ExprMatch(instance.Substring(1), expr.Substring(1), caseSensitive);
         }
+    }
 
-        /// <summary>
-        /// If the string is a path, this concatenates <paramref name="file"/>
-        /// at the end of the string as a subpath.
-        /// E.g. <c>"this/is".PathJoin("path") == "this/is/path"</c>.
-        /// </summary>
-        /// <param name="instance">The path that will be concatenated.</param>
-        /// <param name="file">File name to concatenate with the path.</param>
-        /// <returns>The concatenated path with the given file name.</returns>
-        public static string PathJoin(this string instance, string file)
+    /// <summary>
+    /// Do a simple case sensitive expression match, using ? and * wildcards
+    /// (see <see cref="ExprMatch(string, string, bool)"/>).
+    /// </summary>
+    /// <seealso cref="MatchN(string, string)"/>
+    /// <param name="instance">The string to check.</param>
+    /// <param name="expr">Expression to check.</param>
+    /// <param name="caseSensitive">
+    /// If <see langword="true"/>, the check will be case sensitive.
+    /// </param>
+    /// <returns>If the expression has any matches.</returns>
+    public static bool Match(this string instance, string expr, bool caseSensitive = true)
+    {
+        if (instance.Length == 0 || expr.Length == 0)
+            return false;
+
+        return instance.ExprMatch(expr, caseSensitive);
+    }
+
+    /// <summary>
+    /// Do a simple case insensitive expression match, using ? and * wildcards
+    /// (see <see cref="ExprMatch(string, string, bool)"/>).
+    /// </summary>
+    /// <seealso cref="Match(string, string, bool)"/>
+    /// <param name="instance">The string to check.</param>
+    /// <param name="expr">Expression to check.</param>
+    /// <returns>If the expression has any matches.</returns>
+    public static bool MatchN(this string instance, string expr)
+    {
+        if (instance.Length == 0 || expr.Length == 0)
+            return false;
+
+        return instance.ExprMatch(expr, caseSensitive: false);
+    }
+
+    /// <summary>
+    /// Returns the MD5 hash of the string as an array of bytes.
+    /// </summary>
+    /// <seealso cref="Md5Text(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The MD5 hash of the string.</returns>
+    public static byte[] Md5Buffer(this string instance)
+    {
+#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
+        return MD5.HashData(Encoding.UTF8.GetBytes(instance));
+#pragma warning restore CA5351
+    }
+
+    /// <summary>
+    /// Returns the MD5 hash of the string as a string.
+    /// </summary>
+    /// <seealso cref="Md5Buffer(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The MD5 hash of the string.</returns>
+    public static string Md5Text(this string instance)
+    {
+        return instance.Md5Buffer().HexEncode();
+    }
+
+    /// <summary>
+    /// Perform a case-insensitive comparison to another string, return -1 if less, 0 if equal and +1 if greater.
+    /// </summary>
+    /// <seealso cref="CasecmpTo(string, string)"/>
+    /// <seealso cref="CompareTo(string, string, bool)"/>
+    /// <param name="instance">The string to compare.</param>
+    /// <param name="to">The other string to compare.</param>
+    /// <returns>-1 if less, 0 if equal and +1 if greater.</returns>
+    public static int NocasecmpTo(this string instance, string to)
+    {
+        return instance.CompareTo(to, caseSensitive: false);
+    }
+
+    /// <summary>
+    /// Format a number to have an exact number of <paramref name="digits"/>
+    /// after the decimal point.
+    /// </summary>
+    /// <seealso cref="PadZeros(string, int)"/>
+    /// <param name="instance">The string to pad.</param>
+    /// <param name="digits">Amount of digits after the decimal point.</param>
+    /// <returns>The string padded with zeroes.</returns>
+    public static string PadDecimals(this string instance, int digits)
+    {
+        int c = instance.Find(".");
+
+        if (c == -1)
         {
-            if (instance.Length > 0 && instance[instance.Length - 1] == '/')
-                return instance + file;
-            return instance + "/" + file;
-        }
-
-        /// <summary>
-        /// Replace occurrences of a substring for different ones inside the string.
-        /// </summary>
-        /// <seealso cref="ReplaceN(string, string, string)"/>
-        /// <param name="instance">The string to modify.</param>
-        /// <param name="what">The substring to be replaced in the string.</param>
-        /// <param name="forwhat">The substring that replaces <paramref name="what"/>.</param>
-        /// <returns>The string with the substring occurrences replaced.</returns>
-        public static string Replace(this string instance, string what, string forwhat)
-        {
-            return instance.Replace(what, forwhat);
-        }
-
-        /// <summary>
-        /// Replace occurrences of a substring for different ones inside the string, but search case-insensitive.
-        /// </summary>
-        /// <seealso cref="Replace(string, string, string)"/>
-        /// <param name="instance">The string to modify.</param>
-        /// <param name="what">The substring to be replaced in the string.</param>
-        /// <param name="forwhat">The substring that replaces <paramref name="what"/>.</param>
-        /// <returns>The string with the substring occurrences replaced.</returns>
-        public static string ReplaceN(this string instance, string what, string forwhat)
-        {
-            return Regex.Replace(instance, what, forwhat, RegexOptions.IgnoreCase);
-        }
-
-        /// <summary>
-        /// Returns the index of the last occurrence of the specified string in this instance,
-        /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing to
-        /// the beginning of the string.
-        /// </summary>
-        /// <seealso cref="Find(string, string, int, bool)"/>
-        /// <seealso cref="Find(string, char, int, bool)"/>
-        /// <seealso cref="FindN(string, string, int)"/>
-        /// <seealso cref="RFindN(string, string, int)"/>
-        /// <param name="instance">The string that will be searched.</param>
-        /// <param name="what">The substring to search in the string.</param>
-        /// <param name="from">The position at which to start searching.</param>
-        /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
-        /// <returns>The position at which the substring was found, or -1 if not found.</returns>
-        public static int RFind(this string instance, string what, int from = -1, bool caseSensitive = true)
-        {
-            if (from == -1)
-                from = instance.Length - 1;
-
-            return instance.LastIndexOf(what, from,
-                caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Returns the index of the last case-insensitive occurrence of the specified string in this instance,
-        /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing to
-        /// the beginning of the string.
-        /// </summary>
-        /// <seealso cref="Find(string, string, int, bool)"/>
-        /// <seealso cref="Find(string, char, int, bool)"/>
-        /// <seealso cref="FindN(string, string, int)"/>
-        /// <seealso cref="RFind(string, string, int, bool)"/>
-        /// <param name="instance">The string that will be searched.</param>
-        /// <param name="what">The substring to search in the string.</param>
-        /// <param name="from">The position at which to start searching.</param>
-        /// <returns>The position at which the substring was found, or -1 if not found.</returns>
-        public static int RFindN(this string instance, string what, int from = -1)
-        {
-            if (from == -1)
-                from = instance.Length - 1;
-
-            return instance.LastIndexOf(what, from, StringComparison.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Returns the right side of the string from a given position.
-        /// </summary>
-        /// <seealso cref="Left(string, int)"/>
-        /// <param name="instance">The original string.</param>
-        /// <param name="pos">The position in the string from which the right side starts.</param>
-        /// <returns>The right side of the string from the given position.</returns>
-        public static string Right(this string instance, int pos)
-        {
-            if (pos >= instance.Length)
+            if (digits <= 0)
                 return instance;
 
-            if (pos < 0)
-                return string.Empty;
-
-            return instance.Substring(pos, instance.Length - pos);
+            instance += ".";
+            c = instance.Length - 1;
+        }
+        else
+        {
+            if (digits <= 0)
+                return instance.Substring(0, c);
         }
 
-        /// <summary>
-        /// Returns the SHA-1 hash of the string as an array of bytes.
-        /// </summary>
-        /// <seealso cref="Sha1Text(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The SHA-1 hash of the string.</returns>
-        public static byte[] Sha1Buffer(this string instance)
+        if (instance.Length - (c + 1) > digits)
         {
+            instance = instance.Substring(0, c + digits + 1);
+        }
+        else
+        {
+            while (instance.Length - (c + 1) < digits)
+            {
+                instance += "0";
+            }
+        }
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Format a number to have an exact number of <paramref name="digits"/>
+    /// before the decimal point.
+    /// </summary>
+    /// <seealso cref="PadDecimals(string, int)"/>
+    /// <param name="instance">The string to pad.</param>
+    /// <param name="digits">Amount of digits before the decimal point.</param>
+    /// <returns>The string padded with zeroes.</returns>
+    public static string PadZeros(this string instance, int digits)
+    {
+        string s = instance;
+        int end = s.Find(".");
+
+        if (end == -1)
+            end = s.Length;
+
+        if (end == 0)
+            return s;
+
+        int begin = 0;
+
+        while (begin < end && (s[begin] < '0' || s[begin] > '9'))
+        {
+            begin++;
+        }
+
+        if (begin >= end)
+            return s;
+
+        while (end - begin < digits)
+        {
+            s = s.Insert(begin, "0");
+            end++;
+        }
+
+        return s;
+    }
+
+    /// <summary>
+    /// If the string is a path, this concatenates <paramref name="file"/>
+    /// at the end of the string as a subpath.
+    /// E.g. <c>"this/is".PathJoin("path") == "this/is/path"</c>.
+    /// </summary>
+    /// <param name="instance">The path that will be concatenated.</param>
+    /// <param name="file">File name to concatenate with the path.</param>
+    /// <returns>The concatenated path with the given file name.</returns>
+    public static string PathJoin(this string instance, string file)
+    {
+        if (instance.Length > 0 && instance[instance.Length - 1] == '/')
+            return instance + file;
+        return instance + "/" + file;
+    }
+
+    /// <summary>
+    /// Replace occurrences of a substring for different ones inside the string.
+    /// </summary>
+    /// <seealso cref="ReplaceN(string, string, string)"/>
+    /// <param name="instance">The string to modify.</param>
+    /// <param name="what">The substring to be replaced in the string.</param>
+    /// <param name="forwhat">The substring that replaces <paramref name="what"/>.</param>
+    /// <returns>The string with the substring occurrences replaced.</returns>
+    public static string Replace(this string instance, string what, string forwhat)
+    {
+        return instance.Replace(what, forwhat);
+    }
+
+    /// <summary>
+    /// Replace occurrences of a substring for different ones inside the string, but search case-insensitive.
+    /// </summary>
+    /// <seealso cref="Replace(string, string, string)"/>
+    /// <param name="instance">The string to modify.</param>
+    /// <param name="what">The substring to be replaced in the string.</param>
+    /// <param name="forwhat">The substring that replaces <paramref name="what"/>.</param>
+    /// <returns>The string with the substring occurrences replaced.</returns>
+    public static string ReplaceN(this string instance, string what, string forwhat)
+    {
+        return Regex.Replace(instance, what, forwhat, RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the index of the last occurrence of the specified string in this instance,
+    /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing to
+    /// the beginning of the string.
+    /// </summary>
+    /// <seealso cref="Find(string, string, int, bool)"/>
+    /// <seealso cref="Find(string, char, int, bool)"/>
+    /// <seealso cref="FindN(string, string, int)"/>
+    /// <seealso cref="RFindN(string, string, int)"/>
+    /// <param name="instance">The string that will be searched.</param>
+    /// <param name="what">The substring to search in the string.</param>
+    /// <param name="from">The position at which to start searching.</param>
+    /// <param name="caseSensitive">If <see langword="true"/>, the search is case sensitive.</param>
+    /// <returns>The position at which the substring was found, or -1 if not found.</returns>
+    public static int RFind(this string instance, string what, int from = -1, bool caseSensitive = true)
+    {
+        if (from == -1)
+            from = instance.Length - 1;
+
+        return instance.LastIndexOf(what, from,
+            caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the index of the last case-insensitive occurrence of the specified string in this instance,
+    /// or <c>-1</c>. Optionally, the starting search index can be specified, continuing to
+    /// the beginning of the string.
+    /// </summary>
+    /// <seealso cref="Find(string, string, int, bool)"/>
+    /// <seealso cref="Find(string, char, int, bool)"/>
+    /// <seealso cref="FindN(string, string, int)"/>
+    /// <seealso cref="RFind(string, string, int, bool)"/>
+    /// <param name="instance">The string that will be searched.</param>
+    /// <param name="what">The substring to search in the string.</param>
+    /// <param name="from">The position at which to start searching.</param>
+    /// <returns>The position at which the substring was found, or -1 if not found.</returns>
+    public static int RFindN(this string instance, string what, int from = -1)
+    {
+        if (from == -1)
+            from = instance.Length - 1;
+
+        return instance.LastIndexOf(what, from, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the right side of the string from a given position.
+    /// </summary>
+    /// <seealso cref="Left(string, int)"/>
+    /// <param name="instance">The original string.</param>
+    /// <param name="pos">The position in the string from which the right side starts.</param>
+    /// <returns>The right side of the string from the given position.</returns>
+    public static string Right(this string instance, int pos)
+    {
+        if (pos >= instance.Length)
+            return instance;
+
+        if (pos < 0)
+            return string.Empty;
+
+        return instance.Substring(pos, instance.Length - pos);
+    }
+
+    /// <summary>
+    /// Returns the SHA-1 hash of the string as an array of bytes.
+    /// </summary>
+    /// <seealso cref="Sha1Text(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The SHA-1 hash of the string.</returns>
+    public static byte[] Sha1Buffer(this string instance)
+    {
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
-            return SHA1.HashData(Encoding.UTF8.GetBytes(instance));
+        return SHA1.HashData(Encoding.UTF8.GetBytes(instance));
 #pragma warning restore CA5350
+    }
+
+    /// <summary>
+    /// Returns the SHA-1 hash of the string as a string.
+    /// </summary>
+    /// <seealso cref="Sha1Buffer(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The SHA-1 hash of the string.</returns>
+    public static string Sha1Text(this string instance)
+    {
+        return instance.Sha1Buffer().HexEncode();
+    }
+
+    /// <summary>
+    /// Returns the SHA-256 hash of the string as an array of bytes.
+    /// </summary>
+    /// <seealso cref="Sha256Text(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The SHA-256 hash of the string.</returns>
+    public static byte[] Sha256Buffer(this string instance)
+    {
+        return SHA256.HashData(Encoding.UTF8.GetBytes(instance));
+    }
+
+    /// <summary>
+    /// Returns the SHA-256 hash of the string as a string.
+    /// </summary>
+    /// <seealso cref="Sha256Buffer(string)"/>
+    /// <param name="instance">The string to hash.</param>
+    /// <returns>The SHA-256 hash of the string.</returns>
+    public static string Sha256Text(this string instance)
+    {
+        return instance.Sha256Buffer().HexEncode();
+    }
+
+    /// <summary>
+    /// Returns the similarity index of the text compared to this string.
+    /// 1 means totally similar and 0 means totally dissimilar.
+    /// </summary>
+    /// <param name="instance">The string to compare.</param>
+    /// <param name="text">The other string to compare.</param>
+    /// <returns>The similarity index.</returns>
+    public static float Similarity(this string instance, string text)
+    {
+        if (instance == text)
+        {
+            // Equal strings are totally similar
+            return 1.0f;
         }
 
-        /// <summary>
-        /// Returns the SHA-1 hash of the string as a string.
-        /// </summary>
-        /// <seealso cref="Sha1Buffer(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The SHA-1 hash of the string.</returns>
-        public static string Sha1Text(this string instance)
+        if (instance.Length < 2 || text.Length < 2)
         {
-            return instance.Sha1Buffer().HexEncode();
+            // No way to calculate similarity without a single bigram
+            return 0.0f;
         }
 
-        /// <summary>
-        /// Returns the SHA-256 hash of the string as an array of bytes.
-        /// </summary>
-        /// <seealso cref="Sha256Text(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The SHA-256 hash of the string.</returns>
-        public static byte[] Sha256Buffer(this string instance)
-        {
-            return SHA256.HashData(Encoding.UTF8.GetBytes(instance));
-        }
+        string[] sourceBigrams = instance.Bigrams();
+        string[] targetBigrams = text.Bigrams();
 
-        /// <summary>
-        /// Returns the SHA-256 hash of the string as a string.
-        /// </summary>
-        /// <seealso cref="Sha256Buffer(string)"/>
-        /// <param name="instance">The string to hash.</param>
-        /// <returns>The SHA-256 hash of the string.</returns>
-        public static string Sha256Text(this string instance)
-        {
-            return instance.Sha256Buffer().HexEncode();
-        }
+        int sourceSize = sourceBigrams.Length;
+        int targetSize = targetBigrams.Length;
 
-        /// <summary>
-        /// Returns the similarity index of the text compared to this string.
-        /// 1 means totally similar and 0 means totally dissimilar.
-        /// </summary>
-        /// <param name="instance">The string to compare.</param>
-        /// <param name="text">The other string to compare.</param>
-        /// <returns>The similarity index.</returns>
-        public static float Similarity(this string instance, string text)
+        float sum = sourceSize + targetSize;
+        float inter = 0;
+
+        for (int i = 0; i < sourceSize; i++)
         {
-            if (instance == text)
+            for (int j = 0; j < targetSize; j++)
             {
-                // Equal strings are totally similar
-                return 1.0f;
-            }
-
-            if (instance.Length < 2 || text.Length < 2)
-            {
-                // No way to calculate similarity without a single bigram
-                return 0.0f;
-            }
-
-            string[] sourceBigrams = instance.Bigrams();
-            string[] targetBigrams = text.Bigrams();
-
-            int sourceSize = sourceBigrams.Length;
-            int targetSize = targetBigrams.Length;
-
-            float sum = sourceSize + targetSize;
-            float inter = 0;
-
-            for (int i = 0; i < sourceSize; i++)
-            {
-                for (int j = 0; j < targetSize; j++)
+                if (sourceBigrams[i] == targetBigrams[j])
                 {
-                    if (sourceBigrams[i] == targetBigrams[j])
-                    {
-                        inter++;
-                        break;
-                    }
+                    inter++;
+                    break;
                 }
             }
-
-            return 2.0f * inter / sum;
         }
 
-        /// <summary>
-        /// Returns a simplified canonical path.
-        /// </summary>
-        public static string SimplifyPath(this string instance)
+        return 2.0f * inter / sum;
+    }
+
+    /// <summary>
+    /// Returns a simplified canonical path.
+    /// </summary>
+    public static string SimplifyPath(this string instance)
+    {
+        using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
+        NativeFuncs.godotsharp_string_simplify_path(instanceStr, out godot_string simplifiedPath);
+        using (simplifiedPath)
+            return Marshaling.ConvertStringToManaged(simplifiedPath);
+    }
+
+    /// <summary>
+    /// Split the string by a divisor string, return an array of the substrings.
+    /// Example "One,Two,Three" will return ["One","Two","Three"] if split by ",".
+    /// </summary>
+    /// <seealso cref="SplitFloats(string, string, bool)"/>
+    /// <param name="instance">The string to split.</param>
+    /// <param name="divisor">The divisor string that splits the string.</param>
+    /// <param name="allowEmpty">
+    /// If <see langword="true"/>, the array may include empty strings.
+    /// </param>
+    /// <returns>The array of strings split from the string.</returns>
+    public static string[] Split(this string instance, string divisor, bool allowEmpty = true)
+    {
+        return instance.Split(divisor,
+            allowEmpty ? StringSplitOptions.None : StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    /// <summary>
+    /// Split the string in floats by using a divisor string, return an array of the substrings.
+    /// Example "1,2.5,3" will return [1,2.5,3] if split by ",".
+    /// </summary>
+    /// <seealso cref="Split(string, string, bool)"/>
+    /// <param name="instance">The string to split.</param>
+    /// <param name="divisor">The divisor string that splits the string.</param>
+    /// <param name="allowEmpty">
+    /// If <see langword="true"/>, the array may include empty floats.
+    /// </param>
+    /// <returns>The array of floats split from the string.</returns>
+    public static float[] SplitFloats(this string instance, string divisor, bool allowEmpty = true)
+    {
+        var ret = new List<float>();
+        int from = 0;
+        int len = instance.Length;
+
+        while (true)
         {
-            using godot_string instanceStr = Marshaling.ConvertStringToNative(instance);
-            NativeFuncs.godotsharp_string_simplify_path(instanceStr, out godot_string simplifiedPath);
-            using (simplifiedPath)
-                return Marshaling.ConvertStringToManaged(simplifiedPath);
+            int end = instance.Find(divisor, from, caseSensitive: true);
+            if (end < 0)
+                end = len;
+            if (allowEmpty || end > from)
+                ret.Add(float.Parse(instance.Substring(from)));
+            if (end == len)
+                break;
+
+            from = end + divisor.Length;
         }
 
-        /// <summary>
-        /// Split the string by a divisor string, return an array of the substrings.
-        /// Example "One,Two,Three" will return ["One","Two","Three"] if split by ",".
-        /// </summary>
-        /// <seealso cref="SplitFloats(string, string, bool)"/>
-        /// <param name="instance">The string to split.</param>
-        /// <param name="divisor">The divisor string that splits the string.</param>
-        /// <param name="allowEmpty">
-        /// If <see langword="true"/>, the array may include empty strings.
-        /// </param>
-        /// <returns>The array of strings split from the string.</returns>
-        public static string[] Split(this string instance, string divisor, bool allowEmpty = true)
-        {
-            return instance.Split(divisor,
-                allowEmpty ? StringSplitOptions.None : StringSplitOptions.RemoveEmptyEntries);
-        }
+        return ret.ToArray();
+    }
 
-        /// <summary>
-        /// Split the string in floats by using a divisor string, return an array of the substrings.
-        /// Example "1,2.5,3" will return [1,2.5,3] if split by ",".
-        /// </summary>
-        /// <seealso cref="Split(string, string, bool)"/>
-        /// <param name="instance">The string to split.</param>
-        /// <param name="divisor">The divisor string that splits the string.</param>
-        /// <param name="allowEmpty">
-        /// If <see langword="true"/>, the array may include empty floats.
-        /// </param>
-        /// <returns>The array of floats split from the string.</returns>
-        public static float[] SplitFloats(this string instance, string divisor, bool allowEmpty = true)
-        {
-            var ret = new List<float>();
-            int from = 0;
-            int len = instance.Length;
-
-            while (true)
-            {
-                int end = instance.Find(divisor, from, caseSensitive: true);
-                if (end < 0)
-                    end = len;
-                if (allowEmpty || end > from)
-                    ret.Add(float.Parse(instance.Substring(from)));
-                if (end == len)
-                    break;
-
-                from = end + divisor.Length;
-            }
-
-            return ret.ToArray();
-        }
-
-        private static readonly char[] _nonPrintable =
-        {
+    private static readonly char[] _nonPrintable =
+    {
             (char)00, (char)01, (char)02, (char)03, (char)04, (char)05,
             (char)06, (char)07, (char)08, (char)09, (char)10, (char)11,
             (char)12, (char)13, (char)14, (char)15, (char)16, (char)17,
@@ -1655,241 +1655,240 @@ namespace Godot
             (char)30, (char)31, (char)32
         };
 
-        /// <summary>
-        /// Returns a copy of the string stripped of any non-printable character
-        /// (including tabulations, spaces and line breaks) at the beginning and the end.
-        /// The optional arguments are used to toggle stripping on the left and right
-        /// edges respectively.
-        /// </summary>
-        /// <param name="instance">The string to strip.</param>
-        /// <param name="left">If the left side should be stripped.</param>
-        /// <param name="right">If the right side should be stripped.</param>
-        /// <returns>The string stripped of any non-printable characters.</returns>
-        public static string StripEdges(this string instance, bool left = true, bool right = true)
+    /// <summary>
+    /// Returns a copy of the string stripped of any non-printable character
+    /// (including tabulations, spaces and line breaks) at the beginning and the end.
+    /// The optional arguments are used to toggle stripping on the left and right
+    /// edges respectively.
+    /// </summary>
+    /// <param name="instance">The string to strip.</param>
+    /// <param name="left">If the left side should be stripped.</param>
+    /// <param name="right">If the right side should be stripped.</param>
+    /// <returns>The string stripped of any non-printable characters.</returns>
+    public static string StripEdges(this string instance, bool left = true, bool right = true)
+    {
+        if (left)
         {
-            if (left)
-            {
-                if (right)
-                    return instance.Trim(_nonPrintable);
-                return instance.TrimStart(_nonPrintable);
-            }
-
-            return instance.TrimEnd(_nonPrintable);
+            if (right)
+                return instance.Trim(_nonPrintable);
+            return instance.TrimStart(_nonPrintable);
         }
 
+        return instance.TrimEnd(_nonPrintable);
+    }
 
-        /// <summary>
-        /// Returns a copy of the string stripped of any escape character.
-        /// These include all non-printable control characters of the first page
-        /// of the ASCII table (&lt; 32), such as tabulation (<c>\t</c>) and
-        /// newline (<c>\n</c> and <c>\r</c>) characters, but not spaces.
-        /// </summary>
-        /// <param name="instance">The string to strip.</param>
-        /// <returns>The string stripped of any escape characters.</returns>
-        public static string StripEscapes(this string instance)
+
+    /// <summary>
+    /// Returns a copy of the string stripped of any escape character.
+    /// These include all non-printable control characters of the first page
+    /// of the ASCII table (&lt; 32), such as tabulation (<c>\t</c>) and
+    /// newline (<c>\n</c> and <c>\r</c>) characters, but not spaces.
+    /// </summary>
+    /// <param name="instance">The string to strip.</param>
+    /// <returns>The string stripped of any escape characters.</returns>
+    public static string StripEscapes(this string instance)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < instance.Length; i++)
         {
-            var sb = new StringBuilder();
-            for (int i = 0; i < instance.Length; i++)
-            {
-                // Escape characters on first page of the ASCII table, before 32 (Space).
-                if (instance[i] < 32)
-                    continue;
+            // Escape characters on first page of the ASCII table, before 32 (Space).
+            if (instance[i] < 32)
+                continue;
 
-                sb.Append(instance[i]);
-            }
-
-            return sb.ToString();
+            sb.Append(instance[i]);
         }
 
-        /// <summary>
-        /// Returns part of the string from the position <paramref name="from"/>, with length <paramref name="len"/>.
-        /// </summary>
-        /// <param name="instance">The string to slice.</param>
-        /// <param name="from">The position in the string that the part starts from.</param>
-        /// <param name="len">The length of the returned part.</param>
-        /// <returns>
-        /// Part of the string from the position <paramref name="from"/>, with length <paramref name="len"/>.
-        /// </returns>
-        public static string Substr(this string instance, int from, int len)
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Returns part of the string from the position <paramref name="from"/>, with length <paramref name="len"/>.
+    /// </summary>
+    /// <param name="instance">The string to slice.</param>
+    /// <param name="from">The position in the string that the part starts from.</param>
+    /// <param name="len">The length of the returned part.</param>
+    /// <returns>
+    /// Part of the string from the position <paramref name="from"/>, with length <paramref name="len"/>.
+    /// </returns>
+    public static string Substr(this string instance, int from, int len)
+    {
+        int max = instance.Length - from;
+        return instance.Substring(from, len > max ? max : len);
+    }
+
+    /// <summary>
+    /// Converts the String (which is a character array) to PackedByteArray (which is an array of bytes).
+    /// The conversion is faster compared to <see cref="ToUtf8Buffer(string)"/>,
+    /// as this method assumes that all the characters in the String are ASCII characters.
+    /// </summary>
+    /// <seealso cref="ToUtf8Buffer(string)"/>
+    /// <seealso cref="ToUtf16Buffer(string)"/>
+    /// <seealso cref="ToUtf32Buffer(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The string as ASCII encoded bytes.</returns>
+    public static byte[] ToAsciiBuffer(this string instance)
+    {
+        return Encoding.ASCII.GetBytes(instance);
+    }
+
+    /// <summary>
+    /// Converts a string, containing a decimal number, into a <see langword="float" />.
+    /// </summary>
+    /// <seealso cref="ToInt(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The number representation of the string.</returns>
+    public static float ToFloat(this string instance)
+    {
+        return float.Parse(instance);
+    }
+
+    /// <summary>
+    /// Converts a string, containing an integer number, into an <see langword="int" />.
+    /// </summary>
+    /// <seealso cref="ToFloat(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The number representation of the string.</returns>
+    public static int ToInt(this string instance)
+    {
+        return int.Parse(instance);
+    }
+
+    /// <summary>
+    /// Converts the string (which is an array of characters) to an UTF-16 encoded array of bytes.
+    /// </summary>
+    /// <seealso cref="ToAsciiBuffer(string)"/>
+    /// <seealso cref="ToUtf32Buffer(string)"/>
+    /// <seealso cref="ToUtf8Buffer(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The string as UTF-16 encoded bytes.</returns>
+    public static byte[] ToUtf16Buffer(this string instance)
+    {
+        return Encoding.Unicode.GetBytes(instance);
+    }
+
+    /// <summary>
+    /// Converts the string (which is an array of characters) to an UTF-32 encoded array of bytes.
+    /// </summary>
+    /// <seealso cref="ToAsciiBuffer(string)"/>
+    /// <seealso cref="ToUtf16Buffer(string)"/>
+    /// <seealso cref="ToUtf8Buffer(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The string as UTF-32 encoded bytes.</returns>
+    public static byte[] ToUtf32Buffer(this string instance)
+    {
+        return Encoding.UTF32.GetBytes(instance);
+    }
+
+    /// <summary>
+    /// Converts the string (which is an array of characters) to an UTF-8 encoded array of bytes.
+    /// The conversion is a bit slower than <see cref="ToAsciiBuffer(string)"/>,
+    /// but supports all UTF-8 characters. Therefore, you should prefer this function
+    /// over <see cref="ToAsciiBuffer(string)"/>.
+    /// </summary>
+    /// <seealso cref="ToAsciiBuffer(string)"/>
+    /// <seealso cref="ToUtf16Buffer(string)"/>
+    /// <seealso cref="ToUtf32Buffer(string)"/>
+    /// <param name="instance">The string to convert.</param>
+    /// <returns>The string as UTF-8 encoded bytes.</returns>
+    public static byte[] ToUtf8Buffer(this string instance)
+    {
+        return Encoding.UTF8.GetBytes(instance);
+    }
+
+    /// <summary>
+    /// Removes a given string from the start if it starts with it or leaves the string unchanged.
+    /// </summary>
+    /// <param name="instance">The string to remove the prefix from.</param>
+    /// <param name="prefix">The string to remove from the start.</param>
+    /// <returns>A copy of the string with the prefix string removed from the start.</returns>
+    public static string TrimPrefix(this string instance, string prefix)
+    {
+        if (instance.StartsWith(prefix))
+            return instance.Substring(prefix.Length);
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Removes a given string from the end if it ends with it or leaves the string unchanged.
+    /// </summary>
+    /// <param name="instance">The string to remove the suffix from.</param>
+    /// <param name="suffix">The string to remove from the end.</param>
+    /// <returns>A copy of the string with the suffix string removed from the end.</returns>
+    public static string TrimSuffix(this string instance, string suffix)
+    {
+        if (instance.EndsWith(suffix))
+            return instance.Substring(0, instance.Length - suffix.Length);
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Decodes a string in URL encoded format. This is meant to
+    /// decode parameters in a URL when receiving an HTTP request.
+    /// This mostly wraps around <see cref="Uri.UnescapeDataString"/>,
+    /// but also handles <c>+</c>.
+    /// See <see cref="URIEncode"/> for encoding.
+    /// </summary>
+    /// <param name="instance">The string to decode.</param>
+    /// <returns>The unescaped string.</returns>
+    public static string URIDecode(this string instance)
+    {
+        return Uri.UnescapeDataString(instance.Replace("+", "%20"));
+    }
+
+    /// <summary>
+    /// Encodes a string to URL friendly format. This is meant to
+    /// encode parameters in a URL when sending an HTTP request.
+    /// This wraps around <see cref="Uri.EscapeDataString"/>.
+    /// See <see cref="URIDecode"/> for decoding.
+    /// </summary>
+    /// <param name="instance">The string to encode.</param>
+    /// <returns>The escaped string.</returns>
+    public static string URIEncode(this string instance)
+    {
+        return Uri.EscapeDataString(instance);
+    }
+
+    private const string _uniqueNodePrefix = "%";
+    private static readonly string[] _invalidNodeNameCharacters = { ".", ":", "@", "/", "\"", _uniqueNodePrefix };
+
+    /// <summary>
+    /// Removes any characters from the string that are prohibited in
+    /// <see cref="Node"/> names (<c>.</c> <c>:</c> <c>@</c> <c>/</c> <c>"</c>).
+    /// </summary>
+    /// <param name="instance">The string to sanitize.</param>
+    /// <returns>The string sanitized as a valid node name.</returns>
+    public static string ValidateNodeName(this string instance)
+    {
+        string name = instance.Replace(_invalidNodeNameCharacters[0], "");
+        for (int i = 1; i < _invalidNodeNameCharacters.Length; i++)
         {
-            int max = instance.Length - from;
-            return instance.Substring(from, len > max ? max : len);
+            name = name.Replace(_invalidNodeNameCharacters[i], "");
         }
+        return name;
+    }
 
-        /// <summary>
-        /// Converts the String (which is a character array) to PackedByteArray (which is an array of bytes).
-        /// The conversion is faster compared to <see cref="ToUtf8Buffer(string)"/>,
-        /// as this method assumes that all the characters in the String are ASCII characters.
-        /// </summary>
-        /// <seealso cref="ToUtf8Buffer(string)"/>
-        /// <seealso cref="ToUtf16Buffer(string)"/>
-        /// <seealso cref="ToUtf32Buffer(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The string as ASCII encoded bytes.</returns>
-        public static byte[] ToAsciiBuffer(this string instance)
-        {
-            return Encoding.ASCII.GetBytes(instance);
-        }
+    /// <summary>
+    /// Returns a copy of the string with special characters escaped using the XML standard.
+    /// </summary>
+    /// <seealso cref="XMLUnescape(string)"/>
+    /// <param name="instance">The string to escape.</param>
+    /// <returns>The escaped string.</returns>
+    public static string XMLEscape(this string instance)
+    {
+        return SecurityElement.Escape(instance);
+    }
 
-        /// <summary>
-        /// Converts a string, containing a decimal number, into a <see langword="float" />.
-        /// </summary>
-        /// <seealso cref="ToInt(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The number representation of the string.</returns>
-        public static float ToFloat(this string instance)
-        {
-            return float.Parse(instance);
-        }
-
-        /// <summary>
-        /// Converts a string, containing an integer number, into an <see langword="int" />.
-        /// </summary>
-        /// <seealso cref="ToFloat(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The number representation of the string.</returns>
-        public static int ToInt(this string instance)
-        {
-            return int.Parse(instance);
-        }
-
-        /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-16 encoded array of bytes.
-        /// </summary>
-        /// <seealso cref="ToAsciiBuffer(string)"/>
-        /// <seealso cref="ToUtf32Buffer(string)"/>
-        /// <seealso cref="ToUtf8Buffer(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The string as UTF-16 encoded bytes.</returns>
-        public static byte[] ToUtf16Buffer(this string instance)
-        {
-            return Encoding.Unicode.GetBytes(instance);
-        }
-
-        /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-32 encoded array of bytes.
-        /// </summary>
-        /// <seealso cref="ToAsciiBuffer(string)"/>
-        /// <seealso cref="ToUtf16Buffer(string)"/>
-        /// <seealso cref="ToUtf8Buffer(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The string as UTF-32 encoded bytes.</returns>
-        public static byte[] ToUtf32Buffer(this string instance)
-        {
-            return Encoding.UTF32.GetBytes(instance);
-        }
-
-        /// <summary>
-        /// Converts the string (which is an array of characters) to an UTF-8 encoded array of bytes.
-        /// The conversion is a bit slower than <see cref="ToAsciiBuffer(string)"/>,
-        /// but supports all UTF-8 characters. Therefore, you should prefer this function
-        /// over <see cref="ToAsciiBuffer(string)"/>.
-        /// </summary>
-        /// <seealso cref="ToAsciiBuffer(string)"/>
-        /// <seealso cref="ToUtf16Buffer(string)"/>
-        /// <seealso cref="ToUtf32Buffer(string)"/>
-        /// <param name="instance">The string to convert.</param>
-        /// <returns>The string as UTF-8 encoded bytes.</returns>
-        public static byte[] ToUtf8Buffer(this string instance)
-        {
-            return Encoding.UTF8.GetBytes(instance);
-        }
-
-        /// <summary>
-        /// Removes a given string from the start if it starts with it or leaves the string unchanged.
-        /// </summary>
-        /// <param name="instance">The string to remove the prefix from.</param>
-        /// <param name="prefix">The string to remove from the start.</param>
-        /// <returns>A copy of the string with the prefix string removed from the start.</returns>
-        public static string TrimPrefix(this string instance, string prefix)
-        {
-            if (instance.StartsWith(prefix))
-                return instance.Substring(prefix.Length);
-
-            return instance;
-        }
-
-        /// <summary>
-        /// Removes a given string from the end if it ends with it or leaves the string unchanged.
-        /// </summary>
-        /// <param name="instance">The string to remove the suffix from.</param>
-        /// <param name="suffix">The string to remove from the end.</param>
-        /// <returns>A copy of the string with the suffix string removed from the end.</returns>
-        public static string TrimSuffix(this string instance, string suffix)
-        {
-            if (instance.EndsWith(suffix))
-                return instance.Substring(0, instance.Length - suffix.Length);
-
-            return instance;
-        }
-
-        /// <summary>
-        /// Decodes a string in URL encoded format. This is meant to
-        /// decode parameters in a URL when receiving an HTTP request.
-        /// This mostly wraps around <see cref="Uri.UnescapeDataString"/>,
-        /// but also handles <c>+</c>.
-        /// See <see cref="URIEncode"/> for encoding.
-        /// </summary>
-        /// <param name="instance">The string to decode.</param>
-        /// <returns>The unescaped string.</returns>
-        public static string URIDecode(this string instance)
-        {
-            return Uri.UnescapeDataString(instance.Replace("+", "%20"));
-        }
-
-        /// <summary>
-        /// Encodes a string to URL friendly format. This is meant to
-        /// encode parameters in a URL when sending an HTTP request.
-        /// This wraps around <see cref="Uri.EscapeDataString"/>.
-        /// See <see cref="URIDecode"/> for decoding.
-        /// </summary>
-        /// <param name="instance">The string to encode.</param>
-        /// <returns>The escaped string.</returns>
-        public static string URIEncode(this string instance)
-        {
-            return Uri.EscapeDataString(instance);
-        }
-
-        private const string _uniqueNodePrefix = "%";
-        private static readonly string[] _invalidNodeNameCharacters = { ".", ":", "@", "/", "\"", _uniqueNodePrefix };
-
-        /// <summary>
-        /// Removes any characters from the string that are prohibited in
-        /// <see cref="Node"/> names (<c>.</c> <c>:</c> <c>@</c> <c>/</c> <c>"</c>).
-        /// </summary>
-        /// <param name="instance">The string to sanitize.</param>
-        /// <returns>The string sanitized as a valid node name.</returns>
-        public static string ValidateNodeName(this string instance)
-        {
-            string name = instance.Replace(_invalidNodeNameCharacters[0], "");
-            for (int i = 1; i < _invalidNodeNameCharacters.Length; i++)
-            {
-                name = name.Replace(_invalidNodeNameCharacters[i], "");
-            }
-            return name;
-        }
-
-        /// <summary>
-        /// Returns a copy of the string with special characters escaped using the XML standard.
-        /// </summary>
-        /// <seealso cref="XMLUnescape(string)"/>
-        /// <param name="instance">The string to escape.</param>
-        /// <returns>The escaped string.</returns>
-        public static string XMLEscape(this string instance)
-        {
-            return SecurityElement.Escape(instance);
-        }
-
-        /// <summary>
-        /// Returns a copy of the string with escaped characters replaced by their meanings
-        /// according to the XML standard.
-        /// </summary>
-        /// <seealso cref="XMLEscape(string)"/>
-        /// <param name="instance">The string to unescape.</param>
-        /// <returns>The unescaped string.</returns>
-        public static string? XMLUnescape(this string instance)
-        {
-            return SecurityElement.FromString(instance)?.Text;
-        }
+    /// <summary>
+    /// Returns a copy of the string with escaped characters replaced by their meanings
+    /// according to the XML standard.
+    /// </summary>
+    /// <seealso cref="XMLEscape(string)"/>
+    /// <param name="instance">The string to unescape.</param>
+    /// <returns>The unescaped string.</returns>
+    public static string? XMLUnescape(this string instance)
+    {
+        return SecurityElement.FromString(instance)?.Text;
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -1,163 +1,162 @@
 using System;
 using Godot.NativeInterop;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// StringNames are immutable strings designed for general-purpose representation of unique names.
+/// StringName ensures that only one instance of a given name exists (so two StringNames with the
+/// same value are the same object).
+/// Comparing them is much faster than with regular strings, because only the pointers are compared,
+/// not the whole strings.
+/// </summary>
+public sealed class StringName : IDisposable, IEquatable<StringName>
 {
-    /// <summary>
-    /// StringNames are immutable strings designed for general-purpose representation of unique names.
-    /// StringName ensures that only one instance of a given name exists (so two StringNames with the
-    /// same value are the same object).
-    /// Comparing them is much faster than with regular strings, because only the pointers are compared,
-    /// not the whole strings.
-    /// </summary>
-    public sealed class StringName : IDisposable, IEquatable<StringName>
+    internal godot_string_name.movable NativeValue;
+
+    private WeakReference<IDisposable> _weakReferenceToSelf;
+
+    ~StringName()
     {
-        internal godot_string_name.movable NativeValue;
+        Dispose(false);
+    }
 
-        private WeakReference<IDisposable> _weakReferenceToSelf;
+    /// <summary>
+    /// Disposes of this <see cref="StringName"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
 
-        ~StringName()
+    public void Dispose(bool disposing)
+    {
+        // Always dispose `NativeValue` even if disposing is true
+        NativeValue.DangerousSelfRef.Dispose();
+
+        if (_weakReferenceToSelf != null)
         {
-            Dispose(false);
+            DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
         }
+    }
 
-        /// <summary>
-        /// Disposes of this <see cref="StringName"/>.
-        /// </summary>
-        public void Dispose()
+    private StringName(godot_string_name nativeValueToOwn)
+    {
+        NativeValue = (godot_string_name.movable)nativeValueToOwn;
+        _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+    }
+
+    // Explicit name to make it very clear
+    internal static StringName CreateTakingOwnershipOfDisposableValue(godot_string_name nativeValueToOwn)
+        => new StringName(nativeValueToOwn);
+
+    /// <summary>
+    /// Constructs an empty <see cref="StringName"/>.
+    /// </summary>
+    public StringName()
+    {
+    }
+
+    /// <summary>
+    /// Constructs a <see cref="StringName"/> from the given <paramref name="name"/> string.
+    /// </summary>
+    /// <param name="name">String to construct the <see cref="StringName"/> from.</param>
+    public StringName(string name)
+    {
+        if (!string.IsNullOrEmpty(name))
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public void Dispose(bool disposing)
-        {
-            // Always dispose `NativeValue` even if disposing is true
-            NativeValue.DangerousSelfRef.Dispose();
-
-            if (_weakReferenceToSelf != null)
-            {
-                DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
-            }
-        }
-
-        private StringName(godot_string_name nativeValueToOwn)
-        {
-            NativeValue = (godot_string_name.movable)nativeValueToOwn;
+            NativeValue = (godot_string_name.movable)NativeFuncs.godotsharp_string_name_new_from_string(name);
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
         }
+    }
 
-        // Explicit name to make it very clear
-        internal static StringName CreateTakingOwnershipOfDisposableValue(godot_string_name nativeValueToOwn)
-            => new StringName(nativeValueToOwn);
+    /// <summary>
+    /// Converts a string to a <see cref="StringName"/>.
+    /// </summary>
+    /// <param name="from">The string to convert.</param>
+    public static implicit operator StringName(string from) => new StringName(from);
 
-        /// <summary>
-        /// Constructs an empty <see cref="StringName"/>.
-        /// </summary>
-        public StringName()
-        {
-        }
+    /// <summary>
+    /// Converts a <see cref="StringName"/> to a string.
+    /// </summary>
+    /// <param name="from">The <see cref="StringName"/> to convert.</param>
+    public static implicit operator string(StringName from) => from?.ToString();
 
-        /// <summary>
-        /// Constructs a <see cref="StringName"/> from the given <paramref name="name"/> string.
-        /// </summary>
-        /// <param name="name">String to construct the <see cref="StringName"/> from.</param>
-        public StringName(string name)
-        {
-            if (!string.IsNullOrEmpty(name))
-            {
-                NativeValue = (godot_string_name.movable)NativeFuncs.godotsharp_string_name_new_from_string(name);
-                _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
-            }
-        }
+    /// <summary>
+    /// Converts this <see cref="StringName"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this <see cref="StringName"/>.</returns>
+    public override string ToString()
+    {
+        if (IsEmpty)
+            return string.Empty;
 
-        /// <summary>
-        /// Converts a string to a <see cref="StringName"/>.
-        /// </summary>
-        /// <param name="from">The string to convert.</param>
-        public static implicit operator StringName(string from) => new StringName(from);
+        var src = (godot_string_name)NativeValue;
+        NativeFuncs.godotsharp_string_name_as_string(out godot_string dest, src);
+        using (dest)
+            return Marshaling.ConvertStringToManaged(dest);
+    }
 
-        /// <summary>
-        /// Converts a <see cref="StringName"/> to a string.
-        /// </summary>
-        /// <param name="from">The <see cref="StringName"/> to convert.</param>
-        public static implicit operator string(StringName from) => from?.ToString();
+    /// <summary>
+    /// Check whether this <see cref="StringName"/> is empty.
+    /// </summary>
+    /// <returns>If the <see cref="StringName"/> is empty.</returns>
+    public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
 
-        /// <summary>
-        /// Converts this <see cref="StringName"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this <see cref="StringName"/>.</returns>
-        public override string ToString()
-        {
-            if (IsEmpty)
-                return string.Empty;
+    public static bool operator ==(StringName left, StringName right)
+    {
+        if (left is null)
+            return right is null;
+        return left.Equals(right);
+    }
 
-            var src = (godot_string_name)NativeValue;
-            NativeFuncs.godotsharp_string_name_as_string(out godot_string dest, src);
-            using (dest)
-                return Marshaling.ConvertStringToManaged(dest);
-        }
+    public static bool operator !=(StringName left, StringName right)
+    {
+        return !(left == right);
+    }
 
-        /// <summary>
-        /// Check whether this <see cref="StringName"/> is empty.
-        /// </summary>
-        /// <returns>If the <see cref="StringName"/> is empty.</returns>
-        public bool IsEmpty => NativeValue.DangerousSelfRef.IsEmpty;
+    public bool Equals(StringName other)
+    {
+        if (other is null)
+            return false;
+        return NativeValue.DangerousSelfRef == other.NativeValue.DangerousSelfRef;
+    }
 
-        public static bool operator ==(StringName left, StringName right)
-        {
-            if (left is null)
-                return right is null;
-            return left.Equals(right);
-        }
+    public static bool operator ==(StringName left, in godot_string_name right)
+    {
+        if (left is null)
+            return right.IsEmpty;
+        return left.Equals(right);
+    }
 
-        public static bool operator !=(StringName left, StringName right)
-        {
-            return !(left == right);
-        }
+    public static bool operator !=(StringName left, in godot_string_name right)
+    {
+        return !(left == right);
+    }
 
-        public bool Equals(StringName other)
-        {
-            if (other is null)
-                return false;
-            return NativeValue.DangerousSelfRef == other.NativeValue.DangerousSelfRef;
-        }
+    public static bool operator ==(in godot_string_name left, StringName right)
+    {
+        return right == left;
+    }
 
-        public static bool operator ==(StringName left, in godot_string_name right)
-        {
-            if (left is null)
-                return right.IsEmpty;
-            return left.Equals(right);
-        }
+    public static bool operator !=(in godot_string_name left, StringName right)
+    {
+        return !(right == left);
+    }
 
-        public static bool operator !=(StringName left, in godot_string_name right)
-        {
-            return !(left == right);
-        }
+    public bool Equals(in godot_string_name other)
+    {
+        return NativeValue.DangerousSelfRef == other;
+    }
 
-        public static bool operator ==(in godot_string_name left, StringName right)
-        {
-            return right == left;
-        }
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || (obj is StringName other && Equals(other));
+    }
 
-        public static bool operator !=(in godot_string_name left, StringName right)
-        {
-            return !(right == left);
-        }
-
-        public bool Equals(in godot_string_name other)
-        {
-            return NativeValue.DangerousSelfRef == other;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return ReferenceEquals(this, obj) || (obj is StringName other && Equals(other));
-        }
-
-        public override int GetHashCode()
-        {
-            return NativeValue.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return NativeValue.GetHashCode();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -2,649 +2,648 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 2×3 matrix (2 rows, 3 columns) used for 2D linear transformations.
+/// It can represent transformations such as translation, rotation, or scaling.
+/// It consists of a three <see cref="Vector2"/> values: x, y, and the origin.
+///
+/// For more information, read this documentation article:
+/// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Transform2D : IEquatable<Transform2D>
 {
     /// <summary>
-    /// 2×3 matrix (2 rows, 3 columns) used for 2D linear transformations.
-    /// It can represent transformations such as translation, rotation, or scaling.
-    /// It consists of a three <see cref="Vector2"/> values: x, y, and the origin.
-    ///
-    /// For more information, read this documentation article:
-    /// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+    /// The basis matrix's X vector (column 0). Equivalent to array index <c>[0]</c>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Transform2D : IEquatable<Transform2D>
+    public Vector2 X;
+
+    /// <summary>
+    /// The basis matrix's Y vector (column 1). Equivalent to array index <c>[1]</c>.
+    /// </summary>
+    public Vector2 Y;
+
+    /// <summary>
+    /// The origin vector (column 2, the third column). Equivalent to array index <c>[2]</c>.
+    /// The origin vector represents translation.
+    /// </summary>
+    public Vector2 Origin;
+
+    /// <summary>
+    /// Returns the transform's rotation (in radians).
+    /// </summary>
+    public readonly real_t Rotation => Mathf.Atan2(X.Y, X.X);
+
+    /// <summary>
+    /// Returns the scale.
+    /// </summary>
+    public readonly Vector2 Scale
     {
-        /// <summary>
-        /// The basis matrix's X vector (column 0). Equivalent to array index <c>[0]</c>.
-        /// </summary>
-        public Vector2 X;
-
-        /// <summary>
-        /// The basis matrix's Y vector (column 1). Equivalent to array index <c>[1]</c>.
-        /// </summary>
-        public Vector2 Y;
-
-        /// <summary>
-        /// The origin vector (column 2, the third column). Equivalent to array index <c>[2]</c>.
-        /// The origin vector represents translation.
-        /// </summary>
-        public Vector2 Origin;
-
-        /// <summary>
-        /// Returns the transform's rotation (in radians).
-        /// </summary>
-        public readonly real_t Rotation => Mathf.Atan2(X.Y, X.X);
-
-        /// <summary>
-        /// Returns the scale.
-        /// </summary>
-        public readonly Vector2 Scale
+        get
         {
-            get
+            real_t detSign = Mathf.Sign(BasisDeterminant());
+            return new Vector2(X.Length(), detSign * Y.Length());
+        }
+    }
+
+    /// <summary>
+    /// Returns the transform's skew (in radians).
+    /// </summary>
+    public readonly real_t Skew
+    {
+        get
+        {
+            real_t detSign = Mathf.Sign(BasisDeterminant());
+            return Mathf.Acos(X.Normalized().Dot(detSign * Y.Normalized())) - Mathf.Pi * 0.5f;
+        }
+    }
+
+    /// <summary>
+    /// Access whole columns in the form of <see cref="Vector2"/>.
+    /// The third column is the <see cref="Origin"/> vector.
+    /// </summary>
+    /// <param name="column">Which column vector.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="column"/> is not 0, 1 or 2.
+    /// </exception>
+    public Vector2 this[int column]
+    {
+        readonly get
+        {
+            switch (column)
             {
-                real_t detSign = Mathf.Sign(BasisDeterminant());
-                return new Vector2(X.Length(), detSign * Y.Length());
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Origin;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
-
-        /// <summary>
-        /// Returns the transform's skew (in radians).
-        /// </summary>
-        public readonly real_t Skew
+        set
         {
-            get
+            switch (column)
             {
-                real_t detSign = Mathf.Sign(BasisDeterminant());
-                return Mathf.Acos(X.Normalized().Dot(detSign * Y.Normalized())) - Mathf.Pi * 0.5f;
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Origin = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
+    }
 
-        /// <summary>
-        /// Access whole columns in the form of <see cref="Vector2"/>.
-        /// The third column is the <see cref="Origin"/> vector.
-        /// </summary>
-        /// <param name="column">Which column vector.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="column"/> is not 0, 1 or 2.
-        /// </exception>
-        public Vector2 this[int column]
+    /// <summary>
+    /// Access matrix elements in column-major order.
+    /// The third column is the <see cref="Origin"/> vector.
+    /// </summary>
+    /// <param name="column">Which column, the matrix horizontal position.</param>
+    /// <param name="row">Which row, the matrix vertical position.</param>
+    public real_t this[int column, int row]
+    {
+        readonly get
         {
-            readonly get
-            {
-                switch (column)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Origin;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-            set
-            {
-                switch (column)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Origin = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
+            return this[column][row];
+        }
+        set
+        {
+            Vector2 columnVector = this[column];
+            columnVector[row] = value;
+            this[column] = columnVector;
+        }
+    }
+
+    /// <summary>
+    /// Returns the inverse of the transform, under the assumption that
+    /// the transformation is composed of rotation, scaling, and translation.
+    /// </summary>
+    /// <seealso cref="Inverse"/>
+    /// <returns>The inverse transformation matrix.</returns>
+    public readonly Transform2D AffineInverse()
+    {
+        real_t det = BasisDeterminant();
+
+        if (det == 0)
+            throw new InvalidOperationException("Matrix determinant is zero and cannot be inverted.");
+
+        Transform2D inv = this;
+
+        inv[0, 0] = this[1, 1];
+        inv[1, 1] = this[0, 0];
+
+        real_t detInv = 1.0f / det;
+
+        inv[0] *= new Vector2(detInv, -detInv);
+        inv[1] *= new Vector2(-detInv, detInv);
+
+        inv[2] = inv.BasisXform(-inv[2]);
+
+        return inv;
+    }
+
+    /// <summary>
+    /// Returns the determinant of the basis matrix. If the basis is
+    /// uniformly scaled, its determinant is the square of the scale.
+    ///
+    /// A negative determinant means the Y scale is negative.
+    /// A zero determinant means the basis isn't invertible,
+    /// and is usually considered invalid.
+    /// </summary>
+    /// <returns>The determinant of the basis matrix.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly real_t BasisDeterminant()
+    {
+        return (X.X * Y.Y) - (X.Y * Y.X);
+    }
+
+    /// <summary>
+    /// Returns a vector transformed (multiplied) by the basis matrix.
+    /// This method does not account for translation (the <see cref="Origin"/> vector).
+    /// </summary>
+    /// <seealso cref="BasisXformInv(Vector2)"/>
+    /// <param name="v">A vector to transform.</param>
+    /// <returns>The transformed vector.</returns>
+    public readonly Vector2 BasisXform(Vector2 v)
+    {
+        return new Vector2(Tdotx(v), Tdoty(v));
+    }
+
+    /// <summary>
+    /// Returns a vector transformed (multiplied) by the inverse basis matrix.
+    /// This method does not account for translation (the <see cref="Origin"/> vector).
+    ///
+    /// Note: This results in a multiplication by the inverse of the
+    /// basis matrix only if it represents a rotation-reflection.
+    /// </summary>
+    /// <seealso cref="BasisXform(Vector2)"/>
+    /// <param name="v">A vector to inversely transform.</param>
+    /// <returns>The inversely transformed vector.</returns>
+    public readonly Vector2 BasisXformInv(Vector2 v)
+    {
+        return new Vector2(X.Dot(v), Y.Dot(v));
+    }
+
+    /// <summary>
+    /// Interpolates this transform to the other <paramref name="transform"/> by <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="transform">The other transform.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated transform.</returns>
+    public readonly Transform2D InterpolateWith(Transform2D transform, real_t weight)
+    {
+        return new Transform2D
+        (
+            Mathf.LerpAngle(Rotation, transform.Rotation, weight),
+            Scale.Lerp(transform.Scale, weight),
+            Mathf.LerpAngle(Skew, transform.Skew, weight),
+            Origin.Lerp(transform.Origin, weight)
+        );
+    }
+
+    /// <summary>
+    /// Returns the inverse of the transform, under the assumption that
+    /// the transformation is composed of rotation and translation
+    /// (no scaling, use <see cref="AffineInverse"/> for transforms with scaling).
+    /// </summary>
+    /// <returns>The inverse matrix.</returns>
+    public readonly Transform2D Inverse()
+    {
+        Transform2D inv = this;
+
+        // Swap
+        inv.X.Y = Y.X;
+        inv.Y.X = X.Y;
+
+        inv.Origin = inv.BasisXform(-inv.Origin);
+
+        return inv;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this transform is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return X.IsFinite() && Y.IsFinite() && Origin.IsFinite();
+    }
+
+    /// <summary>
+    /// Returns the transform with the basis orthogonal (90 degrees),
+    /// and normalized axis vectors (scale of 1 or -1).
+    /// </summary>
+    /// <returns>The orthonormalized transform.</returns>
+    public readonly Transform2D Orthonormalized()
+    {
+        Transform2D ortho = this;
+
+        Vector2 orthoX = ortho.X;
+        Vector2 orthoY = ortho.Y;
+
+        orthoX.Normalize();
+        orthoY = orthoY - orthoX * orthoX.Dot(orthoY);
+        orthoY.Normalize();
+
+        ortho.X = orthoX;
+        ortho.Y = orthoY;
+
+        return ortho;
+    }
+
+    /// <summary>
+    /// Rotates the transform by <paramref name="angle"/> (in radians).
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    /// <returns>The rotated transformation matrix.</returns>
+    public readonly Transform2D Rotated(real_t angle)
+    {
+        return new Transform2D(angle, new Vector2()) * this;
+    }
+
+    /// <summary>
+    /// Rotates the transform by <paramref name="angle"/> (in radians).
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    /// <returns>The rotated transformation matrix.</returns>
+    public readonly Transform2D RotatedLocal(real_t angle)
+    {
+        return this * new Transform2D(angle, new Vector2());
+    }
+
+    /// <summary>
+    /// Scales the transform by the given scaling factor.
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="scale">The scale to introduce.</param>
+    /// <returns>The scaled transformation matrix.</returns>
+    public readonly Transform2D Scaled(Vector2 scale)
+    {
+        Transform2D copy = this;
+        copy.X *= scale;
+        copy.Y *= scale;
+        copy.Origin *= scale;
+        return copy;
+    }
+
+    /// <summary>
+    /// Scales the transform by the given scaling factor.
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="scale">The scale to introduce.</param>
+    /// <returns>The scaled transformation matrix.</returns>
+    public readonly Transform2D ScaledLocal(Vector2 scale)
+    {
+        Transform2D copy = this;
+        copy.X *= scale;
+        copy.Y *= scale;
+        return copy;
+    }
+
+    private readonly real_t Tdotx(Vector2 with)
+    {
+        return (this[0, 0] * with[0]) + (this[1, 0] * with[1]);
+    }
+
+    private readonly real_t Tdoty(Vector2 with)
+    {
+        return (this[0, 1] * with[0]) + (this[1, 1] * with[1]);
+    }
+
+    /// <summary>
+    /// Translates the transform by the given <paramref name="offset"/>.
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="offset">The offset to translate by.</param>
+    /// <returns>The translated matrix.</returns>
+    public readonly Transform2D Translated(Vector2 offset)
+    {
+        Transform2D copy = this;
+        copy.Origin += offset;
+        return copy;
+    }
+
+    /// <summary>
+    /// Translates the transform by the given <paramref name="offset"/>.
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="offset">The offset to translate by.</param>
+    /// <returns>The translated matrix.</returns>
+    public readonly Transform2D TranslatedLocal(Vector2 offset)
+    {
+        Transform2D copy = this;
+        copy.Origin += copy.BasisXform(offset);
+        return copy;
+    }
+
+    // Constants
+    private static readonly Transform2D _identity = new Transform2D(1, 0, 0, 1, 0, 0);
+    private static readonly Transform2D _flipX = new Transform2D(-1, 0, 0, 1, 0, 0);
+    private static readonly Transform2D _flipY = new Transform2D(1, 0, 0, -1, 0, 0);
+
+    /// <summary>
+    /// The identity transform, with no translation, rotation, or scaling applied.
+    /// This is used as a replacement for <c>Transform2D()</c> in GDScript.
+    /// Do not use <c>new Transform2D()</c> with no arguments in C#, because it sets all values to zero.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Down, Vector2.Zero)</c>.</value>
+    public static Transform2D Identity { get { return _identity; } }
+    /// <summary>
+    /// The transform that will flip something along the X axis.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform2D(Vector2.Left, Vector2.Down, Vector2.Zero)</c>.</value>
+    public static Transform2D FlipX { get { return _flipX; } }
+    /// <summary>
+    /// The transform that will flip something along the Y axis.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Up, Vector2.Zero)</c>.</value>
+    public static Transform2D FlipY { get { return _flipY; } }
+
+    /// <summary>
+    /// Constructs a transformation matrix from 3 vectors (matrix columns).
+    /// </summary>
+    /// <param name="xAxis">The X vector, or column index 0.</param>
+    /// <param name="yAxis">The Y vector, or column index 1.</param>
+    /// <param name="originPos">The origin vector, or column index 2.</param>
+    public Transform2D(Vector2 xAxis, Vector2 yAxis, Vector2 originPos)
+    {
+        X = xAxis;
+        Y = yAxis;
+        Origin = originPos;
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from the given components.
+    /// Arguments are named such that xy is equal to calling <c>X.Y</c>.
+    /// </summary>
+    /// <param name="xx">The X component of the X column vector, accessed via <c>t.X.X</c> or <c>[0][0]</c>.</param>
+    /// <param name="xy">The Y component of the X column vector, accessed via <c>t.X.Y</c> or <c>[0][1]</c>.</param>
+    /// <param name="yx">The X component of the Y column vector, accessed via <c>t.Y.X</c> or <c>[1][0]</c>.</param>
+    /// <param name="yy">The Y component of the Y column vector, accessed via <c>t.Y.Y</c> or <c>[1][1]</c>.</param>
+    /// <param name="ox">The X component of the origin vector, accessed via <c>t.Origin.X</c> or <c>[2][0]</c>.</param>
+    /// <param name="oy">The Y component of the origin vector, accessed via <c>t.Origin.Y</c> or <c>[2][1]</c>.</param>
+    public Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy)
+    {
+        X = new Vector2(xx, xy);
+        Y = new Vector2(yx, yy);
+        Origin = new Vector2(ox, oy);
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from a <paramref name="rotation"/> value and
+    /// <paramref name="origin"/> vector.
+    /// </summary>
+    /// <param name="rotation">The rotation of the new transform, in radians.</param>
+    /// <param name="origin">The origin vector, or column index 2.</param>
+    public Transform2D(real_t rotation, Vector2 origin)
+    {
+        (real_t sin, real_t cos) = Mathf.SinCos(rotation);
+        X.X = Y.Y = cos;
+        X.Y = Y.X = sin;
+        Y.X *= -1;
+        Origin = origin;
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from a <paramref name="rotation"/> value,
+    /// <paramref name="scale"/> vector, <paramref name="skew"/> value, and
+    /// <paramref name="origin"/> vector.
+    /// </summary>
+    /// <param name="rotation">The rotation of the new transform, in radians.</param>
+    /// <param name="scale">The scale of the new transform.</param>
+    /// <param name="skew">The skew of the new transform, in radians.</param>
+    /// <param name="origin">The origin vector, or column index 2.</param>
+    public Transform2D(real_t rotation, Vector2 scale, real_t skew, Vector2 origin)
+    {
+        (real_t rotationSin, real_t rotationCos) = Mathf.SinCos(rotation);
+        (real_t rotationSkewSin, real_t rotationSkewCos) = Mathf.SinCos(rotation + skew);
+        X.X = rotationCos * scale.X;
+        Y.Y = rotationSkewCos * scale.Y;
+        Y.X = -rotationSkewSin * scale.Y;
+        X.Y = rotationSin * scale.X;
+        Origin = origin;
+    }
+
+    /// <summary>
+    /// Composes these two transformation matrices by multiplying them
+    /// together. This has the effect of transforming the second transform
+    /// (the child) by the first transform (the parent).
+    /// </summary>
+    /// <param name="left">The parent transform.</param>
+    /// <param name="right">The child transform.</param>
+    /// <returns>The composed transform.</returns>
+    public static Transform2D operator *(Transform2D left, Transform2D right)
+    {
+        left.Origin = left * right.Origin;
+
+        real_t x0 = left.Tdotx(right.X);
+        real_t x1 = left.Tdoty(right.X);
+        real_t y0 = left.Tdotx(right.Y);
+        real_t y1 = left.Tdoty(right.Y);
+
+        left.X.X = x0;
+        left.X.Y = x1;
+        left.Y.X = y0;
+        left.Y.Y = y1;
+
+        return left;
+    }
+
+    /// <summary>
+    /// Returns a Vector2 transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="vector">A Vector2 to transform.</param>
+    /// <returns>The transformed Vector2.</returns>
+    public static Vector2 operator *(Transform2D transform, Vector2 vector)
+    {
+        return new Vector2(transform.Tdotx(vector), transform.Tdoty(vector)) + transform.Origin;
+    }
+
+    /// <summary>
+    /// Returns a Vector2 transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="vector">A Vector2 to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed Vector2.</returns>
+    public static Vector2 operator *(Vector2 vector, Transform2D transform)
+    {
+        Vector2 vInv = vector - transform.Origin;
+        return new Vector2(transform.X.Dot(vInv), transform.Y.Dot(vInv));
+    }
+
+    /// <summary>
+    /// Returns a Rect2 transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="rect">A Rect2 to transform.</param>
+    /// <returns>The transformed Rect2.</returns>
+    public static Rect2 operator *(Transform2D transform, Rect2 rect)
+    {
+        Vector2 pos = transform * rect.Position;
+        Vector2 toX = transform.X * rect.Size.X;
+        Vector2 toY = transform.Y * rect.Size.Y;
+
+        return new Rect2(pos, new Vector2()).Expand(pos + toX).Expand(pos + toY).Expand(pos + toX + toY);
+    }
+
+    /// <summary>
+    /// Returns a Rect2 transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="rect">A Rect2 to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed Rect2.</returns>
+    public static Rect2 operator *(Rect2 rect, Transform2D transform)
+    {
+        Vector2 pos = rect.Position * transform;
+        Vector2 to1 = new Vector2(rect.Position.X, rect.Position.Y + rect.Size.Y) * transform;
+        Vector2 to2 = new Vector2(rect.Position.X + rect.Size.X, rect.Position.Y + rect.Size.Y) * transform;
+        Vector2 to3 = new Vector2(rect.Position.X + rect.Size.X, rect.Position.Y) * transform;
+
+        return new Rect2(pos, new Vector2()).Expand(to1).Expand(to2).Expand(to3);
+    }
+
+    /// <summary>
+    /// Returns a copy of the given Vector2[] transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="array">A Vector2[] to transform.</param>
+    /// <returns>The transformed copy of the Vector2[].</returns>
+    public static Vector2[] operator *(Transform2D transform, Vector2[] array)
+    {
+        Vector2[] newArray = new Vector2[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            newArray[i] = transform * array[i];
         }
 
-        /// <summary>
-        /// Access matrix elements in column-major order.
-        /// The third column is the <see cref="Origin"/> vector.
-        /// </summary>
-        /// <param name="column">Which column, the matrix horizontal position.</param>
-        /// <param name="row">Which row, the matrix vertical position.</param>
-        public real_t this[int column, int row]
+        return newArray;
+    }
+
+    /// <summary>
+    /// Returns a copy of the given Vector2[] transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="array">A Vector2[] to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed copy of the Vector2[].</returns>
+    public static Vector2[] operator *(Vector2[] array, Transform2D transform)
+    {
+        Vector2[] newArray = new Vector2[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
         {
-            readonly get
-            {
-                return this[column][row];
-            }
-            set
-            {
-                Vector2 columnVector = this[column];
-                columnVector[row] = value;
-                this[column] = columnVector;
-            }
+            newArray[i] = array[i] * transform;
         }
 
-        /// <summary>
-        /// Returns the inverse of the transform, under the assumption that
-        /// the transformation is composed of rotation, scaling, and translation.
-        /// </summary>
-        /// <seealso cref="Inverse"/>
-        /// <returns>The inverse transformation matrix.</returns>
-        public readonly Transform2D AffineInverse()
-        {
-            real_t det = BasisDeterminant();
+        return newArray;
+    }
 
-            if (det == 0)
-                throw new InvalidOperationException("Matrix determinant is zero and cannot be inverted.");
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left transform.</param>
+    /// <param name="right">The right transform.</param>
+    /// <returns>Whether or not the transforms are exactly equal.</returns>
+    public static bool operator ==(Transform2D left, Transform2D right)
+    {
+        return left.Equals(right);
+    }
 
-            Transform2D inv = this;
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left transform.</param>
+    /// <param name="right">The right transform.</param>
+    /// <returns>Whether or not the transforms are not equal.</returns>
+    public static bool operator !=(Transform2D left, Transform2D right)
+    {
+        return !left.Equals(right);
+    }
 
-            inv[0, 0] = this[1, 1];
-            inv[1, 1] = this[0, 0];
+    /// <summary>
+    /// Returns <see langword="true"/> if the transform is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the transform and the object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Transform2D other && Equals(other);
+    }
 
-            real_t detInv = 1.0f / det;
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other transform to compare.</param>
+    /// <returns>Whether or not the matrices are exactly equal.</returns>
+    public readonly bool Equals(Transform2D other)
+    {
+        return X.Equals(other.X) && Y.Equals(other.Y) && Origin.Equals(other.Origin);
+    }
 
-            inv[0] *= new Vector2(detInv, -detInv);
-            inv[1] *= new Vector2(-detInv, detInv);
+    /// <summary>
+    /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Vector2.IsEqualApprox(Vector2)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other transform to compare.</param>
+    /// <returns>Whether or not the matrices are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Transform2D other)
+    {
+        return X.IsEqualApprox(other.X) && Y.IsEqualApprox(other.Y) && Origin.IsEqualApprox(other.Origin);
+    }
 
-            inv[2] = inv.BasisXform(-inv[2]);
+    /// <summary>
+    /// Serves as the hash function for <see cref="Transform2D"/>.
+    /// </summary>
+    /// <returns>A hash code for this transform.</returns>
+    public override readonly int GetHashCode()
+    {
+        return X.GetHashCode() ^ Y.GetHashCode() ^ Origin.GetHashCode();
+    }
 
-            return inv;
-        }
+    /// <summary>
+    /// Converts this <see cref="Transform2D"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this transform.</returns>
+    public override readonly string ToString()
+    {
+        return $"[X: {X}, Y: {Y}, O: {Origin}]";
+    }
 
-        /// <summary>
-        /// Returns the determinant of the basis matrix. If the basis is
-        /// uniformly scaled, its determinant is the square of the scale.
-        ///
-        /// A negative determinant means the Y scale is negative.
-        /// A zero determinant means the basis isn't invertible,
-        /// and is usually considered invalid.
-        /// </summary>
-        /// <returns>The determinant of the basis matrix.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private readonly real_t BasisDeterminant()
-        {
-            return (X.X * Y.Y) - (X.Y * Y.X);
-        }
-
-        /// <summary>
-        /// Returns a vector transformed (multiplied) by the basis matrix.
-        /// This method does not account for translation (the <see cref="Origin"/> vector).
-        /// </summary>
-        /// <seealso cref="BasisXformInv(Vector2)"/>
-        /// <param name="v">A vector to transform.</param>
-        /// <returns>The transformed vector.</returns>
-        public readonly Vector2 BasisXform(Vector2 v)
-        {
-            return new Vector2(Tdotx(v), Tdoty(v));
-        }
-
-        /// <summary>
-        /// Returns a vector transformed (multiplied) by the inverse basis matrix.
-        /// This method does not account for translation (the <see cref="Origin"/> vector).
-        ///
-        /// Note: This results in a multiplication by the inverse of the
-        /// basis matrix only if it represents a rotation-reflection.
-        /// </summary>
-        /// <seealso cref="BasisXform(Vector2)"/>
-        /// <param name="v">A vector to inversely transform.</param>
-        /// <returns>The inversely transformed vector.</returns>
-        public readonly Vector2 BasisXformInv(Vector2 v)
-        {
-            return new Vector2(X.Dot(v), Y.Dot(v));
-        }
-
-        /// <summary>
-        /// Interpolates this transform to the other <paramref name="transform"/> by <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="transform">The other transform.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated transform.</returns>
-        public readonly Transform2D InterpolateWith(Transform2D transform, real_t weight)
-        {
-            return new Transform2D
-            (
-                Mathf.LerpAngle(Rotation, transform.Rotation, weight),
-                Scale.Lerp(transform.Scale, weight),
-                Mathf.LerpAngle(Skew, transform.Skew, weight),
-                Origin.Lerp(transform.Origin, weight)
-            );
-        }
-
-        /// <summary>
-        /// Returns the inverse of the transform, under the assumption that
-        /// the transformation is composed of rotation and translation
-        /// (no scaling, use <see cref="AffineInverse"/> for transforms with scaling).
-        /// </summary>
-        /// <returns>The inverse matrix.</returns>
-        public readonly Transform2D Inverse()
-        {
-            Transform2D inv = this;
-
-            // Swap
-            inv.X.Y = Y.X;
-            inv.Y.X = X.Y;
-
-            inv.Origin = inv.BasisXform(-inv.Origin);
-
-            return inv;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this transform is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return X.IsFinite() && Y.IsFinite() && Origin.IsFinite();
-        }
-
-        /// <summary>
-        /// Returns the transform with the basis orthogonal (90 degrees),
-        /// and normalized axis vectors (scale of 1 or -1).
-        /// </summary>
-        /// <returns>The orthonormalized transform.</returns>
-        public readonly Transform2D Orthonormalized()
-        {
-            Transform2D ortho = this;
-
-            Vector2 orthoX = ortho.X;
-            Vector2 orthoY = ortho.Y;
-
-            orthoX.Normalize();
-            orthoY = orthoY - orthoX * orthoX.Dot(orthoY);
-            orthoY.Normalize();
-
-            ortho.X = orthoX;
-            ortho.Y = orthoY;
-
-            return ortho;
-        }
-
-        /// <summary>
-        /// Rotates the transform by <paramref name="angle"/> (in radians).
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        /// <returns>The rotated transformation matrix.</returns>
-        public readonly Transform2D Rotated(real_t angle)
-        {
-            return new Transform2D(angle, new Vector2()) * this;
-        }
-
-        /// <summary>
-        /// Rotates the transform by <paramref name="angle"/> (in radians).
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        /// <returns>The rotated transformation matrix.</returns>
-        public readonly Transform2D RotatedLocal(real_t angle)
-        {
-            return this * new Transform2D(angle, new Vector2());
-        }
-
-        /// <summary>
-        /// Scales the transform by the given scaling factor.
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="scale">The scale to introduce.</param>
-        /// <returns>The scaled transformation matrix.</returns>
-        public readonly Transform2D Scaled(Vector2 scale)
-        {
-            Transform2D copy = this;
-            copy.X *= scale;
-            copy.Y *= scale;
-            copy.Origin *= scale;
-            return copy;
-        }
-
-        /// <summary>
-        /// Scales the transform by the given scaling factor.
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="scale">The scale to introduce.</param>
-        /// <returns>The scaled transformation matrix.</returns>
-        public readonly Transform2D ScaledLocal(Vector2 scale)
-        {
-            Transform2D copy = this;
-            copy.X *= scale;
-            copy.Y *= scale;
-            return copy;
-        }
-
-        private readonly real_t Tdotx(Vector2 with)
-        {
-            return (this[0, 0] * with[0]) + (this[1, 0] * with[1]);
-        }
-
-        private readonly real_t Tdoty(Vector2 with)
-        {
-            return (this[0, 1] * with[0]) + (this[1, 1] * with[1]);
-        }
-
-        /// <summary>
-        /// Translates the transform by the given <paramref name="offset"/>.
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="offset">The offset to translate by.</param>
-        /// <returns>The translated matrix.</returns>
-        public readonly Transform2D Translated(Vector2 offset)
-        {
-            Transform2D copy = this;
-            copy.Origin += offset;
-            return copy;
-        }
-
-        /// <summary>
-        /// Translates the transform by the given <paramref name="offset"/>.
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="offset">The offset to translate by.</param>
-        /// <returns>The translated matrix.</returns>
-        public readonly Transform2D TranslatedLocal(Vector2 offset)
-        {
-            Transform2D copy = this;
-            copy.Origin += copy.BasisXform(offset);
-            return copy;
-        }
-
-        // Constants
-        private static readonly Transform2D _identity = new Transform2D(1, 0, 0, 1, 0, 0);
-        private static readonly Transform2D _flipX = new Transform2D(-1, 0, 0, 1, 0, 0);
-        private static readonly Transform2D _flipY = new Transform2D(1, 0, 0, -1, 0, 0);
-
-        /// <summary>
-        /// The identity transform, with no translation, rotation, or scaling applied.
-        /// This is used as a replacement for <c>Transform2D()</c> in GDScript.
-        /// Do not use <c>new Transform2D()</c> with no arguments in C#, because it sets all values to zero.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Down, Vector2.Zero)</c>.</value>
-        public static Transform2D Identity { get { return _identity; } }
-        /// <summary>
-        /// The transform that will flip something along the X axis.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform2D(Vector2.Left, Vector2.Down, Vector2.Zero)</c>.</value>
-        public static Transform2D FlipX { get { return _flipX; } }
-        /// <summary>
-        /// The transform that will flip something along the Y axis.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform2D(Vector2.Right, Vector2.Up, Vector2.Zero)</c>.</value>
-        public static Transform2D FlipY { get { return _flipY; } }
-
-        /// <summary>
-        /// Constructs a transformation matrix from 3 vectors (matrix columns).
-        /// </summary>
-        /// <param name="xAxis">The X vector, or column index 0.</param>
-        /// <param name="yAxis">The Y vector, or column index 1.</param>
-        /// <param name="originPos">The origin vector, or column index 2.</param>
-        public Transform2D(Vector2 xAxis, Vector2 yAxis, Vector2 originPos)
-        {
-            X = xAxis;
-            Y = yAxis;
-            Origin = originPos;
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from the given components.
-        /// Arguments are named such that xy is equal to calling <c>X.Y</c>.
-        /// </summary>
-        /// <param name="xx">The X component of the X column vector, accessed via <c>t.X.X</c> or <c>[0][0]</c>.</param>
-        /// <param name="xy">The Y component of the X column vector, accessed via <c>t.X.Y</c> or <c>[0][1]</c>.</param>
-        /// <param name="yx">The X component of the Y column vector, accessed via <c>t.Y.X</c> or <c>[1][0]</c>.</param>
-        /// <param name="yy">The Y component of the Y column vector, accessed via <c>t.Y.Y</c> or <c>[1][1]</c>.</param>
-        /// <param name="ox">The X component of the origin vector, accessed via <c>t.Origin.X</c> or <c>[2][0]</c>.</param>
-        /// <param name="oy">The Y component of the origin vector, accessed via <c>t.Origin.Y</c> or <c>[2][1]</c>.</param>
-        public Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy)
-        {
-            X = new Vector2(xx, xy);
-            Y = new Vector2(yx, yy);
-            Origin = new Vector2(ox, oy);
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from a <paramref name="rotation"/> value and
-        /// <paramref name="origin"/> vector.
-        /// </summary>
-        /// <param name="rotation">The rotation of the new transform, in radians.</param>
-        /// <param name="origin">The origin vector, or column index 2.</param>
-        public Transform2D(real_t rotation, Vector2 origin)
-        {
-            (real_t sin, real_t cos) = Mathf.SinCos(rotation);
-            X.X = Y.Y = cos;
-            X.Y = Y.X = sin;
-            Y.X *= -1;
-            Origin = origin;
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from a <paramref name="rotation"/> value,
-        /// <paramref name="scale"/> vector, <paramref name="skew"/> value, and
-        /// <paramref name="origin"/> vector.
-        /// </summary>
-        /// <param name="rotation">The rotation of the new transform, in radians.</param>
-        /// <param name="scale">The scale of the new transform.</param>
-        /// <param name="skew">The skew of the new transform, in radians.</param>
-        /// <param name="origin">The origin vector, or column index 2.</param>
-        public Transform2D(real_t rotation, Vector2 scale, real_t skew, Vector2 origin)
-        {
-            (real_t rotationSin, real_t rotationCos) = Mathf.SinCos(rotation);
-            (real_t rotationSkewSin, real_t rotationSkewCos) = Mathf.SinCos(rotation + skew);
-            X.X = rotationCos * scale.X;
-            Y.Y = rotationSkewCos * scale.Y;
-            Y.X = -rotationSkewSin * scale.Y;
-            X.Y = rotationSin * scale.X;
-            Origin = origin;
-        }
-
-        /// <summary>
-        /// Composes these two transformation matrices by multiplying them
-        /// together. This has the effect of transforming the second transform
-        /// (the child) by the first transform (the parent).
-        /// </summary>
-        /// <param name="left">The parent transform.</param>
-        /// <param name="right">The child transform.</param>
-        /// <returns>The composed transform.</returns>
-        public static Transform2D operator *(Transform2D left, Transform2D right)
-        {
-            left.Origin = left * right.Origin;
-
-            real_t x0 = left.Tdotx(right.X);
-            real_t x1 = left.Tdoty(right.X);
-            real_t y0 = left.Tdotx(right.Y);
-            real_t y1 = left.Tdoty(right.Y);
-
-            left.X.X = x0;
-            left.X.Y = x1;
-            left.Y.X = y0;
-            left.Y.Y = y1;
-
-            return left;
-        }
-
-        /// <summary>
-        /// Returns a Vector2 transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="vector">A Vector2 to transform.</param>
-        /// <returns>The transformed Vector2.</returns>
-        public static Vector2 operator *(Transform2D transform, Vector2 vector)
-        {
-            return new Vector2(transform.Tdotx(vector), transform.Tdoty(vector)) + transform.Origin;
-        }
-
-        /// <summary>
-        /// Returns a Vector2 transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="vector">A Vector2 to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed Vector2.</returns>
-        public static Vector2 operator *(Vector2 vector, Transform2D transform)
-        {
-            Vector2 vInv = vector - transform.Origin;
-            return new Vector2(transform.X.Dot(vInv), transform.Y.Dot(vInv));
-        }
-
-        /// <summary>
-        /// Returns a Rect2 transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="rect">A Rect2 to transform.</param>
-        /// <returns>The transformed Rect2.</returns>
-        public static Rect2 operator *(Transform2D transform, Rect2 rect)
-        {
-            Vector2 pos = transform * rect.Position;
-            Vector2 toX = transform.X * rect.Size.X;
-            Vector2 toY = transform.Y * rect.Size.Y;
-
-            return new Rect2(pos, new Vector2()).Expand(pos + toX).Expand(pos + toY).Expand(pos + toX + toY);
-        }
-
-        /// <summary>
-        /// Returns a Rect2 transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="rect">A Rect2 to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed Rect2.</returns>
-        public static Rect2 operator *(Rect2 rect, Transform2D transform)
-        {
-            Vector2 pos = rect.Position * transform;
-            Vector2 to1 = new Vector2(rect.Position.X, rect.Position.Y + rect.Size.Y) * transform;
-            Vector2 to2 = new Vector2(rect.Position.X + rect.Size.X, rect.Position.Y + rect.Size.Y) * transform;
-            Vector2 to3 = new Vector2(rect.Position.X + rect.Size.X, rect.Position.Y) * transform;
-
-            return new Rect2(pos, new Vector2()).Expand(to1).Expand(to2).Expand(to3);
-        }
-
-        /// <summary>
-        /// Returns a copy of the given Vector2[] transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="array">A Vector2[] to transform.</param>
-        /// <returns>The transformed copy of the Vector2[].</returns>
-        public static Vector2[] operator *(Transform2D transform, Vector2[] array)
-        {
-            Vector2[] newArray = new Vector2[array.Length];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                newArray[i] = transform * array[i];
-            }
-
-            return newArray;
-        }
-
-        /// <summary>
-        /// Returns a copy of the given Vector2[] transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="array">A Vector2[] to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed copy of the Vector2[].</returns>
-        public static Vector2[] operator *(Vector2[] array, Transform2D transform)
-        {
-            Vector2[] newArray = new Vector2[array.Length];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                newArray[i] = array[i] * transform;
-            }
-
-            return newArray;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left transform.</param>
-        /// <param name="right">The right transform.</param>
-        /// <returns>Whether or not the transforms are exactly equal.</returns>
-        public static bool operator ==(Transform2D left, Transform2D right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left transform.</param>
-        /// <param name="right">The right transform.</param>
-        /// <returns>Whether or not the transforms are not equal.</returns>
-        public static bool operator !=(Transform2D left, Transform2D right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transform is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Transform2D other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are exactly equal.</returns>
-        public readonly bool Equals(Transform2D other)
-        {
-            return X.Equals(other.X) && Y.Equals(other.Y) && Origin.Equals(other.Origin);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Vector2.IsEqualApprox(Vector2)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Transform2D other)
-        {
-            return X.IsEqualApprox(other.X) && Y.IsEqualApprox(other.Y) && Origin.IsEqualApprox(other.Origin);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Transform2D"/>.
-        /// </summary>
-        /// <returns>A hash code for this transform.</returns>
-        public override readonly int GetHashCode()
-        {
-            return X.GetHashCode() ^ Y.GetHashCode() ^ Origin.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Transform2D"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this transform.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {X}, Y: {Y}, O: {Origin}]";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Transform2D"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this transform.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, O: {Origin.ToString(format)}]";
-        }
+    /// <summary>
+    /// Converts this <see cref="Transform2D"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this transform.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"[X: {X.ToString(format)}, Y: {Y.ToString(format)}, O: {Origin.ToString(format)}]";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -2,676 +2,675 @@ using System;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 3×4 matrix (3 rows, 4 columns) used for 3D linear transformations.
+/// It can represent transformations such as translation, rotation, or scaling.
+/// It consists of a <see cref="Godot.Basis"/> (first 3 columns) and a
+/// <see cref="Vector3"/> for the origin (last column).
+///
+/// For more information, read this documentation article:
+/// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Transform3D : IEquatable<Transform3D>
 {
     /// <summary>
-    /// 3×4 matrix (3 rows, 4 columns) used for 3D linear transformations.
-    /// It can represent transformations such as translation, rotation, or scaling.
-    /// It consists of a <see cref="Godot.Basis"/> (first 3 columns) and a
-    /// <see cref="Vector3"/> for the origin (last column).
-    ///
-    /// For more information, read this documentation article:
-    /// https://docs.godotengine.org/en/latest/tutorials/math/matrices_and_transforms.html
+    /// The <see cref="Godot.Basis"/> of this transform. Contains the X, Y, and Z basis
+    /// vectors (columns 0 to 2) and is responsible for rotation and scale.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Transform3D : IEquatable<Transform3D>
+    public Basis Basis;
+
+    /// <summary>
+    /// The origin vector (column 3, the fourth column). Equivalent to array index <c>[3]</c>.
+    /// </summary>
+    public Vector3 Origin;
+
+    /// <summary>
+    /// Access whole columns in the form of <see cref="Vector3"/>.
+    /// The fourth column is the <see cref="Origin"/> vector.
+    /// </summary>
+    /// <param name="column">Which column vector.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="column"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    public Vector3 this[int column]
     {
-        /// <summary>
-        /// The <see cref="Godot.Basis"/> of this transform. Contains the X, Y, and Z basis
-        /// vectors (columns 0 to 2) and is responsible for rotation and scale.
-        /// </summary>
-        public Basis Basis;
-
-        /// <summary>
-        /// The origin vector (column 3, the fourth column). Equivalent to array index <c>[3]</c>.
-        /// </summary>
-        public Vector3 Origin;
-
-        /// <summary>
-        /// Access whole columns in the form of <see cref="Vector3"/>.
-        /// The fourth column is the <see cref="Origin"/> vector.
-        /// </summary>
-        /// <param name="column">Which column vector.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="column"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        public Vector3 this[int column]
+        readonly get
         {
-            readonly get
+            switch (column)
             {
-                switch (column)
-                {
-                    case 0:
-                        return Basis.Column0;
-                    case 1:
-                        return Basis.Column1;
-                    case 2:
-                        return Basis.Column2;
-                    case 3:
-                        return Origin;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
-            }
-            set
-            {
-                switch (column)
-                {
-                    case 0:
-                        Basis.Column0 = value;
-                        return;
-                    case 1:
-                        Basis.Column1 = value;
-                        return;
-                    case 2:
-                        Basis.Column2 = value;
-                        return;
-                    case 3:
-                        Origin = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(column));
-                }
+                case 0:
+                    return Basis.Column0;
+                case 1:
+                    return Basis.Column1;
+                case 2:
+                    return Basis.Column2;
+                case 3:
+                    return Origin;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
-
-        /// <summary>
-        /// Access matrix elements in column-major order.
-        /// The fourth column is the <see cref="Origin"/> vector.
-        /// </summary>
-        /// <param name="column">Which column, the matrix horizontal position.</param>
-        /// <param name="row">Which row, the matrix vertical position.</param>
-        public real_t this[int column, int row]
+        set
         {
-            readonly get
+            switch (column)
             {
-                if (column == 3)
-                {
-                    return Origin[row];
-                }
-                return Basis[column, row];
-            }
-            set
-            {
-                if (column == 3)
-                {
-                    Origin[row] = value;
+                case 0:
+                    Basis.Column0 = value;
                     return;
-                }
-                Basis[column, row] = value;
+                case 1:
+                    Basis.Column1 = value;
+                    return;
+                case 2:
+                    Basis.Column2 = value;
+                    return;
+                case 3:
+                    Origin = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(column));
             }
         }
+    }
 
-        /// <summary>
-        /// Returns the inverse of the transform, under the assumption that
-        /// the transformation is composed of rotation, scaling, and translation.
-        /// </summary>
-        /// <seealso cref="Inverse"/>
-        /// <returns>The inverse transformation matrix.</returns>
-        public readonly Transform3D AffineInverse()
+    /// <summary>
+    /// Access matrix elements in column-major order.
+    /// The fourth column is the <see cref="Origin"/> vector.
+    /// </summary>
+    /// <param name="column">Which column, the matrix horizontal position.</param>
+    /// <param name="row">Which row, the matrix vertical position.</param>
+    public real_t this[int column, int row]
+    {
+        readonly get
         {
-            Basis basisInv = Basis.Inverse();
-            return new Transform3D(basisInv, basisInv * -Origin);
-        }
-
-        /// <summary>
-        /// Returns a transform interpolated between this transform and another
-        /// <paramref name="transform"/> by a given <paramref name="weight"/>
-        /// (on the range of 0.0 to 1.0).
-        /// </summary>
-        /// <param name="transform">The other transform.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated transform.</returns>
-        public readonly Transform3D InterpolateWith(Transform3D transform, real_t weight)
-        {
-            Vector3 sourceScale = Basis.Scale;
-            Quaternion sourceRotation = Basis.GetRotationQuaternion();
-            Vector3 sourceLocation = Origin;
-
-            Vector3 destinationScale = transform.Basis.Scale;
-            Quaternion destinationRotation = transform.Basis.GetRotationQuaternion();
-            Vector3 destinationLocation = transform.Origin;
-
-            var interpolated = new Transform3D();
-            Quaternion quaternion = sourceRotation.Slerp(destinationRotation, weight).Normalized();
-            Vector3 scale = sourceScale.Lerp(destinationScale, weight);
-            interpolated.Basis.SetQuaternionScale(quaternion, scale);
-            interpolated.Origin = sourceLocation.Lerp(destinationLocation, weight);
-
-            return interpolated;
-        }
-
-        /// <summary>
-        /// Returns the inverse of the transform, under the assumption that
-        /// the transformation is composed of rotation and translation
-        /// (no scaling, use <see cref="AffineInverse"/> for transforms with scaling).
-        /// </summary>
-        /// <returns>The inverse matrix.</returns>
-        public readonly Transform3D Inverse()
-        {
-            Basis basisTr = Basis.Transposed();
-            return new Transform3D(basisTr, basisTr * -Origin);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this transform is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return Basis.IsFinite() && Origin.IsFinite();
-        }
-
-        /// <summary>
-        /// Returns a copy of the transform rotated such that the forward axis (-Z)
-        /// points towards the <paramref name="target"/> position.
-        /// The up axis (+Y) points as close to the <paramref name="up"/> vector
-        /// as possible while staying perpendicular to the forward axis.
-        /// The resulting transform is orthonormalized.
-        /// The existing rotation, scale, and skew information from the original transform is discarded.
-        /// The <paramref name="target"/> and <paramref name="up"/> vectors cannot be zero,
-        /// cannot be parallel to each other, and are defined in global/parent space.
-        /// </summary>
-        /// <param name="target">The object to look at.</param>
-        /// <param name="up">The relative up direction.</param>
-        /// <param name="useModelFront">
-        /// If true, then the model is oriented in reverse,
-        /// towards the model front axis (+Z, Vector3.ModelFront),
-        /// which is more useful for orienting 3D models.
-        /// </param>
-        /// <returns>The resulting transform.</returns>
-        public readonly Transform3D LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
-        {
-            Transform3D t = this;
-            t.SetLookAt(Origin, target, up ?? Vector3.Up, useModelFront);
-            return t;
-        }
-
-        /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public readonly Transform3D LookingAt(Vector3 target, Vector3 up)
-        {
-            return LookingAt(target, up, false);
-        }
-
-        /// <summary>
-        /// Returns the transform with the basis orthogonal (90 degrees),
-        /// and normalized axis vectors (scale of 1 or -1).
-        /// </summary>
-        /// <returns>The orthonormalized transform.</returns>
-        public readonly Transform3D Orthonormalized()
-        {
-            return new Transform3D(Basis.Orthonormalized(), Origin);
-        }
-
-        /// <summary>
-        /// Rotates the transform around the given <paramref name="axis"/> by <paramref name="angle"/> (in radians).
-        /// The axis must be a normalized vector.
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="axis">The axis to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        /// <returns>The rotated transformation matrix.</returns>
-        public readonly Transform3D Rotated(Vector3 axis, real_t angle)
-        {
-            return new Transform3D(new Basis(axis, angle), new Vector3()) * this;
-        }
-
-        /// <summary>
-        /// Rotates the transform around the given <paramref name="axis"/> by <paramref name="angle"/> (in radians).
-        /// The axis must be a normalized vector.
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="axis">The axis to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate, in radians.</param>
-        /// <returns>The rotated transformation matrix.</returns>
-        public readonly Transform3D RotatedLocal(Vector3 axis, real_t angle)
-        {
-            Basis tmpBasis = new Basis(axis, angle);
-            return new Transform3D(Basis * tmpBasis, Origin);
-        }
-
-        /// <summary>
-        /// Scales the transform by the given 3D <paramref name="scale"/> factor.
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="scale">The scale to introduce.</param>
-        /// <returns>The scaled transformation matrix.</returns>
-        public readonly Transform3D Scaled(Vector3 scale)
-        {
-            return new Transform3D(Basis.Scaled(scale), Origin * scale);
-        }
-
-        /// <summary>
-        /// Scales the transform by the given 3D <paramref name="scale"/> factor.
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="scale">The scale to introduce.</param>
-        /// <returns>The scaled transformation matrix.</returns>
-        public readonly Transform3D ScaledLocal(Vector3 scale)
-        {
-            Basis tmpBasis = Basis.FromScale(scale);
-            return new Transform3D(Basis * tmpBasis, Origin);
-        }
-
-        private void SetLookAt(Vector3 eye, Vector3 target, Vector3 up, bool useModelFront = false)
-        {
-            Basis = Basis.LookingAt(target - eye, up, useModelFront);
-            Origin = eye;
-        }
-
-        /// <summary>
-        /// Translates the transform by the given <paramref name="offset"/>.
-        /// The operation is done in the parent/global frame, equivalent to
-        /// multiplying the matrix from the left.
-        /// </summary>
-        /// <param name="offset">The offset to translate by.</param>
-        /// <returns>The translated matrix.</returns>
-        public readonly Transform3D Translated(Vector3 offset)
-        {
-            return new Transform3D(Basis, Origin + offset);
-        }
-
-        /// <summary>
-        /// Translates the transform by the given <paramref name="offset"/>.
-        /// The operation is done in the local frame, equivalent to
-        /// multiplying the matrix from the right.
-        /// </summary>
-        /// <param name="offset">The offset to translate by.</param>
-        /// <returns>The translated matrix.</returns>
-        public readonly Transform3D TranslatedLocal(Vector3 offset)
-        {
-            return new Transform3D(Basis, new Vector3
-            (
-                Origin[0] + Basis.Row0.Dot(offset),
-                Origin[1] + Basis.Row1.Dot(offset),
-                Origin[2] + Basis.Row2.Dot(offset)
-            ));
-        }
-
-        // Constants
-        private static readonly Transform3D _identity = new Transform3D(Basis.Identity, Vector3.Zero);
-        private static readonly Transform3D _flipX = new Transform3D(new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3.Zero);
-        private static readonly Transform3D _flipY = new Transform3D(new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1), Vector3.Zero);
-        private static readonly Transform3D _flipZ = new Transform3D(new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1), Vector3.Zero);
-
-        /// <summary>
-        /// The identity transform, with no translation, rotation, or scaling applied.
-        /// This is used as a replacement for <c>Transform()</c> in GDScript.
-        /// Do not use <c>new Transform()</c> with no arguments in C#, because it sets all values to zero.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
-        public static Transform3D Identity { get { return _identity; } }
-        /// <summary>
-        /// The transform that will flip something along the X axis.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform(Vector3.Left, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
-        public static Transform3D FlipX { get { return _flipX; } }
-        /// <summary>
-        /// The transform that will flip something along the Y axis.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Down, Vector3.Back, Vector3.Zero)</c>.</value>
-        public static Transform3D FlipY { get { return _flipY; } }
-        /// <summary>
-        /// The transform that will flip something along the Z axis.
-        /// </summary>
-        /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Forward, Vector3.Zero)</c>.</value>
-        public static Transform3D FlipZ { get { return _flipZ; } }
-
-        /// <summary>
-        /// Constructs a transformation matrix from 4 vectors (matrix columns).
-        /// </summary>
-        /// <param name="column0">The X vector, or column index 0.</param>
-        /// <param name="column1">The Y vector, or column index 1.</param>
-        /// <param name="column2">The Z vector, or column index 2.</param>
-        /// <param name="origin">The origin vector, or column index 3.</param>
-        public Transform3D(Vector3 column0, Vector3 column1, Vector3 column2, Vector3 origin)
-        {
-            Basis = new Basis(column0, column1, column2);
-            Origin = origin;
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from the given components.
-        /// Arguments are named such that xy is equal to calling <c>Basis.X.Y</c>.
-        /// </summary>
-        /// <param name="xx">The X component of the X column vector, accessed via <c>t.Basis.X.X</c> or <c>[0][0]</c>.</param>
-        /// <param name="yx">The X component of the Y column vector, accessed via <c>t.Basis.Y.X</c> or <c>[1][0]</c>.</param>
-        /// <param name="zx">The X component of the Z column vector, accessed via <c>t.Basis.Z.X</c> or <c>[2][0]</c>.</param>
-        /// <param name="xy">The Y component of the X column vector, accessed via <c>t.Basis.X.Y</c> or <c>[0][1]</c>.</param>
-        /// <param name="yy">The Y component of the Y column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[1][1]</c>.</param>
-        /// <param name="zy">The Y component of the Z column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[2][1]</c>.</param>
-        /// <param name="xz">The Z component of the X column vector, accessed via <c>t.Basis.X.Y</c> or <c>[0][2]</c>.</param>
-        /// <param name="yz">The Z component of the Y column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[1][2]</c>.</param>
-        /// <param name="zz">The Z component of the Z column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[2][2]</c>.</param>
-        /// <param name="ox">The X component of the origin vector, accessed via <c>t.Origin.X</c> or <c>[2][0]</c>.</param>
-        /// <param name="oy">The Y component of the origin vector, accessed via <c>t.Origin.Y</c> or <c>[2][1]</c>.</param>
-        /// <param name="oz">The Z component of the origin vector, accessed via <c>t.Origin.Z</c> or <c>[2][2]</c>.</param>
-        public Transform3D(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz, real_t ox, real_t oy, real_t oz)
-        {
-            Basis = new Basis(xx, yx, zx, xy, yy, zy, xz, yz, zz);
-            Origin = new Vector3(ox, oy, oz);
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from the given <paramref name="basis"/> and
-        /// <paramref name="origin"/> vector.
-        /// </summary>
-        /// <param name="basis">The <see cref="Godot.Basis"/> to create the basis from.</param>
-        /// <param name="origin">The origin vector, or column index 3.</param>
-        public Transform3D(Basis basis, Vector3 origin)
-        {
-            Basis = basis;
-            Origin = origin;
-        }
-
-        /// <summary>
-        /// Constructs a transformation matrix from the given <paramref name="projection"/>
-        /// by trimming the last row of the projection matrix (<c>projection.X.W</c>,
-        /// <c>projection.Y.W</c>, <c>projection.Z.W</c>, and <c>projection.W.W</c>
-        /// are not copied over).
-        /// </summary>
-        /// <param name="projection">The <see cref="Projection"/> to create the transform from.</param>
-        public Transform3D(Projection projection)
-        {
-            Basis = new Basis
-            (
-                projection.X.X, projection.Y.X, projection.Z.X,
-                projection.X.Y, projection.Y.Y, projection.Z.Y,
-                projection.X.Z, projection.Y.Z, projection.Z.Z
-            );
-            Origin = new Vector3
-            (
-                projection.W.X,
-                projection.W.Y,
-                projection.W.Z
-            );
-        }
-
-        /// <summary>
-        /// Composes these two transformation matrices by multiplying them
-        /// together. This has the effect of transforming the second transform
-        /// (the child) by the first transform (the parent).
-        /// </summary>
-        /// <param name="left">The parent transform.</param>
-        /// <param name="right">The child transform.</param>
-        /// <returns>The composed transform.</returns>
-        public static Transform3D operator *(Transform3D left, Transform3D right)
-        {
-            left.Origin = left * right.Origin;
-            left.Basis *= right.Basis;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns a Vector3 transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="vector">A Vector3 to transform.</param>
-        /// <returns>The transformed Vector3.</returns>
-        public static Vector3 operator *(Transform3D transform, Vector3 vector)
-        {
-            return new Vector3
-            (
-                transform.Basis.Row0.Dot(vector) + transform.Origin.X,
-                transform.Basis.Row1.Dot(vector) + transform.Origin.Y,
-                transform.Basis.Row2.Dot(vector) + transform.Origin.Z
-            );
-        }
-
-        /// <summary>
-        /// Returns a Vector3 transformed (multiplied) by the transposed transformation matrix.
-        ///
-        /// Note: This results in a multiplication by the inverse of the
-        /// transformation matrix only if it represents a rotation-reflection.
-        /// </summary>
-        /// <param name="vector">A Vector3 to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed Vector3.</returns>
-        public static Vector3 operator *(Vector3 vector, Transform3D transform)
-        {
-            Vector3 vInv = vector - transform.Origin;
-
-            return new Vector3
-            (
-                (transform.Basis.Row0[0] * vInv.X) + (transform.Basis.Row1[0] * vInv.Y) + (transform.Basis.Row2[0] * vInv.Z),
-                (transform.Basis.Row0[1] * vInv.X) + (transform.Basis.Row1[1] * vInv.Y) + (transform.Basis.Row2[1] * vInv.Z),
-                (transform.Basis.Row0[2] * vInv.X) + (transform.Basis.Row1[2] * vInv.Y) + (transform.Basis.Row2[2] * vInv.Z)
-            );
-        }
-
-        /// <summary>
-        /// Returns an AABB transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="aabb">An AABB to transform.</param>
-        /// <returns>The transformed AABB.</returns>
-        public static Aabb operator *(Transform3D transform, Aabb aabb)
-        {
-            Vector3 min = aabb.Position;
-            Vector3 max = aabb.Position + aabb.Size;
-
-            Vector3 tmin = transform.Origin;
-            Vector3 tmax = transform.Origin;
-            for (int i = 0; i < 3; i++)
+            if (column == 3)
             {
-                for (int j = 0; j < 3; j++)
+                return Origin[row];
+            }
+            return Basis[column, row];
+        }
+        set
+        {
+            if (column == 3)
+            {
+                Origin[row] = value;
+                return;
+            }
+            Basis[column, row] = value;
+        }
+    }
+
+    /// <summary>
+    /// Returns the inverse of the transform, under the assumption that
+    /// the transformation is composed of rotation, scaling, and translation.
+    /// </summary>
+    /// <seealso cref="Inverse"/>
+    /// <returns>The inverse transformation matrix.</returns>
+    public readonly Transform3D AffineInverse()
+    {
+        Basis basisInv = Basis.Inverse();
+        return new Transform3D(basisInv, basisInv * -Origin);
+    }
+
+    /// <summary>
+    /// Returns a transform interpolated between this transform and another
+    /// <paramref name="transform"/> by a given <paramref name="weight"/>
+    /// (on the range of 0.0 to 1.0).
+    /// </summary>
+    /// <param name="transform">The other transform.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated transform.</returns>
+    public readonly Transform3D InterpolateWith(Transform3D transform, real_t weight)
+    {
+        Vector3 sourceScale = Basis.Scale;
+        Quaternion sourceRotation = Basis.GetRotationQuaternion();
+        Vector3 sourceLocation = Origin;
+
+        Vector3 destinationScale = transform.Basis.Scale;
+        Quaternion destinationRotation = transform.Basis.GetRotationQuaternion();
+        Vector3 destinationLocation = transform.Origin;
+
+        var interpolated = new Transform3D();
+        Quaternion quaternion = sourceRotation.Slerp(destinationRotation, weight).Normalized();
+        Vector3 scale = sourceScale.Lerp(destinationScale, weight);
+        interpolated.Basis.SetQuaternionScale(quaternion, scale);
+        interpolated.Origin = sourceLocation.Lerp(destinationLocation, weight);
+
+        return interpolated;
+    }
+
+    /// <summary>
+    /// Returns the inverse of the transform, under the assumption that
+    /// the transformation is composed of rotation and translation
+    /// (no scaling, use <see cref="AffineInverse"/> for transforms with scaling).
+    /// </summary>
+    /// <returns>The inverse matrix.</returns>
+    public readonly Transform3D Inverse()
+    {
+        Basis basisTr = Basis.Transposed();
+        return new Transform3D(basisTr, basisTr * -Origin);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this transform is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Basis.IsFinite() && Origin.IsFinite();
+    }
+
+    /// <summary>
+    /// Returns a copy of the transform rotated such that the forward axis (-Z)
+    /// points towards the <paramref name="target"/> position.
+    /// The up axis (+Y) points as close to the <paramref name="up"/> vector
+    /// as possible while staying perpendicular to the forward axis.
+    /// The resulting transform is orthonormalized.
+    /// The existing rotation, scale, and skew information from the original transform is discarded.
+    /// The <paramref name="target"/> and <paramref name="up"/> vectors cannot be zero,
+    /// cannot be parallel to each other, and are defined in global/parent space.
+    /// </summary>
+    /// <param name="target">The object to look at.</param>
+    /// <param name="up">The relative up direction.</param>
+    /// <param name="useModelFront">
+    /// If true, then the model is oriented in reverse,
+    /// towards the model front axis (+Z, Vector3.ModelFront),
+    /// which is more useful for orienting 3D models.
+    /// </param>
+    /// <returns>The resulting transform.</returns>
+    public readonly Transform3D LookingAt(Vector3 target, Vector3? up = null, bool useModelFront = false)
+    {
+        Transform3D t = this;
+        t.SetLookAt(Origin, target, up ?? Vector3.Up, useModelFront);
+        return t;
+    }
+
+    /// <inheritdoc cref="LookingAt(Vector3, Nullable{Vector3}, bool)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public readonly Transform3D LookingAt(Vector3 target, Vector3 up)
+    {
+        return LookingAt(target, up, false);
+    }
+
+    /// <summary>
+    /// Returns the transform with the basis orthogonal (90 degrees),
+    /// and normalized axis vectors (scale of 1 or -1).
+    /// </summary>
+    /// <returns>The orthonormalized transform.</returns>
+    public readonly Transform3D Orthonormalized()
+    {
+        return new Transform3D(Basis.Orthonormalized(), Origin);
+    }
+
+    /// <summary>
+    /// Rotates the transform around the given <paramref name="axis"/> by <paramref name="angle"/> (in radians).
+    /// The axis must be a normalized vector.
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="axis">The axis to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    /// <returns>The rotated transformation matrix.</returns>
+    public readonly Transform3D Rotated(Vector3 axis, real_t angle)
+    {
+        return new Transform3D(new Basis(axis, angle), new Vector3()) * this;
+    }
+
+    /// <summary>
+    /// Rotates the transform around the given <paramref name="axis"/> by <paramref name="angle"/> (in radians).
+    /// The axis must be a normalized vector.
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="axis">The axis to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate, in radians.</param>
+    /// <returns>The rotated transformation matrix.</returns>
+    public readonly Transform3D RotatedLocal(Vector3 axis, real_t angle)
+    {
+        Basis tmpBasis = new Basis(axis, angle);
+        return new Transform3D(Basis * tmpBasis, Origin);
+    }
+
+    /// <summary>
+    /// Scales the transform by the given 3D <paramref name="scale"/> factor.
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="scale">The scale to introduce.</param>
+    /// <returns>The scaled transformation matrix.</returns>
+    public readonly Transform3D Scaled(Vector3 scale)
+    {
+        return new Transform3D(Basis.Scaled(scale), Origin * scale);
+    }
+
+    /// <summary>
+    /// Scales the transform by the given 3D <paramref name="scale"/> factor.
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="scale">The scale to introduce.</param>
+    /// <returns>The scaled transformation matrix.</returns>
+    public readonly Transform3D ScaledLocal(Vector3 scale)
+    {
+        Basis tmpBasis = Basis.FromScale(scale);
+        return new Transform3D(Basis * tmpBasis, Origin);
+    }
+
+    private void SetLookAt(Vector3 eye, Vector3 target, Vector3 up, bool useModelFront = false)
+    {
+        Basis = Basis.LookingAt(target - eye, up, useModelFront);
+        Origin = eye;
+    }
+
+    /// <summary>
+    /// Translates the transform by the given <paramref name="offset"/>.
+    /// The operation is done in the parent/global frame, equivalent to
+    /// multiplying the matrix from the left.
+    /// </summary>
+    /// <param name="offset">The offset to translate by.</param>
+    /// <returns>The translated matrix.</returns>
+    public readonly Transform3D Translated(Vector3 offset)
+    {
+        return new Transform3D(Basis, Origin + offset);
+    }
+
+    /// <summary>
+    /// Translates the transform by the given <paramref name="offset"/>.
+    /// The operation is done in the local frame, equivalent to
+    /// multiplying the matrix from the right.
+    /// </summary>
+    /// <param name="offset">The offset to translate by.</param>
+    /// <returns>The translated matrix.</returns>
+    public readonly Transform3D TranslatedLocal(Vector3 offset)
+    {
+        return new Transform3D(Basis, new Vector3
+        (
+            Origin[0] + Basis.Row0.Dot(offset),
+            Origin[1] + Basis.Row1.Dot(offset),
+            Origin[2] + Basis.Row2.Dot(offset)
+        ));
+    }
+
+    // Constants
+    private static readonly Transform3D _identity = new Transform3D(Basis.Identity, Vector3.Zero);
+    private static readonly Transform3D _flipX = new Transform3D(new Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3.Zero);
+    private static readonly Transform3D _flipY = new Transform3D(new Basis(1, 0, 0, 0, -1, 0, 0, 0, 1), Vector3.Zero);
+    private static readonly Transform3D _flipZ = new Transform3D(new Basis(1, 0, 0, 0, 1, 0, 0, 0, -1), Vector3.Zero);
+
+    /// <summary>
+    /// The identity transform, with no translation, rotation, or scaling applied.
+    /// This is used as a replacement for <c>Transform()</c> in GDScript.
+    /// Do not use <c>new Transform()</c> with no arguments in C#, because it sets all values to zero.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
+    public static Transform3D Identity { get { return _identity; } }
+    /// <summary>
+    /// The transform that will flip something along the X axis.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform(Vector3.Left, Vector3.Up, Vector3.Back, Vector3.Zero)</c>.</value>
+    public static Transform3D FlipX { get { return _flipX; } }
+    /// <summary>
+    /// The transform that will flip something along the Y axis.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Down, Vector3.Back, Vector3.Zero)</c>.</value>
+    public static Transform3D FlipY { get { return _flipY; } }
+    /// <summary>
+    /// The transform that will flip something along the Z axis.
+    /// </summary>
+    /// <value>Equivalent to <c>new Transform(Vector3.Right, Vector3.Up, Vector3.Forward, Vector3.Zero)</c>.</value>
+    public static Transform3D FlipZ { get { return _flipZ; } }
+
+    /// <summary>
+    /// Constructs a transformation matrix from 4 vectors (matrix columns).
+    /// </summary>
+    /// <param name="column0">The X vector, or column index 0.</param>
+    /// <param name="column1">The Y vector, or column index 1.</param>
+    /// <param name="column2">The Z vector, or column index 2.</param>
+    /// <param name="origin">The origin vector, or column index 3.</param>
+    public Transform3D(Vector3 column0, Vector3 column1, Vector3 column2, Vector3 origin)
+    {
+        Basis = new Basis(column0, column1, column2);
+        Origin = origin;
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from the given components.
+    /// Arguments are named such that xy is equal to calling <c>Basis.X.Y</c>.
+    /// </summary>
+    /// <param name="xx">The X component of the X column vector, accessed via <c>t.Basis.X.X</c> or <c>[0][0]</c>.</param>
+    /// <param name="yx">The X component of the Y column vector, accessed via <c>t.Basis.Y.X</c> or <c>[1][0]</c>.</param>
+    /// <param name="zx">The X component of the Z column vector, accessed via <c>t.Basis.Z.X</c> or <c>[2][0]</c>.</param>
+    /// <param name="xy">The Y component of the X column vector, accessed via <c>t.Basis.X.Y</c> or <c>[0][1]</c>.</param>
+    /// <param name="yy">The Y component of the Y column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[1][1]</c>.</param>
+    /// <param name="zy">The Y component of the Z column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[2][1]</c>.</param>
+    /// <param name="xz">The Z component of the X column vector, accessed via <c>t.Basis.X.Y</c> or <c>[0][2]</c>.</param>
+    /// <param name="yz">The Z component of the Y column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[1][2]</c>.</param>
+    /// <param name="zz">The Z component of the Z column vector, accessed via <c>t.Basis.Y.Y</c> or <c>[2][2]</c>.</param>
+    /// <param name="ox">The X component of the origin vector, accessed via <c>t.Origin.X</c> or <c>[2][0]</c>.</param>
+    /// <param name="oy">The Y component of the origin vector, accessed via <c>t.Origin.Y</c> or <c>[2][1]</c>.</param>
+    /// <param name="oz">The Z component of the origin vector, accessed via <c>t.Origin.Z</c> or <c>[2][2]</c>.</param>
+    public Transform3D(real_t xx, real_t yx, real_t zx, real_t xy, real_t yy, real_t zy, real_t xz, real_t yz, real_t zz, real_t ox, real_t oy, real_t oz)
+    {
+        Basis = new Basis(xx, yx, zx, xy, yy, zy, xz, yz, zz);
+        Origin = new Vector3(ox, oy, oz);
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from the given <paramref name="basis"/> and
+    /// <paramref name="origin"/> vector.
+    /// </summary>
+    /// <param name="basis">The <see cref="Godot.Basis"/> to create the basis from.</param>
+    /// <param name="origin">The origin vector, or column index 3.</param>
+    public Transform3D(Basis basis, Vector3 origin)
+    {
+        Basis = basis;
+        Origin = origin;
+    }
+
+    /// <summary>
+    /// Constructs a transformation matrix from the given <paramref name="projection"/>
+    /// by trimming the last row of the projection matrix (<c>projection.X.W</c>,
+    /// <c>projection.Y.W</c>, <c>projection.Z.W</c>, and <c>projection.W.W</c>
+    /// are not copied over).
+    /// </summary>
+    /// <param name="projection">The <see cref="Projection"/> to create the transform from.</param>
+    public Transform3D(Projection projection)
+    {
+        Basis = new Basis
+        (
+            projection.X.X, projection.Y.X, projection.Z.X,
+            projection.X.Y, projection.Y.Y, projection.Z.Y,
+            projection.X.Z, projection.Y.Z, projection.Z.Z
+        );
+        Origin = new Vector3
+        (
+            projection.W.X,
+            projection.W.Y,
+            projection.W.Z
+        );
+    }
+
+    /// <summary>
+    /// Composes these two transformation matrices by multiplying them
+    /// together. This has the effect of transforming the second transform
+    /// (the child) by the first transform (the parent).
+    /// </summary>
+    /// <param name="left">The parent transform.</param>
+    /// <param name="right">The child transform.</param>
+    /// <returns>The composed transform.</returns>
+    public static Transform3D operator *(Transform3D left, Transform3D right)
+    {
+        left.Origin = left * right.Origin;
+        left.Basis *= right.Basis;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns a Vector3 transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="vector">A Vector3 to transform.</param>
+    /// <returns>The transformed Vector3.</returns>
+    public static Vector3 operator *(Transform3D transform, Vector3 vector)
+    {
+        return new Vector3
+        (
+            transform.Basis.Row0.Dot(vector) + transform.Origin.X,
+            transform.Basis.Row1.Dot(vector) + transform.Origin.Y,
+            transform.Basis.Row2.Dot(vector) + transform.Origin.Z
+        );
+    }
+
+    /// <summary>
+    /// Returns a Vector3 transformed (multiplied) by the transposed transformation matrix.
+    ///
+    /// Note: This results in a multiplication by the inverse of the
+    /// transformation matrix only if it represents a rotation-reflection.
+    /// </summary>
+    /// <param name="vector">A Vector3 to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed Vector3.</returns>
+    public static Vector3 operator *(Vector3 vector, Transform3D transform)
+    {
+        Vector3 vInv = vector - transform.Origin;
+
+        return new Vector3
+        (
+            (transform.Basis.Row0[0] * vInv.X) + (transform.Basis.Row1[0] * vInv.Y) + (transform.Basis.Row2[0] * vInv.Z),
+            (transform.Basis.Row0[1] * vInv.X) + (transform.Basis.Row1[1] * vInv.Y) + (transform.Basis.Row2[1] * vInv.Z),
+            (transform.Basis.Row0[2] * vInv.X) + (transform.Basis.Row1[2] * vInv.Y) + (transform.Basis.Row2[2] * vInv.Z)
+        );
+    }
+
+    /// <summary>
+    /// Returns an AABB transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="aabb">An AABB to transform.</param>
+    /// <returns>The transformed AABB.</returns>
+    public static Aabb operator *(Transform3D transform, Aabb aabb)
+    {
+        Vector3 min = aabb.Position;
+        Vector3 max = aabb.Position + aabb.Size;
+
+        Vector3 tmin = transform.Origin;
+        Vector3 tmax = transform.Origin;
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                real_t e = transform.Basis[i][j] * min[j];
+                real_t f = transform.Basis[i][j] * max[j];
+                if (e < f)
                 {
-                    real_t e = transform.Basis[i][j] * min[j];
-                    real_t f = transform.Basis[i][j] * max[j];
-                    if (e < f)
-                    {
-                        tmin[i] += e;
-                        tmax[i] += f;
-                    }
-                    else
-                    {
-                        tmin[i] += f;
-                        tmax[i] += e;
-                    }
+                    tmin[i] += e;
+                    tmax[i] += f;
+                }
+                else
+                {
+                    tmin[i] += f;
+                    tmax[i] += e;
                 }
             }
-
-            return new Aabb(tmin, tmax - tmin);
         }
 
-        /// <summary>
-        /// Returns an AABB transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="aabb">An AABB to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed AABB.</returns>
-        public static Aabb operator *(Aabb aabb, Transform3D transform)
+        return new Aabb(tmin, tmax - tmin);
+    }
+
+    /// <summary>
+    /// Returns an AABB transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="aabb">An AABB to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed AABB.</returns>
+    public static Aabb operator *(Aabb aabb, Transform3D transform)
+    {
+        Vector3 pos = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z + aabb.Size.Z) * transform;
+        Vector3 to1 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z) * transform;
+        Vector3 to2 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y, aabb.Position.Z + aabb.Size.Z) * transform;
+        Vector3 to3 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y, aabb.Position.Z) * transform;
+        Vector3 to4 = new Vector3(aabb.Position.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z + aabb.Size.Z) * transform;
+        Vector3 to5 = new Vector3(aabb.Position.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z) * transform;
+        Vector3 to6 = new Vector3(aabb.Position.X, aabb.Position.Y, aabb.Position.Z + aabb.Size.Z) * transform;
+        Vector3 to7 = new Vector3(aabb.Position.X, aabb.Position.Y, aabb.Position.Z) * transform;
+
+        return new Aabb(pos, new Vector3()).Expand(to1).Expand(to2).Expand(to3).Expand(to4).Expand(to5).Expand(to6).Expand(to7);
+    }
+
+    /// <summary>
+    /// Returns a Plane transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="plane">A Plane to transform.</param>
+    /// <returns>The transformed Plane.</returns>
+    public static Plane operator *(Transform3D transform, Plane plane)
+    {
+        Basis bInvTrans = transform.Basis.Inverse().Transposed();
+
+        // Transform a single point on the plane.
+        Vector3 point = transform * (plane.Normal * plane.D);
+
+        // Use inverse transpose for correct normals with non-uniform scaling.
+        Vector3 normal = (bInvTrans * plane.Normal).Normalized();
+
+        real_t d = normal.Dot(point);
+        return new Plane(normal, d);
+    }
+
+    /// <summary>
+    /// Returns a Plane transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="plane">A Plane to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed Plane.</returns>
+    public static Plane operator *(Plane plane, Transform3D transform)
+    {
+        Transform3D tInv = transform.AffineInverse();
+        Basis bTrans = transform.Basis.Transposed();
+
+        // Transform a single point on the plane.
+        Vector3 point = tInv * (plane.Normal * plane.D);
+
+        // Note that instead of precalculating the transpose, an alternative
+        // would be to use the transpose for the basis transform.
+        // However that would be less SIMD friendly (requiring a swizzle).
+        // So the cost is one extra precalced value in the calling code.
+        // This is probably worth it, as this could be used in bottleneck areas. And
+        // where it is not a bottleneck, the non-fast method is fine.
+
+        // Use transpose for correct normals with non-uniform scaling.
+        Vector3 normal = (bTrans * plane.Normal).Normalized();
+
+        real_t d = normal.Dot(point);
+        return new Plane(normal, d);
+    }
+
+    /// <summary>
+    /// Returns a copy of the given Vector3[] transformed (multiplied) by the transformation matrix.
+    /// </summary>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <param name="array">A Vector3[] to transform.</param>
+    /// <returns>The transformed copy of the Vector3[].</returns>
+    public static Vector3[] operator *(Transform3D transform, Vector3[] array)
+    {
+        Vector3[] newArray = new Vector3[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
         {
-            Vector3 pos = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z + aabb.Size.Z) * transform;
-            Vector3 to1 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z) * transform;
-            Vector3 to2 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y, aabb.Position.Z + aabb.Size.Z) * transform;
-            Vector3 to3 = new Vector3(aabb.Position.X + aabb.Size.X, aabb.Position.Y, aabb.Position.Z) * transform;
-            Vector3 to4 = new Vector3(aabb.Position.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z + aabb.Size.Z) * transform;
-            Vector3 to5 = new Vector3(aabb.Position.X, aabb.Position.Y + aabb.Size.Y, aabb.Position.Z) * transform;
-            Vector3 to6 = new Vector3(aabb.Position.X, aabb.Position.Y, aabb.Position.Z + aabb.Size.Z) * transform;
-            Vector3 to7 = new Vector3(aabb.Position.X, aabb.Position.Y, aabb.Position.Z) * transform;
-
-            return new Aabb(pos, new Vector3()).Expand(to1).Expand(to2).Expand(to3).Expand(to4).Expand(to5).Expand(to6).Expand(to7);
+            newArray[i] = transform * array[i];
         }
 
-        /// <summary>
-        /// Returns a Plane transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="plane">A Plane to transform.</param>
-        /// <returns>The transformed Plane.</returns>
-        public static Plane operator *(Transform3D transform, Plane plane)
+        return newArray;
+    }
+
+    /// <summary>
+    /// Returns a copy of the given Vector3[] transformed (multiplied) by the inverse transformation matrix.
+    /// </summary>
+    /// <param name="array">A Vector3[] to inversely transform.</param>
+    /// <param name="transform">The transformation to apply.</param>
+    /// <returns>The inversely transformed copy of the Vector3[].</returns>
+    public static Vector3[] operator *(Vector3[] array, Transform3D transform)
+    {
+        Vector3[] newArray = new Vector3[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
         {
-            Basis bInvTrans = transform.Basis.Inverse().Transposed();
-
-            // Transform a single point on the plane.
-            Vector3 point = transform * (plane.Normal * plane.D);
-
-            // Use inverse transpose for correct normals with non-uniform scaling.
-            Vector3 normal = (bInvTrans * plane.Normal).Normalized();
-
-            real_t d = normal.Dot(point);
-            return new Plane(normal, d);
+            newArray[i] = array[i] * transform;
         }
 
-        /// <summary>
-        /// Returns a Plane transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="plane">A Plane to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed Plane.</returns>
-        public static Plane operator *(Plane plane, Transform3D transform)
-        {
-            Transform3D tInv = transform.AffineInverse();
-            Basis bTrans = transform.Basis.Transposed();
+        return newArray;
+    }
 
-            // Transform a single point on the plane.
-            Vector3 point = tInv * (plane.Normal * plane.D);
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left transform.</param>
+    /// <param name="right">The right transform.</param>
+    /// <returns>Whether or not the transforms are exactly equal.</returns>
+    public static bool operator ==(Transform3D left, Transform3D right)
+    {
+        return left.Equals(right);
+    }
 
-            // Note that instead of precalculating the transpose, an alternative
-            // would be to use the transpose for the basis transform.
-            // However that would be less SIMD friendly (requiring a swizzle).
-            // So the cost is one extra precalced value in the calling code.
-            // This is probably worth it, as this could be used in bottleneck areas. And
-            // where it is not a bottleneck, the non-fast method is fine.
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left transform.</param>
+    /// <param name="right">The right transform.</param>
+    /// <returns>Whether or not the transforms are not equal.</returns>
+    public static bool operator !=(Transform3D left, Transform3D right)
+    {
+        return !left.Equals(right);
+    }
 
-            // Use transpose for correct normals with non-uniform scaling.
-            Vector3 normal = (bTrans * plane.Normal).Normalized();
+    /// <summary>
+    /// Returns <see langword="true"/> if the transform is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the transform and the object are exactly equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Transform3D other && Equals(other);
+    }
 
-            real_t d = normal.Dot(point);
-            return new Plane(normal, d);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the transforms are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other transform to compare.</param>
+    /// <returns>Whether or not the matrices are exactly equal.</returns>
+    public readonly bool Equals(Transform3D other)
+    {
+        return Basis.Equals(other.Basis) && Origin.Equals(other.Origin);
+    }
 
-        /// <summary>
-        /// Returns a copy of the given Vector3[] transformed (multiplied) by the transformation matrix.
-        /// </summary>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <param name="array">A Vector3[] to transform.</param>
-        /// <returns>The transformed copy of the Vector3[].</returns>
-        public static Vector3[] operator *(Transform3D transform, Vector3[] array)
-        {
-            Vector3[] newArray = new Vector3[array.Length];
+    /// <summary>
+    /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other transform to compare.</param>
+    /// <returns>Whether or not the matrices are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Transform3D other)
+    {
+        return Basis.IsEqualApprox(other.Basis) && Origin.IsEqualApprox(other.Origin);
+    }
 
-            for (int i = 0; i < array.Length; i++)
-            {
-                newArray[i] = transform * array[i];
-            }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Transform3D"/>.
+    /// </summary>
+    /// <returns>A hash code for this transform.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Basis.GetHashCode() ^ Origin.GetHashCode();
+    }
 
-            return newArray;
-        }
+    /// <summary>
+    /// Converts this <see cref="Transform3D"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this transform.</returns>
+    public override readonly string ToString()
+    {
+        return $"[X: {Basis.X}, Y: {Basis.Y}, Z: {Basis.Z}, O: {Origin}]";
+    }
 
-        /// <summary>
-        /// Returns a copy of the given Vector3[] transformed (multiplied) by the inverse transformation matrix.
-        /// </summary>
-        /// <param name="array">A Vector3[] to inversely transform.</param>
-        /// <param name="transform">The transformation to apply.</param>
-        /// <returns>The inversely transformed copy of the Vector3[].</returns>
-        public static Vector3[] operator *(Vector3[] array, Transform3D transform)
-        {
-            Vector3[] newArray = new Vector3[array.Length];
-
-            for (int i = 0; i < array.Length; i++)
-            {
-                newArray[i] = array[i] * transform;
-            }
-
-            return newArray;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left transform.</param>
-        /// <param name="right">The right transform.</param>
-        /// <returns>Whether or not the transforms are exactly equal.</returns>
-        public static bool operator ==(Transform3D left, Transform3D right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left transform.</param>
-        /// <param name="right">The right transform.</param>
-        /// <returns>Whether or not the transforms are not equal.</returns>
-        public static bool operator !=(Transform3D left, Transform3D right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transform is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the transform and the object are exactly equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Transform3D other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the transforms are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are exactly equal.</returns>
-        public readonly bool Equals(Transform3D other)
-        {
-            return Basis.Equals(other.Basis) && Origin.Equals(other.Origin);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this transform and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Vector3.IsEqualApprox(Vector3)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other transform to compare.</param>
-        /// <returns>Whether or not the matrices are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Transform3D other)
-        {
-            return Basis.IsEqualApprox(other.Basis) && Origin.IsEqualApprox(other.Origin);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Transform3D"/>.
-        /// </summary>
-        /// <returns>A hash code for this transform.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Basis.GetHashCode() ^ Origin.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Transform3D"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this transform.</returns>
-        public override readonly string ToString()
-        {
-            return $"[X: {Basis.X}, Y: {Basis.Y}, Z: {Basis.Z}, O: {Origin}]";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Transform3D"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this transform.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"[X: {Basis.X.ToString(format)}, Y: {Basis.Y.ToString(format)}, Z: {Basis.Z.ToString(format)}, O: {Origin.ToString(format)}]";
-        }
+    /// <summary>
+    /// Converts this <see cref="Transform3D"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this transform.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"[X: {Basis.X.ToString(format)}, Y: {Basis.Y.ToString(format)}, Z: {Basis.Z.ToString(format)}, O: {Origin.ToString(format)}]";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -1,1024 +1,1023 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector2 : IEquatable<Vector2>
 {
     /// <summary>
-    /// 2-element structure that can be used to represent positions in 2D space or any other pair of numeric values.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2 : IEquatable<Vector2>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public real_t X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public real_t Y;
+
+    /// <summary>
+    /// Access vector components using their index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0 or 1.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>.
+    /// </value>
+    public real_t this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public real_t X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public real_t Y;
-
-        /// <summary>
-        /// Access vector components using their index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0 or 1.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>.
-        /// </value>
-        public real_t this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out real_t x, out real_t y)
+        set
         {
-            x = X;
-            y = Y;
-        }
-
-        internal void Normalize()
-        {
-            real_t lengthsq = LengthSquared();
-
-            if (lengthsq == 0)
+            switch (index)
             {
-                X = Y = 0f;
-            }
-            else
-            {
-                real_t length = Mathf.Sqrt(lengthsq);
-                X /= length;
-                Y /= length;
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
-        public readonly Vector2 Abs()
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out real_t x, out real_t y)
+    {
+        x = X;
+        y = Y;
+    }
+
+    internal void Normalize()
+    {
+        real_t lengthsq = LengthSquared();
+
+        if (lengthsq == 0)
         {
-            return new Vector2(Mathf.Abs(X), Mathf.Abs(Y));
+            X = Y = 0f;
+        }
+        else
+        {
+            real_t length = Mathf.Sqrt(lengthsq);
+            X /= length;
+            Y /= length;
+        }
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
+    public readonly Vector2 Abs()
+    {
+        return new Vector2(Mathf.Abs(X), Mathf.Abs(Y));
+    }
+
+    /// <summary>
+    /// Returns this vector's angle with respect to the X axis, or (1, 0) vector, in radians.
+    ///
+    /// Equivalent to the result of <see cref="Mathf.Atan2(real_t, real_t)"/> when
+    /// called with the vector's <see cref="Y"/> and <see cref="X"/> as parameters: <c>Mathf.Atan2(v.Y, v.X)</c>.
+    /// </summary>
+    /// <returns>The angle of this vector, in radians.</returns>
+    public readonly real_t Angle()
+    {
+        return Mathf.Atan2(Y, X);
+    }
+
+    /// <summary>
+    /// Returns the angle to the given vector, in radians.
+    /// </summary>
+    /// <param name="to">The other vector to compare this vector to.</param>
+    /// <returns>The angle between the two vectors, in radians.</returns>
+    public readonly real_t AngleTo(Vector2 to)
+    {
+        return Mathf.Atan2(Cross(to), Dot(to));
+    }
+
+    /// <summary>
+    /// Returns the angle between the line connecting the two points and the X axis, in radians.
+    /// </summary>
+    /// <param name="to">The other vector to compare this vector to.</param>
+    /// <returns>The angle between the two vectors, in radians.</returns>
+    public readonly real_t AngleToPoint(Vector2 to)
+    {
+        return Mathf.Atan2(to.Y - Y, to.X - X);
+    }
+
+    /// <summary>
+    /// Returns the aspect ratio of this vector, the ratio of <see cref="X"/> to <see cref="Y"/>.
+    /// </summary>
+    /// <returns>The <see cref="X"/> component divided by the <see cref="Y"/> component.</returns>
+    public readonly real_t Aspect()
+    {
+        return X / Y;
+    }
+
+    /// <summary>
+    /// Returns the vector "bounced off" from a plane defined by the given normal.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to bounce off. Must be normalized.</param>
+    /// <returns>The bounced vector.</returns>
+    public readonly Vector2 Bounce(Vector2 normal)
+    {
+        return -Reflect(normal);
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded up (towards positive infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
+    public readonly Vector2 Ceil()
+    {
+        return new Vector2(Mathf.Ceil(X), Mathf.Ceil(Y));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector2 Clamp(Vector2 min, Vector2 max)
+    {
+        return new Vector2
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y)
+        );
+    }
+
+    /// <summary>
+    /// Returns the cross product of this vector and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector.</param>
+    /// <returns>The cross product value.</returns>
+    public readonly real_t Cross(Vector2 with)
+    {
+        return (X * with.Y) - (Y * with.X);
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector2 CubicInterpolate(Vector2 b, Vector2 preA, Vector2 postB, real_t weight)
+    {
+        return new Vector2
+        (
+            Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
+            Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight)
+        );
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="t"></param>
+    /// <param name="preAT"></param>
+    /// <param name="postBT"></param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector2 CubicInterpolateInTime(Vector2 b, Vector2 preA, Vector2 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+    {
+        return new Vector2
+        (
+            Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT)
+        );
+    }
+
+    /// <summary>
+    /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
+    /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination vector.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector2 BezierInterpolate(Vector2 control1, Vector2 control2, Vector2 end, real_t t)
+    {
+        return new Vector2
+        (
+            Mathf.BezierInterpolate(X, control1.X, control2.X, end.X, t),
+            Mathf.BezierInterpolate(Y, control1.Y, control2.Y, end.Y, t)
+        );
+    }
+
+    /// <summary>
+    /// Returns the derivative at the given <paramref name="t"/> on the Bezier curve defined by this vector
+    /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public readonly Vector2 BezierDerivative(Vector2 control1, Vector2 control2, Vector2 end, real_t t)
+    {
+        return new Vector2(
+            Mathf.BezierDerivative(X, control1.X, control2.X, end.X, t),
+            Mathf.BezierDerivative(Y, control1.Y, control2.Y, end.Y, t)
+        );
+    }
+
+    /// <summary>
+    /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
+    /// </summary>
+    /// <param name="to">The other vector to point towards.</param>
+    /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
+    public readonly Vector2 DirectionTo(Vector2 to)
+    {
+        return new Vector2(to.X - X, to.Y - Y).Normalized();
+    }
+
+    /// <summary>
+    /// Returns the squared distance between this vector and <paramref name="to"/>.
+    /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+    /// you need to compare vectors or need the squared distance for some formula.
+    /// </summary>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The squared distance between the two vectors.</returns>
+    public readonly real_t DistanceSquaredTo(Vector2 to)
+    {
+        return (X - to.X) * (X - to.X) + (Y - to.Y) * (Y - to.Y);
+    }
+
+    /// <summary>
+    /// Returns the distance between this vector and <paramref name="to"/>.
+    /// </summary>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The distance between the two vectors.</returns>
+    public readonly real_t DistanceTo(Vector2 to)
+    {
+        return Mathf.Sqrt((X - to.X) * (X - to.X) + (Y - to.Y) * (Y - to.Y));
+    }
+
+    /// <summary>
+    /// Returns the dot product of this vector and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector to use.</param>
+    /// <returns>The dot product of the two vectors.</returns>
+    public readonly real_t Dot(Vector2 with)
+    {
+        return (X * with.X) + (Y * with.Y);
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded down (towards negative infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
+    public readonly Vector2 Floor()
+    {
+        return new Vector2(Mathf.Floor(X), Mathf.Floor(Y));
+    }
+
+    /// <summary>
+    /// Returns the inverse of this vector. This is the same as <c>new Vector2(1 / v.X, 1 / v.Y)</c>.
+    /// </summary>
+    /// <returns>The inverse of this vector.</returns>
+    public readonly Vector2 Inverse()
+    {
+        return new Vector2(1 / X, 1 / Y);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Mathf.IsFinite(X) && Mathf.IsFinite(Y);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
+    /// </summary>
+    /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
+    public readonly bool IsNormalized()
+    {
+        return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
+    }
+
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        return Mathf.Sqrt((X * X) + (Y * Y));
+    }
+
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly real_t LengthSquared()
+    {
+        return (X * X) + (Y * Y);
+    }
+
+    /// <summary>
+    /// Returns the result of the linear interpolation between
+    /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="to">The destination vector for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting vector of the interpolation.</returns>
+    public readonly Vector2 Lerp(Vector2 to, real_t weight)
+    {
+        return new Vector2
+        (
+            Mathf.Lerp(X, to.X, weight),
+            Mathf.Lerp(Y, to.Y, weight)
+        );
+    }
+
+    /// <summary>
+    /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
+    /// </summary>
+    /// <param name="length">The length to limit to.</param>
+    /// <returns>The vector with its length limited.</returns>
+    public readonly Vector2 LimitLength(real_t length = 1.0f)
+    {
+        Vector2 v = this;
+        real_t l = Length();
+
+        if (l > 0 && length < l)
+        {
+            v /= l;
+            v *= length;
         }
 
-        /// <summary>
-        /// Returns this vector's angle with respect to the X axis, or (1, 0) vector, in radians.
-        ///
-        /// Equivalent to the result of <see cref="Mathf.Atan2(real_t, real_t)"/> when
-        /// called with the vector's <see cref="Y"/> and <see cref="X"/> as parameters: <c>Mathf.Atan2(v.Y, v.X)</c>.
-        /// </summary>
-        /// <returns>The angle of this vector, in radians.</returns>
-        public readonly real_t Angle()
-        {
-            return Mathf.Atan2(Y, X);
-        }
+        return v;
+    }
 
-        /// <summary>
-        /// Returns the angle to the given vector, in radians.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <returns>The angle between the two vectors, in radians.</returns>
-        public readonly real_t AngleTo(Vector2 to)
-        {
-            return Mathf.Atan2(Cross(to), Dot(to));
-        }
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If both components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        return X < Y ? Axis.Y : Axis.X;
+    }
 
-        /// <summary>
-        /// Returns the angle between the line connecting the two points and the X axis, in radians.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <returns>The angle between the two vectors, in radians.</returns>
-        public readonly real_t AngleToPoint(Vector2 to)
-        {
-            return Mathf.Atan2(to.Y - Y, to.X - X);
-        }
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If both components are equal, this method returns <see cref="Axis.Y"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        return X < Y ? Axis.X : Axis.Y;
+    }
 
-        /// <summary>
-        /// Returns the aspect ratio of this vector, the ratio of <see cref="X"/> to <see cref="Y"/>.
-        /// </summary>
-        /// <returns>The <see cref="X"/> component divided by the <see cref="Y"/> component.</returns>
-        public readonly real_t Aspect()
-        {
-            return X / Y;
-        }
+    /// <summary>
+    /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
+    /// </summary>
+    /// <param name="to">The vector to move towards.</param>
+    /// <param name="delta">The amount to move towards by.</param>
+    /// <returns>The resulting vector.</returns>
+    public readonly Vector2 MoveToward(Vector2 to, real_t delta)
+    {
+        Vector2 v = this;
+        Vector2 vd = to - v;
+        real_t len = vd.Length();
+        if (len <= delta || len < Mathf.Epsilon)
+            return to;
 
-        /// <summary>
-        /// Returns the vector "bounced off" from a plane defined by the given normal.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to bounce off. Must be normalized.</param>
-        /// <returns>The bounced vector.</returns>
-        public readonly Vector2 Bounce(Vector2 normal)
-        {
-            return -Reflect(normal);
-        }
+        return v + (vd / len * delta);
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components rounded up (towards positive infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
-        public readonly Vector2 Ceil()
-        {
-            return new Vector2(Mathf.Ceil(X), Mathf.Ceil(Y));
-        }
+    /// <summary>
+    /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+    /// </summary>
+    /// <returns>A normalized version of the vector.</returns>
+    public readonly Vector2 Normalized()
+    {
+        Vector2 v = this;
+        v.Normalize();
+        return v;
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector2 Clamp(Vector2 min, Vector2 max)
-        {
-            return new Vector2
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y)
-            );
-        }
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="mod"/>.
+    /// </summary>
+    /// <param name="mod">A value representing the divisor of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
+    /// </returns>
+    public readonly Vector2 PosMod(real_t mod)
+    {
+        Vector2 v;
+        v.X = Mathf.PosMod(X, mod);
+        v.Y = Mathf.PosMod(Y, mod);
+        return v;
+    }
 
-        /// <summary>
-        /// Returns the cross product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector.</param>
-        /// <returns>The cross product value.</returns>
-        public readonly real_t Cross(Vector2 with)
-        {
-            return (X * with.Y) - (Y * with.X);
-        }
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="modv"/>'s components.
+    /// </summary>
+    /// <param name="modv">A vector representing the divisors of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
+    /// </returns>
+    public readonly Vector2 PosMod(Vector2 modv)
+    {
+        Vector2 v;
+        v.X = Mathf.PosMod(X, modv.X);
+        v.Y = Mathf.PosMod(Y, modv.Y);
+        return v;
+    }
 
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector2 CubicInterpolate(Vector2 b, Vector2 preA, Vector2 postB, real_t weight)
-        {
-            return new Vector2
-            (
-                Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
-                Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight)
-            );
-        }
+    /// <summary>
+    /// Returns this vector projected onto another vector <paramref name="onNormal"/>.
+    /// </summary>
+    /// <param name="onNormal">The vector to project onto.</param>
+    /// <returns>The projected vector.</returns>
+    public readonly Vector2 Project(Vector2 onNormal)
+    {
+        return onNormal * (Dot(onNormal) / onNormal.LengthSquared());
+    }
 
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="t"></param>
-        /// <param name="preAT"></param>
-        /// <param name="postBT"></param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector2 CubicInterpolateInTime(Vector2 b, Vector2 preA, Vector2 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
-        {
-            return new Vector2
-            (
-                Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT)
-            );
-        }
-
-        /// <summary>
-        /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
-        /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination vector.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector2 BezierInterpolate(Vector2 control1, Vector2 control2, Vector2 end, real_t t)
-        {
-            return new Vector2
-            (
-                Mathf.BezierInterpolate(X, control1.X, control2.X, end.X, t),
-                Mathf.BezierInterpolate(Y, control1.Y, control2.Y, end.Y, t)
-            );
-        }
-
-        /// <summary>
-        /// Returns the derivative at the given <paramref name="t"/> on the Bezier curve defined by this vector
-        /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public readonly Vector2 BezierDerivative(Vector2 control1, Vector2 control2, Vector2 end, real_t t)
-        {
-            return new Vector2(
-                Mathf.BezierDerivative(X, control1.X, control2.X, end.X, t),
-                Mathf.BezierDerivative(Y, control1.Y, control2.Y, end.Y, t)
-            );
-        }
-
-        /// <summary>
-        /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to point towards.</param>
-        /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
-        public readonly Vector2 DirectionTo(Vector2 to)
-        {
-            return new Vector2(to.X - X, to.Y - Y).Normalized();
-        }
-
-        /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="to"/>.
-        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
-        /// you need to compare vectors or need the squared distance for some formula.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The squared distance between the two vectors.</returns>
-        public readonly real_t DistanceSquaredTo(Vector2 to)
-        {
-            return (X - to.X) * (X - to.X) + (Y - to.Y) * (Y - to.Y);
-        }
-
-        /// <summary>
-        /// Returns the distance between this vector and <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The distance between the two vectors.</returns>
-        public readonly real_t DistanceTo(Vector2 to)
-        {
-            return Mathf.Sqrt((X - to.X) * (X - to.X) + (Y - to.Y) * (Y - to.Y));
-        }
-
-        /// <summary>
-        /// Returns the dot product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector to use.</param>
-        /// <returns>The dot product of the two vectors.</returns>
-        public readonly real_t Dot(Vector2 with)
-        {
-            return (X * with.X) + (Y * with.Y);
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components rounded down (towards negative infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
-        public readonly Vector2 Floor()
-        {
-            return new Vector2(Mathf.Floor(X), Mathf.Floor(Y));
-        }
-
-        /// <summary>
-        /// Returns the inverse of this vector. This is the same as <c>new Vector2(1 / v.X, 1 / v.Y)</c>.
-        /// </summary>
-        /// <returns>The inverse of this vector.</returns>
-        public readonly Vector2 Inverse()
-        {
-            return new Vector2(1 / X, 1 / Y);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return Mathf.IsFinite(X) && Mathf.IsFinite(Y);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
-        /// </summary>
-        /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
-        public readonly bool IsNormalized()
-        {
-            return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            return Mathf.Sqrt((X * X) + (Y * Y));
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly real_t LengthSquared()
-        {
-            return (X * X) + (Y * Y);
-        }
-
-        /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector2 Lerp(Vector2 to, real_t weight)
-        {
-            return new Vector2
-            (
-                Mathf.Lerp(X, to.X, weight),
-                Mathf.Lerp(Y, to.Y, weight)
-            );
-        }
-
-        /// <summary>
-        /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
-        /// </summary>
-        /// <param name="length">The length to limit to.</param>
-        /// <returns>The vector with its length limited.</returns>
-        public readonly Vector2 LimitLength(real_t length = 1.0f)
-        {
-            Vector2 v = this;
-            real_t l = Length();
-
-            if (l > 0 && length < l)
-            {
-                v /= l;
-                v *= length;
-            }
-
-            return v;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If both components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            return X < Y ? Axis.Y : Axis.X;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If both components are equal, this method returns <see cref="Axis.Y"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
-        {
-            return X < Y ? Axis.X : Axis.Y;
-        }
-
-        /// <summary>
-        /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
-        /// </summary>
-        /// <param name="to">The vector to move towards.</param>
-        /// <param name="delta">The amount to move towards by.</param>
-        /// <returns>The resulting vector.</returns>
-        public readonly Vector2 MoveToward(Vector2 to, real_t delta)
-        {
-            Vector2 v = this;
-            Vector2 vd = to - v;
-            real_t len = vd.Length();
-            if (len <= delta || len < Mathf.Epsilon)
-                return to;
-
-            return v + (vd / len * delta);
-        }
-
-        /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
-        /// </summary>
-        /// <returns>A normalized version of the vector.</returns>
-        public readonly Vector2 Normalized()
-        {
-            Vector2 v = this;
-            v.Normalize();
-            return v;
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="mod"/>.
-        /// </summary>
-        /// <param name="mod">A value representing the divisor of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
-        /// </returns>
-        public readonly Vector2 PosMod(real_t mod)
-        {
-            Vector2 v;
-            v.X = Mathf.PosMod(X, mod);
-            v.Y = Mathf.PosMod(Y, mod);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="modv"/>'s components.
-        /// </summary>
-        /// <param name="modv">A vector representing the divisors of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
-        /// </returns>
-        public readonly Vector2 PosMod(Vector2 modv)
-        {
-            Vector2 v;
-            v.X = Mathf.PosMod(X, modv.X);
-            v.Y = Mathf.PosMod(Y, modv.Y);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns this vector projected onto another vector <paramref name="onNormal"/>.
-        /// </summary>
-        /// <param name="onNormal">The vector to project onto.</param>
-        /// <returns>The projected vector.</returns>
-        public readonly Vector2 Project(Vector2 onNormal)
-        {
-            return onNormal * (Dot(onNormal) / onNormal.LengthSquared());
-        }
-
-        /// <summary>
-        /// Returns this vector reflected from a plane defined by the given <paramref name="normal"/>.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to reflect from. Must be normalized.</param>
-        /// <returns>The reflected vector.</returns>
-        public readonly Vector2 Reflect(Vector2 normal)
-        {
+    /// <summary>
+    /// Returns this vector reflected from a plane defined by the given <paramref name="normal"/>.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to reflect from. Must be normalized.</param>
+    /// <returns>The reflected vector.</returns>
+    public readonly Vector2 Reflect(Vector2 normal)
+    {
 #if DEBUG
-            if (!normal.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized.", nameof(normal));
-            }
+        if (!normal.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized.", nameof(normal));
+        }
 #endif
-            return (2 * Dot(normal) * normal) - this;
-        }
+        return (2 * Dot(normal) * normal) - this;
+    }
 
-        /// <summary>
-        /// Rotates this vector by <paramref name="angle"/> radians.
-        /// </summary>
-        /// <param name="angle">The angle to rotate by, in radians.</param>
-        /// <returns>The rotated vector.</returns>
-        public readonly Vector2 Rotated(real_t angle)
+    /// <summary>
+    /// Rotates this vector by <paramref name="angle"/> radians.
+    /// </summary>
+    /// <param name="angle">The angle to rotate by, in radians.</param>
+    /// <returns>The rotated vector.</returns>
+    public readonly Vector2 Rotated(real_t angle)
+    {
+        (real_t sin, real_t cos) = Mathf.SinCos(angle);
+        return new Vector2
+        (
+            X * cos - Y * sin,
+            X * sin + Y * cos
+        );
+    }
+
+    /// <summary>
+    /// Returns this vector with all components rounded to the nearest integer,
+    /// with halfway cases rounded towards the nearest multiple of two.
+    /// </summary>
+    /// <returns>The rounded vector.</returns>
+    public readonly Vector2 Round()
+    {
+        return new Vector2(Mathf.Round(X), Mathf.Round(Y));
+    }
+
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector2 Sign()
+    {
+        Vector2 v;
+        v.X = Mathf.Sign(X);
+        v.Y = Mathf.Sign(Y);
+        return v;
+    }
+
+    /// <summary>
+    /// Returns the result of the spherical linear interpolation between
+    /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
+    ///
+    /// This method also handles interpolating the lengths if the input vectors
+    /// have different lengths. For the special case of one or both input vectors
+    /// having zero length, this method behaves like <see cref="Lerp(Vector2, real_t)"/>.
+    /// </summary>
+    /// <param name="to">The destination vector for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting vector of the interpolation.</returns>
+    public readonly Vector2 Slerp(Vector2 to, real_t weight)
+    {
+        real_t startLengthSquared = LengthSquared();
+        real_t endLengthSquared = to.LengthSquared();
+        if (startLengthSquared == 0.0 || endLengthSquared == 0.0)
         {
-            (real_t sin, real_t cos) = Mathf.SinCos(angle);
-            return new Vector2
-            (
-                X * cos - Y * sin,
-                X * sin + Y * cos
-            );
+            // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
+            return Lerp(to, weight);
         }
+        real_t startLength = Mathf.Sqrt(startLengthSquared);
+        real_t resultLength = Mathf.Lerp(startLength, Mathf.Sqrt(endLengthSquared), weight);
+        real_t angle = AngleTo(to);
+        return Rotated(angle * weight) * (resultLength / startLength);
+    }
 
-        /// <summary>
-        /// Returns this vector with all components rounded to the nearest integer,
-        /// with halfway cases rounded towards the nearest multiple of two.
-        /// </summary>
-        /// <returns>The rounded vector.</returns>
-        public readonly Vector2 Round()
+    /// <summary>
+    /// Returns this vector slid along a plane defined by the given <paramref name="normal"/>.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to slide on.</param>
+    /// <returns>The slid vector.</returns>
+    public readonly Vector2 Slide(Vector2 normal)
+    {
+        return this - (normal * Dot(normal));
+    }
+
+    /// <summary>
+    /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
+    /// This can also be used to round to an arbitrary number of decimals.
+    /// </summary>
+    /// <param name="step">A vector value representing the step size to snap to.</param>
+    /// <returns>The snapped vector.</returns>
+    public readonly Vector2 Snapped(Vector2 step)
+    {
+        return new Vector2(Mathf.Snapped(X, step.X), Mathf.Snapped(Y, step.Y));
+    }
+
+    /// <summary>
+    /// Returns a perpendicular vector rotated 90 degrees counter-clockwise
+    /// compared to the original, with the same length.
+    /// </summary>
+    /// <returns>The perpendicular vector.</returns>
+    public readonly Vector2 Orthogonal()
+    {
+        return new Vector2(Y, -X);
+    }
+
+    // Constants
+    private static readonly Vector2 _zero = new Vector2(0, 0);
+    private static readonly Vector2 _one = new Vector2(1, 1);
+    private static readonly Vector2 _inf = new Vector2(Mathf.Inf, Mathf.Inf);
+
+    private static readonly Vector2 _up = new Vector2(0, -1);
+    private static readonly Vector2 _down = new Vector2(0, 1);
+    private static readonly Vector2 _right = new Vector2(1, 0);
+    private static readonly Vector2 _left = new Vector2(-1, 0);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(0, 0)</c>.</value>
+    public static Vector2 Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(1, 1)</c>.</value>
+    public static Vector2 One { get { return _one; } }
+    /// <summary>
+    /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(Mathf.Inf, Mathf.Inf)</c>.</value>
+    public static Vector2 Inf { get { return _inf; } }
+
+    /// <summary>
+    /// Up unit vector. Y is down in 2D, so this vector points -Y.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(0, -1)</c>.</value>
+    public static Vector2 Up { get { return _up; } }
+    /// <summary>
+    /// Down unit vector. Y is down in 2D, so this vector points +Y.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(0, 1)</c>.</value>
+    public static Vector2 Down { get { return _down; } }
+    /// <summary>
+    /// Right unit vector. Represents the direction of right.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(1, 0)</c>.</value>
+    public static Vector2 Right { get { return _right; } }
+    /// <summary>
+    /// Left unit vector. Represents the direction of left.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2(-1, 0)</c>.</value>
+    public static Vector2 Left { get { return _left; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector2"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    public Vector2(real_t x, real_t y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    /// <summary>
+    /// Creates a unit Vector2 rotated to the given angle. This is equivalent to doing
+    /// <c>Vector2(Mathf.Cos(angle), Mathf.Sin(angle))</c> or <c>Vector2.Right.Rotated(angle)</c>.
+    /// </summary>
+    /// <param name="angle">Angle of the vector, in radians.</param>
+    /// <returns>The resulting vector.</returns>
+    public static Vector2 FromAngle(real_t angle)
+    {
+        (real_t sin, real_t cos) = Mathf.SinCos(angle);
+        return new Vector2(cos, sin);
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector2"/>
+    /// with the components of the given <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector2 operator +(Vector2 left, Vector2 right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector2"/>
+    /// by the components of the given <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector2 operator -(Vector2 left, Vector2 right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector2"/>.
+    /// This is the same as writing <c>new Vector2(-v.X, -v.Y)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// With floats, the number zero can be either positive or negative.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector2 operator -(Vector2 vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2 operator *(Vector2 vec, real_t scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2 operator *(real_t scale, Vector2 vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2"/>
+    /// by the components of the given <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2 operator *(Vector2 left, Vector2 right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector2 operator /(Vector2 vec, real_t divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector2"/>
+    /// by the components of the given <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector2 operator /(Vector2 vec, Vector2 divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector2"/>
+    /// with the components of the given <see cref="real_t"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(real_t)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector2(10, -20) % 7); // Prints "(3, -6)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector2 operator %(Vector2 vec, real_t divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector2"/>
+    /// with the components of the given <see cref="Vector2"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(Vector2)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector2(10, -20) % new Vector2(7, 8)); // Prints "(3, -4)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector2 operator %(Vector2 vec, Vector2 divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public static bool operator ==(Vector2 left, Vector2 right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector2 left, Vector2 right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector2"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector2 left, Vector2 right)
+    {
+        if (left.X == right.X)
         {
-            return new Vector2(Mathf.Round(X), Mathf.Round(Y));
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector2 Sign()
+    /// <summary>
+    /// Compares two <see cref="Vector2"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector2 left, Vector2 right)
+    {
+        if (left.X == right.X)
         {
-            Vector2 v;
-            v.X = Mathf.Sign(X);
-            v.Y = Mathf.Sign(Y);
-            return v;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Returns the result of the spherical linear interpolation between
-        /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
-        ///
-        /// This method also handles interpolating the lengths if the input vectors
-        /// have different lengths. For the special case of one or both input vectors
-        /// having zero length, this method behaves like <see cref="Lerp(Vector2, real_t)"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector2 Slerp(Vector2 to, real_t weight)
+    /// <summary>
+    /// Compares two <see cref="Vector2"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector2 left, Vector2 right)
+    {
+        if (left.X == right.X)
         {
-            real_t startLengthSquared = LengthSquared();
-            real_t endLengthSquared = to.LengthSquared();
-            if (startLengthSquared == 0.0 || endLengthSquared == 0.0)
-            {
-                // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
-                return Lerp(to, weight);
-            }
-            real_t startLength = Mathf.Sqrt(startLengthSquared);
-            real_t resultLength = Mathf.Lerp(startLength, Mathf.Sqrt(endLengthSquared), weight);
-            real_t angle = AngleTo(to);
-            return Rotated(angle * weight) * (resultLength / startLength);
+            return left.Y <= right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Returns this vector slid along a plane defined by the given <paramref name="normal"/>.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to slide on.</param>
-        /// <returns>The slid vector.</returns>
-        public readonly Vector2 Slide(Vector2 normal)
+    /// <summary>
+    /// Compares two <see cref="Vector2"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector2 left, Vector2 right)
+    {
+        if (left.X == right.X)
         {
-            return this - (normal * Dot(normal));
+            return left.Y >= right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
-        /// This can also be used to round to an arbitrary number of decimals.
-        /// </summary>
-        /// <param name="step">A vector value representing the step size to snap to.</param>
-        /// <returns>The snapped vector.</returns>
-        public readonly Vector2 Snapped(Vector2 step)
-        {
-            return new Vector2(Mathf.Snapped(X, step.X), Mathf.Snapped(Y, step.Y));
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector2 other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns a perpendicular vector rotated 90 degrees counter-clockwise
-        /// compared to the original, with the same length.
-        /// </summary>
-        /// <returns>The perpendicular vector.</returns>
-        public readonly Vector2 Orthogonal()
-        {
-            return new Vector2(Y, -X);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public readonly bool Equals(Vector2 other)
+    {
+        return X == other.X && Y == other.Y;
+    }
 
-        // Constants
-        private static readonly Vector2 _zero = new Vector2(0, 0);
-        private static readonly Vector2 _one = new Vector2(1, 1);
-        private static readonly Vector2 _inf = new Vector2(Mathf.Inf, Mathf.Inf);
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other vector to compare.</param>
+    /// <returns>Whether or not the vectors are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Vector2 other)
+    {
+        return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y);
+    }
 
-        private static readonly Vector2 _up = new Vector2(0, -1);
-        private static readonly Vector2 _down = new Vector2(0, 1);
-        private static readonly Vector2 _right = new Vector2(1, 0);
-        private static readonly Vector2 _left = new Vector2(-1, 0);
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector's values are approximately zero,
+    /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
+    /// This method is faster than using <see cref="IsEqualApprox"/> with one value
+    /// as a zero vector.
+    /// </summary>
+    /// <returns>Whether or not the vector is approximately zero.</returns>
+    public readonly bool IsZeroApprox()
+    {
+        return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y);
+    }
 
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(0, 0)</c>.</value>
-        public static Vector2 Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(1, 1)</c>.</value>
-        public static Vector2 One { get { return _one; } }
-        /// <summary>
-        /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(Mathf.Inf, Mathf.Inf)</c>.</value>
-        public static Vector2 Inf { get { return _inf; } }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector2"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode();
+    }
 
-        /// <summary>
-        /// Up unit vector. Y is down in 2D, so this vector points -Y.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(0, -1)</c>.</value>
-        public static Vector2 Up { get { return _up; } }
-        /// <summary>
-        /// Down unit vector. Y is down in 2D, so this vector points +Y.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(0, 1)</c>.</value>
-        public static Vector2 Down { get { return _down; } }
-        /// <summary>
-        /// Right unit vector. Represents the direction of right.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(1, 0)</c>.</value>
-        public static Vector2 Right { get { return _right; } }
-        /// <summary>
-        /// Left unit vector. Represents the direction of left.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2(-1, 0)</c>.</value>
-        public static Vector2 Left { get { return _left; } }
+    /// <summary>
+    /// Converts this <see cref="Vector2"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y})";
+    }
 
-        /// <summary>
-        /// Constructs a new <see cref="Vector2"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        public Vector2(real_t x, real_t y)
-        {
-            X = x;
-            Y = y;
-        }
-
-        /// <summary>
-        /// Creates a unit Vector2 rotated to the given angle. This is equivalent to doing
-        /// <c>Vector2(Mathf.Cos(angle), Mathf.Sin(angle))</c> or <c>Vector2.Right.Rotated(angle)</c>.
-        /// </summary>
-        /// <param name="angle">Angle of the vector, in radians.</param>
-        /// <returns>The resulting vector.</returns>
-        public static Vector2 FromAngle(real_t angle)
-        {
-            (real_t sin, real_t cos) = Mathf.SinCos(angle);
-            return new Vector2(cos, sin);
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector2"/>
-        /// with the components of the given <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector2 operator +(Vector2 left, Vector2 right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector2"/>
-        /// by the components of the given <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector2 operator -(Vector2 left, Vector2 right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector2"/>.
-        /// This is the same as writing <c>new Vector2(-v.X, -v.Y)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// With floats, the number zero can be either positive or negative.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector2 operator -(Vector2 vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2 operator *(Vector2 vec, real_t scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2 operator *(real_t scale, Vector2 vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2"/>
-        /// by the components of the given <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2 operator *(Vector2 left, Vector2 right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector2 operator /(Vector2 vec, real_t divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector2"/>
-        /// by the components of the given <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector2 operator /(Vector2 vec, Vector2 divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector2"/>
-        /// with the components of the given <see cref="real_t"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(real_t)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector2(10, -20) % 7); // Prints "(3, -6)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector2 operator %(Vector2 vec, real_t divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector2"/>
-        /// with the components of the given <see cref="Vector2"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(Vector2)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector2(10, -20) % new Vector2(7, 8)); // Prints "(3, -4)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector2 operator %(Vector2 vec, Vector2 divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public static bool operator ==(Vector2 left, Vector2 right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector2 left, Vector2 right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector2"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector2 left, Vector2 right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y < right.Y;
-            }
-            return left.X < right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector2"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector2 left, Vector2 right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y > right.Y;
-            }
-            return left.X > right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector2"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector2 left, Vector2 right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y <= right.Y;
-            }
-            return left.X < right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector2"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector2 left, Vector2 right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y >= right.Y;
-            }
-            return left.X > right.X;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector2 other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public readonly bool Equals(Vector2 other)
-        {
-            return X == other.X && Y == other.Y;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Vector2 other)
-        {
-            return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector's values are approximately zero,
-        /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
-        /// This method is faster than using <see cref="IsEqualApprox"/> with one value
-        /// as a zero vector.
-        /// </summary>
-        /// <returns>Whether or not the vector is approximately zero.</returns>
-        public readonly bool IsZeroApprox()
-        {
-            return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector2"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Vector2"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y})";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Vector2"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector2"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -1,566 +1,565 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 2-element structure that can be used to represent 2D grid coordinates or pairs of integers.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector2I : IEquatable<Vector2I>
 {
     /// <summary>
-    /// 2-element structure that can be used to represent 2D grid coordinates or pairs of integers.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2I : IEquatable<Vector2I>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public int X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public int Y;
+
+    /// <summary>
+    /// Access vector components using their index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0 or 1.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>.
+    /// </value>
+    public int this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public int X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public int Y;
-
-        /// <summary>
-        /// Access vector components using their index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0 or 1.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>.
-        /// </value>
-        public int this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out int x, out int y)
+        set
         {
-            x = X;
-            y = Y;
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
-        public readonly Vector2I Abs()
-        {
-            return new Vector2I(Mathf.Abs(X), Mathf.Abs(Y));
-        }
-
-        /// <summary>
-        /// Returns the aspect ratio of this vector, the ratio of <see cref="X"/> to <see cref="Y"/>.
-        /// </summary>
-        /// <returns>The <see cref="X"/> component divided by the <see cref="Y"/> component.</returns>
-        public readonly real_t Aspect()
-        {
-            return X / (real_t)Y;
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(int, int, int)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector2I Clamp(Vector2I min, Vector2I max)
-        {
-            return new Vector2I
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y)
-            );
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-
-            return Mathf.Sqrt(x2 + y2);
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly int LengthSquared()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-
-            return x2 + y2;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If both components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            return X < Y ? Axis.Y : Axis.X;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If both components are equal, this method returns <see cref="Axis.Y"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
-        {
-            return X < Y ? Axis.X : Axis.Y;
-        }
-
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(int)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector2I Sign()
-        {
-            Vector2I v = this;
-            v.X = Mathf.Sign(v.X);
-            v.Y = Mathf.Sign(v.Y);
-            return v;
-        }
-
-        // Constants
-        private static readonly Vector2I _zero = new Vector2I(0, 0);
-        private static readonly Vector2I _one = new Vector2I(1, 1);
-
-        private static readonly Vector2I _up = new Vector2I(0, -1);
-        private static readonly Vector2I _down = new Vector2I(0, 1);
-        private static readonly Vector2I _right = new Vector2I(1, 0);
-        private static readonly Vector2I _left = new Vector2I(-1, 0);
-
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(0, 0)</c>.</value>
-        public static Vector2I Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(1, 1)</c>.</value>
-        public static Vector2I One { get { return _one; } }
-
-        /// <summary>
-        /// Up unit vector. Y is down in 2D, so this vector points -Y.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(0, -1)</c>.</value>
-        public static Vector2I Up { get { return _up; } }
-        /// <summary>
-        /// Down unit vector. Y is down in 2D, so this vector points +Y.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(0, 1)</c>.</value>
-        public static Vector2I Down { get { return _down; } }
-        /// <summary>
-        /// Right unit vector. Represents the direction of right.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(1, 0)</c>.</value>
-        public static Vector2I Right { get { return _right; } }
-        /// <summary>
-        /// Left unit vector. Represents the direction of left.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector2I(-1, 0)</c>.</value>
-        public static Vector2I Left { get { return _left; } }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector2I"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        public Vector2I(int x, int y)
-        {
-            X = x;
-            Y = y;
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector2I"/>
-        /// with the components of the given <see cref="Vector2I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector2I operator +(Vector2I left, Vector2I right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector2I"/>
-        /// by the components of the given <see cref="Vector2I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector2I operator -(Vector2I left, Vector2I right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector2I"/>.
-        /// This is the same as writing <c>new Vector2I(-v.X, -v.Y)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector2I operator -(Vector2I vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2I operator *(Vector2I vec, int scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2I operator *(int scale, Vector2I vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector2I"/>
-        /// by the components of the given <see cref="Vector2I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector2I operator *(Vector2I left, Vector2I right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector2I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector2I operator /(Vector2I vec, int divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector2I"/>
-        /// by the components of the given <see cref="Vector2I"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector2I operator /(Vector2I vec, Vector2I divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector2I"/>
-        /// with the components of the given <see langword="int"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector2I(10, -20) % 7); // Prints "(3, -6)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector2I operator %(Vector2I vec, int divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector2I"/>
-        /// with the components of the given <see cref="Vector2I"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector2I(10, -20) % new Vector2I(7, 8)); // Prints "(3, -4)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector2I operator %(Vector2I vec, Vector2I divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public static bool operator ==(Vector2I left, Vector2I right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector2I left, Vector2I right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector2I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector2I left, Vector2I right)
-        {
-            if (left.X == right.X)
+            switch (index)
             {
-                return left.Y < right.Y;
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
-            return left.X < right.X;
         }
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector2I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector2I left, Vector2I right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y > right.Y;
-            }
-            return left.X > right.X;
-        }
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out int x, out int y)
+    {
+        x = X;
+        y = Y;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector2I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector2I left, Vector2I right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y <= right.Y;
-            }
-            return left.X < right.X;
-        }
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
+    public readonly Vector2I Abs()
+    {
+        return new Vector2I(Mathf.Abs(X), Mathf.Abs(Y));
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector2I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector2I left, Vector2I right)
-        {
-            if (left.X == right.X)
-            {
-                return left.Y >= right.Y;
-            }
-            return left.X > right.X;
-        }
+    /// <summary>
+    /// Returns the aspect ratio of this vector, the ratio of <see cref="X"/> to <see cref="Y"/>.
+    /// </summary>
+    /// <returns>The <see cref="X"/> component divided by the <see cref="Y"/> component.</returns>
+    public readonly real_t Aspect()
+    {
+        return X / (real_t)Y;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector2I"/> to a <see cref="Vector2"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static implicit operator Vector2(Vector2I value)
-        {
-            return new Vector2(value.X, value.Y);
-        }
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(int, int, int)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector2I Clamp(Vector2I min, Vector2I max)
+    {
+        return new Vector2I
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y)
+        );
+    }
 
-        /// <summary>
-        /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/> by truncating
-        /// components' fractional parts (rounding towards zero). For a different
-        /// behavior consider passing the result of <see cref="Vector2.Ceil"/>,
-        /// <see cref="Vector2.Floor"/> or <see cref="Vector2.Round"/> to this conversion operator instead.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector2I(Vector2 value)
-        {
-            return new Vector2I((int)value.X, (int)value.Y);
-        }
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is equal
-        /// to the given object (<see paramref="obj"/>).
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector2I other && Equals(other);
-        }
+        return Mathf.Sqrt(x2 + y2);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public readonly bool Equals(Vector2I other)
-        {
-            return X == other.X && Y == other.Y;
-        }
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly int LengthSquared()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector2I"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode();
-        }
+        return x2 + y2;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector2I"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y})";
-        }
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If both components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        return X < Y ? Axis.Y : Axis.X;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector2I"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If both components are equal, this method returns <see cref="Axis.Y"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        return X < Y ? Axis.X : Axis.Y;
+    }
+
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(int)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector2I Sign()
+    {
+        Vector2I v = this;
+        v.X = Mathf.Sign(v.X);
+        v.Y = Mathf.Sign(v.Y);
+        return v;
+    }
+
+    // Constants
+    private static readonly Vector2I _zero = new Vector2I(0, 0);
+    private static readonly Vector2I _one = new Vector2I(1, 1);
+
+    private static readonly Vector2I _up = new Vector2I(0, -1);
+    private static readonly Vector2I _down = new Vector2I(0, 1);
+    private static readonly Vector2I _right = new Vector2I(1, 0);
+    private static readonly Vector2I _left = new Vector2I(-1, 0);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(0, 0)</c>.</value>
+    public static Vector2I Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(1, 1)</c>.</value>
+    public static Vector2I One { get { return _one; } }
+
+    /// <summary>
+    /// Up unit vector. Y is down in 2D, so this vector points -Y.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(0, -1)</c>.</value>
+    public static Vector2I Up { get { return _up; } }
+    /// <summary>
+    /// Down unit vector. Y is down in 2D, so this vector points +Y.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(0, 1)</c>.</value>
+    public static Vector2I Down { get { return _down; } }
+    /// <summary>
+    /// Right unit vector. Represents the direction of right.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(1, 0)</c>.</value>
+    public static Vector2I Right { get { return _right; } }
+    /// <summary>
+    /// Left unit vector. Represents the direction of left.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector2I(-1, 0)</c>.</value>
+    public static Vector2I Left { get { return _left; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector2I"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    public Vector2I(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector2I"/>
+    /// with the components of the given <see cref="Vector2I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector2I operator +(Vector2I left, Vector2I right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector2I"/>
+    /// by the components of the given <see cref="Vector2I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector2I operator -(Vector2I left, Vector2I right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector2I"/>.
+    /// This is the same as writing <c>new Vector2I(-v.X, -v.Y)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector2I operator -(Vector2I vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2I operator *(Vector2I vec, int scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2I operator *(int scale, Vector2I vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector2I"/>
+    /// by the components of the given <see cref="Vector2I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector2I operator *(Vector2I left, Vector2I right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector2I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector2I operator /(Vector2I vec, int divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector2I"/>
+    /// by the components of the given <see cref="Vector2I"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector2I operator /(Vector2I vec, Vector2I divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector2I"/>
+    /// with the components of the given <see langword="int"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector2I(10, -20) % 7); // Prints "(3, -6)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector2I operator %(Vector2I vec, int divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector2I"/>
+    /// with the components of the given <see cref="Vector2I"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector2I(10, -20) % new Vector2I(7, 8)); // Prints "(3, -4)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector2I operator %(Vector2I vec, Vector2I divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public static bool operator ==(Vector2I left, Vector2I right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector2I left, Vector2I right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector2I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector2I left, Vector2I right)
+    {
+        if (left.X == right.X)
         {
-            return $"({X.ToString(format)}, {Y.ToString(format)})";
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector2I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector2I left, Vector2I right)
+    {
+        if (left.X == right.X)
+        {
+            return left.Y > right.Y;
+        }
+        return left.X > right.X;
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector2I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector2I left, Vector2I right)
+    {
+        if (left.X == right.X)
+        {
+            return left.Y <= right.Y;
+        }
+        return left.X < right.X;
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector2I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector2I left, Vector2I right)
+    {
+        if (left.X == right.X)
+        {
+            return left.Y >= right.Y;
+        }
+        return left.X > right.X;
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Vector2I"/> to a <see cref="Vector2"/>.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static implicit operator Vector2(Vector2I value)
+    {
+        return new Vector2(value.X, value.Y);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="Vector2"/> to a <see cref="Vector2I"/> by truncating
+    /// components' fractional parts (rounding towards zero). For a different
+    /// behavior consider passing the result of <see cref="Vector2.Ceil"/>,
+    /// <see cref="Vector2.Floor"/> or <see cref="Vector2.Round"/> to this conversion operator instead.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static explicit operator Vector2I(Vector2 value)
+    {
+        return new Vector2I((int)value.X, (int)value.Y);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is equal
+    /// to the given object (<see paramref="obj"/>).
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector2I other && Equals(other);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public readonly bool Equals(Vector2I other)
+    {
+        return X == other.X && Y == other.Y;
+    }
+
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector2I"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode();
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Vector2I"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y})";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Vector2I"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -1,1126 +1,1125 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 3-element structure that can be used to represent positions in 3D space or any other pair of numeric values.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector3 : IEquatable<Vector3>
 {
     /// <summary>
-    /// 3-element structure that can be used to represent positions in 3D space or any other pair of numeric values.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3 : IEquatable<Vector3>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y,
+        /// <summary>
+        /// The vector's Z axis.
+        /// </summary>
+        Z
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public real_t X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public real_t Y;
+
+    /// <summary>
+    /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
+    /// </summary>
+    public real_t Z;
+
+    /// <summary>
+    /// Access vector components using their index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0, 1 or 2.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>,
+    /// <c>[2]</c> is equivalent to <see cref="Z"/>.
+    /// </value>
+    public real_t this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y,
-            /// <summary>
-            /// The vector's Z axis.
-            /// </summary>
-            Z
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public real_t X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public real_t Y;
-
-        /// <summary>
-        /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
-        /// </summary>
-        public real_t Z;
-
-        /// <summary>
-        /// Access vector components using their index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0, 1 or 2.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>,
-        /// <c>[2]</c> is equivalent to <see cref="Z"/>.
-        /// </value>
-        public real_t this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Z = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Z;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out real_t x, out real_t y, out real_t z)
+        set
         {
-            x = X;
-            y = Y;
-            z = Z;
-        }
-
-        internal void Normalize()
-        {
-            real_t lengthsq = LengthSquared();
-
-            if (lengthsq == 0)
+            switch (index)
             {
-                X = Y = Z = 0f;
-            }
-            else
-            {
-                real_t length = Mathf.Sqrt(lengthsq);
-                X /= length;
-                Y /= length;
-                Z /= length;
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Z = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
-        public readonly Vector3 Abs()
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out real_t x, out real_t y, out real_t z)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+    }
+
+    internal void Normalize()
+    {
+        real_t lengthsq = LengthSquared();
+
+        if (lengthsq == 0)
         {
-            return new Vector3(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z));
+            X = Y = Z = 0f;
+        }
+        else
+        {
+            real_t length = Mathf.Sqrt(lengthsq);
+            X /= length;
+            Y /= length;
+            Z /= length;
+        }
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
+    public readonly Vector3 Abs()
+    {
+        return new Vector3(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z));
+    }
+
+    /// <summary>
+    /// Returns the unsigned minimum angle to the given vector, in radians.
+    /// </summary>
+    /// <param name="to">The other vector to compare this vector to.</param>
+    /// <returns>The unsigned angle between the two vectors, in radians.</returns>
+    public readonly real_t AngleTo(Vector3 to)
+    {
+        return Mathf.Atan2(Cross(to).Length(), Dot(to));
+    }
+
+    /// <summary>
+    /// Returns this vector "bounced off" from a plane defined by the given normal.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to bounce off. Must be normalized.</param>
+    /// <returns>The bounced vector.</returns>
+    public readonly Vector3 Bounce(Vector3 normal)
+    {
+        return -Reflect(normal);
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded up (towards positive infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
+    public readonly Vector3 Ceil()
+    {
+        return new Vector3(Mathf.Ceil(X), Mathf.Ceil(Y), Mathf.Ceil(Z));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector3 Clamp(Vector3 min, Vector3 max)
+    {
+        return new Vector3
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y),
+            Mathf.Clamp(Z, min.Z, max.Z)
+        );
+    }
+
+    /// <summary>
+    /// Returns the cross product of this vector and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector.</param>
+    /// <returns>The cross product vector.</returns>
+    public readonly Vector3 Cross(Vector3 with)
+    {
+        return new Vector3
+        (
+            (Y * with.Z) - (Z * with.Y),
+            (Z * with.X) - (X * with.Z),
+            (X * with.Y) - (Y * with.X)
+        );
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector3 CubicInterpolate(Vector3 b, Vector3 preA, Vector3 postB, real_t weight)
+    {
+        return new Vector3
+        (
+            Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
+            Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight),
+            Mathf.CubicInterpolate(Z, b.Z, preA.Z, postB.Z, weight)
+        );
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="t"></param>
+    /// <param name="preAT"></param>
+    /// <param name="postBT"></param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector3 CubicInterpolateInTime(Vector3 b, Vector3 preA, Vector3 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+    {
+        return new Vector3
+        (
+            Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(Z, b.Z, preA.Z, postB.Z, weight, t, preAT, postBT)
+        );
+    }
+
+    /// <summary>
+    /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
+    /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination vector.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector3 BezierInterpolate(Vector3 control1, Vector3 control2, Vector3 end, real_t t)
+    {
+        return new Vector3
+        (
+            Mathf.BezierInterpolate(X, control1.X, control2.X, end.X, t),
+            Mathf.BezierInterpolate(Y, control1.Y, control2.Y, end.Y, t),
+            Mathf.BezierInterpolate(Z, control1.Z, control2.Z, end.Z, t)
+        );
+    }
+
+    /// <summary>
+    /// Returns the derivative at the given <paramref name="t"/> on the Bezier curve defined by this vector
+    /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
+    /// </summary>
+    /// <param name="control1">Control point that defines the bezier curve.</param>
+    /// <param name="control2">Control point that defines the bezier curve.</param>
+    /// <param name="end">The destination value for the interpolation.</param>
+    /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting value of the interpolation.</returns>
+    public readonly Vector3 BezierDerivative(Vector3 control1, Vector3 control2, Vector3 end, real_t t)
+    {
+        return new Vector3(
+            Mathf.BezierDerivative(X, control1.X, control2.X, end.X, t),
+            Mathf.BezierDerivative(Y, control1.Y, control2.Y, end.Y, t),
+            Mathf.BezierDerivative(Z, control1.Z, control2.Z, end.Y, t)
+        );
+    }
+
+    /// <summary>
+    /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
+    /// </summary>
+    /// <param name="to">The other vector to point towards.</param>
+    /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
+    public readonly Vector3 DirectionTo(Vector3 to)
+    {
+        return new Vector3(to.X - X, to.Y - Y, to.Z - Z).Normalized();
+    }
+
+    /// <summary>
+    /// Returns the squared distance between this vector and <paramref name="to"/>.
+    /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+    /// you need to compare vectors or need the squared distance for some formula.
+    /// </summary>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The squared distance between the two vectors.</returns>
+    public readonly real_t DistanceSquaredTo(Vector3 to)
+    {
+        return (to - this).LengthSquared();
+    }
+
+    /// <summary>
+    /// Returns the distance between this vector and <paramref name="to"/>.
+    /// </summary>
+    /// <seealso cref="DistanceSquaredTo(Vector3)"/>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The distance between the two vectors.</returns>
+    public readonly real_t DistanceTo(Vector3 to)
+    {
+        return (to - this).Length();
+    }
+
+    /// <summary>
+    /// Returns the dot product of this vector and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector to use.</param>
+    /// <returns>The dot product of the two vectors.</returns>
+    public readonly real_t Dot(Vector3 with)
+    {
+        return (X * with.X) + (Y * with.Y) + (Z * with.Z);
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded down (towards negative infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
+    public readonly Vector3 Floor()
+    {
+        return new Vector3(Mathf.Floor(X), Mathf.Floor(Y), Mathf.Floor(Z));
+    }
+
+    /// <summary>
+    /// Returns the inverse of this vector. This is the same as <c>new Vector3(1 / v.X, 1 / v.Y, 1 / v.Z)</c>.
+    /// </summary>
+    /// <returns>The inverse of this vector.</returns>
+    public readonly Vector3 Inverse()
+    {
+        return new Vector3(1 / X, 1 / Y, 1 / Z);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
+    /// </summary>
+    /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
+    public readonly bool IsNormalized()
+    {
+        return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
+    }
+
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        real_t x2 = X * X;
+        real_t y2 = Y * Y;
+        real_t z2 = Z * Z;
+
+        return Mathf.Sqrt(x2 + y2 + z2);
+    }
+
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly real_t LengthSquared()
+    {
+        real_t x2 = X * X;
+        real_t y2 = Y * Y;
+        real_t z2 = Z * Z;
+
+        return x2 + y2 + z2;
+    }
+
+    /// <summary>
+    /// Returns the result of the linear interpolation between
+    /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="to">The destination vector for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting vector of the interpolation.</returns>
+    public readonly Vector3 Lerp(Vector3 to, real_t weight)
+    {
+        return new Vector3
+        (
+            Mathf.Lerp(X, to.X, weight),
+            Mathf.Lerp(Y, to.Y, weight),
+            Mathf.Lerp(Z, to.Z, weight)
+        );
+    }
+
+    /// <summary>
+    /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
+    /// </summary>
+    /// <param name="length">The length to limit to.</param>
+    /// <returns>The vector with its length limited.</returns>
+    public readonly Vector3 LimitLength(real_t length = 1.0f)
+    {
+        Vector3 v = this;
+        real_t l = Length();
+
+        if (l > 0 && length < l)
+        {
+            v /= l;
+            v *= length;
         }
 
-        /// <summary>
-        /// Returns the unsigned minimum angle to the given vector, in radians.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <returns>The unsigned angle between the two vectors, in radians.</returns>
-        public readonly real_t AngleTo(Vector3 to)
-        {
-            return Mathf.Atan2(Cross(to).Length(), Dot(to));
-        }
+        return v;
+    }
 
-        /// <summary>
-        /// Returns this vector "bounced off" from a plane defined by the given normal.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to bounce off. Must be normalized.</param>
-        /// <returns>The bounced vector.</returns>
-        public readonly Vector3 Bounce(Vector3 normal)
-        {
-            return -Reflect(normal);
-        }
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        return X < Y ? (Y < Z ? Axis.Z : Axis.Y) : (X < Z ? Axis.Z : Axis.X);
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components rounded up (towards positive infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
-        public readonly Vector3 Ceil()
-        {
-            return new Vector3(Mathf.Ceil(X), Mathf.Ceil(Y), Mathf.Ceil(Z));
-        }
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.Z"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        return X < Y ? (X < Z ? Axis.X : Axis.Z) : (Y < Z ? Axis.Y : Axis.Z);
+    }
 
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector3 Clamp(Vector3 min, Vector3 max)
-        {
-            return new Vector3
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y),
-                Mathf.Clamp(Z, min.Z, max.Z)
-            );
-        }
+    /// <summary>
+    /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
+    /// </summary>
+    /// <param name="to">The vector to move towards.</param>
+    /// <param name="delta">The amount to move towards by.</param>
+    /// <returns>The resulting vector.</returns>
+    public readonly Vector3 MoveToward(Vector3 to, real_t delta)
+    {
+        Vector3 v = this;
+        Vector3 vd = to - v;
+        real_t len = vd.Length();
+        if (len <= delta || len < Mathf.Epsilon)
+            return to;
 
-        /// <summary>
-        /// Returns the cross product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector.</param>
-        /// <returns>The cross product vector.</returns>
-        public readonly Vector3 Cross(Vector3 with)
-        {
-            return new Vector3
-            (
-                (Y * with.Z) - (Z * with.Y),
-                (Z * with.X) - (X * with.Z),
-                (X * with.Y) - (Y * with.X)
-            );
-        }
+        return v + (vd / len * delta);
+    }
 
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector3 CubicInterpolate(Vector3 b, Vector3 preA, Vector3 postB, real_t weight)
-        {
-            return new Vector3
-            (
-                Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
-                Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight),
-                Mathf.CubicInterpolate(Z, b.Z, preA.Z, postB.Z, weight)
-            );
-        }
+    /// <summary>
+    /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+    /// </summary>
+    /// <returns>A normalized version of the vector.</returns>
+    public readonly Vector3 Normalized()
+    {
+        Vector3 v = this;
+        v.Normalize();
+        return v;
+    }
 
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="t"></param>
-        /// <param name="preAT"></param>
-        /// <param name="postBT"></param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector3 CubicInterpolateInTime(Vector3 b, Vector3 preA, Vector3 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
-        {
-            return new Vector3
-            (
-                Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(Z, b.Z, preA.Z, postB.Z, weight, t, preAT, postBT)
-            );
-        }
+    /// <summary>
+    /// Returns the outer product with <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector.</param>
+    /// <returns>A <see cref="Basis"/> representing the outer product matrix.</returns>
+    public readonly Basis Outer(Vector3 with)
+    {
+        return new Basis(
+            X * with.X, X * with.Y, X * with.Z,
+            Y * with.X, Y * with.Y, Y * with.Z,
+            Z * with.X, Z * with.Y, Z * with.Z
+        );
+    }
 
-        /// <summary>
-        /// Returns the point at the given <paramref name="t"/> on a one-dimensional Bezier curve defined by this vector
-        /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination vector.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector3 BezierInterpolate(Vector3 control1, Vector3 control2, Vector3 end, real_t t)
-        {
-            return new Vector3
-            (
-                Mathf.BezierInterpolate(X, control1.X, control2.X, end.X, t),
-                Mathf.BezierInterpolate(Y, control1.Y, control2.Y, end.Y, t),
-                Mathf.BezierInterpolate(Z, control1.Z, control2.Z, end.Z, t)
-            );
-        }
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="mod"/>.
+    /// </summary>
+    /// <param name="mod">A value representing the divisor of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
+    /// </returns>
+    public readonly Vector3 PosMod(real_t mod)
+    {
+        Vector3 v;
+        v.X = Mathf.PosMod(X, mod);
+        v.Y = Mathf.PosMod(Y, mod);
+        v.Z = Mathf.PosMod(Z, mod);
+        return v;
+    }
 
-        /// <summary>
-        /// Returns the derivative at the given <paramref name="t"/> on the Bezier curve defined by this vector
-        /// and the given <paramref name="control1"/>, <paramref name="control2"/>, and <paramref name="end"/> points.
-        /// </summary>
-        /// <param name="control1">Control point that defines the bezier curve.</param>
-        /// <param name="control2">Control point that defines the bezier curve.</param>
-        /// <param name="end">The destination value for the interpolation.</param>
-        /// <param name="t">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting value of the interpolation.</returns>
-        public readonly Vector3 BezierDerivative(Vector3 control1, Vector3 control2, Vector3 end, real_t t)
-        {
-            return new Vector3(
-                Mathf.BezierDerivative(X, control1.X, control2.X, end.X, t),
-                Mathf.BezierDerivative(Y, control1.Y, control2.Y, end.Y, t),
-                Mathf.BezierDerivative(Z, control1.Z, control2.Z, end.Y, t)
-            );
-        }
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="modv"/>'s components.
+    /// </summary>
+    /// <param name="modv">A vector representing the divisors of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
+    /// </returns>
+    public readonly Vector3 PosMod(Vector3 modv)
+    {
+        Vector3 v;
+        v.X = Mathf.PosMod(X, modv.X);
+        v.Y = Mathf.PosMod(Y, modv.Y);
+        v.Z = Mathf.PosMod(Z, modv.Z);
+        return v;
+    }
 
-        /// <summary>
-        /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to point towards.</param>
-        /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
-        public readonly Vector3 DirectionTo(Vector3 to)
-        {
-            return new Vector3(to.X - X, to.Y - Y, to.Z - Z).Normalized();
-        }
+    /// <summary>
+    /// Returns this vector projected onto another vector <paramref name="onNormal"/>.
+    /// </summary>
+    /// <param name="onNormal">The vector to project onto.</param>
+    /// <returns>The projected vector.</returns>
+    public readonly Vector3 Project(Vector3 onNormal)
+    {
+        return onNormal * (Dot(onNormal) / onNormal.LengthSquared());
+    }
 
-        /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="to"/>.
-        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
-        /// you need to compare vectors or need the squared distance for some formula.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The squared distance between the two vectors.</returns>
-        public readonly real_t DistanceSquaredTo(Vector3 to)
-        {
-            return (to - this).LengthSquared();
-        }
-
-        /// <summary>
-        /// Returns the distance between this vector and <paramref name="to"/>.
-        /// </summary>
-        /// <seealso cref="DistanceSquaredTo(Vector3)"/>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The distance between the two vectors.</returns>
-        public readonly real_t DistanceTo(Vector3 to)
-        {
-            return (to - this).Length();
-        }
-
-        /// <summary>
-        /// Returns the dot product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector to use.</param>
-        /// <returns>The dot product of the two vectors.</returns>
-        public readonly real_t Dot(Vector3 with)
-        {
-            return (X * with.X) + (Y * with.Y) + (Z * with.Z);
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components rounded down (towards negative infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
-        public readonly Vector3 Floor()
-        {
-            return new Vector3(Mathf.Floor(X), Mathf.Floor(Y), Mathf.Floor(Z));
-        }
-
-        /// <summary>
-        /// Returns the inverse of this vector. This is the same as <c>new Vector3(1 / v.X, 1 / v.Y, 1 / v.Z)</c>.
-        /// </summary>
-        /// <returns>The inverse of this vector.</returns>
-        public readonly Vector3 Inverse()
-        {
-            return new Vector3(1 / X, 1 / Y, 1 / Z);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
-        /// </summary>
-        /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
-        public readonly bool IsNormalized()
-        {
-            return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            real_t x2 = X * X;
-            real_t y2 = Y * Y;
-            real_t z2 = Z * Z;
-
-            return Mathf.Sqrt(x2 + y2 + z2);
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly real_t LengthSquared()
-        {
-            real_t x2 = X * X;
-            real_t y2 = Y * Y;
-            real_t z2 = Z * Z;
-
-            return x2 + y2 + z2;
-        }
-
-        /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector3 Lerp(Vector3 to, real_t weight)
-        {
-            return new Vector3
-            (
-                Mathf.Lerp(X, to.X, weight),
-                Mathf.Lerp(Y, to.Y, weight),
-                Mathf.Lerp(Z, to.Z, weight)
-            );
-        }
-
-        /// <summary>
-        /// Returns the vector with a maximum length by limiting its length to <paramref name="length"/>.
-        /// </summary>
-        /// <param name="length">The length to limit to.</param>
-        /// <returns>The vector with its length limited.</returns>
-        public readonly Vector3 LimitLength(real_t length = 1.0f)
-        {
-            Vector3 v = this;
-            real_t l = Length();
-
-            if (l > 0 && length < l)
-            {
-                v /= l;
-                v *= length;
-            }
-
-            return v;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            return X < Y ? (Y < Z ? Axis.Z : Axis.Y) : (X < Z ? Axis.Z : Axis.X);
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.Z"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
-        {
-            return X < Y ? (X < Z ? Axis.X : Axis.Z) : (Y < Z ? Axis.Y : Axis.Z);
-        }
-
-        /// <summary>
-        /// Moves this vector toward <paramref name="to"/> by the fixed <paramref name="delta"/> amount.
-        /// </summary>
-        /// <param name="to">The vector to move towards.</param>
-        /// <param name="delta">The amount to move towards by.</param>
-        /// <returns>The resulting vector.</returns>
-        public readonly Vector3 MoveToward(Vector3 to, real_t delta)
-        {
-            Vector3 v = this;
-            Vector3 vd = to - v;
-            real_t len = vd.Length();
-            if (len <= delta || len < Mathf.Epsilon)
-                return to;
-
-            return v + (vd / len * delta);
-        }
-
-        /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
-        /// </summary>
-        /// <returns>A normalized version of the vector.</returns>
-        public readonly Vector3 Normalized()
-        {
-            Vector3 v = this;
-            v.Normalize();
-            return v;
-        }
-
-        /// <summary>
-        /// Returns the outer product with <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector.</param>
-        /// <returns>A <see cref="Basis"/> representing the outer product matrix.</returns>
-        public readonly Basis Outer(Vector3 with)
-        {
-            return new Basis(
-                X * with.X, X * with.Y, X * with.Z,
-                Y * with.X, Y * with.Y, Y * with.Z,
-                Z * with.X, Z * with.Y, Z * with.Z
-            );
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="mod"/>.
-        /// </summary>
-        /// <param name="mod">A value representing the divisor of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
-        /// </returns>
-        public readonly Vector3 PosMod(real_t mod)
-        {
-            Vector3 v;
-            v.X = Mathf.PosMod(X, mod);
-            v.Y = Mathf.PosMod(Y, mod);
-            v.Z = Mathf.PosMod(Z, mod);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="modv"/>'s components.
-        /// </summary>
-        /// <param name="modv">A vector representing the divisors of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
-        /// </returns>
-        public readonly Vector3 PosMod(Vector3 modv)
-        {
-            Vector3 v;
-            v.X = Mathf.PosMod(X, modv.X);
-            v.Y = Mathf.PosMod(Y, modv.Y);
-            v.Z = Mathf.PosMod(Z, modv.Z);
-            return v;
-        }
-
-        /// <summary>
-        /// Returns this vector projected onto another vector <paramref name="onNormal"/>.
-        /// </summary>
-        /// <param name="onNormal">The vector to project onto.</param>
-        /// <returns>The projected vector.</returns>
-        public readonly Vector3 Project(Vector3 onNormal)
-        {
-            return onNormal * (Dot(onNormal) / onNormal.LengthSquared());
-        }
-
-        /// <summary>
-        /// Returns this vector reflected from a plane defined by the given <paramref name="normal"/>.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to reflect from. Must be normalized.</param>
-        /// <returns>The reflected vector.</returns>
-        public readonly Vector3 Reflect(Vector3 normal)
-        {
+    /// <summary>
+    /// Returns this vector reflected from a plane defined by the given <paramref name="normal"/>.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to reflect from. Must be normalized.</param>
+    /// <returns>The reflected vector.</returns>
+    public readonly Vector3 Reflect(Vector3 normal)
+    {
 #if DEBUG
-            if (!normal.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized.", nameof(normal));
-            }
-#endif
-            return (2.0f * Dot(normal) * normal) - this;
-        }
-
-        /// <summary>
-        /// Rotates this vector around a given <paramref name="axis"/> vector by <paramref name="angle"/> (in radians).
-        /// The <paramref name="axis"/> vector must be a normalized vector.
-        /// </summary>
-        /// <param name="axis">The vector to rotate around. Must be normalized.</param>
-        /// <param name="angle">The angle to rotate by, in radians.</param>
-        /// <returns>The rotated vector.</returns>
-        public readonly Vector3 Rotated(Vector3 axis, real_t angle)
+        if (!normal.IsNormalized())
         {
+            throw new ArgumentException("Argument is not normalized.", nameof(normal));
+        }
+#endif
+        return (2.0f * Dot(normal) * normal) - this;
+    }
+
+    /// <summary>
+    /// Rotates this vector around a given <paramref name="axis"/> vector by <paramref name="angle"/> (in radians).
+    /// The <paramref name="axis"/> vector must be a normalized vector.
+    /// </summary>
+    /// <param name="axis">The vector to rotate around. Must be normalized.</param>
+    /// <param name="angle">The angle to rotate by, in radians.</param>
+    /// <returns>The rotated vector.</returns>
+    public readonly Vector3 Rotated(Vector3 axis, real_t angle)
+    {
 #if DEBUG
-            if (!axis.IsNormalized())
-            {
-                throw new ArgumentException("Argument is not normalized.", nameof(axis));
-            }
+        if (!axis.IsNormalized())
+        {
+            throw new ArgumentException("Argument is not normalized.", nameof(axis));
+        }
 #endif
-            return new Basis(axis, angle) * this;
-        }
+        return new Basis(axis, angle) * this;
+    }
 
-        /// <summary>
-        /// Returns this vector with all components rounded to the nearest integer,
-        /// with halfway cases rounded towards the nearest multiple of two.
-        /// </summary>
-        /// <returns>The rounded vector.</returns>
-        public readonly Vector3 Round()
-        {
-            return new Vector3(Mathf.Round(X), Mathf.Round(Y), Mathf.Round(Z));
-        }
+    /// <summary>
+    /// Returns this vector with all components rounded to the nearest integer,
+    /// with halfway cases rounded towards the nearest multiple of two.
+    /// </summary>
+    /// <returns>The rounded vector.</returns>
+    public readonly Vector3 Round()
+    {
+        return new Vector3(Mathf.Round(X), Mathf.Round(Y), Mathf.Round(Z));
+    }
 
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector3 Sign()
-        {
-            Vector3 v;
-            v.X = Mathf.Sign(X);
-            v.Y = Mathf.Sign(Y);
-            v.Z = Mathf.Sign(Z);
-            return v;
-        }
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector3 Sign()
+    {
+        Vector3 v;
+        v.X = Mathf.Sign(X);
+        v.Y = Mathf.Sign(Y);
+        v.Z = Mathf.Sign(Z);
+        return v;
+    }
 
-        /// <summary>
-        /// Returns the signed angle to the given vector, in radians.
-        /// The sign of the angle is positive in a counter-clockwise
-        /// direction and negative in a clockwise direction when viewed
-        /// from the side specified by the <paramref name="axis"/>.
-        /// </summary>
-        /// <param name="to">The other vector to compare this vector to.</param>
-        /// <param name="axis">The reference axis to use for the angle sign.</param>
-        /// <returns>The signed angle between the two vectors, in radians.</returns>
-        public readonly real_t SignedAngleTo(Vector3 to, Vector3 axis)
-        {
-            Vector3 crossTo = Cross(to);
-            real_t unsignedAngle = Mathf.Atan2(crossTo.Length(), Dot(to));
-            real_t sign = crossTo.Dot(axis);
-            return (sign < 0) ? -unsignedAngle : unsignedAngle;
-        }
+    /// <summary>
+    /// Returns the signed angle to the given vector, in radians.
+    /// The sign of the angle is positive in a counter-clockwise
+    /// direction and negative in a clockwise direction when viewed
+    /// from the side specified by the <paramref name="axis"/>.
+    /// </summary>
+    /// <param name="to">The other vector to compare this vector to.</param>
+    /// <param name="axis">The reference axis to use for the angle sign.</param>
+    /// <returns>The signed angle between the two vectors, in radians.</returns>
+    public readonly real_t SignedAngleTo(Vector3 to, Vector3 axis)
+    {
+        Vector3 crossTo = Cross(to);
+        real_t unsignedAngle = Mathf.Atan2(crossTo.Length(), Dot(to));
+        real_t sign = crossTo.Dot(axis);
+        return (sign < 0) ? -unsignedAngle : unsignedAngle;
+    }
 
-        /// <summary>
-        /// Returns the result of the spherical linear interpolation between
-        /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
-        ///
-        /// This method also handles interpolating the lengths if the input vectors
-        /// have different lengths. For the special case of one or both input vectors
-        /// having zero length, this method behaves like <see cref="Lerp(Vector3, real_t)"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector3 Slerp(Vector3 to, real_t weight)
+    /// <summary>
+    /// Returns the result of the spherical linear interpolation between
+    /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
+    ///
+    /// This method also handles interpolating the lengths if the input vectors
+    /// have different lengths. For the special case of one or both input vectors
+    /// having zero length, this method behaves like <see cref="Lerp(Vector3, real_t)"/>.
+    /// </summary>
+    /// <param name="to">The destination vector for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting vector of the interpolation.</returns>
+    public readonly Vector3 Slerp(Vector3 to, real_t weight)
+    {
+        real_t startLengthSquared = LengthSquared();
+        real_t endLengthSquared = to.LengthSquared();
+        if (startLengthSquared == 0.0 || endLengthSquared == 0.0)
         {
-            real_t startLengthSquared = LengthSquared();
-            real_t endLengthSquared = to.LengthSquared();
-            if (startLengthSquared == 0.0 || endLengthSquared == 0.0)
+            // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
+            return Lerp(to, weight);
+        }
+        real_t startLength = Mathf.Sqrt(startLengthSquared);
+        real_t resultLength = Mathf.Lerp(startLength, Mathf.Sqrt(endLengthSquared), weight);
+        real_t angle = AngleTo(to);
+        return Rotated(Cross(to).Normalized(), angle * weight) * (resultLength / startLength);
+    }
+
+    /// <summary>
+    /// Returns this vector slid along a plane defined by the given <paramref name="normal"/>.
+    /// </summary>
+    /// <param name="normal">The normal vector defining the plane to slide on.</param>
+    /// <returns>The slid vector.</returns>
+    public readonly Vector3 Slide(Vector3 normal)
+    {
+        return this - (normal * Dot(normal));
+    }
+
+    /// <summary>
+    /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
+    /// This can also be used to round to an arbitrary number of decimals.
+    /// </summary>
+    /// <param name="step">A vector value representing the step size to snap to.</param>
+    /// <returns>The snapped vector.</returns>
+    public readonly Vector3 Snapped(Vector3 step)
+    {
+        return new Vector3
+        (
+            Mathf.Snapped(X, step.X),
+            Mathf.Snapped(Y, step.Y),
+            Mathf.Snapped(Z, step.Z)
+        );
+    }
+
+    // Constants
+    private static readonly Vector3 _zero = new Vector3(0, 0, 0);
+    private static readonly Vector3 _one = new Vector3(1, 1, 1);
+    private static readonly Vector3 _inf = new Vector3(Mathf.Inf, Mathf.Inf, Mathf.Inf);
+
+    private static readonly Vector3 _up = new Vector3(0, 1, 0);
+    private static readonly Vector3 _down = new Vector3(0, -1, 0);
+    private static readonly Vector3 _right = new Vector3(1, 0, 0);
+    private static readonly Vector3 _left = new Vector3(-1, 0, 0);
+    private static readonly Vector3 _forward = new Vector3(0, 0, -1);
+    private static readonly Vector3 _back = new Vector3(0, 0, 1);
+
+    private static readonly Vector3 _modelLeft = new Vector3(1, 0, 0);
+    private static readonly Vector3 _modelRight = new Vector3(-1, 0, 0);
+    private static readonly Vector3 _modelTop = new Vector3(0, 1, 0);
+    private static readonly Vector3 _modelBottom = new Vector3(0, -1, 0);
+    private static readonly Vector3 _modelFront = new Vector3(0, 0, 1);
+    private static readonly Vector3 _modelRear = new Vector3(0, 0, -1);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(0, 0, 0)</c>.</value>
+    public static Vector3 Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(1, 1, 1)</c>.</value>
+    public static Vector3 One { get { return _one; } }
+    /// <summary>
+    /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(Mathf.Inf, Mathf.Inf, Mathf.Inf)</c>.</value>
+    public static Vector3 Inf { get { return _inf; } }
+
+    /// <summary>
+    /// Up unit vector.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(0, 1, 0)</c>.</value>
+    public static Vector3 Up { get { return _up; } }
+    /// <summary>
+    /// Down unit vector.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(0, -1, 0)</c>.</value>
+    public static Vector3 Down { get { return _down; } }
+    /// <summary>
+    /// Right unit vector. Represents the local direction of right,
+    /// and the global direction of east.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(1, 0, 0)</c>.</value>
+    public static Vector3 Right { get { return _right; } }
+    /// <summary>
+    /// Left unit vector. Represents the local direction of left,
+    /// and the global direction of west.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(-1, 0, 0)</c>.</value>
+    public static Vector3 Left { get { return _left; } }
+    /// <summary>
+    /// Forward unit vector. Represents the local direction of forward,
+    /// and the global direction of north.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(0, 0, -1)</c>.</value>
+    public static Vector3 Forward { get { return _forward; } }
+    /// <summary>
+    /// Back unit vector. Represents the local direction of back,
+    /// and the global direction of south.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3(0, 0, 1)</c>.</value>
+    public static Vector3 Back { get { return _back; } }
+
+    /// <summary>
+    /// Unit vector pointing towards the left side of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelLeft { get { return _modelLeft; } }
+    /// <summary>
+    /// Unit vector pointing towards the right side of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelRight { get { return _modelRight; } }
+    /// <summary>
+    /// Unit vector pointing towards the top side (up) of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelTop { get { return _modelTop; } }
+    /// <summary>
+    /// Unit vector pointing towards the bottom side (down) of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelBottom { get { return _modelBottom; } }
+    /// <summary>
+    /// Unit vector pointing towards the front side (facing forward) of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelFront { get { return _modelFront; } }
+    /// <summary>
+    /// Unit vector pointing towards the rear side (back) of imported 3D assets.
+    /// </summary>
+    public static Vector3 ModelRear { get { return _modelRear; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector3"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    /// <param name="z">The vector's Z component.</param>
+    public Vector3(real_t x, real_t y, real_t z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector3"/>
+    /// with the components of the given <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector3 operator +(Vector3 left, Vector3 right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        left.Z += right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector3"/>
+    /// by the components of the given <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector3 operator -(Vector3 left, Vector3 right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        left.Z -= right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector3"/>.
+    /// This is the same as writing <c>new Vector3(-v.X, -v.Y, -v.Z)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// With floats, the number zero can be either positive or negative.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector3 operator -(Vector3 vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        vec.Z = -vec.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3 operator *(Vector3 vec, real_t scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3 operator *(real_t scale, Vector3 vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3"/>
+    /// by the components of the given <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3 operator *(Vector3 left, Vector3 right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        left.Z *= right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector3"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector3 operator /(Vector3 vec, real_t divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        vec.Z /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector3"/>
+    /// by the components of the given <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector3 operator /(Vector3 vec, Vector3 divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        vec.Z /= divisorv.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector3"/>
+    /// with the components of the given <see cref="real_t"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(real_t)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector3(10, -20, 30) % 7); // Prints "(3, -6, 2)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector3 operator %(Vector3 vec, real_t divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        vec.Z %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector3"/>
+    /// with the components of the given <see cref="Vector3"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(Vector3)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector3(10, -20, 30) % new Vector3(7, 8, 9)); // Prints "(3, -4, 3)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector3 operator %(Vector3 vec, Vector3 divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        vec.Z %= divisorv.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public static bool operator ==(Vector3 left, Vector3 right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector3 left, Vector3 right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector3"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector3 left, Vector3 right)
+    {
+        if (left.X == right.X)
+        {
+            if (left.Y == right.Y)
             {
-                // Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
-                return Lerp(to, weight);
+                return left.Z < right.Z;
             }
-            real_t startLength = Mathf.Sqrt(startLengthSquared);
-            real_t resultLength = Mathf.Lerp(startLength, Mathf.Sqrt(endLengthSquared), weight);
-            real_t angle = AngleTo(to);
-            return Rotated(Cross(to).Normalized(), angle * weight) * (resultLength / startLength);
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Returns this vector slid along a plane defined by the given <paramref name="normal"/>.
-        /// </summary>
-        /// <param name="normal">The normal vector defining the plane to slide on.</param>
-        /// <returns>The slid vector.</returns>
-        public readonly Vector3 Slide(Vector3 normal)
+    /// <summary>
+    /// Compares two <see cref="Vector3"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector3 left, Vector3 right)
+    {
+        if (left.X == right.X)
         {
-            return this - (normal * Dot(normal));
-        }
-
-        /// <summary>
-        /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
-        /// This can also be used to round to an arbitrary number of decimals.
-        /// </summary>
-        /// <param name="step">A vector value representing the step size to snap to.</param>
-        /// <returns>The snapped vector.</returns>
-        public readonly Vector3 Snapped(Vector3 step)
-        {
-            return new Vector3
-            (
-                Mathf.Snapped(X, step.X),
-                Mathf.Snapped(Y, step.Y),
-                Mathf.Snapped(Z, step.Z)
-            );
-        }
-
-        // Constants
-        private static readonly Vector3 _zero = new Vector3(0, 0, 0);
-        private static readonly Vector3 _one = new Vector3(1, 1, 1);
-        private static readonly Vector3 _inf = new Vector3(Mathf.Inf, Mathf.Inf, Mathf.Inf);
-
-        private static readonly Vector3 _up = new Vector3(0, 1, 0);
-        private static readonly Vector3 _down = new Vector3(0, -1, 0);
-        private static readonly Vector3 _right = new Vector3(1, 0, 0);
-        private static readonly Vector3 _left = new Vector3(-1, 0, 0);
-        private static readonly Vector3 _forward = new Vector3(0, 0, -1);
-        private static readonly Vector3 _back = new Vector3(0, 0, 1);
-
-        private static readonly Vector3 _modelLeft = new Vector3(1, 0, 0);
-        private static readonly Vector3 _modelRight = new Vector3(-1, 0, 0);
-        private static readonly Vector3 _modelTop = new Vector3(0, 1, 0);
-        private static readonly Vector3 _modelBottom = new Vector3(0, -1, 0);
-        private static readonly Vector3 _modelFront = new Vector3(0, 0, 1);
-        private static readonly Vector3 _modelRear = new Vector3(0, 0, -1);
-
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(0, 0, 0)</c>.</value>
-        public static Vector3 Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(1, 1, 1)</c>.</value>
-        public static Vector3 One { get { return _one; } }
-        /// <summary>
-        /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(Mathf.Inf, Mathf.Inf, Mathf.Inf)</c>.</value>
-        public static Vector3 Inf { get { return _inf; } }
-
-        /// <summary>
-        /// Up unit vector.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(0, 1, 0)</c>.</value>
-        public static Vector3 Up { get { return _up; } }
-        /// <summary>
-        /// Down unit vector.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(0, -1, 0)</c>.</value>
-        public static Vector3 Down { get { return _down; } }
-        /// <summary>
-        /// Right unit vector. Represents the local direction of right,
-        /// and the global direction of east.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(1, 0, 0)</c>.</value>
-        public static Vector3 Right { get { return _right; } }
-        /// <summary>
-        /// Left unit vector. Represents the local direction of left,
-        /// and the global direction of west.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(-1, 0, 0)</c>.</value>
-        public static Vector3 Left { get { return _left; } }
-        /// <summary>
-        /// Forward unit vector. Represents the local direction of forward,
-        /// and the global direction of north.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(0, 0, -1)</c>.</value>
-        public static Vector3 Forward { get { return _forward; } }
-        /// <summary>
-        /// Back unit vector. Represents the local direction of back,
-        /// and the global direction of south.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3(0, 0, 1)</c>.</value>
-        public static Vector3 Back { get { return _back; } }
-
-        /// <summary>
-        /// Unit vector pointing towards the left side of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelLeft { get { return _modelLeft; } }
-        /// <summary>
-        /// Unit vector pointing towards the right side of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelRight { get { return _modelRight; } }
-        /// <summary>
-        /// Unit vector pointing towards the top side (up) of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelTop { get { return _modelTop; } }
-        /// <summary>
-        /// Unit vector pointing towards the bottom side (down) of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelBottom { get { return _modelBottom; } }
-        /// <summary>
-        /// Unit vector pointing towards the front side (facing forward) of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelFront { get { return _modelFront; } }
-        /// <summary>
-        /// Unit vector pointing towards the rear side (back) of imported 3D assets.
-        /// </summary>
-        public static Vector3 ModelRear { get { return _modelRear; } }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector3"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        /// <param name="z">The vector's Z component.</param>
-        public Vector3(real_t x, real_t y, real_t z)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector3"/>
-        /// with the components of the given <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector3 operator +(Vector3 left, Vector3 right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector3"/>
-        /// by the components of the given <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector3 operator -(Vector3 left, Vector3 right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector3"/>.
-        /// This is the same as writing <c>new Vector3(-v.X, -v.Y, -v.Z)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// With floats, the number zero can be either positive or negative.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector3 operator -(Vector3 vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3 operator *(Vector3 vec, real_t scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3 operator *(real_t scale, Vector3 vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3"/>
-        /// by the components of the given <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3 operator *(Vector3 left, Vector3 right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector3"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector3 operator /(Vector3 vec, real_t divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector3"/>
-        /// by the components of the given <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector3 operator /(Vector3 vec, Vector3 divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector3"/>
-        /// with the components of the given <see cref="real_t"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(real_t)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector3(10, -20, 30) % 7); // Prints "(3, -6, 2)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector3 operator %(Vector3 vec, real_t divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector3"/>
-        /// with the components of the given <see cref="Vector3"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(Vector3)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector3(10, -20, 30) % new Vector3(7, 8, 9)); // Prints "(3, -4, 3)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector3 operator %(Vector3 vec, Vector3 divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public static bool operator ==(Vector3 left, Vector3 right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector3 left, Vector3 right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector3"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector3 left, Vector3 right)
-        {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z < right.Z;
-                }
-                return left.Y < right.Y;
+                return left.Z > right.Z;
             }
-            return left.X < right.X;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector3 left, Vector3 right)
+    /// <summary>
+    /// Compares two <see cref="Vector3"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector3 left, Vector3 right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z > right.Z;
-                }
-                return left.Y > right.Y;
+                return left.Z <= right.Z;
             }
-            return left.X > right.X;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector3 left, Vector3 right)
+    /// <summary>
+    /// Compares two <see cref="Vector3"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector3 left, Vector3 right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z <= right.Z;
-                }
-                return left.Y < right.Y;
+                return left.Z >= right.Z;
             }
-            return left.X < right.X;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector3 left, Vector3 right)
-        {
-            if (left.X == right.X)
-            {
-                if (left.Y == right.Y)
-                {
-                    return left.Z >= right.Z;
-                }
-                return left.Y > right.Y;
-            }
-            return left.X > right.X;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector3 other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector3 other && Equals(other);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public readonly bool Equals(Vector3 other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z;
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public readonly bool Equals(Vector3 other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other vector to compare.</param>
+    /// <returns>Whether or not the vectors are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Vector3 other)
+    {
+        return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Vector3 other)
-        {
-            return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z);
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector's values are approximately zero,
+    /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
+    /// This method is faster than using <see cref="IsEqualApprox"/> with one value
+    /// as a zero vector.
+    /// </summary>
+    /// <returns>Whether or not the vector is approximately zero.</returns>
+    public readonly bool IsZeroApprox()
+    {
+        return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y) && Mathf.IsZeroApprox(Z);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector's values are approximately zero,
-        /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
-        /// This method is faster than using <see cref="IsEqualApprox"/> with one value
-        /// as a zero vector.
-        /// </summary>
-        /// <returns>Whether or not the vector is approximately zero.</returns>
-        public readonly bool IsZeroApprox()
-        {
-            return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y) && Mathf.IsZeroApprox(Z);
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector3"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode();
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector3"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode();
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector3"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y}, {Z})";
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector3"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z})";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Vector3"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector3"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -1,621 +1,620 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 3-element structure that can be used to represent 3D grid coordinates or sets of integers.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector3I : IEquatable<Vector3I>
 {
     /// <summary>
-    /// 3-element structure that can be used to represent 3D grid coordinates or sets of integers.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector3I : IEquatable<Vector3I>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y,
+        /// <summary>
+        /// The vector's Z axis.
+        /// </summary>
+        Z
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public int X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public int Y;
+
+    /// <summary>
+    /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
+    /// </summary>
+    public int Z;
+
+    /// <summary>
+    /// Access vector components using their <paramref name="index"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0, 1 or 2.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>,
+    /// <c>[2]</c> is equivalent to <see cref="Z"/>.
+    /// </value>
+    public int this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y,
-            /// <summary>
-            /// The vector's Z axis.
-            /// </summary>
-            Z
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public int X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public int Y;
-
-        /// <summary>
-        /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
-        /// </summary>
-        public int Z;
-
-        /// <summary>
-        /// Access vector components using their <paramref name="index"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0, 1 or 2.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>,
-        /// <c>[2]</c> is equivalent to <see cref="Z"/>.
-        /// </value>
-        public int this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Z = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Z;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out int x, out int y, out int z)
+        set
         {
-            x = X;
-            y = Y;
-            z = Z;
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
-        public readonly Vector3I Abs()
-        {
-            return new Vector3I(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z));
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(int, int, int)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector3I Clamp(Vector3I min, Vector3I max)
-        {
-            return new Vector3I
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y),
-                Mathf.Clamp(Z, min.Z, max.Z)
-            );
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-            int z2 = Z * Z;
-
-            return Mathf.Sqrt(x2 + y2 + z2);
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly int LengthSquared()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-            int z2 = Z * Z;
-
-            return x2 + y2 + z2;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            return X < Y ? (Y < Z ? Axis.Z : Axis.Y) : (X < Z ? Axis.Z : Axis.X);
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.Z"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
-        {
-            return X < Y ? (X < Z ? Axis.X : Axis.Z) : (Y < Z ? Axis.Y : Axis.Z);
-        }
-
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(int)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector3I Sign()
-        {
-            Vector3I v = this;
-            v.X = Mathf.Sign(v.X);
-            v.Y = Mathf.Sign(v.Y);
-            v.Z = Mathf.Sign(v.Z);
-            return v;
-        }
-
-        // Constants
-        private static readonly Vector3I _zero = new Vector3I(0, 0, 0);
-        private static readonly Vector3I _one = new Vector3I(1, 1, 1);
-
-        private static readonly Vector3I _up = new Vector3I(0, 1, 0);
-        private static readonly Vector3I _down = new Vector3I(0, -1, 0);
-        private static readonly Vector3I _right = new Vector3I(1, 0, 0);
-        private static readonly Vector3I _left = new Vector3I(-1, 0, 0);
-        private static readonly Vector3I _forward = new Vector3I(0, 0, -1);
-        private static readonly Vector3I _back = new Vector3I(0, 0, 1);
-
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(0, 0, 0)</c>.</value>
-        public static Vector3I Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(1, 1, 1)</c>.</value>
-        public static Vector3I One { get { return _one; } }
-
-        /// <summary>
-        /// Up unit vector.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(0, 1, 0)</c>.</value>
-        public static Vector3I Up { get { return _up; } }
-        /// <summary>
-        /// Down unit vector.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(0, -1, 0)</c>.</value>
-        public static Vector3I Down { get { return _down; } }
-        /// <summary>
-        /// Right unit vector. Represents the local direction of right,
-        /// and the global direction of east.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(1, 0, 0)</c>.</value>
-        public static Vector3I Right { get { return _right; } }
-        /// <summary>
-        /// Left unit vector. Represents the local direction of left,
-        /// and the global direction of west.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(-1, 0, 0)</c>.</value>
-        public static Vector3I Left { get { return _left; } }
-        /// <summary>
-        /// Forward unit vector. Represents the local direction of forward,
-        /// and the global direction of north.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(0, 0, -1)</c>.</value>
-        public static Vector3I Forward { get { return _forward; } }
-        /// <summary>
-        /// Back unit vector. Represents the local direction of back,
-        /// and the global direction of south.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector3I(0, 0, 1)</c>.</value>
-        public static Vector3I Back { get { return _back; } }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector3I"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        /// <param name="z">The vector's Z component.</param>
-        public Vector3I(int x, int y, int z)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector3I"/>
-        /// with the components of the given <see cref="Vector3I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector3I operator +(Vector3I left, Vector3I right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector3I"/>
-        /// by the components of the given <see cref="Vector3I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector3I operator -(Vector3I left, Vector3I right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector3I"/>.
-        /// This is the same as writing <c>new Vector3I(-v.X, -v.Y, -v.Z)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector3I operator -(Vector3I vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3I operator *(Vector3I vec, int scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3I operator *(int scale, Vector3I vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector3I"/>
-        /// by the components of the given <see cref="Vector3I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector3I operator *(Vector3I left, Vector3I right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector3I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector3I operator /(Vector3I vec, int divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector3I"/>
-        /// by the components of the given <see cref="Vector3I"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector3I operator /(Vector3I vec, Vector3I divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector3I"/>
-        /// with the components of the given <see langword="int"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector3I(10, -20, 30) % 7); // Prints "(3, -6, 2)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector3I operator %(Vector3I vec, int divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector3I"/>
-        /// with the components of the given <see cref="Vector3I"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector3I(10, -20, 30) % new Vector3I(7, 8, 9)); // Prints "(3, -4, 3)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector3I operator %(Vector3I vec, Vector3I divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public static bool operator ==(Vector3I left, Vector3I right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector3I left, Vector3I right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector3I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector3I left, Vector3I right)
-        {
-            if (left.X == right.X)
+            switch (index)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z < right.Z;
-                }
-                return left.Y < right.Y;
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Z = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
-            return left.X < right.X;
         }
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector3I left, Vector3I right)
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out int x, out int y, out int z)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
+    public readonly Vector3I Abs()
+    {
+        return new Vector3I(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(int, int, int)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector3I Clamp(Vector3I min, Vector3I max)
+    {
+        return new Vector3I
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y),
+            Mathf.Clamp(Z, min.Z, max.Z)
+        );
+    }
+
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
+        int z2 = Z * Z;
+
+        return Mathf.Sqrt(x2 + y2 + z2);
+    }
+
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly int LengthSquared()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
+        int z2 = Z * Z;
+
+        return x2 + y2 + z2;
+    }
+
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        return X < Y ? (Y < Z ? Axis.Z : Axis.Y) : (X < Z ? Axis.Z : Axis.X);
+    }
+
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.Z"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        return X < Y ? (X < Z ? Axis.X : Axis.Z) : (Y < Z ? Axis.Y : Axis.Z);
+    }
+
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(int)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector3I Sign()
+    {
+        Vector3I v = this;
+        v.X = Mathf.Sign(v.X);
+        v.Y = Mathf.Sign(v.Y);
+        v.Z = Mathf.Sign(v.Z);
+        return v;
+    }
+
+    // Constants
+    private static readonly Vector3I _zero = new Vector3I(0, 0, 0);
+    private static readonly Vector3I _one = new Vector3I(1, 1, 1);
+
+    private static readonly Vector3I _up = new Vector3I(0, 1, 0);
+    private static readonly Vector3I _down = new Vector3I(0, -1, 0);
+    private static readonly Vector3I _right = new Vector3I(1, 0, 0);
+    private static readonly Vector3I _left = new Vector3I(-1, 0, 0);
+    private static readonly Vector3I _forward = new Vector3I(0, 0, -1);
+    private static readonly Vector3I _back = new Vector3I(0, 0, 1);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(0, 0, 0)</c>.</value>
+    public static Vector3I Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(1, 1, 1)</c>.</value>
+    public static Vector3I One { get { return _one; } }
+
+    /// <summary>
+    /// Up unit vector.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(0, 1, 0)</c>.</value>
+    public static Vector3I Up { get { return _up; } }
+    /// <summary>
+    /// Down unit vector.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(0, -1, 0)</c>.</value>
+    public static Vector3I Down { get { return _down; } }
+    /// <summary>
+    /// Right unit vector. Represents the local direction of right,
+    /// and the global direction of east.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(1, 0, 0)</c>.</value>
+    public static Vector3I Right { get { return _right; } }
+    /// <summary>
+    /// Left unit vector. Represents the local direction of left,
+    /// and the global direction of west.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(-1, 0, 0)</c>.</value>
+    public static Vector3I Left { get { return _left; } }
+    /// <summary>
+    /// Forward unit vector. Represents the local direction of forward,
+    /// and the global direction of north.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(0, 0, -1)</c>.</value>
+    public static Vector3I Forward { get { return _forward; } }
+    /// <summary>
+    /// Back unit vector. Represents the local direction of back,
+    /// and the global direction of south.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector3I(0, 0, 1)</c>.</value>
+    public static Vector3I Back { get { return _back; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector3I"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    /// <param name="z">The vector's Z component.</param>
+    public Vector3I(int x, int y, int z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector3I"/>
+    /// with the components of the given <see cref="Vector3I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector3I operator +(Vector3I left, Vector3I right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        left.Z += right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector3I"/>
+    /// by the components of the given <see cref="Vector3I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector3I operator -(Vector3I left, Vector3I right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        left.Z -= right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector3I"/>.
+    /// This is the same as writing <c>new Vector3I(-v.X, -v.Y, -v.Z)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector3I operator -(Vector3I vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        vec.Z = -vec.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3I operator *(Vector3I vec, int scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3I operator *(int scale, Vector3I vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector3I"/>
+    /// by the components of the given <see cref="Vector3I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector3I operator *(Vector3I left, Vector3I right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        left.Z *= right.Z;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector3I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector3I operator /(Vector3I vec, int divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        vec.Z /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector3I"/>
+    /// by the components of the given <see cref="Vector3I"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector3I operator /(Vector3I vec, Vector3I divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        vec.Z /= divisorv.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector3I"/>
+    /// with the components of the given <see langword="int"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector3I(10, -20, 30) % 7); // Prints "(3, -6, 2)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector3I operator %(Vector3I vec, int divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        vec.Z %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector3I"/>
+    /// with the components of the given <see cref="Vector3I"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector3I(10, -20, 30) % new Vector3I(7, 8, 9)); // Prints "(3, -4, 3)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector3I operator %(Vector3I vec, Vector3I divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        vec.Z %= divisorv.Z;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public static bool operator ==(Vector3I left, Vector3I right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector3I left, Vector3I right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector3I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector3I left, Vector3I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z > right.Z;
-                }
-                return left.Y > right.Y;
+                return left.Z < right.Z;
             }
-            return left.X > right.X;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector3I left, Vector3I right)
+    /// <summary>
+    /// Compares two <see cref="Vector3I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector3I left, Vector3I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z <= right.Z;
-                }
-                return left.Y < right.Y;
+                return left.Z > right.Z;
             }
-            return left.X < right.X;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector3I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y values of the two vectors, and then with the Z values.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector3I left, Vector3I right)
+    /// <summary>
+    /// Compares two <see cref="Vector3I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector3I left, Vector3I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
-                {
-                    return left.Z >= right.Z;
-                }
-                return left.Y > right.Y;
+                return left.Z <= right.Z;
             }
-            return left.X > right.X;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector3I"/> to a <see cref="Vector3"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static implicit operator Vector3(Vector3I value)
+    /// <summary>
+    /// Compares two <see cref="Vector3I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y values of the two vectors, and then with the Z values.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector3I left, Vector3I right)
+    {
+        if (left.X == right.X)
         {
-            return new Vector3(value.X, value.Y, value.Z);
+            if (left.Y == right.Y)
+            {
+                return left.Z >= right.Z;
+            }
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/> by truncating
-        /// components' fractional parts (rounding towards zero). For a different
-        /// behavior consider passing the result of <see cref="Vector3.Ceil"/>,
-        /// <see cref="Vector3.Floor"/> or <see cref="Vector3.Round"/> to this conversion operator instead.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector3I(Vector3 value)
-        {
-            return new Vector3I((int)value.X, (int)value.Y, (int)value.Z);
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector3I"/> to a <see cref="Vector3"/>.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static implicit operator Vector3(Vector3I value)
+    {
+        return new Vector3(value.X, value.Y, value.Z);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is equal
-        /// to the given object (<see paramref="obj"/>).
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector3I other && Equals(other);
-        }
+    /// <summary>
+    /// Converts a <see cref="Vector3"/> to a <see cref="Vector3I"/> by truncating
+    /// components' fractional parts (rounding towards zero). For a different
+    /// behavior consider passing the result of <see cref="Vector3.Ceil"/>,
+    /// <see cref="Vector3.Floor"/> or <see cref="Vector3.Round"/> to this conversion operator instead.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static explicit operator Vector3I(Vector3 value)
+    {
+        return new Vector3I((int)value.X, (int)value.Y, (int)value.Z);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public readonly bool Equals(Vector3I other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is equal
+    /// to the given object (<see paramref="obj"/>).
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector3I other && Equals(other);
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector3I"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode();
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public readonly bool Equals(Vector3I other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector3I"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z})";
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector3I"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode();
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector3I"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector3I"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y}, {Z})";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Vector3I"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -1,908 +1,907 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 4-element structure that can be used to represent positions in 4D space or any other pair of numeric values.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector4 : IEquatable<Vector4>
 {
     /// <summary>
-    /// 4-element structure that can be used to represent positions in 4D space or any other pair of numeric values.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4 : IEquatable<Vector4>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y,
+        /// <summary>
+        /// The vector's Z axis.
+        /// </summary>
+        Z,
+        /// <summary>
+        /// The vector's W axis.
+        /// </summary>
+        W
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public real_t X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public real_t Y;
+
+    /// <summary>
+    /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
+    /// </summary>
+    public real_t Z;
+
+    /// <summary>
+    /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
+    /// </summary>
+    public real_t W;
+
+    /// <summary>
+    /// Access vector components using their index.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>,
+    /// <c>[2]</c> is equivalent to <see cref="Z"/>.
+    /// <c>[3]</c> is equivalent to <see cref="W"/>.
+    /// </value>
+    public real_t this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y,
-            /// <summary>
-            /// The vector's Z axis.
-            /// </summary>
-            Z,
-            /// <summary>
-            /// The vector's W axis.
-            /// </summary>
-            W
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public real_t X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public real_t Y;
-
-        /// <summary>
-        /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
-        /// </summary>
-        public real_t Z;
-
-        /// <summary>
-        /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
-        /// </summary>
-        public real_t W;
-
-        /// <summary>
-        /// Access vector components using their index.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>,
-        /// <c>[2]</c> is equivalent to <see cref="Z"/>.
-        /// <c>[3]</c> is equivalent to <see cref="W"/>.
-        /// </value>
-        public real_t this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Z;
+                case 3:
+                    return W;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+        set
+        {
+            switch (index)
+            {
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Z = value;
+                    return;
+                case 3:
+                    W = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out real_t x, out real_t y, out real_t z, out real_t w)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+        w = W;
+    }
+
+    internal void Normalize()
+    {
+        real_t lengthsq = LengthSquared();
+
+        if (lengthsq == 0)
+        {
+            X = Y = Z = W = 0f;
+        }
+        else
+        {
+            real_t length = Mathf.Sqrt(lengthsq);
+            X /= length;
+            Y /= length;
+            Z /= length;
+            W /= length;
+        }
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
+    public readonly Vector4 Abs()
+    {
+        return new Vector4(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z), Mathf.Abs(W));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded up (towards positive infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
+    public readonly Vector4 Ceil()
+    {
+        return new Vector4(Mathf.Ceil(X), Mathf.Ceil(Y), Mathf.Ceil(Z), Mathf.Ceil(W));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector4 Clamp(Vector4 min, Vector4 max)
+    {
+        return new Vector4
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y),
+            Mathf.Clamp(Z, min.Z, max.Z),
+            Mathf.Clamp(W, min.W, max.W)
+        );
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector4 CubicInterpolate(Vector4 b, Vector4 preA, Vector4 postB, real_t weight)
+    {
+        return new Vector4
+        (
+            Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
+            Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight),
+            Mathf.CubicInterpolate(Z, b.Z, preA.Z, postB.Z, weight),
+            Mathf.CubicInterpolate(W, b.W, preA.W, postB.W, weight)
+        );
+    }
+
+    /// <summary>
+    /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
+    /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
+    /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
+    /// by the time values.
+    /// </summary>
+    /// <param name="b">The destination vector.</param>
+    /// <param name="preA">A vector before this vector.</param>
+    /// <param name="postB">A vector after <paramref name="b"/>.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <param name="t"></param>
+    /// <param name="preAT"></param>
+    /// <param name="postBT"></param>
+    /// <returns>The interpolated vector.</returns>
+    public readonly Vector4 CubicInterpolateInTime(Vector4 b, Vector4 preA, Vector4 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
+    {
+        return new Vector4
+        (
+            Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(Z, b.Z, preA.Z, postB.Z, weight, t, preAT, postBT),
+            Mathf.CubicInterpolateInTime(W, b.W, preA.W, postB.W, weight, t, preAT, postBT)
+        );
+    }
+
+    /// <summary>
+    /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
+    /// </summary>
+    /// <param name="to">The other vector to point towards.</param>
+    /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
+    public readonly Vector4 DirectionTo(Vector4 to)
+    {
+        Vector4 ret = new Vector4(to.X - X, to.Y - Y, to.Z - Z, to.W - W);
+        ret.Normalize();
+        return ret;
+    }
+
+    /// <summary>
+    /// Returns the squared distance between this vector and <paramref name="to"/>.
+    /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
+    /// you need to compare vectors or need the squared distance for some formula.
+    /// </summary>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The squared distance between the two vectors.</returns>
+    public readonly real_t DistanceSquaredTo(Vector4 to)
+    {
+        return (to - this).LengthSquared();
+    }
+
+    /// <summary>
+    /// Returns the distance between this vector and <paramref name="to"/>.
+    /// </summary>
+    /// <param name="to">The other vector to use.</param>
+    /// <returns>The distance between the two vectors.</returns>
+    public readonly real_t DistanceTo(Vector4 to)
+    {
+        return (to - this).Length();
+    }
+
+    /// <summary>
+    /// Returns the dot product of this vector and <paramref name="with"/>.
+    /// </summary>
+    /// <param name="with">The other vector to use.</param>
+    /// <returns>The dot product of the two vectors.</returns>
+    public readonly real_t Dot(Vector4 with)
+    {
+        return (X * with.X) + (Y * with.Y) + (Z * with.Z) + (W * with.W);
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components rounded down (towards negative infinity).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
+    public readonly Vector4 Floor()
+    {
+        return new Vector4(Mathf.Floor(X), Mathf.Floor(Y), Mathf.Floor(Z), Mathf.Floor(W));
+    }
+
+    /// <summary>
+    /// Returns the inverse of this vector. This is the same as <c>new Vector4(1 / v.X, 1 / v.Y, 1 / v.Z, 1 / v.W)</c>.
+    /// </summary>
+    /// <returns>The inverse of this vector.</returns>
+    public readonly Vector4 Inverse()
+    {
+        return new Vector4(1 / X, 1 / Y, 1 / Z, 1 / W);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector is finite, by calling
+    /// <see cref="Mathf.IsFinite"/> on each component.
+    /// </summary>
+    /// <returns>Whether this vector is finite or not.</returns>
+    public readonly bool IsFinite()
+    {
+        return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z) && Mathf.IsFinite(W);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
+    /// </summary>
+    /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
+    public readonly bool IsNormalized()
+    {
+        return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
+    }
+
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        real_t x2 = X * X;
+        real_t y2 = Y * Y;
+        real_t z2 = Z * Z;
+        real_t w2 = W * W;
+
+        return Mathf.Sqrt(x2 + y2 + z2 + w2);
+    }
+
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly real_t LengthSquared()
+    {
+        real_t x2 = X * X;
+        real_t y2 = Y * Y;
+        real_t z2 = Z * Z;
+        real_t w2 = W * W;
+
+        return x2 + y2 + z2 + w2;
+    }
+
+    /// <summary>
+    /// Returns the result of the linear interpolation between
+    /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
+    /// </summary>
+    /// <param name="to">The destination vector for interpolation.</param>
+    /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
+    /// <returns>The resulting vector of the interpolation.</returns>
+    public readonly Vector4 Lerp(Vector4 to, real_t weight)
+    {
+        return new Vector4
+        (
+            Mathf.Lerp(X, to.X, weight),
+            Mathf.Lerp(Y, to.Y, weight),
+            Mathf.Lerp(Z, to.Z, weight),
+            Mathf.Lerp(W, to.W, weight)
+        );
+    }
+
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        int max_index = 0;
+        real_t max_value = X;
+        for (int i = 1; i < 4; i++)
+        {
+            if (this[i] > max_value)
+            {
+                max_index = i;
+                max_value = this[i];
+            }
+        }
+        return (Axis)max_index;
+    }
+
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.W"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        int min_index = 0;
+        real_t min_value = X;
+        for (int i = 1; i < 4; i++)
+        {
+            if (this[i] <= min_value)
+            {
+                min_index = i;
+                min_value = this[i];
+            }
+        }
+        return (Axis)min_index;
+    }
+
+    /// <summary>
+    /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
+    /// </summary>
+    /// <returns>A normalized version of the vector.</returns>
+    public readonly Vector4 Normalized()
+    {
+        Vector4 v = this;
+        v.Normalize();
+        return v;
+    }
+
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="mod"/>.
+    /// </summary>
+    /// <param name="mod">A value representing the divisor of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
+    /// </returns>
+    public readonly Vector4 PosMod(real_t mod)
+    {
+        return new Vector4(
+            Mathf.PosMod(X, mod),
+            Mathf.PosMod(Y, mod),
+            Mathf.PosMod(Z, mod),
+            Mathf.PosMod(W, mod)
+        );
+    }
+
+    /// <summary>
+    /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
+    /// and <paramref name="modv"/>'s components.
+    /// </summary>
+    /// <param name="modv">A vector representing the divisors of the operation.</param>
+    /// <returns>
+    /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
+    /// </returns>
+    public readonly Vector4 PosMod(Vector4 modv)
+    {
+        return new Vector4(
+            Mathf.PosMod(X, modv.X),
+            Mathf.PosMod(Y, modv.Y),
+            Mathf.PosMod(Z, modv.Z),
+            Mathf.PosMod(W, modv.W)
+        );
+    }
+
+    /// <summary>
+    /// Returns this vector with all components rounded to the nearest integer,
+    /// with halfway cases rounded towards the nearest multiple of two.
+    /// </summary>
+    /// <returns>The rounded vector.</returns>
+    public readonly Vector4 Round()
+    {
+        return new Vector4(Mathf.Round(X), Mathf.Round(Y), Mathf.Round(Z), Mathf.Round(W));
+    }
+
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector4 Sign()
+    {
+        Vector4 v;
+        v.X = Mathf.Sign(X);
+        v.Y = Mathf.Sign(Y);
+        v.Z = Mathf.Sign(Z);
+        v.W = Mathf.Sign(W);
+        return v;
+    }
+
+    /// <summary>
+    /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
+    /// This can also be used to round to an arbitrary number of decimals.
+    /// </summary>
+    /// <param name="step">A vector value representing the step size to snap to.</param>
+    /// <returns>The snapped vector.</returns>
+    public readonly Vector4 Snapped(Vector4 step)
+    {
+        return new Vector4(
+            Mathf.Snapped(X, step.X),
+            Mathf.Snapped(Y, step.Y),
+            Mathf.Snapped(Z, step.Z),
+            Mathf.Snapped(W, step.W)
+        );
+    }
+
+    // Constants
+    private static readonly Vector4 _zero = new Vector4(0, 0, 0, 0);
+    private static readonly Vector4 _one = new Vector4(1, 1, 1, 1);
+    private static readonly Vector4 _inf = new Vector4(Mathf.Inf, Mathf.Inf, Mathf.Inf, Mathf.Inf);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector4(0, 0, 0, 0)</c>.</value>
+    public static Vector4 Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector4(1, 1, 1, 1)</c>.</value>
+    public static Vector4 One { get { return _one; } }
+    /// <summary>
+    /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector4(Mathf.Inf, Mathf.Inf, Mathf.Inf, Mathf.Inf)</c>.</value>
+    public static Vector4 Inf { get { return _inf; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector4"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    /// <param name="z">The vector's Z component.</param>
+    /// <param name="w">The vector's W component.</param>
+    public Vector4(real_t x, real_t y, real_t z, real_t w)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        W = w;
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector4"/>
+    /// with the components of the given <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector4 operator +(Vector4 left, Vector4 right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        left.Z += right.Z;
+        left.W += right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector4"/>
+    /// by the components of the given <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector4 operator -(Vector4 left, Vector4 right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        left.Z -= right.Z;
+        left.W -= right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector4"/>.
+    /// This is the same as writing <c>new Vector4(-v.X, -v.Y, -v.Z, -v.W)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// With floats, the number zero can be either positive or negative.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector4 operator -(Vector4 vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        vec.Z = -vec.Z;
+        vec.W = -vec.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4 operator *(Vector4 vec, real_t scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        vec.W *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4 operator *(real_t scale, Vector4 vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        vec.W *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4"/>
+    /// by the components of the given <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4 operator *(Vector4 left, Vector4 right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        left.Z *= right.Z;
+        left.W *= right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector4"/>
+    /// by the given <see cref="real_t"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector4 operator /(Vector4 vec, real_t divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        vec.Z /= divisor;
+        vec.W /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector4"/>
+    /// by the components of the given <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector4 operator /(Vector4 vec, Vector4 divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        vec.Z /= divisorv.Z;
+        vec.W /= divisorv.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector4"/>
+    /// with the components of the given <see cref="real_t"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(real_t)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector4(10, -20, 30, 40) % 7); // Prints "(3, -6, 2, 5)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector4 operator %(Vector4 vec, real_t divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        vec.Z %= divisor;
+        vec.W %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector4"/>
+    /// with the components of the given <see cref="Vector4"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="PosMod(Vector4)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector4(10, -20, 30, 10) % new Vector4(7, 8, 9, 10)); // Prints "(3, -4, 3, 0)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector4 operator %(Vector4 vec, Vector4 divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        vec.Z %= divisorv.Z;
+        vec.W %= divisorv.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public static bool operator ==(Vector4 left, Vector4 right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector4 left, Vector4 right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector4"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector4 left, Vector4 right)
+    {
+        if (left.X == right.X)
+        {
+            if (left.Y == right.Y)
+            {
+                if (left.Z == right.Z)
                 {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    case 3:
-                        return W;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
+                    return left.W < right.W;
                 }
+                return left.Z < right.Z;
             }
-            set
+            return left.Y < right.Y;
+        }
+        return left.X < right.X;
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector4"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector4 left, Vector4 right)
+    {
+        if (left.X == right.X)
+        {
+            if (left.Y == right.Y)
             {
-                switch (index)
+                if (left.Z == right.Z)
                 {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Z = value;
-                        return;
-                    case 3:
-                        W = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
+                    return left.W > right.W;
                 }
+                return left.Z > right.Z;
             }
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out real_t x, out real_t y, out real_t z, out real_t w)
+    /// <summary>
+    /// Compares two <see cref="Vector4"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector4 left, Vector4 right)
+    {
+        if (left.X == right.X)
         {
-            x = X;
-            y = Y;
-            z = Z;
-            w = W;
-        }
-
-        internal void Normalize()
-        {
-            real_t lengthsq = LengthSquared();
-
-            if (lengthsq == 0)
+            if (left.Y == right.Y)
             {
-                X = Y = Z = W = 0f;
-            }
-            else
-            {
-                real_t length = Mathf.Sqrt(lengthsq);
-                X /= length;
-                Y /= length;
-                Z /= length;
-                W /= length;
-            }
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(real_t)"/> called on each component.</returns>
-        public readonly Vector4 Abs()
-        {
-            return new Vector4(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z), Mathf.Abs(W));
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components rounded up (towards positive infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Ceil"/> called on each component.</returns>
-        public readonly Vector4 Ceil()
-        {
-            return new Vector4(Mathf.Ceil(X), Mathf.Ceil(Y), Mathf.Ceil(Z), Mathf.Ceil(W));
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(real_t, real_t, real_t)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector4 Clamp(Vector4 min, Vector4 max)
-        {
-            return new Vector4
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y),
-                Mathf.Clamp(Z, min.Z, max.Z),
-                Mathf.Clamp(W, min.W, max.W)
-            );
-        }
-
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector4 CubicInterpolate(Vector4 b, Vector4 preA, Vector4 postB, real_t weight)
-        {
-            return new Vector4
-            (
-                Mathf.CubicInterpolate(X, b.X, preA.X, postB.X, weight),
-                Mathf.CubicInterpolate(Y, b.Y, preA.Y, postB.Y, weight),
-                Mathf.CubicInterpolate(Z, b.Z, preA.Z, postB.Z, weight),
-                Mathf.CubicInterpolate(W, b.W, preA.W, postB.W, weight)
-            );
-        }
-
-        /// <summary>
-        /// Performs a cubic interpolation between vectors <paramref name="preA"/>, this vector,
-        /// <paramref name="b"/>, and <paramref name="postB"/>, by the given amount <paramref name="weight"/>.
-        /// It can perform smoother interpolation than <see cref="CubicInterpolate"/>
-        /// by the time values.
-        /// </summary>
-        /// <param name="b">The destination vector.</param>
-        /// <param name="preA">A vector before this vector.</param>
-        /// <param name="postB">A vector after <paramref name="b"/>.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <param name="t"></param>
-        /// <param name="preAT"></param>
-        /// <param name="postBT"></param>
-        /// <returns>The interpolated vector.</returns>
-        public readonly Vector4 CubicInterpolateInTime(Vector4 b, Vector4 preA, Vector4 postB, real_t weight, real_t t, real_t preAT, real_t postBT)
-        {
-            return new Vector4
-            (
-                Mathf.CubicInterpolateInTime(X, b.X, preA.X, postB.X, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(Y, b.Y, preA.Y, postB.Y, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(Z, b.Z, preA.Z, postB.Z, weight, t, preAT, postBT),
-                Mathf.CubicInterpolateInTime(W, b.W, preA.W, postB.W, weight, t, preAT, postBT)
-            );
-        }
-
-        /// <summary>
-        /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to point towards.</param>
-        /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
-        public readonly Vector4 DirectionTo(Vector4 to)
-        {
-            Vector4 ret = new Vector4(to.X - X, to.Y - Y, to.Z - Z, to.W - W);
-            ret.Normalize();
-            return ret;
-        }
-
-        /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="to"/>.
-        /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
-        /// you need to compare vectors or need the squared distance for some formula.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The squared distance between the two vectors.</returns>
-        public readonly real_t DistanceSquaredTo(Vector4 to)
-        {
-            return (to - this).LengthSquared();
-        }
-
-        /// <summary>
-        /// Returns the distance between this vector and <paramref name="to"/>.
-        /// </summary>
-        /// <param name="to">The other vector to use.</param>
-        /// <returns>The distance between the two vectors.</returns>
-        public readonly real_t DistanceTo(Vector4 to)
-        {
-            return (to - this).Length();
-        }
-
-        /// <summary>
-        /// Returns the dot product of this vector and <paramref name="with"/>.
-        /// </summary>
-        /// <param name="with">The other vector to use.</param>
-        /// <returns>The dot product of the two vectors.</returns>
-        public readonly real_t Dot(Vector4 with)
-        {
-            return (X * with.X) + (Y * with.Y) + (Z * with.Z) + (W * with.W);
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components rounded down (towards negative infinity).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Floor"/> called on each component.</returns>
-        public readonly Vector4 Floor()
-        {
-            return new Vector4(Mathf.Floor(X), Mathf.Floor(Y), Mathf.Floor(Z), Mathf.Floor(W));
-        }
-
-        /// <summary>
-        /// Returns the inverse of this vector. This is the same as <c>new Vector4(1 / v.X, 1 / v.Y, 1 / v.Z, 1 / v.W)</c>.
-        /// </summary>
-        /// <returns>The inverse of this vector.</returns>
-        public readonly Vector4 Inverse()
-        {
-            return new Vector4(1 / X, 1 / Y, 1 / Z, 1 / W);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector is finite, by calling
-        /// <see cref="Mathf.IsFinite"/> on each component.
-        /// </summary>
-        /// <returns>Whether this vector is finite or not.</returns>
-        public readonly bool IsFinite()
-        {
-            return Mathf.IsFinite(X) && Mathf.IsFinite(Y) && Mathf.IsFinite(Z) && Mathf.IsFinite(W);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is normalized, and <see langword="false"/> otherwise.
-        /// </summary>
-        /// <returns>A <see langword="bool"/> indicating whether or not the vector is normalized.</returns>
-        public readonly bool IsNormalized()
-        {
-            return Mathf.Abs(LengthSquared() - 1.0f) < Mathf.Epsilon;
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            real_t x2 = X * X;
-            real_t y2 = Y * Y;
-            real_t z2 = Z * Z;
-            real_t w2 = W * W;
-
-            return Mathf.Sqrt(x2 + y2 + z2 + w2);
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly real_t LengthSquared()
-        {
-            real_t x2 = X * X;
-            real_t y2 = Y * Y;
-            real_t z2 = Z * Z;
-            real_t w2 = W * W;
-
-            return x2 + y2 + z2 + w2;
-        }
-
-        /// <summary>
-        /// Returns the result of the linear interpolation between
-        /// this vector and <paramref name="to"/> by amount <paramref name="weight"/>.
-        /// </summary>
-        /// <param name="to">The destination vector for interpolation.</param>
-        /// <param name="weight">A value on the range of 0.0 to 1.0, representing the amount of interpolation.</param>
-        /// <returns>The resulting vector of the interpolation.</returns>
-        public readonly Vector4 Lerp(Vector4 to, real_t weight)
-        {
-            return new Vector4
-            (
-                Mathf.Lerp(X, to.X, weight),
-                Mathf.Lerp(Y, to.Y, weight),
-                Mathf.Lerp(Z, to.Z, weight),
-                Mathf.Lerp(W, to.W, weight)
-            );
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            int max_index = 0;
-            real_t max_value = X;
-            for (int i = 1; i < 4; i++)
-            {
-                if (this[i] > max_value)
+                if (left.Z == right.Z)
                 {
-                    max_index = i;
-                    max_value = this[i];
+                    return left.W <= right.W;
                 }
+                return left.Z < right.Z;
             }
-            return (Axis)max_index;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.W"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
+    /// <summary>
+    /// Compares two <see cref="Vector4"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector4 left, Vector4 right)
+    {
+        if (left.X == right.X)
         {
-            int min_index = 0;
-            real_t min_value = X;
-            for (int i = 1; i < 4; i++)
+            if (left.Y == right.Y)
             {
-                if (this[i] <= min_value)
+                if (left.Z == right.Z)
                 {
-                    min_index = i;
-                    min_value = this[i];
+                    return left.W >= right.W;
                 }
+                return left.Z > right.Z;
             }
-            return (Axis)min_index;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Returns the vector scaled to unit length. Equivalent to <c>v / v.Length()</c>.
-        /// </summary>
-        /// <returns>A normalized version of the vector.</returns>
-        public readonly Vector4 Normalized()
-        {
-            Vector4 v = this;
-            v.Normalize();
-            return v;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is exactly equal
+    /// to the given object (<see paramref="obj"/>).
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector4 other && Equals(other);
+    }
 
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="mod"/>.
-        /// </summary>
-        /// <param name="mod">A value representing the divisor of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="mod"/>.
-        /// </returns>
-        public readonly Vector4 PosMod(real_t mod)
-        {
-            return new Vector4(
-                Mathf.PosMod(X, mod),
-                Mathf.PosMod(Y, mod),
-                Mathf.PosMod(Z, mod),
-                Mathf.PosMod(W, mod)
-            );
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are exactly equal.
+    /// Note: Due to floating-point precision errors, consider using
+    /// <see cref="IsEqualApprox"/> instead, which is more reliable.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are exactly equal.</returns>
+    public readonly bool Equals(Vector4 other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
+    }
 
-        /// <summary>
-        /// Returns a vector composed of the <see cref="Mathf.PosMod(real_t, real_t)"/> of this vector's components
-        /// and <paramref name="modv"/>'s components.
-        /// </summary>
-        /// <param name="modv">A vector representing the divisors of the operation.</param>
-        /// <returns>
-        /// A vector with each component <see cref="Mathf.PosMod(real_t, real_t)"/> by <paramref name="modv"/>'s components.
-        /// </returns>
-        public readonly Vector4 PosMod(Vector4 modv)
-        {
-            return new Vector4(
-                Mathf.PosMod(X, modv.X),
-                Mathf.PosMod(Y, modv.Y),
-                Mathf.PosMod(Z, modv.Z),
-                Mathf.PosMod(W, modv.W)
-            );
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
+    /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
+    /// </summary>
+    /// <param name="other">The other vector to compare.</param>
+    /// <returns>Whether or not the vectors are approximately equal.</returns>
+    public readonly bool IsEqualApprox(Vector4 other)
+    {
+        return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z) && Mathf.IsEqualApprox(W, other.W);
+    }
 
-        /// <summary>
-        /// Returns this vector with all components rounded to the nearest integer,
-        /// with halfway cases rounded towards the nearest multiple of two.
-        /// </summary>
-        /// <returns>The rounded vector.</returns>
-        public readonly Vector4 Round()
-        {
-            return new Vector4(Mathf.Round(X), Mathf.Round(Y), Mathf.Round(Z), Mathf.Round(W));
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if this vector's values are approximately zero,
+    /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
+    /// This method is faster than using <see cref="IsEqualApprox"/> with one value
+    /// as a zero vector.
+    /// </summary>
+    /// <returns>Whether or not the vector is approximately zero.</returns>
+    public readonly bool IsZeroApprox()
+    {
+        return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y) && Mathf.IsZeroApprox(Z) && Mathf.IsZeroApprox(W);
+    }
 
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(real_t)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector4 Sign()
-        {
-            Vector4 v;
-            v.X = Mathf.Sign(X);
-            v.Y = Mathf.Sign(Y);
-            v.Z = Mathf.Sign(Z);
-            v.W = Mathf.Sign(W);
-            return v;
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector4"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+    }
 
-        /// <summary>
-        /// Returns this vector with each component snapped to the nearest multiple of <paramref name="step"/>.
-        /// This can also be used to round to an arbitrary number of decimals.
-        /// </summary>
-        /// <param name="step">A vector value representing the step size to snap to.</param>
-        /// <returns>The snapped vector.</returns>
-        public readonly Vector4 Snapped(Vector4 step)
-        {
-            return new Vector4(
-                Mathf.Snapped(X, step.X),
-                Mathf.Snapped(Y, step.Y),
-                Mathf.Snapped(Z, step.Z),
-                Mathf.Snapped(W, step.W)
-            );
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector4"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override string ToString()
+    {
+        return $"({X}, {Y}, {Z}, {W})";
+    }
 
-        // Constants
-        private static readonly Vector4 _zero = new Vector4(0, 0, 0, 0);
-        private static readonly Vector4 _one = new Vector4(1, 1, 1, 1);
-        private static readonly Vector4 _inf = new Vector4(Mathf.Inf, Mathf.Inf, Mathf.Inf, Mathf.Inf);
-
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector4(0, 0, 0, 0)</c>.</value>
-        public static Vector4 Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector4(1, 1, 1, 1)</c>.</value>
-        public static Vector4 One { get { return _one; } }
-        /// <summary>
-        /// Infinity vector, a vector with all components set to <see cref="Mathf.Inf"/>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector4(Mathf.Inf, Mathf.Inf, Mathf.Inf, Mathf.Inf)</c>.</value>
-        public static Vector4 Inf { get { return _inf; } }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector4"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        /// <param name="z">The vector's Z component.</param>
-        /// <param name="w">The vector's W component.</param>
-        public Vector4(real_t x, real_t y, real_t z, real_t w)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-            W = w;
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector4"/>
-        /// with the components of the given <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector4 operator +(Vector4 left, Vector4 right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            left.W += right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector4"/>
-        /// by the components of the given <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector4 operator -(Vector4 left, Vector4 right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            left.W -= right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector4"/>.
-        /// This is the same as writing <c>new Vector4(-v.X, -v.Y, -v.Z, -v.W)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// With floats, the number zero can be either positive or negative.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector4 operator -(Vector4 vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            vec.W = -vec.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4 operator *(Vector4 vec, real_t scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4 operator *(real_t scale, Vector4 vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4"/>
-        /// by the components of the given <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4 operator *(Vector4 left, Vector4 right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            left.W *= right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector4"/>
-        /// by the given <see cref="real_t"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector4 operator /(Vector4 vec, real_t divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            vec.W /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector4"/>
-        /// by the components of the given <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector4 operator /(Vector4 vec, Vector4 divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            vec.W /= divisorv.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector4"/>
-        /// with the components of the given <see cref="real_t"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(real_t)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector4(10, -20, 30, 40) % 7); // Prints "(3, -6, 2, 5)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector4 operator %(Vector4 vec, real_t divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            vec.W %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector4"/>
-        /// with the components of the given <see cref="Vector4"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="PosMod(Vector4)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector4(10, -20, 30, 10) % new Vector4(7, 8, 9, 10)); // Prints "(3, -4, 3, 0)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector4 operator %(Vector4 vec, Vector4 divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            vec.W %= divisorv.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public static bool operator ==(Vector4 left, Vector4 right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector4 left, Vector4 right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector4"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector4 left, Vector4 right)
-        {
-            if (left.X == right.X)
-            {
-                if (left.Y == right.Y)
-                {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W < right.W;
-                    }
-                    return left.Z < right.Z;
-                }
-                return left.Y < right.Y;
-            }
-            return left.X < right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector4"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector4 left, Vector4 right)
-        {
-            if (left.X == right.X)
-            {
-                if (left.Y == right.Y)
-                {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W > right.W;
-                    }
-                    return left.Z > right.Z;
-                }
-                return left.Y > right.Y;
-            }
-            return left.X > right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector4"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector4 left, Vector4 right)
-        {
-            if (left.X == right.X)
-            {
-                if (left.Y == right.Y)
-                {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W <= right.W;
-                    }
-                    return left.Z < right.Z;
-                }
-                return left.Y < right.Y;
-            }
-            return left.X < right.X;
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector4"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector4 left, Vector4 right)
-        {
-            if (left.X == right.X)
-            {
-                if (left.Y == right.Y)
-                {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W >= right.W;
-                    }
-                    return left.Z > right.Z;
-                }
-                return left.Y > right.Y;
-            }
-            return left.X > right.X;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is exactly equal
-        /// to the given object (<see paramref="obj"/>).
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector4 other && Equals(other);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are exactly equal.
-        /// Note: Due to floating-point precision errors, consider using
-        /// <see cref="IsEqualApprox"/> instead, which is more reliable.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are exactly equal.</returns>
-        public readonly bool Equals(Vector4 other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector and <paramref name="other"/> are approximately equal,
-        /// by running <see cref="Mathf.IsEqualApprox(real_t, real_t)"/> on each component.
-        /// </summary>
-        /// <param name="other">The other vector to compare.</param>
-        /// <returns>Whether or not the vectors are approximately equal.</returns>
-        public readonly bool IsEqualApprox(Vector4 other)
-        {
-            return Mathf.IsEqualApprox(X, other.X) && Mathf.IsEqualApprox(Y, other.Y) && Mathf.IsEqualApprox(Z, other.Z) && Mathf.IsEqualApprox(W, other.W);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if this vector's values are approximately zero,
-        /// by running <see cref="Mathf.IsZeroApprox(real_t)"/> on each component.
-        /// This method is faster than using <see cref="IsEqualApprox"/> with one value
-        /// as a zero vector.
-        /// </summary>
-        /// <returns>Whether or not the vector is approximately zero.</returns>
-        public readonly bool IsZeroApprox()
-        {
-            return Mathf.IsZeroApprox(X) && Mathf.IsZeroApprox(Y) && Mathf.IsZeroApprox(Z) && Mathf.IsZeroApprox(W);
-        }
-
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector4"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Vector4"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
-
-        /// <summary>
-        /// Converts this <see cref="Vector4"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector4"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}, {W.ToString(format)})";
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -1,642 +1,641 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Godot
+namespace Godot;
+
+/// <summary>
+/// 4-element structure that can be used to represent 4D grid coordinates or sets of integers.
+/// </summary>
+[Serializable]
+[StructLayout(LayoutKind.Sequential)]
+public struct Vector4I : IEquatable<Vector4I>
 {
     /// <summary>
-    /// 4-element structure that can be used to represent 4D grid coordinates or sets of integers.
+    /// Enumerated index values for the axes.
+    /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
     /// </summary>
-    [Serializable]
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector4I : IEquatable<Vector4I>
+    public enum Axis
     {
         /// <summary>
-        /// Enumerated index values for the axes.
-        /// Returned by <see cref="MaxAxisIndex"/> and <see cref="MinAxisIndex"/>.
+        /// The vector's X axis.
         /// </summary>
-        public enum Axis
+        X = 0,
+        /// <summary>
+        /// The vector's Y axis.
+        /// </summary>
+        Y,
+        /// <summary>
+        /// The vector's Z axis.
+        /// </summary>
+        Z,
+        /// <summary>
+        /// The vector's W axis.
+        /// </summary>
+        W
+    }
+
+    /// <summary>
+    /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
+    /// </summary>
+    public int X;
+
+    /// <summary>
+    /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
+    /// </summary>
+    public int Y;
+
+    /// <summary>
+    /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
+    /// </summary>
+    public int Z;
+
+    /// <summary>
+    /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
+    /// </summary>
+    public int W;
+
+    /// <summary>
+    /// Access vector components using their <paramref name="index"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index"/> is not 0, 1, 2 or 3.
+    /// </exception>
+    /// <value>
+    /// <c>[0]</c> is equivalent to <see cref="X"/>,
+    /// <c>[1]</c> is equivalent to <see cref="Y"/>,
+    /// <c>[2]</c> is equivalent to <see cref="Z"/>.
+    /// <c>[3]</c> is equivalent to <see cref="W"/>.
+    /// </value>
+    public int this[int index]
+    {
+        readonly get
         {
-            /// <summary>
-            /// The vector's X axis.
-            /// </summary>
-            X = 0,
-            /// <summary>
-            /// The vector's Y axis.
-            /// </summary>
-            Y,
-            /// <summary>
-            /// The vector's Z axis.
-            /// </summary>
-            Z,
-            /// <summary>
-            /// The vector's W axis.
-            /// </summary>
-            W
-        }
-
-        /// <summary>
-        /// The vector's X component. Also accessible by using the index position <c>[0]</c>.
-        /// </summary>
-        public int X;
-
-        /// <summary>
-        /// The vector's Y component. Also accessible by using the index position <c>[1]</c>.
-        /// </summary>
-        public int Y;
-
-        /// <summary>
-        /// The vector's Z component. Also accessible by using the index position <c>[2]</c>.
-        /// </summary>
-        public int Z;
-
-        /// <summary>
-        /// The vector's W component. Also accessible by using the index position <c>[3]</c>.
-        /// </summary>
-        public int W;
-
-        /// <summary>
-        /// Access vector components using their <paramref name="index"/>.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// <paramref name="index"/> is not 0, 1, 2 or 3.
-        /// </exception>
-        /// <value>
-        /// <c>[0]</c> is equivalent to <see cref="X"/>,
-        /// <c>[1]</c> is equivalent to <see cref="Y"/>,
-        /// <c>[2]</c> is equivalent to <see cref="Z"/>.
-        /// <c>[3]</c> is equivalent to <see cref="W"/>.
-        /// </value>
-        public int this[int index]
-        {
-            readonly get
+            switch (index)
             {
-                switch (index)
-                {
-                    case 0:
-                        return X;
-                    case 1:
-                        return Y;
-                    case 2:
-                        return Z;
-                    case 3:
-                        return W;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-            set
-            {
-                switch (index)
-                {
-                    case 0:
-                        X = value;
-                        return;
-                    case 1:
-                        Y = value;
-                        return;
-                    case 2:
-                        Z = value;
-                        return;
-                    case 3:
-                        W = value;
-                        return;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(index));
-                }
+                case 0:
+                    return X;
+                case 1:
+                    return Y;
+                case 2:
+                    return Z;
+                case 3:
+                    return W;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
         }
-
-        /// <summary>
-        /// Helper method for deconstruction into a tuple.
-        /// </summary>
-        public readonly void Deconstruct(out int x, out int y, out int z, out int w)
+        set
         {
-            x = X;
-            y = Y;
-            z = Z;
-            w = W;
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components in absolute values (i.e. positive).
-        /// </summary>
-        /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
-        public readonly Vector4I Abs()
-        {
-            return new Vector4I(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z), Mathf.Abs(W));
-        }
-
-        /// <summary>
-        /// Returns a new vector with all components clamped between the
-        /// components of <paramref name="min"/> and <paramref name="max"/> using
-        /// <see cref="Mathf.Clamp(int, int, int)"/>.
-        /// </summary>
-        /// <param name="min">The vector with minimum allowed values.</param>
-        /// <param name="max">The vector with maximum allowed values.</param>
-        /// <returns>The vector with all components clamped.</returns>
-        public readonly Vector4I Clamp(Vector4I min, Vector4I max)
-        {
-            return new Vector4I
-            (
-                Mathf.Clamp(X, min.X, max.X),
-                Mathf.Clamp(Y, min.Y, max.Y),
-                Mathf.Clamp(Z, min.Z, max.Z),
-                Mathf.Clamp(W, min.W, max.W)
-            );
-        }
-
-        /// <summary>
-        /// Returns the length (magnitude) of this vector.
-        /// </summary>
-        /// <seealso cref="LengthSquared"/>
-        /// <returns>The length of this vector.</returns>
-        public readonly real_t Length()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-            int z2 = Z * Z;
-            int w2 = W * W;
-
-            return Mathf.Sqrt(x2 + y2 + z2 + w2);
-        }
-
-        /// <summary>
-        /// Returns the squared length (squared magnitude) of this vector.
-        /// This method runs faster than <see cref="Length"/>, so prefer it if
-        /// you need to compare vectors or need the squared length for some formula.
-        /// </summary>
-        /// <returns>The squared length of this vector.</returns>
-        public readonly int LengthSquared()
-        {
-            int x2 = X * X;
-            int y2 = Y * Y;
-            int z2 = Z * Z;
-            int w2 = W * W;
-
-            return x2 + y2 + z2 + w2;
-        }
-
-        /// <summary>
-        /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.X"/>.
-        /// </summary>
-        /// <returns>The index of the highest axis.</returns>
-        public readonly Axis MaxAxisIndex()
-        {
-            int max_index = 0;
-            int max_value = X;
-            for (int i = 1; i < 4; i++)
+            switch (index)
             {
-                if (this[i] > max_value)
-                {
-                    max_index = i;
-                    max_value = this[i];
-                }
+                case 0:
+                    X = value;
+                    return;
+                case 1:
+                    Y = value;
+                    return;
+                case 2:
+                    Z = value;
+                    return;
+                case 3:
+                    W = value;
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(index));
             }
-            return (Axis)max_index;
         }
+    }
 
-        /// <summary>
-        /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
-        /// If all components are equal, this method returns <see cref="Axis.W"/>.
-        /// </summary>
-        /// <returns>The index of the lowest axis.</returns>
-        public readonly Axis MinAxisIndex()
+    /// <summary>
+    /// Helper method for deconstruction into a tuple.
+    /// </summary>
+    public readonly void Deconstruct(out int x, out int y, out int z, out int w)
+    {
+        x = X;
+        y = Y;
+        z = Z;
+        w = W;
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components in absolute values (i.e. positive).
+    /// </summary>
+    /// <returns>A vector with <see cref="Mathf.Abs(int)"/> called on each component.</returns>
+    public readonly Vector4I Abs()
+    {
+        return new Vector4I(Mathf.Abs(X), Mathf.Abs(Y), Mathf.Abs(Z), Mathf.Abs(W));
+    }
+
+    /// <summary>
+    /// Returns a new vector with all components clamped between the
+    /// components of <paramref name="min"/> and <paramref name="max"/> using
+    /// <see cref="Mathf.Clamp(int, int, int)"/>.
+    /// </summary>
+    /// <param name="min">The vector with minimum allowed values.</param>
+    /// <param name="max">The vector with maximum allowed values.</param>
+    /// <returns>The vector with all components clamped.</returns>
+    public readonly Vector4I Clamp(Vector4I min, Vector4I max)
+    {
+        return new Vector4I
+        (
+            Mathf.Clamp(X, min.X, max.X),
+            Mathf.Clamp(Y, min.Y, max.Y),
+            Mathf.Clamp(Z, min.Z, max.Z),
+            Mathf.Clamp(W, min.W, max.W)
+        );
+    }
+
+    /// <summary>
+    /// Returns the length (magnitude) of this vector.
+    /// </summary>
+    /// <seealso cref="LengthSquared"/>
+    /// <returns>The length of this vector.</returns>
+    public readonly real_t Length()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
+        int z2 = Z * Z;
+        int w2 = W * W;
+
+        return Mathf.Sqrt(x2 + y2 + z2 + w2);
+    }
+
+    /// <summary>
+    /// Returns the squared length (squared magnitude) of this vector.
+    /// This method runs faster than <see cref="Length"/>, so prefer it if
+    /// you need to compare vectors or need the squared length for some formula.
+    /// </summary>
+    /// <returns>The squared length of this vector.</returns>
+    public readonly int LengthSquared()
+    {
+        int x2 = X * X;
+        int y2 = Y * Y;
+        int z2 = Z * Z;
+        int w2 = W * W;
+
+        return x2 + y2 + z2 + w2;
+    }
+
+    /// <summary>
+    /// Returns the axis of the vector's highest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.X"/>.
+    /// </summary>
+    /// <returns>The index of the highest axis.</returns>
+    public readonly Axis MaxAxisIndex()
+    {
+        int max_index = 0;
+        int max_value = X;
+        for (int i = 1; i < 4; i++)
         {
-            int min_index = 0;
-            int min_value = X;
-            for (int i = 1; i < 4; i++)
+            if (this[i] > max_value)
             {
-                if (this[i] <= min_value)
-                {
-                    min_index = i;
-                    min_value = this[i];
-                }
+                max_index = i;
+                max_value = this[i];
             }
-            return (Axis)min_index;
         }
+        return (Axis)max_index;
+    }
 
-        /// <summary>
-        /// Returns a vector with each component set to one or negative one, depending
-        /// on the signs of this vector's components, or zero if the component is zero,
-        /// by calling <see cref="Mathf.Sign(int)"/> on each component.
-        /// </summary>
-        /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
-        public readonly Vector4I Sign()
+    /// <summary>
+    /// Returns the axis of the vector's lowest value. See <see cref="Axis"/>.
+    /// If all components are equal, this method returns <see cref="Axis.W"/>.
+    /// </summary>
+    /// <returns>The index of the lowest axis.</returns>
+    public readonly Axis MinAxisIndex()
+    {
+        int min_index = 0;
+        int min_value = X;
+        for (int i = 1; i < 4; i++)
         {
-            return new Vector4I(Mathf.Sign(X), Mathf.Sign(Y), Mathf.Sign(Z), Mathf.Sign(W));
-        }
-
-        // Constants
-        private static readonly Vector4I _zero = new Vector4I(0, 0, 0, 0);
-        private static readonly Vector4I _one = new Vector4I(1, 1, 1, 1);
-
-        /// <summary>
-        /// Zero vector, a vector with all components set to <c>0</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector4I(0, 0, 0, 0)</c>.</value>
-        public static Vector4I Zero { get { return _zero; } }
-        /// <summary>
-        /// One vector, a vector with all components set to <c>1</c>.
-        /// </summary>
-        /// <value>Equivalent to <c>new Vector4I(1, 1, 1, 1)</c>.</value>
-        public static Vector4I One { get { return _one; } }
-
-        /// <summary>
-        /// Constructs a new <see cref="Vector4I"/> with the given components.
-        /// </summary>
-        /// <param name="x">The vector's X component.</param>
-        /// <param name="y">The vector's Y component.</param>
-        /// <param name="z">The vector's Z component.</param>
-        /// <param name="w">The vector's W component.</param>
-        public Vector4I(int x, int y, int z, int w)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-            W = w;
-        }
-
-        /// <summary>
-        /// Adds each component of the <see cref="Vector4I"/>
-        /// with the components of the given <see cref="Vector4I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The added vector.</returns>
-        public static Vector4I operator +(Vector4I left, Vector4I right)
-        {
-            left.X += right.X;
-            left.Y += right.Y;
-            left.Z += right.Z;
-            left.W += right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Subtracts each component of the <see cref="Vector4I"/>
-        /// by the components of the given <see cref="Vector4I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The subtracted vector.</returns>
-        public static Vector4I operator -(Vector4I left, Vector4I right)
-        {
-            left.X -= right.X;
-            left.Y -= right.Y;
-            left.Z -= right.Z;
-            left.W -= right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Returns the negative value of the <see cref="Vector4I"/>.
-        /// This is the same as writing <c>new Vector4I(-v.X, -v.Y, -v.Z, -v.W)</c>.
-        /// This operation flips the direction of the vector while
-        /// keeping the same magnitude.
-        /// </summary>
-        /// <param name="vec">The vector to negate/flip.</param>
-        /// <returns>The negated/flipped vector.</returns>
-        public static Vector4I operator -(Vector4I vec)
-        {
-            vec.X = -vec.X;
-            vec.Y = -vec.Y;
-            vec.Z = -vec.Z;
-            vec.W = -vec.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4I operator *(Vector4I vec, int scale)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="scale">The scale to multiply by.</param>
-        /// <param name="vec">The vector to multiply.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4I operator *(int scale, Vector4I vec)
-        {
-            vec.X *= scale;
-            vec.Y *= scale;
-            vec.Z *= scale;
-            vec.W *= scale;
-            return vec;
-        }
-
-        /// <summary>
-        /// Multiplies each component of the <see cref="Vector4I"/>
-        /// by the components of the given <see cref="Vector4I"/>.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>The multiplied vector.</returns>
-        public static Vector4I operator *(Vector4I left, Vector4I right)
-        {
-            left.X *= right.X;
-            left.Y *= right.Y;
-            left.Z *= right.Z;
-            left.W *= right.W;
-            return left;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector4I"/>
-        /// by the given <see langword="int"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector4I operator /(Vector4I vec, int divisor)
-        {
-            vec.X /= divisor;
-            vec.Y /= divisor;
-            vec.Z /= divisor;
-            vec.W /= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Divides each component of the <see cref="Vector4I"/>
-        /// by the components of the given <see cref="Vector4I"/>.
-        /// </summary>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The divided vector.</returns>
-        public static Vector4I operator /(Vector4I vec, Vector4I divisorv)
-        {
-            vec.X /= divisorv.X;
-            vec.Y /= divisorv.Y;
-            vec.Z /= divisorv.Z;
-            vec.W /= divisorv.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector4I"/>
-        /// with the components of the given <see langword="int"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector4I(10, -20, 30, -40) % 7); // Prints "(3, -6, 2, -5)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisor">The divisor value.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector4I operator %(Vector4I vec, int divisor)
-        {
-            vec.X %= divisor;
-            vec.Y %= divisor;
-            vec.Z %= divisor;
-            vec.W %= divisor;
-            return vec;
-        }
-
-        /// <summary>
-        /// Gets the remainder of each component of the <see cref="Vector4I"/>
-        /// with the components of the given <see cref="Vector4I"/>.
-        /// This operation uses truncated division, which is often not desired
-        /// as it does not work well with negative numbers.
-        /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
-        /// if you want to handle negative numbers.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// GD.Print(new Vector4I(10, -20, 30, -40) % new Vector4I(6, 7, 8, 9)); // Prints "(4, -6, 6, -4)"
-        /// </code>
-        /// </example>
-        /// <param name="vec">The dividend vector.</param>
-        /// <param name="divisorv">The divisor vector.</param>
-        /// <returns>The remainder vector.</returns>
-        public static Vector4I operator %(Vector4I vec, Vector4I divisorv)
-        {
-            vec.X %= divisorv.X;
-            vec.Y %= divisorv.Y;
-            vec.Z %= divisorv.Z;
-            vec.W %= divisorv.W;
-            return vec;
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public static bool operator ==(Vector4I left, Vector4I right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are not equal.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the vectors are not equal.</returns>
-        public static bool operator !=(Vector4I left, Vector4I right)
-        {
-            return !left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two <see cref="Vector4I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than the right.</returns>
-        public static bool operator <(Vector4I left, Vector4I right)
-        {
-            if (left.X == right.X)
+            if (this[i] <= min_value)
             {
-                if (left.Y == right.Y)
-                {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W < right.W;
-                    }
-                    return left.Z < right.Z;
-                }
-                return left.Y < right.Y;
+                min_index = i;
+                min_value = this[i];
             }
-            return left.X < right.X;
         }
+        return (Axis)min_index;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector4I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than the right.</returns>
-        public static bool operator >(Vector4I left, Vector4I right)
+    /// <summary>
+    /// Returns a vector with each component set to one or negative one, depending
+    /// on the signs of this vector's components, or zero if the component is zero,
+    /// by calling <see cref="Mathf.Sign(int)"/> on each component.
+    /// </summary>
+    /// <returns>A vector with all components as either <c>1</c>, <c>-1</c>, or <c>0</c>.</returns>
+    public readonly Vector4I Sign()
+    {
+        return new Vector4I(Mathf.Sign(X), Mathf.Sign(Y), Mathf.Sign(Z), Mathf.Sign(W));
+    }
+
+    // Constants
+    private static readonly Vector4I _zero = new Vector4I(0, 0, 0, 0);
+    private static readonly Vector4I _one = new Vector4I(1, 1, 1, 1);
+
+    /// <summary>
+    /// Zero vector, a vector with all components set to <c>0</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector4I(0, 0, 0, 0)</c>.</value>
+    public static Vector4I Zero { get { return _zero; } }
+    /// <summary>
+    /// One vector, a vector with all components set to <c>1</c>.
+    /// </summary>
+    /// <value>Equivalent to <c>new Vector4I(1, 1, 1, 1)</c>.</value>
+    public static Vector4I One { get { return _one; } }
+
+    /// <summary>
+    /// Constructs a new <see cref="Vector4I"/> with the given components.
+    /// </summary>
+    /// <param name="x">The vector's X component.</param>
+    /// <param name="y">The vector's Y component.</param>
+    /// <param name="z">The vector's Z component.</param>
+    /// <param name="w">The vector's W component.</param>
+    public Vector4I(int x, int y, int z, int w)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+        W = w;
+    }
+
+    /// <summary>
+    /// Adds each component of the <see cref="Vector4I"/>
+    /// with the components of the given <see cref="Vector4I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The added vector.</returns>
+    public static Vector4I operator +(Vector4I left, Vector4I right)
+    {
+        left.X += right.X;
+        left.Y += right.Y;
+        left.Z += right.Z;
+        left.W += right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Subtracts each component of the <see cref="Vector4I"/>
+    /// by the components of the given <see cref="Vector4I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The subtracted vector.</returns>
+    public static Vector4I operator -(Vector4I left, Vector4I right)
+    {
+        left.X -= right.X;
+        left.Y -= right.Y;
+        left.Z -= right.Z;
+        left.W -= right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Returns the negative value of the <see cref="Vector4I"/>.
+    /// This is the same as writing <c>new Vector4I(-v.X, -v.Y, -v.Z, -v.W)</c>.
+    /// This operation flips the direction of the vector while
+    /// keeping the same magnitude.
+    /// </summary>
+    /// <param name="vec">The vector to negate/flip.</param>
+    /// <returns>The negated/flipped vector.</returns>
+    public static Vector4I operator -(Vector4I vec)
+    {
+        vec.X = -vec.X;
+        vec.Y = -vec.Y;
+        vec.Z = -vec.Z;
+        vec.W = -vec.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4I operator *(Vector4I vec, int scale)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        vec.W *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="scale">The scale to multiply by.</param>
+    /// <param name="vec">The vector to multiply.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4I operator *(int scale, Vector4I vec)
+    {
+        vec.X *= scale;
+        vec.Y *= scale;
+        vec.Z *= scale;
+        vec.W *= scale;
+        return vec;
+    }
+
+    /// <summary>
+    /// Multiplies each component of the <see cref="Vector4I"/>
+    /// by the components of the given <see cref="Vector4I"/>.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>The multiplied vector.</returns>
+    public static Vector4I operator *(Vector4I left, Vector4I right)
+    {
+        left.X *= right.X;
+        left.Y *= right.Y;
+        left.Z *= right.Z;
+        left.W *= right.W;
+        return left;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector4I"/>
+    /// by the given <see langword="int"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector4I operator /(Vector4I vec, int divisor)
+    {
+        vec.X /= divisor;
+        vec.Y /= divisor;
+        vec.Z /= divisor;
+        vec.W /= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Divides each component of the <see cref="Vector4I"/>
+    /// by the components of the given <see cref="Vector4I"/>.
+    /// </summary>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The divided vector.</returns>
+    public static Vector4I operator /(Vector4I vec, Vector4I divisorv)
+    {
+        vec.X /= divisorv.X;
+        vec.Y /= divisorv.Y;
+        vec.Z /= divisorv.Z;
+        vec.W /= divisorv.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector4I"/>
+    /// with the components of the given <see langword="int"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector4I(10, -20, 30, -40) % 7); // Prints "(3, -6, 2, -5)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisor">The divisor value.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector4I operator %(Vector4I vec, int divisor)
+    {
+        vec.X %= divisor;
+        vec.Y %= divisor;
+        vec.Z %= divisor;
+        vec.W %= divisor;
+        return vec;
+    }
+
+    /// <summary>
+    /// Gets the remainder of each component of the <see cref="Vector4I"/>
+    /// with the components of the given <see cref="Vector4I"/>.
+    /// This operation uses truncated division, which is often not desired
+    /// as it does not work well with negative numbers.
+    /// Consider using <see cref="Mathf.PosMod(int, int)"/> instead
+    /// if you want to handle negative numbers.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// GD.Print(new Vector4I(10, -20, 30, -40) % new Vector4I(6, 7, 8, 9)); // Prints "(4, -6, 6, -4)"
+    /// </code>
+    /// </example>
+    /// <param name="vec">The dividend vector.</param>
+    /// <param name="divisorv">The divisor vector.</param>
+    /// <returns>The remainder vector.</returns>
+    public static Vector4I operator %(Vector4I vec, Vector4I divisorv)
+    {
+        vec.X %= divisorv.X;
+        vec.Y %= divisorv.Y;
+        vec.Z %= divisorv.Z;
+        vec.W %= divisorv.W;
+        return vec;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public static bool operator ==(Vector4I left, Vector4I right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are not equal.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the vectors are not equal.</returns>
+    public static bool operator !=(Vector4I left, Vector4I right)
+    {
+        return !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="Vector4I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than the right.</returns>
+    public static bool operator <(Vector4I left, Vector4I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
+                if (left.Z == right.Z)
                 {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W > right.W;
-                    }
-                    return left.Z > right.Z;
+                    return left.W < right.W;
                 }
-                return left.Y > right.Y;
+                return left.Z < right.Z;
             }
-            return left.X > right.X;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector4I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is less than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is less than or equal to the right.</returns>
-        public static bool operator <=(Vector4I left, Vector4I right)
+    /// <summary>
+    /// Compares two <see cref="Vector4I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than the right.</returns>
+    public static bool operator >(Vector4I left, Vector4I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
+                if (left.Z == right.Z)
                 {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W <= right.W;
-                    }
-                    return left.Z < right.Z;
+                    return left.W > right.W;
                 }
-                return left.Y < right.Y;
+                return left.Z > right.Z;
             }
-            return left.X < right.X;
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Compares two <see cref="Vector4I"/> vectors by first checking if
-        /// the X value of the <paramref name="left"/> vector is greater than
-        /// or equal to the X value of the <paramref name="right"/> vector.
-        /// If the X values are exactly equal, then it repeats this check
-        /// with the Y, Z and finally W values of the two vectors.
-        /// This operator is useful for sorting vectors.
-        /// </summary>
-        /// <param name="left">The left vector.</param>
-        /// <param name="right">The right vector.</param>
-        /// <returns>Whether or not the left is greater than or equal to the right.</returns>
-        public static bool operator >=(Vector4I left, Vector4I right)
+    /// <summary>
+    /// Compares two <see cref="Vector4I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is less than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is less than or equal to the right.</returns>
+    public static bool operator <=(Vector4I left, Vector4I right)
+    {
+        if (left.X == right.X)
         {
-            if (left.X == right.X)
+            if (left.Y == right.Y)
             {
-                if (left.Y == right.Y)
+                if (left.Z == right.Z)
                 {
-                    if (left.Z == right.Z)
-                    {
-                        return left.W >= right.W;
-                    }
-                    return left.Z > right.Z;
+                    return left.W <= right.W;
                 }
-                return left.Y > right.Y;
+                return left.Z < right.Z;
             }
-            return left.X > right.X;
+            return left.Y < right.Y;
         }
+        return left.X < right.X;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector4I"/> to a <see cref="Vector4"/>.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static implicit operator Vector4(Vector4I value)
+    /// <summary>
+    /// Compares two <see cref="Vector4I"/> vectors by first checking if
+    /// the X value of the <paramref name="left"/> vector is greater than
+    /// or equal to the X value of the <paramref name="right"/> vector.
+    /// If the X values are exactly equal, then it repeats this check
+    /// with the Y, Z and finally W values of the two vectors.
+    /// This operator is useful for sorting vectors.
+    /// </summary>
+    /// <param name="left">The left vector.</param>
+    /// <param name="right">The right vector.</param>
+    /// <returns>Whether or not the left is greater than or equal to the right.</returns>
+    public static bool operator >=(Vector4I left, Vector4I right)
+    {
+        if (left.X == right.X)
         {
-            return new Vector4(value.X, value.Y, value.Z, value.W);
+            if (left.Y == right.Y)
+            {
+                if (left.Z == right.Z)
+                {
+                    return left.W >= right.W;
+                }
+                return left.Z > right.Z;
+            }
+            return left.Y > right.Y;
         }
+        return left.X > right.X;
+    }
 
-        /// <summary>
-        /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/> by truncating
-        /// components' fractional parts (rounding towards zero). For a different
-        /// behavior consider passing the result of <see cref="Vector4.Ceil"/>,
-        /// <see cref="Vector4.Floor"/> or <see cref="Vector4.Round"/> to this conversion operator instead.
-        /// </summary>
-        /// <param name="value">The vector to convert.</param>
-        public static explicit operator Vector4I(Vector4 value)
-        {
-            return new Vector4I((int)value.X, (int)value.Y, (int)value.Z, (int)value.W);
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector4I"/> to a <see cref="Vector4"/>.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static implicit operator Vector4(Vector4I value)
+    {
+        return new Vector4(value.X, value.Y, value.Z, value.W);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vector is equal
-        /// to the given object (<see paramref="obj"/>).
-        /// </summary>
-        /// <param name="obj">The object to compare with.</param>
-        /// <returns>Whether or not the vector and the object are equal.</returns>
-        public override readonly bool Equals(object obj)
-        {
-            return obj is Vector4I other && Equals(other);
-        }
+    /// <summary>
+    /// Converts a <see cref="Vector4"/> to a <see cref="Vector4I"/> by truncating
+    /// components' fractional parts (rounding towards zero). For a different
+    /// behavior consider passing the result of <see cref="Vector4.Ceil"/>,
+    /// <see cref="Vector4.Floor"/> or <see cref="Vector4.Round"/> to this conversion operator instead.
+    /// </summary>
+    /// <param name="value">The vector to convert.</param>
+    public static explicit operator Vector4I(Vector4 value)
+    {
+        return new Vector4I((int)value.X, (int)value.Y, (int)value.Z, (int)value.W);
+    }
 
-        /// <summary>
-        /// Returns <see langword="true"/> if the vectors are equal.
-        /// </summary>
-        /// <param name="other">The other vector.</param>
-        /// <returns>Whether or not the vectors are equal.</returns>
-        public readonly bool Equals(Vector4I other)
-        {
-            return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vector is equal
+    /// to the given object (<see paramref="obj"/>).
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns>Whether or not the vector and the object are equal.</returns>
+    public override readonly bool Equals(object obj)
+    {
+        return obj is Vector4I other && Equals(other);
+    }
 
-        /// <summary>
-        /// Serves as the hash function for <see cref="Vector4I"/>.
-        /// </summary>
-        /// <returns>A hash code for this vector.</returns>
-        public override readonly int GetHashCode()
-        {
-            return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
-        }
+    /// <summary>
+    /// Returns <see langword="true"/> if the vectors are equal.
+    /// </summary>
+    /// <param name="other">The other vector.</param>
+    /// <returns>Whether or not the vectors are equal.</returns>
+    public readonly bool Equals(Vector4I other)
+    {
+        return X == other.X && Y == other.Y && Z == other.Z && W == other.W;
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector4I"/> to a string.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public override readonly string ToString()
-        {
-            return $"({X}, {Y}, {Z}, {W})";
-        }
+    /// <summary>
+    /// Serves as the hash function for <see cref="Vector4I"/>.
+    /// </summary>
+    /// <returns>A hash code for this vector.</returns>
+    public override readonly int GetHashCode()
+    {
+        return Y.GetHashCode() ^ X.GetHashCode() ^ Z.GetHashCode() ^ W.GetHashCode();
+    }
 
-        /// <summary>
-        /// Converts this <see cref="Vector4I"/> to a string with the given <paramref name="format"/>.
-        /// </summary>
-        /// <returns>A string representation of this vector.</returns>
-        public readonly string ToString(string format)
-        {
-            return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}), {W.ToString(format)})";
-        }
+    /// <summary>
+    /// Converts this <see cref="Vector4I"/> to a string.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public override readonly string ToString()
+    {
+        return $"({X}, {Y}, {Z}, {W})";
+    }
+
+    /// <summary>
+    /// Converts this <see cref="Vector4I"/> to a string with the given <paramref name="format"/>.
+    /// </summary>
+    /// <returns>A string representation of this vector.</returns>
+    public readonly string ToString(string format)
+    {
+        return $"({X.ToString(format)}, {Y.ToString(format)}, {Z.ToString(format)}), {W.ToString(format)})";
     }
 }


### PR DESCRIPTION
Implements the C#10 namespace formatting on all GodotSharp files that weren't previously updated to the new style. This doesn't include any other solution as GodotSharp is comfortably using C#10 uniformly & this keeps the scope focused

Being a formatting PR, there's a second commit which updates [.git-blame-ignore-revs](https://github.com/godotengine/godot/blob/master/.git-blame-ignore-revs)