### PR TITLE
Fix spacing between icon and "Output" button

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7824,6 +7824,7 @@ EditorNode::EditorNode() {
 
 	log = memnew(EditorLog);
 	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
+	output_button->set_theme_type_variation("BottomPanelButton");
 	log->set_tool_button(output_button);
 
 	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1453,6 +1453,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
 	// Bottom panel.
+	theme->set_type_variation("BottomPanelButton", "Button");
+	// Add separation for the warning/error icon.
+	theme->set_constant("h_separation", "BottomPanelButton", 6 * EDSCALE);
 	Ref<StyleBoxFlat> style_bottom_panel = style_content_panel->duplicate();
 	style_bottom_panel->set_corner_radius_all(corner_radius * EDSCALE);
 	theme->set_stylebox("BottomPanel", "EditorStyles", style_bottom_panel);

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -54,8 +54,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
-	// Add separation for the warning/error icon that is displayed later.
-	db->add_theme_constant_override("h_separation", 6 * EDSCALE);
+	db->set_theme_type_variation("BottomPanelButton");
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.


### PR DESCRIPTION
| Before: | After: |
|---|---|
| ![Screenshot_20230725_191326](https://github.com/godotengine/godot/assets/30739239/f55ee70d-fc5f-4bdf-af5b-eb7c086bda8b) | ![Screenshot_20230725_181745](https://github.com/godotengine/godot/assets/30739239/88acccf5-5d13-4d8d-a1ea-4048fcbf0086) |