### PR TITLE
[3.x] PulseAudio: Remove `get_latency()` caching

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -132,7 +132,7 @@
 		<method name="get_output_latency" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the audio driver's output latency.
+				Returns the audio driver's output latency. This can be expensive, it is not recommended to call this every frame.
 			</description>
 		</method>
 		<method name="get_speaker_mode" qualifiers="const">

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -114,7 +114,7 @@
 			Number of islands in the 3D physics engine.
 		</constant>
 		<constant name="AUDIO_OUTPUT_LATENCY" value="30" enum="Monitor">
-			Output latency of the [AudioServer].
+			Output latency of the [AudioServer]. Equivalent to calling [method AudioServer.get_output_latency], it is not recommended to call this every frame.
 		</constant>
 		<constant name="MONITOR_MAX" value="31" enum="Monitor">
 			Represents the size of the [enum Monitor] enum.

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -353,27 +353,24 @@ Error AudioDriverPulseAudio::init() {
 }
 
 float AudioDriverPulseAudio::get_latency() {
-	if (latency == 0) { //only do this once since it's approximate anyway
-		lock();
+	lock();
 
-		pa_usec_t palat = 0;
-		if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
-			int negative = 0;
+	pa_usec_t pa_lat = 0;
+	if (pa_stream_get_state(pa_str) == PA_STREAM_READY) {
+		int negative = 0;
 
-			if (pa_stream_get_latency(pa_str, &palat, &negative) >= 0) {
-				if (negative) {
-					palat = 0;
-				}
+		if (pa_stream_get_latency(pa_str, &pa_lat, &negative) >= 0) {
+			if (negative) {
+				pa_lat = 0;
 			}
 		}
-
-		if (palat > 0) {
-			latency = double(palat) / 1000000.0;
-		}
-
-		unlock();
 	}
 
+	if (pa_lat > 0) {
+		latency = double(pa_lat) / 1000000.0;
+	}
+
+	unlock();
 	return latency;
 }
 


### PR DESCRIPTION
3.x backport of #45152