### PR TITLE
CI: Free disk space on Linux runners

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -85,6 +85,12 @@ jobs:
           sudo add-apt-repository ppa:kisak/kisak-mesa
           sudo apt-get install -qq mesa-vulkan-drivers
 
+      - name: Free disk space on runner
+        run: |
+          echo "Disk usage before:" && df -h
+          sudo rm -rf /usr/local/lib/android
+          echo "Disk usage after:" && df -h
+
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache
         with:


### PR DESCRIPTION
Removing the Android toolchain saves ~14~ 12 GiB, which gives us more room for growth and to avoid running into out-of-space errors in the Linux sanitizers + debug symbols builds.

Related to #79919, though the caches were just one part of the problem, the real issue is that our Linux sanitizers builds take 12 GiB, and adding godot-cpp on top with 2 GiB leaves only a few GiB left for the cache itself.

Related to #80091, which may not be strictly needed after this, but might still be a nice improvement overall.

---

Inspired from https://github.com/marketplace/actions/free-disk-space-ubuntu which does the same and more, but instead of adding a thirdparty dependency we don't control, we just do the minimal change for our needs.

On a repo without cache (my fork), @YuriSizov and I found that the base Ubuntu image gives us around 19 GiB of disk space:
```
/dev/root        84G   66G   19G  79% /
```

That doesn't match the 14 GiB documented by GitHub, which seems to be the size of the `/mnt` point, but we're not using it so it's a bit confusing.

After the GCC sanitizers build, we have:
```
/dev/root        84G   77G  6.8G  92% /
```

And after the godot-cpp build:
```
/dev/root        84G   79G  4.7G  95% /
```

Adding a ~1 GiB zipped cache hit, and possibly multi-GiB `SCONS_CACHE` folder once unzipped, we're indeed close to full and that's why CI has been failing sporadically lately.

Freeing 14 GiB should give us a lot of breathing room.

For the record, here's everything included in the Ubuntu 20.04 runners: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md

https://github.com/marketplace/actions/free-disk-space-ubuntu can free up to 31 GiB by removing more stuff, but would also take longer (up to 3 min extra). For now just removing Android stuff on the Linux jobs should be good.