### PR TITLE
Disconnect graph connections when ports are removed in visual shaders

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -387,6 +387,8 @@ class VisualShaderEditor : public VBoxContainer {
 	void _edit_port_default_input(Object *p_button, int p_node, int p_port);
 	void _port_edited(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 
+	void _node_ports_removed(int p_id);
+
 	int to_node = -1;
 	int to_slot = -1;
 	int from_node = -1;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -406,6 +406,8 @@ void VisualShaderNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "default_input_values", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "set_default_input_values", "get_default_input_values");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "expanded_output_ports", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_output_ports_expanded", "_get_output_ports_expanded");
 
+	ADD_SIGNAL(MethodInfo("node_ports_removed"));
+
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR);
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR_INT);
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR_UINT);

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4936,7 +4936,11 @@ void VisualShaderNodeVectorCompose::set_op_type(OpType p_op_type) {
 		default:
 			break;
 	}
+	bool ports_removed = p_op_type < op_type;
 	op_type = p_op_type;
+	if (ports_removed) {
+		emit_signal("node_ports_removed");
+	}
 	emit_changed();
 }
 
@@ -5100,7 +5104,11 @@ void VisualShaderNodeVectorDecompose::set_op_type(OpType p_op_type) {
 		default:
 			break;
 	}
+	bool ports_removed = p_op_type < op_type;
 	op_type = p_op_type;
+	if (ports_removed) {
+		emit_signal("node_ports_removed");
+	}
 	emit_changed();
 }
 


### PR DESCRIPTION
For VectorCompose and VectorDecompose nodes, the 'changed' signal is connected to two new functions, which handle the deletion of connections from/to deleted ports.

Note: this revealed a new bug, described in https://github.com/godotengine/godot/issues/79417#issuecomment-1641272449.
I don't see this new issue being directly caused by the code I wrote, and since this is my first ever contribution to this project, I am not too familiar with the code, so I decided to go ahead with the PR anyway.

Bugsquad edit, fixes https://github.com/godotengine/godot/issues/79417