### PR TITLE
Alternative to PanoramaSkyMaterial for dynamic panorama generation with GLSL

### DIFF
--- a/doc/classes/ComputePanoramaSkyMaterial.xml
+++ b/doc/classes/ComputePanoramaSkyMaterial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ComputePanoramaSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="ComputePanoramaSkyMaterial" inherits="PanoramaSkyCommonMaterial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-			A [Material] used with [Sky] to draw a background texture which is precomputed.
+		A [Material] used with [Sky] to draw a background panorama texture which is precomputed.
 	</brief_description>
 	<description>
 		This class is differs from [PanoramaSkyMaterial] in that it uses [RID] instead of [Texture2D] to set the panorama texture which resides on GPU.
@@ -9,26 +9,48 @@
 		[code]
 		# copy the panorama from image2D output of a compute shader to a texture2D which is owned by RenderingServer.
 		panorama_rid=RenderingServer.texture_rd_create(compute_panorama_rid)
-    # save old panorama_rid for further disposal
-    var old_panorama_rid=env.sky.sky_material.get_panorama()
 		# set the panorama to this sky material
 		WorldEnvironment.Environment.sky.sky_material.set_panorama(panorama_rid)
-
-    if old_panorama_rid:
-      rd.free_rid(old_panorama_rid) # rd is the result of RenderingServer.get_rendering_device()
 		[/code]
 
 		This class utilizes the mechanism first introduced in following PR:[https://github.com/godotengine/godot/pull/79288].
-		This [Material] can not be converted to shader as there is no sense to do so.
+		This [Material] can not be converted to shader as there is no sense to do so. No plugins implemented.
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_panorama" qualifiers="const">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="get_panorama_size" qualifiers="const">
+			<return type="Vector2i" />
+			<description>
+			</description>
+		</method>
+		<method name="set_panorama">
+			<return type="void" />
+			<param index="0" name="RID" type="RID" />
+			<description>
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
 			Inherited from [PanoramaSkyCommonMaterial].
 		</member>
-		<member name="panorama" type="RID" setter="set_panorama" getter="get_panorama">
-			A [RID] of a [Texture2D] owned by RenderingServer to be applied to the [PanoramaSkyMaterial].
+		<member name="panorama_scale" type="int" setter="set_panorama_scale" getter="get_panorama_scale" enum="ComputePanoramaSkyMaterial.PanoramaScale" default="1">
 		</member>
 	</members>
+	<constants>
+		<constant name="DOUBLE_SIZE" value="0" enum="PanoramaScale">
+		</constant>
+		<constant name="FULL_SIZE" value="1" enum="PanoramaScale">
+		</constant>
+		<constant name="HALF_SIZE" value="2" enum="PanoramaScale">
+		</constant>
+		<constant name="QUARTER_SIZE" value="3" enum="PanoramaScale">
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/ComputePanoramaSkyMaterial.xml
+++ b/doc/classes/ComputePanoramaSkyMaterial.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ComputePanoramaSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+			A [Material] used with [Sky] to draw a background texture which is precomputed.
+	</brief_description>
+	<description>
+		This class is differs from [PanoramaSkyMaterial] in that it uses [RID] instead of [Texture2D] to set the panorama texture which resides on GPU.
+		One need to generate panorama using GLSL compute shader first, then use
+		[code]
+		# copy the panorama from image2D output of a compute shader to a texture2D which is owned by RenderingServer.
+		panorama_rid=RenderingServer.texture_rd_create(compute_panorama_rid)
+    # save old panorama_rid for further disposal
+    var old_panorama_rid=env.sky.sky_material.get_panorama()
+		# set the panorama to this sky material
+		WorldEnvironment.Environment.sky.sky_material.set_panorama(panorama_rid)
+
+    if old_panorama_rid:
+      rd.free_rid(old_panorama_rid) # rd is the result of RenderingServer.get_rendering_device()
+		[/code]
+
+		This class utilizes the mechanism first introduced in following PR:[https://github.com/godotengine/godot/pull/79288].
+		This [Material] can not be converted to shader as there is no sense to do so.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
+			Inherited from [PanoramaSkyCommonMaterial].
+		</member>
+		<member name="panorama" type="RID" setter="set_panorama" getter="get_panorama">
+			A [RID] of a [Texture2D] owned by RenderingServer to be applied to the [PanoramaSkyMaterial].
+		</member>
+	</members>
+</class>

--- a/doc/classes/PanoramaSkyCommonMaterial.xml
+++ b/doc/classes/PanoramaSkyCommonMaterial.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PanoramaSkyCommonMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A base class for a [Material] which is used with [Sky] to draw a background texture.
+	</brief_description>
+	<description>
+		This is a base class for [PanoramaSkyMaterial] and [ComputePanoramaSkyMaterial] which implements common functionality, though this class is not exported to the editor.
+		You should not use this class directly, but rather use one of its derived classes.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
+			A boolean value to determine if the background texture should be filtered or not.
+		</member>
+	</members>
+</class>

--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="PanoramaSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="PanoramaSkyMaterial" inherits="PanoramaSkyCommonMaterial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A [Material] used with [Sky] to draw a background texture.
 	</brief_description>

--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
-			A boolean value to determine if the background texture should be filtered or not.
+			Inherited from [PanoramaSkyCommonMaterial].
 		</member>
 		<member name="panorama" type="Texture2D" setter="set_panorama" getter="get_panorama">
 			[Texture2D] to be applied to the [PanoramaSkyMaterial].

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -828,6 +828,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(StandardMaterial3D);
 	GDREGISTER_CLASS(ORMMaterial3D);
 	GDREGISTER_CLASS(ProceduralSkyMaterial);
+	GDREGISTER_CLASS(ComputePanoramaSkyMaterial);
 	GDREGISTER_CLASS(PanoramaSkyMaterial);
 	GDREGISTER_CLASS(PhysicalSkyMaterial);
 	SceneTree::add_idle_callback(BaseMaterial3D::flush_changes);
@@ -1215,6 +1216,7 @@ void unregister_scene_types() {
 #ifndef _3D_DISABLED
 	BaseMaterial3D::finish_shaders();
 	PhysicalSkyMaterial::cleanup_shader();
+	ComputePanoramaSkyMaterial::cleanup_shader();
 	PanoramaSkyMaterial::cleanup_shader();
 	ProceduralSkyMaterial::cleanup_shader();
 #endif // _3D_DISABLED

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -82,7 +82,7 @@ void Sky::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &Sky::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &Sky::get_material);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial"), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,ComputePanoramaSkyMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,High-Quality,High-Quality Incremental,Real-Time"), "set_process_mode", "get_process_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512,1024,2048"), "set_radiance_size", "get_radiance_size");
 

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -28,13 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-
 #include "sky_material.h"
