### PR TITLE
Fix file permissions for the web platform (affects every Unix-like platform)

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -108,10 +108,7 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 			last_error = ERR_FILE_CANT_OPEN;
 			return last_error;
 		}
-		// Fix temporary file permissions (defaults to 0600 instead of 0666 & ~umask).
-		mode_t mask = umask(022);
-		umask(mask);
-		fchmod(fd, 0666 & ~mask);
+		fchmod(fd, 0666);
 		path = String::utf8(cs.ptr());
 
 		f = fdopen(fd, mode_string);


### PR DESCRIPTION
Fixes #79594.

~~`umask()` is now called only once and will be applied to `fchmod()` automatically as it has been called just before.~~
`umask()` was removed, [see bruvzg's comment](https://github.com/godotengine/godot/pull/79866#discussion_r1273456052).

With this PR, the web platform now imports correctly files.

If needed, a MRP is simply creating a new project from the project explorer: if the icon is correctly imported, the fix worked.