### PR TITLE
[MinGW] Force separate debug symbols if executable size is larger than 1.9 GB.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -59,7 +59,7 @@ if env["vsproj"]:
             env.vs_srcs += ["platform/windows/" + str(x)]
 
 if not os.getenv("VCINSTALLDIR"):
-    if env["debug_symbols"] and env["separate_debug_symbols"]:
+    if env["debug_symbols"]:
         env.AddPostAction(prog, run_in_subprocess(platform_windows_builders.make_debug_mingw))
         if env["windows_subsystem"] == "gui":
             env.AddPostAction(prog_wrap, run_in_subprocess(platform_windows_builders.make_debug_mingw))

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -10,19 +10,21 @@ from platform_methods import subprocess_main
 
 
 def make_debug_mingw(target, source, env):
-    mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
-    if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
-        os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
-    else:
-        os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
-    if try_cmd("strip --version", env["mingw_prefix"], env["arch"]):
-        os.system(mingw_bin_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0]))
-    else:
-        os.system("strip --strip-debug --strip-unneeded {0}".format(target[0]))
-    if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
-        os.system(mingw_bin_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
-    else:
-        os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
+    # Force separate debug symbols if executable size is larger than 1.9 GB.
+    if env["separate_debug_symbols"] or os.stat(target[0]).st_size >= 2040109465:
+        mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
+        else:
+            os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(target[0]))
+        if try_cmd("strip --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "strip --strip-debug --strip-unneeded {0}".format(target[0]))
+        else:
+            os.system("strip --strip-debug --strip-unneeded {0}".format(target[0]))
+        if try_cmd("objcopy --version", env["mingw_prefix"], env["arch"]):
+            os.system(mingw_bin_prefix + "objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
+        else:
+            os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(target[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Windows PE32+ executable format is limited to 2 GB size (in reality usually about 1.90 - 1.95 GB since limit applies to the memory map no size on disk), and full debug symbols are huge.

Godot editor size with symbols is already close to the limit and if a large module is added, it easily exceeds it, rendering executable unusable.

This change automatically enables separation of the debug symbols if the limit is exceeded.