### PR TITLE
Simpler default values for AudioStreamRandomizer

### DIFF
--- a/doc/classes/AudioStreamRandomizer.xml
+++ b/doc/classes/AudioStreamRandomizer.xml
@@ -68,10 +68,10 @@
 		<member name="playback_mode" type="int" setter="set_playback_mode" getter="get_playback_mode" enum="AudioStreamRandomizer.PlaybackMode" default="0">
 			Controls how this AudioStreamRandomizer picks which AudioStream to play next.
 		</member>
-		<member name="random_pitch" type="float" setter="set_random_pitch" getter="get_random_pitch" default="1.1">
+		<member name="random_pitch" type="float" setter="set_random_pitch" getter="get_random_pitch" default="1.0">
 			The intensity of random pitch variation. A value of 1 means no variation.
 		</member>
-		<member name="random_volume_offset_db" type="float" setter="set_random_volume_offset_db" getter="get_random_volume_offset_db" default="5.0">
+		<member name="random_volume_offset_db" type="float" setter="set_random_volume_offset_db" getter="get_random_volume_offset_db" default="0.0">
 			The intensity of random volume variation. A value of 0 means no variation.
 		</member>
 		<member name="streams_count" type="int" setter="set_streams_count" getter="get_streams_count" default="0">

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -223,8 +223,8 @@ private:
 
 	HashSet<AudioStreamPlaybackRandomizer *> playbacks;
 	Vector<PoolEntry> audio_stream_pool;
-	float random_pitch_scale = 1.1f;
-	float random_volume_offset_db = 5.0f;
+	float random_pitch_scale = 1.0f;
+	float random_volume_offset_db = 0.0f;
 
 	Ref<AudioStreamPlayback> instance_playback_random();
 	Ref<AudioStreamPlayback> instance_playback_no_repeats();


### PR DESCRIPTION
AudioStreamRandomizer has two purposes:

- select from a list of audio streams
- randomize parameters like volume and pitch

Using this class for the first use-case means you will always have to reset the arbitrary default values of pitch and volume variation to 1 and 0 respectively.
And for the latter use-case, the defaults are chosen very arbitrary and will likely need to be adjusted anyway. So no time is saved by having values that aren't just 1 and 0 for them either.
