### PR TITLE
CI: Make extension API compatibility check mandatory

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Check for GDExtension compatibility
         if: ${{ matrix.api-compat }}
         run: |
-          ./misc/scripts/validate_extension_api.sh "${{ matrix.bin }}" || true # don't fail the CI for now
+          ./misc/scripts/validate_extension_api.sh "${{ matrix.bin }}"
 
       # Download and run the test project
       - name: Test Godot project


### PR DESCRIPTION
This means that any PR which breaks the extension API should handle it properly, that is:

- Add compatibility methods to ensure that existing function hashes work
- Document the changes in the relevant `misc/extension_api_validation/` file

For `4.1`, we should make sure before cherry-picking that we don't actually have compatibility breakages that slipped past our watch.