### PR TITLE
Fix Camera2D->get_viewport() crashes editor on startup inside main screen plugin

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -40,8 +40,8 @@ void Camera2D::_update_scroll() {
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		queue_redraw();
-		// Only set viewport transform when not bound to the main viewport.
-		if (get_tree()->get_edited_scene_root() && get_viewport() == get_tree()->get_edited_scene_root()->get_viewport()) {
+		
+		if (!viewport || !custom_viewport) {
 			return;
 		}
 	}


### PR DESCRIPTION
A fix to access memory violation which results in an editor crash on startup when using Camera2D inside a SubViewport in main screen editor plugin because the get_viewport() function returns a nullptr.

To produce the error create a main screen editor plugin Control then add SubViewportContainer -> SubViewport -> Node2D -> Camera2D and set the plugin enabled then restart the engine and it will crash on startup.