### PR TITLE
Add handles to control Curve3D tilt

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -40,39 +40,29 @@
 #include "scene/gui/menu_button.h"
 #include "scene/resources/curve.h"
 
-static bool _is_in_handle(int p_id, int p_num_points) {
-	int t = (p_id + 1) % 2;
-	int idx = (p_id + 1) / 2;
-	// order of points is [out_0, out_1, in_1, out_2, in_2, ... out_n-1, in_n-1, in_n]
-	if (idx == 0) {
-		return false;
-	} else if (idx == (p_num_points - 1)) {
-		return true;
-	} else {
-		return (t == 1);
-	}
-}
-
 String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {
 	Ref<Curve3D> c = path->get_curve();
 	if (c.is_null()) {
 		return "";
 	}
 
+	// Primary handles: position.
 	if (!p_secondary) {
 		return TTR("Curve Point #") + itos(p_id);
 	}
 
-	// (p_id + 1) Accounts for the first point only having an "out" handle
-	int idx = (p_id + 1) / 2;
-	String n = TTR("Curve Point #") + itos(idx);
-	if (_is_in_handle(p_id, c->get_point_count())) {
-		n += " In";
-	} else {
-		n += " Out";
+	// Secondary handles: in, out, tilt.
+	const HandleInfo info = _secondary_handles_info[p_id];
+	switch (info.type) {
+		case HandleType::HANDLE_TYPE_IN:
+			return TTR("Handle In #") + itos(info.point_idx);
+		case HandleType::HANDLE_TYPE_OUT:
+			return TTR("Handle Out #") + itos(info.point_idx);
+		case HandleType::HANDLE_TYPE_TILT:
+			return TTR("Handle Tilt #") + itos(info.point_idx);
 	}
 
-	return n;
+	return "";
 }
 
 Variant Path3DGizmo::get_handle_value(int p_id, bool p_secondary) const {
@@ -81,23 +71,27 @@ Variant Path3DGizmo::get_handle_value(int p_id, bool p_secondary) const {
 		return Variant();
 	}
 
+	// Primary handles: position.
 	if (!p_secondary) {
 		original = c->get_point_position(p_id);
 		return original;
 	}
 
-	// (p_id + 1) Accounts for the first point only having an "out" handle
-	int idx = (p_id + 1) / 2;
-
+	// Secondary handles: in, out, tilt.
+	const HandleInfo info = _secondary_handles_info[p_id];
 	Vector3 ofs;
-	if (_is_in_handle(p_id, c->get_point_count())) {
-		ofs = c->get_point_in(idx);
-	} else {
-		ofs = c->get_point_out(idx);
+	switch (info.type) {
+		case HandleType::HANDLE_TYPE_TILT:
+			return c->get_point_tilt(info.point_idx);
+		case HandleType::HANDLE_TYPE_IN:
+			ofs = c->get_point_in(info.point_idx);
+			break;
+		case HandleType::HANDLE_TYPE_OUT:
+			ofs = c->get_point_out(info.point_idx);
+			break;
 	}
 
-	original = ofs + c->get_point_position(idx);
-
+	original = ofs + c->get_point_position(info.point_idx);
 	return ofs;
 }
 
@@ -107,17 +101,17 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 		return;
 	}
 
-	Transform3D gt = path->get_global_transform();
-	Transform3D gi = gt.affine_inverse();
-	Vector3 ray_from = p_camera->project_ray_origin(p_point);
-	Vector3 ray_dir = p_camera->project_ray_normal(p_point);
+	const Transform3D gt = path->get_global_transform();
+	const Transform3D gi = gt.affine_inverse();
+	const Vector3 ray_from = p_camera->project_ray_origin(p_point);
+	const Vector3 ray_dir = p_camera->project_ray_normal(p_point);
+	const Plane p = Plane(p_camera->get_transform().basis.get_column(2), gt.xform(original));
 
-	// Setting curve point positions
+	// Primary handles: position.
 	if (!p_secondary) {
-		const Plane p = Plane(p_camera->get_transform().basis.get_column(2), gt.xform(original));
-
 		Vector3 inters;
-
+		// Special cas for primary handle, the handle id equals control point id.
+		const int idx = p_id;
 		if (p.intersects_ray(ray_from, ray_dir, &inters)) {
 			if (Node3DEditor::get_singleton()->is_snap_enabled()) {
 				float snap = Node3DEditor::get_singleton()->get_translate_snap();
@@ -125,45 +119,74 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 			}
 
 			Vector3 local = gi.xform(inters);
-			c->set_point_position(p_id, local);
+			c->set_point_position(idx, local);
 		}
 
 		return;
 	}
 
-	// (p_id + 1) Accounts for the first point only having an "out" handle
-	int idx = (p_id + 1) / 2;
+	// Secondary handles: in, out, tilt.
+	const HandleInfo info = _secondary_handles_info[p_id];
+	switch (info.type) {
+		case HandleType::HANDLE_TYPE_OUT:
+		case HandleType::HANDLE_TYPE_IN: {
+			const int idx = info.point_idx;
+			const Vector3 base = c->get_point_position(idx);
 
-	Vector3 base = c->get_point_position(idx);
+			Vector3 inters;
+			if (p.intersects_ray(ray_from, ray_dir, &inters)) {
+				if (!Path3DEditorPlugin::singleton->is_handle_clicked()) {
+					orig_in_length = c->get_point_in(idx).length();
+					orig_out_length = c->get_point_out(idx).length();
+					Path3DEditorPlugin::singleton->set_handle_clicked(true);
+				}
 
-	Plane p(p_camera->get_transform().basis.get_column(2), gt.xform(original));
+				Vector3 local = gi.xform(inters) - base;
+				if (Node3DEditor::get_singleton()->is_snap_enabled()) {
+					float snap = Node3DEditor::get_singleton()->get_translate_snap();
+					local.snap(Vector3(snap, snap, snap));
+				}
 
-	Vector3 inters;
-
-	// Setting curve in/out positions
-	if (p.intersects_ray(ray_from, ray_dir, &inters)) {
-		if (!Path3DEditorPlugin::singleton->is_handle_clicked()) {
-			orig_in_length = c->get_point_in(idx).length();
-			orig_out_length = c->get_point_out(idx).length();
-			Path3DEditorPlugin::singleton->set_handle_clicked(true);
-		}
-
-		Vector3 local = gi.xform(inters) - base;
-		if (Node3DEditor::get_singleton()->is_snap_enabled()) {
-			float snap = Node3DEditor::get_singleton()->get_translate_snap();
-			local.snap(Vector3(snap, snap, snap));
-		}
-
-		if (_is_in_handle(p_id, c->get_point_count())) {
-			c->set_point_in(idx, local);
-			if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-				c->set_point_out(idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -local : (-local.normalized() * orig_out_length));
+				if (info.type == HandleType::HANDLE_TYPE_IN) {
+					c->set_point_in(idx, local);
+					if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
+						c->set_point_out(idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -local : (-local.normalized() * orig_out_length));
+					}
+				} else {
+					c->set_point_out(idx, local);
+					if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
+						c->set_point_in(idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -local : (-local.normalized() * orig_in_length));
+					}
+				}
 			}
-		} else {
-			c->set_point_out(idx, local);
-			if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-				c->set_point_in(idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -local : (-local.normalized() * orig_in_length));
+			break;
+		}
+		case HandleType::HANDLE_TYPE_TILT: {
+			const int idx = info.point_idx;
+			const Vector3 position = c->get_point_position(idx);
+			const Basis posture = c->get_point_baked_posture(idx);
+			const Vector3 tangent = -posture.get_column(2);
+			const Vector3 up = posture.get_column(1);
+			const Plane p_tilt = Plane(tangent, position);
+
+			Vector3 intersection;
+
+			if (p_tilt.intersects_ray(ray_from, ray_dir, &intersection)) {
+				Vector3 direction = intersection - position;
+				direction.normalize(); // FIXME: redundant?
+				real_t tilt_angle = up.signed_angle_to(direction, tangent);
+
+				if (Node3DEditor::get_singleton()->is_snap_enabled()) {
+					real_t snap = Node3DEditor::get_singleton()->get_rotate_snap();
+
+					tilt_angle = Math::rad_to_deg(tilt_angle) + snap * 0.5; // Else it won't reach +180.
+					tilt_angle -= Math::fmod(tilt_angle, snap);
+					tilt_angle = Math::deg_to_rad(tilt_angle);
+				}
+
+				c->set_point_tilt(idx, tilt_angle);
 			}
+			break;
 		}
 	}
 }
