### PR TITLE
Fix reimporting scene with default values selected

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1065,7 +1065,7 @@ void SceneImportSettings::_viewport_input(const Ref<InputEvent> &p_input) {
 void SceneImportSettings::_re_import() {
 	HashMap<StringName, Variant> main_settings;
 
-	main_settings = defaults;
+	main_settings = scene_import_settings_data->current;
 	main_settings.erase("_subresources");
 	Dictionary nodes;
 	Dictionary materials;


### PR DESCRIPTION
This commit fixes #78140

When the scene was re-imported with non-default values of some settings, re-importing it again using default values for those settings didn't have the effect. For example, the ticket #78140 mentions this issue with "Root Type" setting, however the problem affected any setting. 

The reason of the problem was that when handling the reimport, a wrong dictionary object of the settings was used.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
