### PR TITLE
Add FileAccess and DirAccess icons

### DIFF
--- a/editor/icons/DirAccess.svg
+++ b/editor/icons/DirAccess.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M3 10v3h11V5H9.5l-1-2H3v3" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linejoin="round"/><path d="M6 11V9H1V7h5V5l3 3z" fill="#e0e0e0"/></svg>

--- a/editor/icons/FileAccess.svg
+++ b/editor/icons/FileAccess.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M15 6v8a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-3h2v2h8V7h-3a1 1 0 0 1-1-1V3H5v4H3V2a1 1 0 0 1 1-1h6zm-9 6v-2H1V8h5V6l3 3z" fill="#e0e0e0"/></svg>


### PR DESCRIPTION
Most RefCounteds don't have icons, but these few are pretty prominent so I gave them icons.

![image](https://github.com/godotengine/godot/assets/85438892/8657a725-6975-4986-807e-c883bd6aaa95)