### PR TITLE
Disable NavigationMesh `edge_max_length` property by default

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -105,8 +105,8 @@
 		<member name="edge_max_error" type="float" setter="set_edge_max_error" getter="get_edge_max_error" default="1.3">
 			The maximum distance a simplified contour's border edges should deviate the original raw contour.
 		</member>
-		<member name="edge_max_length" type="float" setter="set_edge_max_length" getter="get_edge_max_length" default="12.0">
-			The maximum allowed length for contour edges along the border of the mesh.
+		<member name="edge_max_length" type="float" setter="set_edge_max_length" getter="get_edge_max_length" default="0.0">
+			The maximum allowed length for contour edges along the border of the mesh. A value of [code]0.0[/code] disables this feature.
 			[b]Note:[/b] While baking, this value will be rounded up to the nearest multiple of [member cell_size].
 		</member>
 		<member name="filter_baking_aabb" type="AABB" setter="set_filter_baking_aabb" getter="get_filter_baking_aabb" default="AABB(0, 0, 0, 0, 0, 0)">

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -99,7 +99,7 @@ protected:
 	float agent_max_slope = 45.0f;
 	float region_min_size = 2.0f;
 	float region_merge_size = 20.0f;
-	float edge_max_length = 12.0f;
+	float edge_max_length = 0.0f;
 	float edge_max_error = 1.3f;
 	float vertices_per_polygon = 6.0f;
 	float detail_sample_distance = 6.0f;


### PR DESCRIPTION
Disables NavigationMesh `edge_max_length` property by default.

This `edge_max_length` is an optional ReCast 3D baking property that was set to `12.0` in ancient Godot times for arbitrary reasons.

The value is so nonsensical low that basically every baking of a larger and flat surface would turn out as an inefficient and ugly navigation mesh that would also be bug-ridden in pathfinding due to the forced high density of long edges only in some areas.

Users could not connect this always unwanted result to this specific bake property so it should be disabled by default.

If `edge_max_length`  is set to `0.0` that optional feature is disabled in the ReCast baking process.
It can still be enabled by user choice in the inspector or script manually.

![edgelen](https://github.com/godotengine/godot/assets/52464204/ade8dd58-59f5-4dbe-8d38-55e5ea23dda1)

The idea of this `edge_max_length` property is that for pathfinding algorithms that travel through polygon centers or midpoints of edges it is better to keep the polygons and edges at a reasonable size to have a more accurate pathfinding result. It just does not work with large, flat and open areas.

Godot pathfinding does not use such a cheap and bug-prone algorithm. The Godot pathfinding always travels through the calculated closest edge positions so the actual length of the edge or its midpoint does not really matter in this case.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
