### PR TITLE
Don't clear window style when minimizing it (MS Windows)

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1463,7 +1463,7 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_fullscre
 		r_style_ex |= WS_EX_TOPMOST | WS_EX_NOACTIVATE;
 	}
 
-	if (!p_borderless && !p_no_activate_focus) {
+	if (!p_fullscreen && !p_borderless && !p_no_activate_focus) {
 		r_style |= WS_VISIBLE;
 	}
 
@@ -1504,7 +1504,7 @@ void DisplayServerWindows::window_set_mode(WindowMode p_mode, WindowID p_window)
 	ERR_FAIL_COND(!windows.has(p_window));
 	WindowData &wd = windows[p_window];
 
-	if (wd.fullscreen && p_mode != WINDOW_MODE_FULLSCREEN && p_mode != WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
+	if (wd.fullscreen && (p_mode != WINDOW_MODE_FULLSCREEN) && (p_mode != WINDOW_MODE_EXCLUSIVE_FULLSCREEN) && (p_mode != WINDOW_MODE_MINIMIZED)) {
 		RECT rect;
 
 		wd.fullscreen = false;


### PR DESCRIPTION
- When the window is minimized, do not clear the window styling to avoid unexpected defaults when restoring it. (Exclude WINDOW_MODE_MINIMIZED from being a valid state for clear)
- Also, do not make borders visible on full screen. This fixes a state where the game may be full screen but the border still appears when restoring a window (there is no "bordered full screen" mode anyway)

Fixes #79641 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
