### PR TITLE
doc: Clarify when to construct a StringName ahead of time

### DIFF
--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		[StringName]s are immutable strings designed for general-purpose representation of unique names (also called "string interning"). Two [StringName]s with the same value are the same object. Comparing them is extremely fast compared to regular [String]s.
-		You will usually just pass a [String] to methods expecting a [StringName] and it will be automatically converted, but you may occasionally want to construct a [StringName] ahead of time with the [StringName] constructor or, in GDScript, the literal syntax [code]&amp;"example"[/code].
+		You will usually pass a [String] to methods expecting a [StringName] and it will be automatically converted (often at compile time), but in rare cases you can construct a [StringName] ahead of time with the [StringName] constructor or, in GDScript, the literal syntax [code]&amp;"example"[/code]. Manually constructing a [StringName] allows you to control when the conversion from [String] occurs or to use the literal and prevent conversions entirely.
 		See also [NodePath], which is a similar concept specifically designed to store pre-parsed scene tree paths.
 		All of [String]'s methods are available in this class too. They convert the [StringName] into a string, and they also return a string. This is highly inefficient and should only be used if the string is desired.
 		[b]Note:[/b] In a boolean context, a [StringName] will evaluate to [code]false[/code] if it is empty ([code]StringName("")[/code]). Otherwise, a [StringName] will always evaluate to [code]true[/code]. The [code]not[/code] operator cannot be used. Instead, [method is_empty] should be used to check for empty [StringName]s.


### PR DESCRIPTION
*I'm not certain my edit is 100% correct.*

Clarify that manual StringName construction is an optimization for controlling when you pay the construction cost. Avoiding the word "optimization" so people don't use `&""` everywhere by default.


Old text:
> You will usually just pass a [String](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string) to methods expecting a StringName and it will be automatically converted, but you may occasionally want to construct a StringName ahead of time with the StringName constructor or, in GDScript, the literal syntax &"example".

That immediately suggests the question: when and why? 

I can only think of performance reasons:

* when doing a lot of string comparisons
* when StringName conversions occur every `process` or especially in a tight loop

I assume there's never a non-perf reason?



# Uncertainty

I looked up the docs because the [finite_state_machine demo uses &""](https://github.com/godotengine/godot-demo-projects/blob/f7e3ceb31eee9607b1676b52a0636aa67e371a70/2d/finite_state_machine/player/states/motion/motion.gd#L11) for `Input.get_axis`:

```gdscript
func get_input_direction():
	var input_direction = Vector2(
			Input.get_axis(&"move_left", &"move_right"),
			Input.get_axis(&"move_up", &"move_down")
	)
	return input_direction
```

I assume this is a good example of how to optimize with `&""` and that using the literal `&""` constructs the 4 StringNames at parse time and not per invocation of `get_input_direction()`?

If that's incorrect and this is the correct optimization:

```gdscript
var move_left = &"move_left"
var move_right = &"move_right"
var move_up = &"move_up"
var move_down = &"move_down"
func get_input_direction():
	var input_direction = Vector2(
			Input.get_axis(move_left, move_right),
			Input.get_axis(move_up, move_down)
	)
	return input_direction
```


Then a better final line would be:

> Manual construction allows you to control when StringName conversions occur (moving them out of loops or hot code paths).