### PR TITLE
Fix Windows console wrapper and icon being swapped

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -168,10 +168,10 @@ Error EditorExportPlatformWindows::sign_shared_object(const Ref<EditorExportPres
 
 Error EditorExportPlatformWindows::modify_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	if (p_preset->get("application/modify_resources")) {
-		_rcedit_add_data(p_preset, p_path, true);
+		_rcedit_add_data(p_preset, p_path, false);
 		String wrapper_path = p_path.get_basename() + ".console.exe";
 		if (FileAccess::exists(wrapper_path)) {
-			_rcedit_add_data(p_preset, wrapper_path, false);
+			_rcedit_add_data(p_preset, wrapper_path, true);
 		}
 	}
 	return OK;


### PR DESCRIPTION

Fixed the issue where when exporting on a windows system, the console wrapper icon and normal one would be swapped, this was fixed because the boolean value for if the icon was the console wrapper icon or not was backwards in the modify_template function

*Bugsquad edit:*
- Fixes #80238.