### PR TITLE
[3.x] Add shader tracking & precomp

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -2676,6 +2676,52 @@
 				Returns the parameters of a shader.
 			</description>
 		</method>
+		<method name="shader_preload_canvas">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Add the canvas (2D) shaders contained in the file at the given path to the pre compile queue.
+			</description>
+		</method>
+		<method name="shader_preload_get_stage" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the progress of the preloader.
+				You can use this in combination with [code]shader_preload_get_stage_count()[/code] to calculate the progress in percent.
+			</description>
+		</method>
+		<method name="shader_preload_get_stage_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total number of all shaders that have been added to the preloader queue.
+			</description>
+		</method>
+		<method name="shader_preload_is_running" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns true if the preloader is currently processing the queue.
+			</description>
+		</method>
+		<method name="shader_preload_particle">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Add the particle shaders contained in the file at the given path to the pre compile queue.
+			</description>
+		</method>
+		<method name="shader_preload_spatial">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Add the spatial (3D) shaders contained in the file at the given path to the pre compile queue.
+			</description>
+		</method>
+		<method name="shader_preload_start">
+			<return type="void" />
+			<description>
+				Tell the preloader to start processing the queue.
+			</description>
+		</method>
 		<method name="shader_set_code">
 			<return type="void" />
 			<argument index="0" name="shader" type="RID" />

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -269,6 +269,14 @@ public:
 	void set_shader_async_hidden_forbidden(bool p_forbidden) {}
 	bool is_shader_async_hidden_forbidden() { return false; }
 
+	virtual Error shader_preload_spatial(const String &p_file_path) { return Error::OK; }
+	virtual Error shader_preload_canvas(const String &p_file_path) { return Error::OK; }
+	virtual Error shader_preload_particle(const String &p_file_path) { return Error::OK; }
+	virtual void shader_preload_start() {}
+	virtual bool shader_preload_is_running() const { return false; }
+	virtual int shader_preload_get_stage() const { return 0; }
+	virtual int shader_preload_get_stage_count() const { return 0; }
+
 	/* COMMON MATERIAL API */
 
 	RID material_create() { return RID(); }

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -551,6 +551,14 @@ public:
 	void _update_shader(Shader *p_shader) const;
 	void update_dirty_shaders();
 
+	virtual Error shader_preload_spatial(const String &p_file_path) { return Error::OK; }
+	virtual Error shader_preload_canvas(const String &p_file_path) { return Error::OK; }
+	virtual Error shader_preload_particle(const String &p_file_path) { return Error::OK; }
+	virtual void shader_preload_start() {}
+	virtual bool shader_preload_is_running() const { return false; }
+	virtual int shader_preload_get_stage() const { return 0; }
+	virtual int shader_preload_get_stage_count() const { return 0; }
+
 	/* COMMON MATERIAL API */
 
 	struct Material : public RID_Data {

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -33,6 +33,8 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 
+#include "shader_tracker_gles3.h"
+
 RasterizerStorage *RasterizerGLES3::get_storage() {
 	return storage;
 }
@@ -414,6 +416,8 @@ void RasterizerGLES3::end_frame(bool p_swap_buffers) {
 	}
 
 	ShaderGLES3::advance_async_shaders_compilation();
+
+	ShaderPreLoader::compile();
 
 	if (p_swap_buffers) {
 		OS::get_singleton()->swap_buffers();

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2329,6 +2329,10 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 		_material_make_dirty(E->self());
 	}
 
+	if (shaders.tracker) {
+		shaders.tracker->add_shader(p_shader->mode, p_shader->code, actions, p_shader->shader->get_conditional_version());
+	}
+
 	p_shader->valid = true;
 	p_shader->version++;
 }
@@ -2523,6 +2527,34 @@ void RasterizerStorageGLES3::set_shader_async_hidden_forbidden(bool p_forbidden)
 
 bool RasterizerStorageGLES3::is_shader_async_hidden_forbidden() {
 	return ShaderGLES3::async_hidden_forbidden;
+}
+
+Error RasterizerStorageGLES3::shader_preload_spatial(const String &p_file_path) {
+	return shaders.preLoader->load_spatial(p_file_path);
+}
+
+Error RasterizerStorageGLES3::shader_preload_canvas(const String &p_file_path) {
+	return shaders.preLoader->load_canvas(p_file_path);
+}
+
+Error RasterizerStorageGLES3::shader_preload_particle(const String &p_file_path) {
+	return shaders.preLoader->load_particle(p_file_path);
+}
+
+void RasterizerStorageGLES3::shader_preload_start() {
+	shaders.preLoader->start();
+}
+
+bool RasterizerStorageGLES3::shader_preload_is_running() const {
+	return shaders.preLoader->is_running();
+}
+
+int RasterizerStorageGLES3::shader_preload_get_stage() const {
+	return shaders.preLoader->get_stage();
+}
+
+int RasterizerStorageGLES3::shader_preload_get_stage_count() const {
+	return shaders.preLoader->get_stage_count();
 }
 
 /* COMMON MATERIAL API */
