### PR TITLE
Fix error message when reimporting resources with an empty scene open

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -543,8 +543,11 @@ void ImportDock::_reimport_and_cleanup() {
 		Ref<Resource> old_res = old_resources[path];
 		Ref<Resource> new_res = ResourceLoader::load(path);
 
-		for (int j = 0; j < EditorNode::get_editor_data().get_edited_scene_count(); j++) {
-			_replace_resource_in_object(EditorNode::get_editor_data().get_edited_scene_root(j), old_res, new_res);
+		for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
+			Node *edited_scene_root = EditorNode::get_editor_data().get_edited_scene_root(i);
+			if (likely(edited_scene_root)) {
+				_replace_resource_in_object(edited_scene_root, old_res, new_res);
+			}
 		}
 		for (Ref<Resource> res : external_resources) {
 			_replace_resource_in_object(res.ptr(), old_res, new_res);


### PR DESCRIPTION
When reimporting, the import dock has code that will update the resource in all scenes currently opened in the editor.
If the scene is empty (like when no scene is open), this will fail and print this error message:

```
ERROR: Parameter "p_object" is null.
   at: _replace_resource_in_object (editor/import_dock.cpp:606)
```

This PR adds a check to see if the edited scene has a root node, and if not, don't try to update it.

This PR is very minor. The only behavior difference is the lack of a useless error message being printed.