### PR TITLE
[3.x] Fix 2D MultiMesh hierarchical culling

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -455,6 +455,7 @@ public:
 	AABB _multimesh_get_aabb(RID p_multimesh) const { return AABB(); }
 
 	MMInterpolator *_multimesh_get_interpolator(RID p_multimesh) const { return nullptr; }
+	void multimesh_attach_canvas_item(RID p_multimesh, RID p_canvas_item, bool p_attach) {}
 
 	/* IMMEDIATE API */
 

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3388,6 +3388,24 @@ RasterizerStorage::MMInterpolator *RasterizerStorageGLES2::_multimesh_get_interp
 	return &multimesh->interpolator;
 }
 
+void RasterizerStorageGLES2::multimesh_attach_canvas_item(RID p_multimesh, RID p_canvas_item, bool p_attach) {
+	MultiMesh *multimesh = multimesh_owner.getornull(p_multimesh);
+	ERR_FAIL_NULL(multimesh);
+	ERR_FAIL_COND(!p_canvas_item.is_valid());
+
+	if (p_attach) {
+		int64_t found = multimesh->linked_canvas_items.find(p_canvas_item);
+		if (found == -1) {
+			multimesh->linked_canvas_items.push_back(p_canvas_item);
+		}
+	} else {
+		int64_t found = multimesh->linked_canvas_items.find(p_canvas_item);
+		if (found != -1) {
+			multimesh->linked_canvas_items.remove_unordered(found);
+		}
+	}
+}
+
 void RasterizerStorageGLES2::update_dirty_multimeshes() {
 	while (multimesh_update_list.first()) {
 		MultiMesh *multimesh = multimesh_update_list.first()->self();
@@ -3457,6 +3475,14 @@ void RasterizerStorageGLES2::update_dirty_multimeshes() {
 			}
 
 			multimesh->aabb = aabb;
+
+			// Inform any linked canvas items that bounds have changed
+			// (for hierarchical culling).
+			int num_linked = multimesh->linked_canvas_items.size();
+			for (int n = 0; n < num_linked; n++) {
+				const RID &rid = multimesh->linked_canvas_items[n];
+				VSG::canvas->_canvas_item_invalidate_local_bound(rid);
+			}
 		}
 
 		multimesh->dirty_aabb = false;
@@ -4128,7 +4154,7 @@ void RasterizerStorageGLES2::update_dirty_skeletons() {
 		int num_linked = skeleton->linked_canvas_items.size();
 		for (int n = 0; n < num_linked; n++) {
 			const RID &rid = skeleton->linked_canvas_items[n];
-			VSG::canvas->_canvas_item_skeleton_moved(rid);
+			VSG::canvas->_canvas_item_invalidate_local_bound(rid);
 		}
 
 		ele = ele->next();
@@ -6052,6 +6078,14 @@ bool RasterizerStorageGLES2::free(RID p_rid) {
 		_interpolation_data.notify_free_multimesh(p_rid);
 
 		MultiMesh *multimesh = multimesh_owner.get(p_rid);
+
+		// remove any references in linked canvas items
+		int num_linked = multimesh->linked_canvas_items.size();
+		for (int n = 0; n < num_linked; n++) {
+			const RID &rid = multimesh->linked_canvas_items[n];
+			VSG::canvas->_canvas_item_remove_references(rid, p_rid);
+		}
+
 		multimesh->instance_remove_deps();
 
 		if (multimesh->mesh.is_valid()) {

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -789,6 +789,7 @@ public:
 		bool dirty_data;
 
 		MMInterpolator interpolator;
+		LocalVector<RID> linked_canvas_items;
 
 		MultiMesh() :
 				size(0),
@@ -835,6 +836,7 @@ public:
 
 	virtual AABB _multimesh_get_aabb(RID p_multimesh) const;
 	virtual MMInterpolator *_multimesh_get_interpolator(RID p_multimesh) const;
+	virtual void multimesh_attach_canvas_item(RID p_multimesh, RID p_canvas_item, bool p_attach);
 
 	void update_dirty_multimeshes();
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -818,6 +818,7 @@ public:
 		bool dirty_data;
 
 		MMInterpolator interpolator;
+		LocalVector<RID> linked_canvas_items;
 
 		MultiMesh() :
 				size(0),
@@ -867,6 +868,7 @@ public:
 
 	virtual AABB _multimesh_get_aabb(RID p_multimesh) const;
 	virtual MMInterpolator *_multimesh_get_interpolator(RID p_multimesh) const;
+	virtual void multimesh_attach_canvas_item(RID p_multimesh, RID p_canvas_item, bool p_attach);
 
 	/* IMMEDIATE API */
 

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -256,7 +256,6 @@ public:
 	void canvas_item_set_use_parent_material(RID p_item, bool p_enable);
 
 	void canvas_item_attach_skeleton(RID p_item, RID p_skeleton);
-	void _canvas_item_skeleton_moved(RID p_item);
 	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
 	Rect2 _debug_canvas_item_get_rect(RID p_item);
 	Rect2 _debug_canvas_item_get_local_bound(RID p_item);
@@ -264,6 +263,9 @@ public:
 	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
 	void canvas_item_reset_physics_interpolation(RID p_item);
 	void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform);
+
+	void _canvas_item_invalidate_local_bound(RID p_item);
+	void _canvas_item_remove_references(RID p_item, RID p_rid);
 
 	RID canvas_light_create();
 	void canvas_light_attach_to_canvas(RID p_light, RID p_canvas);


### PR DESCRIPTION
Fixes updating local bounds for MultiMeshes used in canvas items by introducing a back link.

This version as well as fixing `CPUParticles2D`, also fixes `MultiMeshInstance2D` and direct use of `VisualServer`.

Fixes #80086
Alternative to #80090

_before_

https://github.com/godotengine/godot/assets/21999379/d5ccc84e-ad5f-4301-8a61-47c5205472ee

_after_

https://github.com/godotengine/godot/assets/21999379/e770d74f-f7a4-4661-b848-7ee042b23176

This PR is basically an automated version of #80090 . `canvas_item_invalidate_local_bound()` is called automatically when changing the `MultiMesh`. This means users don't have to call this function.

The downside is that the machinery for maintaining the backlink is fairly complex, and complexity often equals bug prone and more maintenance burden. The system is equivalent to that used for `Skeleton`, which maintains a backlink to the `canvas_item`. However, the situation here is more complex for two reasons:

1) `MultiMesh` references are stored in Item commands, rather than directly in the `canvas_item`. This means that adding / removing links has to to take place via the command list, rather than directly via the `canvas_item`. There can also potentially be _multiple_ commands referencing the same `MultiMesh`. There is no need to reference count here, because commands are only cleared all at once, so there either _is_, or _is not_ a reference held at any one time.
2) Order of deletion is not guaranteed. We have to support both the `MultiMesh` being deleted before the `canvas_item`, and the other way around, with code to support both.

## Designed to keep CanvasItem "light"
* We could alternatively keep a `LocalVector` of linked `MultiMeshes` on the `CanvasItem`, which would in some ways be simpler (with no need to iterate through commands). However we want to keep `CanvasItem` as light as possible (most `CanvasItem`s will be rects, and not care about `MultiMesh`), and storing the links in the commands is effectively "free", so it's probably worth the extra hassle.
* Storing the `canvas_item` RID on each `Command::MultiMesh` is a little superfluous, but it enables us to clear out the links in the destructor with _no cost_ to `CanvasItem`s that do not contain multimeshes. The 8 extra bytes is likely to be unimportant, because most `Command::MultiMesh`es will only be stored singly on `CanvasItems`. Essentially it is more important to keep the typical `CanvasItem` light than the `Command::MultiMesh`.
There may be a slightly better way of doing this (e.g. using a static or global to store the canvas_item RID during deletion) but storing the canvas_item RID is at least thread safe.

## Notes
* It turned out for #80090 that in order to support `MultiMeshInstance2D` we would have to introduce similar complexity scene side, so I'm now leading with this PR.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
