### PR TITLE
[3.x] Physics Interpolation 2D: Reset on `NOTIFICATION_ENTER_TREE`

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -583,6 +583,19 @@ void CanvasItem::_notification(int p_what) {
 			if (!block_transform_notify && !xform_change.in_list()) {
 				get_tree()->xform_change_list.add(&xform_change);
 			}
+
+			// If using physics interpolation, reset for this node only,
+			// as a helper, as in most cases, users will want items reset when
+			// adding to the tree.
+			// In cases where they move immediately after adding,
+			// there will be little cost in having two resets as these are cheap,
+			// and it is worth it for convenience.
+			// Do not propagate to children, as each child of an added branch
+			// receives its own NOTIFICATION_ENTER_TREE, and this would
+			// cause unnecessary duplicate resets.
+			if (is_physics_interpolated_and_enabled()) {
+				notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+			}
 		} break;
 		case NOTIFICATION_MOVED_IN_PARENT: {
 			if (!is_inside_tree()) {


### PR DESCRIPTION
As a convenience, physics interpolation is reset automatically on entering the tree. This will be desired in most situations, and saves the user having to write code for this explicitly.

## Notes
* This is fairly no-brainer, but I didn't add it initially because it is not present in 3D physics interpolation (users have to call reset manually on adding nodes in 3D). I didn't add in 3D because I found some situations where it caused problems, but this may be revisited.
* There are possibly some advanced situations where _not_ having a reset on entering the tree could be useful, such as moving a node from one branch of the `SceneTree` to another and keeping the "flow" of interpolation. But if we get reports needing this, we can easily add an option to prevent the auto-reset.
* Overall I think this is worth going for as it will make physics interpolation far simpler to use for beginners. At worst we can easily revert / add option to turn off per node.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
