### PR TITLE
[3.x] Hierarchical culling: Add extra check to `skeleton_attach_canvas_item`

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -3780,6 +3780,13 @@ void RasterizerStorageGLES2::skeleton_attach_canvas_item(RID p_skeleton, RID p_c
 	ERR_FAIL_COND(!p_canvas_item.is_valid());
 
 	if (p_attach) {
+#ifdef DEV_ENABLED
+		// skeleton_attach_canvas_item() is not bound,
+		// and checks in canvas_item_attach_skeleton() should prevent this,
+		// but there isn't much harm in a DEV_ENABLED check here.
+		int64_t found = skeleton->linked_canvas_items.find(p_canvas_item);
+		ERR_FAIL_COND(found != -1);
+#endif
 		skeleton->linked_canvas_items.push_back(p_canvas_item);
 	} else {
 		int64_t found = skeleton->linked_canvas_items.find(p_canvas_item);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -5322,6 +5322,13 @@ void RasterizerStorageGLES3::skeleton_attach_canvas_item(RID p_skeleton, RID p_c
 	ERR_FAIL_COND(!p_canvas_item.is_valid());
 
 	if (p_attach) {
+#ifdef DEV_ENABLED
+		// skeleton_attach_canvas_item() is not bound,
+		// and checks in canvas_item_attach_skeleton() should prevent this,
+		// but there isn't much harm in a DEV_ENABLED check here.
+		int64_t found = skeleton->linked_canvas_items.find(p_canvas_item);
+		ERR_FAIL_COND(found != -1);
+#endif
 		skeleton->linked_canvas_items.push_back(p_canvas_item);
 	} else {
 		int64_t found = skeleton->linked_canvas_items.find(p_canvas_item);


### PR DESCRIPTION
Although this check shouldn't be able to fail currently, it provides a small level of extra logic checking at only small cost in DEV builds.

## Notes
* Adds extra check suggested by @kleonc - https://github.com/godotengine/godot/pull/80106#discussion_r1285171472
* Probably not strictly speaking necessary, but no harm in doing this to prevent future bugs.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
