### PR TITLE
[String] Fix Unicode parsing error message encoding and related JSON tests.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1750,7 +1750,7 @@ Vector<uint8_t> String::hex_decode() const {
 
 void String::print_unicode_error(const String &p_message, bool p_critical) const {
 	if (p_critical) {
-		print_error(vformat("Unicode parsing error, some characters were replaced with � (U+FFFD): %s", p_message));
+		print_error(vformat(U"Unicode parsing error, some characters were replaced with � (U+FFFD): %s", p_message));
 	} else {
 		print_error(vformat("Unicode parsing error: %s", p_message));
 	}

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -186,20 +186,21 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 	}
 
 	SUBCASE("Valid unicode escape sequences") {
-		String json_string = "\"\\u0000\"";
+		String json_string = "\"\\u0020\"";
 		json.parse(json_string);
 
 		CHECK_MESSAGE(
 				json.get_error_line() == 0,
-				vformat("Parsing valid unicode escape sequence with value `0000` as JSON should parse successfully."));
+				vformat("Parsing valid unicode escape sequence with value `0020` as JSON should parse successfully."));
 
 		String json_value = json.get_data();
 		CHECK_MESSAGE(
-				json_value == "\0",
-				vformat("Parsing valid unicode escape sequence with value `0000` as JSON should return the expected value."));
+				json_value == " ",
+				vformat("Parsing valid unicode escape sequence with value `0020` as JSON should return the expected value."));
 	}
 
 	SUBCASE("Invalid escape sequences") {
+		ERR_PRINT_OFF
 		for (char32_t i = 0; i < 128; i++) {
 			bool skip = false;
 			for (int j = 0; j < valid_escapes.size(); j++) {
@@ -228,6 +229,7 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 					err == ERR_PARSE_ERROR,
 					vformat("Parsing invalid escape sequence with ASCII value `%d` as JSON should fail to parse with ERR_PARSE_ERROR.", i));
 		}
+		ERR_PRINT_ON
 	}
 }
 } // namespace TestJSON


### PR DESCRIPTION
- Changes JSON valid Unicode test to actually use valid sequence (`\u0000` is not valid).
- Adds error print suppression to JSON invalid Unicode test.
- Fixes encoding of the `Unicode parsing error` message string literal.

See https://github.com/godotengine/godot/issues/79806 (not fixing the main issue, but test issues were mentioned in comments).