### PR TITLE
Use image index instead of texture index for `source_images`

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3400,10 +3400,11 @@ Ref<Texture2D> GLTFDocument::_get_texture(Ref<GLTFState> p_state, const GLTFText
 	const GLTFImageIndex image = p_state->textures[p_texture]->get_src_image();
 	ERR_FAIL_INDEX_V(image, p_state->images.size(), Ref<Texture2D>());
 	if (GLTFState::GLTFHandleBinary(p_state->handle_binary_image) == GLTFState::GLTFHandleBinary::HANDLE_BINARY_EMBED_AS_BASISU) {
+		ERR_FAIL_INDEX_V(image, p_state->source_images.size(), Ref<Texture2D>());
 		Ref<PortableCompressedTexture2D> portable_texture;
 		portable_texture.instantiate();
 		portable_texture->set_keep_compressed_buffer(true);
-		Ref<Image> new_img = p_state->source_images[p_texture]->duplicate();
+		Ref<Image> new_img = p_state->source_images[image]->duplicate();
 		ERR_FAIL_COND_V(new_img.is_null(), Ref<Texture2D>());
 		new_img->generate_mipmaps();
 		if (p_texture_types) {


### PR DESCRIPTION
Godot was indexing into the images array using `p_texture` (which is meant for the textures array, not images.)

Fixes #80316
We wanted to remove or clean up source_images, but until we decide, it is still worth fixing this bug.

```
Total basis file slices: 11
Slice: 0, alpha: 0, orig width/height: 512x1024, width/height: 512x1024, first_block: 0, image_index: 0, mip_level: 0, iframe: 0
Slice: 1, alpha: 0, orig width/height: 256x512, width/height: 256x512, first_block: 32768, image_index: 0, mip_level: 1, iframe: 0
Slice: 2, alpha: 0, orig width/height: 128x256, width/height: 128x256, first_block: 40960, image_index: 0, mip_level: 2, iframe: 0
Slice: 3, alpha: 0, orig width/height: 64x128, width/height: 64x128, first_block: 43008, image_index: 0, mip_level: 3, iframe: 0
Slice: 4, alpha: 0, orig width/height: 32x64, width/height: 32x64, first_block: 43520, image_index: 0, mip_level: 4, iframe: 0
Slice: 5, alpha: 0, orig width/height: 16x32, width/height: 16x32, first_block: 43648, image_index: 0, mip_level: 5, iframe: 0
Slice: 6, alpha: 0, orig width/height: 8x16, width/height: 8x16, first_block: 43680, image_index: 0, mip_level: 6, iframe: 0
Slice: 7, alpha: 0, orig width/height: 4x8, width/height: 4x8, first_block: 43688, image_index: 0, mip_level: 7, iframe: 0
Slice: 8, alpha: 0, orig width/height: 2x4, width/height: 4x4, first_block: 43690, image_index: 0, mip_level: 8, iframe: 0
Slice: 9, alpha: 0, orig width/height: 1x2, width/height: 4x4, first_block: 43691, image_index: 0, mip_level: 9, iframe: 0
Slice: 10, alpha: 0, orig width/height: 1x1, width/height: 4x4, first_block: 43692, image_index: 0, mip_level: 10, iframe: 0
ERROR: FATAL: Index p_index = 42 is out of bounds (size() = 42).
   at: CowData<class Ref<class Image> >::get (S:\repo\godot-fire\core/templates/cowdata.h:155)

================================================================
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.2.dev.custom_build (85ff82196504f013409f94b89708758e13cc4076)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[0] GLTFDocument::_get_texture (S:\repo\godot-fire\modules\gltf\gltf_document.cpp:3393)
[1] GLTFDocument::_parse_materials (S:\repo\godot-fire\modules\gltf\gltf_document.cpp:3932)
[2] GLTFDocument::_parse_gltf_state (S:\repo\godot-fire\modules\gltf\gltf_document.cpp:7390)
[3] GLTFDocument::_parse (S:\repo\godot-fire\modules\gltf\gltf_document.cpp:7026)
[4] GLTFDocument::append_from_file (S:\repo\godot-fire\modules\gltf\gltf_document.cpp:7454)
[5] call_with_variant_args_ret_helper<GLTFDocument,enum Error,String,Ref<GLTFState>,unsigned int,String,0,1,2,3> (S:\repo\godot-fire\core\variant\binder_common.h:755)
[6] call_with_variant_args_ret_dv<GLTFDocument,enum Error,String,Ref<GLTFState>,unsigned int,String> (S:\repo\godot-fire\core\variant\binder_common.h:534)
[7] MethodBindTR<GLTFDocument,enum Error,String,Ref<GLTFState>,unsigned int,String>::call (S:\repo\godot-fire\core\object\method_bind.h:494)
[8] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1779)
[9] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1892)
[10] Object::callp (S:\repo\godot-fire\core\object\object.cpp:719)
[11] Variant::callp (S:\repo\godot-fire\core\variant\variant_call.cpp:1174)
[12] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1661)
[13] GDScriptLambdaSelfCallable::call (S:\repo\godot-fire\modules\gdscript\gdscript_lambda_callable.cpp:155)
[14] Callable::callp (S:\repo\godot-fire\core\variant\callable.cpp:51)
[15] Object::emit_signalp (S:\repo\godot-fire\core\object\object.cpp:1073)
[16] Node::emit_signalp (S:\repo\godot-fire\scene\main\node.cpp:3571)
[17] Window::_window_drop_files (S:\repo\godot-fire\scene\main\window.cpp:1483)
[18] CallableCustomMethodPointer<Window,Vector<String> const &>::call (S:\repo\godot-fire\core\object\callable_method_pointer.h:104)
[19] Callable::callp (S:\repo\godot-fire\core\variant\callable.cpp:51)
[20] DisplayServerWindows::WndProc (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:3881)
[21] WndProc (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:3901)
[22] <couldn't map PC to fn name>
[23] <couldn't map PC to fn name>
[24] <couldn't map PC to fn name>
[25] <couldn't map PC to fn name>
[26] <couldn't map PC to fn name>
[27] DisplayServerWindows::process_events (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:2290)
[28] OS_Windows::run (S:\repo\godot-fire\platform\windows\os_windows.cpp:1479)
[29] widechar_main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:182)
[30] _main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:206)
[31] main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:226)
[32] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[33] <couldn't map PC to fn name>
-- END OF BACKTRACE --
================================================================
```
repro steps: [godot-vrm project](https://github.com/V-Sekai/godot-vrm), `load_at_runtime_scene.tscn`, drag in this VRM file: https://github.com/godotengine/godot/files/12268455/47999701980962516models1854603302827712615.zip