@@ -176,54 +199,72 @@ void Path3DGizmo::commit_handle(int p_id, bool p_secondary, const Variant &p_res
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 
+	// Primary handles: position.
 	if (!p_secondary) {
+		// Special cas for primary handle, the handle id equals control point id.
+		const int idx = p_id;
 		if (p_cancel) {
-			c->set_point_position(p_id, p_restore);
+			c->set_point_position(idx, p_restore);
 			return;
 		}
 		ur->create_action(TTR("Set Curve Point Position"));
-		ur->add_do_method(c.ptr(), "set_point_position", p_id, c->get_point_position(p_id));
-		ur->add_undo_method(c.ptr(), "set_point_position", p_id, p_restore);
+		ur->add_do_method(c.ptr(), "set_point_position", idx, c->get_point_position(idx));
+		ur->add_undo_method(c.ptr(), "set_point_position", idx, p_restore);
 		ur->commit_action();
 
 		return;
 	}
 
-	// (p_id + 1) Accounts for the first point only having an "out" handle
-	int idx = (p_id + 1) / 2;
+	// Secondary handles: in, out, tilt.
+	const HandleInfo info = _secondary_handles_info[p_id];
+	const int idx = info.point_idx;
+	switch (info.type) {
+		case HandleType::HANDLE_TYPE_OUT: {
+			if (p_cancel) {
+				c->set_point_out(idx, p_restore);
 
-	if (_is_in_handle(p_id, c->get_point_count())) {
-		if (p_cancel) {
-			c->set_point_in(p_id, p_restore);
-			return;
+				return;
+			}
+
+			ur->create_action(TTR("Set Curve Out Position"));
+			ur->add_do_method(c.ptr(), "set_point_out", idx, c->get_point_out(idx));
+			ur->add_undo_method(c.ptr(), "set_point_out", idx, p_restore);
+
+			if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
+				ur->add_do_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_out(idx) : (-c->get_point_out(idx).normalized() * orig_in_length));
+				ur->add_undo_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_in_length));
+			}
+			ur->commit_action();
+			break;
 		}
