### PR TITLE
Remove debugging print from shader cache

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -504,7 +504,6 @@ void ShaderRD::_compile_version(Version *p_version, int p_group) {
 
 	if (shader_cache_dir_valid) {
 		if (_load_from_cache(p_version, p_group)) {
-			print_line("loaded from cache!");
 			return;
 		}
 	}


### PR DESCRIPTION
It prints several times every time you start the editor.

- See https://github.com/godotengine/godot/pull/79606.
