### PR TITLE
[3.x] Fix AnimatedSprite normal map loading

### DIFF
--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -274,6 +274,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 		}
 
 		animations[d["name"]] = anim;
+		animations[d["name"]].normal_name = String(d["name"]) + NORMAL_SUFFIX;
 	}
 }
 


### PR DESCRIPTION
Normal map names are now correctly set up during loading.

Fixes #43435

## Notes
* Had never spotted this issue before, only took a couple mins to track down.
* It's not really rendering, just a bit of code missing in the AnimatedSprite.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
