### PR TITLE
Document performance caveats of RGB image formats versus RGBA

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -107,6 +107,7 @@
 			<param index="0" name="format" type="int" enum="Image.Format" />
 			<description>
 				Converts the image's format. See [enum Format] constants.
+				[b]Note:[/b] Converting to [constant FORMAT_RGBA8] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently convert an image, consider using [constant FORMAT_RGBA8], or better, [constant FORMAT_RG8] or [constant FORMAT_R8] if possible. The same applies to [constant FORMAT_RGBAH] and [constant FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="copy_from">
@@ -124,6 +125,7 @@
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<description>
 				Creates an empty image of given size and format. See [enum Format] constants. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for this image. See the [method generate_mipmaps].
+				[b]Note:[/b] Creating an image in [constant FORMAT_RGBA8] [param format] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently create an image, consider using [constant FORMAT_RGBA8], or better, [constant FORMAT_RG8] or [constant FORMAT_R8] if possible. The same applies to [constant FORMAT_RGBAH] and [constant FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="create_from_data" qualifiers="static">
@@ -135,6 +137,7 @@
 			<param index="4" name="data" type="PackedByteArray" />
 			<description>
 				Creates a new image of given size and format. See [enum Format] constants. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code] then loads mipmaps for this image from [param data]. See [method generate_mipmaps].
+				[b]Note:[/b] Creating an image in [constant FORMAT_RGBA8] [param format] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently create an image, consider using [constant FORMAT_RGBA8], or better, [constant FORMAT_RG8] or [constant FORMAT_R8] if possible. The same applies to [constant FORMAT_RGBAH] and [constant FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="crop">
@@ -487,6 +490,7 @@
 			<param index="4" name="data" type="PackedByteArray" />
 			<description>
 				Overwrites data of an existing [Image]. Non-static equivalent of [method create_from_data].
+				[b]Note:[/b] Setting image data with the [constant FORMAT_RGBA8] [param format] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently set image data, consider using [constant FORMAT_RGBA8], or better, [constant FORMAT_RG8] or [constant FORMAT_R8] if possible. The same applies to [constant FORMAT_RGBAH] and [constant FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="set_pixel">
@@ -582,6 +586,7 @@
 		<constant name="FORMAT_RGB8" value="4" enum="Format">
 			OpenGL texture format [code]RGB[/code] with three components, each with a bitdepth of 8.
 			[b]Note:[/b] When creating an [ImageTexture], an sRGB to linear color space conversion is performed.
+			[b]Note:[/b] This format is slow to procedurally create and update, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently create or update an image, consider using [constant FORMAT_RGBA8], or better, [constant FORMAT_RG8] or [constant FORMAT_R8] if possible. The same applies to [constant FORMAT_RGBAH] and [constant FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 		</constant>
 		<constant name="FORMAT_RGBA8" value="5" enum="Format">
 			OpenGL texture format [code]RGBA[/code] with four components, each with a bitdepth of 8.

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -64,6 +64,7 @@
 				Replaces the texture's data with a new [Image].
 				[b]Note:[/b] The texture has to be created using [method create_from_image] or initialized first with the [method set_image] method before it can be updated. The new image dimensions, format, and mipmaps configuration should match the existing texture's image configuration.
 				Use this method over [method set_image] if you need to update the texture frequently, which is faster than allocating additional memory for a new texture each time.
+				[b]Note:[/b] Updating an [ImageTexture] that uses the [constant Image.FORMAT_RGBA8] format is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently update an [ImageTexture], consider using [constant Image.FORMAT_RGBA8], or better, [constant Image.FORMAT_RG8] or [constant Image.FORMAT_R8] if possible. The same applies to [constant Image.FORMAT_RGBAH] and [constant Image.FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/ImageTexture3D.xml
+++ b/doc/classes/ImageTexture3D.xml
@@ -20,6 +20,7 @@
 			<param index="5" name="data" type="Image[]" />
 			<description>
 				Creates the [ImageTexture3D] with specified [param width], [param height], and [param depth]. See [enum Image.Format] for [param format] options. If [param use_mipmaps] is [code]true[/code], then generate mipmaps for the [ImageTexture3D].
+				[b]Note:[/b] Creating an [ImageTexture3D] with the [constant Image.FORMAT_RGBA8] [param format] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently create an [ImageTexture3D], consider using [constant Image.FORMAT_RGBA8], or better, [constant Image.FORMAT_RG8] or [constant Image.FORMAT_R8] if possible. The same applies to [constant Image.FORMAT_RGBAH] and [constant Image.FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="update">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3254,7 +3254,10 @@
 			<param index="4" name="mipmaps" type="bool" />
 			<param index="5" name="data" type="Image[]" />
 			<description>
+				Creates a 3-dimensional texture and adds it to the RenderingServer. It can be accessed with the RID that is returned. This RID will be used in all [code]texture_3d_*[/code] RenderingServer functions.
+				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] method.
 				[b]Note:[/b] The equivalent resource is [Texture3D].
+				[b]Note:[/b] Creating a [Texture3D] with the [constant Image.FORMAT_RGBA8] [param format] is slow, as it is not aligned to 1, 2 or 4 bytes. If you need to frequently create a [Texture3D], consider using [constant Image.FORMAT_RGBA8], or better, [constant Image.FORMAT_RG8] or [constant Image.FORMAT_R8] if possible. The same applies to [constant Image.FORMAT_RGBAH] and [constant Image.FORMAT_RGBAF] versus their RGB/RG/R counterparts.
 			</description>
 		</method>
 		<method name="texture_3d_get" qualifiers="const">


### PR DESCRIPTION
For context, @lyuma ran this benchmark on a 4096×4096 texture:

```gdscript
func _process(delta):
	var time_start: int = Time.get_ticks_usec()
	image_texture.update(image)
	var time_end: int = Time.get_ticks_usec()
	print(str(0.001 * (time_end - time_start)) + " ms")
```

These are the results they got depending on the Image format used:

Format | Time taken to update
-|-
RF | 21ms
RGF | 48ms
**RGBF** | **650ms**
RGBAF | 100ms
 | 
RH | 10ms
RGH | 20ms
**RGBH** | **800ms**
RGBAH | 48ms
 | 
R8 | 6.0ms
RG8 | 12ms
**RGB8** | **51ms**
RGBA8 | 21ms

Counterintuitively, the more memory-intensive RGBA formats always outperform the RGB format by a significant margin (by a 5× factor on average on this test). This is due to memory alignment, as RGB uses 3 components whereas other formats use 1, 2 or 4 components (powers of 2).

Considering how important the difference is, I think it's better to add notes everywhere it's relevant, even if it's a bit redundant.

- See https://github.com/godotengine/godot/issues/76994.
