### PR TITLE
Avoid returning incompatible ternary operator types

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2251,6 +2251,9 @@ void GDScriptAnalyzer::resolve_return(GDScriptParser::ReturnNode *p_return) {
 			if (!is_type_compatible(expected_type, result, true, p_return)) {
 				downgrade_node_type_source(p_return);
 			}
+			if (p_return->return_value->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+				reduce_ternary_op(static_cast<GDScriptParser::TernaryOpNode *>(p_return->return_value), false, &expected_type);
+			}
 		} else if (!is_type_compatible(expected_type, result, true, p_return)) {
 			mark_node_unsafe(p_return);
 			if (!is_type_compatible(result, expected_type)) {
@@ -4252,7 +4255,7 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 	p_subscript->set_datatype(result_type);
 }
 
-void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op, bool p_is_root) {
+void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op, bool p_is_root, const GDScriptParser::DataType *p_expected_type) {
 	reduce_expression(p_ternary_op->condition);
 	reduce_expression(p_ternary_op->true_expr, p_is_root);
 	reduce_expression(p_ternary_op->false_expr, p_is_root);
@@ -4279,6 +4282,19 @@ void GDScriptAnalyzer::reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternar
 		false_type = p_ternary_op->false_expr->get_datatype();
 	} else {
 		false_type.kind = GDScriptParser::DataType::VARIANT;
+	}
+
+	if (p_expected_type) {
+		if (true_type.is_variant() && p_ternary_op->true_expr->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+			reduce_ternary_op(static_cast<GDScriptParser::TernaryOpNode *>(p_ternary_op->true_expr), false, p_expected_type);
+		} else if (!is_type_compatible(*p_expected_type, true_type, true, p_ternary_op)) {
+			push_error(vformat(R"(Cannot return value of type "%s" in the true expression because the function return type is "%s".)", true_type.to_string(), p_expected_type->to_string()), p_ternary_op);
+		}
+		if (false_type.is_variant() && p_ternary_op->false_expr->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+			reduce_ternary_op(static_cast<GDScriptParser::TernaryOpNode *>(p_ternary_op->false_expr), false, p_expected_type);
+		} else if (!is_type_compatible(*p_expected_type, false_type, true, p_ternary_op)) {
+			push_error(vformat(R"(Cannot return value of type "%s" in the false expression because the function return type is "%s".)", false_type.to_string(), p_expected_type->to_string()), p_ternary_op);
+		}
 	}
 
 	if (true_type.is_variant() || false_type.is_variant()) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -101,7 +101,7 @@ class GDScriptAnalyzer {
 	void reduce_preload(GDScriptParser::PreloadNode *p_preload);
 	void reduce_self(GDScriptParser::SelfNode *p_self);
 	void reduce_subscript(GDScriptParser::SubscriptNode *p_subscript, bool p_can_be_pseudo_type = false);
-	void reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op, bool p_is_root = false);
+	void reduce_ternary_op(GDScriptParser::TernaryOpNode *p_ternary_op, bool p_is_root = false, const GDScriptParser::DataType *p_expected_type = nullptr);
 	void reduce_type_test(GDScriptParser::TypeTestNode *p_type_test);
 	void reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op);
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_nested_ternary_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_nested_ternary_type.gd
@@ -1,0 +1,2 @@
+func test() -> int:
+	return 1 if randf() < 0.5 else 2 if randf() < 0.5 else "3"

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_nested_ternary_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_nested_ternary_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot return value of type "String" in the false expression because the function return type is "int".

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_ternary_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_ternary_type.gd
@@ -1,0 +1,2 @@
+func test() -> int:
+	return "test" if randf() < 0.5 else 1

--- a/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_ternary_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/return_incompatible_ternary_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot return value of type "String" in the true expression because the function return type is "int".


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #80097
This allows the compiler to check if all the types of each ternary operator in a return statement are compatible with the expected return type.