### PR TITLE
Silence errors about invalid deferred callables during tests

### DIFF
--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -9,4 +9,7 @@ env.CommandNoCache(["gdvirtual.gen.inc"], "make_virtuals.py", run_in_subprocess(
 
 env_object = env.Clone()
 
+if env["tests"]:
+    env_object.Append(CPPDEFINES=["TESTS_ENABLED"])
+
 env_object.add_source_files(env.core_sources, "*.cpp")


### PR DESCRIPTION
Addresses the complaint in https://github.com/godotengine/godot/pull/78987#issuecomment-1653354563:
> So we also get a lot of "ERROR: Trying to execute a deferred call/notification/set on a previously freed instance. Consider using queue_free() instead of free()." from running tests (you can see the CI run for this very PR). How should we avoid that?

**NOTE:** I'm not very fond of having to tweak the build system to let the `TESTS_ENABLED` macro reach the message queue implementation. Maybe the queue should expose some way of disabling the message. Or maybe even the error should only be printed when the debugger is attached so both the editor and tests are already out of the equation? Suggestions welcome.