### PR TITLE
Check if shader cache directory is available before using cache

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -667,7 +667,7 @@ void ShaderGLES3::_clear_version(Version *p_version) {
 
 void ShaderGLES3::_initialize_version(Version *p_version) {
 	ERR_FAIL_COND(p_version->variants.size() > 0);
-	if (_load_from_cache(p_version)) {
+	if (shader_cache_dir_valid && _load_from_cache(p_version)) {
 		return;
 	}
 	p_version->variants.reserve(variant_count);
@@ -678,7 +678,9 @@ void ShaderGLES3::_initialize_version(Version *p_version) {
 		_compile_specialization(spec, i, p_version, specialization_default_mask);
 		p_version->variants[i].insert(specialization_default_mask, spec);
 	}
-	_save_to_cache(p_version);
+	if (shader_cache_dir_valid) {
+		_save_to_cache(p_version);
+	}
 }
 
 void ShaderGLES3::version_set_code(RID p_version, const HashMap<String, String> &p_code, const String &p_uniforms, const String &p_vertex_globals, const String &p_fragment_globals, const Vector<String> &p_custom_defines, const LocalVector<ShaderGLES3::TextureUniformData> &p_texture_uniforms, bool p_initialize) {


### PR DESCRIPTION
Might help: https://github.com/godotengine/godot/issues/79115

At any rate, this is necessary to allow users to turn off the shader cache. 

We use ``shader_cache_dir_valid`` as a shorthand for if the shader cache is enabled _and_ if the cache location is readable/writable in RD. we should be using the same structure here

CC @ChibiDenDen 