### PR TITLE
Show alert if .NET assemblies dir does not exist

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -376,6 +376,12 @@ void GDMono::initialize() {
 
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
 
+	// Check that the .NET assemblies directory exists before trying to use it.
+	if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
+		OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
+		ERR_FAIL_MSG(".NET: Assemblies not found");
+	}
+
 	if (!load_hostfxr(hostfxr_dll_handle)) {
 #if !defined(TOOLS_ENABLED)
 		godot_plugins_initialize = try_load_native_aot_library(hostfxr_dll_handle);


### PR DESCRIPTION
Shows a clearer message to users when the data directory is missing.

- Resolves this comment: https://github.com/godotengine/godot/pull/78846#discussion_r1282113302.