### PR TITLE
Prevent SubViewportContainer overriding Subviewport's cursor with its own cursor

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -247,6 +247,10 @@ PackedStringArray SubViewportContainer::get_configuration_warnings() const {
 		warnings.push_back(RTR("This node doesn't have a SubViewport as child, so it can't display its intended content.\nConsider adding a SubViewport as a child to provide something displayable."));
 	}
 
+	if (get_default_cursor_shape() != Control::CURSOR_ARROW) {
+		warnings.push_back(RTR("The default mouse cursor shape of SubViewportContainer has no effect.\nConsider leaving it at its initial value `CURSOR_ARROW`."));
+	}
+
 	return warnings;
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2075,7 +2075,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		}
 
-		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE)) {
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CURSOR_SHAPE) && !Object::cast_to<SubViewportContainer>(over)) {
 			DisplayServer::get_singleton()->cursor_set_shape(ds_cursor_shape);
 		}
 	}


### PR DESCRIPTION
Fixes #74805 

A fix to the same issue is being worked on as part of a larger effort at #67791. However, to my knowledge, the cursor issue is not strictly related to notifications or signals, but instead is caused by the fact that SubViewportContainer inherits from Control, and all Control nodes define their own cursor. Currently whatever cursor the SubViewportContainer returns, it overrides the cursor that should be shown based on the contents of the viewport.

This fix is a oneliner that skips setting the cursor for all SubViewportContainer nodes. (One alternative that I can think of would be to allow Control nodes to return a "null" cursor shape from the get_cursor_shape function, which would be handled in viewport.cpp in a way that causes the cursor update to be skipped. This would get rid of the cast.)

Here is a demo with nested subviewports:
[nested-subviewports-demo.zip](https://github.com/godotengine/godot/files/12137447/nested-subviewports-demo.zip)

It shows the default cursor in the master branch, shows the correct I-Beam and resize cursors with this fix applied.

