### PR TITLE
GDScript: Fix regression with native signal not found

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/first_class_callable_and_signal.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/first_class_callable_and_signal.gd
@@ -1,0 +1,14 @@
+# GH-80157
+
+extends Node
+
+func f():
+	pass
+
+signal s()
+
+func test():
+	print(f)
+	print(s)
+	print(get_child)
+	print(ready)

--- a/modules/gdscript/tests/scripts/runtime/features/first_class_callable_and_signal.out
+++ b/modules/gdscript/tests/scripts/runtime/features/first_class_callable_and_signal.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+Node::f
+Node::[signal]s
+Node::get_child
+Node::[signal]ready


### PR DESCRIPTION
* Fixes a regression from https://github.com/godotengine/godot/pull/79880.
* Adds missing test cases.
* Closes #80157.
