### PR TITLE
CI: Only cache objects that are part of the current build

### DIFF
--- a/.github/actions/godot-cache/action.yml
+++ b/.github/actions/godot-cache/action.yml
@@ -20,3 +20,14 @@ runs:
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}
+
+    - name: 
+      uses: pyTooling/Actions/with-post-step@v0.4.6
+      if: runner.os != 'Windows'
+      with:
+        main: |
+          # Now, after downloading the cache set the last access time of all files in the cache to a date far in the past
+          find "${{inputs.scons-cache}}" -exec touch {} -at 0001010000 \;
+        post: |
+          # And just before uploading the new cache, delete all files that were not accessed in the last day, ie during this build
+          find "${{inputs.scons-cache}}" -atime +1 -delete


### PR DESCRIPTION
This is the first idea from https://github.com/godotengine/godot/issues/79919#issuecomment-1653910161
This prevents caches from growing any larger than absolutely necessary to get effectively incremental builds in the CI, but makes selection of which cache to fetch significantly more important as the cache no longer contains any objects from previous (or potentially unrelated) builds.

Currently disabled on windows as the `find` command is an entirely different tool there and those builds don't have space issues rn, so I didn't go looking for how to best do this on windows for this PR. (But if desired the best way would probably to rewrite this is JS, which would also eliminated the dependency for running stuff in the post step)