### PR TITLE
FastNoiseLite: Fix cellular jitter using incorrect default value

### DIFF
--- a/modules/noise/doc_classes/FastNoiseLite.xml
+++ b/modules/noise/doc_classes/FastNoiseLite.xml
@@ -13,7 +13,7 @@
 		<member name="cellular_distance_function" type="int" setter="set_cellular_distance_function" getter="get_cellular_distance_function" enum="FastNoiseLite.CellularDistanceFunction" default="0">
 			Determines how the distance to the nearest/second-nearest point is computed. See [enum CellularDistanceFunction] for options.
 		</member>
-		<member name="cellular_jitter" type="float" setter="set_cellular_jitter" getter="get_cellular_jitter" default="0.45">
+		<member name="cellular_jitter" type="float" setter="set_cellular_jitter" getter="get_cellular_jitter" default="1.0">
 			Maximum distance a point can move off of its grid position. Set to [code]0[/code] for an even grid.
 		</member>
 		<member name="cellular_return_type" type="int" setter="set_cellular_return_type" getter="get_cellular_return_type" enum="FastNoiseLite.CellularReturnType" default="1">

--- a/modules/noise/fastnoise_lite.h
+++ b/modules/noise/fastnoise_lite.h
@@ -116,7 +116,7 @@ private:
 	// Cellular specific.
 	CellularDistanceFunction cellular_distance_function = DISTANCE_EUCLIDEAN;
 	CellularReturnType cellular_return_type = RETURN_DISTANCE;
-	real_t cellular_jitter = 0.45;
+	real_t cellular_jitter = 1.0;
 
 	// Domain warp specific.
 	bool domain_warp_enabled = false;


### PR DESCRIPTION
Hi I'm the creator of the FastNoiseLite library, I was looking through the godot usage of it and I noticed this error. It seems to be a relic from the original  godot PR for FastNoise which was originally based on FastNoise legacy where the default was 0.45

Default value for cellular jitter should be 1.0, using 0.45 will make the cellular noise have an overly grid shaped appearance

Cellular Jitter = 0.45
![cellular0_45](https://github.com/godotengine/godot/assets/1349548/6f352fb5-7f92-4b9f-b6d9-9945ef20d350)

Cellular Jitter = 1.0
![cellular1_0](https://github.com/godotengine/godot/assets/1349548/eacbcfa4-4778-4671-93c3-00492762b282)

The other issue I see is that the OpenSimplex noise type is just named Simplex, which is a disservice to @KdotJPG who created the open license OpenSimplex algorithms. This is obviously a harder thing to fix though because it would cause breaking changes to existing code