### PR TITLE
Fix various typos in classref

### DIFF
--- a/doc/classes/Bone2D.xml
+++ b/doc/classes/Bone2D.xml
@@ -61,7 +61,7 @@
 			<param index="0" name="angle" type="float" />
 			<description>
 				Sets the bone angle for the [Bone2D]. This is typically set to the rotation from the [Bone2D] to a child [Bone2D] node.
-				[b]Note:[/b] [b]Note:[/b] This is different from the [Bone2D]'s rotation. The bone's angle is the rotation of the bone shown by the gizmo, which is unaffected by the [Bone2D]'s [member Node2D.transform].
+				[b]Note:[/b] This is different from the [Bone2D]'s rotation. The bone's angle is the rotation of the bone shown by the gizmo, which is unaffected by the [Bone2D]'s [member Node2D.transform].
 			</description>
 		</method>
 		<method name="set_length">

--- a/doc/classes/RDPipelineMultisampleState.xml
+++ b/doc/classes/RDPipelineMultisampleState.xml
@@ -25,7 +25,7 @@
 			The number of MSAA samples (or SSAA samples if [member enable_sample_shading] is [code]true[/code]) to perform. Higher values result in better antialiasing, at the cost of performance.
 		</member>
 		<member name="sample_masks" type="int[]" setter="set_sample_masks" getter="get_sample_masks" default="[]">
-			The sampleSee the [url=https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-samplemask]sample mask Vulkan documentation[/url] for more details.
+			The sample mask array. See the [url=https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-samplemask]sample mask Vulkan documentation[/url] for more details.
 		</member>
 	</members>
 </class>

--- a/doc/classes/RDPipelineRasterizationState.xml
+++ b/doc/classes/RDPipelineRasterizationState.xml
@@ -29,7 +29,7 @@
 			The winding order to use to determine which face of a triangle is considered its front face.
 		</member>
 		<member name="line_width" type="float" setter="set_line_width" getter="get_line_width" default="1.0">
-			THe line width to use when drawing lines (in pixels). Thick lines may not be supported on all hardware.
+			The line width to use when drawing lines (in pixels). Thick lines may not be supported on all hardware.
 		</member>
 		<member name="patch_control_points" type="int" setter="set_patch_control_points" getter="get_patch_control_points" default="1">
 			The number of control points to use when drawing a patch with tessellation enabled. Higher values result in higher quality at the cost of performance.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1786,7 +1786,7 @@
 		<constant name="STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT" value="1" enum="StorageBufferUsage" is_bitfield="true">
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER" value="0" enum="UniformType">
-			Sampler uniform. TODO: Difference between sampler and texture uniform
+			Sampler uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER_WITH_TEXTURE" value="1" enum="UniformType">
 			Sampler uniform with a texture.
@@ -1795,16 +1795,16 @@
 			Texture uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_IMAGE" value="3" enum="UniformType">
-			Image uniform. TODO: Difference between texture and image uniform
+			Image uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_TEXTURE_BUFFER" value="4" enum="UniformType">
-			Texture buffer uniform. TODO: Difference between texture and texture buffe uniformr
+			Texture buffer uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_SAMPLER_WITH_TEXTURE_BUFFER" value="5" enum="UniformType">
-			Sampler uniform with a texture buffer. TODO: Difference between texture and texture buffer uniform
+			Sampler uniform with a texture buffer.
 		</constant>
 		<constant name="UNIFORM_TYPE_IMAGE_BUFFER" value="6" enum="UniformType">
-			Image buffer uniform. TODO: Difference between texture and image uniforms
+			Image buffer uniform.
 		</constant>
 		<constant name="UNIFORM_TYPE_UNIFORM_BUFFER" value="7" enum="UniformType">
 			Uniform buffer uniform.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1375,7 +1375,7 @@
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				Tries to free an object in the RenderingServer. To avoid memory leaks, this should be called after using an object as memory management does not occur automatically when using RendeeringServer directly.
+				Tries to free an object in the RenderingServer. To avoid memory leaks, this should be called after using an object as memory management does not occur automatically when using RenderingServer directly.
 			</description>
 		</method>
 		<method name="get_default_clear_color">

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -101,7 +101,7 @@
 		<method name="_get_system_info" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<description>
-				Returns a [Dictionary] with system informationr elated to this interface.
+				Returns a [Dictionary] with system information related to this interface.
 			</description>
 		</method>
 		<method name="_get_tracking_status" qualifiers="virtual const">

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -150,7 +150,7 @@
 			Allows an application to act as an AccountAuthenticator for the AccountManager.
 		</member>
 		<member name="permissions/battery_stats" type="bool" setter="" getter="">
-			Allows an application to collect battery statistics. Sett [url=https://developer.android.com/reference/android/Manifest.permission#BATTERY_STATS]BATTERY_STATS[/url].
+			Allows an application to collect battery statistics. See [url=https://developer.android.com/reference/android/Manifest.permission#BATTERY_STATS]BATTERY_STATS[/url].
 		</member>
 		<member name="permissions/bind_accessibility_service" type="bool" setter="" getter="">
 			Must be required by an AccessibilityService, to ensure that only the system can bind to it. See [url=https://developer.android.com/reference/android/Manifest.permission#BIND_ACCESSIBILITY_SERVICE]BIND_ACCESSIBILITY_SERVICE[/url].

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -23,7 +23,7 @@
 			Copyright notice for the bundle visible to the user (localized).
 		</member>
 		<member name="application/icon" type="String" setter="" getter="">
-			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/macos_native_icon], and  then to [member ProjectSettings.application/config/icon].
+			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/macos_native_icon], and then to [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -25,7 +25,7 @@
 			Version number of the file. Required. See [url=https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block]StringFileInfo[/url].
 		</member>
 		<member name="application/icon" type="String" setter="" getter="">
-			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/windows_native_icon], and  then to [member ProjectSettings.application/config/icon].
+			Application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/windows_native_icon], and then to [member ProjectSettings.application/config/icon].
 		</member>
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.


### PR DESCRIPTION
Found when translating the classref recently :P

> Texture buffer uniform. TODO: Difference between texture and texture buffe uniform

This one does not end with a period because all these `TODO`s don't end with a period.