### PR TITLE
Tweak warning when using an empty project name in project creation dialog

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -380,7 +380,8 @@ void ProjectDialog::_text_changed(const String &p_text) {
 	_test_path();
 
 	if (p_text.strip_edges().is_empty()) {
-		_set_message(TTR("It would be a good idea to name your project."), MESSAGE_ERROR);
+		// Reuse existing translation for "Unnamed Project" to ensure consistency.
+		_set_message(vformat(TTR("Project name is empty (it will appear as \"%s\")."), TTR("Unnamed Project")), MESSAGE_WARNING);
 	}
 }
 


### PR DESCRIPTION
This does not actually prevent creating the project, so it is now a warning instead of an error.

*It would be a good idea to use more friendly tone as well.*

## Preview

![image](https://github.com/godotengine/godot/assets/180032/ade40759-59a9-4f07-8945-6dc8dc54b54c)