### PR TITLE
[3.x] Add `debug_canvas_item_get_local_bound()` function to VisualServer

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -806,6 +806,14 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="debug_canvas_item_get_local_bound">
+			<return type="Rect2" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Returns the bounding rectangle for a canvas item and its descendants in local space, as calculated by the renderer. This bound is used internally for culling.
+				[b]Warning:[/b] This function is intended for debugging in the editor, and will pass through and return a zero [Rect2] in exported projects.
+			</description>
+		</method>
 		<method name="debug_canvas_item_get_rect">
 			<return type="Rect2" />
 			<argument index="0" name="item" type="RID" />

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1470,6 +1470,12 @@ Rect2 VisualServerCanvas::_debug_canvas_item_get_rect(RID p_item) {
 	return canvas_item->get_rect();
 }
 
+Rect2 VisualServerCanvas::_debug_canvas_item_get_local_bound(RID p_item) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND_V(!canvas_item, Rect2());
+	return canvas_item->local_bound;
+}
+
 void VisualServerCanvas::canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -259,6 +259,7 @@ public:
 	void _canvas_item_skeleton_moved(RID p_item);
 	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
 	Rect2 _debug_canvas_item_get_rect(RID p_item);
+	Rect2 _debug_canvas_item_get_local_bound(RID p_item);
 
 	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
 	void canvas_item_reset_physics_interpolation(RID p_item);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -720,6 +720,7 @@ public:
 	BIND2(canvas_item_attach_skeleton, RID, RID)
 	BIND2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	BIND1R(Rect2, _debug_canvas_item_get_rect, RID)
+	BIND1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	BIND2(canvas_item_set_interpolated, RID, bool)
 	BIND1(canvas_item_reset_physics_interpolation, RID)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -624,6 +624,7 @@ public:
 	FUNC2(canvas_item_attach_skeleton, RID, RID)
 	FUNC2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	FUNC1R(Rect2, _debug_canvas_item_get_rect, RID)
+	FUNC1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	FUNC2(canvas_item_set_interpolated, RID, bool)
 	FUNC1(canvas_item_reset_physics_interpolation, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2206,6 +2206,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_material", "item", "material"), &VisualServer::canvas_item_set_material);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_use_parent_material", "item", "enabled"), &VisualServer::canvas_item_set_use_parent_material);
 	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &VisualServer::debug_canvas_item_get_rect);
+	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_local_bound", "item"), &VisualServer::debug_canvas_item_get_local_bound);
 	ClassDB::bind_method(D_METHOD("canvas_light_create"), &VisualServer::canvas_light_create);
 	ClassDB::bind_method(D_METHOD("canvas_light_attach_to_canvas", "light", "canvas"), &VisualServer::canvas_light_attach_to_canvas);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_enabled", "light", "enabled"), &VisualServer::canvas_light_set_enabled);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1060,14 +1060,15 @@ public:
 	virtual void canvas_item_attach_skeleton(RID p_item, RID p_skeleton) = 0;
 	virtual void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) = 0;
 
-	Rect2 debug_canvas_item_get_rect(RID p_item) {
 #ifdef TOOLS_ENABLED
-		return _debug_canvas_item_get_rect(p_item);
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return _debug_canvas_item_get_rect(p_item); }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return _debug_canvas_item_get_local_bound(p_item); }
 #else
-		return Rect2();
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return Rect2(); }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return Rect2(); }
 #endif
-	}
 	virtual Rect2 _debug_canvas_item_get_rect(RID p_item) = 0;
+	virtual Rect2 _debug_canvas_item_get_local_bound(RID p_item) = 0;
 
 	virtual void canvas_item_set_interpolated(RID p_item, bool p_interpolated) = 0;
 	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;


### PR DESCRIPTION
Useful for debugging hierarchical culling.

## Notes
* Forgot to add this as part of  #68738
* It is super useful for debugging hierarchical culling bugs as it can be used to show the debug bound of a node and all descendants (used in a similar way to `debug_canvas_item_get_rect()` in #75612 )
* This is primarily for use by engine devs to debug the engine, rather than for users.
* Now coming in useful for debugging 2D particle bounds which don't seem correct.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
