### PR TITLE
C#: Add analyzer release tracking

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,30 @@
+## Release 4.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GD0001  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0001.html)
+GD0002  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0002.html)
+GD0101  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0101.html)
+GD0102  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0102.html)
+GD0103  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0103.html)
+GD0104  |  Usage   |  Error   | ScriptPropertiesGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0104.html)
+GD0105  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0105.html)
+GD0106  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0106.html)
+GD0201  |  Usage   |  Error   | ScriptSignalsGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0201.html)
+GD0202  |  Usage   |  Error   | ScriptSignalsGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0202.html)
+GD0203  |  Usage   |  Error   | ScriptSignalsGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0203.html)
+GD0301  |  Usage   |  Error   | MustBeVariantAnalyzer, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0301.html)
+GD0302  |  Usage   |  Error   | MustBeVariantAnalyzer, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0302.html)
+GD0303  |  Usage   |  Error   | MustBeVariantAnalyzer, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0303.html)
+
+## Release 4.2
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GD0107  |  Usage   |  Error   | ScriptPropertyDefValGenerator, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0107.html)
+GD0401  |  Usage   |  Error   | GlobalClassAnalyzer, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0401.html)
+GD0402  |  Usage   |  Error   | GlobalClassAnalyzer, [Documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/diagnostics/GD0402.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+GD0003  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0003.html)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -20,6 +20,11 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
+  <!-- Analyzer release tracking -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />


### PR DESCRIPTION
Fixes diagnostic [RS2008](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md#rs2008-enable-analyzer-release-tracking).

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
