### PR TITLE
Fix NoiseTexture3d crashing on compatibility renderer

### DIFF
--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -347,5 +347,8 @@ Vector<Ref<Image>> NoiseTexture3D::get_data() const {
 
 Image::Format NoiseTexture3D::get_format() const {
 	ERR_FAIL_COND_V(!texture.is_valid(), Image::FORMAT_L8);
-	return RS::get_singleton()->texture_3d_get(texture)[0]->get_format();
+
+	Vector<Ref<Image>> texture_3d = RS::get_singleton()->texture_3d_get(texture);
+	ERR_FAIL_COND_V(texture_3d.size() == 0, Image::FORMAT_L8);
+	return texture_3d[0]->get_format();
 }


### PR DESCRIPTION
Fixes #79360 
Fixes #80302

Checks whether the 3d noise texture has any layers while getting its format, avoiding crashing due to reaching outside of the layer array's boundaries.

Cause pinpointed by <a href=https://github.com/saierXP>saierXP</a> in https://github.com/godotengine/godot/issues/80302#issuecomment-1666686697