### PR TITLE
Unbind the framebuffer when updating meshes

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1075,6 +1075,7 @@ void MeshStorage::update_mesh_instances() {
 	}
 
 	glEnable(GL_RASTERIZER_DISCARD);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	// Process skeletons and blend shapes using transform feedback
 	while (dirty_mesh_instance_arrays.first()) {
 		MeshInstance *mi = dirty_mesh_instance_arrays.first()->self();


### PR DESCRIPTION
Skeleton-driven meshes are rendered corrupted (missing, frozen, exploded, or stuttering) when running mobile XR games using the gl_compatibility renderer. Additionally users have reported streams of "Mismatch between shader number of views and FBO number of views" error messages in logcat outputs.

The cause is having an XR framebuffer with two views bound when calling the skeleton vertex shaders to deform the meshes. The skeleton shaders don't actually render to the framebuffer, but the mobile GLES drivers will still verify the shaders and framebuffer are compatible. In this case the XR framebuffer has two views (stereoscopic left and right eyes) but the shaders are not configured for two views and so GLES refuses to run the skeleton vertex shader.

This pull request fixes the issue #79769 by unbinding the framebuffer with a `glBindFramebuffer(GL_FRAMEBUFFER, 0);` at the beginning of `MeshStorage::update_mesh_instances()` at the same time rasterization is disabled.