### PR TITLE
Dismiss currently visible or upcoming tooltips when pressing Escape

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2184,6 +2184,18 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			return;
 		}
 
+		if (p_event->is_action_pressed("ui_cancel")) {
+			// Cancel tooltip timer or hide tooltip when pressing Escape (this is standard behavior in most applications).
+			_gui_cancel_tooltip();
+			if (gui.tooltip_popup) {
+				// If a tooltip was hidden, prevent other actions associated with `ui_cancel` from occurring.
+				// For instance, this prevents the node from being deselected when pressing Escape
+				// to hide a documentation tooltip in the inspector.
+				set_input_as_handled();
+				return;
+			}
+		}
+
 		if (gui.key_focus && !gui.key_focus->is_visible_in_tree()) {
 			gui.key_focus->release_focus();
 		}


### PR DESCRIPTION
This is standard UI behavior in most applications out there.

## Preview

*The editor inspector's documentation tooltips already have a special case for being dismissable, but prior to this PR, the node would always be deselected when pressing <kbd>Escape</kbd> while a tooltip is visible.*

https://github.com/godotengine/godot/assets/180032/e901e332-ebb6-43fc-aa2e-22cc1d57aac7