### PR TITLE
CI: Extract godot-cpp testing into its own job

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,0 +1,18 @@
+name: Download Godot artifact
+description: Download the Godot artifact.
+inputs:
+  name:
+    description: The artifact name.
+    default: "${{ github.job }}"
+  path:
+    description: The path to download and extract to.
+    required: true
+    default: "./"
+runs:
+  using: "composite"
+  steps:
+    - name: Download Godot Artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}

--- a/.github/actions/godot-api-dump/action.yml
+++ b/.github/actions/godot-api-dump/action.yml
@@ -1,0 +1,24 @@
+name: Dump Godot API
+description: Dump Godot API for GDExtension
+inputs:
+  bin:
+    description: The path to the Godot executable
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Dump GDExtension interface and API
+    - name: Dump GDExtension interface and API for godot-cpp build
+      shell: sh
+      run: |
+        ${{ inputs.bin }} --headless --dump-gdextension-interface --dump-extension-api
+        mkdir godot-api
+        cp -f gdextension_interface.h godot-api/
+        cp -f extension_api.json godot-api/
+
+    - name: Upload API dump
+      uses: ./.github/actions/upload-artifact
+      with:
+        name: 'godot-api-dump'
+        path: './godot-api/*'
+

--- a/.github/actions/godot-cache/action.yml
+++ b/.github/actions/godot-cache/action.yml
@@ -16,7 +16,20 @@ runs:
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+
+        # We try to match an existing cache to restore from it. Each potential key is checked against
+        # all existing caches as a prefix. E.g. 'linux-template-minimal' would match any cache that
+        # starts with "linux-template-minimal", such as "linux-template-minimal-master-refs/heads/master-6588a4a29af1621086feac0117d5d4d37af957fd".
+        #
+        # We check these prefixes in this order:
+        #
+        #   1. The exact match, including the base branch, the commit reference, and the SHA hash of the commit.
+        #   2. A partial match for the same base branch and the same commit reference.
+        #   3. A partial match for the same base branch and the base branch commit reference.
+        #   4. A partial match for the same base branch only (not ideal, matches any PR with the same base branch).
+
         restore-keys: |
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+          ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-refs/heads/${{env.GODOT_BASE_BRANCH}}
           ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}

--- a/.github/actions/godot-converter-test/action.yml
+++ b/.github/actions/godot-converter-test/action.yml
@@ -1,0 +1,18 @@
+name: Test Godot project converter
+description: Test the Godot project converter.
+inputs:
+  bin:
+    description: The path to the Godot executable
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Test 3-to-4 conversion
+      shell: sh
+      run: |
+        mkdir converter_test
+        cd converter_test
+        touch project.godot
+        ../${{ inputs.bin }} --headless --validate-conversion-3to4
+        cd ..
+        rm converter_test -rf

