### PR TITLE
Explain which nodes receive `NOTIFICATION_WM_SIZE_CHANGED`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1073,7 +1073,8 @@
 			Specific to the Android platform.
 		</constant>
 		<constant name="NOTIFICATION_WM_SIZE_CHANGED" value="1008">
-			Notification received from the OS when the window is resized.
+			Notification received when the window is resized.
+			[b]Note:[/b] Only the resized [Window] node receives this notification, and it's not propagated to the child nodes.
 		</constant>
 		<constant name="NOTIFICATION_WM_DPI_CHANGE" value="1009">
 			Notification received from the OS when the screen's DPI has been changed. Only implemented on macOS.


### PR DESCRIPTION
resolve #79336

As shown in that issue, it can be unclear, which nodes receive the `NOTIFICATION_WM_SIZE_CHANGED`.
This PR makes it explicit in the docs.