### PR TITLE
[3.x] Fix OccluderPolyShape handles disappear after release click

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -7270,7 +7270,7 @@ void SpatialEditorPlugin::edit(Object *p_object) {
 }
 
 bool SpatialEditorPlugin::handles(Object *p_object) const {
-	if (p_object->is_class("Spatial")) {
+	if (p_object->is_class("Spatial") || p_object->is_class("Resource")) {
 		return true;
 	} else {
 		// This ensures that gizmos are cleared when selecting a non-Spatial node.


### PR DESCRIPTION
Fixes #79939

Also checked the 4.0 version. The problem was fixed by replacing this special logic with reworking the EditorPlugin editing logic ;) Since this code is intended to deselect when non-Spatial node is selected, excluding Resource here makes sense.