### PR TITLE
Avoid crash on exiting due to late prints

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6730,6 +6730,9 @@ void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_err
 }
 
 void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool p_rich) {
+	if (!singleton) {
+		return;
+	}
 	if (p_error) {
 		singleton->log->add_message(p_string, EditorLog::MSG_TYPE_ERROR);
 	} else if (p_rich) {
@@ -6845,6 +6848,7 @@ EditorNode::EditorNode() {
 		DisplayServer::get_singleton()->cursor_set_custom_image(Ref<Resource>());
 	}
 
+	DEV_ASSERT(!singleton);
 	singleton = this;
 
 	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
@@ -8210,6 +8214,8 @@ EditorNode::~EditorNode() {
 
 	GDExtensionEditorPlugins::editor_node_add_plugin = nullptr;
 	GDExtensionEditorPlugins::editor_node_remove_plugin = nullptr;
+
+	singleton = nullptr;
 }
 
 /*


### PR DESCRIPTION
Fixes #80152.

**UPDATE:** Probably fixes #79379.
*Bugsquad edit:* And fixes #79506.

The MRP there adds a message when the `EditorNode` has already been destroyed. The most obvious fix is done here, which is just validating the singleton when a deferred call happens. The problem is that static calls in the message queue can't be validated.

Now, there are potential alternatives to this fix that may be done instead of in addition:

a) Let the static callables have some sort of custom validation.
  For instance, there's this call:
  `callable_mp_static(&EditorNode::_print_handler_impl).bind(p_string, p_error, p_rich).call_deferred();`
  With this approach it could become something like this:
  `callable_mp_static(&EditorNode::_print_handler_impl).bind(p_string, p_error, p_rich).add_validator([]() -> bool{ return EditorNode::get_singleton(); }).call_deferred();`

b) Like a), but using a sentinel pointer:
  `callable_mp_static(&EditorNode::_print_handler_impl).bind(p_string, p_error, p_rich).add_validity_sentinel(&EditorNode::singleton).call_deferred();`

c) Make all deferred calls of this kind via the object instance instead of static. That would enable the current validated call mechanism to do its magic.