### PR TITLE
C#: Error when registering abstract class as global

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -388,7 +388,7 @@ namespace Godot.SourceGenerators
         public static readonly DiagnosticDescriptor GlobalClassMustDeriveFromGodotObjectRule =
             new DiagnosticDescriptor(id: "GD0401",
                 title: "The class must derive from GodotObject or a derived class",
-                messageFormat: "The class '{0}' must derive from GodotObject or a derived class.",
+                messageFormat: "The class '{0}' must derive from GodotObject or a derived class",
                 category: "Usage",
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
@@ -435,6 +435,36 @@ namespace Godot.SourceGenerators
 
             context.ReportDiagnostic(Diagnostic.Create(
                 new DiagnosticDescriptor(id: "GD0402",
+                    title: message,
+                    messageFormat: message,
+                    category: "Usage",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description),
+                classSyntax.GetLocation(),
+                classSyntax.SyntaxTree.FilePath));
+        }
+
+        public static readonly DiagnosticDescriptor GlobalClassMustNotBeAbstractRule =
+            new DiagnosticDescriptor(id: "GD0403",
+                title: "The class must not be declared abstract",
+                messageFormat: "The class '{0}' must not be declared abstract",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The class must be a non-abstract type. Remove the abstract modifier or the '[GlobalClass]' attribute.");
+
+        public static void ReportGlobalClassMustNotBeAbstract(
+            SyntaxNodeAnalysisContext context,
+            SyntaxNode classSyntax,
+            ISymbol typeSymbol)
+        {
+            string message = $"The class '{typeSymbol.ToDisplayString()}' must not be declared abstract";
+
+            string description = $"{message}. Remove the abstract modifier or the '[GlobalClass]' attribute.";
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(id: "GD0403",
                     title: message,
                     messageFormat: message,
                     category: "Usage",

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GlobalClassAnalyzer.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GlobalClassAnalyzer.cs
@@ -14,7 +14,8 @@ namespace Godot.SourceGenerators
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(
                 Common.GlobalClassMustDeriveFromGodotObjectRule,
-                Common.GlobalClassMustNotBeGenericRule);
+                Common.GlobalClassMustNotBeGenericRule,
+                Common.GlobalClassMustNotBeAbstractRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -34,6 +35,9 @@ namespace Godot.SourceGenerators
 
             if (typeSymbol.IsGenericType)
                 Common.ReportGlobalClassMustNotBeGeneric(context, typeClassDecl, typeSymbol);
+
+            if (typeSymbol.IsAbstract)
+                Common.ReportGlobalClassMustNotBeAbstract(context, typeClassDecl, typeSymbol);
 
             if (!typeSymbol.InheritsFrom("GodotSharp", GodotClasses.GodotObject))
                 Common.ReportGlobalClassMustDeriveFromGodotObject(context, typeClassDecl, typeSymbol);


### PR DESCRIPTION
Global classes must be instantiable. We are already reporting an error for generic classes, abstract classes can't be instantiated either.

- Follow-up to https://github.com/godotengine/godot/pull/79007.