### PR TITLE
[3.x] Fix CPUParticles2D hierarchical culling

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -325,6 +325,14 @@
 				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="canvas_item_invalidate_local_bound">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Invalidates the local bounds of the given [CanvasItem]. This will trigger bounds update through the tree.
+				[b]Note:[/b] For hierarchical culling to work correctly, in some cases local bounds must be explicitly invalidated. E.g. updates to some resources (such as [MultiMesh]) do not automatically update the local bounds of [CanvasItem]s which use these resources.
+			</description>
+		</method>
 		<method name="canvas_item_set_clip">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -728,6 +728,14 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="debug_canvas_item_get_local_bound">
+			<return type="Rect2" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Returns the bounding rectangle for a canvas item and its descendants in local space, as calculated by the renderer. This bound is used internally for culling.
+				[b]Warning:[/b] This function is intended for debugging in the editor, and will pass through and return a zero [Rect2] in exported projects.
+			</description>
+		</method>
 		<method name="debug_canvas_item_get_rect">
 			<return type="Rect2" />
 			<argument index="0" name="item" type="RID" />

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1036,6 +1036,11 @@ void CPUParticles2D::_update_render_thread() {
 	if (OS::get_singleton()->is_update_pending(true)) {
 		update_mutex.lock();
 		VS::get_singleton()->multimesh_set_as_bulk_array(multimesh, particle_data);
+
+		// Changing the multimesh changes the bounding rect, but with hierarchical
+		// culling we need to invalidate parent bounds through the tree so that they
+		// will be recalculated up to date, to prevent the particles being culled incorrectly.
+		VS::get_singleton()->canvas_item_invalidate_local_bound(get_canvas_item());
 		update_mutex.unlock();
 	}
 }

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -872,6 +872,12 @@ void VisualServerCanvas::canvas_item_set_self_modulate(RID p_item, const Color &
 	_make_bound_dirty(canvas_item);
 }
 
+void VisualServerCanvas::canvas_item_invalidate_local_bound(RID p_item) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND(!canvas_item);
+	_make_bound_dirty(canvas_item);
+}
+
 void VisualServerCanvas::canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1409,6 +1409,12 @@ Rect2 VisualServerCanvas::_debug_canvas_item_get_rect(RID p_item) {
 	return canvas_item->get_rect();
 }
 
+Rect2 VisualServerCanvas::_debug_canvas_item_get_local_bound(RID p_item) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND_V(!canvas_item, Rect2());
+	return canvas_item->local_bound;
+}
+
 void VisualServerCanvas::canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -258,6 +258,7 @@ public:
 	void canvas_item_attach_skeleton(RID p_item, RID p_skeleton);
 	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
 	Rect2 _debug_canvas_item_get_rect(RID p_item);
+	Rect2 _debug_canvas_item_get_local_bound(RID p_item);
 	void _canvas_item_skeleton_moved(RID p_item);
 
 	RID canvas_light_create();

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -224,6 +224,7 @@ public:
 	void canvas_item_set_custom_rect(RID p_item, bool p_custom_rect, const Rect2 &p_rect = Rect2());
 	void canvas_item_set_modulate(RID p_item, const Color &p_color);
 	void canvas_item_set_self_modulate(RID p_item, const Color &p_color);
+	void canvas_item_invalidate_local_bound(RID p_item);
 
 	void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable);
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -695,6 +695,7 @@ public:
 	BIND3(canvas_item_set_custom_rect, RID, bool, const Rect2 &)
 	BIND2(canvas_item_set_modulate, RID, const Color &)
 	BIND2(canvas_item_set_self_modulate, RID, const Color &)
+	BIND1(canvas_item_invalidate_local_bound, RID)
 
 	BIND2(canvas_item_set_draw_behind_parent, RID, bool)
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -722,6 +722,7 @@ public:
 	BIND2(canvas_item_attach_skeleton, RID, RID)
 	BIND2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	BIND1R(Rect2, _debug_canvas_item_get_rect, RID)
