### PR TITLE
Fix API hash related crash in `EditorSettings`

### DIFF
--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -481,6 +481,8 @@ void DocTools::generate(bool p_basic_types) {
 							default_value_valid = true;
 						}
 					}
+				} else if (name == "EditorSettings") {
+					// Special case for editor settings, to prevent hardware or OS specific settings to affect the result.
 				} else if (import_option) {
 					default_value = import_options_default[E.name];
 					default_value_valid = true;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6822,7 +6822,6 @@ EditorNode::EditorNode() {
 	// No scripting by default if in editor.
 	ScriptServer::set_scripting_enabled(false);
 
-	EditorSettings::ensure_class_registered();
 	EditorHelp::generate_doc();
 	SceneState::set_disable_placeholders(true);
 	ResourceLoader::clear_translation_remaps(); // Using no remaps if in editor.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -878,13 +878,6 @@ EditorSettings *EditorSettings::get_singleton() {
 	return singleton.ptr();
 }
 
-void EditorSettings::ensure_class_registered() {
-	ClassDB::APIType prev_api = ClassDB::get_current_api();
-	ClassDB::set_current_api(ClassDB::API_EDITOR);
-	GDREGISTER_CLASS(EditorSettings); // Otherwise it can't be unserialized.
-	ClassDB::set_current_api(prev_api);
-}
-
 void EditorSettings::create() {
 	// IMPORTANT: create() *must* create a valid EditorSettings singleton,
 	// as the rest of the engine code will assume it. As such, it should never
@@ -894,8 +887,6 @@ void EditorSettings::create() {
 		ERR_PRINT("Can't recreate EditorSettings as it already exists.");
 		return;
 	}
-
-	ensure_class_registered();
 
 	String config_file_path;
 	Ref<ConfigFile> extra_config = memnew(ConfigFile);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -117,7 +117,6 @@ public:
 
 	static EditorSettings *get_singleton();
 
-	static void ensure_class_registered();
 	static void create();
 	void setup_language();
 	void setup_network();

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -140,7 +140,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorScript);
 	GDREGISTER_CLASS(EditorSelection);
 	GDREGISTER_CLASS(EditorFileDialog);
-	GDREGISTER_ABSTRACT_CLASS(EditorSettings);
+	GDREGISTER_CLASS(EditorSettings);
 	GDREGISTER_CLASS(EditorNode3DGizmo);
 	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);


### PR DESCRIPTION
Crash due to manipulating API after getting the hash, which happens with `--verbose`

Instead of registering `EditorSettings` as abstract, and then registering as complete when creating an instance, we now register it as complete from the start.

This behavior is equivalent to how it worked prior to #78615, where the built-in documentation doesn't show the default values of `EditorSettings`, the abstract state of `EditorSettings` is and has always been false, and it is and has been possible to instance it from scripts (required for the loading of the settings)

I don't think the loss of the built-in documentation for these settings is a major loss, `EditorSettings` itself remains in the documentation, and the results of `--doctool` remains the same

In summary, I think this is a good balanced solution to the issue, without having to mess with the specific registration location of `EditorSettings`. Unless there is some reason for it being abstract that I have missed (other than the documentation generation)

* Fixes: #80062
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
