### PR TITLE
Further separate icon from text of buttons in both editor and default themes

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -115,7 +115,7 @@
 		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="h_separation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [Button]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="icon_max_width" data_type="constant" type="int" default="0">

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -74,7 +74,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
-		<theme_item name="h_separation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [ColorPickerButton]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -69,7 +69,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
-		<theme_item name="h_separation" data_type="constant" type="int" default="3">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [MenuButton]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -262,7 +262,7 @@
 		<theme_item name="arrow_margin" data_type="constant" type="int" default="4">
 			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
-		<theme_item name="h_separation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between [OptionButton]'s icon and text. Negative values will be treated as [code]0[/code] when used.
 		</theme_item>
 		<theme_item name="modulate_arrow" data_type="constant" type="int" default="0">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7853,7 +7853,6 @@ EditorNode::EditorNode() {
 
 	log = memnew(EditorLog);
 	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
-	output_button->set_theme_type_variation("BottomPanelButton");
 	log->set_tool_button(output_button);
 
 	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -914,7 +914,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 	theme->set_color("icon_disabled_color", "Button", icon_disabled_color);
 
-	theme->set_constant("h_separation", "Button", 2 * EDSCALE);
+	theme->set_constant("h_separation", "Button", 4 * EDSCALE);
 	theme->set_constant("outline_size", "Button", 0);
 
 	const float ACTION_BUTTON_EXTRA_MARGIN = 32 * EDSCALE;
@@ -1478,9 +1478,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
 	// Bottom panel.
-	theme->set_type_variation("BottomPanelButton", "Button");
-	// Add separation for the warning/error icon.
-	theme->set_constant("h_separation", "BottomPanelButton", 6 * EDSCALE);
 	Ref<StyleBoxFlat> style_bottom_panel = style_content_panel->duplicate();
 	style_bottom_panel->set_corner_radius_all(corner_radius * EDSCALE);
 	theme->set_stylebox("BottomPanel", "EditorStyles", style_bottom_panel);

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -54,7 +54,6 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
-	db->set_theme_type_variation("BottomPanelButton");
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -183,7 +183,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("icon_focus_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 0.4));
 
-	theme->set_constant("h_separation", "Button", Math::round(2 * scale));
+	theme->set_constant("h_separation", "Button", Math::round(4 * scale));
 	theme->set_constant("icon_max_width", "Button", 0);
 
 	// MenuBar
@@ -259,7 +259,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "OptionButton", control_font_disabled_color);
 	theme->set_color("font_outline_color", "OptionButton", Color(1, 1, 1));
 
-	theme->set_constant("h_separation", "OptionButton", Math::round(2 * scale));
+	theme->set_constant("h_separation", "OptionButton", Math::round(4 * scale));
 	theme->set_constant("arrow_margin", "OptionButton", Math::round(4 * scale));
 	theme->set_constant("outline_size", "OptionButton", 0);
 	theme->set_constant("modulate_arrow", "OptionButton", false);
@@ -282,7 +282,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "MenuButton", Color(1, 1, 1, 0.3));
 	theme->set_color("font_outline_color", "MenuButton", Color(1, 1, 1));
 
-	theme->set_constant("h_separation", "MenuButton", Math::round(3 * scale));
+	theme->set_constant("h_separation", "MenuButton", Math::round(4 * scale));
 	theme->set_constant("outline_size", "MenuButton", 0);
 
 	// CheckBox
@@ -788,7 +788,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("children_hl_line_width", "Tree", 1);
 	theme->set_constant("parent_hl_line_margin", "Tree", 0);
 	theme->set_constant("draw_guides", "Tree", 1);
-	theme->set_constant("scroll_border", "Tree", 4);
+	theme->set_constant("scroll_border", "Tree", Math::round(4 * scale));
 	theme->set_constant("scroll_speed", "Tree", 12);
 	theme->set_constant("outline_size", "Tree", 0);
 	theme->set_constant("icon_max_width", "Tree", 0);
@@ -803,9 +803,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_stylebox("panel", "ItemList", make_flat_stylebox(style_normal_color));
 	theme->set_stylebox("focus", "ItemList", focus);
-	theme->set_constant("h_separation", "ItemList", 4);
-	theme->set_constant("v_separation", "ItemList", 2);
-	theme->set_constant("icon_margin", "ItemList", 4);
+	theme->set_constant("h_separation", "ItemList", Math::round(4 * scale));
+	theme->set_constant("v_separation", "ItemList", Math::round(2 * scale));
+	theme->set_constant("icon_margin", "ItemList", Math::round(4 * scale));
 	theme->set_constant("line_separation", "ItemList", Math::round(2 * scale));
 
 	theme->set_font("font", "ItemList", Ref<Font>());
@@ -1005,7 +1005,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
 	theme->set_color("font_outline_color", "ColorPickerButton", Color(1, 1, 1));
 
-	theme->set_constant("h_separation", "ColorPickerButton", Math::round(2 * scale));
+	theme->set_constant("h_separation", "ColorPickerButton", Math::round(4 * scale));
 	theme->set_constant("outline_size", "ColorPickerButton", 0);
 
 	// ColorPresetButton


### PR DESCRIPTION
I've noticed that the the icon and text separation in buttons seems a little too modest, making it look like there's almost no separation at all. This PR makes so that the default separation is **4** instead of **2**, and it also removes the `BottomPanelButton` theme variation, as I don't feel like it's needed after this change.

| Before: | After:|
|---|---|
| ![image](https://github.com/godotengine/godot/assets/30739239/6f8f65e2-8600-49ae-8175-a3dde51420b5) | ![image](https://github.com/godotengine/godot/assets/30739239/9425fa13-9ad7-4de2-9111-ac96ab3a0247) |
![image](https://github.com/godotengine/godot/assets/30739239/ff09ebbe-38bf-4e76-a911-49b99bf77b59) | ![image](https://github.com/godotengine/godot/assets/30739239/c68cd1b4-c574-4ec9-b22e-c78dc11fe140)
| ![image](https://github.com/godotengine/godot/assets/30739239/44be61ec-f0bb-4a4e-af92-5b585634c172) | ![image](https://github.com/godotengine/godot/assets/30739239/427d249d-baa5-4736-9ff7-14a87dd3ff1d)