### PR TITLE
Clarify that `Callable` will not be encoded with `var_to_bytes`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1428,6 +1428,7 @@
 			<description>
 				Encodes a [Variant] value to a byte array, without encoding objects. Deserialization can be done with [method bytes_to_var].
 				[b]Note:[/b] If you need object serialization, see [method var_to_bytes_with_objects].
+				[b]Note:[/b] Encoding [Callable] is not supported and will result in an empty value, regardless of the data.
 			</description>
 		</method>
 		<method name="var_to_bytes_with_objects">
@@ -1435,6 +1436,7 @@
 			<param index="0" name="variable" type="Variant" />
 			<description>
 				Encodes a [Variant] value to a byte array. Encoding objects is allowed (and can potentially include executable code). Deserialization can be done with [method bytes_to_var_with_objects].
+				[b]Note:[/b] Encoding [Callable] is not supported and will result in an empty value, regardless of the data.
 			</description>
 		</method>
 		<method name="var_to_str">


### PR DESCRIPTION
Only added to `@GlobalScope`, can add to `FileAccess` as well if desired, but it links there so didn't want to repeat too much

* Fixes: #79802 
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
