### PR TITLE
Vulkan: Fix dangling pointers in `_clean_up_swap_chain`

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1775,6 +1775,7 @@ Error VulkanContext::_clean_up_swap_chain(Window *window) {
 	fpDestroySwapchainKHR(device, window->swapchain, nullptr);
 	window->swapchain = VK_NULL_HANDLE;
 	vkDestroyRenderPass(device, window->render_pass, nullptr);
+	window->render_pass = VK_NULL_HANDLE;
 	if (window->swapchain_image_resources) {
 		for (uint32_t i = 0; i < swapchainImageCount; i++) {
 			vkDestroyImageView(device, window->swapchain_image_resources[i].view, nullptr);
@@ -1783,6 +1784,7 @@ Error VulkanContext::_clean_up_swap_chain(Window *window) {
 
 		free(window->swapchain_image_resources);
 		window->swapchain_image_resources = nullptr;
+		swapchainImageCount = 0;
 	}
 	if (separate_present_queue) {
 		vkDestroyCommandPool(device, window->present_cmd_pool, nullptr);


### PR DESCRIPTION
In `_clean_up_swap_chain`, the state was not fully reset to the empty state, leaving the `render_pass` pointer and the `swapchainImageCount` with their previous values.

This causes a double free when `_clean_up_swap_chain` has been called twice without recreating the state in between. With this patch, the second `_clean_up_swap_chain` effectively behaves as a no-op if there is nothing to free.

`swapchainImageCount` is reset to 0 in this patch, because while the previous change is enough to fix the crash, the vulkan context fails to be recreated if there are any image resources currently active. However, we just freed all resources, so it makes sense to reset the count.

Fixes #65391
Fixes #73922 

Maybe fixes these #64766 #70837 #72080
However, I couldn't reproduce the latter crashes to begin with. @nathanfranke @henriquelalves @michael-nischt please check if this PR fixes your issue
