### PR TITLE
Fix uninitialized variable ending up sent to Vulkan

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4687,7 +4687,7 @@ Vector<uint8_t> RenderingDeviceVulkan::shader_compile_binary_from_spirv(const Ve
 			"Number of uniform sets is larger than what is supported by the hardware (" + itos(limits.maxBoundDescriptorSets) + ").");
 
 	// Collect reflection data into binary data.
-	RenderingDeviceVulkanShaderBinaryData binary_data;
+	RenderingDeviceVulkanShaderBinaryData binary_data{};
 	Vector<Vector<RenderingDeviceVulkanShaderBinaryDataBinding>> uniform_info; // Set bindings.
 	Vector<RenderingDeviceVulkanShaderBinarySpecializationConstant> specialization_constants;
 	{

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -382,7 +382,7 @@ String ShaderRD::_version_get_sha1(Version *p_version) const {
 }
 
 static const char *shader_file_header = "GDSC";
-static const uint32_t cache_file_version = 2;
+static const uint32_t cache_file_version = 3;
 
 bool ShaderRD::_load_from_cache(Version *p_version) {
 	String sha1 = _version_get_sha1(p_version);


### PR DESCRIPTION
The first time a shader is compiled Godot performs the following:

```cpp
for (uint32_t i = 0; i < SHADER_STAGE_MAX; i++) {
	if(spirv_data.push_constant_stages_mask.has_flag((ShaderStage)(1 << i))) {
		binary_data.push_constant_vk_stages_mask |= shader_stage_masks[i];
	}
}
```

However `binary_data.push_constant_vk_stages_mask` is never initialized to 0 and thus contains garbage data or'ed with the good data.

This value is used by push constants (and many other things) thus it can be a big deal.

Fortunately because the relevant flags are always guaranteed to be set (but not guaranteed to be unset), the damage is restricted to:

1. Performance (unnecessary flushing & over-excessive barriers)
2. Overwriting push descriptors already set (this would be serious, doesn't seem to be an issue)
3. Driver implementations going crazy when they see bits set they don't expect (unknown if this is an issue)

This uninitialized value is later saved into the binary cache.

Valgrind is able to detect this bug on the first run, but not on the subsequent ones because the data comes from a file.

cache_file_version has been bumped to force rebuild of all cached shaders. Because the ones generated so far are compromised.

## Can this fix TDRs? (aka DEVICE_LOST)

Possibly.

## Should this be backported to older versions?

Probably, I didn't check
