### PR TITLE
Update C# example of `tween_method` with a parameter to the lambda method

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -366,7 +366,7 @@
 				[/gdscript]
 				[csharp]
 				Tween tween = CreateTween();
-				tween.TweenMethod(Callable.From(() =&gt; LookAt(Vector3.Up)), new Vector3(-1.0f, 0.0f, -1.0f), new Vector3(1.0f, 0.0f, -1.0f), 1.0f); // The LookAt() method takes up vector as second argument.
+				tween.TweenMethod(Callable.From((Vector3 target) =&gt; LookAt(target, Vector3.Up)), new Vector3(-1.0f, 0.0f, -1.0f), new Vector3(1.0f, 0.0f, -1.0f), 1.0f); // Use lambdas to bind additional arguments for the call.
 				[/csharp]
 				[/codeblocks]
 				[b]Example:[/b] Setting the text of a [Label], using an intermediate method and after a delay:


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-docs/issues/7738

In the C# example the lambda method is missing a parameter which causes an error since the tween_method expects a method with a pass in parameter, this updates the documentation to reflect that and also uses the parameter in the lambda to match the GDScript example.

I hope I haven't messed anything, it's my first PR so please have mercy.