### PR TITLE
Fix `get_cursor_shape()` in tile atlas editor

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1533,66 +1533,6 @@ void TileSetAtlasSourceEditor::_end_dragging() {
 	// Change mouse accordingly.
 }
 
-Control::CursorShape TileSetAtlasSourceEditor::get_cursor_shape(const Point2 &p_pos) const {
-	Control::CursorShape cursor_shape = get_default_cursor_shape();
-	if (drag_type == DRAG_TYPE_NONE) {
-		if (selection.size() == 1) {
-			// Change the cursor depending on the hovered thing.
-			TileSelection selected = selection.front()->get();
-			if (selected.tile != TileSetSource::INVALID_ATLAS_COORDS && selected.alternative == 0) {
-				Transform2D xform = tile_atlas_control->get_global_transform().affine_inverse() * get_global_transform();
-				Vector2 mouse_local_pos = xform.xform(p_pos);
-				Vector2i size_in_atlas = tile_set_atlas_source->get_tile_size_in_atlas(selected.tile);
-				Rect2 region = tile_set_atlas_source->get_tile_texture_region(selected.tile);
-				Size2 zoomed_size = resize_handle->get_size() / tile_atlas_view->get_zoom();
-				Rect2 rect = region.grow_individual(zoomed_size.x, zoomed_size.y, 0, 0);
-				const Vector2i coords[] = { Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1), Vector2i(0, 1) };
-				const Vector2i directions[] = { Vector2i(0, -1), Vector2i(1, 0), Vector2i(0, 1), Vector2i(-1, 0) };
-				bool can_grow[4];
-				for (int i = 0; i < 4; i++) {
-					can_grow[i] = tile_set_atlas_source->has_room_for_tile(selected.tile + directions[i], tile_set_atlas_source->get_tile_size_in_atlas(selected.tile), tile_set_atlas_source->get_tile_animation_columns(selected.tile), tile_set_atlas_source->get_tile_animation_separation(selected.tile), tile_set_atlas_source->get_tile_animation_frames_count(selected.tile), selected.tile);
-					can_grow[i] |= (i % 2 == 0) ? size_in_atlas.y > 1 : size_in_atlas.x > 1;
-				}
-				for (int i = 0; i < 4; i++) {
-					Vector2 pos = rect.position + rect.size * coords[i];
-					if (can_grow[i] && can_grow[(i + 3) % 4] && Rect2(pos, zoomed_size).has_point(mouse_local_pos)) {
-						cursor_shape = (i % 2) ? CURSOR_BDIAGSIZE : CURSOR_FDIAGSIZE;
-					}
-					Vector2 next_pos = rect.position + rect.size * coords[(i + 1) % 4];
-					if (can_grow[i] && Rect2((pos + next_pos) / 2.0, zoomed_size).has_point(mouse_local_pos)) {
-						cursor_shape = (i % 2) ? CURSOR_HSIZE : CURSOR_VSIZE;
-					}
-				}
-			}
-		}
-	} else {
-		switch (drag_type) {
-			case DRAG_TYPE_RESIZE_TOP_LEFT:
-			case DRAG_TYPE_RESIZE_BOTTOM_RIGHT:
-				cursor_shape = CURSOR_FDIAGSIZE;
-				break;
-			case DRAG_TYPE_RESIZE_TOP:
-			case DRAG_TYPE_RESIZE_BOTTOM:
-				cursor_shape = CURSOR_VSIZE;
-				break;
-			case DRAG_TYPE_RESIZE_TOP_RIGHT:
-			case DRAG_TYPE_RESIZE_BOTTOM_LEFT:
-				cursor_shape = CURSOR_BDIAGSIZE;
-				break;
-			case DRAG_TYPE_RESIZE_LEFT:
-			case DRAG_TYPE_RESIZE_RIGHT:
-				cursor_shape = CURSOR_HSIZE;
-				break;
-			case DRAG_TYPE_MOVE_TILE:
-				cursor_shape = CURSOR_MOVE;
-				break;
-			default:
-				break;
-		}
-	}
-	return cursor_shape;
-}
-
 HashMap<Vector2i, List<const PropertyInfo *>> TileSetAtlasSourceEditor::_group_properties_per_tiles(const List<PropertyInfo> &r_list, const TileSetAtlasSource *p_atlas) {
 	// Group properties per tile.
 	HashMap<Vector2i, List<const PropertyInfo *>> per_tile;
@@ -2611,7 +2551,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	empty_base_tile_popup_menu->connect("id_pressed", callable_mp(this, &TileSetAtlasSourceEditor::_menu_option));
 	tile_atlas_view->add_child(empty_base_tile_popup_menu);
 
-	tile_atlas_control = memnew(Control);
+	tile_atlas_control = memnew(TileAtlasControl(this));
 	tile_atlas_control->connect("draw", callable_mp(this, &TileSetAtlasSourceEditor::_tile_atlas_control_draw));
 	tile_atlas_control->connect("mouse_exited", callable_mp(this, &TileSetAtlasSourceEditor::_tile_atlas_control_mouse_exited));
 	tile_atlas_control->connect("gui_input", callable_mp(this, &TileSetAtlasSourceEditor::_tile_atlas_control_gui_input));
@@ -2838,4 +2778,64 @@ bool EditorInspectorPluginTileData::parse_property(Object *p_object, const Varia
 		}
 	}
 	return false;
