### PR TITLE
GDScript: Optimize operators by assuming the types

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -226,7 +226,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 
 	if (opcodes.size()) {
 		function->code = opcodes;
-		function->_code_ptr = &function->code[0];
+		function->_code_ptr = &function->code.write[0];
 		function->_code_size = opcodes.size();
 
 	} else {
@@ -577,6 +577,12 @@ void GDScriptByteCodeGenerator::write_unary_operator(const Address &p_target, Va
 	append(Address());
 	append(p_target);
 	append(p_operator);
+	append(0); // Signature storage.
+	append(0); // Return type storage.
+	constexpr int _pointer_size = sizeof(Variant::ValidatedOperatorEvaluator) / sizeof(*(opcodes.ptr()));
+	for (int i = 0; i < _pointer_size; i++) {
+		append(0); // Space for function pointer.
+	}
 }
 
 void GDScriptByteCodeGenerator::write_binary_operator(const Address &p_target, Variant::Operator p_operator, const Address &p_left_operand, const Address &p_right_operand) {
@@ -610,6 +616,12 @@ void GDScriptByteCodeGenerator::write_binary_operator(const Address &p_target, V
 	append(p_right_operand);
 	append(p_target);
 	append(p_operator);
+	append(0); // Signature storage.
+	append(0); // Return type storage.
+	constexpr int _pointer_size = sizeof(Variant::ValidatedOperatorEvaluator) / sizeof(*(opcodes.ptr()));
+	for (int i = 0; i < _pointer_size; i++) {
+		append(0); // Space for function pointer.
+	}
 }
 
 void GDScriptByteCodeGenerator::write_type_test(const Address &p_target, const Address &p_source, const GDScriptDataType &p_type) {

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -113,6 +113,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 
 		switch (opcode) {
 			case OPCODE_OPERATOR: {
+				constexpr int _pointer_size = sizeof(Variant::ValidatedOperatorEvaluator) / sizeof(*_code_ptr);
 				int operation = _code_ptr[ip + 4];
 
 				text += "operator ";
@@ -125,7 +126,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				text += " ";
 				text += DADDR(2);
 
-				incr += 5;
+				incr += 7 + _pointer_size;
 			} break;
 			case OPCODE_OPERATOR_VALIDATED: {
 				text += "validated operator ";

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -473,7 +473,7 @@ private:
 	MethodBind **_methods_ptr = nullptr;
 	int _lambdas_count = 0;
 	GDScriptFunction **_lambdas_ptr = nullptr;
-	const int *_code_ptr = nullptr;
+	int *_code_ptr = nullptr;
 	int _code_size = 0;
 	int _argument_count = 0;
 	int _stack_size = 0;


### PR DESCRIPTION
This assumes that operators are called usually with the same type of operands as the first time. So it stores the types of the first run and if matched it uses an optimized path by calling the validated operator function directly. Otherwise it uses the regular untyped evaluator.

With this change, if operators do use the same type they run quite faster. OTOH, if the types mismatch it takes longer to run than they would with the previous code.

**Note:** this change may be a bit controversial as it makes operators slower when they fall in the non-optimized path (i.e. when the current operand types are different than the ones during the first run). The first time it ever runs is much slower, but since they are expected to run multiple times, this cost is amortized over time, as long as the optimized path is hit often.

I measured about 20% to 30% decrease in the execution time, when it falls into the optimized path. There's about 15% to 25% increase when it falls into the non-optimal path. All compared to the previous implementation of the operator opcode.

This doesn't affect validated operators (i.e. when types are known at compile time). The validated version is still faster.