### PR TITLE
Initialize shader placeholders up front

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -161,7 +161,7 @@ void ShaderRD::_clear_version(Version *p_version) {
 	// Clear versions if they exist.
 	if (p_version->variants) {
 		for (int i = 0; i < variant_defines.size(); i++) {
-			if (variants_enabled[i] && group_enabled[variant_defines[i].group]) {
+			if (p_version->variants[i].is_valid()) {
 				RD::get_singleton()->free(p_version->variants[i]);
 			}
 		}


### PR DESCRIPTION
Then use the placeholder to create the shader instead of swapping RIDs This fixes a false positive that reported leaked shaders

Fixes recent regression from #79606 mentioned here https://github.com/godotengine/godot/pull/79606#issuecomment-1660989975
