### PR TITLE
Expose `Window`'s `_get_contents_minimum_size()` to scripting

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_contents_minimum_size" qualifiers="virtual const">
+			<return type="Vector2" />
+			<description>
+				Virtual method to be implemented by the user. Overrides the value returned by [method get_contents_minimum_size].
+			</description>
+		</method>
 		<method name="add_theme_color_override">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
@@ -92,6 +98,7 @@
 			<return type="Vector2" />
 			<description>
 				Returns the combined minimum size from the child [Control] nodes of the window. Use [method child_controls_changed] to update it when children nodes have changed.
+				The value returned by this method can be overridden with [method _get_contents_minimum_size].
 			</description>
 		</method>
 		<method name="get_flag" qualifiers="const">

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1748,7 +1748,9 @@ Rect2i Window::fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) co
 
 Size2 Window::get_contents_minimum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
-	return _get_contents_minimum_size();
+	Vector2 ms = _get_contents_minimum_size();
+	GDVIRTUAL_CALL(_get_contents_minimum_size, ms);
+	return ms;
 }
 
 Size2 Window::get_clamped_minimum_size() const {
@@ -2760,6 +2762,8 @@ void Window::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_OTHER_SCREEN);
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_MOUSE_FOCUS);
 	BIND_ENUM_CONSTANT(WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS);
+
+	GDVIRTUAL_BIND(_get_contents_minimum_size);
 }
 
 Window::Window() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -205,7 +205,6 @@ protected:
 	virtual void _update_theme_item_cache();
 
 	virtual void _post_popup() {}
-	virtual Size2 _get_contents_minimum_size() const;
 	static void _bind_methods();
 	void _notification(int p_what);
 
@@ -216,6 +215,8 @@ protected:
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
+
+	GDVIRTUAL0RC(Vector2, _get_contents_minimum_size)
 
 public:
 	enum {
@@ -408,6 +409,8 @@ public:
 
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;
+
+	virtual Size2 _get_contents_minimum_size() const;
 
 	Window();
 	~Window();

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -199,6 +199,7 @@ SceneStringNames::SceneStringNames() {
 	_window_input = StaticCString::create("_window_input");
 	window_input = StaticCString::create("window_input");
 	_window_unhandled_input = StaticCString::create("_window_unhandled_input");
+	_get_contents_minimum_size = StaticCString::create("_get_contents_minimum_size");
 
 	theme_changed = StaticCString::create("theme_changed");
 	parameters_base_path = "parameters/";

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -210,6 +210,7 @@ public:
 	StringName _window_input;
 	StringName _window_unhandled_input;
 	StringName window_input;
+	StringName _get_contents_minimum_size;
 
 	StringName theme_changed;
 	StringName shader_overrides_group;


### PR DESCRIPTION
The `_get_contents_minimum_size()` method is used by Godot's `Accept/ConfirmationDialog`, and it would be very useful for users that intend to make dialogs with custom behavior.