### PR TITLE
Avoid retrieving the object ID of a stack variable if it is nil

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -232,7 +232,7 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array) {
 	PropertyHint h = PROPERTY_HINT_NONE;
 	String hs;
 
-	if (var.var_type == Variant::OBJECT) {
+	if (var.var_type == Variant::OBJECT && v) {
 		v = Object::cast_to<EncodedObjectAsID>(v)->get_object_id();
 		h = PROPERTY_HINT_OBJECT_ID;
 		hs = "Object";


### PR DESCRIPTION
Fixes #80236
*Bugsquad edit:* Fixes #80442

This PR ensures `EditorDebuggerInspector` checks if the value of a stack variable is Nil before retrieving its object ID.