### PR TITLE
Remove `CanvasItem::_invalidate_global_transform`

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -147,10 +147,6 @@ void CanvasItem::_redraw_callback() {
 	pending_update = false; // don't change to false until finished drawing (avoid recursive update)
 }
 
-void CanvasItem::_invalidate_global_transform() {
-	_set_global_invalid(true);
-}
-
 Transform2D CanvasItem::get_global_transform_with_canvas() const {
 	ERR_READ_THREAD_GUARD_V(Transform2D());
 	if (canvas_layer) {
@@ -449,7 +445,7 @@ void CanvasItem::set_as_top_level(bool p_top_level) {
 
 	if (!is_inside_tree()) {
 		top_level = p_top_level;
-		propagate_call(SNAME("_invalidate_global_transform"));
+		_notify_transform();
 		return;
 	}
 
@@ -1067,7 +1063,6 @@ void CanvasItem::_validate_property(PropertyInfo &p_property) const {
 
 void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_top_level_raise_self"), &CanvasItem::_top_level_raise_self);
-	ClassDB::bind_method(D_METHOD("_invalidate_global_transform"), &CanvasItem::_invalidate_global_transform);
 
 #ifdef TOOLS_ENABLED
 	ClassDB::bind_method(D_METHOD("_edit_set_state", "state"), &CanvasItem::_edit_set_state);

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -132,7 +132,6 @@ private:
 	virtual void _top_level_changed_on_parent();
 
 	void _redraw_callback();
-	void _invalidate_global_transform();
 
 	void _enter_canvas();
 	void _exit_canvas();


### PR DESCRIPTION
The only use of that function can be replaced by `_notify_transform`, which makes the `propagate_call` unnecessary.
As far as I can tell, the `data.blocked`-checks of `propagate_call` are not needed in this case, because `_invalidate_global_transform` causes no user-noticeable changes.

Updated 2023-08-30: With #80105 merged, this PR can now be considered ready.