### PR TITLE
Enable depth writes during shadow pass and depth pass. Disable during color pass

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2170,7 +2170,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 		if (scene_state.current_depth_draw != shader->depth_draw) {
 			switch (shader->depth_draw) {
 				case GLES3::SceneShaderData::DEPTH_DRAW_OPAQUE: {
-					glDepthMask(p_pass_mode == PASS_MODE_COLOR);
+					glDepthMask((p_pass_mode == PASS_MODE_COLOR && !GLES3::Config::get_singleton()->use_depth_prepass) ||
+							p_pass_mode == PASS_MODE_DEPTH ||
+							p_pass_mode == PASS_MODE_SHADOW);
 				} break;
 				case GLES3::SceneShaderData::DEPTH_DRAW_ALWAYS: {
 					glDepthMask(GL_TRUE);


### PR DESCRIPTION
This fixes an unreported performance bug. Basically, without this change, the depth prepass did nothing

Tested with https://github.com/godotengine/godot/issues/68959 and verified the results in Renderdoc. 

Performance without this change: **22 ms** per frame
With this change: **18 ms** per frame
Same scene in 3.5.1: **18 ms** per frame