### PR TITLE
Clarify that `ok_button_text` does not work reliably in `FileDialog`

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[FileDialog] is a preset dialog used to choose files and directories in the filesystem. It supports filter masks. [FileDialog] automatically sets its window title according to the [member file_mode]. If you want to use a custom title, disable this by setting [member mode_overrides_title] to [code]false[/code].
+		[b]Note:[/b] The text of the OK button is automatically set based on [member file_mode] and selection, and setting it manually might not work as expected.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -82,7 +83,6 @@
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files" default="false">
 			If [code]true[/code], the dialog will show hidden files.
 		</member>
-		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Save a File&quot;" />
 		<member name="use_native_dialog" type="bool" setter="set_use_native_dialog" getter="get_use_native_dialog" default="false">
 			If [code]true[/code], [member access] is set to [constant ACCESS_FILESYSTEM], and it is supported by the current [DisplayServer], OS native dialog will be used instead of custom one.
 			[b]Note:[/b] On macOS, sandboxed apps always use native dialogs to access host filesystem.

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -788,7 +788,11 @@ String FileDialog::get_root_subfolder() const {
 }
 
 void FileDialog::set_mode_overrides_title(bool p_override) {
+	if (mode_overrides_title == p_override) {
+		return;
+	}
 	mode_overrides_title = p_override;
+	notify_property_list_changed();
 }
 
 bool FileDialog::is_mode_overriding_title() const {
@@ -961,6 +965,14 @@ void FileDialog::_update_drives(bool p_select) {
 		if (p_select) {
 			drives->select(dir_access->get_current_drive());
 		}
+	}
+}
+
+void FileDialog::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "ok_button_text") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	} else if (p_property.name == "title" && mode_overrides_title) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -168,6 +168,8 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+	//bind helpers
 
 public:
 	virtual void popup(const Rect2i &p_rect = Rect2i()) override;


### PR DESCRIPTION
Hide the `ok_button_text` property
Also hide the `title` property if generated by mode

Got an alternative solution, outlined in the issue, and can change this to use that solution if desired, but starting out with a more basic approach, if wanted I can merge that process into this as a separate commit for testing as well

* Fixes: #79803 

Can be retargeted for 4.1 if superseded, assuming we don't want to break compat for 4.1
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
