### PR TITLE
Fix display of embedded `Window`

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -348,7 +348,13 @@ void Viewport::_sub_window_update(Window *p_window) {
 		close_icon->draw(sw.canvas_item, r.position + Vector2(r.size.width - close_h_ofs, -close_v_ofs));
 	}
 
-	RS::get_singleton()->canvas_item_add_texture_rect(sw.canvas_item, r, sw.window->get_texture()->get_rid());
+	const Transform2D xform = sw.window->window_transform * sw.window->stretch_transform;
+	Rect2 vr = xform.xform(sw.window->get_visible_rect());
+	vr.position += p_window->get_position();
+	if (vr != r) {
+		RS::get_singleton()->canvas_item_add_rect(sw.canvas_item, r, Color());
+	}
+	RS::get_singleton()->canvas_item_add_texture_rect(sw.canvas_item, vr, sw.window->get_texture()->get_rid());
 }
 
 void Viewport::_sub_window_grab_focus(Window *p_window) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1239,7 +1239,7 @@ void Window::_update_viewport_size() {
 
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);
-	} else {
+	} else if (!is_embedded()) {
 		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), Rect2i(), DisplayServer::INVALID_WINDOW_ID);
 	}
 


### PR DESCRIPTION
Fix Rect of texture to take window and stretch transform into account.
resolve #66809
resolve part of #72760

MRP: [WindowsTestbed.zip](https://github.com/godotengine/godot/files/12231066/WindowsTestbed.zip) (run and set "Window height" to 150)

There is no need for `viewport_attach_to_screen` for embedded windows, since their display is handled via `Viewport::_sub_window_update`.

![image](https://github.com/godotengine/godot/assets/6299227/c72fa9cf-8a8b-496e-93ba-75fc8e92452c) ![image](https://github.com/godotengine/godot/assets/6299227/61631f9c-e9d4-4ba0-8a3b-6ba70f2617d3)

Updated 2023-08-05: Draw black bars at the sides, that aren't covered by the content.
Updated 2024-12-16: Rebased on master for good measure. insert `const` expression, fix rounding issue.