### PR TITLE
Add missing TTR for Tabs and Spaces

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -891,7 +891,7 @@ void CodeTextEditor::_line_col_changed() {
 	sb.append(itos(positional_column + 1).lpad(3));
 
 	sb.append(" | ");
-	sb.append(text_editor->is_indent_using_spaces() ? "Spaces" : "Tabs");
+	sb.append(text_editor->is_indent_using_spaces() ? TTR("Spaces") : TTR("Tabs"));
 
 	line_and_col_txt->set_text(sb.as_string());
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