+		case HandleType::HANDLE_TYPE_IN: {
+			if (p_cancel) {
+				c->set_point_in(idx, p_restore);
+				return;
+			}
 
-		ur->create_action(TTR("Set Curve In Position"));
-		ur->add_do_method(c.ptr(), "set_point_in", idx, c->get_point_in(idx));
-		ur->add_undo_method(c.ptr(), "set_point_in", idx, p_restore);
+			ur->create_action(TTR("Set Curve In Position"));
+			ur->add_do_method(c.ptr(), "set_point_in", idx, c->get_point_in(idx));
+			ur->add_undo_method(c.ptr(), "set_point_in", idx, p_restore);
 
-		if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-			ur->add_do_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_in(idx) : (-c->get_point_in(idx).normalized() * orig_out_length));
-			ur->add_undo_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_out_length));
+			if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
+				ur->add_do_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_in(idx) : (-c->get_point_in(idx).normalized() * orig_out_length));
+				ur->add_undo_method(c.ptr(), "set_point_out", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_out_length));
+			}
+			ur->commit_action();
+			break;
 		}
-		ur->commit_action();
-
-	} else {
-		if (p_cancel) {
-			c->set_point_out(idx, p_restore);
-
-			return;
+		case HandleType::HANDLE_TYPE_TILT: {
+			if (p_cancel) {
+				c->set_point_tilt(idx, p_restore);
+				return;
+			}
+			ur->create_action(TTR("Set Curve Point Tilt"));
+			ur->add_do_method(c.ptr(), "set_point_tilt", idx, c->get_point_tilt(idx));
+			ur->add_undo_method(c.ptr(), "set_point_tilt", idx, p_restore);
+			ur->commit_action();
+			break;
 		}
-
-		ur->create_action(TTR("Set Curve Out Position"));
-		ur->add_do_method(c.ptr(), "set_point_out", idx, c->get_point_out(idx));
-		ur->add_undo_method(c.ptr(), "set_point_out", idx, p_restore);
-
-		if (Path3DEditorPlugin::singleton->mirror_angle_enabled()) {
-			ur->add_do_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -c->get_point_out(idx) : (-c->get_point_out(idx).normalized() * orig_in_length));
-			ur->add_undo_method(c.ptr(), "set_point_in", idx, Path3DEditorPlugin::singleton->mirror_length_enabled() ? -static_cast<Vector3>(p_restore) : (-static_cast<Vector3>(p_restore).normalized() * orig_in_length));
-		}
-		ur->commit_action();
 	}
 }
 
