### PR TITLE
Automatically add path to built-in scripts

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2053,6 +2053,10 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 		return;
 	}
 
+	if (p_script->is_built_in()) {
+		p_script->set_path(edited_scene->get_scene_file_path() + "::");
+	}
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Attach Script"), UndoRedo::MERGE_DISABLE, selected.front()->get());
 	for (Node *E : selected) {


### PR DESCRIPTION
Freshly created built-in scripts don't have a path. They show as [unsaved] and can't be saved using the save script shortcut (this is especially prominent after #79337)

This PR adds an default path to newly created scripts, so they can be recognized as part of the scene.

Before:

https://github.com/godotengine/godot/assets/2223172/13a51f8b-2fee-4316-80ab-cb205677f953

After:

https://github.com/godotengine/godot/assets/2223172/f926ad4d-b821-4ce1-95f8-380ab0914bfd