+}
+
+Control::CursorShape TileSetAtlasSourceEditor::TileAtlasControl::get_cursor_shape(const Point2 &p_pos) const {
+	Control::CursorShape cursor_shape = get_default_cursor_shape();
+	if (editor->drag_type == DRAG_TYPE_NONE) {
+		if (editor->selection.size() == 1) {
+			// Change the cursor depending on the hovered thing.
+			TileSelection selected = editor->selection.front()->get();
+			if (selected.tile != TileSetSource::INVALID_ATLAS_COORDS && selected.alternative == 0) {
+				Transform2D xform = editor->tile_atlas_control->get_global_transform().affine_inverse() * get_global_transform();
+				Vector2 mouse_local_pos = xform.xform(p_pos);
+				Vector2i size_in_atlas = editor->tile_set_atlas_source->get_tile_size_in_atlas(selected.tile);
+				Rect2 region = editor->tile_set_atlas_source->get_tile_texture_region(selected.tile);
+				Size2 zoomed_size = editor->resize_handle->get_size() / editor->tile_atlas_view->get_zoom();
+				Rect2 rect = region.grow_individual(zoomed_size.x, zoomed_size.y, 0, 0);
+				const Vector2i coords[] = { Vector2i(0, 0), Vector2i(1, 0), Vector2i(1, 1), Vector2i(0, 1) };
+				const Vector2i directions[] = { Vector2i(0, -1), Vector2i(1, 0), Vector2i(0, 1), Vector2i(-1, 0) };
+				bool can_grow[4];
+				for (int i = 0; i < 4; i++) {
+					can_grow[i] = editor->tile_set_atlas_source->has_room_for_tile(selected.tile + directions[i], editor->tile_set_atlas_source->get_tile_size_in_atlas(selected.tile), editor->tile_set_atlas_source->get_tile_animation_columns(selected.tile), editor->tile_set_atlas_source->get_tile_animation_separation(selected.tile), editor->tile_set_atlas_source->get_tile_animation_frames_count(selected.tile), selected.tile);
+					can_grow[i] |= (i % 2 == 0) ? size_in_atlas.y > 1 : size_in_atlas.x > 1;
+				}
+				for (int i = 0; i < 4; i++) {
+					Vector2 pos = rect.position + rect.size * coords[i];
+					if (can_grow[i] && can_grow[(i + 3) % 4] && Rect2(pos, zoomed_size).has_point(mouse_local_pos)) {
+						cursor_shape = (i % 2) ? CURSOR_BDIAGSIZE : CURSOR_FDIAGSIZE;
+					}
+					Vector2 next_pos = rect.position + rect.size * coords[(i + 1) % 4];
+					if (can_grow[i] && Rect2((pos + next_pos) / 2.0, zoomed_size).has_point(mouse_local_pos)) {
+						cursor_shape = (i % 2) ? CURSOR_HSIZE : CURSOR_VSIZE;
+					}
+				}
+			}
+		}
+	} else {
+		switch (editor->drag_type) {
+			case DRAG_TYPE_RESIZE_TOP_LEFT:
+			case DRAG_TYPE_RESIZE_BOTTOM_RIGHT:
+				cursor_shape = CURSOR_FDIAGSIZE;
+				break;
+			case DRAG_TYPE_RESIZE_TOP:
+			case DRAG_TYPE_RESIZE_BOTTOM:
+				cursor_shape = CURSOR_VSIZE;
+				break;
+			case DRAG_TYPE_RESIZE_TOP_RIGHT:
+			case DRAG_TYPE_RESIZE_BOTTOM_LEFT:
+				cursor_shape = CURSOR_BDIAGSIZE;
+				break;
+			case DRAG_TYPE_RESIZE_LEFT:
+			case DRAG_TYPE_RESIZE_RIGHT:
+				cursor_shape = CURSOR_HSIZE;
+				break;
+			case DRAG_TYPE_MOVE_TILE:
+				cursor_shape = CURSOR_MOVE;
+				break;
+			default:
+				break;
+		}
+	}
+	return cursor_shape;
 }

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -112,6 +112,15 @@ public:
 		}
 	};
 
+	class TileAtlasControl : public Control {
+		TileSetAtlasSourceEditor *editor = nullptr;
+
+	public:
+		virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+		TileAtlasControl(TileSetAtlasSourceEditor *p_editor) { editor = p_editor; }
+	};
+	friend class TileAtlasControl;
+
 private:
 	bool read_only = false;
 
@@ -278,8 +287,6 @@ protected:
 public:
 	void edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_source, int p_source_id);
 	void init_source();
-
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	TileSetAtlasSourceEditor();
 	~TileSetAtlasSourceEditor();


### PR DESCRIPTION
TileAtlasSourceEditor has `get_cursor_shape()` implemented, but it was broken. The part where you edit the tiles is actually a Control `tile_atlas_control`. Unfortunately the only way to implement `get_cursor_shape()` is to override a virtual method, so I had to add a new, very minimal class to fix it.

https://github.com/godotengine/godot/assets/2223172/b06eaa45-581a-4a38-8f0c-a0723b44c4a1