@@ -260,60 +301,126 @@ void Path3DGizmo::redraw() {
 		}
 
 		const Transform3D *r = frames.ptr();
-		Vector<Vector3> v3p;
-		for (int i = 0; i < sample_count - 1; i++) {
+		Vector<Vector3> _collision_segments;
+		Vector<Vector3> bones;
+		Vector<Vector3> ribbon;
+		for (int i = 0; i < sample_count; i++) {
 			const Vector3 p1 = r[i].origin;
-			const Vector3 p2 = r[i + 1].origin;
 			const Vector3 side = r[i].basis.get_column(0);
 			const Vector3 up = r[i].basis.get_column(1);
 			const Vector3 forward = r[i].basis.get_column(2);
 
-			// Curve segment.
-			v3p.push_back(p1);
-			v3p.push_back(p2);
+			// Collision segments.
+			if (i != sample_count) {
+				const Vector3 p2 = r[i + 1].origin;
+				_collision_segments.push_back(p1);
+				_collision_segments.push_back(p2);
+			}
+
+			// Path3D as a ribbon.
+			ribbon.push_back(p1);
 
 			// Fish Bone.
-			v3p.push_back(p1);
-			v3p.push_back(p1 + (side + forward + up * 0.3) * 0.06);
+			const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
+			const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
+			bones.push_back(p1);
+			bones.push_back(p_left);
 
-			v3p.push_back(p1);
-			v3p.push_back(p1 + (-side + forward + up * 0.3) * 0.06);
+			bones.push_back(p1);
+			bones.push_back(p_right);
 		}
 
-		add_lines(v3p, path_material);
-		add_collision_segments(v3p);
+		add_collision_segments(_collision_segments);
+		add_lines(bones, path_material);
+		add_vertices(ribbon, path_material, Mesh::PRIMITIVE_LINE_STRIP);
 	}
 
