### PR TITLE
Fix motion vectors being corrupted when using `precision=double`

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -234,6 +234,12 @@ void RenderSceneDataRD::update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p
 		RendererRD::MaterialStorage::store_transform(prev_cam_transform, prev_ubo.inv_view_matrix);
 		RendererRD::MaterialStorage::store_transform(prev_cam_transform.affine_inverse(), prev_ubo.view_matrix);
 
+#ifdef REAL_T_IS_DOUBLE
+		RendererRD::MaterialStorage::split_double(-prev_cam_transform.origin.x, &prev_ubo.inv_view_matrix[12], &prev_ubo.inv_view_matrix[3]);
+		RendererRD::MaterialStorage::split_double(-prev_cam_transform.origin.y, &prev_ubo.inv_view_matrix[13], &prev_ubo.inv_view_matrix[7]);
+		RendererRD::MaterialStorage::split_double(-prev_cam_transform.origin.z, &prev_ubo.inv_view_matrix[14], &prev_ubo.inv_view_matrix[11]);
+#endif
+
 		for (uint32_t v = 0; v < view_count; v++) {
 			prev_projection = prev_correction * view_projection[v];
 			RendererRD::MaterialStorage::store_camera(prev_projection, prev_ubo.projection_matrix_view[v]);


### PR DESCRIPTION
See Issue #69528. When building with precision=double, the TAA pass would break due to the motion vectors being corrupted. It was apparent the origin of the camera itself was corrupted in the UBO for the previous frame because the camera origin was only being split correctly for the current block but not for the previous block (to effectively support the double precision float on the shader).

_Production edit: Fixes https://github.com/godotengine/godot/issues/69528_