### PR TITLE
Improve `Window._get_contents_minimum_size()`'s code

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1748,9 +1748,11 @@ Rect2i Window::fit_rect_in_parent(Rect2i p_rect, const Rect2i &p_parent_rect) co
 
 Size2 Window::get_contents_minimum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
-	Vector2 ms = _get_contents_minimum_size();
-	GDVIRTUAL_CALL(_get_contents_minimum_size, ms);
-	return ms;
+	Vector2 ms;
+	if (GDVIRTUAL_CALL(_get_contents_minimum_size, ms)) {
+		return ms;
+	}
+	return _get_contents_minimum_size();
 }
 
 Size2 Window::get_clamped_minimum_size() const {


### PR DESCRIPTION
Take into account the suggested changes from here: https://github.com/godotengine/godot/pull/80178#discussion_r1283105928