### PR TITLE
Suppress NavigationServer race conditions

### DIFF
--- a/misc/error_suppressions/tsan.txt
+++ b/misc/error_suppressions/tsan.txt
@@ -4,4 +4,5 @@
 deadlock:tests/core/templates/test_command_queue.h
 deadlock:modules/text_server_adv/text_server_adv.cpp
 deadlock:modules/text_server_fb/text_server_fb.cpp
+race:modules/navigation/nav_map.cpp
 


### PR DESCRIPTION
Temporary workaround for spurious errors in CI, details (and proper fix) here: https://github.com/godotengine/godot/pull/73777#issuecomment-1667819660

I'm not sure what's causing the inconsistent behavior in CI since I can reproduce the races reliably on my local machine.