### PR TITLE
Expose the `TabBar` of a `TabContainer`

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -30,6 +30,13 @@
 				Returns the previously active tab index.
 			</description>
 		</method>
+		<method name="get_tab_bar" qualifiers="const">
+			<return type="TabBar" />
+			<description>
+				Returns the [TabBar] contained in this container.
+				[b]Warning:[/b] This is a required internal node, removing and freeing it or editing its tabs may cause a crash. If you wish to edit the tabs, use the methods provided in [TabContainer].
+			</description>
+		</method>
 		<method name="get_tab_button_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="tab_idx" type="int" />

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -620,6 +620,10 @@ void TabContainer::remove_child_notify(Node *p_child) {
 	}
 }
 
+TabBar *TabContainer::get_tab_bar() const {
+	return tab_bar;
+}
+
 int TabContainer::get_tab_count() const {
 	return tab_bar->get_tab_count();
 }
@@ -947,6 +951,7 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_tab"), &TabContainer::get_current_tab);
 	ClassDB::bind_method(D_METHOD("get_previous_tab"), &TabContainer::get_previous_tab);
 	ClassDB::bind_method(D_METHOD("get_current_tab_control"), &TabContainer::get_current_tab_control);
+	ClassDB::bind_method(D_METHOD("get_tab_bar"), &TabContainer::get_tab_bar);
 	ClassDB::bind_method(D_METHOD("get_tab_control", "tab_idx"), &TabContainer::get_tab_control);
 	ClassDB::bind_method(D_METHOD("set_tab_alignment", "alignment"), &TabContainer::set_tab_alignment);
 	ClassDB::bind_method(D_METHOD("get_tab_alignment"), &TabContainer::get_tab_alignment);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -111,6 +111,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	TabBar *get_tab_bar() const;
+
 	int get_tab_idx_at_point(const Point2 &p_point) const;
 	int get_tab_idx_from_control(Control *p_child) const;
 


### PR DESCRIPTION
Add `TabContainer::get_tab_bar` method to retrieve the `TabBar` of a `TabContainer`.

- Implements point 2 of https://github.com/godotengine/godot-proposals/issues/2514#issuecomment-808800291.