### PR TITLE
Initialize MSDF parameters in BaseMaterial3D with default

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -269,7 +269,7 @@
 			Specifies the channel of the [member metallic_texture] in which the metallic information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
 		<member name="msdf_outline_size" type="float" setter="set_msdf_outline_size" getter="get_msdf_outline_size" default="0.0">
-			The width of the shape outine.
+			The width of the shape outline.
 		</member>
 		<member name="msdf_pixel_range" type="float" setter="set_msdf_pixel_range" getter="get_msdf_pixel_range" default="4.0">
 			The width of the range around the shape between the minimum and maximum representable signed distance.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2876,7 +2876,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "proximity_fade_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:m"), "set_proximity_fade_distance", "get_proximity_fade_distance");
 	ADD_GROUP("MSDF", "msdf_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "msdf_pixel_range", PROPERTY_HINT_RANGE, "1,100,1"), "set_msdf_pixel_range", "get_msdf_pixel_range");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "msdf_outline_size", PROPERTY_HINT_RANGE, "1,250,1"), "set_msdf_outline_size", "get_msdf_outline_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "msdf_outline_size", PROPERTY_HINT_RANGE, "0,250,1"), "set_msdf_outline_size", "get_msdf_outline_size");
 	ADD_GROUP("Distance Fade", "distance_fade_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "distance_fade_mode", PROPERTY_HINT_ENUM, "Disabled,PixelAlpha,PixelDither,ObjectDither"), "set_distance_fade", "get_distance_fade");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "distance_fade_min_distance", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:m"), "set_distance_fade_min_distance", "get_distance_fade_min_distance");
@@ -3063,6 +3063,9 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_refraction_texture_channel(TEXTURE_CHANNEL_RED);
 
 	set_grow(0.0);
+
+	set_msdf_pixel_range(4.0);
+	set_msdf_outline_size(0.0);
 
 	set_heightmap_deep_parallax_min_layers(8);
 	set_heightmap_deep_parallax_max_layers(32);


### PR DESCRIPTION
This fixes the initialization of MSDF parameters in BaseMaterial3D when using the default values.

The problem seems to be that `msdf_pixel_range` will not be initialized when loading the material using its default value.
The left material is a `StandardMaterial3D` with a MSDF texture and `albedo_texture_msdf` enabled. The right material is the same but converted to a `ShaderMaterial`. When opening the scene, the left texture look blurry. When setting `msdf_pixel_range` of the `StandardMaterial3D` to another value than 4, it looks sharp.

![msdf_standard_vs_shader](https://github.com/godotengine/godot/assets/4883379/b45627aa-02e6-4739-ab16-e85066f5e28d)

I also changed the minimum range value of `msdf_outline_size` to 0 which is the default according to the documentation.

Test project: [msdf.zip](https://github.com/godotengine/godot/files/12194425/msdf.zip)
