### PR TITLE
AnimationNodeBlendTree Plugin: inherited types in 'add_node' and 'Quick Load' of animation resources.

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -46,6 +46,7 @@ class EditorFileDialog;
 class EditorProperty;
 class MenuButton;
 class PanelContainer;
+class EditorQuickOpen;
 
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);
@@ -129,13 +130,17 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _update_theme();
 
 	EditorFileDialog *open_file = nullptr;
+	EditorQuickOpen *quick_open = nullptr;
+
 	Ref<AnimationNode> file_loaded;
 	void _file_opened(const String &p_file);
+	void _file_quick_selected();
 
 	enum {
 		MENU_LOAD_FILE = 1000,
 		MENU_PASTE = 1001,
-		MENU_LOAD_FILE_CONFIRM = 1002
+		MENU_LOAD_FILE_CONFIRM = 1002,
+		MENU_QUICK_LOAD_FILE = 1003
 	};
 
 protected:


### PR DESCRIPTION
AnimationNodeBlendTree Plugin: 

Added inherited types to 'add_node' menu.
Also added 'Quick Load' of animation node resources.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
