### PR TITLE
Revert incorrect `Rect2.expand` description.

### DIFF
--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -83,7 +83,7 @@
 			<return type="Rect2" />
 			<param index="0" name="to" type="Vector2" />
 			<description>
-				Returns a copy of this rectangle expanded to include the given [param to] point, if necessary.
+				Returns a copy of this rectangle expanded to align the edges with the given [param to] point, if necessary.
 				[codeblocks]
 				[gdscript]
 				var rect = Rect2(0, 0, 5, 2)

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -82,7 +82,7 @@
 			<return type="Rect2i" />
 			<param index="0" name="to" type="Vector2i" />
 			<description>
-				Returns a copy of this rectangle expanded to include the given [param to] point, if necessary.
+				Returns a copy of this rectangle expanded to align the edges with the given [param to] point, if necessary.
 				[codeblocks]
 				[gdscript]
 				var rect = Rect2i(0, 0, 5, 2)


### PR DESCRIPTION
As you can see here: https://github.com/godotengine/godot/pull/69816#discussion_r1281826300

> I am pretty sure this change is wrong. It was specifically modified because, when expanded to the right or bottom, the `to` point is not included in the rectangle by the `has_point`. (and this is on purpose)

> Agh, this reply is technically correct. Saying "_expanded to include_" does imply that by calling `has_point` with the same point on the new rectangle , the result may or may not be `true`. I would like to think of a way to say this in a simpler way. At worst, the description needs to be mostly reverted back.

This PR reverts the description to say "align the" with a bit of tweaking to have it match the previous changes.

Also affects Rect2i of course.