-	// 2. Draw handles.
+	// 2. Draw handles when selected.
 	if (Path3DEditorPlugin::singleton->get_edited_path() == path) {
-		Vector<Vector3> v3p;
-		Vector<Vector3> handle_points;
-		Vector<Vector3> sec_handle_points;
+		PackedVector3Array handle_lines;
+		PackedVector3Array primary_handle_points;
+		PackedVector3Array secondary_handle_points;
+		PackedInt32Array collected_secondary_handle_ids; // Avoid shadowing member on Node3DEditorGizmo.
 
-		for (int i = 0; i < c->get_point_count(); i++) {
-			Vector3 p = c->get_point_position(i);
-			handle_points.push_back(p);
-			// Push out points first so they get selected if the In and Out points are on top of each other.
-			if (i < c->get_point_count() - 1) {
-				v3p.push_back(p);
-				v3p.push_back(p + c->get_point_out(i));
-				sec_handle_points.push_back(p + c->get_point_out(i));
+		_secondary_handles_info.resize(c->get_point_count() * 3);
+
+		for (int idx = 0; idx < c->get_point_count(); idx++) {
+			// Collect primary-handles.
+			const Vector3 pos = c->get_point_position(idx);
+			primary_handle_points.append(pos);
+
+			HandleInfo info;
+			info.point_idx = idx;
+
+			// Collect in-handles except for the first point.
+			if (idx > 0) {
+				info.type = HandleType::HANDLE_TYPE_IN;
+				const int handle_idx = idx * 3 + 0;
+				collected_secondary_handle_ids.append(handle_idx);
+				_secondary_handles_info.write[handle_idx] = info;
+
+				const Vector3 in = c->get_point_in(idx);
+				secondary_handle_points.append(pos + in);
+				handle_lines.append(pos);
+				handle_lines.append(pos + in);
 			}
-			if (i > 0) {
-				v3p.push_back(p);
-				v3p.push_back(p + c->get_point_in(i));
-				sec_handle_points.push_back(p + c->get_point_in(i));
+
+			// Collect out-handles except for the last point.
+			if (idx < c->get_point_count()) {
+				info.type = HandleType::HANDLE_TYPE_OUT;
+				const int handle_idx = idx * 3 + 1;
+				collected_secondary_handle_ids.append(handle_idx);
+				_secondary_handles_info.write[handle_idx] = info;
+
+				const Vector3 out = c->get_point_out(idx);
+				secondary_handle_points.append(pos + out);
+				handle_lines.append(pos);
+				handle_lines.append(pos + out);
+			}
+
+			// Collect tilt-handles.
+			{
+				{
+					info.type = HandleType::HANDLE_TYPE_TILT;
+					const int handle_idx = idx * 3 + 2;
+					collected_secondary_handle_ids.append(handle_idx);
+					_secondary_handles_info.write[handle_idx] = info;
+
+					const Basis posture = c->get_point_baked_posture(idx, true);
+					const Vector3 up = posture.get_column(1);
+					secondary_handle_points.append(pos + up);
+					handle_lines.append(pos);
+					handle_lines.append(pos + up);
+				}
+
+				// Tilt disk.
+				{
+					const Basis posture = c->get_point_baked_posture(idx, false);
+					const Vector3 up = posture.get_column(1);
+					const Vector3 side = posture.get_column(0);
+
+					PackedVector3Array disk;
+					disk.append(pos);
+
+					const int n = 24;
+					for (int i = 0; i <= n; i++) {
+						const float a = Math_TAU * i / n;
+						const Vector3 edge = sin(a) * side + cos(a) * up;
+						disk.append(pos + edge);
+					}
+					add_vertices(disk, path_material, Mesh::PRIMITIVE_LINE_STRIP);
+				}
 			}
 		}
 
-		if (v3p.size() > 1) {
-			add_lines(v3p, path_thin_material);
+		if (handle_lines.size() > 1) {
+			add_lines(handle_lines, path_thin_material);
 		}
-		if (handle_points.size()) {
-			add_handles(handle_points, handles_material);
+		if (primary_handle_points.size()) {
+			add_handles(primary_handle_points, handles_material);
 		}
-		if (sec_handle_points.size()) {
-			add_handles(sec_handle_points, sec_handles_material, Vector<int>(), false, true);
+		if (secondary_handle_points.size()) {
+			add_handles(secondary_handle_points, sec_handles_material, collected_secondary_handle_ids, false, true);
 		}
 	}
 }
@@ -447,6 +554,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 				real_t dist_to_p = p_camera->unproject_position(gt.xform(c->get_point_position(i))).distance_to(mbpos);
 				real_t dist_to_p_out = p_camera->unproject_position(gt.xform(c->get_point_position(i) + c->get_point_out(i))).distance_to(mbpos);
 				real_t dist_to_p_in = p_camera->unproject_position(gt.xform(c->get_point_position(i) + c->get_point_in(i))).distance_to(mbpos);
+				real_t dist_to_p_up = p_camera->unproject_position(gt.xform(c->get_point_position(i) + c->get_point_baked_posture(i, true).get_column(1))).distance_to(mbpos);
 
 				// Find the offset and point index of the place to break up.
 				// Also check for the control points.
@@ -459,16 +567,23 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_out < click_dist) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-					ur->create_action(TTR("Remove Out-Control Point"));
+					ur->create_action(TTR("Reset Out-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_out", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_out", i, c->get_point_out(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_in < click_dist) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-					ur->create_action(TTR("Remove In-Control Point"));
+					ur->create_action(TTR("Reset In-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_in", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_in", i, c->get_point_in(i));
+					ur->commit_action();
+					return EditorPlugin::AFTER_GUI_INPUT_STOP;
+				} else if (dist_to_p_up < click_dist) {
+					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+					ur->create_action(TTR("Reset Point Tilt"));
+					ur->add_do_method(c.ptr(), "set_point_tilt", i, 0.0f);
+					ur->add_undo_method(c.ptr(), "set_point_tilt", i, c->get_point_tilt(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				}
@@ -497,6 +612,8 @@ void Path3DEditorPlugin::edit(Object *p_object) {
 			pre->get_curve()->emit_signal(SNAME("changed"));
 		}
 	}
+
+	update_overlays();
 	//collision_polygon_editor->edit(Object::cast_to<Node>(p_object));
 }
 

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -42,10 +42,25 @@ class MenuButton;
 class Path3DGizmo : public EditorNode3DGizmo {
 	GDCLASS(Path3DGizmo, EditorNode3DGizmo);
 
+	// Map handle id to control point id and handle type.
+	enum HandleType {
+		HANDLE_TYPE_IN,
+		HANDLE_TYPE_OUT,
+		HANDLE_TYPE_TILT,
+	};
+
+	struct HandleInfo {
+		int point_idx; // Index of control point.
+		HandleType type; // Type of this handle.
+	};
+
 	Path3D *path = nullptr;
 	mutable Vector3 original;
 	mutable float orig_in_length;
 	mutable float orig_out_length;
+
+	// Cache information of secondary handles.
+	Vector<HandleInfo> _secondary_handles_info;
 
 public:
 	virtual String get_handle_name(int p_id, bool p_secondary) const override;

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -258,6 +258,10 @@ class Curve3D : public Resource {
 	};
 
 	Vector<Point> points;
+#ifdef TOOLS_ENABLED
+	// For Path3DGizmo.
+	mutable Vector<size_t> points_in_cache;
+#endif
 
 	mutable bool baked_cache_dirty = false;
 	mutable PackedVector3Array baked_point_cache;
@@ -280,6 +284,7 @@ class Curve3D : public Resource {
 	Vector3 _sample_baked(Interval p_interval, bool p_cubic) const;
 	real_t _sample_baked_tilt(Interval p_interval) const;
 	Basis _sample_posture(Interval p_interval, bool p_apply_tilt = false) const;
+	Basis _compose_posture(int p_index) const;
 
 	real_t bake_interval = 0.2;
 	bool up_vector_enabled = true;
@@ -302,6 +307,11 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	// For Path3DGizmo.
+	Basis get_point_baked_posture(int p_index, bool p_apply_tilt = false) const;
+#endif
+
 	int get_point_count() const;
 	void set_point_count(int p_count);
 	void add_point(const Vector3 &p_position, const Vector3 &p_in = Vector3(), const Vector3 &p_out = Vector3(), int p_atpos = -1);


### PR DESCRIPTION
This PR add handles to control Curve3D tilt. The implementation of in, out handles are also revamped, as the original ones are too hacky, specifically the mapping between handle ids and control point ids.

https://github.com/godotengine/godot/assets/6020486/0afdbd77-0d79-41de-b308-0907939a0b81

The behaviour of this PR is similar with PR https://github.com/godotengine/godot/pull/68873, but `disks` are added to indicate the tilt handles trajectories, and an blue radial line is add to indicate the "natural" up vector before tilt.

An internal helper method Curve3D::_get_posture_at_control_point() is added to facilitate tile handle implantation, it could be promoted to an public method if someone found it useful.

When a Path3D is modified by handles, the transform of PathFollow3D is not updated, hence the attached camera view also doesn't change. This issue is fixed by a related PR https://github.com/godotengine/godot/pull/80233, which makes tweaking camera easier.