### PR TITLE
Assign temporary path to preloaded resources

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -90,6 +90,10 @@ String Resource::get_path() const {
 	return path_cache;
 }
 
+void Resource::set_path_cache(const String &p_path) {
+	path_cache = p_path;
+}
+
 String Resource::generate_scene_unique_id() {
 	// Generate a unique enough hash, but still user-readable.
 	// If it's not unique it does not matter because the saver will try again.

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -103,6 +103,7 @@ public:
 
 	virtual void set_path(const String &p_path, bool p_take_over = false);
 	String get_path() const;
+	void set_path_cache(const String &p_path); // Set raw path without involving resource cache.
 	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
 
 	static String generate_scene_unique_id();

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -774,6 +774,8 @@ Error ResourceLoaderBinary::load() {
 			res = Ref<Resource>(r);
 			if (!path.is_empty() && cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); //if got here because the resource with same path has different type, replace it
+			} else if (!path.is_resource_file()) {
+				r->set_path_cache(path);
 			}
 			r->set_scene_unique_id(id);
 		}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -341,6 +341,8 @@ void ResourceLoader::_thread_load_function(void *p_userdata) {
 	if (load_task.resource.is_valid()) {
 		if (load_task.cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 			load_task.resource->set_path(load_task.local_path);
+		} else if (!load_task.local_path.is_resource_file()) {
+			load_task.resource->set_path_cache(load_task.local_path);
 		}
 
 		if (load_task.xl_remapped) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -992,6 +992,7 @@ void GDScript::set_path(const String &p_path, bool p_take_over) {
 
 	String old_path = path;
 	path = p_path;
+	path_valid = true;
 	GDScriptCache::move_script(old_path, p_path);
 
 	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
@@ -1000,6 +1001,9 @@ void GDScript::set_path(const String &p_path, bool p_take_over) {
 }
 
 String GDScript::get_script_path() const {
+	if (!path_valid && !get_path().is_empty()) {
+		return get_path();
+	}
 	return path;
 }
 
@@ -1035,6 +1039,7 @@ Error GDScript::load_source_code(const String &p_path) {
 
 	source = s;
 	path = p_path;
+	path_valid = true;
 #ifdef TOOLS_ENABLED
 	source_changed_cache = true;
 	set_edited(false);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -171,6 +171,7 @@ class GDScript : public Script {
 	//exported members
 	String source;
 	String path;
+	bool path_valid = false; // False if using default path.
 	StringName local_name; // Inner class identifier or `class_name`.
 	StringName global_name; // `class_name`.
 	String fully_qualified_name;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -577,6 +577,8 @@ Error ResourceLoaderText::load() {
 		if (do_assign) {
 			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
+			} else if (!path.is_resource_file()) {
+				res->set_path_cache(path);
 			}
 			res->set_scene_unique_id(id);
 		}


### PR DESCRIPTION
Fixes #72854 in a safe and very hacky way.
The issue is waiting for a "proper" fix (see the discussion in #72257), but it kept annoying me in the meantime so I'm coming with another hack 🤷‍♂️

I added a method to Resource that sets the path completely bypassing the cache, so `Resource.get_path()` will return the "correct" path, while not causing unwanted side-effects. The method is called for built-in resources loaded with CACHE_MODE_IGNORE.

It was not enough, because GDScript keeps its own `path`, set with the regular `set_path()` method. I could make `set_temporary_path()` virtual, but instead I added a flag to track whether the path is valid and try returning `get_path()` if it's not.

Here's an extended MRP for the debugger bug that this fixes:
[PreloadBug.zip](https://github.com/godotengine/godot/files/12265238/PreloadBug.zip)
Preloaded built-in scripts still can't be clicked for some reason, but at least you can see their path.

EDIT:
Fixes #80812