### PR TITLE
Remove GPU readback from `NoiseTexture3D.get_format()`

### DIFF
--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -110,6 +110,7 @@ void NoiseTexture3D::_set_texture_data(const TypedArray<Image> &p_data) {
 		} else {
 			texture = RS::get_singleton()->texture_3d_create(data[0]->get_format(), data[0]->get_width(), data[0]->get_height(), data.size(), false, data);
 		}
+		format = data[0]->get_format();
 	}
 	emit_changed();
 }
@@ -346,6 +347,5 @@ Vector<Ref<Image>> NoiseTexture3D::get_data() const {
 }
 
 Image::Format NoiseTexture3D::get_format() const {
-	ERR_FAIL_COND_V(!texture.is_valid(), Image::FORMAT_L8);
-	return RS::get_singleton()->texture_3d_get(texture)[0]->get_format();
+	return format;
 }

--- a/modules/noise/noise_texture_3d.h
+++ b/modules/noise/noise_texture_3d.h
@@ -60,6 +60,8 @@ private:
 	Ref<Gradient> color_ramp;
 	Ref<Noise> noise;
 
+	Image::Format format = Image::FORMAT_L8;
+
 	void _thread_done(const TypedArray<Image> &p_data);
 	static void _thread_function(void *p_ud);
 


### PR DESCRIPTION
I caught this issue while reviewing another PR. When accessing the format of the NoiseTexture3D it was requesting a GPU->CPU copy of the texture data, then throwing away the texture data and only using the format. This is not only an expensive operation, it also causes a full GPU->CPU sync making it very expensive to call at runtime. 

This is a very low risk bug fix

*Bugsquad edit:* 
- Fixes #79360
- Fixes #80302