### PR TITLE
Add path to missing import texture metadata to error message

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -418,7 +418,7 @@ void ResourceImporterTexture::_save_editor_meta(const Dictionary &p_metadata, co
 
 Dictionary ResourceImporterTexture::_load_editor_meta(const String &p_path) const {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(f.is_null(), Dictionary(), "Missing required editor-specific import metadata for a texture; please, reimport.");
+	ERR_FAIL_COND_V_MSG(f.is_null(), Dictionary(), vformat("Missing required editor-specific import metadata for a texture (please reimport it using the 'Import' tab): '%s'", p_path));
 
 	return f->get_var();
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Before, the error message would just warn that a texture needed to be reimported but would not list which texture. This change adds the file path to the error output for the `Missing required editor-specific import metadata for a texture; please, reimport` message and updates the sentence structure.

Now changed to `Missing required editor-specific import metadata for a texture (please reimport it using the 'Import' tab): FILE_PATH`

fixes: #79550