### PR TITLE
Fix issue with four subpasses always been requested in mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -722,16 +722,9 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 			using_subpass_post_process = false;
 		}
 
-		// We do this last because our get_color_fbs creates and caches the framebuffer if we need it.
-		RID four_subpasses = rb_data->get_color_fbs(RenderBufferDataForwardMobile::FB_CONFIG_FOUR_SUBPASSES);
-		if (using_subpass_post_process && four_subpasses.is_null()) {
-			// can't do blit subpass because we don't have all subpasses
-			using_subpass_post_process = false;
-		}
-
 		if (using_subpass_post_process) {
 			// all as subpasses
-			framebuffer = four_subpasses;
+			framebuffer = rb_data->get_color_fbs(RenderBufferDataForwardMobile::FB_CONFIG_FOUR_SUBPASSES);
 		} else if (using_subpass_transparent) {
 			// our tonemap pass is separate
 			framebuffer = rb_data->get_color_fbs(RenderBufferDataForwardMobile::FB_CONFIG_THREE_SUBPASSES);


### PR DESCRIPTION
Little bit of history, originally we didn't communicate our scaling settings to the render implementation (just wasn't communicated) so we allowed `get_color_fbs` to silently fail early on if the size of the 3D render buffer differed from our render target.
If it failed we simply fell back to our 3 subpass + 1 normal pass approach.

Then we did a rework of the scaling logic and did pass this information. We can see in `_render_scene` we are now properly checking `(rb->get_scaling_3d_mode() != RS::VIEWPORT_SCALING_3D_MODE_OFF)` and we removed the silent fail from `get_color_fbs` however I omitted to change the logic that always attempted to retrieve the 4 sub-pass framebuffer.

This PR changes that.

Fixes #70093