### PR TITLE
Fix XWayland popup issues

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3647,10 +3647,12 @@ void DisplayServerX11::_window_changed(XEvent *event) {
 		return;
 	}
 
-	// Query display server about a possible new window state.
-	wd.fullscreen = _window_fullscreen_check(window_id);
-	wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE") && !wd.fullscreen;
-	wd.minimized = _window_minimize_check(window_id) && !wd.fullscreen && !wd.maximized;
+	if (!is_xwayland) {
+		// Query display server about a possible new window state.
+		wd.fullscreen = _window_fullscreen_check(window_id);
+		wd.maximized = _window_maximize_check(window_id, "_NET_WM_STATE") && !wd.fullscreen;
+		wd.minimized = _window_minimize_check(window_id) && !wd.fullscreen && !wd.maximized;
+	}
 
 	// Readjusting the window position if the window is being reparented by the window manager for decoration
 	Window root, parent, *children;
@@ -5991,6 +5993,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	XSetErrorHandler(&default_window_error_handler);
 
 	r_error = OK;
+
+	if ((OS::get_singleton()->has_environment("XDG_SESSION_TYPE") && OS::get_singleton()->get_environment("XDG_SESSION_TYPE") == "wayland") || OS::get_singleton()->has_environment("WAYLAND_DISPLAY")) {
+		is_xwayland = true;
+	}
 }
 
 DisplayServerX11::~DisplayServerX11() {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -365,6 +365,8 @@ class DisplayServerX11 : public DisplayServer {
 	static Bool _predicate_clipboard_incr(Display *display, XEvent *event, XPointer arg);
 	static Bool _predicate_clipboard_save_targets(Display *display, XEvent *event, XPointer arg);
 
+	bool is_xwayland = false;
+
 protected:
 	void _window_changed(XEvent *event);
 


### PR DESCRIPTION
Fixes #77333

Reverts https://github.com/godotengine/godot/commit/0f5b448a9c11d6f66942934c4156a87b387356a3 as @PorkrollPosadist [found out](https://github.com/godotengine/godot/issues/77333#issuecomment-1648912027) that it was that commit that caused #77333.

Needs to be tested by XWayland users.

_Bugsquad edit, alternative to: #80036_