### PR TITLE
[3.5] Fix Tween cheatsheet URL

### DIFF
--- a/doc/classes/SceneTreeTween.xml
+++ b/doc/classes/SceneTreeTween.xml
@@ -45,7 +45,7 @@
 		    tween = create_tween()
 		[/codeblock]
 		Some [Tweener]s use transitions and eases. The first accepts a [enum Tween.TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum Tween.EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum Tween.TransitionType] constants with [constant Tween.EASE_IN_OUT], and use the one that looks best.
-		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
+		[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
 		[b]Note:[/b] All [SceneTreeTween]s will automatically start by default. To prevent a [SceneTreeTween] from autostarting, you can call [method stop] immediately after it is created.
 		[b]Note:[/b] [SceneTreeTween]s are processing after all of nodes in the current frame, i.e. after [method Node._process] or [method Node._physics_process] (depending on [enum Tween.TweenProcessMode]).
 	</description>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -16,7 +16,7 @@
 		[/codeblock]
 		Many methods require a property name, such as [code]"position"[/code] above. You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using [code]"property:component"[/code] (e.g. [code]position:x[/code]), where it would only apply to that particular component.
 		Many of the methods accept [code]trans_type[/code] and [code]ease_type[/code]. The first accepts an [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [constant EASE_IN_OUT], and use the one that looks best.
-		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
+		[url=https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
 		[b]Note:[/b] Tween methods will return [code]false[/code] if the requested operation cannot be completed.
 		[b]Note:[/b] For an alternative method of tweening, that doesn't require using nodes, see [SceneTreeTween].
 	</description>


### PR DESCRIPTION
 The [tween cheatsheet][] `.png` URL for `3.5` is now a [404][] as [the cheatsheet][] in `master` now points to an updated `.webp` file that references `4.1`. So for this change the `Tween` and `SceneTreeTween` docs now point to the `3.x` relevant image.

[404]: https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png
[tween cheatsheet]: https://raw.githubusercontent.com/godotengine/godot-docs/3.5/img/tween_cheatsheet.png
[the cheatsheet]: https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.webp