### PR TITLE
Add state sync after call to `_integrate_forces` in `_body_state_changed`

### DIFF
--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -212,6 +212,8 @@ private:
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState2D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState2D *p_state);
 
+	void _sync_body_state(PhysicsDirectBodyState2D *p_state);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -222,6 +222,8 @@ private:
 	void _body_inout(int p_status, const RID &p_body, ObjectID p_instance, int p_body_shape, int p_local_shape);
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 
+	void _sync_body_state(PhysicsDirectBodyState3D *p_state);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -692,6 +694,7 @@ protected:
 	static void _bind_methods();
 
 private:
+	void _sync_body_state(PhysicsDirectBodyState3D *p_state);
 	static Skeleton3D *find_skeleton_parent(Node *p_parent);
 
 	void _update_joint_offset();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
in issue #79835 , the root cause is that `_physics_process` is called after `_integrate_forces` (called from RigidBody3D::_body_state_changed) while `_integrate_forces` modifies `GodotBody3D`'s linear_velocity, `_physics_process` reads from now obsolete `RigidBody3D::linear_velocity` and when we update it using `RigidBody3D::set_linear_velocity` which also updates `GodotBody3D::linear_velocity`.

This can be prevented by updating `RigidBody3D`'s mutable state as soon as we return from `_integrate_forces`, which is what I have added.

* *Bugsquad edit, fixes: #79835*