### PR TITLE
Fix or workaround recent extension API compatibility issues

### DIFF
--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -4,7 +4,20 @@ This file contains the expected output of --validate-extension-api when run agai
 Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored. They
 should instead be used to justify these changes and describe how users should work around these changes.
 
+Add new entries at the end of the file.
+
 ========================================================================================================================
+
+Misc
+----
+Validate extension JSON: API was removed: classes/FramebufferCacheRD
+Validate extension JSON: API was removed: classes/UniformSetCacheRD
+
+FIXME: These aren't written when dumping the interface with a headless build
+(since there's no RD backend in use). We need to fix this inconsistency somehow.
+
+
+## Changes between 4.0-stable and 4.1-stable
 
 GH-78517
 --------
@@ -36,9 +49,11 @@ Validate extension JSON: Error: Field 'classes/RenderingServer/methods/instances
 
 The previous argument was a serialization bug, there's no actual API change.
 
+
 GH-78237
 --------
 Validate extension JSON: Error: Field 'classes/WebRTCPeerConnectionExtension/methods/_create_data_channel/return_value': type changed value in new API, from "Object" to "WebRTCDataChannel".
+
 
 GH-77757
 --------
@@ -135,13 +150,6 @@ Validate extension JSON: API was removed: classes/NavigationServer3D/methods/age
 Navigation avoidance was reworked entirely.
 Migration: TODO
 
-
-GH-?????
---------
-Validate extension JSON: API was removed: classes/FramebufferCacheRD
-Validate extension JSON: API was removed: classes/UniformSetCacheRD
-
-Unsure where these come from; when dumping the interface, these do actually still exist
 
 GH-76176
 --------
@@ -260,7 +268,6 @@ Validate extension JSON: Error: Field 'classes/SyntaxHighlighter/methods/get_tex
 Function was made `const`. No adjustments should be necessary.
 
 
-
 GH-75250 & GH-76401
 -------------------
 Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_paragraph', from 3DD1D1C2 to BFDC71FE. This means that the function has changed and no compatibility function was provided.
@@ -359,6 +366,9 @@ Validate extension JSON: Error: Hash changed for 'classes/UndoRedo/methods/creat
 
 Added a optional parameters with default values. No adjustments should be necessary.
 
+
+## Changes between 4.1-stable and 4.2-stable
+
 GH-79911
 --------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_RASTER': value changed value in new API, from 1.0 to 9.
@@ -379,3 +389,47 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/barrier/a
 Validate extension JSON: Error: Hash changed for 'classes/RenderingDevice/methods/barrier', from 0FE50041 to DD9E8DAB. This means that the function has changed and no compatibility function was provided.
 
 Raster barrier was split into vertex and fragment barriers for use in mobile renderer.
+
+
+GH-79308
+--------
+Validate extension JSON: API was removed: classes/GraphEdit/methods/get_scroll_ofs
+Validate extension JSON: API was removed: classes/GraphEdit/methods/get_snap
+Validate extension JSON: API was removed: classes/GraphEdit/methods/get_zoom_hbox
+Validate extension JSON: API was removed: classes/GraphEdit/methods/is_using_snap
+Validate extension JSON: API was removed: classes/GraphEdit/methods/set_scroll_ofs
+Validate extension JSON: API was removed: classes/GraphEdit/methods/set_snap
+Validate extension JSON: API was removed: classes/GraphEdit/methods/set_use_snap
+Validate extension JSON: API was removed: classes/GraphEdit/properties/snap_distance
+Validate extension JSON: API was removed: classes/GraphEdit/properties/use_snap
+Validate extension JSON: API was removed: classes/GraphNode/methods/is_comment
+Validate extension JSON: API was removed: classes/GraphNode/methods/set_comment
+Validate extension JSON: API was removed: classes/GraphNode/properties/comment
+Validate extension JSON: Error: Field 'classes/GraphEdit/properties/scroll_offset': getter changed value in new API, from "get_scroll_ofs" to &"get_scroll_offset".
+Validate extension JSON: Error: Field 'classes/GraphEdit/properties/scroll_offset': setter changed value in new API, from "set_scroll_ofs" to &"set_scroll_offset".
+
+Intentional compatibility breakage during refactoring of API marked as experimental.
+
+FIXME: Still a WIP, review this list once the work is completed, especially if compatibility
+code is added.
+
+
+GH-73196
+--------
+Validate extension JSON: Error: Field 'classes/CodeEdit/methods/get_text_for_symbol_lookup': is_const changed value in new API, from false to true.
+
+Function was made `const`. No adjustments should be necessary.
+
+
+GH-78328
+--------
+Validate extension JSON: Error: Field 'classes/TileMap/methods/get_used_rect': is_const changed value in new API, from false to true.
+
+Function was made `const`. No adjustments should be necessary.
+
+
+GH-79606
+--------
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_create_from_bytecode/arguments': size changed value in new API, from 1 to 2.
+
+Added optional argument. Compatibility method registered.

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -21,7 +21,7 @@ fi
 
 # Fix copyright headers, but not all files get them.
 for f in $files; do
-    if [[ "$f" == *"inc" ]]; then
+    if [[ "$f" == *"inc" && "$f" != *"compat.inc" ]]; then
         continue
     elif [[ "$f" == *"glsl" ]]; then
         continue

--- a/scene/gui/code_edit.compat.inc
+++ b/scene/gui/code_edit.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tile_map.compat.inc                                                   */
+/*  code_edit.compat.inc                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,12 +30,12 @@
 
 #ifndef DISABLE_DEPRECATED
 
-Rect2i TileMap::_get_used_rect_bind_compat_78328() {
-	return get_used_rect();
+String CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196() {
+	return get_text_for_symbol_lookup();
 }
 
-void TileMap::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("get_used_rect"), &TileMap::_get_used_rect_bind_compat_78328);
+void CodeEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_text_for_symbol_lookup"), &CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196);
 }
 
 #endif

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "code_edit.h"
+#include "code_edit.compat.inc"
 
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -287,6 +287,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	String _get_text_for_symbol_lookup_bind_compat_73196();
+	static void _bind_compatibility_methods();
+#endif
+
 	virtual void _update_theme_item_cache() override;
 
 	/* Text manipulation */

--- a/servers/rendering/rendering_device.compat.inc
+++ b/servers/rendering/rendering_device.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  tile_map.compat.inc                                                   */
+/*  rendering_device.compat.inc                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,12 +30,12 @@
 
 #ifndef DISABLE_DEPRECATED
 
-Rect2i TileMap::_get_used_rect_bind_compat_78328() {
-	return get_used_rect();
+RID RenderingDevice::_shader_create_from_bytecode_bind_compat_79606(const Vector<uint8_t> &p_shader_binary) {
+	return shader_create_from_bytecode(p_shader_binary, RID());
 }
 
-void TileMap::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("get_used_rect"), &TileMap::_get_used_rect_bind_compat_78328);
+void RenderingDevice::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("shader_create_from_bytecode", "binary_data"), &RenderingDevice::_shader_create_from_bytecode_bind_compat_79606);
 }
 
 #endif

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "rendering_device.h"
+#include "rendering_device.compat.inc"
 
 #include "rendering_device_binds.h"
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -141,6 +141,11 @@ private:
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	RID _shader_create_from_bytecode_bind_compat_79606(const Vector<uint8_t> &p_shader_binary);
+	static void _bind_compatibility_methods();
+#endif
+
 	Capabilities device_capabilities;
 
 public:


### PR DESCRIPTION
- Add compatibility methods for `RenderingDevice::shader_create_from_bytecode` (follow-up to #79606) and `CodeEdit::get_text_for_symbol_loopup` (follow-up to #73196).
- Silence errors which now have compatibility methods.
- Acknowledge GraphEdit/GraphNode compat breakage, intended and WIP (follow-up to #79308).

~Draft as I'm still getting this error despite the compat method I added:~
```
Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_create_from_bytecode/arguments': size changed value in new API, from 1 to 2.
```