### PR TITLE
Implement reloading of GDExtensions

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -79,6 +79,7 @@ private:
 
 	bool editor_hint = false;
 	bool project_manager_hint = false;
+	bool extension_reloading = false;
 
 	static Engine *singleton;
 
@@ -136,12 +137,18 @@ public:
 
 	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) { project_manager_hint = p_enabled; }
 	_FORCE_INLINE_ bool is_project_manager_hint() const { return project_manager_hint; }
+
+	_FORCE_INLINE_ void set_extension_reloading_enabled(bool p_enabled) { extension_reloading = p_enabled; }
+	_FORCE_INLINE_ bool is_extension_reloading_enabled() const { return extension_reloading; }
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
 
 	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_project_manager_hint() const { return false; }
+
+	_FORCE_INLINE_ void set_extension_reloading_enabled(bool p_enabled) {}
+	_FORCE_INLINE_ bool is_extension_reloading_enabled() const { return false; }
 #endif
 
 	Dictionary get_version_info() const;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -162,6 +162,14 @@ class GDExtensionMethodBind : public MethodBind {
 	List<PropertyInfo> arguments_info;
 	List<GodotTypeInfo::Metadata> arguments_metadata;
 
+#ifdef TOOLS_ENABLED
+	friend class GDExtension;
+
+	StringName name;
+	bool is_reloading = false;
+	bool valid = true;
+#endif
+
 protected:
 	virtual Variant::Type _gen_argument_type(int p_arg) const override {
 		if (p_arg < 0) {
@@ -179,6 +187,10 @@ protected:
 	}
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual bool is_valid() const override { return valid; }
+#endif
+
 #ifdef DEBUG_METHODS_ENABLED
 	virtual GodotTypeInfo::Metadata get_argument_meta(int p_arg) const override {
 		if (p_arg < 0) {
@@ -190,6 +202,9 @@ public:
 #endif
 
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const override {
+#ifdef TOOLS_ENABLED
+		ERR_FAIL_COND_V_MSG(!valid, Variant(), vformat("Cannot call invalid GDExtension method bind '%s'. It's probably cached - you may need to restart Godot.", name));
+#endif
 		Variant ret;
 		GDExtensionClassInstancePtr extension_instance = is_static() ? nullptr : p_object->_get_extension_instance();
 		GDExtensionCallError ce{ GDEXTENSION_CALL_OK, 0, 0 };
@@ -200,6 +215,9 @@ public:
 		return ret;
 	}
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const override {
+#ifdef TOOLS_ENABLED
+		ERR_FAIL_COND_MSG(!valid, vformat("Cannot call invalid GDExtension method bind '%s'. It's probably cached - you may need to restart Godot.", name));
+#endif
 		ERR_FAIL_COND_MSG(vararg, "Validated methods don't have ptrcall support. This is most likely an engine bug.");
 		GDExtensionClassInstancePtr extension_instance = is_static() ? nullptr : p_object->_get_extension_instance();
 
@@ -234,6 +252,9 @@ public:
 	}
 
 	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) const override {
+#ifdef TOOLS_ENABLED
+		ERR_FAIL_COND_MSG(!valid, vformat("Cannot call invalid GDExtension method bind '%s'. It's probably cached - you may need to restart Godot.", name));
+#endif
 		ERR_FAIL_COND_MSG(vararg, "Vararg methods don't have ptrcall support. This is most likely an engine bug.");
 		GDExtensionClassInstancePtr extension_instance = p_object->_get_extension_instance();
 		ptrcall_func(method_userdata, extension_instance, reinterpret_cast<GDExtensionConstTypePtr *>(p_args), (GDExtensionTypePtr)r_ret);
@@ -243,7 +264,43 @@ public:
 		return false;
 	}
 
-	explicit GDExtensionMethodBind(const GDExtensionClassMethodInfo *p_method_info) {
+#ifdef TOOLS_ENABLED
+	bool try_update(const GDExtensionClassMethodInfo *p_method_info) {
+		if (is_static() != (bool)(p_method_info->method_flags & GDEXTENSION_METHOD_FLAG_STATIC)) {
+			return false;
+		}
+
+		if (vararg != (bool)(p_method_info->method_flags & GDEXTENSION_METHOD_FLAG_VARARG)) {
+			return false;
+		}
+
+		if (has_return() != (bool)p_method_info->has_return_value) {
+			return false;
+		}
+
+		if (has_return() && return_value_info.type != (Variant::Type)p_method_info->return_value_info->type) {
+			return false;
+		}
+
+		if (argument_count != p_method_info->argument_count) {
+			return false;
+		}
+
+		for (uint32_t i = 0; i < p_method_info->argument_count; i++) {
+			if (arguments_info[i].type != (Variant::Type)p_method_info->arguments_info[i].type) {
+				return false;
+			}
+		}
+
+		update(p_method_info);
+		return true;
+	}
+#endif
+
+	void update(const GDExtensionClassMethodInfo *p_method_info) {
+#ifdef TOOLS_ENABLED
+		name = *reinterpret_cast<StringName *>(p_method_info->name);
+#endif
 		method_userdata = p_method_info->method_userdata;
 		call_func = p_method_info->call_func;
 		validated_call_func = nullptr;
@@ -255,6 +312,8 @@ public:
 			return_value_metadata = GodotTypeInfo::Metadata(p_method_info->return_value_metadata);
 		}
 
+		arguments_info.clear();
+		arguments_metadata.clear();
 		for (uint32_t i = 0; i < p_method_info->argument_count; i++) {
 			arguments_info.push_back(PropertyInfo(p_method_info->arguments_info[i]));
 			arguments_metadata.push_back(GodotTypeInfo::Metadata(p_method_info->arguments_metadata[i]));
@@ -279,6 +338,10 @@ public:
 
 		set_default_arguments(defargs);
 	}
+
+	explicit GDExtensionMethodBind(const GDExtensionClassMethodInfo *p_method_info) {
+		update(p_method_info);
+	}
 };
 
 #ifndef DISABLE_DEPRECATED
@@ -300,6 +363,7 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		p_extension_funcs->unreference_func, // GDExtensionClassUnreference unreference_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
+		nullptr, // GDExtensionClassRecreateInstance recreate_instance_func;
 		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
 		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 		nullptr, // GDExtensionClassCallVirtualWithData call_virtual_func;
@@ -341,13 +405,31 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 		ERR_FAIL_MSG("Attempt to register an extension class '" + String(class_name) + "' using non-existing parent class '" + String(parent_class_name) + "'");
 	}
 
+#ifdef TOOLS_ENABLED
+	Extension *extension = nullptr;
+	if (self->is_reloading && self->extension_classes.has(class_name)) {
+		extension = &self->extension_classes[class_name];
+		if (!parent_extension && parent_class_name != extension->gdextension.parent_class_name) {
+			ERR_FAIL_MSG(vformat("GDExtension class '%s' attempt to change parent type from '%s' to '%s' on hot reload. Restart Godot for this change to take effect.", class_name, extension->gdextension.parent_class_name, parent_class_name));
+		}
+		extension->is_reloading = false;
+	} else {
+		self->extension_classes[class_name] = Extension();
+		extension = &self->extension_classes[class_name];
+	}
+#else
 	self->extension_classes[class_name] = Extension();
-
 	Extension *extension = &self->extension_classes[class_name];
+#endif
 
 	if (parent_extension) {
 		extension->gdextension.parent = &parent_extension->gdextension;
 		parent_extension->gdextension.children.push_back(&extension->gdextension);
+	}
+
+	if (self->reloadable && p_extension_funcs->recreate_instance_func == nullptr) {
+		ERR_PRINT(vformat("Extension marked as reloadable, but attempted to register class '%s' which doesn't support reloading. Perhaps your language binding don't support it? Reloading disabled for this extension.", class_name));
+		self->reloadable = false;
 	}
 
 	extension->gdextension.library = self;
@@ -376,10 +458,24 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	extension->gdextension.class_userdata = p_extension_funcs->class_userdata;
 	extension->gdextension.create_instance = p_extension_funcs->create_instance_func;
 	extension->gdextension.free_instance = p_extension_funcs->free_instance_func;
+	extension->gdextension.recreate_instance = p_extension_funcs->recreate_instance_func;
 	extension->gdextension.get_virtual = p_extension_funcs->get_virtual_func;
 	extension->gdextension.get_virtual_call_data = p_extension_funcs->get_virtual_call_data_func;
 	extension->gdextension.call_virtual_with_data = p_extension_funcs->call_virtual_with_data_func;
 	extension->gdextension.get_rid = p_extension_funcs->get_rid_func;
+
+	extension->gdextension.reloadable = self->reloadable;
+#ifdef TOOLS_ENABLED
+	if (extension->gdextension.reloadable) {
+		extension->gdextension.tracking_userdata = extension;
+		extension->gdextension.track_instance = &GDExtension::_track_instance;
+		extension->gdextension.untrack_instance = &GDExtension::_untrack_instance;
+	} else {
+		extension->gdextension.tracking_userdata = nullptr;
+		extension->gdextension.track_instance = nullptr;
+		extension->gdextension.untrack_instance = nullptr;
+	}
+#endif
 
 	ClassDB::register_extension_class(&extension->gdextension);
 }
@@ -391,10 +487,39 @@ void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_
 	StringName method_name = *reinterpret_cast<const StringName *>(p_method_info->name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension method '" + String(method_name) + "' for unexisting class '" + class_name + "'.");
 
-	//Extension *extension = &self->extension_classes[class_name];
+#ifdef TOOLS_ENABLED
+	Extension *extension = &self->extension_classes[class_name];
+	GDExtensionMethodBind *method = nullptr;
 
+	// If the extension is still marked as reloading, that means it failed to register again.
+	if (extension->is_reloading) {
+		return;
+	}
+
+	if (self->is_reloading && extension->methods.has(method_name)) {
+		method = extension->methods[method_name];
+
+		// Try to update the method bind. If it doesn't work (because it's incompatible) then
+		// mark as invalid and create a new one.
+		if (!method->is_reloading || !method->try_update(p_method_info)) {
+			method->valid = false;
+			self->invalid_methods.push_back(method);
+
+			method = nullptr;
+		}
+	}
+
+	if (method == nullptr) {
+		method = memnew(GDExtensionMethodBind(p_method_info));
+		method->set_instance_class(class_name);
+		extension->methods[method_name] = method;
+	} else {
+		method->is_reloading = false;
+	}
+#else
 	GDExtensionMethodBind *method = memnew(GDExtensionMethodBind(p_method_info));
 	method->set_instance_class(class_name);
+#endif
 
 	ClassDB::bind_method_custom(class_name, method);
 }
@@ -405,6 +530,14 @@ void GDExtension::_register_extension_class_integer_constant(GDExtensionClassLib
 	StringName enum_name = *reinterpret_cast<const StringName *>(p_enum_name);
 	StringName constant_name = *reinterpret_cast<const StringName *>(p_constant_name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension constant '" + constant_name + "' for unexisting class '" + class_name + "'.");
+
+#ifdef TOOLS_ENABLED
+	// If the extension is still marked as reloading, that means it failed to register again.
+	Extension *extension = &self->extension_classes[class_name];
+	if (extension->is_reloading) {
+		return;
+	}
+#endif
 
 	ClassDB::bind_integer_constant(class_name, enum_name, constant_name, p_constant_value, p_is_bitfield);
 }
@@ -422,6 +555,14 @@ void GDExtension::_register_extension_class_property_indexed(GDExtensionClassLib
 	String property_name = *reinterpret_cast<const StringName *>(p_info->name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class property '" + property_name + "' for unexisting class '" + class_name + "'.");
 
+#ifdef TOOLS_ENABLED
+	// If the extension is still marked as reloading, that means it failed to register again.
+	Extension *extension = &self->extension_classes[class_name];
+	if (extension->is_reloading) {
+		return;
+	}
+#endif
+
 	PropertyInfo pinfo(*p_info);
 
 	ClassDB::add_property(class_name, pinfo, setter, getter, p_index);
@@ -435,6 +576,14 @@ void GDExtension::_register_extension_class_property_group(GDExtensionClassLibra
 	String prefix = *reinterpret_cast<const String *>(p_prefix);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class property group '" + group_name + "' for unexisting class '" + class_name + "'.");
 
+#ifdef TOOLS_ENABLED
+	// If the extension is still marked as reloading, that means it failed to register again.
+	Extension *extension = &self->extension_classes[class_name];
+	if (extension->is_reloading) {
+		return;
+	}
+#endif
+
 	ClassDB::add_property_group(class_name, group_name, prefix);
 }
 
@@ -446,6 +595,14 @@ void GDExtension::_register_extension_class_property_subgroup(GDExtensionClassLi
 	String prefix = *reinterpret_cast<const String *>(p_prefix);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class property subgroup '" + subgroup_name + "' for unexisting class '" + class_name + "'.");
 
+#ifdef TOOLS_ENABLED
+	// If the extension is still marked as reloading, that means it failed to register again.
+	Extension *extension = &self->extension_classes[class_name];
+	if (extension->is_reloading) {
+		return;
+	}
+#endif
+
 	ClassDB::add_property_subgroup(class_name, subgroup_name, prefix);
 }
 
@@ -455,6 +612,14 @@ void GDExtension::_register_extension_class_signal(GDExtensionClassLibraryPtr p_
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	StringName signal_name = *reinterpret_cast<const StringName *>(p_signal_name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class signal '" + signal_name + "' for unexisting class '" + class_name + "'.");
+
+#ifdef TOOLS_ENABLED
+	// If the extension is still marked as reloading, that means it failed to register again.
+	Extension *extension = &self->extension_classes[class_name];
+	if (extension->is_reloading) {
+		return;
+	}
+#endif
 
 	MethodInfo s;
 	s.name = signal_name;
@@ -470,14 +635,32 @@ void GDExtension::_unregister_extension_class(GDExtensionClassLibraryPtr p_libra
 
 	StringName class_name = *reinterpret_cast<const StringName *>(p_class_name);
 	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to unregister unexisting extension class '" + class_name + "'.");
+
 	Extension *ext = &self->extension_classes[class_name];
+#ifdef TOOLS_ENABLED
+	if (ext->is_reloading) {
+		self->_clear_extension(ext);
+	}
+#endif
 	ERR_FAIL_COND_MSG(ext->gdextension.children.size(), "Attempt to unregister class '" + class_name + "' while other extension classes inherit from it.");
 
+#ifdef TOOLS_ENABLED
+	ClassDB::unregister_extension_class(class_name, !ext->is_reloading);
+#else
 	ClassDB::unregister_extension_class(class_name);
+#endif
+
 	if (ext->gdextension.parent != nullptr) {
 		ext->gdextension.parent->children.erase(&ext->gdextension);
 	}
+
+#ifdef TOOLS_ENABLED
+	if (!ext->is_reloading) {
+		self->extension_classes.erase(class_name);
+	}
+#else
 	self->extension_classes.erase(class_name);
+#endif
 }
 
 void GDExtension::_get_library_path(GDExtensionClassLibraryPtr p_library, GDExtensionUninitializedStringPtr r_path) {
@@ -540,6 +723,11 @@ void GDExtension::close_library() {
 #endif
 
 	library = nullptr;
+	class_icon_paths.clear();
+
+#ifdef TOOLS_ENABLED
+	instance_bindings.clear();
+#endif
 }
 
 bool GDExtension::is_library_open() const {
@@ -590,6 +778,12 @@ GDExtension::~GDExtension() {
 	if (library != nullptr) {
 		close_library();
 	}
+#ifdef TOOLS_ENABLED
+	// If we have any invalid method binds still laying around, we can finally free them!
+	for (GDExtensionMethodBind *E : invalid_methods) {
+		memdelete(E);
+	}
+#endif
 }
 
 void GDExtension::initialize_gdextensions() {
@@ -610,27 +804,22 @@ void GDExtension::initialize_gdextensions() {
 	register_interface_function("get_library_path", (GDExtensionInterfaceFunctionPtr)&GDExtension::_get_library_path);
 }
 
-Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path, Ref<GDExtension> &p_extension) {
+	ERR_FAIL_COND_V_MSG(p_extension.is_valid() && p_extension->is_library_open(), ERR_ALREADY_IN_USE, "Cannot load GDExtension resource into already opened library.");
+
 	Ref<ConfigFile> config;
 	config.instantiate();
 
 	Error err = config->load(p_path);
 
-	if (r_error) {
-		*r_error = err;
-	}
-
 	if (err != OK) {
 		ERR_PRINT("Error loading GDExtension configuration file: " + p_path);
-		return Ref<Resource>();
+		return err;
 	}
 
 	if (!config->has_section_key("configuration", "entry_symbol")) {
-		if (r_error) {
-			*r_error = ERR_INVALID_DATA;
-		}
 		ERR_PRINT("GDExtension configuration file must contain a \"configuration/entry_symbol\" key: " + p_path);
-		return Ref<Resource>();
+		return ERR_INVALID_DATA;
 	}
 
 	String entry_symbol = config->get_value("configuration", "entry_symbol");
@@ -648,19 +837,13 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 			}
 		}
 	} else {
-		if (r_error) {
-			*r_error = ERR_INVALID_DATA;
-		}
 		ERR_PRINT("GDExtension configuration file must contain a \"configuration/compatibility_minimum\" key: " + p_path);
-		return Ref<Resource>();
+		return ERR_INVALID_DATA;
 	}
 
 	if (compatibility_minimum[0] < 4 || (compatibility_minimum[0] == 4 && compatibility_minimum[1] == 0)) {
-		if (r_error) {
-			*r_error = ERR_INVALID_DATA;
-		}
 		ERR_PRINT(vformat("GDExtension's compatibility_minimum (%d.%d.%d) must be at least 4.1.0: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
-		return Ref<Resource>();
+		return ERR_INVALID_DATA;
 	}
 
 	bool compatible = true;
@@ -673,42 +856,42 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 		compatible = VERSION_PATCH >= compatibility_minimum[2];
 	}
 	if (!compatible) {
-		if (r_error) {
-			*r_error = ERR_INVALID_DATA;
-		}
 		ERR_PRINT(vformat("GDExtension only compatible with Godot version %d.%d.%d or later: %s", compatibility_minimum[0], compatibility_minimum[1], compatibility_minimum[2], p_path));
-		return Ref<Resource>();
+		return ERR_INVALID_DATA;
 	}
 
 	String library_path = GDExtension::find_extension_library(p_path, config, [](String p_feature) { return OS::get_singleton()->has_feature(p_feature); });
 
 	if (library_path.is_empty()) {
-		if (r_error) {
-			*r_error = ERR_FILE_NOT_FOUND;
-		}
 		const String os_arch = OS::get_singleton()->get_name().to_lower() + "." + Engine::get_singleton()->get_architecture_name();
 		ERR_PRINT(vformat("No GDExtension library found for current OS and architecture (%s) in configuration file: %s", os_arch, p_path));
-		return Ref<Resource>();
+		return ERR_FILE_NOT_FOUND;
 	}
 
 	if (!library_path.is_resource_file() && !library_path.is_absolute_path()) {
 		library_path = p_path.get_base_dir().path_join(library_path);
 	}
 
-	Ref<GDExtension> lib;
-	lib.instantiate();
-	String abs_path = ProjectSettings::get_singleton()->globalize_path(library_path);
+	if (p_extension.is_null()) {
+		p_extension.instantiate();
+	}
 
+#ifdef TOOLS_ENABLED
+	p_extension->set_reloadable(config->get_value("configuration", "reloadable", false) && Engine::get_singleton()->is_extension_reloading_enabled());
+
+	p_extension->update_last_modified_time(MAX(
+			FileAccess::get_modified_time(library_path),
+			FileAccess::get_modified_time(p_path)));
+#endif
+
+	String abs_path = ProjectSettings::get_singleton()->globalize_path(library_path);
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
 	// If running on the editor on Windows, we copy the library and open the copy.
 	// This is so the original file isn't locked and can be updated by a compiler.
 	if (Engine::get_singleton()->is_editor_hint()) {
 		if (!FileAccess::exists(abs_path)) {
-			if (r_error) {
-				*r_error = ERR_FILE_NOT_FOUND;
-			}
 			ERR_PRINT("GDExtension library not found: " + library_path);
-			return Ref<Resource>();
+			return ERR_FILE_NOT_FOUND;
 		}
 
 		// Copy the file to the same directory as the original with a prefix in the name.
@@ -722,36 +905,29 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 
 		Error copy_err = DirAccess::copy_absolute(abs_path, copy_path);
 		if (copy_err) {
-			if (r_error) {
-				*r_error = ERR_CANT_CREATE;
-			}
 			ERR_PRINT("Error copying GDExtension library: " + library_path);
-			return Ref<Resource>();
+			return ERR_CANT_CREATE;
 		}
 		FileAccess::set_hidden_attribute(copy_path, true);
 
 		// Save the copied path so it can be deleted later.
-		lib->set_temp_library_path(copy_path);
+		p_extension->set_temp_library_path(copy_path);
 
 		// Use the copy to open the library.
 		abs_path = copy_path;
 	}
 #endif
-	err = lib->open_library(abs_path, entry_symbol);
 
-	if (r_error) {
-		*r_error = err;
-	}
-
+	err = p_extension->open_library(abs_path, entry_symbol);
 	if (err != OK) {
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
 		// If the DLL fails to load, make sure that temporary DLL copies are cleaned up.
 		if (Engine::get_singleton()->is_editor_hint()) {
-			DirAccess::remove_absolute(lib->get_temp_library_path());
+			DirAccess::remove_absolute(p_extension->get_temp_library_path());
 		}
 #endif
 		// Errors already logged in open_library()
-		return Ref<Resource>();
+		return err;
 	}
 
 	// Handle icons if any are specified.
@@ -759,10 +935,20 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 		List<String> keys;
 		config->get_section_keys("icons", &keys);
 		for (const String &key : keys) {
-			lib->class_icon_paths[key] = config->get_value("icons", key);
+			p_extension->class_icon_paths[key] = config->get_value("icons", key);
 		}
 	}
 
+	return OK;
+}
+
+Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	Ref<GDExtension> lib;
+	Error err = load_gdextension_resource(p_path, lib);
+	if (err != OK && r_error) {
+		// Errors already logged in load_gdextension_resource().
+		*r_error = err;
+	}
 	return lib;
 }
 
@@ -783,6 +969,183 @@ String GDExtensionResourceLoader::get_resource_type(const String &p_path) const 
 }
 
 #ifdef TOOLS_ENABLED
+bool GDExtension::has_library_changed() const {
+	if (FileAccess::get_modified_time(get_path()) > last_modified_time) {
+		return true;
+	}
+	if (FileAccess::get_modified_time(library_path) > last_modified_time) {
+		return true;
+	}
+	return false;
+}
+
+void GDExtension::prepare_reload() {
+	is_reloading = true;
+
+	for (KeyValue<StringName, Extension> &E : extension_classes) {
+		E.value.is_reloading = true;
+
+		for (KeyValue<StringName, GDExtensionMethodBind *> &M : E.value.methods) {
+			M.value->is_reloading = true;
+		}
+
+		for (const ObjectID &obj_id : E.value.instances) {
+			Object *obj = ObjectDB::get_instance(obj_id);
+			if (!obj) {
+				continue;
+			}
+
+			// Store instance state so it can be restored after reload.
+			List<Pair<String, Variant>> state;
+			List<PropertyInfo> prop_list;
+			obj->get_property_list(&prop_list);
+			for (const PropertyInfo &P : prop_list) {
+				if (!(P.usage & PROPERTY_USAGE_STORAGE)) {
+					continue;
+				}
+
+				Variant value = obj->get(P.name);
+				Variant default_value = ClassDB::class_get_default_property_value(obj->get_class_name(), P.name);
+
+				if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value))) {
+					continue;
+				}
+
+				if (P.type == Variant::OBJECT && value.is_zero() && !(P.usage & PROPERTY_USAGE_STORE_IF_NULL)) {
+					continue;
+				}
+
+				state.push_back(Pair<String, Variant>(P.name, value));
+			}
+			E.value.instance_state[obj_id] = state;
+		}
+	}
+}
+
+void GDExtension::_clear_extension(Extension *p_extension) {
+	// Clear out hierarchy information because it may change.
+	p_extension->gdextension.parent = nullptr;
+	p_extension->gdextension.children.clear();
+
+	// Clear all objects of any GDExtension data. It will become its native parent class
+	// until the reload can reset the object with the new GDExtension data.
+	for (const ObjectID &obj_id : p_extension->instances) {
+		Object *obj = ObjectDB::get_instance(obj_id);
+		if (!obj) {
+			continue;
+		}
+
+		obj->clear_internal_extension();
+	}
+}
+
+void GDExtension::track_instance_binding(Object *p_object) {
+	instance_bindings.push_back(p_object->get_instance_id());
+}
+
+void GDExtension::untrack_instance_binding(Object *p_object) {
+	instance_bindings.erase(p_object->get_instance_id());
+}
+
+void GDExtension::clear_instance_bindings() {
+	for (ObjectID obj_id : instance_bindings) {
+		Object *obj = ObjectDB::get_instance(obj_id);
+		if (!obj) {
+			continue;
+		}
+
+		obj->free_instance_binding(this);
+	}
+	instance_bindings.clear();
+}
+
+void GDExtension::finish_reload() {
+	is_reloading = false;
+
+	// Clean up any classes or methods that didn't get re-added.
+	Vector<StringName> classes_to_remove;
+	for (KeyValue<StringName, Extension> &E : extension_classes) {
+		if (E.value.is_reloading) {
+			E.value.is_reloading = false;
+			classes_to_remove.push_back(E.key);
+		}
+
+		Vector<StringName> methods_to_remove;
+		for (KeyValue<StringName, GDExtensionMethodBind *> &M : E.value.methods) {
+			if (M.value->is_reloading) {
+				M.value->valid = false;
+				invalid_methods.push_back(M.value);
+
+				M.value->is_reloading = false;
+				methods_to_remove.push_back(M.key);
+			}
+		}
+		for (const StringName &method_name : methods_to_remove) {
+			E.value.methods.erase(method_name);
+		}
+	}
+	for (const StringName &class_name : classes_to_remove) {
+		extension_classes.erase(class_name);
+	}
+
+	// Reset any the extension on instances made from the classes that remain.
+	for (KeyValue<StringName, Extension> &E : extension_classes) {
+		// Loop over 'instance_state' rather than 'instance' because new instances
+		// may have been created when re-initializing the extension.
+		for (const KeyValue<ObjectID, List<Pair<String, Variant>>> &S : E.value.instance_state) {
+			Object *obj = ObjectDB::get_instance(S.key);
+			if (!obj) {
+				continue;
+			}
+
+			obj->reset_internal_extension(&E.value.gdextension);
+		}
+	}
+
+	// Now that all the classes are back, restore the state.
+	for (KeyValue<StringName, Extension> &E : extension_classes) {
+		for (const KeyValue<ObjectID, List<Pair<String, Variant>>> &S : E.value.instance_state) {
+			Object *obj = ObjectDB::get_instance(S.key);
+			if (!obj) {
+				continue;
+			}
+
+			for (const Pair<String, Variant> &state : S.value) {
+				obj->set(state.first, state.second);
+			}
+		}
+	}
+
+	// Finally, let the objects know that we are done reloading them.
+	for (KeyValue<StringName, Extension> &E : extension_classes) {
+		for (const KeyValue<ObjectID, List<Pair<String, Variant>>> &S : E.value.instance_state) {
+			Object *obj = ObjectDB::get_instance(S.key);
+			if (!obj) {
+				continue;
+			}
+
+			obj->notification(NOTIFICATION_EXTENSION_RELOADED);
+		}
+
+		// Clear the instance state, we're done looping.
+		E.value.instance_state.clear();
+	}
+}
+
+void GDExtension::_track_instance(void *p_user_data, void *p_instance) {
+	Extension *extension = reinterpret_cast<Extension *>(p_user_data);
+	Object *obj = reinterpret_cast<Object *>(p_instance);
+
+	extension->instances.insert(obj->get_instance_id());
+}
+
+void GDExtension::_untrack_instance(void *p_user_data, void *p_instance) {
+	Extension *extension = reinterpret_cast<Extension *>(p_user_data);
+	Object *obj = reinterpret_cast<Object *>(p_instance);
+
+	extension->instances.erase(obj->get_instance_id());
+}
+
 Vector<StringName> GDExtensionEditorPlugins::extension_classes;
 GDExtensionEditorPlugins::EditorPluginRegisterFunc GDExtensionEditorPlugins::editor_node_add_plugin = nullptr;
 GDExtensionEditorPlugins::EditorPluginRegisterFunc GDExtensionEditorPlugins::editor_node_remove_plugin = nullptr;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -267,6 +267,7 @@ typedef void (*GDExtensionClassUnreference)(GDExtensionClassInstancePtr p_instan
 typedef void (*GDExtensionClassCallVirtual)(GDExtensionClassInstancePtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
 typedef GDExtensionObjectPtr (*GDExtensionClassCreateInstance)(void *p_class_userdata);
 typedef void (*GDExtensionClassFreeInstance)(void *p_class_userdata, GDExtensionClassInstancePtr p_instance);
+typedef GDExtensionClassInstancePtr (*GDExtensionClassRecreateInstance)(void *p_class_userdata, GDExtensionObjectPtr p_object);
 typedef GDExtensionClassCallVirtual (*GDExtensionClassGetVirtual)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
 typedef void *(*GDExtensionClassGetVirtualCallData)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
 typedef void (*GDExtensionClassCallVirtualWithData)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, void *p_virtual_call_userdata, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
@@ -308,6 +309,7 @@ typedef struct {
 	GDExtensionClassUnreference unreference_func;
 	GDExtensionClassCreateInstance create_instance_func; // (Default) constructor; mandatory. If the class is not instantiable, consider making it virtual or abstract.
 	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
+	GDExtensionClassRecreateInstance recreate_instance_func;
 	// Queries a virtual function by name and returns a callback to invoke the requested virtual function.
 	GDExtensionClassGetVirtual get_virtual_func;
 	// Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -32,6 +32,41 @@
 
 #include "core/extension/gdextension_compat_hashes.h"
 #include "core/io/file_access.h"
+#include "core/object/script_language.h"
+
+GDExtensionManager::LoadStatus GDExtensionManager::_load_extension_internal(const Ref<GDExtension> &p_extension) {
+	if (level >= 0) { // Already initialized up to some level.
+		int32_t minimum_level = p_extension->get_minimum_library_initialization_level();
+		if (minimum_level < MIN(level, GDExtension::INITIALIZATION_LEVEL_SCENE)) {
+			return LOAD_STATUS_NEEDS_RESTART;
+		}
+		// Initialize up to current level.
+		for (int32_t i = minimum_level; i <= level; i++) {
+			p_extension->initialize_library(GDExtension::InitializationLevel(i));
+		}
+	}
+
+	for (const KeyValue<String, String> &kv : p_extension->class_icon_paths) {
+		gdextension_class_icon_paths[kv.key] = kv.value;
+	}
+
+	return LOAD_STATUS_OK;
+}
+
+GDExtensionManager::LoadStatus GDExtensionManager::_unload_extension_internal(const Ref<GDExtension> &p_extension) {
+	if (level >= 0) { // Already initialized up to some level.
+		// Deinitialize down from current level.
+		for (int32_t i = level; i >= GDExtension::INITIALIZATION_LEVEL_CORE; i--) {
+			p_extension->deinitialize_library(GDExtension::InitializationLevel(i));
+		}
+	}
+
+	for (const KeyValue<String, String> &kv : p_extension->class_icon_paths) {
+		gdextension_class_icon_paths.erase(kv.key);
+	}
+
+	return LOAD_STATUS_OK;
+}
 
 GDExtensionManager::LoadStatus GDExtensionManager::load_extension(const String &p_path) {
 	if (gdextension_map.has(p_path)) {
@@ -42,19 +77,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::load_extension(const String &
 		return LOAD_STATUS_FAILED;
 	}
 
-	if (level >= 0) { // Already initialized up to some level.
-		int32_t minimum_level = extension->get_minimum_library_initialization_level();
-		if (minimum_level < MIN(level, GDExtension::INITIALIZATION_LEVEL_SCENE)) {
-			return LOAD_STATUS_NEEDS_RESTART;
-		}
-		// Initialize up to current level.
-		for (int32_t i = minimum_level; i <= level; i++) {
-			extension->initialize_library(GDExtension::InitializationLevel(i));
-		}
-	}
-
-	for (const KeyValue<String, String> &kv : extension->class_icon_paths) {
-		gdextension_class_icon_paths[kv.key] = kv.value;
+	LoadStatus status = _load_extension_internal(extension);
+	if (status != LOAD_STATUS_OK) {
+		return status;
 	}
 
 	gdextension_map[p_path] = extension;
@@ -62,8 +87,52 @@ GDExtensionManager::LoadStatus GDExtensionManager::load_extension(const String &
 }
 
 GDExtensionManager::LoadStatus GDExtensionManager::reload_extension(const String &p_path) {
-	return LOAD_STATUS_OK; //TODO
+#ifndef TOOLS_ENABLED
+	ERR_FAIL_V_MSG(LOAD_STATUS_FAILED, "GDExtensions can only be reloaded in an editor build.");
+#else
+	ERR_FAIL_COND_V_MSG(!Engine::get_singleton()->is_extension_reloading_enabled(), LOAD_STATUS_FAILED, "GDExtension reloading is disabled.");
+
+	if (!gdextension_map.has(p_path)) {
+		return LOAD_STATUS_NOT_LOADED;
+	}
+
+	Ref<GDExtension> extension = gdextension_map[p_path];
+	ERR_FAIL_COND_V_MSG(!extension->is_reloadable(), LOAD_STATUS_FAILED, vformat("This GDExtension is not marked as 'reloadable' or doesn't support reloading: %s.", p_path));
+
+	LoadStatus status;
+
+	extension->prepare_reload();
+
+	// Unload library if it's open. It may not be open if the developer made a
+	// change that broke loading in a previous hot-reload attempt.
+	if (extension->is_library_open()) {
+		status = _unload_extension_internal(extension);
+		if (status != LOAD_STATUS_OK) {
+			// We need to clear these no matter what.
+			extension->clear_instance_bindings();
+			return status;
+		}
+
+		extension->clear_instance_bindings();
+		extension->close_library();
+	}
+
+	Error err = GDExtensionResourceLoader::load_gdextension_resource(p_path, extension);
+	if (err != OK) {
+		return LOAD_STATUS_FAILED;
+	}
+
+	status = _load_extension_internal(extension);
+	if (status != LOAD_STATUS_OK) {
+		return status;
+	}
+
+	extension->finish_reload();
+
+	return LOAD_STATUS_OK;
+#endif
 }
+
 GDExtensionManager::LoadStatus GDExtensionManager::unload_extension(const String &p_path) {
 	if (!gdextension_map.has(p_path)) {
 		return LOAD_STATUS_NOT_LOADED;
@@ -71,19 +140,9 @@ GDExtensionManager::LoadStatus GDExtensionManager::unload_extension(const String
 
 	Ref<GDExtension> extension = gdextension_map[p_path];
 
-	if (level >= 0) { // Already initialized up to some level.
-		int32_t minimum_level = extension->get_minimum_library_initialization_level();
-		if (minimum_level < MIN(level, GDExtension::INITIALIZATION_LEVEL_SCENE)) {
-			return LOAD_STATUS_NEEDS_RESTART;
-		}
-		// Deinitialize down to current level.
-		for (int32_t i = level; i >= minimum_level; i--) {
-			extension->deinitialize_library(GDExtension::InitializationLevel(i));
-		}
-	}
-
-	for (const KeyValue<String, String> &kv : extension->class_icon_paths) {
-		gdextension_class_icon_paths.erase(kv.key);
+	LoadStatus status = _unload_extension_internal(extension);
+	if (status != LOAD_STATUS_OK) {
+		return status;
 	}
 
 	gdextension_map.erase(p_path);
@@ -136,6 +195,36 @@ void GDExtensionManager::deinitialize_extensions(GDExtension::InitializationLeve
 	level = int32_t(p_level) - 1;
 }
 
+#ifdef TOOLS_ENABLED
+void GDExtensionManager::track_instance_binding(void *p_token, Object *p_object) {
+	for (KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
+		if (E.value.ptr() == p_token) {
+			if (E.value->is_reloadable()) {
+				E.value->track_instance_binding(p_object);
+				return;
+			}
+		}
+	}
+}
+
+void GDExtensionManager::untrack_instance_binding(void *p_token, Object *p_object) {
+	for (KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
+		if (E.value.ptr() == p_token) {
+			if (E.value->is_reloadable()) {
+				E.value->untrack_instance_binding(p_object);
+				return;
+			}
+		}
+	}
+}
+
+void GDExtensionManager::_reload_all_scripts() {
+	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+		ScriptServer::get_language(i)->reload_all_scripts();
+	}
+}
+#endif // TOOLS_ENABLED
+
 void GDExtensionManager::load_extensions() {
 	Ref<FileAccess> f = FileAccess::open(GDExtension::get_extension_list_config_file(), FileAccess::READ);
 	while (f.is_valid() && !f->eof_reached()) {
@@ -149,9 +238,33 @@ void GDExtensionManager::load_extensions() {
 	OS::get_singleton()->load_platform_gdextensions();
 }
 
+void GDExtensionManager::reload_extensions() {
+#ifdef TOOLS_ENABLED
+	bool reloaded = false;
+	for (const KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
+		if (!E.value->is_reloadable()) {
+			continue;
+		}
+
+		if (E.value->has_library_changed()) {
+			reloaded = true;
+			reload_extension(E.value->get_path());
+		}
+	}
+
+	if (reloaded) {
+		emit_signal("extensions_reloaded");
+
+		// Reload all scripts to clear out old references.
+		callable_mp_static(&GDExtensionManager::_reload_all_scripts).call_deferred();
+	}
+#endif
+}
+
 GDExtensionManager *GDExtensionManager::get_singleton() {
 	return singleton;
 }
+
 void GDExtensionManager::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_extension", "path"), &GDExtensionManager::load_extension);
 	ClassDB::bind_method(D_METHOD("reload_extension", "path"), &GDExtensionManager::reload_extension);
@@ -166,6 +279,8 @@ void GDExtensionManager::_bind_methods() {
 	BIND_ENUM_CONSTANT(LOAD_STATUS_ALREADY_LOADED);
 	BIND_ENUM_CONSTANT(LOAD_STATUS_NOT_LOADED);
 	BIND_ENUM_CONSTANT(LOAD_STATUS_NEEDS_RESTART);
+
+	ADD_SIGNAL(MethodInfo("extensions_reloaded"));
 }
 
 GDExtensionManager *GDExtensionManager::singleton = nullptr;

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -53,6 +53,15 @@ public:
 		LOAD_STATUS_NEEDS_RESTART,
 	};
 
+private:
+	LoadStatus _load_extension_internal(const Ref<GDExtension> &p_extension);
+	LoadStatus _unload_extension_internal(const Ref<GDExtension> &p_extension);
+
+#ifdef TOOLS_ENABLED
+	static void _reload_all_scripts();
+#endif
+
+public:
 	LoadStatus load_extension(const String &p_path);
 	LoadStatus reload_extension(const String &p_path);
 	LoadStatus unload_extension(const String &p_path);
@@ -66,9 +75,15 @@ public:
 	void initialize_extensions(GDExtension::InitializationLevel p_level);
 	void deinitialize_extensions(GDExtension::InitializationLevel p_level);
 
+#ifdef TOOLS_ENABLED
+	void track_instance_binding(void *p_token, Object *p_object);
+	void untrack_instance_binding(void *p_token, Object *p_object);
+#endif
+
 	static GDExtensionManager *get_singleton();
 
 	void load_extensions();
+	void reload_extensions();
 
 	GDExtensionManager();
 };

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -348,7 +348,13 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 	}
 #endif
 	if (ti->gdextension && ti->gdextension->create_instance) {
-		return (Object *)ti->gdextension->create_instance(ti->gdextension->class_userdata);
+		Object *obj = (Object *)ti->gdextension->create_instance(ti->gdextension->class_userdata);
+#ifdef TOOLS_ENABLED
+		if (ti->gdextension->track_instance) {
+			ti->gdextension->track_instance(ti->gdextension->tracking_userdata, obj);
+		}
+#endif
+		return obj;
 	} else {
 		return ti->creation_func();
 	}
@@ -1545,6 +1551,14 @@ bool ClassDB::is_class_exposed(const StringName &p_class) {
 	return ti->exposed;
 }
 
+bool ClassDB::is_class_reloadable(const StringName &p_class) {
+	OBJTYPE_RLOCK;
+
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
+	return ti->reloadable;
+}
+
 void ClassDB::add_resource_base_extension(const StringName &p_extension, const StringName &p_class) {
 	if (resource_base_extensions.has(p_extension)) {
 		return;
@@ -1683,15 +1697,18 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 			parent = classes.getptr(parent->name);
 		}
 	}
+	c.reloadable = p_extension->reloadable;
 
 	classes[p_extension->class_name] = c;
 }
 
-void ClassDB::unregister_extension_class(const StringName &p_class) {
+void ClassDB::unregister_extension_class(const StringName &p_class, bool p_free_method_binds) {
 	ClassInfo *c = classes.getptr(p_class);
 	ERR_FAIL_NULL_MSG(c, "Class '" + String(p_class) + "' does not exist.");
-	for (KeyValue<StringName, MethodBind *> &F : c->method_map) {
-		memdelete(F.value);
+	if (p_free_method_binds) {
+		for (KeyValue<StringName, MethodBind *> &F : c->method_map) {
+			memdelete(F.value);
+		}
 	}
 	classes.erase(p_class);
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -131,6 +131,7 @@ public:
 		StringName name;
 		bool disabled = false;
 		bool exposed = false;
+		bool reloadable = false;
 		bool is_virtual = false;
 		Object *(*creation_func)() = nullptr;
 
@@ -228,7 +229,7 @@ public:
 	}
 
 	static void register_extension_class(ObjectGDExtension *p_extension);
-	static void unregister_extension_class(const StringName &p_class);
+	static void unregister_extension_class(const StringName &p_class, bool p_free_method_binds = true);
 
 	template <class T>
 	static Object *_create_ptr_func() {
@@ -426,6 +427,7 @@ public:
 	static bool is_class_enabled(const StringName &p_class);
 
 	static bool is_class_exposed(const StringName &p_class);
+	static bool is_class_reloadable(const StringName &p_class);
 
 	static void add_resource_base_extension(const StringName &p_extension, const StringName &p_class);
 	static void get_resource_base_extensions(List<String> *p_extensions);

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -22,6 +22,7 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
         } else if (_get_extension()->get_virtual) {\\
             _gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
         }\\
+        GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized); \\
         _gdvirtual_##m_name##_initialized = true;\\
     }\\
 	if (_gdvirtual_##m_name) {\\
@@ -56,6 +57,7 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const { \\
         } else if (_get_extension()->get_virtual) {\\
              _gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
         }\\
+        GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized); \\
         _gdvirtual_##m_name##_initialized = true;\\
     }\\
 	if (_gdvirtual_##m_name) {\\
@@ -175,6 +177,18 @@ def run(target, source, env):
 
 #include "core/object/script_instance.h"
 
+#ifdef TOOLS_ENABLED
+#define GDVIRTUAL_TRACK(m_virtual, m_initialized) \\
+    if (_get_extension()->reloadable) {\\
+        VirtualMethodTracker *tracker = memnew(VirtualMethodTracker);\\
+        tracker->method = (void **)&m_virtual;\\
+        tracker->initialized = &m_initialized;\\
+        tracker->next = virtual_method_list;\\
+        virtual_method_list = tracker;\\
+    }
+#else
+#define GDVIRTUAL_TRACK(m_virtual, m_initialized)
+#endif
 
 """
 

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -111,6 +111,10 @@ public:
 
 	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
 
+#ifdef TOOLS_ENABLED
+	virtual bool is_valid() const { return true; }
+#endif
+
 	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) const = 0;
 	virtual void validated_call(Object *p_object, const Variant **p_args, Variant *r_ret) const = 0;
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -31,6 +31,7 @@
 #include "object.h"
 
 #include "core/core_string_names.h"
+#include "core/extension/gdextension_manager.h"
 #include "core/io/resource.h"
 #include "core/object/class_db.h"
 #include "core/object/message_queue.h"
@@ -1791,14 +1792,17 @@ StringName Object::get_class_name_for_extension(const GDExtension *p_library) co
 }
 
 void Object::set_instance_binding(void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
-	// This is only meant to be used on creation by the binder.
-	ERR_FAIL_COND(_instance_bindings != nullptr);
-	_instance_bindings = (InstanceBinding *)memalloc(sizeof(InstanceBinding));
+	// This is only meant to be used on creation by the binder, but we also
+	// need to account for reloading (where the 'binding' will be cleared).
+	ERR_FAIL_COND(_instance_bindings != nullptr && _instance_bindings[0].binding != nullptr);
+	if (_instance_bindings == nullptr) {
+		_instance_bindings = (InstanceBinding *)memalloc(sizeof(InstanceBinding));
+		_instance_binding_count = 1;
+	}
 	_instance_bindings[0].binding = p_binding;
 	_instance_bindings[0].free_callback = p_callbacks->free_callback;
 	_instance_bindings[0].reference_callback = p_callbacks->reference_callback;
 	_instance_bindings[0].token = p_token;
-	_instance_binding_count = 1;
 }
 
 void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
@@ -1825,6 +1829,12 @@ void *Object::get_instance_binding(void *p_token, const GDExtensionInstanceBindi
 		binding = p_callbacks->create_callback(p_token, this);
 		_instance_bindings[_instance_binding_count].binding = binding;
 
+#ifdef TOOLS_ENABLED
+		if (!_extension && Engine::get_singleton()->is_extension_reloading_enabled()) {
+			GDExtensionManager::get_singleton()->track_instance_binding(p_token, this);
+		}
+#endif
+
 		_instance_binding_count++;
 	}
 
@@ -1847,6 +1857,71 @@ bool Object::has_instance_binding(void *p_token) {
 
 	return found;
 }
+
+#ifdef TOOLS_ENABLED
+void Object::free_instance_binding(void *p_token) {
+	bool found = false;
+	_instance_binding_mutex.lock();
+	for (uint32_t i = 0; i < _instance_binding_count; i++) {
+		if (!found && _instance_bindings[i].token == p_token) {
+			if (_instance_bindings[i].free_callback) {
+				_instance_bindings[i].free_callback(_instance_bindings[i].token, this, _instance_bindings[i].binding);
+			}
+			found = true;
+		}
+		if (found) {
+			if (i + 1 < _instance_binding_count) {
+				_instance_bindings[i] = _instance_bindings[i + 1];
+			} else {
+				_instance_bindings[i] = { nullptr };
+			}
+		}
+	}
+	if (found) {
+		_instance_binding_count--;
+	}
+	_instance_binding_mutex.unlock();
+}
+
+void Object::clear_internal_extension() {
+	ERR_FAIL_NULL(_extension);
+
+	// Free the instance inside the GDExtension.
+	if (_extension->free_instance) {
+		_extension->free_instance(_extension->class_userdata, _extension_instance);
+	}
+	_extension = nullptr;
+	_extension_instance = nullptr;
+
+	// Clear the instance bindings.
+	_instance_binding_mutex.lock();
+	if (_instance_bindings[0].free_callback) {
+		_instance_bindings[0].free_callback(_instance_bindings[0].token, this, _instance_bindings[0].binding);
+	}
+	_instance_bindings[0].binding = nullptr;
+	_instance_bindings[0].token = nullptr;
+	_instance_bindings[0].free_callback = nullptr;
+	_instance_bindings[0].reference_callback = nullptr;
+	_instance_binding_mutex.unlock();
+
+	// Clear the virtual methods.
+	while (virtual_method_list) {
+		(*virtual_method_list->method) = nullptr;
+		(*virtual_method_list->initialized) = false;
+		virtual_method_list = virtual_method_list->next;
+	}
+}
+
+void Object::reset_internal_extension(ObjectGDExtension *p_extension) {
+	ERR_FAIL_COND(_extension != nullptr);
+
+	if (p_extension) {
+		_extension_instance = p_extension->recreate_instance ? p_extension->recreate_instance(p_extension->class_userdata, (GDExtensionObjectPtr)this) : nullptr;
+		ERR_FAIL_NULL_MSG(_extension_instance, "Unable to recreate GDExtension instance - does this extension support hot reloading?");
+		_extension = p_extension;
+	}
+}
+#endif
 
 void Object::_construct_object(bool p_reference) {
 	type_is_reference = p_reference;
@@ -1878,11 +1953,25 @@ Object::~Object() {
 	}
 	script_instance = nullptr;
 
-	if (_extension && _extension->free_instance) {
-		_extension->free_instance(_extension->class_userdata, _extension_instance);
+	if (_extension) {
+#ifdef TOOLS_ENABLED
+		if (_extension->untrack_instance) {
+			_extension->untrack_instance(_extension->tracking_userdata, this);
+		}
+#endif
+		if (_extension->free_instance) {
+			_extension->free_instance(_extension->class_userdata, _extension_instance);
+		}
 		_extension = nullptr;
 		_extension_instance = nullptr;
 	}
+#ifdef TOOLS_ENABLED
+	else if (_instance_bindings != nullptr && Engine::get_singleton()->is_extension_reloading_enabled()) {
+		for (uint32_t i = 0; i < _instance_binding_count; i++) {
+			GDExtensionManager::get_singleton()->untrack_instance_binding(_instance_bindings[i].token, this);
+		}
+	}
+#endif
 
 	if (_emitting) {
 		//@todo this may need to actually reach the debugger prioritarily somehow because it may crash before

--- a/doc/classes/GDExtensionManager.xml
+++ b/doc/classes/GDExtensionManager.xml
@@ -43,6 +43,13 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="extensions_reloaded">
+			<description>
+				Emitted after the editor has automatically reloaded any extensions.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="LOAD_STATUS_OK" value="0" enum="LoadStatus">
 		</constant>

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -597,6 +597,7 @@ private:
 	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 
 	void _update_from_settings();
+	void _gdextensions_reloaded();
 
 	void _renderer_selected(int);
 	void _update_renderer_color();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1605,6 +1605,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor) {
 		Engine::get_singleton()->set_editor_hint(true);
+		Engine::get_singleton()->set_extension_reloading_enabled(true);
 	}
 #endif
 


### PR DESCRIPTION
This is a ~~draft~~ PR adding "live" reloading of GDExtensions!

This would (partially) fix https://github.com/godotengine/godot/issues/66231

In order to work with godot-cpp, you need to use the companion PR https://github.com/godotengine/godot-cpp/pull/1200

## What works in my limited testing on Linux/Windows

- After re-compiling the extension, if you unfocus and then refocus the editor window, the extension will unload and then reload, replacing all the classes with their new versions
- It will reuse the method bind objects if the same method is re-added, so if GDScript or some other scripting language cached the method binds, they should keep working!
- The cached virtual method pointers will be cleared, so the new implementation will be picked up. (In my test project, I have it printing something in `_process()` and after reload it'll immediately start printing the new text!)
- Object properties will be saved and restored after the reload

## How to test

- Compile Godot using the code from this PR.
- Update your language binding to support hot-reload:
  - With godot-cpp, use this PR: https://github.com/godotengine/godot-cpp/pull/1200
  - Other language bindings need to be updated to pass `GDExtensionClassCreationInfo2::recreate_instance_func` which is used to create a new object defined by the GDExtension for a pre-existing object on the Godot side.
- Add `reloadable = true` to your .gdextension file

### Downloading pre-compiled binaries:

1. Login into github
2. Click the "checks" tab of this PR
3. On the right there's an "artifacts" button.
4. Download the appropriate build for your plaform

![image](https://github.com/godotengine/godot/assets/7917475/ba40d17f-8ba7-46cc-8dea-fc9758e383fb)

---

## TODO:

_UPDATE: I think the remaining TODO's can be done in follow-ups. What's in this PR should provide a working basis that can be built upon!_

- ~~Actual "live reloading" where the editor detects that the shared library has been updated and automatically initiates the reload. In the current PR, you have to manually call `GDExtensionManager.reload_extension(path)`~~
- ~~With the previous point, I think we probably want to allow GDExtensions to mark themselves as not being safe to reload. Or maybe each GDExtension should opt in? It's really only the developer of the GDExtension that wants live reloading - users of third-party GDExtensions probably don't want or need this, especially given all the extra accounting necessary to make it work.~~
- When methods are gone after the reload, it marks the method binds as "invalid" and if you try to call them an error is printed and it won't be called. However, if something is caching method binds, it should probably check if it's still valid, and if not, stop caching it! If GDScript or anything else in the engine is doing this, we should update it. **This could be handled in a follow-up PR - what is in this PR is at least safe.**
- ~~Right now, it will update an existing method bind that has the same name, regardless of any similarity to the original method. We should probably do some sort of "compatibility check" and only reuse method binds if they have the same signature or something?~~
- ~~Right now, it's trashing all the `Object::_instance_bindings` when clearing out the GDExtension data from an Object before reloading, but we really should be keeping instance bindings from other extensions that may be wrapping the object~~
- ~~This PR adds a new property on the `GDExtensionClassCreationInfo` struct in `gdextension_interface.h` in a way that breaks compatibility. We've already discussed how to handle these sort of situations at GDExtension meetings in the past, I just need to update the PR to do it the right way :-)~~
- I'm sure this implementation has thread safety issues - needs to be evaluated and fixed, but **this could be done in a follow-up PR.**
- I'd love for another binding (Rust, Python, etc) to try this out and make sure it works there as well
- Lots and lots and lots of testing!!

## Differences from @Reduz's proposal:

This implementation is based on this proposed implementation from Juan:

https://files.godot.foundation/s/WcyHmRjLbsggyGL

However, there are a number of differences in this PR, which I'd like to explain!

> A small flag needs to be present somewhere (Engine?) that indicates extension reloading can
> take place. It could be `Engine::is_extension_reloading_enabled()`.

~~I didn't include this, because I'm not entirely sure what this is for and how it should work. What determines if `Engine::is_extension_reloading_enabled()` should return true or false?~~

~~Right now, all the extra accounting necessary to make this work will only kick in where a GDExtension is actually in use, so it shouldn't have any effect if you're not using any GDExtensions. If we do add a way for GDExtensions to opt into reloading, we could make sure it isn't adding anything in that case either.~~

**UPDATE:** This is included now.

> If extension reloading is possible, ClassDB must indicate that reloading will take place. A
> function ClassDB::class_reload_set(const StringName& p_class,bool p_enable) may need to
> exist to mark this class as that it will be reloaded (hence be aware that re-registration will
> happen).

There's quite a bit in the proposal around making sure the class remains in the `ClassDB` (but marked special) during the reload process. I don't think this is actually necessary:

1. Since the `GDExtension` class intercepts all the `register_extension_class()`, `register_extension_class_method()` and `unregister_extension_class()` calls from the GDExtension before calling into `ClassDB`, my PR handles all the special cases for re-registering in `GDExtension` - `ClassDB` doesn't need to know about it
2. I think the class disappearing from `ClassDB` and then re-appearing a moment later is actually fine. We're clearing out the `Object::_extension` and `Object::_extension_instance` on all instances, so during this window when the class isn't in `ClassDB`, an existing instances will simply act like their native parent class. So, if your extension class extends `Node2D`, it will revert to acting like a plain old `Node2D` for a moment. The main thing that changes by the class not being in `ClassDB`, is that it can't be instantiated, but I think that's actually a good thing.
3. If we kept the class in `ClassDB` but marked it special, we'd need to add special cases all over the place to make sure `ClassDB` didn't do something unsafe while the class was reloading. But if the class just isn't there, `ClassDB` is already checking for that everywhere.

Only testing and more time will tell if I'm right or not, though :-)

> Inside `GDExtension::Extension`, we will need to keep track of all Godot classes that have
> instantiated this gdextension. For this, we can hook up to `ObjectGDExtension::create_instance`
> and `ObjectGDExtension::free_instance` (by adding our own static function wrapper in that
> object that replaces the one returned by the extension and that then calls back to it).

I attempted to implement this, but it won't actually work. For `ObjectGDExtension::create_instance` this approach would work just fine, because the function pointer from the GDExtension will return a `GDExtensionObjectPtr` (which is really just an `Object *`), so we can get ahold of the Godot-side instance. But `ObjectGDExtension::free_instance` is passed a `GDExtensionClassInstancePtr` which is the GDExtension-side instance, and that isn't what we need.

So, instead I added some additional function pointers on `ObjectGDExtension` for tracking.

> If a class is gone during a hot reload, we need to create a fake class that can take the data. This
> means mostly disabling existing method binds registered to that class, creating a fake generic
> class that can be used for all reloads that interfaces to ObjectGDExtension and
> GDExtensionClassInstancePtr. The class can contain a generic dictionary that takes
> reads/writes and can work similar to the placeholder classes (ie InstancePlaceholder).

The day after sending his proposal, Juan came back and said he thinks this might not be necessary, so my PR is leaving it out for now to see how it works.

> Copy DLL files before opening

@vnen has a separate PR (https://github.com/godotengine/godot/pull/80188) implementing this.