### PR TITLE
Fix crash on Windows when closing `Window`

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1449,6 +1449,12 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 
 	DEBUG_LOG_X11("delete_sub_window: %lu (%u) \n", wd.x11_window, p_id);
 
+	window_set_rect_changed_callback(Callable(), p_id);
+	window_set_window_event_callback(Callable(), p_id);
+	window_set_input_event_callback(Callable(), p_id);
+	window_set_input_text_callback(Callable(), p_id);
+	window_set_drop_files_callback(Callable(), p_id);
+
 	while (wd.transient_children.size()) {
 		window_set_transient(*wd.transient_children.begin(), INVALID_WINDOW_ID);
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3838,6 +3838,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 		} break;
 		case WM_DESTROY: {
 			Input::get_singleton()->flush_buffered_events();
+			if (window_mouseover_id == window_id) {
+				window_mouseover_id = INVALID_WINDOW_ID;
+				_send_window_event(windows[window_id], WINDOW_EVENT_MOUSE_EXIT);
+			}
 		} break;
 		case WM_SETCURSOR: {
 			if (LOWORD(lParam) == HTCLIENT) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -618,12 +618,6 @@ void Window::_clear_window() {
 
 	bool had_focus = has_focus();
 
-	DisplayServer::get_singleton()->window_set_rect_changed_callback(Callable(), window_id);
-	DisplayServer::get_singleton()->window_set_window_event_callback(Callable(), window_id);
-	DisplayServer::get_singleton()->window_set_input_event_callback(Callable(), window_id);
-	DisplayServer::get_singleton()->window_set_input_text_callback(Callable(), window_id);
-	DisplayServer::get_singleton()->window_set_drop_files_callback(Callable(), window_id);
-
 	if (transient_parent && transient_parent->window_id != DisplayServer::INVALID_WINDOW_ID) {
 		DisplayServer::get_singleton()->window_set_transient(window_id, DisplayServer::INVALID_WINDOW_ID);
 	}


### PR DESCRIPTION
resolve  #80134 
regression from #67791
conflict with #73239

1. Send `WINDOW_EVENT_MOUSE_EXIT` when a window is destroyed.

This fix had been included in #67791 for some time to fix comment https://github.com/godotengine/godot/pull/67791#issuecomment-1384676082, but unfortunately (I apologize) got lost because I have developed the PR on two different computers.
This fix alone however no longer works in current master, because it conflicts with #73239.

2. Ensure, that on Windows, the `event_callback` is still valid during destroying the `Window`.

#73239 cleared the `event_callback` before calling `DisplayServer::delete_sub_window`.
However on Windows it becomes necessary, that this callback is still valid while the `Window` is destroyed.

#73239 had the goal of closing issue #72707, which is linuxbsd-specific.
In this PR I move the changes of #73239 from `Window` to `DisplayServerX11`, so that on linuxbsd #72707 should not be reintroduced. I can't test #72707, because I don't have the specific Window-manager i3wm installed. @bruvzg Since that PR was from you, may I ask you, if you consider this change valid?
