### PR TITLE
Fix crash when using "Close All Tabs"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3617,7 +3617,9 @@ void EditorNode::set_current_scene(int p_idx) {
 	_update_title();
 	_update_scene_tabs();
 
-	call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.
+	if (tabs_to_close.is_empty()) {
+		call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.
+	}
 }
 
 void EditorNode::setup_color_picker(ColorPicker *p_picker) {


### PR DESCRIPTION
Fixes #79943.

I have fixed this in a way so that this deferred call to `_set_main_scene_state` is done only once at the very end after all tabs are closed.

There is a potential for further improvement which can speed-up the closing of the tabs. I could be wrong, and probably I am due to my lack of knowledge about Godot, but I don't see any need to update the editor for each of the closed tab. The update can be done only once at the end when closing of scene tabs is complete. But I will leave this decision to guys smarter then me like Tomasz Chabora who made this original refactor.