### PR TITLE
Allow duplicating entire animations

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -39,6 +39,14 @@
 				Removes all animations. An empty [code]default[/code] animation will be created.
 			</description>
 		</method>
+		<method name="duplicate_animation">
+			<return type="void" />
+			<param index="0" name="anim_from" type="StringName" />
+			<param index="1" name="anim_to" type="StringName" />
+			<description>
+				Duplicate all frames [param anim_from] to the [param anim_to].
+			</description>
+		</method>
 		<method name="get_animation_loop" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="anim" type="StringName" />

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -118,6 +118,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	int sel;
 
 	Button *add_anim = nullptr;
+	Button *duplicate_anim = nullptr;
 	Button *delete_anim = nullptr;
 	SpinBox *anim_speed = nullptr;
 	Button *anim_loop = nullptr;
@@ -201,6 +202,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_selected();
 	void _animation_name_edited();
 	void _animation_add();
+	void _animation_duplicate();
 	void _animation_remove();
 	void _animation_remove_confirmed();
 	void _animation_search_text_changed(const String &p_text);

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -106,6 +106,10 @@ bool SpriteFrames::has_animation(const StringName &p_anim) const {
 	return animations.has(p_anim);
 }
 
+void SpriteFrames::duplicate_animation(const StringName &p_from, const StringName &p_to) {
+	animations[p_to] = animations[p_from];
+}
+
 void SpriteFrames::remove_animation(const StringName &p_anim) {
 	animations.erase(p_anim);
 }
@@ -227,6 +231,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 void SpriteFrames::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "anim"), &SpriteFrames::add_animation);
 	ClassDB::bind_method(D_METHOD("has_animation", "anim"), &SpriteFrames::has_animation);
+	ClassDB::bind_method(D_METHOD("duplicate_animation", "anim_from", "anim_to"), &SpriteFrames::duplicate_animation);
 	ClassDB::bind_method(D_METHOD("remove_animation", "anim"), &SpriteFrames::remove_animation);
 	ClassDB::bind_method(D_METHOD("rename_animation", "anim", "newname"), &SpriteFrames::rename_animation);
 

--- a/scene/resources/sprite_frames.h
+++ b/scene/resources/sprite_frames.h
@@ -60,6 +60,7 @@ protected:
 public:
 	void add_animation(const StringName &p_anim);
 	bool has_animation(const StringName &p_anim) const;
+	void duplicate_animation(const StringName &p_from, const StringName &p_to);
 	void remove_animation(const StringName &p_anim);
 	void rename_animation(const StringName &p_prev, const StringName &p_next);
 


### PR DESCRIPTION
This is the duplicate animation ability for spriteframes. Sometimes the user want to duplicate entire animations instead of a frame only!

this is a better version of: #67533

With the suggestions of: @KoBeWi , @groud and @volokh0x 

demonstration:


https://github.com/godotengine/godot/assets/58845030/8d23c21f-a926-4bb1-8a08-8a55be6f9801




thanks guys!!!

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/3942*