### PR TITLE
Add UndoRedo icon

### DIFF
--- a/editor/icons/UndoRedo.svg
+++ b/editor/icons/UndoRedo.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 9H1V2l2 2a3.875 5 30 0 1 9 11 3.5 5 10 0 0-6-8z" fill="#e0e0e0"/></svg>


### PR DESCRIPTION
UndoRedo is an Object, but its icon still shows up in some places, so why not?

![image](https://github.com/godotengine/godot/assets/85438892/1ef56fe1-c939-4ed4-903b-1c77e81c650d)

![image](https://github.com/godotengine/godot/assets/85438892/63ca7b16-d14d-4582-b2f5-85311860d6c0)

![image](https://github.com/godotengine/godot/assets/85438892/eab9fa06-031a-4cf4-89de-401bd9df2251)

![image](https://github.com/godotengine/godot/assets/85438892/f5ea31d8-4de6-4e0e-ad0d-f40db2a14b15)
