### PR TITLE
Use EWMH for `DisplayServerX11::_window_minimize_check()` implementation

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2096,9 +2096,10 @@ bool DisplayServerX11::_window_maximize_check(WindowID p_window, const char *p_a
 bool DisplayServerX11::_window_minimize_check(WindowID p_window) const {
 	const WindowData &wd = windows[p_window];
 
-	// Using ICCCM -- Inter-Client Communication Conventions Manual
-	Atom property = XInternAtom(x11_display, "WM_STATE", True);
-	if (property == None) {
+	// Using EWMH instead of ICCCM, might work better for Wayland users.
+	Atom property = XInternAtom(x11_display, "_NET_WM_STATE", True);
+	Atom hidden = XInternAtom(x11_display, "_NET_WM_STATE_HIDDEN", True);
+	if (property == None || hidden == None) {
 		return false;
 	}
 
@@ -2106,7 +2107,7 @@ bool DisplayServerX11::_window_minimize_check(WindowID p_window) const {
 	int format;
 	unsigned long len;
 	unsigned long remaining;
-	unsigned char *data = nullptr;
+	Atom *atoms = nullptr;
 
 	int result = XGetWindowProperty(
 			x11_display,
@@ -2115,20 +2116,21 @@ bool DisplayServerX11::_window_minimize_check(WindowID p_window) const {
 			0,
 			32,
 			False,
-			AnyPropertyType,
+			XA_ATOM,
 			&type,
 			&format,
 			&len,
 			&remaining,
-			&data);
+			(unsigned char **)&atoms);
 
-	if (result == Success && data) {
-		long *state = (long *)data;
-		if (state[0] == WM_IconicState) {
-			XFree(data);
-			return true;
+	if (result == Success && atoms) {
+		for (unsigned int i = 0; i < len; i++) {
+			if (atoms[i] == hidden) {
+				XFree(atoms);
+				return true;
+			}
 		}
-		XFree(data);
+		XFree(atoms);
 	}
 
 	return false;


### PR DESCRIPTION
Proposed solution for issue #77333

After a lot of testing (some of which is included in the issue discussion) I observed multiple failure mechanisms which all ended up leading back to `DisplayServerX11::_window_minimize_check()` returning an unexpected result.  Since EWMH features are used liberally throughout the rest of the DisplayServerX11 implementation, I figured I would use use EWMH to figure out the minimized state instead of ICCCM (the original implementation).

In my limited testing so far, this solves the issue on Gnome/Wayland (Gentoo x86_64).  I also tested it on an alternate machine (Fedora 38, Gnome/X11 x86_64).  This patch is going to need some more testing to ensure it doesn't introduce any regressions (i.e. fix XWayland at the expense of breaking X11).  At least a handful of X11 window managers and Wayland compositors should be tried.  Also, it would be wise to test some Godot projects which make advanced use of it's multi-window GUI features to check some corner cases which are less likely to be exposed by point-and-click usage.

* *Bugsquad edit, fixes: #77333*
* *Bugsquad edit, alternative to: #80032*