### PR TITLE
Expose PlaceHolderScriptInstance to GDExtension

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2127,6 +2127,37 @@ typedef void (*GDExtensionInterfaceRefSetObject)(GDExtensionRefPtr p_ref, GDExte
 typedef GDExtensionScriptInstancePtr (*GDExtensionInterfaceScriptInstanceCreate)(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data);
 
 /**
+ * @name placeholder_script_instance_create
+ * @since 4.2
+ *
+ * Creates a placeholder script instance for a given script and instance.
+ *
+ * This interface is optional as a custom placeholder could also be created with script_instance_create().
+ *
+ * @param p_language A pointer to a ScriptLanguage.
+ * @param p_script A pointer to a Script.
+ * @param p_owner A pointer to an Object.
+ *
+ * @return A pointer to a PlaceHolderScriptInstance object.
+ */
+typedef GDExtensionScriptInstancePtr (*GDExtensionInterfacePlaceHolderScriptInstanceCreate)(GDExtensionObjectPtr p_language, GDExtensionObjectPtr p_script, GDExtensionObjectPtr p_owner);
+
+/**
+ * @name placeholder_script_instance_update
+ * @since 4.2
+ *
+ * Updates a placeholder script instance with the given properties and values.
+ *
+ * The passed in placeholder must be an instance of PlaceHolderScriptInstance
+ * such as the one returned by placeholder_script_instance_create().
+ *
+ * @param p_placeholder A pointer to a PlaceHolderScriptInstance.
+ * @param p_properties A pointer to an Array of Dictionary representing PropertyInfo.
+ * @param p_values A pointer to a Dictionary mapping StringName to Variant values.
+ */
+typedef void (*GDExtensionInterfacePlaceHolderScriptInstanceUpdate)(GDExtensionScriptInstancePtr p_placeholder, GDExtensionConstTypePtr p_properties, GDExtensionConstTypePtr p_values);
+
+/**
  * @name object_get_script_instance
  * @since 4.2
  *


### PR DESCRIPTION
Exposes `PlaceHolderScriptInstance` used by the `gdscript` and `csharp_script` modules in Godot to GDExtension. 

While use of this class is technically optional as placeholder implementation can be done with the existing interface, exposing it allows extensions to avoid reimplementing the entire behavior.

This would likely be useful for existing language bindings:
- [godot_dart](https://github.com/fuzzybinary/godot_dart) has used their normal `ScriptInstance` implementation and disabled `call` when used as a placeholder.
- [godot-luau-script](https://github.com/Fumohouse/godot-luau-script) has completely reimplemented `PlaceHolderScriptInstance`

I've started using this in my Python bindings and it seems to work quite well. Without this I would be doing what has been done for the luau bindings.