@@ -8169,6 +8201,11 @@ void RasterizerStorageGLES3::initialize() {
 
 	shaders.compile_queue = nullptr;
 	shaders.cache = nullptr;
+	shaders.tracker = nullptr;
+	if (Main::shader_tracke_enabled()) {
+		shaders.tracker = memnew(ShaderTrackerGLES3);
+	}
+	shaders.preLoader = memnew(ShaderPreLoader);
 	shaders.cache_write_queue = nullptr;
 	bool effectively_on = false;
 	if (config.async_compilation_enabled) {
@@ -8449,6 +8486,12 @@ RasterizerStorageGLES3::RasterizerStorageGLES3() {
 RasterizerStorageGLES3::~RasterizerStorageGLES3() {
 	if (shaders.cache) {
 		memdelete(shaders.cache);
+	}
+	if (shaders.tracker) {
+		memdelete(shaders.tracker);
+	}
+	if (shaders.preLoader) {
+		memdelete(shaders.preLoader);
 	}
 	if (shaders.cache_write_queue) {
 		memdelete(shaders.cache_write_queue);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -38,6 +38,7 @@
 #include "shader_cache_gles3.h"
 #include "shader_compiler_gles3.h"
 #include "shader_gles3.h"
+#include "shader_tracker_gles3.h"
 
 #include "shaders/blend_shape.glsl.gen.h"
 #include "shaders/canvas.glsl.gen.h"
@@ -123,6 +124,8 @@ public:
 
 		ShaderCompilerGLES3 compiler;
 		ShaderCacheGLES3 *cache;
+		ShaderTrackerGLES3 *tracker;
+		ShaderPreLoader *preLoader;
 		ThreadedCallableQueue<GLuint> *cache_write_queue;
 		ThreadedCallableQueue<GLuint> *compile_queue;
 
@@ -565,6 +568,14 @@ public:
 	void _update_shader(Shader *p_shader) const;
 
 	void update_dirty_shaders();
+
+	virtual Error shader_preload_spatial(const String &p_file_path);
+	virtual Error shader_preload_canvas(const String &p_file_path);
+	virtual Error shader_preload_particle(const String &p_file_path);
+	virtual void shader_preload_start();
+	virtual bool shader_preload_is_running() const;
+	virtual int shader_preload_get_stage() const;
+	virtual int shader_preload_get_stage_count() const;
 
 	/* COMMON MATERIAL API */
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -218,6 +218,15 @@ void ShaderGLES3::advance_async_shaders_compilation() {
 	}
 }
 
+void ShaderGLES3::set_conditional_version(uint64_t p_version) {
+	conditional_version = p_version;
+	new_conditional_version = p_version;
+}
+
+uint64_t ShaderGLES3::get_conditional_version() {
+	return conditional_version.key;
+}
+
 void ShaderGLES3::_log_active_compiles() {
 #ifdef DEBUG_ENABLED
 	if (log_active_async_compiles_count) {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -143,6 +143,9 @@ public:
 
 	static void advance_async_shaders_compilation();
 
+	void set_conditional_version(uint64_t p_version);
+	uint64_t get_conditional_version();
+
 private:
 	union VersionKey {
 		static const uint32_t UBERSHADER_FLAG = ((uint32_t)1) << 31;

--- a/drivers/gles3/shader_tracker_gles3.cpp
+++ b/drivers/gles3/shader_tracker_gles3.cpp
@@ -1,0 +1,445 @@
+/**************************************************************************/
+/*  shader_tracker_gles3.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "shader_tracker_gles3.h"
+#include "core/crypto/crypto_core.h"
+#include "core/io/compression.h"
+#include "core/io/file_access_compressed.h"
+#include "core/os/dir_access.h"
+#include "core/os/file_access.h"
+#include "core/os/os.h"
+#include "core/ustring.h"
+#include "rasterizer_storage_gles3.h"
+
+#include "servers/visual/visual_server_globals.h"
+
+const String SPATIAL_LIST_FILE_NAME = "spatial.shaderlist";
+const String CANVAS_LIST_FILE_NAME = "canvas.shaderlist";
+const String PARTICLE_LIST_FILE_NAME = "particle.shaderlist";
+
+const String SHADER_CODE_MARKER = "SHADER_CODE:";
+const String LIST_CODE_SEPERATOR = "SHADER_LIST_START";
+
+ShaderTrackerGLES3::ShaderTrackerGLES3() {
+	spatial_shader_code = Map<uint32_t, String>();
+	canvas_shader_code = Map<uint32_t, String>();
+	particle_shader_code = Map<uint32_t, String>();
+
+	used_spatial_shaders = Map<uint32_t, Map<uint32_t, String>>();
+	used_canvas_shaders = Map<uint32_t, Map<uint32_t, String>>();
+	used_particle_shaders = Map<uint32_t, Map<uint32_t, String>>();
+
+	output_folder = OS::get_singleton()->get_executable_path().get_base_dir();
+}
+
+ShaderTrackerGLES3::~ShaderTrackerGLES3() {
+	FileAccessCompressed *fa_spatial = memnew(FileAccessCompressed);
+	fa_spatial->configure("GCPF"); //, (Compression::Mode)p_compress_mode);
+	Error err = fa_spatial->_open(output_folder.plus_file(SPATIAL_LIST_FILE_NAME), FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(err, "ShaderTracker cannot open file '" + output_folder.plus_file(SPATIAL_LIST_FILE_NAME) + "'. Check user write permissions.");
+	for (Map<uint32_t, String>::Element *e = spatial_shader_code.front(); e; e = e->next()) {
+		fa_spatial->store_string(vformat("%s%d\n", SHADER_CODE_MARKER, e->key()));
+		fa_spatial->store_string(e->value());
+		fa_spatial->store_string("\n");
+	}
+	fa_spatial->store_line(LIST_CODE_SEPERATOR);
+	for (Map<uint32_t, Map<uint32_t, String>>::Element *e = used_spatial_shaders.front(); e; e = e->next()) {
+		for (Map<uint32_t, String>::Element *a = e->value().front(); a; a = a->next()) {
+			fa_spatial->store_string(vformat("%d\n", e->key()));
+			fa_spatial->store_string(a->value());
+		}
+	}
+	memdelete(fa_spatial);
+
+	FileAccessCompressed *fa_canvas = memnew(FileAccessCompressed);
+	fa_canvas->configure("GCPF"); //, (Compression::Mode)p_compress_mode);
+	err = fa_canvas->_open(output_folder.plus_file(CANVAS_LIST_FILE_NAME), FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(err, "ShaderTracker cannot open file '" + output_folder.plus_file(CANVAS_LIST_FILE_NAME) + "'. Check user write permissions.");
+	for (Map<uint32_t, String>::Element *e = canvas_shader_code.front(); e; e = e->next()) {
+		fa_canvas->store_string(vformat("%s%d\n", SHADER_CODE_MARKER, e->key()));
+		fa_canvas->store_string(e->value());
+		fa_canvas->store_string("\n");
+	}
+	fa_canvas->store_line(LIST_CODE_SEPERATOR);
+	for (Map<uint32_t, Map<uint32_t, String>>::Element *e = used_canvas_shaders.front(); e; e = e->next()) {
+		for (Map<uint32_t, String>::Element *a = e->value().front(); a; a = a->next()) {
+			fa_canvas->store_string(vformat("%d\n", e->key()));
+			fa_canvas->store_string(a->value());
+		}
+	}
+	memdelete(fa_canvas);
+
+	FileAccessCompressed *fa_particle = memnew(FileAccessCompressed);
+	fa_particle->configure("GCPF"); //, (Compression::Mode)p_compress_mode);
+	err = fa_particle->_open(output_folder.plus_file(PARTICLE_LIST_FILE_NAME), FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(err, "ShaderTracker cannot open file '" + output_folder.plus_file(PARTICLE_LIST_FILE_NAME) + "'. Check user write permissions.");
+	for (Map<uint32_t, String>::Element *e = particle_shader_code.front(); e; e = e->next()) {
+		fa_particle->store_string(vformat("%s%d\n", SHADER_CODE_MARKER, e->key()));
+		fa_particle->store_string(e->value());
+		fa_particle->store_string("\n");
+	}
+	fa_particle->store_line(LIST_CODE_SEPERATOR);
+	for (Map<uint32_t, Map<uint32_t, String>>::Element *e = used_particle_shaders.front(); e; e = e->next()) {
+		for (Map<uint32_t, String>::Element *a = e->value().front(); a; a = a->next()) {
+			fa_particle->store_string(vformat("%d\n", e->key()));
+			fa_particle->store_string(a->value());
+		}
+	}
+	memdelete(fa_particle);
+}
+
+void ShaderTrackerGLES3::add_shader(VS::ShaderMode p_mode, const String &p_shader_code, ShaderCompilerGLES3::IdentifierActions *p_actions, uint64_t p_conditional_key) {
+	Map<uint32_t, String> *shader_code_map;
+	Map<uint32_t, Map<uint32_t, String>> *shader_action_map;
+
+	if (p_mode == VS::ShaderMode::SHADER_SPATIAL) {
+		shader_code_map = &spatial_shader_code;
+		shader_action_map = &used_spatial_shaders;
+		//_add_spatial_shader(p_shader_code, p_actions, p_conditional_key);
+	} else if (p_mode == VS::ShaderMode::SHADER_CANVAS_ITEM) {
+		shader_code_map = &canvas_shader_code;
+		shader_action_map = &used_canvas_shaders;
+	} else if (p_mode == VS::ShaderMode::SHADER_PARTICLES) {
+		shader_code_map = &particle_shader_code;
+		shader_action_map = &used_particle_shaders;
+	} else {
+		return;
+	}
+
+	uint32_t shader_hash = p_shader_code.hash();
+
+	String serialized = _actions_to_strings(p_actions, p_conditional_key);
+	uint32_t actions_hash = serialized.hash();
+
+	if (!shader_action_map->has(shader_hash)) {
+		shader_action_map->insert(shader_hash, Map<uint32_t, String>());
+		shader_code_map->insert(shader_hash, p_shader_code);
+	}
+	Map<uint32_t, String> *actions_list = &(*shader_action_map)[shader_hash];
+
+	if (actions_list->has(actions_hash)) {
+		return;
+	}
+
+	actions_list->insert(actions_hash, serialized);
+};
+
+String ShaderTrackerGLES3::_strings_to_csv_string(const Vector<String> &p_input) {
+	String line = "";
+	int size = p_input.size();
+	for (int i = 0; i < size; ++i) {
+		String value = p_input[i];
+
+		if (value.find("\n") != -1) {
+			value = value.replace("\n", "");
+		}
+		if (value.find("\"") != -1 || value.find("\n") != -1) {
+			value = "\"" + value.replace("\"", "\"\"") + "\"";
+		}
+		if (i < size - 1) {
+			value += ";";
+		}
+
+		line += value;
+	}
+	return line;
+}
+
+String ShaderTrackerGLES3::_actions_to_strings(ShaderCompilerGLES3::IdentifierActions *p_actions, uint64_t p_conditional_key) {
+	String result = "";
+
+	Vector<String> render_mode_values;
+	for (Map<StringName, Pair<int *, int>>::Element *e = p_actions->render_mode_values.front(); e; e = e->next()) {
+		String tmp = vformat("%s=%d,%d", e->key(), *e->value().first, e->value().second);
+		render_mode_values.push_back(tmp);
+	}
+	result += _strings_to_csv_string(render_mode_values) + "\n";
+
+	Vector<String> render_mode_flags;
+	for (Map<StringName, bool *>::Element *e = p_actions->render_mode_flags.front(); e; e = e->next()) {
+		String tmp = vformat("%s=%d", e->key(), (int)*e->value());
+		render_mode_flags.push_back(tmp);
+	}
+	result += _strings_to_csv_string(render_mode_flags) + "\n";
+
+	Vector<String> usage_flag_pointers;
+	for (Map<StringName, bool *>::Element *e = p_actions->usage_flag_pointers.front(); e; e = e->next()) {
+		String tmp = vformat("%s=%d", e->key(), (int)*e->value());
+		usage_flag_pointers.push_back(tmp);
+	}
+	result += _strings_to_csv_string(usage_flag_pointers) + "\n";
+
+	Vector<String> write_flag_pointers;
+	for (Map<StringName, bool *>::Element *e = p_actions->write_flag_pointers.front(); e; e = e->next()) {
+		String tmp = vformat("%s=%d", e->key(), (int)*e->value());
+		write_flag_pointers.push_back(tmp);
+	}
+	result += _strings_to_csv_string(write_flag_pointers) + "\n";
+	result += vformat("%d\n", p_conditional_key);
+
+	return result;
+}
+
+Error ShaderPreLoader::load_spatial(const String &p_file_path) {
+	return _load(VS::ShaderMode::SHADER_SPATIAL, p_file_path);
+}
+
+Error ShaderPreLoader::load_canvas(const String &p_file_path) {
+	return _load(VS::ShaderMode::SHADER_CANVAS_ITEM, p_file_path);
+}
+
+Error ShaderPreLoader::load_particle(const String &p_file_path) {
+	return _load(VS::ShaderMode::SHADER_PARTICLES, p_file_path);
+}
+
+bool ShaderPreLoader::compiling = false;
+int ShaderPreLoader::spatial_count = 0;
+int ShaderPreLoader::canvas_count = 0;
+int ShaderPreLoader::particle_count = 0;
+int ShaderPreLoader::progress = 0;
+
+Map<uint32_t, String> ShaderPreLoader::spatial_shader_code = Map<uint32_t, String>();
+Vector<ShaderPreLoader::ShaderPermutation> ShaderPreLoader::spatial_shaders = Vector<ShaderPreLoader::ShaderPermutation>();
+Map<uint32_t, String> ShaderPreLoader::canvas_shader_code = Map<uint32_t, String>();
+Vector<ShaderPreLoader::ShaderPermutation> ShaderPreLoader::canvas_shaders = Vector<ShaderPreLoader::ShaderPermutation>();
+Map<uint32_t, String> ShaderPreLoader::particle_shader_code = Map<uint32_t, String>();
+Vector<ShaderPreLoader::ShaderPermutation> ShaderPreLoader::particle_shaders = Vector<ShaderPreLoader::ShaderPermutation>();
+
+Error ShaderPreLoader::_load(VS::ShaderMode p_mode, const String &p_file_path) {
+	if (compiling) {
+		print_error("Can not load new shaderlists while already compiling. Please wait for the current compilation to finish!");
+		return Error::ERR_BUSY;
+	}
+
+	Map<uint32_t, String> *code_map;
+	Vector<ShaderPreLoader::ShaderPermutation> *permutations;
+	int *count;
+	if (p_mode == VS::ShaderMode::SHADER_SPATIAL) {
+		code_map = &spatial_shader_code;
+		permutations = &spatial_shaders;
+		count = &spatial_count;
+	} else if (p_mode == VS::ShaderMode::SHADER_CANVAS_ITEM) {
+		code_map = &canvas_shader_code;
+		permutations = &canvas_shaders;
+		count = &canvas_count;
+	} else if (p_mode == VS::ShaderMode::SHADER_PARTICLES) {
+		code_map = &particle_shader_code;
+		permutations = &particle_shaders;
+		count = &particle_count;
+	} else {
+		return Error::ERR_INVALID_PARAMETER;
+	}
+	progress = 0;
+	code_map->clear();
+	permutations->clear();
+
+	FileAccessCompressed *fa = memnew(FileAccessCompressed);
+	fa->configure("GCPF");
+	Error err = fa->_open(p_file_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(err, err, "ShaderPreLoader cannot open file '" + p_file_path + "'. Check user read permissions & the file location.");
+
+	//Load shader code
+	uint32_t current_shader_id = 0;
+	String current_shader_code = "";
+	for (String line = fa->get_line(); !fa->eof_reached(); line = fa->get_line()) {
+		if (line.begins_with(SHADER_CODE_MARKER)) {
+			// Start of a new shader
+			if (current_shader_id) {
+				//store prev shader
+				current_shader_code = current_shader_code.substr(0, current_shader_code.length() - 1);
+				//current_shader_code = "\n" + current_shader_code;
+				code_map->insert(current_shader_id, current_shader_code);
+
+				if (current_shader_id != current_shader_code.hash()) {
+					print_error("Loaded code hash doesn't match stored hash!");
+				}
+			}
+			current_shader_id = line.split(":")[1].to_int64();
+			current_shader_code = "";
+		} else if (line.begins_with(LIST_CODE_SEPERATOR)) {
+			break;
+		} else {
+			current_shader_code += line + "\n";
+		}
+	}
+	code_map->insert(current_shader_id, current_shader_code);
+
+	//Load shader permutations
+	*count = 0;
+	while (!fa->eof_reached()) {
+		String id = fa->get_line();
+		String render_mode_values = fa->get_line();
+		String render_mode_flags = fa->get_line();
+		String usage_flag_pointers = fa->get_line();
+		String write_flag_pointers = fa->get_line();
+		uint64_t conditional_key = fa->get_line().to_int64();
+
+		uint32_t id_number = id.to_int64();
+
+		if (!id_number)
+			break;
+
+		if (!code_map->has(id_number)) {
+			print_error(vformat("Shaderlist contains a shader id (\"%s\") that is not stored in shadercode!", id));
+			break;
+		}
+		*count = *count + 1;
+
+		String settings = render_mode_values + "\n" + render_mode_flags + "\n" + usage_flag_pointers + "\n" + write_flag_pointers;
+		permutations->push_back(ShaderPermutation{
+				id_number, settings, conditional_key });
+	}
+
+	memdelete(fa);
+
+	return Error::OK;
+}
+
+void ShaderPreLoader::start() {
+	if (!compiling) {
+		progress = 0;
+		compiling = true;
+	}
+}
+
+bool ShaderPreLoader::is_running() const {
+	return compiling;
+}
+
+void ShaderPreLoader::compile() {
+	if (!compiling) {
+		return;
+	}
+
+	if (progress < spatial_count) {
+		ShaderPermutation perm = spatial_shaders.get(progress);
+		String code = spatial_shader_code[perm.code];
+		_compile_shader(VisualServer::ShaderMode::SHADER_SPATIAL, perm, code);
+	} else if (progress < spatial_count + canvas_count) {
+		ShaderPermutation perm = canvas_shaders.get(progress - spatial_count);
+		String code = canvas_shader_code[perm.code];
+		_compile_shader(VisualServer::ShaderMode::SHADER_CANVAS_ITEM, perm, code);
+	} else if (progress < spatial_count + canvas_count + particle_count) {
+		ShaderPermutation perm = particle_shaders.get(progress - spatial_count - canvas_count);
+		String code = particle_shader_code[perm.code];
+		_compile_shader(VisualServer::ShaderMode::SHADER_PARTICLES, perm, code);
+	} else {
+		compiling = false;
+	}
+
+	progress++;
+}
+
+void ShaderPreLoader::_compile_shader(VisualServer::ShaderMode p_shader_mode, const ShaderPermutation &p_perm, const String &p_code) {
+	List<int> int_value_storage;
+	Vector<String> lines = p_perm.actions.split("\n");
+	Map<StringName, Pair<int *, int>> render_mode_values;
+	Map<StringName, bool *> render_mode_flags;
+	Map<StringName, bool *> usage_flag_pointers;
+	Map<StringName, bool *> write_flag_pointers;
+	Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
+
+	deserialize_pair_map(render_mode_values, lines[0], int_value_storage);
+	deserialize_bool_map(render_mode_flags, lines[1], int_value_storage);
+	deserialize_bool_map(usage_flag_pointers, lines[2], int_value_storage);
+	deserialize_bool_map(write_flag_pointers, lines[3], int_value_storage);
+
+	ShaderCompilerGLES3::IdentifierActions actions = {
+		render_mode_values,
+		render_mode_flags,
+		usage_flag_pointers,
+		write_flag_pointers,
+		&uniforms
+	};
+
+	VisualServer *vs = VisualServer::get_singleton();
+	ShaderCompilerGLES3 compiler;
+	ShaderCompilerGLES3::GeneratedCode gen_code;
+
+	RID shader_rid = vs->shader_create();
+
+	//visual_server_globals.h
+	RasterizerStorageGLES3::Shader *shader = ((RasterizerStorageGLES3 *)VSG::storage)->shader_owner.get(shader_rid);
+
+	vs->shader_set_code(shader_rid, p_code);
+
+	shader->shader->set_conditional_version(p_perm.conditional_key);
+
+	Error err = compiler.compile(p_shader_mode, p_code, &actions, "", gen_code);
+	ERR_FAIL_COND_MSG(err, "Failed to compile shader code!");
+
+	shader->shader->set_custom_shader_code(shader->custom_code_id, gen_code.vertex, gen_code.vertex_global, gen_code.fragment, gen_code.light, gen_code.fragment_global, gen_code.uniforms, gen_code.texture_uniforms, gen_code.defines, ShaderGLES3::AsyncMode::ASYNC_MODE_HIDDEN);
+	shader->shader->bind();
+}
+
+int ShaderPreLoader::get_stage() const {
+	return progress;
+}
+
+int ShaderPreLoader::get_stage_count() const {
+	return spatial_count + canvas_count + particle_count;
+}
+
+void ShaderPreLoader::deserialize_pair_map(Map<StringName, Pair<int *, int>> &p_render_mode_values, String p_string, List<int> &p_int_value_storage) {
+	if (p_string.length() <= 1) {
+		return;
+	}
+
+	Vector<String> splits = p_string.split(";");
+	for (int i = 0; i < splits.size(); i++) {
+		String split = splits[i];
+		Vector<String> tmp = split.split("=");
+		String key = tmp[0];
+		Vector<String> values = tmp[1].split(",");
+
+		p_int_value_storage.push_back(values[0].to_int());
+
+		Pair<int *, int> a = Pair<int *, int>(&p_int_value_storage.back()->get(), values[1].to_int());
+		p_render_mode_values.insert(key, a);
+	}
+}
+
+void ShaderPreLoader::deserialize_bool_map(Map<StringName, bool *> &p_render_mode_values, String p_string, List<int> &p_int_value_storage) {
+	if (p_string.length() <= 1) {
+		return;
+	}
+
+	Vector<String> splits = p_string.split(";");
+	for (int i = 0; i < splits.size(); i++) {
+		String split = splits[i];
+		Vector<String> tmp = split.split("=");
+		String key = tmp[0];
+
+		p_int_value_storage.push_back(tmp[1].to_int());
+
+		bool *value = (bool *)&p_int_value_storage.back()->get();
+		p_render_mode_values.insert(key, value);
+	}
+}

--- a/drivers/gles3/shader_tracker_gles3.h
+++ b/drivers/gles3/shader_tracker_gles3.h
@@ -1,0 +1,116 @@
+/**************************************************************************/
+/*  shader_tracker_gles3.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef SHADER_TRACKER_GLES3_H
+#define SHADER_TRACKER_GLES3_H
+
+#include "core/hash_map.h"
+#include "core/list.h"
+#include "servers/visual_server.h"
+#include "shader_compiler_gles3.h"
+#include <atomic>
+
+class String;
+class FileAccess;
+class FileAccessCompressed;
+
+class ShaderTrackerGLES3 {
+	struct ShaderOptionsSerialized {
+		String serialized;
+		unsigned char hash;
+	};
+
+	Map<uint32_t, String> spatial_shader_code;
+	Map<uint32_t, String> canvas_shader_code;
+	Map<uint32_t, String> particle_shader_code;
+
+	//Store all used action hashes and actions for a given shader code hash
+	Map<uint32_t, Map<uint32_t, String>> used_spatial_shaders;
+	Map<uint32_t, Map<uint32_t, String>> used_canvas_shaders;
+	Map<uint32_t, Map<uint32_t, String>> used_particle_shaders;
+
+	String output_folder;
+
+public:
+	ShaderTrackerGLES3();
+
+	void add_shader(VS::ShaderMode p_mode, const String &p_shader_code, ShaderCompilerGLES3::IdentifierActions *p_actions, uint64_t conditional_key);
+
+	~ShaderTrackerGLES3();
+
+	//make me private
+	static String _actions_to_strings(ShaderCompilerGLES3::IdentifierActions *p_actions, uint64_t conditional_key);
+
+private:
+	//void _add_spatial_shader(const String &p_shader_code, ShaderCompilerGLES3::IdentifierActions *p_actions, uint64_t conditional_key);
+
+	static String _strings_to_csv_string(const Vector<String> &p_input);
+};
+
+class ShaderPreLoader {
+	struct ShaderPermutation {
+		uint32_t code;
+		String actions;
+		uint64_t conditional_key;
+	};
+
+private:
+	static bool compiling;
+	static Map<uint32_t, String> spatial_shader_code;
+	static Vector<ShaderPermutation> spatial_shaders;
+	static Map<uint32_t, String> canvas_shader_code;
+	static Vector<ShaderPermutation> canvas_shaders;
+	static Map<uint32_t, String> particle_shader_code;
+	static Vector<ShaderPermutation> particle_shaders;
+
+	static int spatial_count;
+	static int canvas_count;
+	static int particle_count;
+	static int progress;
+
+	static void deserialize_pair_map(Map<StringName, Pair<int *, int>> &p_render_mode_values, String p_data, List<int> &p_int_value_storage);
+	static void deserialize_bool_map(Map<StringName, bool *> &p_map, String p_data, List<int> &p_int_value_storage);
+
+	Error _load(VS::ShaderMode p_mode, const String &p_file_path);
+	static void _compile_shader(VisualServer::ShaderMode p_mode, const ShaderPermutation &p_perm, const String &p_code);
+
+public:
+	Error load_spatial(const String &p_file_path);
+	Error load_canvas(const String &p_file_path);
+	Error load_particle(const String &p_file_path);
+	void start();
+	bool is_running() const;
+	int get_stage() const;
+	int get_stage_count() const;
+
+	static void compile();
+};
+
+#endif // SHADER_TRACKER_GLES3_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -140,7 +140,7 @@ HashMap<Main::CLIScope, Vector<String>> forwardable_cli_arguments;
 #endif
 
 // Display
-
+bool Main::track_shaders = false;
 static OS::VideoMode video_mode;
 static int init_screen = -1;
 static bool init_fullscreen = false;
@@ -171,6 +171,10 @@ static bool print_fps = false;
 // but not if e.g. we fail to load and project and fallback to the manager.
 bool Main::is_project_manager() {
 	return project_manager;
+}
+
+bool Main::shader_tracke_enabled() {
+	return track_shaders;
 }
 
 #ifdef TOOLS_ENABLED
@@ -317,6 +321,7 @@ void Main::print_help(const char *p_binary) {
 		OS::get_singleton()->print("'%s'", OS::get_singleton()->get_tablet_driver_name(i).utf8().get_data());
 	}
 	OS::get_singleton()->print(") (Windows only).\n");
+	OS::get_singleton()->print("  --track-shaders                  Create lists of all used spatial, canvas and particle shaders.\n");
 	OS::get_singleton()->print("\n");
 #endif
 
@@ -707,6 +712,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing tablet driver argument, aborting.\n");
 				goto error;
 			}
+		} else if (I->get() == "--track-shaders") {
+			track_shaders = true;
 		} else if (I->get() == "--enable-vsync-via-compositor") {
 			video_mode.vsync_via_compositor = true;
 			saw_vsync_via_compositor_override = true;

--- a/main/main.h
+++ b/main/main.h
@@ -47,9 +47,11 @@ class Main {
 	static bool force_redraw_requested;
 	static int iterating;
 	static bool agile_input_event_flushing;
+	static bool track_shaders;
 
 public:
 	static bool is_project_manager();
+	static bool shader_tracke_enabled();
 #ifdef TOOLS_ENABLED
 	enum CLIScope {
 		CLI_SCOPE_TOOL, // Editor and project manager.

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -277,6 +277,14 @@ public:
 	virtual void set_shader_async_hidden_forbidden(bool p_forbidden) = 0;
 	virtual bool is_shader_async_hidden_forbidden() = 0;
 
+	virtual Error shader_preload_spatial(const String &p_file_path) = 0;
+	virtual Error shader_preload_canvas(const String &p_file_path) = 0;
+	virtual Error shader_preload_particle(const String &p_file_path) = 0;
+	virtual void shader_preload_start() = 0;
+	virtual bool shader_preload_is_running() const = 0;
+	virtual int shader_preload_get_stage() const = 0;
+	virtual int shader_preload_get_stage_count() const = 0;
+
 	/* COMMON MATERIAL API */
 
 	virtual RID material_create() = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -103,6 +103,8 @@ public:
 
 #define BIND0R(m_r, m_name) \
 	m_r m_name() { return BINDBASE->m_name(); }
+#define BIND0RC(m_r, m_name) \
+	m_r m_name() const { return BINDBASE->m_name(); }
 #define BIND1R(m_r, m_name, m_type1) \
 	m_r m_name(m_type1 arg1) { return BINDBASE->m_name(arg1); }
 #define BIND1RC(m_r, m_name, m_type1) \
@@ -207,6 +209,14 @@ public:
 	BIND2(shader_remove_custom_define, RID, const String &)
 
 	BIND1(set_shader_async_hidden_forbidden, bool)
+
+	BIND1R(Error, shader_preload_spatial, const String &)
+	BIND1R(Error, shader_preload_canvas, const String &)
+	BIND1R(Error, shader_preload_particle, const String &)
+	BIND0N(shader_preload_start)
+	BIND0RC(bool, shader_preload_is_running)
+	BIND0RC(int, shader_preload_get_stage)
+	BIND0RC(int, shader_preload_get_stage_count)
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -131,6 +131,22 @@ public:
 
 	FUNC1(set_shader_async_hidden_forbidden, bool)
 
+	FUNC1R(Error, shader_preload_spatial, const String &)
+	FUNC1R(Error, shader_preload_canvas, const String &)
+	FUNC1R(Error, shader_preload_particle, const String &)
+	FUNC0(shader_preload_start)
+	FUNC0RC(bool, shader_preload_is_running)
+	FUNC0RC(int, shader_preload_get_stage)
+	FUNC0RC(int, shader_preload_get_stage_count)
+
+	//virtual Error shader_preload_spatial(const String &p_file_path);
+	//virtual Error shader_preload_canvas(const String &p_file_path);
+	//virtual Error shader_preload_particle(const String &p_file_path);
+	//virtual void shader_preload_start();
+	//virtual bool shader_preload_is_running() const;
+	//virtual int shader_preload_get_stage() const;
+	//virtual int shader_preload_get_stage_count() const;
+
 	/* COMMON MATERIAL API */
 
 	FUNCRID(material)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1878,6 +1878,14 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_get_default_texture_param", "shader", "name"), &VisualServer::shader_get_default_texture_param);
 	ClassDB::bind_method(D_METHOD("set_shader_async_hidden_forbidden", "forbidden"), &VisualServer::set_shader_async_hidden_forbidden);
 
+	ClassDB::bind_method(D_METHOD("shader_preload_spatial", "path"), &VisualServer::shader_preload_spatial);
+	ClassDB::bind_method(D_METHOD("shader_preload_canvas", "path"), &VisualServer::shader_preload_canvas);
+	ClassDB::bind_method(D_METHOD("shader_preload_particle", "path"), &VisualServer::shader_preload_particle);
+	ClassDB::bind_method(D_METHOD("shader_preload_start"), &VisualServer::shader_preload_start);
+	ClassDB::bind_method(D_METHOD("shader_preload_is_running"), &VisualServer::shader_preload_is_running);
+	ClassDB::bind_method(D_METHOD("shader_preload_get_stage"), &VisualServer::shader_preload_get_stage);
+	ClassDB::bind_method(D_METHOD("shader_preload_get_stage_count"), &VisualServer::shader_preload_get_stage_count);
+
 	ClassDB::bind_method(D_METHOD("material_create"), &VisualServer::material_create);
 	ClassDB::bind_method(D_METHOD("material_set_shader", "shader_material", "shader"), &VisualServer::material_set_shader);
 	ClassDB::bind_method(D_METHOD("material_get_shader", "shader_material"), &VisualServer::material_get_shader);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -209,6 +209,14 @@ public:
 
 	virtual void set_shader_async_hidden_forbidden(bool p_forbidden) = 0;
 
+	virtual Error shader_preload_spatial(const String &p_file_path) = 0;
+	virtual Error shader_preload_canvas(const String &p_file_path) = 0;
+	virtual Error shader_preload_particle(const String &p_file_path) = 0;
+	virtual void shader_preload_start() = 0;
+	virtual bool shader_preload_is_running() const = 0;
+	virtual int shader_preload_get_stage() const = 0;
+	virtual int shader_preload_get_stage_count() const = 0;
+
 	/* COMMON MATERIAL API */
 
 	enum {


### PR DESCRIPTION
This PR adds a launch flag (`--track-shaders`) that can be used to generate a list of all used shaders during the playtesting and QA process. In addition functions are provided that make it possible to load these shadderlists from code and use them to prepopulate the devices shader cache.

I should note that this solution is not quite as elegant as I would like it to be, I am basically generating massive text files containing both the shader's code as well as any additional information that is necessary to compile it. Earlier drafts of this PR attempted to be smarter about this and only store the necessary options, while referencing the shader's source files instead and also trying to automatically infer information from the scene files. However, as I came across more and more edge cases it quickly escalated in complexity until it became nigh unmaintainable.
This, admittedly dumber and brute force-y, approach on the other hand works far better than it has any right to. I have tested it on both windows and linux without any problems and even managed to get the lists themselves to be fairly small (they have a lot of duplicated substrings, which means that compressing them turned out to be quite efficient). All the shaderlists for the tps demo come in at less than 40KB.

## Using this PR

1. First run your game with the `--track-shaders` launch flag.
2. Add some code to you main menu/starting screen to load the generated shader lists and use them to fill your devices cache:
```
onready var progress_bar : ProgressBar = get_node("ProgressBar")

func _process(delta):
	if(VisualServer.shader_preload_is_running()):
		# Update some ui component
		progress_bar.value = VisualServer.shader_preload_get_stage()

func _on_ButtonShaderPrecomp_pressed():
	VisualServer.shader_preload_spatial("res://spatial.shaderlist")
	VisualServer.shader_preload_canvas("res://canvas.shaderlist")
	VisualServer.shader_preload_particle("res://particle.shaderlist")
	progress_bar.max_value = VisualServer.shader_preload_get_stage_count()
	VisualServer.shader_preload_start()
```
3. Run it whenever you deploy your app on a new device

## Performance

On my laptop this PR reduced the initial loading times for new shaders to roughly a third of what it was before during a cold launch. According to my benchmarks my laptop usually spends around 15,14 seconds in total to load and compile all the necessary shaders for the TPS demo. By using this PR I got those times down to around  5,97 seconds.

Note that this PR will not result in any additional performance gains during subsequent runs!

When testing this PR make sure you delete all cached shaders on your device before every launch. This depends a lot on your platform but the usual suspects are godot's built in cache, your driver's cache and maybe your operating system's cache.

### A note on 4.x

We will need something similar to this in 4.x. However, I am cautiously optimistic that the shaders are handled better in 4.x (you would not believe how many string operations we are performing across multiple cpp files  just to prepare a shader for compilation.) so we might be able to come up with a solution that is more elegant than this.
From what I have gathered while talking to W4 employees at the conference I believe that they plan to implement something like this anyways for console support, so for now I will leave 4.x to them.

---

This PR was sponsored by Ramatak with 💚