### PR TITLE
SpriteFrames Editor: Fix Frame Duration applied to wrong frame when switching frame

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1134,18 +1134,16 @@ void SpriteFramesEditor::_frame_duration_changed(double p_value) {
 		return;
 	}
 
-	int index = frame_list->get_current();
+	int index = sel;
 	if (index < 0) {
 		return;
 	}
-
-	sel = index;
 
 	Ref<Texture2D> texture = frames->get_frame_texture(edited_anim, index);
 	float old_duration = frames->get_frame_duration(edited_anim, index);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Set Frame Duration"), UndoRedo::MERGE_DISABLE, EditorNode::get_singleton()->get_edited_scene());
+	undo_redo->create_action(TTR("Set Frame Duration"), UndoRedo::MERGE_ENDS, EditorNode::get_singleton()->get_edited_scene());
 	undo_redo->add_do_method(frames.ptr(), "set_frame", edited_anim, index, texture, p_value);
 	undo_redo->add_undo_method(frames.ptr(), "set_frame", edited_anim, index, texture, old_duration);
 	undo_redo->add_do_method(this, "_update_library");
@@ -1192,7 +1190,7 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 
 	updating = true;
 
-	frame_duration->set_value(1.0); // Default.
+	frame_duration->set_value_no_signal(1.0); // Default.
 
 	if (!p_skip_selector) {
 		animations->clear();
@@ -1294,7 +1292,7 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 		}
 		if (sel == i) {
 			frame_list->select(frame_list->get_item_count() - 1);
-			frame_duration->set_value(frames->get_frame_duration(edited_anim, i));
+			frame_duration->set_value_no_signal(frames->get_frame_duration(edited_anim, i));
 		}
 	}
 
@@ -1876,8 +1874,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	frame_list->set_max_text_lines(2);
 	SET_DRAG_FORWARDING_GCD(frame_list, SpriteFramesEditor);
 	frame_list->connect("gui_input", callable_mp(this, &SpriteFramesEditor::_frame_list_gui_input));
-	frame_list->connect("item_selected", callable_mp(this, &SpriteFramesEditor::_frame_list_item_selected));
-
+	// HACK: The item_selected signal is emitted before the Frame Duration spinbox loses focus and applies the change.
+	frame_list->connect("item_selected", callable_mp(this, &SpriteFramesEditor::_frame_list_item_selected), CONNECT_DEFERRED);
 	sub_vb->add_child(frame_list);
 
 	dialog = memnew(AcceptDialog);


### PR DESCRIPTION
* Splitted from #79692.

Fix frame duration change applied to last frame when switching frame while editing value of Frame Duration spinbox.

Other changes:

1. Fix the `UndoRedo` merging mode of the Frame Duration field to be consistent with the FPS field (I think it was my copy-paste mistake).
2. Use `*_no_signal()` methods in `_update_library()` for Frame Duration control.