### PR TITLE
Edit TileSet source on double click

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -2234,6 +2234,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	sources_list->connect("item_selected", callable_mp(this, &TileMapEditorTilesPlugin::_update_fix_selected_and_hovered).unbind(1));
 	sources_list->connect("item_selected", callable_mp(this, &TileMapEditorTilesPlugin::_update_source_display).unbind(1));
 	sources_list->connect("item_selected", callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::set_sources_lists_current));
+	sources_list->connect("item_activated", callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::display_tile_set_editor_panel).unbind(1));
 	sources_list->connect("visibility_changed", callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::synchronize_sources_list).bind(sources_list, source_sort_button));
 	sources_list->add_user_signal(MethodInfo("sort_request"));
 	sources_list->connect("sort_request", callable_mp(this, &TileMapEditorTilesPlugin::_update_tile_set_sources_list));

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -50,7 +50,8 @@
 #include "scene/resources/tile_set.h"
 
 TilesEditorUtils *TilesEditorUtils::singleton = nullptr;
-TileMapEditorPlugin *local_singleton = nullptr;
+TileMapEditorPlugin *tile_map_plugin_singleton = nullptr;
+TileSetEditorPlugin *tile_set_plugin_singleton = nullptr;
 
 void TilesEditorUtils::_preview_frame_started() {
 	RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<TilesEditorUtils *>(this), &TilesEditorUtils::_pattern_preview_done));
@@ -283,6 +284,11 @@ bool TilesEditorUtils::SourceNameComparator::operator()(const int &p_a, const in
 	return NaturalNoCaseComparator()(name_a, name_b);
 }
 
+void TilesEditorUtils::display_tile_set_editor_panel() {
+	tile_map_plugin_singleton->hide_editor();
+	tile_set_plugin_singleton->make_visible(true);
+}
+
 void TilesEditorUtils::draw_selection_rect(CanvasItem *p_ci, const Rect2 &p_rect, const Color &p_color) {
 	real_t scale = p_ci->get_global_transform().get_scale().x * 0.5;
 	p_ci->draw_set_transform(p_rect.position, 0, Vector2(1, 1) / scale);
@@ -373,13 +379,19 @@ void TileMapEditorPlugin::forward_canvas_draw_over_viewport(Control *p_overlay) 
 	editor->forward_canvas_draw_over_viewport(p_overlay);
 }
 
+void TileMapEditorPlugin::hide_editor() {
+	if (editor->is_visible_in_tree()) {
+		EditorNode::get_singleton()->hide_bottom_panel();
+	}
+}
+
 bool TileMapEditorPlugin::is_editor_visible() const {
 	return editor->is_visible_in_tree();
 }
 
 TileMapEditorPlugin::TileMapEditorPlugin() {
 	memnew(TilesEditorUtils);
-	local_singleton = this;
+	tile_map_plugin_singleton = this;
 
 	editor = memnew(TileMapEditor);
 	editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -392,7 +404,7 @@ TileMapEditorPlugin::TileMapEditorPlugin() {
 }
 
 TileMapEditorPlugin::~TileMapEditorPlugin() {
-	local_singleton = nullptr;
+	tile_map_plugin_singleton = nullptr;
 }
 
 void TileSetEditorPlugin::edit(Object *p_object) {
@@ -406,7 +418,7 @@ bool TileSetEditorPlugin::handles(Object *p_object) const {
 void TileSetEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		if (!local_singleton->is_editor_visible()) {
+		if (!tile_map_plugin_singleton->is_editor_visible()) {
 			EditorNode::get_singleton()->make_bottom_panel_item_visible(editor);
 		}
 	} else {
@@ -418,7 +430,8 @@ void TileSetEditorPlugin::make_visible(bool p_visible) {
 }
 
 TileSetEditorPlugin::TileSetEditorPlugin() {
-	DEV_ASSERT(local_singleton);
+	DEV_ASSERT(tile_map_plugin_singleton);
+	tile_set_plugin_singleton = this;
 
 	editor = memnew(TileSetEditor);
 	editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -428,4 +441,8 @@ TileSetEditorPlugin::TileSetEditorPlugin() {
 
 	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TileSet"), editor);
 	button->hide();
+}
+
+TileSetEditorPlugin::~TileSetEditorPlugin() {
+	tile_set_plugin_singleton = nullptr;
 }

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -101,6 +101,9 @@ public:
 	void set_sorting_option(int p_option);
 	List<int> get_sorted_sources(const Ref<TileSet> p_tile_set) const;
 
+	// Misc.
+	void display_tile_set_editor_panel();
+
 	static void draw_selection_rect(CanvasItem *p_ci, const Rect2 &p_rect, const Color &p_color = Color(1.0, 1.0, 1.0));
 
 	TilesEditorUtils();
@@ -129,6 +132,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
 
+	void hide_editor();
 	bool is_editor_visible() const;
 
 	TileMapEditorPlugin();
@@ -147,6 +151,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 
 	TileSetEditorPlugin();
+	~TileSetEditorPlugin();
 };
 
 #endif // TILES_EDITOR_PLUGIN_H


### PR DESCRIPTION
https://github.com/godotengine/godot-proposals/issues/1769#issuecomment-1021761356

https://github.com/godotengine/godot/assets/2223172/d049c555-4eb7-48cb-9944-cee1cd4d68b8

If you are wondering about the local cpp singletons, they aren't needed anywhere else, so there is no reason to add proper `get_singleton()` methods right now.