### PR TITLE
Make forward declarations with `Ref` safer

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1782,3 +1782,8 @@ String InputEventShortcut::to_string() {
 
 	return vformat("InputEventShortcut: shortcut=%s", shortcut->get_as_text());
 }
+
+InputEventShortcut::~InputEventShortcut() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -567,6 +567,8 @@ public:
 
 	virtual String as_text() const override;
 	virtual String to_string() override;
+
+	~InputEventShortcut();
 };
 
 #endif // INPUT_EVENT_H

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -259,3 +259,8 @@ Error PCKPacker::flush(bool p_verbose) {
 
 	return OK;
 }
+
+PCKPacker::~PCKPacker() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -63,6 +63,7 @@ public:
 	Error flush(bool p_verbose = false);
 
 	PCKPacker() {}
+	~PCKPacker();
 };
 
 #endif // PCK_PACKER_H

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1689,3 +1689,8 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	add_child(menu);
 	menu->connect("id_pressed", callable_mp(this, &AnimationBezierTrackEdit::_menu_selected));
 }
+
+AnimationBezierTrackEdit::~AnimationBezierTrackEdit() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -208,6 +208,7 @@ public:
 	void _bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle, const Animation::HandleMode p_handle_mode);
 
 	AnimationBezierTrackEdit();
+	~AnimationBezierTrackEdit();
 };
 
 #endif // ANIMATION_BEZIER_EDITOR_H

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1802,6 +1802,11 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	set_layout_direction(Control::LAYOUT_DIRECTION_LTR);
 }
 
+AnimationTimelineEdit::~AnimationTimelineEdit() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ////////////////////////////////////
 
 void AnimationTrackEdit::_notification(int p_what) {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -199,6 +199,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	AnimationTimelineEdit();
+	~AnimationTimelineEdit();
 };
 
 class AnimationTrackEdit : public Control {

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -91,6 +91,11 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	EditorRunBar::get_singleton()->get_pause_button()->connect("pressed", callable_mp(this, &EditorDebuggerNode::_paused));
 }
 
+EditorDebuggerNode::~EditorDebuggerNode() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	ScriptEditorDebugger *node = memnew(ScriptEditorDebugger);
 

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -211,6 +211,8 @@ public:
 	bool plugins_capture(ScriptEditorDebugger *p_debugger, const String &p_message, const Array &p_data);
 	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
 	void remove_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);
+
+	~EditorDebuggerNode();
 };
 
 #endif // EDITOR_DEBUGGER_NODE_H

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -700,3 +700,8 @@ EditorProfiler::EditorProfiler() {
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");
 }
+
+EditorProfiler::~EditorProfiler() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -167,6 +167,7 @@ public:
 	Vector<Vector<String>> get_data_as_csv() const;
 
 	EditorProfiler();
+	~EditorProfiler();
 };
 
 #endif // EDITOR_PROFILER_H

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -823,3 +823,8 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	add_child(plot_delay);
 	plot_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_plot));
 }
+
+EditorVisualProfiler::~EditorVisualProfiler() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -147,6 +147,7 @@ public:
 	Vector<Vector<String>> get_data_as_csv() const;
 
 	EditorVisualProfiler();
+	~EditorVisualProfiler();
 };
 
 #endif // EDITOR_VISUAL_PROFILER_H

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2352,6 +2352,11 @@ EditorInspectorArray::EditorInspectorArray(bool p_read_only) {
 	vbox->connect("visibility_changed", callable_mp(this, &EditorInspectorArray::_vbox_visibility_changed));
 }
 
+EditorInspectorArray::~EditorInspectorArray() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ////////////////////////////////////////////////
 ////////////////////////////////////////////////
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -412,6 +412,7 @@ public:
 	VBoxContainer *get_vbox(int p_index);
 
 	EditorInspectorArray(bool p_read_only);
+	~EditorInspectorArray();
 };
 
 class EditorPaginator : public HBoxContainer {

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -366,3 +366,8 @@ String EditorExportPreset::get_version(const StringName &p_preset_string, bool p
 }
 
 EditorExportPreset::EditorExportPreset() {}
+
+EditorExportPreset::~EditorExportPreset() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -165,6 +165,7 @@ public:
 	const HashMap<StringName, Variant> &get_values() const { return values; }
 
 	EditorExportPreset();
+	~EditorExportPreset();
 };
 
 #endif // EDITOR_EXPORT_PRESET_H

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5415,6 +5415,11 @@ CanvasItemEditor::CanvasItemEditor() {
 	callable_mp(this, &CanvasItemEditor::set_state).bind(get_state()).call_deferred();
 }
 
+CanvasItemEditor::~CanvasItemEditor() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 CanvasItemEditor *CanvasItemEditor::singleton = nullptr;
 
 void CanvasItemEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -561,6 +561,7 @@ public:
 	EditorSelection *editor_selection = nullptr;
 
 	CanvasItemEditor();
