### PR TITLE
Add gettext (PO/POT) syntax highlighting to the script editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -583,7 +583,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")
 	_initial_set("docks/filesystem/always_show_folders", true);
-	_initial_set("docks/filesystem/textfile_extensions", "txt,md,cfg,ini,log,json,yml,yaml,toml,xml");
+	_initial_set("docks/filesystem/textfile_extensions", "txt,md,cfg,ini,log,json,yml,yaml,toml,xml,pot");
 
 	// Property editor
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "docks/property_editor/auto_refresh_interval", 0.2, "0.01,1,0.001"); // Update 5 times per second by default.

--- a/editor/plugins/script_editor/syntax_highlighters/editor_syntax_highlighter_gettext.cpp
+++ b/editor/plugins/script_editor/syntax_highlighters/editor_syntax_highlighter_gettext.cpp
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  editor_syntax_highlighter_gettext.cpp                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_syntax_highlighter_gettext.h"
+
+#include "editor/editor_settings.h"
+#include "editor/plugins/script_editor_plugin.h"
+
+void EditorSyntaxHighlighterGettext::_update_cache() {
+	highlighter->set_text_edit(text_edit);
+	highlighter->clear_keyword_colors();
+	highlighter->clear_member_keyword_colors();
+	highlighter->clear_color_regions();
+
+	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+
+	// Disable some of the automatic symbolic highlights, as these don't make sense for gettext.
+	highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
+	highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
+
+	// Key/value keywords.
+	const Color key_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	highlighter->add_keyword_color("msgid", key_color);
+	highlighter->add_keyword_color("msgid_plural", key_color);
+	highlighter->add_keyword_color("msgstr", key_color);
+
+	// String.
+	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+	highlighter->add_color_region("\"", "\"", string_color);
+
+	// Comment.
+	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	highlighter->add_color_region("#", "", comment_color, true);
+}
+
+Ref<EditorSyntaxHighlighter> EditorSyntaxHighlighterGettext::_create() const {
+	Ref<EditorSyntaxHighlighterGettext> syntax_highlighter;
+	syntax_highlighter.instantiate();
+	return syntax_highlighter;
+}

--- a/editor/plugins/script_editor/syntax_highlighters/editor_syntax_highlighter_gettext.h
+++ b/editor/plugins/script_editor/syntax_highlighters/editor_syntax_highlighter_gettext.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  editor_syntax_highlighter_gettext.h                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_SYNTAX_HIGHLIGHTER_GETTEXT_H
+#define EDITOR_SYNTAX_HIGHLIGHTER_GETTEXT_H
+
+#include "editor/plugins/script_editor_plugin.h"
+#include "scene/resources/syntax_highlighter.h"
+
+class EditorSyntaxHighlighterGettext : public EditorSyntaxHighlighter {
+	GDCLASS(EditorSyntaxHighlighterGettext, EditorSyntaxHighlighter)
+
+private:
+	Ref<CodeHighlighter> highlighter;
+
+public:
+	virtual void _update_cache() override;
+	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override { return highlighter->get_line_syntax_highlighting(p_line); }
+
+	virtual PackedStringArray _get_supported_languages() const override { return PackedStringArray{ "po", "pot" }; }
+	virtual String _get_name() const override { return TTR("Gettext (PO/POT)"); }
+
+	virtual Ref<EditorSyntaxHighlighter> _create() const override;
+
+	EditorSyntaxHighlighterGettext() { highlighter.instantiate(); }
+};
+
+#endif // EDITOR_SYNTAX_HIGHLIGHTER_GETTEXT_H

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -57,6 +57,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/inspector_dock.h"
 #include "editor/node_dock.h"
+#include "editor/plugins/script_editor/syntax_highlighters/editor_syntax_highlighter_gettext.h"
 #include "editor/plugins/shader_editor_plugin.h"
 #include "editor/plugins/text_shader_editor.h"
 #include "editor/themes/editor_scale.h"
