### PR TITLE
Fix doubly-reserved unique names in GLTF scene name assignment

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -563,17 +563,17 @@ Error GLTFDocument::_parse_scenes(Ref<GLTFState> p_state) {
 
 	if (scenes.size()) {
 		ERR_FAIL_COND_V(loaded_scene >= scenes.size(), ERR_FILE_CORRUPT);
-		const Dictionary &s = scenes[loaded_scene];
-		ERR_FAIL_COND_V(!s.has("nodes"), ERR_UNAVAILABLE);
-		const Array &nodes = s["nodes"];
+		const Dictionary &scene_dict = scenes[loaded_scene];
+		ERR_FAIL_COND_V(!scene_dict.has("nodes"), ERR_UNAVAILABLE);
+		const Array &nodes = scene_dict["nodes"];
 		for (int j = 0; j < nodes.size(); j++) {
 			p_state->root_nodes.push_back(nodes[j]);
 		}
-
-		if (s.has("name") && !String(s["name"]).is_empty() && !((String)s["name"]).begins_with("Scene")) {
-			p_state->scene_name = _gen_unique_name(p_state, s["name"]);
+		// Determine what to use for the scene name.
+		if (scene_dict.has("name") && !String(scene_dict["name"]).is_empty() && !((String)scene_dict["name"]).begins_with("Scene")) {
+			p_state->scene_name = scene_dict["name"];
 		} else {
-			p_state->scene_name = _gen_unique_name(p_state, p_state->filename);
+			p_state->scene_name = p_state->filename;
 		}
 	}
 
@@ -5271,23 +5271,21 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> p_state) {
 void GLTFDocument::_assign_node_names(Ref<GLTFState> p_state) {
 	for (int i = 0; i < p_state->nodes.size(); i++) {
 		Ref<GLTFNode> gltf_node = p_state->nodes[i];
-
 		// Any joints get unique names generated when the skeleton is made, unique to the skeleton
 		if (gltf_node->skeleton >= 0) {
 			continue;
 		}
-
-		if (gltf_node->get_name().is_empty()) {
+		String gltf_node_name = gltf_node->get_name();
+		if (gltf_node_name.is_empty()) {
 			if (gltf_node->mesh >= 0) {
-				gltf_node->set_name(_gen_unique_name(p_state, "Mesh"));
+				gltf_node_name = "Mesh";
 			} else if (gltf_node->camera >= 0) {
-				gltf_node->set_name(_gen_unique_name(p_state, "Camera3D"));
+				gltf_node_name = "Camera3D";
 			} else {
-				gltf_node->set_name(_gen_unique_name(p_state, "Node"));
+				gltf_node_name = "Node";
 			}
 		}
-
-		gltf_node->set_name(_gen_unique_name(p_state, gltf_node->get_name()));
+		gltf_node->set_name(_gen_unique_name(p_state, gltf_node_name));
 	}
 }
 


### PR DESCRIPTION
This PR has 2 related but technically independent bugfixes. I could separate them but I figured I'd just make one PR. These fixes very slightly change behavior, so do not cherry-pick this to 4.1.x, but it's good for 4.2.

1. Fix double reserving of node names for nodes without a name in `_assign_node_names`. Test file:

```gltf
{
	"asset": { "version": "2.0" },
	"nodes": [{}],
	"scene": 0,
	"scenes": [{ "nodes": [0] }]
}
```

Behavior in master:
<img width="272" alt="Screenshot 2023-08-04 at 12 32 00 PM" src="https://github.com/godotengine/godot/assets/1646875/64871cb1-f6cb-4075-bb9b-e581fd0bbf1a">

Behavior in this PR:
<img width="272" alt="Screenshot 2023-08-04 at 12 26 57 PM" src="https://github.com/godotengine/godot/assets/1646875/5018d97f-ff47-4b63-b917-d469989dc424">

2. Fix scene names in `_parse_scenes` reserving as priority over node names and breaking node names. Test file:

```gltf
{
	"asset": { "version": "2.0" },
	"nodes": [{ "name": "EmptyScene" }],
	"scene": 0,
	"scenes": [{ "nodes": [0], "name": "EmptyScene" }]
}
```

Behavior in master:
<img width="272" alt="Screenshot 2023-08-04 at 12 32 58 PM" src="https://github.com/godotengine/godot/assets/1646875/60402eef-6b05-4b54-8b6d-2cf0d3deb527">

Behavior in this PR:
<img width="272" alt="Screenshot 2023-08-04 at 12 16 29 PM" src="https://github.com/godotengine/godot/assets/1646875/6c4988f6-d744-45d2-8df2-59e68e72d666">

Note: In the future I do want the scene name to be used as the root node name in some situations. However, in the current master this does not happen, and in the future when we do want this to happen, the current part of the code reserving the name is the wrong place to do it. We want to do it later on so that the actual nodes in the GLTF file have their names take priority, and the names of the nodes Godot generates are secondary.