### PR TITLE
Avoid punning `[param enabled]` in documentation

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -66,7 +66,7 @@
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code] the specified [param agent] uses avoidance.
+				If [param enabled] is [code]true[/code], the specified [param agent] uses avoidance.
 			</description>
 		</method>
 		<method name="agent_set_avoidance_layers">
@@ -283,7 +283,7 @@
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code] the specified [param link] will contribute to its current navigation map.
+				If [param enabled] is [code]true[/code], the specified [param link] will contribute to its current navigation map.
 			</description>
 		</method>
 		<method name="link_set_end_position">
@@ -485,7 +485,7 @@
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				Set the navigation [param map] edge connection use. If [param enabled] the navigation map allows navigation regions to use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
+				Set the navigation [param map] edge connection use. If [param enabled] is [code]true[/code], the navigation map allows navigation regions to use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
 			</description>
 		</method>
 		<method name="obstacle_create">
@@ -520,7 +520,7 @@
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] the provided [param obstacle] affects avoidance using agents.
+				If [param enabled] is [code]true[/code], the provided [param obstacle] affects avoidance using agents.
 			</description>
 		</method>
 		<method name="obstacle_set_avoidance_layers">
@@ -744,7 +744,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] the navigation [param region] will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
+				If [param enabled] is [code]true[/code], the navigation [param region] will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
 			</description>
 		</method>
 		<method name="set_debug_enabled">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -73,7 +73,7 @@
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] the provided [param agent] calculates avoidance.
+				If [param enabled] is [code]true[/code], the provided [param agent] calculates avoidance.
 			</description>
 		</method>
 		<method name="agent_set_avoidance_layers">
@@ -324,7 +324,7 @@
 			<param index="0" name="link" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code] the specified [param link] will contribute to its current navigation map.
+				If [param enabled] is [code]true[/code], the specified [param link] will contribute to its current navigation map.
 			</description>
 		</method>
 		<method name="link_set_end_position">
@@ -574,7 +574,7 @@
 			<param index="0" name="map" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				Set the navigation [param map] edge connection use. If [param enabled] the navigation map allows navigation regions to use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
+				Set the navigation [param map] edge connection use. If [param enabled] is [code]true[/code], the navigation map allows navigation regions to use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
 			</description>
 		</method>
 		<method name="obstacle_create">
@@ -616,7 +616,7 @@
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] the provided [param obstacle] affects avoidance using agents.
+				If [param enabled] is [code]true[/code], the provided [param obstacle] affects avoidance using agents.
 			</description>
 		</method>
 		<method name="obstacle_set_avoidance_layers">
@@ -813,7 +813,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] is [code]true[/code] the specified [param region] will contribute to its current navigation map.
+				If [param enabled] is [code]true[/code], the specified [param region] will contribute to its current navigation map.
 			</description>
 		</method>
 		<method name="region_set_enter_cost">
@@ -877,7 +877,7 @@
 			<param index="0" name="region" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				If [param enabled] the navigation [param region] will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
+				If [param enabled] is [code]true[/code], the navigation [param region] will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin.
 			</description>
 		</method>
 		<method name="set_active">


### PR DESCRIPTION
> If [param enabled] the provided [param obstacle] affects avoidance using agents.

`[param enabled]` has to be kept in translation, so the pun will be lost because readers might not know what "enabled" means in English.

Currently, e.g. in Chinese, this sentence will be translated as if it's

> If [param enabled] is [code]true[/code], the provided [param obstacle] affects avoidance using agents.

Weblate's complain about non-match BBCode has to be turned off manually for each entry. And either leaving a bare unmarked-up "true" in the description or translating "true" here feels wrong.

This PR changes `If [param enabled] then XXX` to `If [param enabled] is [code]true[/code], then XXX`, just like in other classrefs.