### PR TITLE
Uncollapse favorites by default in the editor FileSystem dock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5007,10 +5007,15 @@ void EditorNode::_load_editor_layout() {
 	config.instantiate();
 	Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
 	if (err != OK) { // No config.
-		// If config is not found, expand the res:// folder by default.
+		// If config is not found, expand the res:// folder and favorites by default.
 		TreeItem *root = FileSystemDock::get_singleton()->get_tree_control()->get_item_with_metadata("res://", 0);
 		if (root) {
 			root->set_collapsed(false);
+		}
+
+		TreeItem *favorites = FileSystemDock::get_singleton()->get_tree_control()->get_item_with_metadata("Favorites", 0);
+		if (favorites) {
+			favorites->set_collapsed(false);
 		}
 
 		if (overridden_default_layout >= 0) {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/77509.
- This partially addresses https://github.com/godotengine/godot-proposals/issues/7393.