### PR TITLE
Fix tab in `content_margin_left` property description

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -110,7 +110,7 @@
 			[method get_margin] should be used to fetch this value as consumer instead of reading these properties directly. This is because it correctly respects negative values and the fallback mentioned above.
 		</member>
 		<member name="content_margin_left" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">
-			The left margin for the contents of this style box.	Increasing this value reduces the space available to the contents from the left.
+			The left margin for the contents of this style box. Increasing this value reduces the space available to the contents from the left.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
 		<member name="content_margin_right" type="float" setter="set_content_margin" getter="get_content_margin" default="-1.0">


### PR DESCRIPTION
Fixes the misplaced tab character in a StyleBox's content_margin_left description, which caused Godot not to show any space in that spot:
![image](https://github.com/godotengine/godot/assets/102416174/c9fbd3d0-ddb9-47d5-94a7-78b16dd1771a)

If this is not enough for a whole PR feel free to include it in one dedicated for fixing a bigger batch of documentation issues. 