### PR TITLE
[Label] Remove extra line spacing from Label minimum size calculations.

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -303,6 +303,9 @@ void Label::_update_visible() {
 			break;
 		}
 	}
+	if (minsize.height > 0) {
+		minsize.height -= line_spacing;
+	}
 }
 
 inline void draw_glyph(const Glyph &p_gl, const RID &p_canvas, const Color &p_font_color, const Vector2 &p_ofs) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/79910
