### PR TITLE
Fix transparent viewport backgrounds with custom clear color

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1738,7 +1738,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	RenderDataGLES3 render_data;
 	{
 		render_data.render_buffers = rb;
-		render_data.transparent_bg = rb.is_valid() ? rb->is_transparent : false;
+		render_data.transparent_bg = rb.is_valid() ? rt->is_transparent : false;
 		// Our first camera is used by default
 		render_data.cam_transform = p_camera_data->main_transform;
 		render_data.inv_cam_transform = render_data.cam_transform.affine_inverse();
@@ -1984,6 +1984,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 
 	if (!keep_color) {
+		clear_color.a = render_data.transparent_bg ? 0.0f : 1.0f;
 		glClearBufferfv(GL_COLOR, 0, clear_color.components);
 	}
 	RENDER_TIMESTAMP("Render Opaque Pass");

--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -38,8 +38,6 @@ RenderSceneBuffersGLES3::~RenderSceneBuffersGLES3() {
 }
 
 void RenderSceneBuffersGLES3::configure(const RenderSceneBuffersConfiguration *p_config) {
-	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
-
 	//internal_size.x = p_config->get_internal_size().x; // ignore for now
 	//internal_size.y = p_config->get_internal_size().y;
 	width = p_config->get_target_size().x;
@@ -54,10 +52,6 @@ void RenderSceneBuffersGLES3::configure(const RenderSceneBuffersConfiguration *p
 	view_count = p_config->get_view_count();
 
 	free_render_buffer_data();
-
-	GLES3::RenderTarget *rt = texture_storage->get_render_target(render_target);
-
-	is_transparent = rt->is_transparent;
 }
 
 void RenderSceneBuffersGLES3::free_render_buffer_data() {

--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -58,8 +58,6 @@ public:
 	//bool use_debanding = false;
 	uint32_t view_count = 1;
 
-	bool is_transparent = false;
-
 	RID render_target;
 
 	//built-in textures used for ping pong image processing and blurring

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -908,13 +908,19 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		{
 			// regular forward for now
 			Vector<Color> c;
-			c.push_back(clear_color.srgb_to_linear()); // our render buffer
-			if (rb_data.is_valid()) {
-				if (p_render_data->render_buffers->get_msaa_3d() != RS::VIEWPORT_MSAA_DISABLED) {
-					c.push_back(clear_color.srgb_to_linear()); // our resolve buffer
+			{
+				Color cc = clear_color.srgb_to_linear();
+				if (rb_data.is_valid()) {
+					cc.a = 0; // For transparent viewport backgrounds.
 				}
-				if (using_subpass_post_process) {
-					c.push_back(Color()); // our 2D buffer we're copying into
+				c.push_back(cc); // Our render buffer.
+				if (rb_data.is_valid()) {
+					if (p_render_data->render_buffers->get_msaa_3d() != RS::VIEWPORT_MSAA_DISABLED) {
+						c.push_back(clear_color.srgb_to_linear()); // Our resolve buffer.
+					}
+					if (using_subpass_post_process) {
+						c.push_back(Color()); // Our 2D buffer we're copying into.
+					}
 				}
 			}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This fixes #79778. This code change zeroes out the alpha component of the clear color. This basically just ports a change made in #61109 from the Forward+ renderer to the Mobile renderer, as well as an equivalent change to the Compatibility renderer.