### PR TITLE
Don't allow weaker return type in overriden method

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1704,6 +1704,8 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 				} else {
 					valid = valid && is_type_compatible(parent_return_type, return_type);
 				}
+			} else if (!parent_return_type.is_variant() && !parent_return_type.is_void()) {
+				valid = false;
 			}
 
 			int par_count_diff = p_function->parameters.size() - parameters_types.size();

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -144,6 +144,7 @@ public:
 		_FORCE_INLINE_ bool is_resolving() const { return kind == RESOLVING; }
 		_FORCE_INLINE_ bool has_no_type() const { return type_source == UNDETECTED; }
 		_FORCE_INLINE_ bool is_variant() const { return kind == VARIANT || kind == RESOLVING || kind == UNRESOLVED; }
+		_FORCE_INLINE_ bool is_void() const { return kind == BUILTIN && builtin_type == Variant::NIL; }
 		_FORCE_INLINE_ bool is_hard_type() const { return type_source > INFERRED; }
 
 		String to_string() const;

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_with_weaker_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_with_weaker_type.gd
@@ -1,0 +1,7 @@
+class Parent:
+	func override_me() -> bool:
+		return true
+
+class Child extends Parent:
+	func override_me():
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_with_weaker_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_with_weaker_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The function signature doesn't match the parent. Parent signature is "override_me() -> bool".

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_with_wrong_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_with_wrong_type.gd
@@ -1,0 +1,7 @@
+class Parent:
+	func override_me() -> bool:
+		return true
+
+class Child extends Parent:
+	func override_me() -> int:
+		return 1

--- a/modules/gdscript/tests/scripts/analyzer/errors/override_with_wrong_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/override_with_wrong_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+The function signature doesn't match the parent. Parent signature is "override_me() -> bool".

--- a/modules/gdscript/tests/scripts/analyzer/features/override_variant_with_weaker_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_variant_with_weaker_type.gd
@@ -1,0 +1,10 @@
+class Parent:
+	func override_me() -> Variant:
+		return true
+
+class Child extends Parent:
+	func override_me():
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/override_variant_with_weaker_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_variant_with_weaker_type.out
@@ -1,0 +1,1 @@
+GDTEST_OK

--- a/modules/gdscript/tests/scripts/analyzer/features/override_void_with_weaker_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_void_with_weaker_type.gd
@@ -1,0 +1,10 @@
+class Parent:
+	func override_me() -> void:
+		pass
+
+class Child extends Parent:
+	func override_me():
+		pass
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/override_void_with_weaker_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_void_with_weaker_type.out
@@ -1,0 +1,1 @@
+GDTEST_OK

--- a/modules/gdscript/tests/scripts/analyzer/features/override_with_stronger_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_with_stronger_type.gd
@@ -1,0 +1,10 @@
+class Parent:
+	func override_me():
+		pass
+
+class Child extends Parent:
+	func override_me() -> bool:
+		return true
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/features/override_with_stronger_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_with_stronger_type.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
This code
```GDScript
class Parent:
	func override_me() -> bool:
		return true

class Child extends Parent:
	func override_me():
		pass
```
should result in an error, but it didn't.

EDIT:
This breaks methods that return Variant, I'll try to fix it xd

EDIT2:
Fixed and added more tests.

EDIT3:
I added another case for `void`, but it's rather questionable now 😬

* _Bugsquad edit:_ Fixes #90694.