### PR TITLE
Improve overriding the root type or root name in the scene importer

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -48,16 +48,16 @@
 			[b]Note:[/b] Only effective if [member meshes/light_baking] is set to [b]Static Lightmaps[/b].
 		</member>
 		<member name="nodes/apply_root_scale" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], [member nodes/root_scale] will be applied on the meshes and animations directly, while keeping the root node's scale to the default [code](1, 1, 1)[/code]. This means that if you add a child node later on within the imported scene, it won't be scaled. If disabled, [member nodes/root_scale] will multiply the scale of the root node instead.
+			If [code]true[/code], [member nodes/root_scale] will be applied to the descendant nodes, meshes, animations, bones, etc. This means that if you add a child node later on within the imported scene, it won't be scaled. If [code]false[/code], [member nodes/root_scale] will multiply the scale of the root node instead.
 		</member>
-		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;Scene Root&quot;">
-			The name of the root node in the imported scene. This is generally not noticeable when instancing the scene in the editor (or drag-and-dropping from the FileSystem dock), as the root node is renamed to match the filename in this case.
+		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;&quot;">
+			Override for the root node name. If empty, the root node will use what the scene specifies, or the file name if the scene does not specify a root name.
 		</member>
 		<member name="nodes/root_scale" type="float" setter="" getter="" default="1.0">
-			The scale of meshes and animations (if [member nodes/apply_root_scale] is [code]true[/code]), or the scale of the root node in the imported scene (if [member nodes/apply_root_scale] is [code]false[/code]).
+			The uniform scale to use for the scene root. The default value of [code]1.0[/code] will not perform any rescaling. See [member nodes/apply_root_scale] for details of how this scale is applied.
 		</member>
-		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;Node3D&quot;">
-			The node type to use as a root node. Using node types that inherit from [Node3D] is recommended. Otherwise, you'll lose the ability to position the node directly in the 3D editor.
+		<member name="nodes/root_type" type="String" setter="" getter="" default="&quot;&quot;">
+			Override for the root node type. If empty, the root node will use what the scene specifies, or [Node3D] if the scene does not specify a root type. Using a node type that inherits from [Node3D] is recommended. Otherwise, you'll lose the ability to position the node directly in the 3D editor.
 		</member>
 		<member name="skins/use_named_skins" type="bool" setter="" getter="" default="true">
 			If checked, use named [Skin]s for animation. The [MeshInstance3D] node contains 3 properties of relevance here: a skeleton [NodePath] pointing to the [Skeleton3D] node (usually [code]..[/code]), a mesh, and a skin:


### PR DESCRIPTION
The code to override the root type and root name of an imported 3D scene in the current master is a bit weird/hacky.

For the type, the code in master checks if the type is set to anything other than Node3D, if so then it will replace the root node with that type, if not it will keep the node the importer provided. This means that there is no way to explicitly ask for the type to be Node3D. With this PR, the default value is an empty string, and it can be set to Node3D explicitly. Existing *.import files will continue to work, since they would cause Node3D to be replaced with Node3D.

For the name, the code in master checks if the name is different from "Scene Root", if so then it will replace the name with that name, or if it is equal to "Scene Root" then it will use the file name. Similarly to the above, this means that there is no way to explicitly ask for the name to be "Scene Root". Also, this means that there is no way for the importer to suggest a name for the scene (GLTF files may contain this information, but it's currently not used by Godot for the node name). With this PR, the default value is an empty string. Existing *.import files will continue to work. There still is no way to explicitly set the name to "Scene Root" because I added a special case to keep existing *.import files working, but we can remove this special case in a future compatibility breakage.

This PR also adds documentation for the `nodes/` scene import properties.