### PR TITLE
Initialize View Frame Time estimates to match 120 FPS

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2887,8 +2887,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 				fps_label->set_visible(show_fps);
 				RS::get_singleton()->viewport_set_measure_render_time(viewport->get_viewport_rid(), show_fps);
 				for (int i = 0; i < FRAME_TIME_HISTORY; i++) {
-					cpu_time_history[i] = 0;
-					gpu_time_history[i] = 0;
+					// Initialize to 120 FPS, so that the initial estimation until we get enough data is always reasonable.
+					cpu_time_history[i] = 8.333333;
+					gpu_time_history[i] = 8.333333;
 				}
 				cpu_time_history_index = 0;
 				gpu_time_history_index = 0;


### PR DESCRIPTION
When View Frame Time is freshly enabled, this prevents the estimation from being extremely high (close to 100,000 FPS) until enough time has passed to display an accurate estimation.

With https://github.com/godotengine/godot/pull/75512, this is still relevant for the CPU time and GPU time display.

## Preview

*Play the videos at 0.5× speed by right-clicking it and choosing the speed in the browser's context menu.*

### Before

https://github.com/godotengine/godot/assets/180032/6cf75fcc-9f90-4068-b274-0bec661d72db

### After

https://github.com/godotengine/godot/assets/180032/317c558a-b471-4800-b750-d6abd814064a