### PR TITLE
fix missing sensor null exception which caused by kotlin by lazy

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -88,16 +88,16 @@ class Godot(private val context: Context) : SensorEventListener {
 	private val mSensorManager: SensorManager by lazy {
 		requireActivity().getSystemService(Context.SENSOR_SERVICE) as SensorManager
 	}
-	private val mAccelerometer: Sensor by lazy {
+	private val mAccelerometer: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
 	}
-	private val mGravity: Sensor by lazy {
+	private val mGravity: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY)
 	}
-	private val mMagnetometer: Sensor by lazy {
+	private val mMagnetometer: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
 	}
-	private val mGyroscope: Sensor by lazy {
+	private val mGyroscope: Sensor? by lazy {
 		mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
 	}
 	private val mClipboard: ClipboardManager by lazy {


### PR DESCRIPTION
On some device which do not have specified sensor will cause a NullPointerException like

```
Caused by: java.lang.NullPointerException: <get-mAccelerometer>(...) must not be null
at org.godotengine.godot.Godot.getMAccelerometer(Godot.kt:91)
at org.godotengine.godot.Godot.onResume(Godot.kt:495)
at org.godotengine.godot.GodotFragment.onResume(GodotFragment.java:280)
at androidx.fragment.app.Fragment.performResume(Fragment.java:3039)
at androidx.fragment.app.FragmentStateManager.resume(FragmentStateManager.java:607)
at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:306)
at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:112)
at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1647)
at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3128)
at androidx.fragment.app.FragmentManager.dispatchResume(FragmentManager.java:3086)
at androidx.fragment.app.FragmentController.dispatchResume(FragmentController.java:273)
at androidx.fragment.app.FragmentActivity.onResumeFragments(FragmentActivity.java:458)
at androidx.fragment.app.FragmentActivity.onPostResume(FragmentActivity.java:447)
at android.app.Activity.performResume(Activity.java:8023)
```