### PR TITLE
miniupnpc: Update to version 2.2.5

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -302,7 +302,7 @@ License: CC0-1.0
 
 Files: ./thirdparty/miniupnpc/
 Comment: MiniUPnP Project
-Copyright: 2005-2022, Thomas Bernard
+Copyright: 2005-2023, Thomas Bernard
 License: BSD-3-clause
 
 Files: ./thirdparty/minizip/

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -422,7 +422,7 @@ to solve some MSVC warnings. See the patches in the `patches` directory.
 ## miniupnpc
 
 - Upstream: https://github.com/miniupnp/miniupnp
-- Version: 2.2.4 (7d1d8bc3868b08ad003bad235eee57562b95b76d, 2022)
+- Version: 2.2.5 (58837ef586278d18cbebee50be758835ed4be79a, 2023)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/miniupnpc/LICENSE
+++ b/thirdparty/miniupnpc/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2005-2022, Thomas BERNARD
+Copyright (c) 2005-2023, Thomas BERNARD
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/thirdparty/miniupnpc/include/miniupnpc.h
+++ b/thirdparty/miniupnpc/include/miniupnpc.h
@@ -1,4 +1,4 @@
-/* $Id: miniupnpc.h,v 1.61 2022/10/21 21:15:02 nanard Exp $ */
+/* $Id: miniupnpc.h,v 1.62 2023/06/11 23:25:46 nanard Exp $ */
 /* vim: tabstop=4 shiftwidth=4 noexpandtab
  * Project: miniupnp
  * http://miniupnp.free.fr/ or https://miniupnp.tuxfamily.org/
@@ -20,7 +20,7 @@
 #define UPNPDISCOVER_MEMORY_ERROR (-102)
 
 /* versions : */
-#define MINIUPNPC_VERSION	"2.2.4"
+#define MINIUPNPC_VERSION	"2.2.5"
 #define MINIUPNPC_API_VERSION	17
 
 /* Source port:

--- a/thirdparty/miniupnpc/src/miniupnpcstrings.h
+++ b/thirdparty/miniupnpc/src/miniupnpcstrings.h
@@ -4,7 +4,7 @@
 #include "core/version.h"
 
 #define OS_STRING VERSION_NAME "/1.0"
-#define MINIUPNPC_VERSION_STRING "2.2.4"
+#define MINIUPNPC_VERSION_STRING "2.2.5"
 
 #if 0
 /* according to "UPnP Device Architecture 1.0" */


### PR DESCRIPTION
No change for the files we ship, so just bumping the version number.

Upstream changelog: https://github.com/miniupnp/miniupnp/blob/miniupnpc_2_2_5/miniupnpc/Changelog.txt
But they only changed `upnp.c` which we don't include in our tree.