### PR TITLE
Add tooltips to the plugin editor creation dialog

### DIFF
--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -204,6 +204,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	name_edit = memnew(LineEdit);
 	name_edit->set_placeholder("MyPlugin");
+	name_edit->set_tooltip_text(TTR("Required. This name will be displayed in the list of plugins."));
 	name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(name_edit);
 
@@ -215,6 +216,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	subfolder_edit = memnew(LineEdit);
 	subfolder_edit->set_placeholder("\"my_plugin\" -> res://addons/my_plugin");
+	subfolder_edit->set_tooltip_text(TTR("Optional. The folder name should generally use `snake_case` naming (avoid spaces and special characters).\nIf left empty, the folder will be named after the plugin name converted to `snake_case`."));
 	subfolder_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(subfolder_edit);
 
@@ -225,6 +227,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(desc_lb);
 
 	desc_edit = memnew(TextEdit);
+	desc_edit->set_tooltip_text(TTR("Optional. This description should be kept relatively short (up to 5 lines).\nIt will display when hovering the plugin in the list of plugins."));
 	desc_edit->set_custom_minimum_size(Size2(400, 80) * EDSCALE);
 	desc_edit->set_line_wrapping_mode(TextEdit::LineWrappingMode::LINE_WRAPPING_BOUNDARY);
 	desc_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -239,6 +242,7 @@ PluginConfigDialog::PluginConfigDialog() {
 
 	author_edit = memnew(LineEdit);
 	author_edit->set_placeholder("Godette");
+	author_edit->set_tooltip_text(TTR("Optional. The author's username, full name, or organization name."));
 	author_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(author_edit);
 
@@ -249,6 +253,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(version_lb);
 
 	version_edit = memnew(LineEdit);
+	version_edit->set_tooltip_text(TTR("Optional. A human-readable version identifier used for informational purposes only."));
 	version_edit->set_placeholder("1.0");
 	version_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(version_edit);
@@ -260,6 +265,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(script_option_lb);
 
 	script_option_edit = memnew(OptionButton);
+	script_option_edit->set_tooltip_text(TTR("Required. The scripting language to use for the script.\nNote that a plugin may use several languages at once by adding more scripts to the plugin."));
 	int default_lang = 0;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		ScriptLanguage *lang = ScriptServer::get_language(i);
@@ -278,6 +284,7 @@ PluginConfigDialog::PluginConfigDialog() {
 	grid->add_child(script_lb);
 
 	script_edit = memnew(LineEdit);
+	script_edit->set_tooltip_text(TTR("Optional. The path to the script (relative to the add-on folder). If left empty, will default to \"plugin.gd\"."));
 	script_edit->set_placeholder("\"plugin.gd\" -> res://addons/my_plugin/plugin.gd");
 	script_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	grid->add_child(script_edit);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/60865.
- This salvages the rest of https://github.com/godotengine/godot/pull/36677.
