### PR TITLE
Add `OS::get_compositing_window_manager()`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -649,6 +649,10 @@ void OS::benchmark_dump() {
 #endif
 }
 
+OS::CompositingWindowManager OS::get_compositing_window_manager() const {
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_UNKNOWN;
+}
+
 OS::OS() {
 	singleton = this;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -328,6 +328,16 @@ public:
 
 	virtual PreferredTextureFormat get_preferred_texture_format() const;
 
+	enum CompositingWindowManager {
+		COMPOSITING_WINDOW_MANAGER_NONE,
+		COMPOSITING_WINDOW_MANAGER_UNKNOWN,
+		COMPOSITING_WINDOW_MANAGER_DESKTOP_WINDOW_MANAGER,
+		COMPOSITING_WINDOW_MANAGER_QUARTZ_COMPOSITOR,
+		COMPOSITING_WINDOW_MANAGER_X11,
+		COMPOSITING_WINDOW_MANAGER_WAYLAND
+	};
+	virtual CompositingWindowManager get_compositing_window_manager() const;
+
 	OS();
 	virtual ~OS();
 };

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -779,6 +779,10 @@ String OS_Unix::get_executable_path() const {
 #endif
 }
 
+OS::CompositingWindowManager OS_Unix::get_compositing_window_manager() const {
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_UNKNOWN;
+}
+
 void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type) {
 	if (!should_log(true)) {
 		return;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -92,6 +92,8 @@ public:
 
 	virtual String get_executable_path() const override;
 	virtual String get_user_data_dir() const override;
+
+	virtual OS::CompositingWindowManager get_compositing_window_manager() const override;
 };
 
 class UnixTerminalLogger : public StdLogger {

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1130,6 +1130,30 @@ String OS_LinuxBSD::get_system_ca_certificates() {
 	return f->get_as_text();
 }
 
+OS::CompositingWindowManager OS_LinuxBSD::get_compositing_window_manager() const {
+	if (OS::get_singleton()->has_environment("XDG_SESSION_TYPE")) {
+		if (OS::get_singleton()->get_environment("XDG_SESSION_TYPE") == "wayland") {
+			return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_WAYLAND;
+		} else if (OS::get_singleton()->get_environment("XDG_SESSION_TYPE") == "x11") {
+			return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_X11;
+		} else if (OS::get_singleton()->get_environment("XDG_SESSION_TYPE") == "tty") {
+			return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_NONE;
+		} else {
+			return OS::COMPOSITING_WINDOW_MANAGER_UNKNOWN;
+		}
+	}
+
+	if (OS::get_singleton()->has_environment("WAYLAND_DISPLAY")) {
+		return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_WAYLAND;
+	}
+
+	if (OS::get_singleton()->has_environment("DISPLAY")) {
+		return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_X11;
+	}
+
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_NONE;
+}
+
 OS_LinuxBSD::OS_LinuxBSD() {
 	main_loop = nullptr;
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -136,6 +136,8 @@ public:
 
 	virtual String get_system_ca_certificates() override;
 
+	virtual OS::CompositingWindowManager get_compositing_window_manager() const override;
+
 	OS_LinuxBSD();
 	~OS_LinuxBSD();
 };

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -127,6 +127,8 @@ public:
 	virtual String get_system_ca_certificates() override;
 	virtual OS::PreferredTextureFormat get_preferred_texture_format() const override;
 
+	virtual OS::CompositingWindowManager get_compositing_window_manager() const override;
+
 	void run();
 
 	OS_MacOS();

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -748,6 +748,10 @@ OS::PreferredTextureFormat OS_MacOS::get_preferred_texture_format() const {
 	return PREFERRED_TEXTURE_FORMAT_S3TC_BPTC;
 }
 
+OS::CompositingWindowManager OS_MacOS::get_compositing_window_manager() const {
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_QUARTZ_COMPOSITOR;
+}
+
 void OS_MacOS::run() {
 	if (!main_loop) {
 		return;

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -248,6 +248,10 @@ OS_Web *OS_Web::get_singleton() {
 void OS_Web::initialize_joypads() {
 }
 
+OS::CompositingWindowManager OS_Web::get_compositing_window_manager() const {
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_NONE;
+}
+
 OS_Web::OS_Web() {
 	char locale_ptr[16];
 	godot_js_config_locale_get(locale_ptr, 16);

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -107,6 +107,8 @@ public:
 
 	void resume_audio();
 
+	virtual OS::CompositingWindowManager get_compositing_window_manager() const override;
+
 	OS_Web();
 };
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1711,6 +1711,10 @@ String OS_Windows::get_system_ca_certificates() {
 	return certs;
 }
 
+OS::CompositingWindowManager OS_Windows::get_compositing_window_manager() const {
+	return OS::CompositingWindowManager::COMPOSITING_WINDOW_MANAGER_DESKTOP_WINDOW_MANAGER;
+}
+
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	hInstance = _hInstance;
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -230,6 +230,8 @@ public:
 
 	virtual String get_system_ca_certificates() override;
 
+	virtual OS::CompositingWindowManager get_compositing_window_manager() const override;
+
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
 	HINSTANCE get_hinstance() { return hInstance; }


### PR DESCRIPTION
Implements godotengine/godot-proposals#7410.

Each OS implementation is responsible to check for the current compositing window manager.