--- a/.github/actions/godot-project-test/action.yml
+++ b/.github/actions/godot-project-test/action.yml
@@ -1,0 +1,37 @@
+name: Test Godot project
+description: Run the test Godot project.
+inputs:
+  bin:
+    description: The path to the Godot executable
+    required: true
+runs:
+  using: "composite"
+  steps:
+    # Download and extract zip archive with project, folder is renamed to be able to easy change used project
+    - name: Download test project
+      shell: sh
+      run: |
+        wget https://github.com/godotengine/regression-test-project/archive/4.0.zip
+        unzip 4.0.zip
+        mv "regression-test-project-4.0" "test_project"
+
+    # Editor is quite complicated piece of software, so it is easy to introduce bug here.
+
+    - name: Open and close editor (Vulkan)
+      shell: sh
+      run: |
+        xvfb-run ${{ inputs.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+        misc/scripts/check_ci_log.py sanitizers_log.txt
+
+    - name: Open and close editor (GLES3)
+      shell: sh
+      run: |
+        DRI_PRIME=0 xvfb-run ${{ inputs.bin }} --audio-driver Dummy --rendering-driver opengl3 --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
+        misc/scripts/check_ci_log.py sanitizers_log.txt
+
+    # Run test project
+    - name: Run project
+      shell: sh
+      run: |
+        xvfb-run ${{ inputs.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
+        misc/scripts/check_ci_log.py sanitizers_log.txt

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -1,0 +1,54 @@
+name: 🪲 Godot CPP
+on:
+  workflow_call:
+
+# Global Settings
+env:
+  # Used for the cache key, and godot-cpp checkout. Add version suffix to force clean build.
+  GODOT_BASE_BRANCH: master
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests
+  cancel-in-progress: true
+
+jobs:
+  godot-cpp-tests:
+    runs-on: "ubuntu-20.04"
+    name: "Build and test Godot CPP"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup python and scons
+        uses: ./.github/actions/godot-deps
+
+      # Checkout godot-cpp
+      - name: Checkout godot-cpp
+        uses: actions/checkout@v3
+        with:
+          repository: godotengine/godot-cpp
+          ref: ${{ env.GODOT_BASE_BRANCH }}
+          submodules: 'recursive'
+          path: 'godot-cpp'
+
+      # Download generated API dump
+      - name: Download GDExtension interface and API dump
+        uses: ./.github/actions/download-artifact
+        with:
+          name: 'godot-api-dump'
+          path: './godot-api'
+
+      # Extract and override existing files with generated files
+      - name: Extract GDExtension interface and API dump
+        run: |
+          cp -f godot-api/gdextension_interface.h godot-cpp/gdextension/
+          cp -f godot-api/extension_api.json godot-cpp/gdextension/
+
+      # TODO: Add caching to the scons build and store it for CI via the godot-cache
+      # action.
+
+      # Build godot-cpp test extension
+      - name: Build godot-cpp test extension
+        run: |
+          cd godot-cpp/test
+          scons target=template_debug dev_build=yes
+          cd ../..

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,7 +4,7 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key, and godot-cpp checkout. Add version suffix to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes
   DOTNET_NOLOGO: true
@@ -25,53 +25,52 @@ jobs:
           - name: Editor w/ Mono (target=editor)
             cache-name: linux-editor-mono
             target: editor
-            tests: false # Disabled due freeze caused by mix Mono build and CI
             sconsflags: module_mono_enabled=yes
-            doc-test: true
             bin: "./bin/godot.linuxbsd.editor.x86_64.mono"
             build-mono: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            doc-test: true
             proj-conv: true
+            api-compat: true
             artifact: true
-            compat: true
 
           - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
             cache-name: linux-editor-double-sanitizers
             target: editor
-            tests: true
             # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
             sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=gold
-            proj-test: true
-            # Can be turned off for PRs that intentionally break compat with godot-cpp,
-            # until both the upstream PR and the matching godot-cpp changes are merged.
-            godot-cpp-test: true
             bin: "./bin/godot.linuxbsd.editor.dev.double.x86_64.san"
             build-mono: false
+            tests: true
+            proj-test: true
+            # Generate an API dump for godot-cpp tests.
+            api-dump: true
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
           - name: Editor with clang sanitizers (target=editor, tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
             target: editor
-            tests: true
             sconsflags: dev_build=yes use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
             bin: "./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san"
             build-mono: false
+            tests: true
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
           - name: Template w/ Mono (target=template_release)
             cache-name: linux-template-mono
             target: template_release
-            tests: false
             sconsflags: module_mono_enabled=yes
             build-mono: false
+            tests: false
             artifact: true
 
           - name: Minimal template (target=template_release, everything disabled)
             cache-name: linux-template-minimal
             target: template_release
-            tests: false
             sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes deprecated=no minizip=no
+            tests: false
             artifact: true
 
     steps:
@@ -127,6 +126,24 @@ jobs:
         run: |
           ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
 
+      - name: Prepare artifact
+        if: ${{ matrix.artifact }}
+        run: |
+          strip bin/godot.*
+          chmod +x bin/godot.*
+
+      - name: Upload artifact
+        uses: ./.github/actions/upload-artifact
+        if: ${{ matrix.artifact }}
+        with:
+          name: ${{ matrix.cache-name }}
+
+      - name: Dump Godot API
+        uses: ./.github/actions/godot-api-dump
+        if: ${{ matrix.api-dump }}
+        with:
+          bin: ${{ matrix.bin }}
+
       # Execute unit tests for the editor
       - name: Unit tests
         if: ${{ matrix.tests }}
@@ -144,84 +161,22 @@ jobs:
           ${{ matrix.bin }} --doctool --headless 2>&1 > /dev/null || true
           git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
-      # Test 3.x -> 4.x project converter
-      - name: Test project converter
-        if: ${{ matrix.proj-conv }}
-        run: |
-          mkdir converter_test
-          cd converter_test
-          touch project.godot
-          ../${{ matrix.bin }} --headless --validate-conversion-3to4
-          cd ..
-          rm converter_test -rf
-
-      # Download and extract zip archive with project, folder is renamed to be able to easy change used project
-      - name: Download test project
-        if: ${{ matrix.proj-test }}
-        run: |
-          wget https://github.com/godotengine/regression-test-project/archive/4.0.zip
-          unzip 4.0.zip
-          mv "regression-test-project-4.0" "test_project"
-
-      # Editor is quite complicated piece of software, so it is easy to introduce bug here
-      - name: Open and close editor (Vulkan)
-        if: ${{ matrix.proj-test }}
-        run: |
-          xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
-          misc/scripts/check_ci_log.py sanitizers_log.txt
-
-      - name: Open and close editor (GLES3)
-        if: ${{ matrix.proj-test }}
-        run: |
-          DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --rendering-driver opengl3 --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
-          misc/scripts/check_ci_log.py sanitizers_log.txt
-
-      # Run test project
-      - name: Run project
-        if: ${{ matrix.proj-test }}
-        run: |
-          xvfb-run ${{ matrix.bin }} 40 --audio-driver Dummy --path test_project 2>&1 | tee sanitizers_log.txt || true
-          misc/scripts/check_ci_log.py sanitizers_log.txt
-
-      # Checkout godot-cpp
-      - name: Checkout godot-cpp
-        if: ${{ matrix.godot-cpp-test }}
-        uses: actions/checkout@v3
-        with:
-          repository: godotengine/godot-cpp
-          ref: ${{ env.GODOT_BASE_BRANCH }}
-          submodules: 'recursive'
-          path: 'godot-cpp'
-
-      # Dump GDExtension interface and API
-      - name: Dump GDExtension interface and API for godot-cpp build
-        if: ${{ matrix.godot-cpp-test }}
-        run: |
-          ${{ matrix.bin }} --headless --dump-gdextension-interface --dump-extension-api
-          cp -f gdextension_interface.h godot-cpp/gdextension/
-          cp -f extension_api.json godot-cpp/gdextension/
-
-      # Build godot-cpp test extension
-      - name: Build godot-cpp test extension
-        if: ${{ matrix.godot-cpp-test }}
-        run: |
-          cd godot-cpp/test
-          scons target=template_debug dev_build=yes
-          cd ../..
-
+      # Check API backwards compatibility
       - name: Check for GDExtension compatibility
-        if: ${{ matrix.compat }}
+        if: ${{ matrix.api-compat }}
         run: |
           ./misc/scripts/validate_extension_api.sh "${{ matrix.bin }}" || true # don't fail the CI for now
 
-      - name: Prepare artifact
-        if: ${{ matrix.artifact }}
-        run: |
-          strip bin/godot.*
-          chmod +x bin/godot.*
-
-      - name: Upload artifact
-        uses: ./.github/actions/upload-artifact
-        if: ${{ matrix.artifact }}
+      # Download and run the test project
+      - name: Test Godot project
+        uses: ./.github/actions/godot-project-test
+        if: ${{ matrix.proj-test }}
         with:
-          name: ${{ matrix.cache-name }}
+          bin: ${{ matrix.bin }}
+
+      # Test the project converter
+      - name: Test project converter
+        uses: ./.github/actions/godot-converter-test
+        if: ${{ matrix.proj-conv }}
+        with:
+          bin: ${{ matrix.bin }}

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -56,14 +56,6 @@ jobs:
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
 
-      # Execute unit tests for the editor
-      - name: Unit tests
-        if: ${{ matrix.tests }}
-        run: |
-          ${{ matrix.bin }} --version
-          ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test
-
       - name: Prepare artifact
         run: |
           strip bin/godot.*
@@ -73,3 +65,11 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      # Execute unit tests for the editor
+      - name: Unit tests
+        if: ${{ matrix.tests }}
+        run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --help
+          ${{ matrix.bin }} --test

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -6,9 +6,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # First stage: Only static checks, fast and prevent expensive builds from running.
+
   static-checks:
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
+
+  # Second stage: Run all the builds and some of the tests.
 
   android-build:
     name: 🤖 Android
@@ -39,3 +43,15 @@ jobs:
     name: 🌐 Web
     needs: static-checks
     uses: ./.github/workflows/web_builds.yml
+
+  # Third stage: Run auxiliary tests using build artifacts from previous jobs.
+
+  # Can be turned off for PRs that intentionally break compat with godot-cpp,
+  # until both the upstream PR and the matching godot-cpp changes are merged.
+  godot-cpp-test:
+    name: 🪲 Godot CPP
+    # This can be changed to depend on another platform, if we decide to use it for
+    # godot-cpp instead. Make sure to move the .github/actions/godot-api-dump step
+    # appropriately.
+    needs: linux-build
+    uses: ./.github/workflows/godot_cpp_test.yml

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -60,14 +60,6 @@ jobs:
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
 
-      # Execute unit tests for the editor
-      - name: Unit tests
-        if: ${{ matrix.tests }}
-        run: |
-          ${{ matrix.bin }} --version
-          ${{ matrix.bin }} --help
-          ${{ matrix.bin }} --test
-
       - name: Prepare artifact
         run: |
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
@@ -76,3 +68,11 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      # Execute unit tests for the editor
+      - name: Unit tests
+        if: ${{ matrix.tests }}
+        run: |
+          ${{ matrix.bin }} --version
+          ${{ matrix.bin }} --help
+          ${{ matrix.bin }} --test


### PR DESCRIPTION
This PR implements some of the changes discussed in https://github.com/godotengine/godot/issues/79919. I picked one for the title, as it's the most noticeable one, but it's a combination that's going to help us here.

### 1. Extract tasks to test `godot-cpp` into their own workflow/job.

This allows us to separate building Godot and building `godot-cpp` with upstream changes applied. Technically, the `godot-cpp` doesn't depend on any particular platform, it just needs us to dump the API and generate a header. So that's what we do in our Linux SAN build now, and put those files into artifacts.

The separate, but dependent `godot-cpp-test` job then downloads those and does its own thing, same as before. While this doesn't address the disk space issue, with this change the `godot-cpp` build will no longer be capable of triggering it, since it gets its own run without any extra files present. `godot-cpp` is currently the main source of CI failures, as it runs out of disk space.

I also tried to add caching to it, but I failed to locate where scons stores its cache in `godot-cpp/test` builds. Maybe there is no cache at all? Something that can be improve later.

### 2. Ensure that we check for "master" cache before considering a random matching cache.

Our checks for existing cache have 3 steps: the exact match, a partial match (same base branch + same PR), and a random match for the same base branch. This means that any PR can pick cache from any other PR, which doesn't seem useful. It does sound actually harmful, as PRs can start sharing extra cache file that they don't need, never needed in the first place. This inevitably contributes to the cache bloat that is one of the sources of the problem.

It also can slow down builds, as instead of comparing to the base/target branch we may end up considering some cached results from a PR that affected different files — files which are not affected in either master or the current PR. So this can trigger rebuild for no good reason, on top of bloating the scons cache folder.

So I've added a new step before we fall back to just any cache: try to find an existing cache for the same base branch and the matching base branch git reference. This basically means that if you PR against `master`, we'll first check for previous caches from your PR, then for any valid cache from `master`, and only then for a cache from any other PR against `master.`


### 3. Upload artifacts as early as possible.

This is not directly related to the issue, so I can revert this change. It was however requested by @QbieShay and others that we provide artifacts even if checks after builds fail. I wanted to use artifacts to run all tests in separate jobs, so I made this change, before eventually omitting the idea for technical reasons. But the change itself is kept as useful.

It does come with a caveat, though. We have to run strip and delete debug files on Windows before uploading the artifacts. This means that all tests run without them. This means that in case of a test crashing we won't  be able to see a detailed stack trace, as far as I'm aware. So maybe it's not a great idea. It can reduce the disk space usage somewhat though.

I'm open to discussion and to change this either way.

-----

There are also some cosmetic changes as I've moved more steps into reusable actions. Some because they are multi-step and it's easier to maintain this way. And some because they could be technically applied to other builds which are currently not doing the same checks.

-----

Tagging @Faless for a review since he was responsible for at least some of the current CI implementation.

Before this PR finished building you can also see the results of all the changes here: https://github.com/YuriSizov/godot/actions/runs/5716722251