### PR TITLE
GDExtension: `PtrToArg::convert()` uses const-reference where possible

### DIFF
--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -38,26 +38,26 @@
 template <class T>
 struct PtrToArg {};
 
-#define MAKE_PTRARG(m_type)                                            \
-	template <>                                                        \
-	struct PtrToArg<m_type> {                                          \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		typedef m_type EncodeT;                                        \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*((m_type *)p_ptr) = p_val;                                \
-		}                                                              \
-	};                                                                 \
-	template <>                                                        \
-	struct PtrToArg<const m_type &> {                                  \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {      \
-			return *reinterpret_cast<const m_type *>(p_ptr);           \
-		}                                                              \
-		typedef m_type EncodeT;                                        \
-		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) { \
-			*((m_type *)p_ptr) = p_val;                                \
-		}                                                              \
+#define MAKE_PTRARG(m_type)                                              \
+	template <>                                                          \
+	struct PtrToArg<m_type> {                                            \
+		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr);             \
+		}                                                                \
+		typedef m_type EncodeT;                                          \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {   \
+			*((m_type *)p_ptr) = p_val;                                  \
+		}                                                                \
+	};                                                                   \
+	template <>                                                          \
+	struct PtrToArg<const m_type &> {                                    \
+		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) { \
+			return *reinterpret_cast<const m_type *>(p_ptr);             \
+		}                                                                \
+		typedef m_type EncodeT;                                          \
+		_FORCE_INLINE_ static void encode(m_type p_val, void *p_ptr) {   \
+			*((m_type *)p_ptr) = p_val;                                  \
+		}                                                                \
 	}
 
 #define MAKE_PTRARGCONV(m_type, m_conv)                                           \
@@ -85,7 +85,7 @@ struct PtrToArg {};
 #define MAKE_PTRARG_BY_REFERENCE(m_type)                                      \
 	template <>                                                               \
 	struct PtrToArg<m_type> {                                                 \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) {      \
 			return *reinterpret_cast<const m_type *>(p_ptr);                  \
 		}                                                                     \
 		typedef m_type EncodeT;                                               \
@@ -95,7 +95,7 @@ struct PtrToArg {};
 	};                                                                        \
 	template <>                                                               \
 	struct PtrToArg<const m_type &> {                                         \
-		_FORCE_INLINE_ static m_type convert(const void *p_ptr) {             \
+		_FORCE_INLINE_ static const m_type &convert(const void *p_ptr) {      \
 			return *reinterpret_cast<const m_type *>(p_ptr);                  \
 		}                                                                     \
 		typedef m_type EncodeT;                                               \

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -145,8 +145,7 @@ struct PtrToArg<TypedArray<T>> {
 template <class T>
 struct PtrToArg<const TypedArray<T> &> {
 	typedef Array EncodeT;
-	_FORCE_INLINE_ static TypedArray<T>
-	convert(const void *p_ptr) {
+	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
 		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
 	}
 };


### PR DESCRIPTION
Fixes #80074.

In the cases where `reinterpret_cast` is immediately dereferenced, `PtrToArg::convert()` returns a const-reference instead of a value. This allows to reuse the object located at the address of the passed `const void*` pointer, instead of triggering the copy constructor.

We cannot return const-references where temporary values are constructed. Most manual `PtrToArg` specializations fall under this category and are thus untouched.

In some cases, we now return a const-reference to scalar types like `int`, `bool` etc. Since the function is annotated as `_FORCE_INLINE_`, I expect any such indirections to be optimized away though.

I did some tests with the Rust binding (gdext) already, but I'd appreciate some input on this!