### PR TITLE
Fix autoswitch 2D/3D view when clicking on node with floating script editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2357,7 +2357,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			SceneTreeDock::get_singleton()->set_selected(current_node);
 			InspectorDock::get_singleton()->update(current_node);
 			if (!inspector_only && !skip_main_plugin) {
-				skip_main_plugin = stay_in_script_editor_on_node_selected && ScriptEditor::get_singleton()->is_visible_in_tree();
+				skip_main_plugin = stay_in_script_editor_on_node_selected && (ScriptEditor::get_singleton()->is_visible_in_tree() && !ScriptEditor::get_singleton()->is_floating());
 			}
 		} else {
 			NodeDock::get_singleton()->set_node(nullptr);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2556,6 +2556,10 @@ void ScriptEditor::save_all_scripts() {
 	_update_script_names();
 }
 
+bool ScriptEditor::is_floating() const {
+	return floating_activated;
+}
+
 void ScriptEditor::apply_scripts() const {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
@@ -3747,6 +3751,7 @@ void ScriptEditor::_on_find_in_files_modified_files(PackedStringArray paths) {
 
 void ScriptEditor::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
+	floating_activated = p_visible;
 }
 
 void ScriptEditor::_filter_scripts_text_changed(const String &p_newtext) {
@@ -4037,6 +4042,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 		make_floating->connect("request_open_in_screen", callable_mp(window_wrapper, &WindowWrapper::enable_window_on_screen).bind(true));
 
 		menu_hb->add_child(make_floating);
+		floating_activated = false;
 		p_wrapper->connect("window_visibility_changed", callable_mp(this, &ScriptEditor::_window_changed));
 	}
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -274,6 +274,7 @@ class ScriptEditor : public PanelContainer {
 	Button *help_search = nullptr;
 	Button *site_search = nullptr;
 	Button *make_floating = nullptr;
+	bool floating_activated;
 	EditorHelpSearch *help_search_dialog = nullptr;
 
 	ItemList *script_list = nullptr;
@@ -499,6 +500,7 @@ public:
 
 	bool toggle_scripts_panel();
 	bool is_scripts_panel_toggled();
+	bool is_floating() const;
 	void apply_scripts() const;
 	void reload_scripts(bool p_refresh_only = false);
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);


### PR DESCRIPTION
Fix #80015 

### Issue fixed : 

When clicking on a node in the scene tree, editor autoswitch to 2D/3D view when script editor is not visible.
This behaviour is good until we use floating script editor. Because in this case, we can see both the script and the 2D/3D view and autoswitch is expected.

### Fix proposal : 

Check if editor script is floating and allow autoswitch to 2D/3D view when clicking in the scene tree.
Behaviour with non floating script is unchanged.

Before : 

![switch_tab_issue](https://github.com/godotengine/godot/assets/3649998/6ba47f99-0da2-45cc-b897-10f806fba015)

After the fix : 

![switch_tab](https://github.com/godotengine/godot/assets/3649998/30f72d93-7a8e-4e4d-a497-c22174019f1c)
