### PR TITLE
Actually store safe-rect in embedder

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3637,8 +3637,7 @@ void Viewport::subwindow_set_popup_safe_rect(Window *p_window, const Rect2i &p_r
 	int index = _sub_window_find(p_window);
 	ERR_FAIL_COND(index == -1);
 
-	SubWindow sw = gui.sub_windows[index];
-	sw.parent_safe_rect = p_rect;
+	gui.sub_windows.write[index].parent_safe_rect = p_rect;
 }
 
 Rect2i Viewport::subwindow_get_popup_safe_rect(Window *p_window) const {

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -756,6 +756,21 @@ TEST_CASE("[SceneTree][Viewport] Control mouse cursor shape") {
 	}
 }
 
+TEST_CASE("[SceneTree][Viewport] Embedded Windows") {
+	Window *root = SceneTree::get_singleton()->get_root();
+	Window *w = memnew(Window);
+
+	SUBCASE("[Viewport] Safe-rect of embedded Window") {
+		root->add_child(w);
+		root->subwindow_set_popup_safe_rect(w, Rect2i(10, 10, 10, 10));
+		CHECK_EQ(root->subwindow_get_popup_safe_rect(w), Rect2i(10, 10, 10, 10));
+		root->remove_child(w);
+		CHECK_EQ(root->subwindow_get_popup_safe_rect(w), Rect2i());
+	}
+
+	memdelete(w);
+}
+
 } // namespace TestViewport
 
 #endif // TEST_VIEWPORT_H


### PR DESCRIPTION
`sw` is a copy and not a reference.
Add unit-test for this case.

follow-up to #78476