### PR TITLE
Correctly display tooltips for buttons in Tree when they overlap cell content (reverted)

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2411,6 +2411,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (rtl) {
 					button_ofs.x = get_size().width - button_ofs.x - button_texture->get_width();
 				}
+				p_item->cells.write[i].buttons.write[j].rect = Rect2i(button_ofs, button_size);
 				button_texture->draw(ci, button_ofs, p_item->cells[i].buttons[j].disabled ? Color(1, 1, 1, 0.5) : p_item->cells[i].buttons[j].color);
 				item_width_with_buttons -= button_size.width + theme_cache.button_margin;
 			}
@@ -5350,6 +5351,7 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 			return Control::get_tooltip(p_pos);
 		}
 
+		Point2 button_pos = pos;
 		if (h_scroll->is_visible_in_tree()) {
 			pos.x += h_scroll->get_value();
 		}
@@ -5362,22 +5364,13 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 
 		if (it) {
 			const TreeItem::Cell &c = it->cells[col];
-			int col_width = get_column_width(col);
-
-			for (int i = 0; i < col; i++) {
-				pos.x -= get_column_width(i);
-			}
-
 			for (int j = c.buttons.size() - 1; j >= 0; j--) {
-				Ref<Texture2D> b = c.buttons[j].texture;
-				Size2 size = b->get_size() + theme_cache.button_pressed->get_minimum_size();
-				if (pos.x > col_width - size.width) {
+				if (c.buttons[j].rect.has_point(button_pos)) {
 					String tooltip = c.buttons[j].tooltip;
 					if (!tooltip.is_empty()) {
 						return tooltip;
 					}
 				}
-				col_width -= size.width;
 			}
 			String ret;
 			if (it->get_tooltip_text(col) == "") {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -108,6 +108,7 @@ private:
 			Ref<Texture2D> texture;
 			Color color = Color(1, 1, 1, 1);
 			String tooltip;
+			Rect2i rect;
 		};
 
 		Vector<Button> buttons;


### PR DESCRIPTION
Closes #79629 

I copied the 3.x behavior for the SceneTree: once the width becomes too small, the overflowing text of the node's name is hidden.

![TooltipBug](https://github.com/godotengine/godot/assets/52176659/4f8aafd0-56fa-4465-95d8-ea40337bc03b)

The way I found to do this is by creating a second column in the TreeItem and adding the buttons to this column to make sure that there is no overlap. I also set the clip property of the first column to false in order to hide the overflow