### PR TITLE
Fix life cycle of ResourceImporterTexture better

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -790,12 +790,16 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path) co
 ResourceImporterTexture *ResourceImporterTexture::singleton = nullptr;
 
 ResourceImporterTexture::ResourceImporterTexture() {
-	singleton = this;
+	if (!singleton) {
+		singleton = this;
+	}
 	CompressedTexture2D::request_3d_callback = _texture_reimport_3d;
 	CompressedTexture2D::request_roughness_callback = _texture_reimport_roughness;
 	CompressedTexture2D::request_normal_callback = _texture_reimport_normal;
 }
 
 ResourceImporterTexture::~ResourceImporterTexture() {
-	singleton = nullptr;
+	if (singleton == this) {
+		singleton = nullptr;
+	}
 }


### PR DESCRIPTION
Follow-up of #79954.

Since multiple instances of this class can exist at the same time, only one should own the `singleton` variable. Otherwise, without this PR, any of the instances being destroyed would nullify the singleton, when other instances still exist.

CC @aaronfranke 

**UPDATE:** For the records, `SceneTree` uses the same singletoning pattern. It may be beneficial to make it a _de facto_ standard in Godot? Food for thought.

*Bugsquad edit:* Fixes #79999