+	BIND1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	BIND1(canvas_item_clear, RID)
 	BIND2(canvas_item_set_draw_index, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -623,6 +623,7 @@ public:
 	FUNC2(canvas_item_attach_skeleton, RID, RID)
 	FUNC2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	FUNC1R(Rect2, _debug_canvas_item_get_rect, RID)
+	FUNC1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	FUNC1(canvas_item_clear, RID)
 	FUNC2(canvas_item_set_draw_index, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -596,6 +596,7 @@ public:
 	FUNC3(canvas_item_set_custom_rect, RID, bool, const Rect2 &)
 	FUNC2(canvas_item_set_modulate, RID, const Color &)
 	FUNC2(canvas_item_set_self_modulate, RID, const Color &)
+	FUNC1(canvas_item_invalidate_local_bound, RID)
 
 	FUNC2(canvas_item_set_draw_behind_parent, RID, bool)
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2178,6 +2178,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_custom_rect", "item", "use_custom_rect", "rect"), &VisualServer::canvas_item_set_custom_rect, DEFVAL(Rect2()));
 	ClassDB::bind_method(D_METHOD("canvas_item_set_modulate", "item", "color"), &VisualServer::canvas_item_set_modulate);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_self_modulate", "item", "color"), &VisualServer::canvas_item_set_self_modulate);
+	ClassDB::bind_method(D_METHOD("canvas_item_invalidate_local_bound", "item"), &VisualServer::canvas_item_invalidate_local_bound);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_draw_behind_parent", "item", "enabled"), &VisualServer::canvas_item_set_draw_behind_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_line", "item", "from", "to", "color", "width", "antialiased"), &VisualServer::canvas_item_add_line, DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("canvas_item_add_polyline", "item", "points", "colors", "width", "antialiased"), &VisualServer::canvas_item_add_polyline, DEFVAL(1.0), DEFVAL(false));

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2203,6 +2203,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_material", "item", "material"), &VisualServer::canvas_item_set_material);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_use_parent_material", "item", "enabled"), &VisualServer::canvas_item_set_use_parent_material);
 	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &VisualServer::debug_canvas_item_get_rect);
+	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_local_bound", "item"), &VisualServer::debug_canvas_item_get_local_bound);
 	ClassDB::bind_method(D_METHOD("canvas_light_create"), &VisualServer::canvas_light_create);
 	ClassDB::bind_method(D_METHOD("canvas_light_attach_to_canvas", "light", "canvas"), &VisualServer::canvas_light_attach_to_canvas);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_enabled", "light", "enabled"), &VisualServer::canvas_light_set_enabled);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1022,6 +1022,7 @@ public:
 	virtual void canvas_item_set_custom_rect(RID p_item, bool p_custom_rect, const Rect2 &p_rect = Rect2()) = 0;
 	virtual void canvas_item_set_modulate(RID p_item, const Color &p_color) = 0;
 	virtual void canvas_item_set_self_modulate(RID p_item, const Color &p_color) = 0;
+	virtual void canvas_item_invalidate_local_bound(RID p_item) = 0;
 
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1056,14 +1056,15 @@ public:
 	virtual void canvas_item_attach_skeleton(RID p_item, RID p_skeleton) = 0;
 	virtual void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) = 0;
 
-	Rect2 debug_canvas_item_get_rect(RID p_item) {
 #ifdef TOOLS_ENABLED
-		return _debug_canvas_item_get_rect(p_item);
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return _debug_canvas_item_get_rect(p_item); }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return _debug_canvas_item_get_local_bound(p_item); }
 #else
-		return Rect2();
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return Rect2(); }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return Rect2(); }
 #endif
-	}
 	virtual Rect2 _debug_canvas_item_get_rect(RID p_item) = 0;
+	virtual Rect2 _debug_canvas_item_get_local_bound(RID p_item) = 0;
 
 	virtual void canvas_item_clear(RID p_item) = 0;
 	virtual void canvas_item_set_draw_index(RID p_item, int p_index) = 0;


### PR DESCRIPTION
Updating the MultiMesh was previously not triggering a recalculation of local bounds in the hierarchical culling system. This PR adds an explicit function `canvas_item_invalidate_local_bound()` to trigger this update, and ensure particles are correctly culled.

This is called automatically by `CPUParticles2D`, but those users using 2D multimeshes via `VisualServer` directly will need to call `canvas_item_invalidate_local_bound()`.

Fixes #80086
First commit is #80084 , that is useful for debugging and verifying the fix.

_before_

https://github.com/godotengine/godot/assets/21999379/282a73b9-e07e-4224-b395-db14ca8d9983

_after_

https://github.com/godotengine/godot/assets/21999379/40018cc9-36e7-49d8-bfd6-684e198a16f1

## Discussion
There are several ways of fixing this. It is possible to introduce a back link from the `MultiMesh` to the canvas item, and automatically invalidate the local bounds when it is updated. This is the system used for skeletons. However in this case the extra machinery seemed like overkill, and the same function could potentially be used to fix other cases of the same class of problem.

On the downside, this does mean that currently users updating 2D multimeshes directly to the `VisualServer` will be responsible for calling this function themselves, when using hierarchical culling.

I'm unsure which is best longterm, but this PR is nice and simple to get started, and may do the job, and we can always change to the other approach if feedback in a beta suggests it is needed.

### GPUParticles2D
On further examination, GPU version only currently supports custom bounds, so there don't seem any changes needed.

## Demo
[particle_culling.zip](https://github.com/godotengine/godot/files/12216789/particle_culling.zip)

Just run it, the debug rect shows the local bounds correctly updating for the particles, even when the origin is offscreen.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
