### PR TITLE
Support padding `CanvasTexture` in `TileSetAtlasSource`

### DIFF
--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -637,10 +637,11 @@ private:
 	void _clear_tiles_outside_texture();
 
 	bool use_texture_padding = true;
-	Ref<ImageTexture> padded_texture;
+	Ref<Texture2D> padded_texture;
 	bool padded_texture_needs_update = false;
 	void _queue_update_padded_texture();
 	void _update_padded_texture();
+	Ref<Image> _create_padded_image(const Ref<Image> &p_src);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);


### PR DESCRIPTION
Now for a TileSetAtlasSource with `use_texture_padding` enabled and with a CanvasTexture assigned as `texture` the generated padded texture will also be a CanvasTexture, with the diffuse/normal/specular textures padded separately.

Fixes #61832 (https://github.com/godotengine/godot/issues/61832#issuecomment-1296140322).