@@ -255,42 +256,6 @@ void EditorJSONSyntaxHighlighter::_update_cache() {
 
 Ref<EditorSyntaxHighlighter> EditorJSONSyntaxHighlighter::_create() const {
 	Ref<EditorJSONSyntaxHighlighter> syntax_highlighter;
-	syntax_highlighter.instantiate();
-	return syntax_highlighter;
-}
-
-////
-
-void EditorGettextSyntaxHighlighter::_update_cache() {
-	highlighter->set_text_edit(text_edit);
-	highlighter->clear_keyword_colors();
-	highlighter->clear_member_keyword_colors();
-	highlighter->clear_color_regions();
-
-	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
-	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
-
-	// Disable some of the automatic symbolic highlights, as these don't make sense for gettext.
-	highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
-	highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
-
-	// Key/value keywords.
-	const Color key_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-	highlighter->add_keyword_color("msgid", key_color);
-	highlighter->add_keyword_color("msgid_plural", key_color);
-	highlighter->add_keyword_color("msgstr", key_color);
-
-	// String.
-	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
-	highlighter->add_color_region("\"", "\"", string_color);
-
-	// Comment.
-	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
-	highlighter->add_color_region("#", "", comment_color, true);
-}
-
-Ref<EditorSyntaxHighlighter> EditorGettextSyntaxHighlighter::_create() const {
-	Ref<EditorGettextSyntaxHighlighter> syntax_highlighter;
 	syntax_highlighter.instantiate();
 	return syntax_highlighter;
 }
@@ -4367,7 +4332,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	json_syntax_highlighter.instantiate();
 	register_syntax_highlighter(json_syntax_highlighter);
 
-	Ref<EditorGettextSyntaxHighlighter> gettext_syntax_highlighter;
+	Ref<EditorSyntaxHighlighterGettext> gettext_syntax_highlighter;
 	gettext_syntax_highlighter.instantiate();
 	register_syntax_highlighter(gettext_syntax_highlighter);
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -259,6 +259,42 @@ Ref<EditorSyntaxHighlighter> EditorJSONSyntaxHighlighter::_create() const {
 	return syntax_highlighter;
 }
 
+////
+
+void EditorGettextSyntaxHighlighter::_update_cache() {
+	highlighter->set_text_edit(text_edit);
+	highlighter->clear_keyword_colors();
+	highlighter->clear_member_keyword_colors();
+	highlighter->clear_color_regions();
+
+	highlighter->set_symbol_color(EDITOR_GET("text_editor/theme/highlighting/symbol_color"));
+	highlighter->set_number_color(EDITOR_GET("text_editor/theme/highlighting/number_color"));
+
+	// Disable some of the automatic symbolic highlights, as these don't make sense for gettext.
+	highlighter->set_member_variable_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
+	highlighter->set_function_color(EDITOR_GET("text_editor/theme/highlighting/text_color"));
+
+	// Key/value keywords.
+	const Color key_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+	highlighter->add_keyword_color("msgid", key_color);
+	highlighter->add_keyword_color("msgid_plural", key_color);
+	highlighter->add_keyword_color("msgstr", key_color);
+
+	// String.
+	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
+	highlighter->add_color_region("\"", "\"", string_color);
+
+	// Comment.
+	const Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+	highlighter->add_color_region("#", "", comment_color, true);
+}
+
+Ref<EditorSyntaxHighlighter> EditorGettextSyntaxHighlighter::_create() const {
+	Ref<EditorGettextSyntaxHighlighter> syntax_highlighter;
+	syntax_highlighter.instantiate();
+	return syntax_highlighter;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 /*** SCRIPT EDITOR ****/
@@ -4330,6 +4366,10 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	Ref<EditorJSONSyntaxHighlighter> json_syntax_highlighter;
 	json_syntax_highlighter.instantiate();
 	register_syntax_highlighter(json_syntax_highlighter);
+
+	Ref<EditorGettextSyntaxHighlighter> gettext_syntax_highlighter;
+	gettext_syntax_highlighter.instantiate();
+	register_syntax_highlighter(gettext_syntax_highlighter);
 
 	_update_online_doc();
 }

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -120,24 +120,6 @@ public:
 	EditorJSONSyntaxHighlighter() { highlighter.instantiate(); }
 };
 
-class EditorGettextSyntaxHighlighter : public EditorSyntaxHighlighter {
-	GDCLASS(EditorGettextSyntaxHighlighter, EditorSyntaxHighlighter)
-
-private:
-	Ref<CodeHighlighter> highlighter;
-
-public:
-	virtual void _update_cache() override;
-	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override { return highlighter->get_line_syntax_highlighting(p_line); }
-
-	virtual PackedStringArray _get_supported_languages() const override { return PackedStringArray{ "po", "pot" }; }
-	virtual String _get_name() const override { return TTR("Gettext (PO/POT)"); }
-
-	virtual Ref<EditorSyntaxHighlighter> _create() const override;
-
-	EditorGettextSyntaxHighlighter() { highlighter.instantiate(); }
-};
-
 ///////////////////////////////////////////////////////////////////////////////
 
 class ScriptEditorQuickOpen : public ConfirmationDialog {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -120,6 +120,24 @@ public:
 	EditorJSONSyntaxHighlighter() { highlighter.instantiate(); }
 };
 
+class EditorGettextSyntaxHighlighter : public EditorSyntaxHighlighter {
+	GDCLASS(EditorGettextSyntaxHighlighter, EditorSyntaxHighlighter)
+
+private:
+	Ref<CodeHighlighter> highlighter;
+
+public:
+	virtual void _update_cache() override;
+	virtual Dictionary _get_line_syntax_highlighting_impl(int p_line) override { return highlighter->get_line_syntax_highlighting(p_line); }
+
+	virtual PackedStringArray _get_supported_languages() const override { return PackedStringArray{ "po", "pot" }; }
+	virtual String _get_name() const override { return TTR("Gettext (PO/POT)"); }
+
+	virtual Ref<EditorSyntaxHighlighter> _create() const override;
+
+	EditorGettextSyntaxHighlighter() { highlighter.instantiate(); }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 
 class ScriptEditorQuickOpen : public ConfirmationDialog {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/77972 and https://github.com/godotengine/godot/pull/78312.

This also allows viewing and opening POT files in the FileSystem dock.

CSV highlighting à la [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) could be implemented in a separate PR, but it'll require a custom highlighter rather than a standard keyword-based highlighter.

## Preview

![gettext](https://github.com/godotengine/godot/assets/180032/18850501-99dc-4e84-ac3b-0ae4dd05295d)