+#include "core/config/project_settings.h"
 #include "core/io/image.h"
+#include "core/version.h"
 #include "scene/resources/image_texture.h"
 #include "servers/rendering/rendering_device.h"
-#include "core/config/project_settings.h"
-#include "core/version.h"
 
 Mutex ProceduralSkyMaterial::shader_mutex;
 RID ProceduralSkyMaterial::shader_cache[2];
@@ -383,7 +382,7 @@ void PanoramaSkyCommonMaterial::set_filtering_enabled(bool p_enabled) {
 
 RID PanoramaSkyCommonMaterial::get_rid() const {
 	_update_shader();
-  // Don't compile shaders until first use, then compile both
+	// Don't compile shaders until first use, then compile both
 	if (!shader_set) {
 		RS::get_singleton()->material_set_shader(_get_material(), shader_cache[1 - int(filter)]);
 		RS::get_singleton()->material_set_shader(_get_material(), shader_cache[int(filter)]);
@@ -445,47 +444,50 @@ PanoramaSkyCommonMaterial::~PanoramaSkyCommonMaterial() {
 /////////////////////////////////////////
 /* ComputePanoramaSkyMaterial */
 
-void ComputePanoramaSkyMaterial::set_panorama(const RID& p_panorama) {
+void ComputePanoramaSkyMaterial::set_panorama(const RID &p_panorama) {
 	panorama = p_panorama;
-  if ( panorama.is_valid() )
-    RS::get_singleton()->material_set_param(_get_material(), "source_panorama", p_panorama);
+	if (panorama.is_valid())
+		RS::get_singleton()->material_set_param(_get_material(), "source_panorama", p_panorama);
 
 	on_params_change();
 }
 
 RID ComputePanoramaSkyMaterial::get_panorama() const {
-  return panorama;
+	return panorama;
 }
 
 ComputePanoramaSkyMaterial::PanoramaScale ComputePanoramaSkyMaterial::get_panorama_scale() const {
-  return panorama_scale;
+	return panorama_scale;
 }
 
 Vector2i ComputePanoramaSkyMaterial::get_panorama_size() const {
-  return panorama_size;
+	return panorama_size;
 }
 
-void ComputePanoramaSkyMaterial::set_panorama_scale(const ComputePanoramaSkyMaterial::PanoramaScale p_panorama_scale){
-  panorama_scale=p_panorama_scale;
-  switch(panorama_scale)
-  {
-    case ComputePanoramaSkyMaterial::DOUBLE_SIZE:
-      panorama_size.x=8192; panorama_size.y=4096;
-      break;
-    case ComputePanoramaSkyMaterial::FULL_SIZE:
-      panorama_size.x=4096; panorama_size.y=2048;
-      break;
-    case ComputePanoramaSkyMaterial::HALF_SIZE:
-      panorama_size.x=2048; panorama_size.y=1024;
-      break;
-    case ComputePanoramaSkyMaterial::QUARTER_SIZE:
-      panorama_size.x=1024; panorama_size.y=512;
-      break;
-    default:
-      const String msg("ComputePanoramaSkyMaterial::PanoramaScale out of bonds. Aborting.");
-      OS::get_singleton()->alert(msg);
-      ERR_FAIL_MSG(msg);
-  }
+void ComputePanoramaSkyMaterial::set_panorama_scale(const ComputePanoramaSkyMaterial::PanoramaScale p_panorama_scale) {
+	panorama_scale = p_panorama_scale;
+	switch (panorama_scale) {
+		case ComputePanoramaSkyMaterial::DOUBLE_SIZE:
+			panorama_size.x = 8192;
+			panorama_size.y = 4096;
+			break;
+		case ComputePanoramaSkyMaterial::FULL_SIZE:
+			panorama_size.x = 4096;
+			panorama_size.y = 2048;
+			break;
+		case ComputePanoramaSkyMaterial::HALF_SIZE:
+			panorama_size.x = 2048;
+			panorama_size.y = 1024;
+			break;
+		case ComputePanoramaSkyMaterial::QUARTER_SIZE:
+			panorama_size.x = 1024;
+			panorama_size.y = 512;
+			break;
+		default:
+			const String msg("ComputePanoramaSkyMaterial::PanoramaScale out of bonds. Aborting.");
+			OS::get_singleton()->alert(msg);
+			ERR_FAIL_MSG(msg);
+	}
 	on_params_change();
 }
 
@@ -500,19 +502,18 @@ void ComputePanoramaSkyMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_filtering_enabled"), &ComputePanoramaSkyMaterial::is_filtering_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter"), "set_filtering_enabled", "is_filtering_enabled");
-  ADD_PROPERTY(PropertyInfo(Variant::INT, "panorama_scale", PROPERTY_HINT_ENUM, "Double(8192), Full(4096), Half(2048), Quarter(1024)"), "set_panorama_scale", "get_panorama_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "panorama_scale", PROPERTY_HINT_ENUM, "Double(8192), Full(4096), Half(2048), Quarter(1024)"), "set_panorama_scale", "get_panorama_scale");
 
-  BIND_ENUM_CONSTANT(DOUBLE_SIZE)
-  BIND_ENUM_CONSTANT(FULL_SIZE)
-  BIND_ENUM_CONSTANT(HALF_SIZE)
-  BIND_ENUM_CONSTANT(QUARTER_SIZE)
+	BIND_ENUM_CONSTANT(DOUBLE_SIZE)
+	BIND_ENUM_CONSTANT(FULL_SIZE)
+	BIND_ENUM_CONSTANT(HALF_SIZE)
+	BIND_ENUM_CONSTANT(QUARTER_SIZE)
 }
 
 Vector2i ComputePanoramaSkyMaterial::panorama_size;
 
-
 ComputePanoramaSkyMaterial::ComputePanoramaSkyMaterial() {
-  set_panorama_scale(ComputePanoramaSkyMaterial::PanoramaScale::FULL_SIZE);
+	set_panorama_scale(ComputePanoramaSkyMaterial::PanoramaScale::FULL_SIZE);
 }
 
 ComputePanoramaSkyMaterial::~ComputePanoramaSkyMaterial() {
@@ -522,7 +523,7 @@ ComputePanoramaSkyMaterial::~ComputePanoramaSkyMaterial() {
 /* PanoramaSkyMaterial */
 
 void PanoramaSkyMaterial::set_panorama(const Ref<Texture2D> &p_panorama) {
-  panorama = p_panorama;
+	panorama = p_panorama;
 	if (p_panorama.is_valid()) {
 		RS::get_singleton()->material_set_param(_get_material(), "source_panorama", p_panorama->get_rid());
 	} else {
@@ -532,7 +533,7 @@ void PanoramaSkyMaterial::set_panorama(const Ref<Texture2D> &p_panorama) {
 }
 
 Ref<Texture2D> PanoramaSkyMaterial::get_panorama() const {
-  return panorama;
+	return panorama;
 }
 
 void PanoramaSkyMaterial::_bind_methods() {

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -114,20 +114,88 @@ public:
 };
 
 //////////////////////////////////////////////////////
+/**
+ * PanoramaSkyCommonMaterial												 *
+ *													 *											 *
+ * PanoramaSkyCommonMaterial	is a base class for    *
+ * PanoramaSkyMaterial and	     										 *
+ * ComputePanoramaSkyMaterial. 					             *
+**/
+class PanoramaSkyCommonMaterial : public Material {
+	GDCLASS(PanoramaSkyCommonMaterial, Material);
+
+protected:
+	static Mutex shader_mutex;
+	static RID shader_cache[2];
+	mutable bool shader_set = false;
+	bool filter = true;
+
+	static void _update_shader();
+
+	void on_params_change()
+	{
+		notify_property_list_changed();
+		_update_shader();
+	}
+
+public:
+	void set_filtering_enabled(bool p_enabled);
+	bool is_filtering_enabled() const;
+
+	virtual Shader::Mode get_shader_mode() const override;
+	virtual RID get_shader_rid() const override;
+	virtual RID get_rid() const override;
+
+	static void cleanup_shader();
+
+	PanoramaSkyCommonMaterial();
+	~PanoramaSkyCommonMaterial();
+};
+
+//////////////////////////////////////////////////////
+/* ComputePanoramaSkyMaterial */
+class ComputePanoramaSkyMaterial : public PanoramaSkyCommonMaterial {
+	GDCLASS(ComputePanoramaSkyMaterial, Material);
+
+public:
+  enum PanoramaScale {
+    DOUBLE_SIZE,
+    FULL_SIZE,
+    HALF_SIZE,
+    QUARTER_SIZE
+  };
+
+private:
+	RID panorama;
+  PanoramaScale panorama_scale;
+  static Vector2i panorama_size;
+
+protected:
+	static void _bind_methods();
+
+public:
+
+	void set_panorama(const RID& p_panorama);
+	RID get_panorama() const;
+
+  PanoramaScale get_panorama_scale() const;
+  void set_panorama_scale(const PanoramaScale p_panorama_scale);
+
+  Vector2i get_panorama_size() const;
+
+	ComputePanoramaSkyMaterial();
+	~ComputePanoramaSkyMaterial();
+};
+
+
+//////////////////////////////////////////////////////
 /* PanoramaSkyMaterial */
 
-class PanoramaSkyMaterial : public Material {
+class PanoramaSkyMaterial : public PanoramaSkyCommonMaterial {
 	GDCLASS(PanoramaSkyMaterial, Material);
 
 private:
 	Ref<Texture2D> panorama;
-
-	static Mutex shader_mutex;
-	static RID shader_cache[2];
-	static void _update_shader();
-	mutable bool shader_set = false;
-
-	bool filter = true;
 
 protected:
 	static void _bind_methods();
@@ -136,24 +204,15 @@ public:
 	void set_panorama(const Ref<Texture2D> &p_panorama);
 	Ref<Texture2D> get_panorama() const;
 
-	void set_filtering_enabled(bool p_enabled);
-	bool is_filtering_enabled() const;
-
 	void set_energy_multiplier(float p_multiplier);
 	float get_energy_multiplier() const;
-
-	virtual Shader::Mode get_shader_mode() const override;
-	virtual RID get_shader_rid() const override;
-	virtual RID get_rid() const override;
-
-	static void cleanup_shader();
 
 	PanoramaSkyMaterial();
 	~PanoramaSkyMaterial();
 };
 
 //////////////////////////////////////////////////////
-/* PanoramaSkyMaterial */
+/* PhysicalSkyMaterial */
 
 class PhysicalSkyMaterial : public Material {
 	GDCLASS(PhysicalSkyMaterial, Material);
@@ -226,5 +285,7 @@ public:
 	PhysicalSkyMaterial();
 	~PhysicalSkyMaterial();
 };
+
+VARIANT_ENUM_CAST(ComputePanoramaSkyMaterial::PanoramaScale)
 
 #endif // SKY_MATERIAL_H

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -155,7 +155,7 @@ public:
 //////////////////////////////////////////////////////
 /* ComputePanoramaSkyMaterial */
 class ComputePanoramaSkyMaterial : public PanoramaSkyCommonMaterial {
-	GDCLASS(ComputePanoramaSkyMaterial, Material);
+	GDCLASS(ComputePanoramaSkyMaterial, PanoramaSkyCommonMaterial);
 
 public:
   enum PanoramaScale {
@@ -192,7 +192,7 @@ public:
 /* PanoramaSkyMaterial */
 
 class PanoramaSkyMaterial : public PanoramaSkyCommonMaterial {
-	GDCLASS(PanoramaSkyMaterial, Material);
+	GDCLASS(PanoramaSkyMaterial, PanoramaSkyCommonMaterial);
 
 private:
 	Ref<Texture2D> panorama;

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -114,13 +114,7 @@ public:
 };
 
 //////////////////////////////////////////////////////
-/**
- * PanoramaSkyCommonMaterial												 *
- *													 *											 *
- * PanoramaSkyCommonMaterial	is a base class for    *
- * PanoramaSkyMaterial and	     										 *
- * ComputePanoramaSkyMaterial. 					             *
-**/
+/* PanoramaSkyCommonMaterial */
 class PanoramaSkyCommonMaterial : public Material {
 	GDCLASS(PanoramaSkyCommonMaterial, Material);
 
@@ -132,8 +126,7 @@ protected:
 
 	static void _update_shader();
 
-	void on_params_change()
-	{
+	void on_params_change() {
 		notify_property_list_changed();
 		_update_shader();
 	}
@@ -158,35 +151,33 @@ class ComputePanoramaSkyMaterial : public PanoramaSkyCommonMaterial {
 	GDCLASS(ComputePanoramaSkyMaterial, PanoramaSkyCommonMaterial);
 
 public:
-  enum PanoramaScale {
-    DOUBLE_SIZE,
-    FULL_SIZE,
-    HALF_SIZE,
-    QUARTER_SIZE
-  };
+	enum PanoramaScale {
+		DOUBLE_SIZE,
+		FULL_SIZE,
+		HALF_SIZE,
+		QUARTER_SIZE
+	};
 
 private:
 	RID panorama;
-  PanoramaScale panorama_scale;
-  static Vector2i panorama_size;
+	PanoramaScale panorama_scale;
+	static Vector2i panorama_size;
 
 protected:
 	static void _bind_methods();
 
 public:
-
-	void set_panorama(const RID& p_panorama);
+	void set_panorama(const RID &p_panorama);
 	RID get_panorama() const;
 
-  PanoramaScale get_panorama_scale() const;
-  void set_panorama_scale(const PanoramaScale p_panorama_scale);
+	PanoramaScale get_panorama_scale() const;
+	void set_panorama_scale(const PanoramaScale p_panorama_scale);
 
-  Vector2i get_panorama_size() const;
+	Vector2i get_panorama_size() const;
 
 	ComputePanoramaSkyMaterial();
 	~ComputePanoramaSkyMaterial();
 };
-
 
 //////////////////////////////////////////////////////
 /* PanoramaSkyMaterial */


### PR DESCRIPTION
### Why

- It is too expensive to use PhysicalSkyMaterial and to generate volumetric clouds
- Dynamic panorama generation with GLSL compute shaders  might be faster (with Forward+ render) and discrete GPUs then fragment shaders
- Sky and planetary surface are not changing as rapidly (at least in a distance), you do not need to generate them every frame however the static panoramas are not fit for each type of game
- Right now if you want to generate a panorama with GLSL compute shader, then you will need to copy output of a compute shader to system memory and then back to GPU by creating Texture2D object and assigning it to the sky_material (source_panorama sampler2D). On my AMD Ryzen 7 5800X 4.2GHz it takes ~100ms, and at the same time the simple panorama generation (from attached example) takes likes 0.015 -  0.022ms.

### How

The groundwork for this is already done by @BastiaanOlij in #79288
What is missing is the possibility to set the panorama like this:
`
panorama_rid=RenderingServer.texture_rd_create(compute_texture_rid)
$WorldEnvironment.environment.sky.sky_material.set_panorama(panorama_rid)
`

This RP introduces a PanoramaCommonSkyMaterial class that will serve as the base class for both old PanoramaSkyMaterial and new ComputePanoramaSkyMaterial (this class name might be misleading though, please give me some suggestions here). Common members and methods for old and the new class  are moved to PanoramaCommonSkyMaterial. The change itself is small, but it saves a lot of compute time.

ComputePanoramaSkyMaterial expects the panorama in 2:1 aspect ratio same as PanoramaSkyMaterial and provides the editor and script methods to get the required panorama size and to set the panorama scale (based on width of the panorama) limited to 8k, 4k, 2k, 1k. 

Here is the example project:
[ComputePanoramaSkyMaterial.zip](https://github.com/godotengine/godot/files/12245313/ComputePanoramaSkyMaterial.zip)

### Bugs

Error messages at start:

ERROR: Class PanoramaSkyCommonMaterial already has a method set_filtering_enabled.
   at: bind_methodfi (core/object/class_db.cpp:1416)

ERROR: Class PanoramaSkyCommonMaterial already has a method is_filtering_enabled.
   at: bind_methodfi (core/object/class_db.cpp:1416)

These errors are here because get/set filter bindings are in both the PanoramaSkyMaterial and ComputePanoramaSkyMaterial and I didn't figured out how to fix it without removing PanoramaSkyCommonMaterial.

### Disclaimer

This is my first PR, I'm looking forward for advise on the code and be able to allocate time in the next two weeks to fix related issues.