### PR TITLE
Register and cleanup resource importer singletons in a predictable way

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6925,8 +6925,7 @@ EditorNode::EditorNode() {
 
 	{
 		// Register importers at the beginning, so dialogs are created with the right extensions.
-		Ref<ResourceImporterTexture> import_texture;
-		import_texture.instantiate();
+		Ref<ResourceImporterTexture> import_texture = memnew(ResourceImporterTexture(true));
 		ResourceFormatImporter::get_singleton()->add_importer(import_texture);
 
 		Ref<ResourceImporterLayeredTexture> import_cubemap;
@@ -6944,8 +6943,7 @@ EditorNode::EditorNode() {
 		import_cubemap_array->set_mode(ResourceImporterLayeredTexture::MODE_CUBEMAP_ARRAY);
 		ResourceFormatImporter::get_singleton()->add_importer(import_cubemap_array);
 
-		Ref<ResourceImporterLayeredTexture> import_3d;
-		import_3d.instantiate();
+		Ref<ResourceImporterLayeredTexture> import_3d = memnew(ResourceImporterLayeredTexture(true));
 		import_3d->set_mode(ResourceImporterLayeredTexture::MODE_3D);
 		ResourceFormatImporter::get_singleton()->add_importer(import_3d);
 
@@ -6985,12 +6983,10 @@ EditorNode::EditorNode() {
 		import_shader_file.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
 
-		Ref<ResourceImporterScene> import_scene;
-		import_scene.instantiate();
+		Ref<ResourceImporterScene> import_scene = memnew(ResourceImporterScene(false, true));
 		ResourceFormatImporter::get_singleton()->add_importer(import_scene);
 
-		Ref<ResourceImporterScene> import_animation;
-		import_animation = Ref<ResourceImporterScene>(memnew(ResourceImporterScene(true)));
+		Ref<ResourceImporterScene> import_animation = memnew(ResourceImporterScene(true, true));
 		ResourceFormatImporter::get_singleton()->add_importer(import_animation);
 
 		{

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -474,12 +474,19 @@ bool ResourceImporterLayeredTexture::are_import_settings_valid(const String &p_p
 
 ResourceImporterLayeredTexture *ResourceImporterLayeredTexture::singleton = nullptr;
 
-ResourceImporterLayeredTexture::ResourceImporterLayeredTexture() {
-	singleton = this;
+ResourceImporterLayeredTexture::ResourceImporterLayeredTexture(bool p_singleton) {
+	// This should only be set through the EditorNode.
+	if (p_singleton) {
+		singleton = this;
+	}
+
 	mode = MODE_CUBEMAP;
 }
 
 ResourceImporterLayeredTexture::~ResourceImporterLayeredTexture() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
 }
 
 void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source_file, Ref<LayeredTextureImport> r_texture_import) {

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -119,7 +119,7 @@ public:
 
 	void set_mode(Mode p_mode) { mode = p_mode; }
 
-	ResourceImporterLayeredTexture();
+	ResourceImporterLayeredTexture(bool p_singleton = false);
 	~ResourceImporterLayeredTexture();
 };
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2607,13 +2607,26 @@ void ResourceImporterScene::ResourceImporterScene::show_advanced_options(const S
 	SceneImportSettings::get_singleton()->open_settings(p_path, animation_importer);
 }
 
-ResourceImporterScene::ResourceImporterScene(bool p_animation_import) {
-	if (p_animation_import) {
-		animation_singleton = this;
-	} else {
-		scene_singleton = this;
+ResourceImporterScene::ResourceImporterScene(bool p_animation_import, bool p_singleton) {
+	// This should only be set through the EditorNode.
+	if (p_singleton) {
+		if (p_animation_import) {
+			animation_singleton = this;
+		} else {
+			scene_singleton = this;
+		}
 	}
+
 	animation_importer = p_animation_import;
+}
+
+ResourceImporterScene::~ResourceImporterScene() {
+	if (animation_singleton == this) {
+		animation_singleton = nullptr;
+	}
+	if (scene_singleton == this) {
+		scene_singleton = nullptr;
+	}
 }
 
 void ResourceImporterScene::add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -296,7 +296,8 @@ public:
 
 	virtual bool can_import_threaded() const override { return false; }
 
-	ResourceImporterScene(bool p_animation_import = false);
+	ResourceImporterScene(bool p_animation_import = false, bool p_singleton = false);
+	~ResourceImporterScene();
 
 	template <class M>
 	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -789,10 +789,12 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path) co
 
 ResourceImporterTexture *ResourceImporterTexture::singleton = nullptr;
 
-ResourceImporterTexture::ResourceImporterTexture() {
-	if (!singleton) {
+ResourceImporterTexture::ResourceImporterTexture(bool p_singleton) {
+	// This should only be set through the EditorNode.
+	if (p_singleton) {
 		singleton = this;
 	}
+
 	CompressedTexture2D::request_3d_callback = _texture_reimport_3d;
 	CompressedTexture2D::request_roughness_callback = _texture_reimport_roughness;
 	CompressedTexture2D::request_normal_callback = _texture_reimport_normal;

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -107,7 +107,7 @@ public:
 	virtual bool are_import_settings_valid(const String &p_path) const override;
 	virtual String get_import_settings_string() const override;
 
-	ResourceImporterTexture();
+	ResourceImporterTexture(bool p_singleton = false);
 	~ResourceImporterTexture();
 };
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80255. Replaces https://github.com/godotengine/godot/pull/79981.

I think I have an idea of what's happening. We create all importers in `EditorNode`, and we assume those will act as singletons (for some of them which implement the pattern). However, there is a possibility for something else to steal the instance, and then be discarded. In this case it looks like the doc generator does that. It has this bit:

```cpp

if (ClassDB::is_parent_class(name, "ResourceImporter") && name != "EditorImportPlugin" && ClassDB::can_instantiate(name)) {
	import_option = true;
	ResourceImporter *resimp = Object::cast_to<ResourceImporter>(ClassDB::instantiate(name));
	List<ResourceImporter::ImportOption> options;
	resimp->get_import_options("", &options);
	for (int i = 0; i < options.size(); i++) {
		const PropertyInfo &prop = options[i].option;
		properties.push_back(prop);
		import_options_default[prop.name] = options[i].default_value;
	}
	own_properties = properties;
	memdelete(resimp);
}
```

If this code runs after the `EditorNode` constructor, it will assume the place of the singleton, and then it will immediately be destroyed, nulling the reference. My proposed solution to this is to add a flag for the constructor so we explicitly decide which instance is going to be added as the singleton instance. I implemented it for all 3 importers that have singletons. And also made sure we don't leak anything on exit for all of them.

Note that the layered texture importer has the singleton, but it's unused as far as I can see.

----

Due to this being a race condition of sorts, it's hard to reproduce reliably, thus making it harder to validate the fix. But I think the logic is solid. When testing note that the doc generator only runs if you don't have a valid docs cache. So make sure to delete it (`editor_data/cache/editor_doc_cache.res`).