### PR TITLE
More cosmetic improvements in the GLTF code

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFDocument" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		Class for importing and exporting glTF files in and out of Godot.
 	</brief_description>
 	<description>
-		Append a glTF2 3d format from a file, buffer or scene and then write to the filesystem, buffer or scene.
+		GLTFDocument supports reading data from a glTF file, buffer, or Godot scene. This data can then be written to the filesystem, buffer, or used to create a Godot scene.
+		All of the data in a GLTF scene is stored in the [GLTFState] class. GLTFDocument processes state objects, but does not contain any scene data itself.
+		GLTFDocument can be extended with arbitrary functionality by extending the [GLTFDocumentExtension] class and registering it with GLTFDocument via [method register_gltf_document_extension]. This allows for custom data to be imported and exported.
 	</description>
 	<tutorials>
+		<link title="glTF 'What the duck?' guide">https://www.khronos.org/files/gltf20-reference-guide.pdf</link>
+		<link title="Khronos glTF specification">https://registry.khronos.org/glTF/</link>
 	</tutorials>
 	<methods>
 		<method name="append_from_buffer">

--- a/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_texture_webp.cpp
@@ -30,8 +30,6 @@
 
 #include "gltf_document_extension_texture_webp.h"
 
-#include "scene/3d/area_3d.h"
-
 // Import process.
 Error GLTFDocumentExtensionTextureWebP::import_preflight(Ref<GLTFState> p_state, Vector<String> p_extensions) {
 	if (!p_extensions.has("EXT_texture_webp")) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -293,9 +293,9 @@ private:
 	static float get_max_component(const Color &p_color);
 
 public:
-	Error append_from_file(String p_path, Ref<GLTFState> r_state, uint32_t p_flags = 0, String p_base_path = String());
-	Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> r_state, uint32_t p_flags = 0);
-	Error append_from_scene(Node *p_node, Ref<GLTFState> r_state, uint32_t p_flags = 0);
+	Error append_from_file(String p_path, Ref<GLTFState> p_state, uint32_t p_flags = 0, String p_base_path = String());
+	Error append_from_buffer(PackedByteArray p_bytes, String p_base_path, Ref<GLTFState> p_state, uint32_t p_flags = 0);
+	Error append_from_scene(Node *p_node, Ref<GLTFState> p_state, uint32_t p_flags = 0);
 
 public:
 	Node *generate_scene(Ref<GLTFState> p_state, float p_bake_fps = 30.0f, bool p_trimming = false, bool p_remove_immutable_tracks = true);


### PR DESCRIPTION
* Fix an inconsistency of `r_state` vs `p_state`, inverts the change in #79801, now it uses `p_state`.
* Improve documentation of GLTFDocument.
* Rename `texture_dir` to `relative_texture_dir` since it's relative to the GLTF file.
* Rename `new_texture_dir` to `full_texture_dir` since it's the full directory path.
* Rename `Dictionary d` to `image_dict`.
* Rename `Dictionary d` to `texture_dict` and `Ref<GLTFTexture> t` to `gltf_texture`.
* Remove unnecessary Area3D include.

Several of these were taken from #79314, split off for easier reviewing.