### PR TITLE
Add tooltips for tile source types

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -881,7 +881,9 @@ TileSetEditor::TileSetEditor() {
 	sources_add_button->set_flat(false);
 	sources_add_button->set_theme_type_variation("FlatButton");
 	sources_add_button->get_popup()->add_item(TTR("Atlas"));
+	sources_add_button->get_popup()->set_item_tooltip(-1, TTR("A palette of tiles made from a texture."));
 	sources_add_button->get_popup()->add_item(TTR("Scenes Collection"));
+	sources_add_button->get_popup()->set_item_tooltip(-1, TTR("A collection of scenes that can be instantiated and placed as tiles."));
 	sources_add_button->get_popup()->connect("id_pressed", callable_mp(this, &TileSetEditor::_source_add_id_pressed));
 	sources_bottom_actions->add_child(sources_add_button);
 


### PR DESCRIPTION
Inspired by https://github.com/godotengine/godot-proposals/issues/1769#issuecomment-1021703712

This PR adds tooltips to tile source types:
![image](https://github.com/godotengine/godot/assets/2223172/c11ca1cf-070a-443f-a623-683a1f4be038)
![image](https://github.com/godotengine/godot/assets/2223172/5ec12088-cfb6-4b0d-b8b7-467bf185ae0a)
I'm not sure if the descriptions are the best though.