### PR TITLE
Add more array methods: `find_custom`, `rfind_custom`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -353,6 +353,36 @@ int Array::find(const Variant &p_value, int p_from) const {
 	return ret;
 }
 
+int Array::find_custom(const Callable &p_callable, int p_from) const {
+	if (_p->array.size() == 0) {
+		return -1;
+	}
+
+	if (p_from < 0 || size() == 0) {
+		return -1;
+	}
+
+	const Variant *argptrs[1];
+
+	for (int i = p_from; i < size(); i++) {
+		argptrs[0] = &get(i);
+
+		Variant result;
+		Callable::CallError ce;
+
+		p_callable.callp(argptrs, 1, result, ce);
+		if (ce.error != Callable::CallError::CALL_OK) {
+			ERR_FAIL_V_MSG(-1, "Error calling method from 'find_custom': " + Variant::get_callable_error_text(p_callable, argptrs, 1, ce) + ".");
+		}
+		// Return as soon as possible.
+		if (result.operator bool()) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
 int Array::rfind(const Variant &p_value, int p_from) const {
 	if (_p->array.size() == 0) {
 		return -1;
@@ -361,16 +391,51 @@ int Array::rfind(const Variant &p_value, int p_from) const {
 	ERR_FAIL_COND_V(!_p->typed.validate(value, "rfind"), -1);
 
 	if (p_from < 0) {
-		// Relative offset from the end
+		// Relative offset from the end.
 		p_from = _p->array.size() + p_from;
 	}
 	if (p_from < 0 || p_from >= _p->array.size()) {
-		// Limit to array boundaries
+		// Limit to array boundaries.
 		p_from = _p->array.size() - 1;
 	}
 
 	for (int i = p_from; i >= 0; i--) {
 		if (StringLikeVariantComparator::compare(_p->array[i], value)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+int Array::rfind_custom(const Callable &p_callable, int p_from) const {
+	if (_p->array.size() == 0) {
+		return -1;
+	}
+
+	if (p_from < 0) {
+		// Relative offset from the end.
+		p_from = _p->array.size() + p_from;
+	}
+	if (p_from < 0 || p_from >= _p->array.size()) {
+		// Limit to array boundaries.
+		p_from = _p->array.size() - 1;
+	}
+
+	const Variant *argptrs[1];
+
+	for (int i = p_from; i >= 0; i--) {
+		argptrs[0] = &get(i);
+
+		Variant result;
+		Callable::CallError ce;
+
+		p_callable.callp(argptrs, 1, result, ce);
+		if (ce.error != Callable::CallError::CALL_OK) {
+			ERR_FAIL_V_MSG(-1, "Error calling method from 'rfind_custom': " + Variant::get_callable_error_text(p_callable, argptrs, 1, ce) + ".");
+		}
+		// Return as soon as possible.
+		if (result.operator bool()) {
 			return i;
 		}
 	}

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -88,7 +88,9 @@ public:
 	void reverse();
 
 	int find(const Variant &p_value, int p_from = 0) const;
+	int find_custom(const Callable &p_callable, int p_from = 0) const;
 	int rfind(const Variant &p_value, int p_from = -1) const;
+	int rfind_custom(const Callable &p_callable, int p_from = -1) const;
 	int count(const Variant &p_value) const;
 	bool has(const Variant &p_value) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2221,7 +2221,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(Array, back, sarray(), varray());
 	bind_method(Array, pick_random, sarray(), varray());
 	bind_method(Array, find, sarray("what", "from"), varray(0));
+	bind_method(Array, find_custom, sarray("func", "from"), varray(0));
 	bind_method(Array, rfind, sarray("what", "from"), varray(-1));
+	bind_method(Array, rfind_custom, sarray("func", "from"), varray(-1));
 	bind_method(Array, count, sarray("value"), varray());
 	bind_method(Array, has, sarray("value"), varray());
 	bind_method(Array, pop_back, sarray(), varray());

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -307,6 +307,15 @@
 				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
+		<method name="find_custom" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="func" type="Callable" />
+			<param index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for the first value that causes [param func] to return true, or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
+				[param func] is a callable that should accept an array element as an argument, and return a boolean.
+			</description>
+		</method>
 		<method name="front" qualifiers="const">
 			<return type="Variant" />
 			<description>
@@ -558,6 +567,15 @@
 			<param index="1" name="from" type="int" default="-1" />
 			<description>
 				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
+			</description>
+		</method>
+		<method name="rfind_custom" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="func" type="Callable" />
+			<param index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array for the last value that causes [param func] to return true by searching in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
+				[param func] is a callable that should accept an array element as an argument, and return a boolean.
 			</description>
 		</method>
 		<method name="shuffle">

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -129,6 +129,27 @@ TEST_CASE("[Array] has() and count()") {
 	CHECK(arr.count(2) == 0);
 }
 
+static bool array_test_callable(int p_val) {
+	// Basic even number check.
+	return p_val % 2 == 0;
+}
+
+TEST_CASE("[Array] find_custom() and rfind_custom()") {
+	Array arr;
+	arr.push_back(1);
+	arr.push_back(2);
+	arr.push_back(3);
+	arr.push_back(4);
+	arr.push_back(5);
+	arr.push_back(6);
+
+	CHECK(arr.find_custom(callable_mp_static(array_test_callable)) == 1); // Should be the number 2.
+	CHECK(arr.rfind_custom(callable_mp_static(array_test_callable)) == 5); // Should be the number 6.
+
+	CHECK(arr.find_custom(callable_mp_static(array_test_callable), 2) == 3); // Should be the number 4.
+	CHECK(arr.rfind_custom(callable_mp_static(array_test_callable), 4) == 3); // Should be the number 4.
+}
+
 TEST_CASE("[Array] remove_at()") {
 	Array arr;
 	arr.push_back(1);


### PR DESCRIPTION
Added 3 new array functions - `count_custom`, `first_custom`, and `last_custom`. These perform the functions of the existing `count,`, `first`, and `rfind` respectively, but using a Callable as the conditions, like `sort_custom`.
Last could be renamed `rfind_custom` for consistency sake.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/6889*