### PR TITLE
Update outdated C# code sample in `AStarGrid2D` documentation

### DIFF
--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -17,7 +17,7 @@
 		[/gdscript]
 		[csharp]
 		AStarGrid2D astarGrid = new AStarGrid2D();
-		astarGrid.Size = new Vector2I(32, 32);
+		astarGrid.Region = new Rect2I(0, 0, 32, 32);
 		astarGrid.CellSize = new Vector2I(16, 16);
 		astarGrid.Update();
 		GD.Print(astarGrid.GetIdPath(Vector2I.Zero, new Vector2I(3, 4))); // prints (0, 0), (1, 1), (2, 2), (3, 3), (3, 4)


### PR DESCRIPTION
This fixes a minor error in the documentation for the AStarGrid2D API C# example, replacing the now deprecated 'Size' property with the recommended 'Region' property. This encourages newcomers to the API to use the most up-to-date syntax and avoid deprecated properties.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot-docs/issues/7712*