### PR TITLE
In Create New Scene dialog derive the default root node name based on `editor/naming/node_name_casing`

### DIFF
--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -48,6 +48,7 @@ class SceneCreateDialog : public ConfirmationDialog {
 	enum MsgType {
 		MSG_OK,
 		MSG_ERROR,
+		MSG_WARNING,
 	};
 
 	const StringName type_meta = StringName("type");


### PR DESCRIPTION
Fixes #79751 

This PR updates the Create New Scene dialog to respect the `editor/naming/node_name_casing` project setting for the root node name (when it's left empty). I also updated the placeholder text to be more accurate, as well as add a tooltip to the line edit control with more information (so users can discover the project setting if they aren't aware of it yet)