### PR TITLE
Use StringName consistently to refer to the Master audio bus name

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -510,7 +510,7 @@ StringName Area2D::get_audio_bus_name() const {
 			return audio_bus;
 		}
 	}
-	return "Master";
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void Area2D::_validate_property(PropertyInfo &p_property) const {

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -116,10 +116,10 @@ StringName AudioStreamPlayer2D::_get_actual_bus() {
 
 	//check if any area is diverting sound into a bus
 	Ref<World2D> world_2d = get_world_2d();
-	ERR_FAIL_COND_V(world_2d.is_null(), SNAME("Master"));
+	ERR_FAIL_COND_V(world_2d.is_null(), SceneStringNames::get_singleton()->Master);
 
 	PhysicsDirectSpaceState2D *space_state = PhysicsServer2D::get_singleton()->space_get_direct_state(world_2d->get_space());
-	ERR_FAIL_COND_V(space_state == nullptr, SNAME("Master"));
+	ERR_FAIL_COND_V(space_state == nullptr, SceneStringNames::get_singleton()->Master);
 	PhysicsDirectSpaceState2D::ShapeResult sr[MAX_INTERSECT_AREAS];
 
 	PhysicsDirectSpaceState2D::PointParameters point_params;
@@ -316,7 +316,7 @@ StringName AudioStreamPlayer2D::get_bus() const {
 			return default_bus;
 		}
 	}
-	return SNAME("Master");
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void AudioStreamPlayer2D::set_autoplay(bool p_enable) {

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -32,6 +32,7 @@
 #define AUDIO_STREAM_PLAYER_2D_H
 
 #include "scene/2d/node_2d.h"
+#include "scene/scene_string_names.h"
 #include "servers/audio/audio_stream.h"
 #include "servers/audio_server.h"
 
@@ -66,7 +67,7 @@ private:
 	float volume_db = 0.0;
 	float pitch_scale = 1.0;
 	bool autoplay = false;
-	StringName default_bus = SNAME("Master");
+	StringName default_bus = SceneStringNames::get_singleton()->Master;
 	int max_polyphony = 1;
 
 	void _set_playing(bool p_enable);

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -573,7 +573,7 @@ StringName Area3D::get_audio_bus_name() const {
 			return audio_bus;
 		}
 	}
-	return "Master";
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void Area3D::set_use_reverb_bus(bool p_enable) {
@@ -594,7 +594,7 @@ StringName Area3D::get_reverb_bus_name() const {
 			return reverb_bus;
 		}
 	}
-	return "Master";
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void Area3D::set_reverb_amount(float p_amount) {

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -33,6 +33,7 @@
 
 #include "core/templates/vset.h"
 #include "scene/3d/collision_object_3d.h"
+#include "scene/scene_string_names.h"
 
 class Area3D : public CollisionObject3D {
 	GDCLASS(Area3D, CollisionObject3D);
@@ -134,10 +135,10 @@ private:
 	void _clear_monitoring();
 
 	bool audio_bus_override = false;
-	StringName audio_bus = "Master";
+	StringName audio_bus = SceneStringNames::get_singleton()->Master;
 
 	bool use_reverb_bus = false;
-	StringName reverb_bus = "Master";
+	StringName reverb_bus = SceneStringNames::get_singleton()->Master;
 	float reverb_amount = 0.0;
 	float reverb_uniformity = 0.0;
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -35,6 +35,7 @@
 #include "scene/3d/audio_listener_3d.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/main/viewport.h"
+#include "scene/scene_string_names.h"
 
 // Based on "A Novel Multichannel Panning Method for Standard and Arbitrary Loudspeaker Configurations" by Ramy Sadek and Chris Kyriakakis (2004)
 // Speaker-Placement Correction Amplitude Panning (SPCAP)
@@ -635,7 +636,7 @@ StringName AudioStreamPlayer3D::get_bus() const {
 			return bus;
 		}
 	}
-	return SNAME("Master");
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void AudioStreamPlayer3D::set_autoplay(bool p_enable) {

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -200,7 +200,7 @@ StringName AudioStreamPlayer::get_bus() const {
 			return bus;
 		}
 	}
-	return SNAME("Master");
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void AudioStreamPlayer::set_autoplay(bool p_enable) {

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -33,6 +33,7 @@
 
 #include "core/templates/safe_refcount.h"
 #include "scene/main/node.h"
+#include "scene/scene_string_names.h"
 #include "servers/audio/audio_stream.h"
 
 class AudioStreamPlayer : public Node {
@@ -54,7 +55,7 @@ private:
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
-	StringName bus = SNAME("Master");
+	StringName bus = SceneStringNames::get_singleton()->Master;
 	int max_polyphony = 1;
 
 	MixTarget mix_target = MIX_TARGET_STEREO;

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -451,7 +451,7 @@ StringName VideoStreamPlayer::get_bus() const {
 			return bus;
 		}
 	}
-	return "Master";
+	return SceneStringNames::get_singleton()->Master;
 }
 
 void VideoStreamPlayer::_validate_property(PropertyInfo &p_property) const {

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -193,6 +193,9 @@ SceneStringNames::SceneStringNames() {
 
 	path_pp = NodePath("..");
 
+	// Audio bus name.
+	Master = StaticCString::create("Master");
+
 	_default = StaticCString::create("default");
 
 	_window_group = StaticCString::create("_window_group");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -204,6 +204,8 @@ public:
 
 	StringName output;
 
+	StringName Master;
+
 	StringName parameters_base_path;
 
 	StringName _window_group;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -40,6 +40,7 @@
 #include "core/string/string_name.h"
 #include "core/templates/pair.h"
 #include "scene/resources/audio_stream_wav.h"
+#include "scene/scene_string_names.h"
 #include "servers/audio/audio_driver_dummy.h"
 #include "servers/audio/effects/audio_effect_compressor.h"
 
@@ -747,7 +748,7 @@ void AudioServer::set_bus_count(int p_count) {
 		buses[i]->bypass = false;
 		buses[i]->volume_db = 0;
 		if (i > 0) {
-			buses[i]->send = "Master";
+			buses[i]->send = SceneStringNames::get_singleton()->Master;
 		}
 
 		bus_map[attempt] = buses[i];
@@ -1582,7 +1583,7 @@ void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
 	for (int i = 0; i < p_bus_layout->buses.size(); i++) {
 		Bus *bus = memnew(Bus);
 		if (i == 0) {
-			bus->name = "Master";
+			bus->name = SceneStringNames::get_singleton()->Master;
 		} else {
 			bus->name = p_bus_layout->buses[i].name;
 			bus->send = p_bus_layout->buses[i].send;
@@ -1891,5 +1892,5 @@ void AudioBusLayout::_get_property_list(List<PropertyInfo> *p_list) const {
 
 AudioBusLayout::AudioBusLayout() {
 	buses.resize(1);
-	buses.write[0].name = "Master";
+	buses.write[0].name = SceneStringNames::get_singleton()->Master;
 }


### PR DESCRIPTION
These methods internally use StringName, so this should provide a minimal performance boost.