+	~CanvasItemEditor();
 };
 
 class CanvasItemEditorPlugin : public EditorPlugin {

--- a/editor/plugins/gradient_texture_2d_editor_plugin.cpp
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.cpp
@@ -230,6 +230,11 @@ GradientTexture2DEdit::GradientTexture2DEdit() {
 	set_custom_minimum_size(Size2(0, 250 * EDSCALE));
 }
 
+GradientTexture2DEdit::~GradientTexture2DEdit() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ///////////////////////
 
 const int GradientTexture2DEditor::DEFAULT_SNAP = 10;
@@ -306,6 +311,11 @@ GradientTexture2DEditor::GradientTexture2DEditor() {
 	set_mouse_filter(MOUSE_FILTER_STOP);
 	_set_snap_enabled(snap_button->is_pressed());
 	_set_snap_count(snap_count_edit->get_value());
+}
+
+GradientTexture2DEditor::~GradientTexture2DEditor() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
 }
 
 ///////////////////////

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -78,6 +78,7 @@ public:
 	void set_snap_count(int p_snap_count);
 
 	GradientTexture2DEdit();
+	~GradientTexture2DEdit();
 };
 
 class GradientTexture2DEditor : public VBoxContainer {
@@ -102,6 +103,7 @@ public:
 	void set_texture(Ref<GradientTexture2D> &p_texture);
 
 	GradientTexture2DEditor();
+	~GradientTexture2DEditor();
 };
 
 class EditorInspectorPluginGradientTexture2D : public EditorInspectorPlugin {

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1495,6 +1495,11 @@ Polygon2DEditor::Polygon2DEditor() {
 	uv_edit_draw->set_clip_contents(true);
 }
 
+Polygon2DEditor::~Polygon2DEditor() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 Polygon2DEditorPlugin::Polygon2DEditorPlugin() :
 		AbstractPolygon2DEditorPlugin(memnew(Polygon2DEditor), "Polygon2D") {
 }

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -177,6 +177,7 @@ protected:
 
 public:
 	Polygon2DEditor();
+	~Polygon2DEditor();
 };
 
 class Polygon2DEditorPlugin : public AbstractPolygon2DEditorPlugin {

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -118,6 +118,11 @@ StyleBoxPreview::StyleBoxPreview() {
 	add_child(grid_preview);
 }
 
+StyleBoxPreview::~StyleBoxPreview() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 bool EditorInspectorPluginStyleBox::can_handle(Object *p_object) {
 	return Object::cast_to<StyleBox>(p_object) != nullptr;
 }

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -56,6 +56,7 @@ public:
 	void edit(const Ref<StyleBox> &p_stylebox);
 
 	StyleBoxPreview();
+	~StyleBoxPreview();
 };
 
 class EditorInspectorPluginStyleBox : public EditorInspectorPlugin {

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1220,6 +1220,11 @@ TextureRegionEditor::TextureRegionEditor() {
 	set_title(TTR("Region Editor"));
 }
 
+TextureRegionEditor::~TextureRegionEditor() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ////////////////////////
 
 bool EditorInspectorPluginTextureRegion::can_handle(Object *p_object) {

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -143,6 +143,7 @@ public:
 
 	void edit(Object *p_obj);
 	TextureRegionEditor();
+	~TextureRegionEditor();
 };
 
 //

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -292,3 +292,8 @@ SceneCreateDialog::SceneCreateDialog() {
 	set_title(TTR("Create New Scene"));
 	set_min_size(Size2i(400 * EDSCALE, 0));
 }
+
+SceneCreateDialog::~SceneCreateDialog() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -96,6 +96,7 @@ public:
 	Node *create_scene_root();
 
 	SceneCreateDialog();
+	~SceneCreateDialog();
 };
 
 #endif // SCENE_CREATE_DIALOG_H

--- a/scene/3d/importer_mesh_instance_3d.cpp
+++ b/scene/3d/importer_mesh_instance_3d.cpp
@@ -83,3 +83,8 @@ void ImporterMeshInstance3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, "Skin"), "set_skin", "get_skin");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton"), "set_skeleton_path", "get_skeleton_path");
 }
+
+ImporterMeshInstance3D::~ImporterMeshInstance3D() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -60,6 +60,8 @@ public:
 
 	void set_skeleton_path(const NodePath &p_path);
 	NodePath get_skeleton_path() const;
+
+	~ImporterMeshInstance3D();
 };
 
 #endif // IMPORTER_MESH_INSTANCE_3D_H

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1575,3 +1575,8 @@ void LightmapGI::_bind_methods() {
 
 LightmapGI::LightmapGI() {
 }
+
+LightmapGI::~LightmapGI() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -278,6 +278,7 @@ public:
 	virtual PackedStringArray get_configuration_warnings() const override;
 
 	LightmapGI();
+	~LightmapGI();
 };
 
 VARIANT_ENUM_CAST(LightmapGI::BakeQuality);

