### PR TITLE
intialised clear_color variable to make the code more consistent

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1739,7 +1739,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	// We invert luminance_multiplier for sky so that we can combine it with exposure value.
 	float sky_energy_multiplier = 1.0 / _render_buffers_get_luminance_multiplier();
 
-	Color clear_color;
+	Color clear_color = p_default_bg_color;
 	bool keep_color = false;
 
 	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW) {


### PR DESCRIPTION
initialised clear_code variable to p_default_bg_color during declaration to makw it consistent with it's mobile renderer version counterpart render_forward_mobile.cpp

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
