### PR TITLE
Usage notes for DEV_ASSERT macro

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -786,8 +786,19 @@ void _err_flush_stdout();
 		((void)0)
 
 /**
- * This should be a 'free' assert for program flow and should not be needed in any releases,
- *  only used in dev builds.
+ * Note: IN MOST CASES YOU SHOULD NOT USE THIS MACRO.
+ * Do not use unless you understand the trade-offs.
+ *
+ * DEV macros will be compiled out in releases, they are wrapped in DEV_ENABLED.
+ *
+ * Prefer WARNINGS / ERR_FAIL macros (which fail without crashing) - ERR_FAIL should be used in most cases.
+ * Then CRASH_NOW_MSG macros (on rare occasions where error cannot be recovered).
+ *
+ * DEV_ASSERT should generally only be used when both of the following conditions are met:
+ * 1) Bottleneck code where a check in release would be too expensive.
+ * 2) Situations where the check would fail obviously and straight away during the maintenance of the code
+ *    (i.e. strict conditions that should be true no matter what)
+ *    and that can't fail for other contributors once the code is finished and merged.
  */
 #ifdef DEV_ENABLED
 #define DEV_ASSERT(m_cond)                                                                                              \


### PR DESCRIPTION
Make it more clear that DEV_ASSERT is only to be used in specific cases.

## Notes
* Some contributors had been using `DEV_ASSERT` in places better suited to other error macros (e.g. #67791 ), this should make it more clear when to use, both for contributors and production team.
* If in doubt for a particular case ask `core` team.
* Welcome any ideas for better wording.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
