### PR TITLE
Fix ix an error message that floods the editor logs:

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2252,6 +2252,8 @@ ScriptTextEditor::ScriptTextEditor() {
 	breakpoints_menu->set_name("Breakpoints");
 
 	connection_info_dialog = memnew(ConnectionInfoDialog);
+	line_number_gutter = 0;
+	connection_gutter = 0;
 
 	SET_DRAG_FORWARDING_GCD(code_editor->get_text_editor(), ScriptTextEditor);
 }


### PR DESCRIPTION
Fix ix an error message that floods the editor logs:
```
ERROR: Index p_gutter = -1 is out of bounds (gutters.size() = 4).
   at: set_line_gutter_item_color (scene/gui/text_edit.cpp:5900)
```

![image](https://github.com/godotengine/godot/assets/6616005/c5782682-1cf9-41e3-9ca3-50a81baa4f21)