### PR TITLE
Clarify relationship between `basis` and `transform` properties of `Node3D`

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -269,7 +269,7 @@
 	</methods>
 	<members>
 		<member name="basis" type="Basis" setter="set_basis" getter="get_basis">
-			Direct access to the 3x3 basis of the [Transform3D] property.
+			Direct access to the 3x3 basis of the [member transform] property.
 		</member>
 		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position">
 			Global position of this node. This is equivalent to [code]global_transform.origin[/code].


### PR DESCRIPTION
I'm confused about which `Transform3D` the `Node3D.basis` docs refer to:

- `self.transform.basis`, or
- `self.global_transform.basis`

This PR edits the `Node3D.basis` description to clarify this, although I'm not sure I guessed the right one.