### PR TITLE
Make the single window mode check more strict

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7196,7 +7196,7 @@ EditorNode::EditorNode() {
 	dock_select->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	dock_vb->add_child(dock_select);
 
-	if (!SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && EDITOR_GET("interface/multi_window/enable")) {
+	if (!SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable")) {
 		dock_float = memnew(Button);
 		dock_float->set_icon(theme->get_icon("MakeFloating", "EditorIcons"));
 		dock_float->set_text(TTR("Make Floating"));

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -313,7 +313,7 @@ void WindowWrapper::set_margins_enabled(bool p_enabled) {
 }
 
 WindowWrapper::WindowWrapper() {
-	if (SceneTree::get_singleton()->get_root()->is_embedding_subwindows() || !EDITOR_GET("interface/multi_window/enable")) {
+	if (SceneTree::get_singleton()->get_root()->is_embedding_subwindows() || EDITOR_GET("interface/editor/single_window_mode") || !EDITOR_GET("interface/multi_window/enable")) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #79673

Turns out that `SceneTree::is_embedding_subwindows()` is false during editor initialization when the `interface/editor/single_window_mode` editor setting is true (didn't check where the setting is checked).
That's why is not reproducible with the `--single-window` command line flag.

