### PR TITLE
Enhance Vulkan PSO caching

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -805,8 +805,10 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	};
 
 	struct PipelineCache {
+		String file_path;
+		PipelineCacheHeader header = {};
 		size_t current_size = 0;
-		Vector<uint8_t> buffer;
+		LocalVector<uint8_t> buffer;
 		VkPipelineCache cache_object = VK_NULL_HANDLE;
 	};
 
@@ -816,7 +818,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 
 	void _load_pipeline_cache();
 	void _update_pipeline_cache(bool p_closing = false);
-	void _save_pipeline_cache_threaded(size_t pso_blob_size);
+	static void _save_pipeline_cache(void *p_data);
 
 	struct ComputePipeline {
 		RID shader;

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -503,6 +503,7 @@ Error VulkanContext::_initialize_device_extensions() {
 	register_requested_device_extension(VK_KHR_16BIT_STORAGE_EXTENSION_NAME, false);
 	register_requested_device_extension(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME, false);
 	register_requested_device_extension(VK_KHR_MAINTENANCE_2_EXTENSION_NAME, false);
+	register_requested_device_extension(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME, false);
 
 	if (Engine::get_singleton()->is_generate_spirv_debug_info_enabled()) {
 		register_requested_device_extension(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, true);


### PR DESCRIPTION
My goal was just to address any potential threading issue, but I couldn't but overhaul the whole thing to address various other issues. Highlights:
- ~Godot doesn't need to manage its own pipeline cache header. The Vulkan implementation is expected to do so, which includes considering a cache out of date after a driver update, for instance.~ **UPDATE 2:** This is not as true as I though. See the discussion below.
- The editor and the running game were writing the PSO cache to the same file, within a given project. Reusing at runtime a PSO created at edit time is good, but it isn't being properly handled in the current implementation (some file modified timestamp and `vkMergePipelineCaches` would likely have to be involved). Therefore, I've taken the simple path of keeping both separate. **UPDATE (2023-08-30):** The file name now also includes the device name so each one has its own cache, preventing invalidation when switching GPUs.
- Some additional synchronization is also avoided in this PR, via `VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT` and use of `LocalVector` instead of `Vector`.
- The check about the cache having grown at least as much as needed for it to be resaved (see was doing integer math, so fractions of MiB in the project setting were being ignored https://github.com/godotengine/godot/compare/master...RandomShaper:overhaul_vk_pso_cache?expand=1#diff-0d547c4e6687e653e54df1623d33ab291396cca8c6265101c211a028e610b1e9L9135).
- The logic to wait and/or store an udpated cache has been partially rewritten for better clarity.

**NOTE:** I'm marking this as _Needs testing_ because at the moment of writing this I'm not sure yet this fixes the bug referenced below (I still don't know what part of the current implementation is causing it).

**UPDATE:** Maybe the cause was the load of the cache at https://github.com/godotengine/godot/pull/80296/files#diff-0d547c4e6687e653e54df1623d33ab291396cca8c6265101c211a028e610b1e9L9138 while the writing task may still be running.
**UPDATE 2**: It wasn't.

Fixes #78749.
**UPDATE (2023-08-30):** Fixes #81150.