### PR TITLE
Editor: Fix MultiMesh populate default facing direction

### DIFF
--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -193,7 +193,7 @@ void MultiMeshEditor::_populate() {
 
 		Vector3 pos = face.get_random_point_inside();
 		Vector3 normal = face.get_plane().normal;
-		Vector3 op_axis = (face.vertex[0] - face.vertex[1]).normalized();
+		Vector3 op_axis = Vector3(0, 0, -1);
 
 		Transform3D xform;
 


### PR DESCRIPTION
Closes #80246.

Preface: I'm not sure this is the right way to go about it, but the solution works for the cases I tested.

**Current behaviour**
The current implementation uses the target surface's facing direction as default facing direction for the instanced meshes.

**New behaviour**
This fix makes it so the transform will always face forward in the default Z direction.

This makes the random rotation slider work as you'd expect, i.e. if you set random rotation to zero, none of the instances are rotated.