### PR TITLE
Fix life cycle of ResourceImporterTexture not tracked properly

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -797,4 +797,5 @@ ResourceImporterTexture::ResourceImporterTexture() {
 }
 
 ResourceImporterTexture::~ResourceImporterTexture() {
+	singleton = nullptr;
 }


### PR DESCRIPTION
Fixes comment in #79936.

This class is instantiated as part of the generation of docs, and later the object is destroyed. By not nullifying the singleton, the next instantiation (the primary one done by the editor), the false assumption that it's already instantiated is made and a dangling pointer to the destroyed singleton is used.