--- a/scene/3d/lightmapper.cpp
+++ b/scene/3d/lightmapper.cpp
@@ -74,3 +74,8 @@ Ref<Lightmapper> Lightmapper::create() {
 
 Lightmapper::Lightmapper() {
 }
+
+Lightmapper::~Lightmapper() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -195,6 +195,7 @@ public:
 	static Ref<Lightmapper> create();
 
 	Lightmapper();
+	~Lightmapper();
 };
 
 #endif // LIGHTMAPPER_H

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2040,3 +2040,8 @@ GraphEdit::GraphEdit() {
 
 	arranger = Ref<GraphEditArranger>(memnew(GraphEditArranger(this)));
 }
+
+GraphEdit::~GraphEdit() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -371,6 +371,7 @@ public:
 	void arrange_nodes();
 
 	GraphEdit();
+	~GraphEdit();
 };
 
 VARIANT_ENUM_CAST(GraphEdit::PanningScheme);

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -225,3 +225,8 @@ ViewPanner::ViewPanner() {
 	pan_view_shortcut.instantiate();
 	pan_view_shortcut->set_events(inputs);
 }
+
+ViewPanner::~ViewPanner() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -90,6 +90,7 @@ public:
 	void release_pan_key();
 
 	ViewPanner();
+	~ViewPanner();
 };
 
 #endif // VIEW_PANNER_H

--- a/scene/resources/mesh_texture.cpp
+++ b/scene/resources/mesh_texture.cpp
@@ -154,3 +154,8 @@ void MeshTexture::_bind_methods() {
 
 MeshTexture::MeshTexture() {
 }
+
+MeshTexture::~MeshTexture() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}

--- a/scene/resources/mesh_texture.h
+++ b/scene/resources/mesh_texture.h
@@ -70,6 +70,7 @@ public:
 	bool is_pixel_opaque(int p_x, int p_y) const override;
 
 	MeshTexture();
+	~MeshTexture();
 };
 
 #endif // MESH_TEXTURE_H

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1407,6 +1407,11 @@ void VisualShaderNodeTexture2DArray::_bind_methods() {
 VisualShaderNodeTexture2DArray::VisualShaderNodeTexture2DArray() {
 }
 
+VisualShaderNodeTexture2DArray::~VisualShaderNodeTexture2DArray() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 ////////////// Texture3D
 
 String VisualShaderNodeTexture3D::get_caption() const {
@@ -1666,6 +1671,11 @@ void VisualShaderNodeCubemap::_bind_methods() {
 
 VisualShaderNodeCubemap::VisualShaderNodeCubemap() {
 	simple_decl = false;
+}
+
+VisualShaderNodeCubemap::~VisualShaderNodeCubemap() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
 }
 
 ////////////// Linear Depth

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -572,6 +572,7 @@ public:
 	virtual Vector<StringName> get_editable_properties() const override;
 
 	VisualShaderNodeTexture2DArray();
+	~VisualShaderNodeTexture2DArray();
 };
 
 class VisualShaderNodeTexture3D : public VisualShaderNodeSample3D {
@@ -652,6 +653,7 @@ public:
 	virtual String get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const override;
 
 	VisualShaderNodeCubemap();
+	~VisualShaderNodeCubemap();
 };
 
 VARIANT_ENUM_CAST(VisualShaderNodeCubemap::TextureType)

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -735,6 +735,11 @@ VisualShaderNodeParticleMeshEmitter::VisualShaderNodeParticleMeshEmitter() {
 	simple_decl = false;
 }
 
+VisualShaderNodeParticleMeshEmitter::~VisualShaderNodeParticleMeshEmitter() {
+	// Do not remove, kept to prevent forward declaration issues, see:
+	// https://github.com/godotengine/godot/pull/80330
+}
+
 // VisualShaderNodeParticleMultiplyByAxisAngle
 
 void VisualShaderNodeParticleMultiplyByAxisAngle::_bind_methods() {

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -159,6 +159,7 @@ public:
 	Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const override;
 
 	VisualShaderNodeParticleMeshEmitter();
+	~VisualShaderNodeParticleMeshEmitter();
 };
 
 class VisualShaderNodeParticleMultiplyByAxisAngle : public VisualShaderNode {


### PR DESCRIPTION
`Ref`s to forward declared types are context dependent if the destructor is not explicit and in a source file

As seen in: #80278

~~This doesn't affect the current codebase, but makes it unreliable~~

~~g++ seems to define destructors for classes with no explicit destructor when they first are called, meaning that if a class is undefined in that context it will cause errors, and depends entirely on the order of compilation, this makes destructors explicit for classes that have `Ref`s to forward declared classes, I believe I have caught every case (not including cases where the definition occurs in the same header)~~

~~Some of these cases can probably be done by removing the forward declaration instead, also attempted alternative solutions but unfortunately they were unsuccessful~~

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
