### PR TITLE
Make ScrollBar account for its margins

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -256,9 +256,9 @@ void ScrollBar::_notification(int p_what) {
 				grabber = theme_cache.grabber_style;
 			}
 
-			Point2 ofs;
+			Point2 ofs = (orientation == HORIZONTAL) ? Point2(bg->get_margin(SIDE_LEFT), 0) : Point2(0, bg->get_margin(SIDE_TOP));
 
-			decr->draw(ci, Point2());
+			decr->draw(ci, ofs);
 
 			if (orientation == HORIZONTAL) {
 				ofs.x += decr->get_width();
@@ -269,9 +269,9 @@ void ScrollBar::_notification(int p_what) {
 			Size2 area = get_size();
 
 			if (orientation == HORIZONTAL) {
-				area.width -= incr->get_width() + decr->get_width();
+				area.width -= incr->get_width() + decr->get_width() + bg->get_margin(SIDE_LEFT) + bg->get_margin(SIDE_RIGHT);
 			} else {
-				area.height -= incr->get_height() + decr->get_height();
+				area.height -= incr->get_height() + decr->get_height() + bg->get_margin(SIDE_TOP) + bg->get_margin(SIDE_BOTTOM);
 			}
 
 			bg->draw(ci, Rect2(ofs, area));
@@ -466,22 +466,6 @@ double ScrollBar::get_area_size() const {
 			return 0.0;
 		}
 	}
-}
-
-double ScrollBar::get_area_offset() const {
-	double ofs = 0.0;
-
-	if (orientation == VERTICAL) {
-		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_TOP);
-		ofs += theme_cache.decrement_icon->get_height();
-	}
-
-	if (orientation == HORIZONTAL) {
-		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_LEFT);
-		ofs += theme_cache.decrement_icon->get_width();
-	}
-
-	return ofs;
 }
 
 double ScrollBar::get_grabber_offset() const {

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -63,7 +63,6 @@ class ScrollBar : public Range {
 	double get_grabber_size() const;
 	double get_grabber_min_size() const;
 	double get_area_size() const;
-	double get_area_offset() const;
 	double get_grabber_offset() const;
 
 	static void set_can_focus_by_default(bool p_can_focus);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This is a bug fix for #79994 .

There are two main changes:
1. adjust the various components of the scrollbar and its background, so that they take into account the margins.
2. remove the redundant method `get_area_offset`

Fixed view:

https://github.com/godotengine/godot/assets/40772658/7baae652-4c62-4ea8-bdb6-b462b2ae7209

The old version, off of the current master branch:

https://github.com/godotengine/godot/assets/40772658/550bf902-33a9-4895-ace1-d9d2ab893012


* *Bugsquad edit, fixes: #79994*