### PR TITLE
Fix wrong example output of `float*Color` in classref

### DIFF
--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -70,7 +70,7 @@
 			<description>
 				Multiplies each component of the [Color], including the alpha, by the given [float].
 				[codeblock]
-				print(1.5 * Color(0.5, 0.5, 0.5)) # Color(0.75, 0.75, 0.75)
+				print(1.5 * Color(0.5, 0.5, 0.5)) # Prints "(0.75, 0.75, 0.75, 1.5)"
 				[/codeblock]
 			</description>
 		</operator>


### PR DESCRIPTION
* Alpha was not correctly multipied.
* Use the same `# Prints "XXX"` format as other examples.