### PR TITLE
Sort system font menu in Inspector

### DIFF
--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -1020,6 +1020,7 @@ EditorPropertyFontNamesArray::EditorPropertyFontNamesArray() {
 
 	if (OS::get_singleton()) {
 		Vector<String> fonts = OS::get_singleton()->get_system_fonts();
+		fonts.sort();
 		for (int i = 0; i < fonts.size(); i++) {
 			menu->add_item(fonts[i], i + 6);
 		}


### PR DESCRIPTION
The menu showing system font names is not sorted currently (at least on Linux).

Making `get_system_fonts()` to return a sorted array is nicer. This PR sorts the array afterward because I'm not sure if it's expected and we prefer local solutions :stuck_out_tongue: 