### PR TITLE
Lazily allocate RIDs for PlaceholderTextures to avoid allocating GPU resources unless used

### DIFF
--- a/scene/resources/placeholder_textures.cpp
+++ b/scene/resources/placeholder_textures.cpp
@@ -51,6 +51,9 @@ Ref<Image> PlaceholderTexture2D::get_image() const {
 }
 
 RID PlaceholderTexture2D::get_rid() const {
+	if (rid.is_null()) {
+		rid = RenderingServer::get_singleton()->texture_2d_placeholder_create();
+	}
 	return rid;
 }
 
@@ -61,12 +64,13 @@ void PlaceholderTexture2D::_bind_methods() {
 }
 
 PlaceholderTexture2D::PlaceholderTexture2D() {
-	rid = RS::get_singleton()->texture_2d_placeholder_create();
 }
 
 PlaceholderTexture2D::~PlaceholderTexture2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(rid);
+	if (rid.is_valid()) {
+		RS::get_singleton()->free(rid);
+	}
 }
 
 ///////////////////////////////////////////////
@@ -103,6 +107,13 @@ Vector<Ref<Image>> PlaceholderTexture3D::get_data() const {
 	return Vector<Ref<Image>>();
 }
 
+RID PlaceholderTexture3D::get_rid() const {
+	if (rid.is_null()) {
+		rid = RenderingServer::get_singleton()->texture_3d_placeholder_create();
+	}
+	return rid;
+}
+
 void PlaceholderTexture3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &PlaceholderTexture3D::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &PlaceholderTexture3D::get_size);
@@ -110,11 +121,12 @@ void PlaceholderTexture3D::_bind_methods() {
 }
 
 PlaceholderTexture3D::PlaceholderTexture3D() {
-	rid = RS::get_singleton()->texture_3d_placeholder_create();
 }
 PlaceholderTexture3D::~PlaceholderTexture3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(rid);
+	if (rid.is_valid()) {
+		RS::get_singleton()->free(rid);
+	}
 }
 
 /////////////////////////////////////////////////
@@ -159,6 +171,13 @@ Ref<Image> PlaceholderTextureLayered::get_layer_data(int p_layer) const {
 	return Ref<Image>();
 }
 
+RID PlaceholderTextureLayered::get_rid() const {
+	if (rid.is_null()) {
+		rid = RS::get_singleton()->texture_2d_layered_placeholder_create(RS::TextureLayeredType(layered_type));
+	}
+	return rid;
+}
+
 void PlaceholderTextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &PlaceholderTextureLayered::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &PlaceholderTextureLayered::get_size);
@@ -169,9 +188,10 @@ void PlaceholderTextureLayered::_bind_methods() {
 
 PlaceholderTextureLayered::PlaceholderTextureLayered(LayeredType p_type) {
 	layered_type = p_type;
-	rid = RS::get_singleton()->texture_2d_layered_placeholder_create(RS::TextureLayeredType(layered_type));
 }
 PlaceholderTextureLayered::~PlaceholderTextureLayered() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(rid);
+	if (rid.is_valid()) {
+		RS::get_singleton()->free(rid);
+	}
 }

--- a/scene/resources/placeholder_textures.h
+++ b/scene/resources/placeholder_textures.h
@@ -36,7 +36,7 @@
 class PlaceholderTexture2D : public Texture2D {
 	GDCLASS(PlaceholderTexture2D, Texture2D)
 
-	RID rid;
+	mutable RID rid;
 	Size2 size = Size2(1, 1);
 
 protected:
@@ -59,7 +59,7 @@ public:
 class PlaceholderTexture3D : public Texture3D {
 	GDCLASS(PlaceholderTexture3D, Texture3D)
 
-	RID rid;
+	mutable RID rid;
 	Vector3i size = Vector3i(1, 1, 1);
 
 protected:
@@ -74,6 +74,7 @@ public:
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
 	virtual Vector<Ref<Image>> get_data() const override;
+	virtual RID get_rid() const override;
 
 	PlaceholderTexture3D();
 	~PlaceholderTexture3D();
@@ -82,7 +83,7 @@ public:
 class PlaceholderTextureLayered : public TextureLayered {
 	GDCLASS(PlaceholderTextureLayered, TextureLayered)
 
-	RID rid;
+	mutable RID rid;
 	Size2i size = Size2i(1, 1);
 	int layers = 1;
 	LayeredType layered_type = LAYERED_TYPE_2D_ARRAY;
@@ -101,6 +102,7 @@ public:
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
+	virtual RID get_rid() const override;
 
 	PlaceholderTextureLayered(LayeredType p_type);
 	~PlaceholderTextureLayered();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/77762

This may also fix unreported issues with PlaceholderTexture3D and the PlaceholderTextureLayered types. 

The root of the issue here is that Godot instantiates resources to generate documentation in the editor. So the PlaceholderCubemapArray was being allocated on the GPU regardless of whether it was actually being used. 

The ``get_rid()`` function is needed so that the texture types can actually be used. So I added it for PlaceholderTexture3D and PlaceholderTextureLayered. All other texture types lazily allocate RID like this so we don't allocate a texture on the GPU without actually using the texture. 
