### PR TITLE
Core: Add parameter `no_inheritance` to `Script.get_script_*_list()` methods

### DIFF
--- a/core/object/script_language.compat.inc
+++ b/core/object/script_language.compat.inc
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  script_language.compat.inc                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+TypedArray<Dictionary> Script::_get_script_property_list_bind_compat_80418() {
+	return _get_script_property_list(false);
+}
+
+TypedArray<Dictionary> Script::_get_script_method_list_bind_compat_80418() {
+	return _get_script_method_list(false);
+}
+
+TypedArray<Dictionary> Script::_get_script_signal_list_bind_compat_80418() {
+	return _get_script_signal_list(false);
+}
+
+void Script::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list_bind_compat_80418);
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list_bind_compat_80418);
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list_bind_compat_80418);
+}
+
+#endif

--- a/core/object/script_language.compat.inc
+++ b/core/object/script_language.compat.inc
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  script_language.compat.inc                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "script_language.h"
+
+#include "core/object/class_db.h"
+
+TypedArray<Dictionary> Script::_get_script_property_list_bind_compat_80418() {
+	return _get_script_property_list(false);
+}
+
+TypedArray<Dictionary> Script::_get_script_method_list_bind_compat_80418() {
+	return _get_script_method_list(false);
+}
+
+TypedArray<Dictionary> Script::_get_script_signal_list_bind_compat_80418() {
+	return _get_script_signal_list(false);
+}
+
+void Script::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list_bind_compat_80418);
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list_bind_compat_80418);
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list_bind_compat_80418);
+}
+
+#endif

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "script_language.h"
+#include "script_language.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
@@ -72,30 +73,30 @@ Variant Script::_get_property_default_value(const StringName &p_property) {
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_property_list() {
+TypedArray<Dictionary> Script::_get_script_property_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<PropertyInfo> list;
-	get_script_property_list(&list);
+	get_script_property_list(&list, p_no_inheritance);
 	for (const PropertyInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_method_list() {
+TypedArray<Dictionary> Script::_get_script_method_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_method_list(&list);
+	get_script_method_list(&list, p_no_inheritance);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_signal_list() {
+TypedArray<Dictionary> Script::_get_script_signal_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_signal_list(&list);
+	get_script_signal_list(&list, p_no_inheritance);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
@@ -174,9 +175,9 @@ void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
-	ClassDB::bind_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list);
-	ClassDB::bind_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list);
-	ClassDB::bind_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list);
+	ClassDB::bind_method(D_METHOD("get_script_property_list", "no_inheritance"), &Script::_get_script_property_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_script_method_list", "no_inheritance"), &Script::_get_script_method_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_script_signal_list", "no_inheritance"), &Script::_get_script_signal_list, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_script_constant_map"), &Script::_get_script_constant_map);
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "script_language.h"
+#include "script_language.compat.inc"
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
@@ -73,30 +74,30 @@ Variant Script::_get_property_default_value(const StringName &p_property) {
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_property_list() {
+TypedArray<Dictionary> Script::_get_script_property_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<PropertyInfo> list;
-	get_script_property_list(&list);
+	get_script_property_list(&list, p_no_inheritance);
 	for (const PropertyInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_method_list() {
+TypedArray<Dictionary> Script::_get_script_method_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_method_list(&list);
+	get_script_method_list(&list, p_no_inheritance);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_signal_list() {
+TypedArray<Dictionary> Script::_get_script_signal_list(bool p_no_inheritance) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_signal_list(&list);
+	get_script_signal_list(&list, p_no_inheritance);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
@@ -175,9 +176,9 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_script_method", "method_name"), &Script::has_method);
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
-	ClassDB::bind_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list);
-	ClassDB::bind_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list);
-	ClassDB::bind_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list);
+	ClassDB::bind_method(D_METHOD("get_script_property_list", "no_inheritance"), &Script::_get_script_property_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_script_method_list", "no_inheritance"), &Script::_get_script_method_list, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_script_signal_list", "no_inheritance"), &Script::_get_script_signal_list, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_script_constant_map"), &Script::_get_script_constant_map);
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -125,13 +125,20 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	TypedArray<Dictionary> _get_script_property_list_bind_compat_80418();
+	TypedArray<Dictionary> _get_script_method_list_bind_compat_80418();
+	TypedArray<Dictionary> _get_script_signal_list_bind_compat_80418();
+	static void _bind_compatibility_methods();
+#endif
+
 	friend class PlaceHolderScriptInstance;
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {}
 
 	Variant _get_property_default_value(const StringName &p_property);
-	TypedArray<Dictionary> _get_script_property_list();
-	TypedArray<Dictionary> _get_script_method_list();
-	TypedArray<Dictionary> _get_script_signal_list();
+	TypedArray<Dictionary> _get_script_property_list(bool p_no_inheritance = false);
+	TypedArray<Dictionary> _get_script_method_list(bool p_no_inheritance = false);
+	TypedArray<Dictionary> _get_script_signal_list(bool p_no_inheritance = false);
 	Dictionary _get_script_constant_map();
 
 	void _set_debugger_break_language();
@@ -183,13 +190,13 @@ public:
 	virtual ScriptLanguage *get_language() const = 0;
 
 	virtual bool has_script_signal(const StringName &p_signal) const = 0;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const = 0;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const = 0;
 
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const = 0;
 
 	virtual void update_exports() {} //editor tool
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+	virtual void get_script_method_list(List<MethodInfo> *p_list, bool p_no_inheritance = false) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inheritance = false) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -126,13 +126,20 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	TypedArray<Dictionary> _get_script_property_list_bind_compat_80418();
+	TypedArray<Dictionary> _get_script_method_list_bind_compat_80418();
+	TypedArray<Dictionary> _get_script_signal_list_bind_compat_80418();
+	static void _bind_compatibility_methods();
+#endif
+
 	friend class PlaceHolderScriptInstance;
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {}
 
 	Variant _get_property_default_value(const StringName &p_property);
-	TypedArray<Dictionary> _get_script_property_list();
-	TypedArray<Dictionary> _get_script_method_list();
-	TypedArray<Dictionary> _get_script_signal_list();
+	TypedArray<Dictionary> _get_script_property_list(bool p_no_inheritance = false);
+	TypedArray<Dictionary> _get_script_method_list(bool p_no_inheritance = false);
+	TypedArray<Dictionary> _get_script_signal_list(bool p_no_inheritance = false);
 	Dictionary _get_script_constant_map();
 
 	void _set_debugger_break_language();
@@ -183,13 +190,13 @@ public:
 	virtual ScriptLanguage *get_language() const = 0;
 
 	virtual bool has_script_signal(const StringName &p_signal) const = 0;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const = 0;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const = 0;
 
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const = 0;
 
 	virtual void update_exports() {} //editor tool
-	virtual void get_script_method_list(List<MethodInfo> *r_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *r_list) const = 0;
+	virtual void get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance = false) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance = false) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -68,14 +68,25 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_language);
 
 	GDVIRTUAL_BIND(_has_script_signal, "signal");
-	GDVIRTUAL_BIND(_get_script_signal_list);
+	GDVIRTUAL_BIND(_get_script_signal_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_signal_list_bind_compat_80418);
+#endif
 
 	GDVIRTUAL_BIND(_has_property_default_value, "property");
 	GDVIRTUAL_BIND(_get_property_default_value, "property");
 
 	GDVIRTUAL_BIND(_update_exports);
-	GDVIRTUAL_BIND(_get_script_method_list);
-	GDVIRTUAL_BIND(_get_script_property_list);
+
+	GDVIRTUAL_BIND(_get_script_method_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_method_list_bind_compat_80418);
+#endif
+
+	GDVIRTUAL_BIND(_get_script_property_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_property_list_bind_compat_80418);
+#endif
 
 	GDVIRTUAL_BIND(_get_member_line, "member");
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -80,14 +80,25 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_language);
 
 	GDVIRTUAL_BIND(_has_script_signal, "signal");
-	GDVIRTUAL_BIND(_get_script_signal_list);
+	GDVIRTUAL_BIND(_get_script_signal_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_signal_list_bind_compat_80418);
+#endif
 
 	GDVIRTUAL_BIND(_has_property_default_value, "property");
 	GDVIRTUAL_BIND(_get_property_default_value, "property");
 
 	GDVIRTUAL_BIND(_update_exports);
-	GDVIRTUAL_BIND(_get_script_method_list);
-	GDVIRTUAL_BIND(_get_script_property_list);
+
+	GDVIRTUAL_BIND(_get_script_method_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_method_list_bind_compat_80418);
+#endif
+
+	GDVIRTUAL_BIND(_get_script_property_list, "no_inheritance");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_script_property_list_bind_compat_80418);
+#endif
 
 	GDVIRTUAL_BIND(_get_member_line, "member");
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -139,11 +139,41 @@ public:
 	EXBIND0RC(ScriptLanguage *, get_language)
 	EXBIND1RC(bool, has_script_signal, const StringName &)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_signal_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_signal_list)
+#endif
 
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override {
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_signal_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_signal_list_bind_compat_80418, sl)) {
+			HashSet<String> base_signal_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<MethodInfo> base_signals;
+					base->get_script_signal_list(&base_signals);
+					for (const MethodInfo &mi : base_signals) {
+						base_signal_names.insert(mi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const MethodInfo mi = MethodInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_signal_names.has(mi.name)) {
+					continue;
+				}
+				r_signals->push_back(mi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_signal_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_signals->push_back(MethodInfo::from_dict(sl[i]));
 		}
@@ -165,23 +195,83 @@ public:
 
 	EXBIND0(update_exports)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_method_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_method_list)
+#endif
 
-	virtual void get_script_method_list(List<MethodInfo> *r_methods) const override {
+	virtual void get_script_method_list(List<MethodInfo> *r_methods, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_method_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_method_list_bind_compat_80418, sl)) {
+			HashSet<String> base_method_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<MethodInfo> base_methods;
+					base->get_script_method_list(&base_methods);
+					for (const MethodInfo &mi : base_methods) {
+						base_method_names.insert(mi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const MethodInfo mi = MethodInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_method_names.has(mi.name)) {
+					continue;
+				}
+				r_methods->push_back(mi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_method_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_methods->push_back(MethodInfo::from_dict(sl[i]));
 		}
 	}
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_property_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_property_list)
+#endif
 
-	virtual void get_script_property_list(List<PropertyInfo> *r_propertys) const override {
+	virtual void get_script_property_list(List<PropertyInfo> *r_properties, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_property_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_property_list_bind_compat_80418, sl)) {
+			HashSet<String> base_property_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<PropertyInfo> base_properties;
+					base->get_script_property_list(&base_properties);
+					for (const PropertyInfo &pi : base_properties) {
+						base_property_names.insert(pi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const PropertyInfo pi = PropertyInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_property_names.has(pi.name)) {
+					continue;
+				}
+				r_properties->push_back(pi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_property_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
-			r_propertys->push_back(PropertyInfo::from_dict(sl[i]));
+			r_properties->push_back(PropertyInfo::from_dict(sl[i]));
 		}
 	}
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -149,11 +149,41 @@ public:
 	EXBIND0RC(ScriptLanguage *, get_language)
 	EXBIND1RC(bool, has_script_signal, const StringName &)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_signal_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_signal_list)
+#endif
 
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override {
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_signal_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_signal_list_bind_compat_80418, sl)) {
+			HashSet<String> base_signal_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<MethodInfo> base_signals;
+					base->get_script_signal_list(&base_signals);
+					for (const MethodInfo &mi : base_signals) {
+						base_signal_names.insert(mi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const MethodInfo mi = MethodInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_signal_names.has(mi.name)) {
+					continue;
+				}
+				r_signals->push_back(mi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_signal_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_signals->push_back(MethodInfo::from_dict(sl[i]));
 		}
@@ -175,23 +205,83 @@ public:
 
 	EXBIND0(update_exports)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_method_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_method_list)
+#endif
 
-	virtual void get_script_method_list(List<MethodInfo> *r_methods) const override {
+	virtual void get_script_method_list(List<MethodInfo> *r_methods, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_method_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_method_list_bind_compat_80418, sl)) {
+			HashSet<String> base_method_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<MethodInfo> base_methods;
+					base->get_script_method_list(&base_methods);
+					for (const MethodInfo &mi : base_methods) {
+						base_method_names.insert(mi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const MethodInfo mi = MethodInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_method_names.has(mi.name)) {
+					continue;
+				}
+				r_methods->push_back(mi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_method_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_methods->push_back(MethodInfo::from_dict(sl[i]));
 		}
 	}
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list, bool)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC_COMPAT(_get_script_property_list_bind_compat_80418, TypedArray<Dictionary>, _get_script_property_list)
+#endif
 
-	virtual void get_script_property_list(List<PropertyInfo> *r_propertys) const override {
+	virtual void get_script_property_list(List<PropertyInfo> *r_properties, bool p_no_inheritance = false) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_property_list, sl);
+
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_get_script_property_list_bind_compat_80418, sl)) {
+			HashSet<String> base_property_names;
+			if (p_no_inheritance) {
+				const Ref<Script> base = get_base_script();
+				if (base.is_valid()) {
+					List<PropertyInfo> base_properties;
+					base->get_script_property_list(&base_properties);
+					for (const PropertyInfo &pi : base_properties) {
+						base_property_names.insert(pi.name);
+					}
+				}
+			}
+
+			for (int i = 0; i < sl.size(); i++) {
+				const PropertyInfo pi = PropertyInfo::from_dict(sl[i]);
+				if (p_no_inheritance && base_property_names.has(pi.name)) {
+					continue;
+				}
+				r_properties->push_back(pi);
+			}
+
+			return;
+		}
+#endif
+
+		GDVIRTUAL_CALL(_get_script_property_list, p_no_inheritance, sl);
 		for (int i = 0; i < sl.size(); i++) {
-			r_propertys->push_back(PropertyInfo::from_dict(sl[i]));
+			r_properties->push_back(PropertyInfo::from_dict(sl[i]));
 		}
 	}
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -96,6 +96,7 @@
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the methods of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] with the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				See also [method Object.get_method_list] and [method Script.get_script_method_list].
 				[b]Note:[/b] In exported release builds the debug info is not available, so the returned dictionaries will contain only method names.
 			</description>
 		</method>
@@ -129,6 +130,7 @@
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the properties of [param class] or its ancestry if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_property_list] and [method Script.get_script_property_list].
 			</description>
 		</method>
 		<method name="class_get_property_setter">
@@ -153,6 +155,7 @@
 			<param index="1" name="no_inheritance" type="bool" default="false" />
 			<description>
 				Returns an array with all the signals of [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Every element of the array is a [Dictionary] as described in [method class_get_signal].
+				See also [method Object.get_signal_list] and [method Script.get_script_signal_list].
 			</description>
 		</method>
 		<method name="class_has_enum" qualifiers="const">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -668,6 +668,7 @@
 				- [code]flags[/code] is a combination of [enum MethodFlags];
 				- [code]id[/code] is the method's internal identifier [int];
 				- [code]return[/code] is the returned value, as a [Dictionary];
+				See also [method ClassDB.class_get_method_list] and [method Script.get_script_method_list].
 				[b]Note:[/b] The dictionaries of [code]args[/code] and [code]return[/code] are formatted identically to the results of [method get_property_list], although not all entries are used.
 			</description>
 		</method>
@@ -681,6 +682,7 @@
 				- [code]hint[/code] is [i]how[/i] the property is meant to be edited (see [enum PropertyHint]);
 				- [code]hint_string[/code] depends on the hint (see [enum PropertyHint]);
 				- [code]usage[/code] is a combination of [enum PropertyUsageFlags].
+				See also [method ClassDB.class_get_property_list] and [method Script.get_script_property_list].
 				[b]Note:[/b] In GDScript, all class members are treated as properties. In C# and GDExtension, it may be necessary to explicitly mark class members as Godot properties using decorators or attributes.
 			</description>
 		</method>
@@ -704,6 +706,7 @@
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of existing signals as an [Array] of dictionaries.
+				See also [method ClassDB.class_get_signal_list] and [method Script.get_script_signal_list].
 				[b]Note:[/b] Due to the implementation, each [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
 			</description>
 		</method>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -673,6 +673,7 @@
 				- [code]flags[/code] is a combination of [enum MethodFlags];
 				- [code]id[/code] is the method's internal identifier [int];
 				- [code]return[/code] is the returned value, as a [Dictionary];
+				See also [method ClassDB.class_get_method_list] and [method Script.get_script_method_list].
 				[b]Note:[/b] The dictionaries of [code]args[/code] and [code]return[/code] are formatted identically to the results of [method get_property_list], although not all entries are used.
 			</description>
 		</method>
@@ -686,6 +687,7 @@
 				- [code]hint[/code] is [i]how[/i] the property is meant to be edited (see [enum PropertyHint]);
 				- [code]hint_string[/code] depends on the hint (see [enum PropertyHint]);
 				- [code]usage[/code] is a combination of [enum PropertyUsageFlags].
+				See also [method ClassDB.class_get_property_list] and [method Script.get_script_property_list].
 				[b]Note:[/b] In GDScript, all class members are treated as properties. In C# and GDExtension, it may be necessary to explicitly mark class members as Godot properties using decorators or attributes.
 			</description>
 		</method>
@@ -709,6 +711,7 @@
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of existing signals as an [Array] of dictionaries.
+				See also [method ClassDB.class_get_signal_list] and [method Script.get_script_signal_list].
 				[b]Note:[/b] Due to the implementation, each [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
 			</description>
 		</method>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -72,22 +72,31 @@
 		</method>
 		<method name="get_script_method_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of methods in this [Script].
+				Returns an array with all the methods of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_method_list] and [method ClassDB.class_get_method_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native methods.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_method_list].
 			</description>
 		</method>
 		<method name="get_script_property_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of properties in this [Script].
+				Returns an array with all the properties of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_property_list] and [method ClassDB.class_get_property_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native properties.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="get_script_signal_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of signals defined in this [Script].
+				Returns an array with all the signals of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_signal_list] and [method ClassDB.class_get_signal_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native signals.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_signal_list].
 			</description>
 		</method>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -73,22 +73,31 @@
 		</method>
 		<method name="get_script_method_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of methods in this [Script].
+				Returns an array with all the methods of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_method_list] and [method ClassDB.class_get_method_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native methods.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_method_list].
 			</description>
 		</method>
 		<method name="get_script_property_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of properties in this [Script].
+				Returns an array with all the properties of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_property_list] and [method ClassDB.class_get_property_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native properties.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="get_script_signal_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" default="false" />
 			<description>
-				Returns the list of signals defined in this [Script].
+				Returns an array with all the signals of this [Script] or its ancestor scripts if [param no_inheritance] is [code]false[/code].
+				See also [method Object.get_signal_list] and [method ClassDB.class_get_signal_list].
+				[b]Note:[/b] This method does [b]not[/b] return info about native signals.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_signal_list].
 			</description>
 		</method>

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -94,16 +94,19 @@
 		</method>
 		<method name="_get_script_method_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="_get_script_property_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" />
 			<description>
 			</description>
 		</method>
 		<method name="_get_script_signal_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
+			<param index="0" name="no_inheritance" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -96,17 +96,23 @@ void PropertySelector::_update_search() {
 
 			v.get_property_list(&props);
 		} else {
-			Object *obj = ObjectDB::get_instance(script);
-			if (Object::cast_to<Script>(obj)) {
-				props.push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				Object::cast_to<Script>(obj)->get_script_property_list(&props);
+			Ref<Script> script_base = ObjectDB::get_ref<Script>(script);
+			while (script_base.is_valid()) {
+				String class_name = script_base->get_global_name();
+				if (class_name.is_empty()) {
+					class_name = script_base->get_path().get_file();
+				}
+
+				props.push_back(PropertyInfo(Variant::NIL, class_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
+				script_base->get_script_property_list(&props, true);
+				script_base = script_base->get_base_script();
 			}
 
-			StringName base = base_type;
-			while (base) {
-				props.push_back(PropertyInfo(Variant::NIL, base, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				ClassDB::get_property_list(base, &props, true);
-				base = ClassDB::get_parent_class(base);
+			StringName native_base = base_type;
+			while (native_base) {
+				props.push_back(PropertyInfo(Variant::NIL, native_base, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
+				ClassDB::get_property_list(native_base, &props, true);
+				native_base = ClassDB::get_parent_class(native_base);
 			}
 		}
 
@@ -116,17 +122,17 @@ void PropertySelector::_update_search() {
 		for (const PropertyInfo &E : props) {
 			if (E.usage == PROPERTY_USAGE_CATEGORY) {
 				if (category && category->get_first_child() == nullptr) {
-					memdelete(category); //old category was unused
+					memdelete(category); // Old category was unused.
 				}
 				category = search_options->create_item(root);
 				category->set_text(0, E.name);
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
-				if (E.name == "Script Variables") {
-					icon = search_options->get_editor_theme_icon(SNAME("Script"));
-				} else {
+				if (ClassDB::class_exists(E.name) || ScriptServer::is_global_class(E.name)) {
 					icon = EditorNode::get_singleton()->get_class_icon(E.name);
+				} else {
+					icon = search_options->get_editor_theme_icon(SNAME("Script"));
 				}
 				category->set_icon(0, icon);
 				continue;
@@ -164,7 +170,7 @@ void PropertySelector::_update_search() {
 		}
 
 		if (category && category->get_first_child() == nullptr) {
-			memdelete(category); //old category was unused
+			memdelete(category); // Old category was unused.
 		}
 
 		if (found) {
@@ -176,21 +182,28 @@ void PropertySelector::_update_search() {
 		List<MethodInfo> methods;
 
 		if (type != Variant::NIL) {
-			Variant v;
+			methods.push_back(MethodInfo("*" + Variant::get_type_name(type)));
+
+			Variant dummy;
 			Callable::CallError ce;
-			Variant::construct(type, v, nullptr, 0, ce);
-			v.get_method_list(&methods);
+			Variant::construct(type, dummy, nullptr, 0, ce);
+			dummy.get_method_list(&methods);
 		} else {
-			Ref<Script> script_ref = ObjectDB::get_ref<Script>(script);
-			if (script_ref.is_valid()) {
-				if (script_ref->is_built_in()) {
-					script_ref->reload(true);
+			Ref<Script> script_base = ObjectDB::get_ref<Script>(script);
+			while (script_base.is_valid()) {
+				if (script_base->is_built_in()) {
+					script_base->reload(true);
 				}
 
-				List<MethodInfo> script_methods;
-				script_ref->get_script_method_list(&script_methods);
+				String class_name = script_base->get_global_name();
+				if (class_name.is_empty()) {
+					class_name = script_base->get_path().get_file();
+				}
 
-				methods.push_back(MethodInfo("*Script Methods")); // TODO: Split by inheritance.
+				methods.push_back(MethodInfo("*" + class_name));
+
+				List<MethodInfo> script_methods;
+				script_base->get_script_method_list(&script_methods, true);
 
 				for (const MethodInfo &mi : script_methods) {
 					if (mi.name.begins_with("@")) {
@@ -201,46 +214,48 @@ void PropertySelector::_update_search() {
 					}
 					methods.push_back(mi);
 				}
+
+				script_base = script_base->get_base_script();
 			}
 
-			StringName base = base_type;
-			while (base) {
-				methods.push_back(MethodInfo("*" + String(base)));
-				ClassDB::get_method_list(base, &methods, true, true);
-				base = ClassDB::get_parent_class(base);
+			StringName native_base = base_type;
+			while (native_base) {
+				methods.push_back(MethodInfo("*" + String(native_base)));
+				ClassDB::get_method_list(native_base, &methods, true, true);
+				native_base = ClassDB::get_parent_class(native_base);
 			}
 		}
 
 		TreeItem *category = nullptr;
 
 		bool found = false;
-		bool script_methods = false;
+		bool is_native_class = true;
 
 		for (MethodInfo &mi : methods) {
 			if (mi.name.begins_with("*")) {
+				const String class_name = mi.name.replace_first("*", "");
+				is_native_class = ClassDB::class_exists(class_name);
+
 				if (category && category->get_first_child() == nullptr) {
-					memdelete(category); //old category was unused
+					memdelete(category); // Old category was unused.
 				}
 				category = search_options->create_item(root);
-				category->set_text(0, mi.name.replace_first("*", ""));
+				category->set_text(0, class_name);
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
-				script_methods = false;
-				String rep = mi.name.remove_char('*');
-				if (mi.name == "*Script Methods") {
-					icon = search_options->get_editor_theme_icon(SNAME("Script"));
-					script_methods = true;
+				if (is_native_class || ScriptServer::is_global_class(class_name)) {
+					icon = EditorNode::get_singleton()->get_class_icon(class_name);
 				} else {
-					icon = EditorNode::get_singleton()->get_class_icon(rep);
+					icon = search_options->get_editor_theme_icon(SNAME("Script"));
 				}
 				category->set_icon(0, icon);
 
 				continue;
 			}
 
-			String name = mi.name.get_slicec(':', 0);
-			if (!script_methods && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
+			const String name = mi.name.get_slicec(':', 0);
+			if (is_native_class && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
 
@@ -320,7 +335,7 @@ void PropertySelector::_update_search() {
 		}
 
 		if (category && category->get_first_child() == nullptr) {
-			memdelete(category); //old category was unused
+			memdelete(category); // Old category was unused.
 		}
 
 		if (found) {

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -78,17 +78,23 @@ void PropertySelector::_update_search() {
 
 			v.get_property_list(&props);
 		} else {
-			Object *obj = ObjectDB::get_instance(script);
-			if (Object::cast_to<Script>(obj)) {
-				props.push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				Object::cast_to<Script>(obj)->get_script_property_list(&props);
+			Ref<Script> script_base = ObjectDB::get_ref<Script>(script);
+			while (script_base.is_valid()) {
+				String class_name = script_base->get_global_name();
+				if (class_name.is_empty()) {
+					class_name = script_base->get_path().get_file();
+				}
+
+				props.push_back(PropertyInfo(Variant::NIL, class_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
+				script_base->get_script_property_list(&props, true);
+				script_base = script_base->get_base_script();
 			}
 
-			StringName base = base_type;
-			while (base) {
-				props.push_back(PropertyInfo(Variant::NIL, base, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
-				ClassDB::get_property_list(base, &props, true);
-				base = ClassDB::get_parent_class(base);
+			StringName native_base = base_type;
+			while (native_base) {
+				props.push_back(PropertyInfo(Variant::NIL, native_base, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
+				ClassDB::get_property_list(native_base, &props, true);
+				native_base = ClassDB::get_parent_class(native_base);
 			}
 		}
 
@@ -98,17 +104,17 @@ void PropertySelector::_update_search() {
 		for (const PropertyInfo &E : props) {
 			if (E.usage == PROPERTY_USAGE_CATEGORY) {
 				if (category && category->get_first_child() == nullptr) {
-					memdelete(category); //old category was unused
+					memdelete(category); // Old category was unused.
 				}
 				category = search_options->create_item(root);
 				category->set_text(0, E.name);
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
-				if (E.name == "Script Variables") {
-					icon = search_options->get_editor_theme_icon(SNAME("Script"));
-				} else {
+				if (ClassDB::class_exists(E.name) || ScriptServer::is_global_class(E.name)) {
 					icon = EditorNode::get_singleton()->get_class_icon(E.name);
+				} else {
+					icon = search_options->get_editor_theme_icon(SNAME("Script"));
 				}
 				category->set_icon(0, icon);
 				continue;
@@ -149,7 +155,7 @@ void PropertySelector::_update_search() {
 		}
 
 		if (category && category->get_first_child() == nullptr) {
-			memdelete(category); //old category was unused
+			memdelete(category); // Old category was unused.
 		}
 
 		if (found) {
@@ -161,21 +167,28 @@ void PropertySelector::_update_search() {
 		List<MethodInfo> methods;
 
 		if (type != Variant::NIL) {
-			Variant v;
+			methods.push_back(MethodInfo("*" + Variant::get_type_name(type)));
+
+			Variant dummy;
 			Callable::CallError ce;
-			Variant::construct(type, v, nullptr, 0, ce);
-			v.get_method_list(&methods);
+			Variant::construct(type, dummy, nullptr, 0, ce);
+			dummy.get_method_list(&methods);
 		} else {
-			Ref<Script> script_ref = ObjectDB::get_ref<Script>(script);
-			if (script_ref.is_valid()) {
-				if (script_ref->is_built_in()) {
-					script_ref->reload(true);
+			Ref<Script> script_base = ObjectDB::get_ref<Script>(script);
+			while (script_base.is_valid()) {
+				if (script_base->is_built_in()) {
+					script_base->reload(true);
 				}
 
-				List<MethodInfo> script_methods;
-				script_ref->get_script_method_list(&script_methods);
+				String class_name = script_base->get_global_name();
+				if (class_name.is_empty()) {
+					class_name = script_base->get_path().get_file();
+				}
 
-				methods.push_back(MethodInfo("*Script Methods")); // TODO: Split by inheritance.
+				methods.push_back(MethodInfo("*" + class_name));
+
+				List<MethodInfo> script_methods;
+				script_base->get_script_method_list(&script_methods, true);
 
 				for (const MethodInfo &mi : script_methods) {
 					if (mi.name.begins_with("@")) {
@@ -186,6 +199,8 @@ void PropertySelector::_update_search() {
 					}
 					methods.push_back(mi);
 				}
+
+				script_base = script_base->get_base_script();
 			}
 
 			// Skip getters and setters of properties because users will usually use the property instead.
@@ -206,50 +221,50 @@ void PropertySelector::_update_search() {
 				}
 			}
 
-			StringName base = base_type;
-			while (base) {
-				methods.push_back(MethodInfo("*" + String(base)));
+			StringName native_base = base_type;
+			while (native_base) {
+				methods.push_back(MethodInfo("*" + String(native_base)));
 				List<MethodInfo> class_methods;
-				ClassDB::get_method_list(base, &class_methods, true);
+				ClassDB::get_method_list(native_base, &class_methods, true);
 				for (const MethodInfo &mi : class_methods) {
 					if (!methods_to_skip.has(mi.name)) {
 						methods.push_back(mi);
 					}
 				}
-				base = ClassDB::get_parent_class(base);
+				native_base = ClassDB::get_parent_class(native_base);
 			}
 		}
 
 		TreeItem *category = nullptr;
 
 		bool found = false;
-		bool script_methods = false;
+		bool is_native_class = true;
 
 		for (MethodInfo &mi : methods) {
 			if (mi.name.begins_with("*")) {
+				const String class_name = mi.name.replace_first("*", "");
+				is_native_class = ClassDB::class_exists(class_name);
+
 				if (category && category->get_first_child() == nullptr) {
-					memdelete(category); //old category was unused
+					memdelete(category); // Old category was unused.
 				}
 				category = search_options->create_item(root);
-				category->set_text(0, mi.name.replace_first("*", ""));
+				category->set_text(0, class_name);
 				category->set_selectable(0, false);
 
 				Ref<Texture2D> icon;
-				script_methods = false;
-				String rep = mi.name.remove_char('*');
-				if (mi.name == "*Script Methods") {
-					icon = search_options->get_editor_theme_icon(SNAME("Script"));
-					script_methods = true;
+				if (is_native_class || ScriptServer::is_global_class(class_name)) {
+					icon = EditorNode::get_singleton()->get_class_icon(class_name);
 				} else {
-					icon = EditorNode::get_singleton()->get_class_icon(rep);
+					icon = search_options->get_editor_theme_icon(SNAME("Script"));
 				}
 				category->set_icon(0, icon);
 
 				continue;
 			}
 
-			String name = mi.name.get_slicec(':', 0);
-			if (!script_methods && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
+			const String name = mi.name.get_slicec(':', 0);
+			if (is_native_class && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
 
@@ -332,7 +347,7 @@ void PropertySelector::_update_search() {
 		}
 
 		if (category && category->get_first_child() == nullptr) {
-			memdelete(category); //old category was unused
+			memdelete(category); // Old category was unused.
 		}
 
 		if (found) {
@@ -362,32 +377,61 @@ void PropertySelector::_item_selected() {
 	if (!item) {
 		return;
 	}
-	String name = item->get_metadata(0);
 
-	String class_type;
-	if (type != Variant::NIL) {
-		class_type = Variant::get_type_name(type);
-	} else if (!base_type.is_empty()) {
-		class_type = base_type;
-	} else if (instance) {
-		class_type = instance->get_class();
+	const DocTools *doc_data = EditorHelp::get_doc_data();
+	ERR_FAIL_NULL(doc_data);
+
+	// TODO: Consider storing the exact doc class name in the item metadata (along with the member name)
+	// to avoid calculating it via `(type, base_type, script, instance)` and traversing the doc data.
+	String doc_class_name;
+	// Script types.
+	Ref<Script> script_type = ObjectDB::get_ref<Script>(script);
+	if (script_type.is_valid()) {
+		doc_class_name = script_type->get_doc_class_name();
+	}
+	if (doc_class_name.is_empty() && instance != nullptr) {
+		script_type = instance->get_script();
+		if (script_type.is_valid()) {
+			doc_class_name = script_type->get_doc_class_name();
+		}
+	}
+	// Native types.
+	if (doc_class_name.is_empty() && !base_type.is_empty()) {
+		doc_class_name = base_type;
+	}
+	if (doc_class_name.is_empty() && instance != nullptr) {
+		doc_class_name = instance->get_class();
+	}
+	// Built-in types.
+	if (doc_class_name.is_empty() && type != Variant::NIL) {
+		doc_class_name = Variant::get_type_name(type);
 	}
 
-	while (!class_type.is_empty()) {
+	const String member_name = item->get_metadata(0);
+
+	const DocData::ClassDoc *class_doc = doc_data->class_list.getptr(doc_class_name);
+	while (class_doc != nullptr) {
 		if (properties) {
-			if (ClassDB::has_property(class_type, name, true)) {
-				help_bit->parse_symbol("property|" + class_type + "|" + name);
-				break;
+			for (const DocData::PropertyDoc &property : class_doc->properties) {
+				if (property.name == member_name) {
+					help_bit->parse_symbol("property|" + class_doc->name + "|" + member_name);
+					return;
+				}
 			}
 		} else {
-			if (ClassDB::has_method(class_type, name, true)) {
-				help_bit->parse_symbol("method|" + class_type + "|" + name);
-				break;
+			for (const DocData::MethodDoc &method : class_doc->methods) {
+				if (method.name == member_name) {
+					help_bit->parse_symbol("method|" + class_doc->name + "|" + member_name);
+					return;
+				}
 			}
 		}
 
 		// It may be from a parent class, keep looking.
-		class_type = ClassDB::get_parent_class(class_type);
+		if (class_doc->inherits.is_empty()) {
+			return;
+		}
+		class_doc = doc_data->class_list.getptr(class_doc->inherits);
 	}
 }
 

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1559,27 +1559,9 @@ void ConnectionsDock::update_tree() {
 				class_icon = get_editor_theme_icon(native_base);
 			}
 
-			script_base->get_script_signal_list(&class_signals);
+			script_base->get_script_signal_list(&class_signals, true);
 
-			// TODO: Core: Add optional parameter to ignore base classes (no_inheritance like in ClassDB).
-			Ref<Script> base = script_base->get_base_script();
-			if (base.is_valid()) {
-				List<MethodInfo> base_signals;
-				base->get_script_signal_list(&base_signals);
-				HashSet<String> base_signal_names;
-				for (const MethodInfo &signal : base_signals) {
-					base_signal_names.insert(signal.name);
-				}
-				for (List<MethodInfo>::Element *F = class_signals.front(); F;) {
-					List<MethodInfo>::Element *N = F->next();
-					if (base_signal_names.has(F->get().name)) {
-						class_signals.erase(F);
-					}
-					F = N;
-				}
-			}
-
-			script_base = base;
+			script_base = script_base->get_base_script();
 		} else {
 			class_name = native_base;
 			doc_class_name = native_base;

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1590,27 +1590,9 @@ void ConnectionsDock::update_tree() {
 				class_icon = get_editor_theme_icon(native_base);
 			}
 
-			script_base->get_script_signal_list(&class_signals);
+			script_base->get_script_signal_list(&class_signals, true);
 
-			// TODO: Core: Add optional parameter to ignore base classes (no_inheritance like in ClassDB).
-			Ref<Script> base = script_base->get_base_script();
-			if (base.is_valid()) {
-				List<MethodInfo> base_signals;
-				base->get_script_signal_list(&base_signals);
-				HashSet<String> base_signal_names;
-				for (const MethodInfo &signal : base_signals) {
-					base_signal_names.insert(signal.name);
-				}
-				for (List<MethodInfo>::Element *F = class_signals.front(); F;) {
-					List<MethodInfo>::Element *N = F->next();
-					if (base_signal_names.has(F->get().name)) {
-						class_signals.erase(F);
-					}
-					F = N;
-				}
-			}
-
-			script_base = base;
+			script_base = script_base->get_base_script();
 		} else {
 			class_name = native_base;
 			doc_class_name = native_base;

--- a/misc/extension_api_validation/4.5-stable/GH-80418.txt
+++ b/misc/extension_api_validation/4.5-stable/GH-80418.txt
@@ -1,0 +1,10 @@
+GH-80418
+--------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_method_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_property_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_signal_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_method_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_property_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_signal_list': arguments
+
+Added optional argument. Compatibility methods registered.

--- a/misc/extension_api_validation/4.7-stable/GH-80418.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-80418.txt
@@ -1,0 +1,11 @@
+GH-80418
+--------
+
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_method_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_property_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Script/methods/get_script_signal_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_method_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_property_list': arguments
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ScriptExtension/methods/_get_script_signal_list': arguments
+
+Added optional argument. Compatibility methods registered.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -289,14 +289,14 @@ void GDScript::_placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {
 
 #endif
 
-void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance) const {
 	const GDScript *current = this;
 	while (current) {
 		for (const KeyValue<StringName, GDScriptFunction *> &E : current->member_functions) {
 			r_list->push_back(E.value->get_method_info());
 		}
 
-		if (!p_include_base) {
+		if (p_no_inheritance) {
 			return;
 		}
 
@@ -304,11 +304,7 @@ void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_
 	}
 }
 
-void GDScript::get_script_method_list(List<MethodInfo> *r_list) const {
-	_get_script_method_list(r_list, true);
-}
-
-void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance) const {
 	const GDScript *sptr = this;
 	List<PropertyInfo> props;
 
@@ -338,17 +334,13 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 			r_list->push_back(E);
 		}
 
-		if (!p_include_base) {
-			break;
+		if (p_no_inheritance) {
+			return;
 		}
 
 		props.clear();
 		sptr = sptr->base.ptr();
 	}
-}
-
-void GDScript::get_script_property_list(List<PropertyInfo> *r_list) const {
-	_get_script_property_list(r_list, true);
 }
 
 bool GDScript::has_method(const StringName &p_method) const {
@@ -1276,27 +1268,23 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 
-void GDScript::_get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance) const {
 	for (const KeyValue<StringName, MethodInfo> &E : _signals) {
-		r_list->push_back(E.value);
+		r_signals->push_back(E.value);
 	}
 
-	if (!p_include_base) {
+	if (p_no_inheritance) {
 		return;
 	}
 
 	if (base.is_valid()) {
-		base->get_script_signal_list(r_list);
+		base->get_script_signal_list(r_signals);
 	}
 #ifdef TOOLS_ENABLED
 	else if (base_cache.is_valid()) {
-		base_cache->get_script_signal_list(r_list);
+		base_cache->get_script_signal_list(r_signals);
 	}
 #endif
-}
-
-void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
 }
 
 GDScript::GDScript() :

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -298,14 +298,14 @@ void GDScript::_placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {
 
 #endif
 
-void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance) const {
 	const GDScript *current = this;
 	while (current) {
 		for (const KeyValue<StringName, GDScriptFunction *> &E : current->member_functions) {
 			r_list->push_back(E.value->get_method_info());
 		}
 
-		if (!p_include_base) {
+		if (p_no_inheritance) {
 			return;
 		}
 
@@ -313,11 +313,7 @@ void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_
 	}
 }
 
-void GDScript::get_script_method_list(List<MethodInfo> *r_list) const {
-	_get_script_method_list(r_list, true);
-}
-
-void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance) const {
 	const GDScript *sptr = this;
 	List<PropertyInfo> props;
 
@@ -347,17 +343,13 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 			r_list->push_back(E);
 		}
 
-		if (!p_include_base) {
-			break;
+		if (p_no_inheritance) {
+			return;
 		}
 
 		props.clear();
 		sptr = sptr->base.ptr();
 	}
-}
-
-void GDScript::get_script_property_list(List<PropertyInfo> *r_list) const {
-	_get_script_property_list(r_list, true);
 }
 
 bool GDScript::has_method(const StringName &p_method) const {
@@ -1303,27 +1295,23 @@ bool GDScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 
-void GDScript::_get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const {
+void GDScript::get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance) const {
 	for (const KeyValue<StringName, MethodInfo> &E : _signals) {
-		r_list->push_back(E.value);
+		r_signals->push_back(E.value);
 	}
 
-	if (!p_include_base) {
+	if (p_no_inheritance) {
 		return;
 	}
 
 	if (base.is_valid()) {
-		base->get_script_signal_list(r_list);
+		base->get_script_signal_list(r_signals);
 	}
 #ifdef TOOLS_ENABLED
 	else if (base_cache.is_valid()) {
-		base_cache->get_script_signal_list(r_list);
+		base_cache->get_script_signal_list(r_signals);
 	}
 #endif
-}
-
-void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
 }
 
 GDScript::GDScript() :

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -211,10 +211,6 @@ private:
 
 	void _save_orphaned_subclasses();
 
-	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
-	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;
-	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const;
-
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -267,7 +263,7 @@ public:
 	_FORCE_INLINE_ const GDScriptFunction *get_static_initializer() const { return static_initializer; }
 
 	virtual bool has_script_signal(const StringName &p_signal) const override;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override;
 
 	bool is_tool() const override { return tool; }
 	bool is_abstract() const override { return _is_abstract; }
@@ -313,7 +309,7 @@ public:
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
+	virtual void get_script_method_list(List<MethodInfo> *p_list, bool p_no_inheritance = false) const override;
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual bool has_static_method(const StringName &p_method) const override;
 
@@ -321,7 +317,7 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool p_no_inheritance = false) const override;
 
 	virtual ScriptLanguage *get_language() const override;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -202,10 +202,6 @@ private:
 
 	void _save_orphaned_subclasses();
 
-	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
-	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;
-	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const;
-
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -257,7 +253,7 @@ public:
 	_FORCE_INLINE_ const GDScriptFunction *get_static_initializer() const { return static_initializer; }
 
 	virtual bool has_script_signal(const StringName &p_signal) const override;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override;
 
 	bool is_tool() const override { return tool; }
 	bool is_abstract() const override { return _is_abstract; }
@@ -302,7 +298,7 @@ public:
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
+	virtual void get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance = false) const override;
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual bool has_static_method(const StringName &p_method) const override;
 
@@ -310,7 +306,7 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance = false) const override;
 
 	virtual ScriptLanguage *get_language() const override;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2553,7 +2553,7 @@ void CSharpScript::set_source_code(const String &p_code) {
 #endif
 }
 
-void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
+void CSharpScript::get_script_method_list(List<MethodInfo> *p_list, bool p_no_inheritance) const {
 	if (!valid) {
 		return;
 	}
@@ -2562,6 +2562,10 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	while (top != nullptr) {
 		for (const CSharpMethodInfo &E : top->methods) {
 			p_list->push_back(E.method_info);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();
@@ -2717,7 +2721,7 @@ bool CSharpScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 
-void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const {
+void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance) const {
 	if (!valid) {
 		return;
 	}
@@ -2726,17 +2730,13 @@ void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_i
 		r_signals->push_back(signal.method_info);
 	}
 
-	if (!p_include_base) {
+	if (p_no_inheritance) {
 		return;
 	}
 
 	if (base_script.is_valid()) {
 		base_script->get_script_signal_list(r_signals);
 	}
-}
-
-void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {
@@ -2764,12 +2764,16 @@ StringName CSharpScript::get_global_name() const {
 	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance) const {
 #ifdef TOOLS_ENABLED
 	const CSharpScript *top = this;
 	while (top != nullptr) {
 		for (const PropertyInfo &E : top->exported_members_cache) {
 			r_list->push_back(E);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();
@@ -2785,6 +2789,10 @@ void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 
 		for (const PropertyInfo &prop : props) {
 			r_list->push_back(prop);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2502,7 +2502,7 @@ void CSharpScript::set_source_code(const String &p_code) {
 #endif
 }
 
-void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
+void CSharpScript::get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance) const {
 	if (!valid) {
 		return;
 	}
@@ -2510,7 +2510,11 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 	const CSharpScript *top = this;
 	while (top != nullptr) {
 		for (const CSharpMethodInfo &E : top->methods) {
-			p_list->push_back(E.method_info);
+			r_list->push_back(E.method_info);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();
@@ -2671,7 +2675,7 @@ bool CSharpScript::has_script_signal(const StringName &p_signal) const {
 	return false;
 }
 
-void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const {
+void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance) const {
 	if (!valid) {
 		return;
 	}
@@ -2680,17 +2684,13 @@ void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_i
 		r_signals->push_back(signal.method_info);
 	}
 
-	if (!p_include_base) {
+	if (p_no_inheritance) {
 		return;
 	}
 
 	if (base_script.is_valid()) {
 		base_script->get_script_signal_list(r_signals);
 	}
-}
-
-void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {
@@ -2718,12 +2718,16 @@ StringName CSharpScript::get_global_name() const {
 	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance) const {
 #ifdef TOOLS_ENABLED
 	const CSharpScript *top = this;
 	while (top != nullptr) {
 		for (const PropertyInfo &E : top->exported_members_cache) {
 			r_list->push_back(E);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();
@@ -2739,6 +2743,10 @@ void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 
 		for (const PropertyInfo &prop : props) {
 			r_list->push_back(prop);
+		}
+
+		if (p_no_inheritance) {
+			return;
 		}
 
 		top = top->base_script.ptr();

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -220,8 +220,6 @@ private:
 	// Do not use unless you know what you are doing
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
-	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
-
 protected:
 	static void _bind_methods();
 
@@ -257,10 +255,10 @@ public:
 	Error reload(bool p_keep_state = false) override;
 
 	bool has_script_signal(const StringName &p_signal) const override;
-	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
-	void get_script_property_list(List<PropertyInfo> *r_list) const override;
+	void get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance = false) const override;
 	void update_exports() override;
 
 	void get_members(HashSet<StringName> *p_members) override;
@@ -282,7 +280,7 @@ public:
 
 	ScriptLanguage *get_language() const override;
 
-	void get_script_method_list(List<MethodInfo> *p_list) const override;
+	void get_script_method_list(List<MethodInfo> *p_list, bool p_no_inheritance = false) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	MethodInfo get_method_info(const StringName &p_method) const override;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -219,8 +219,6 @@ private:
 	// Do not use unless you know what you are doing
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
-	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
-
 protected:
 	static void _bind_methods();
 
@@ -255,10 +253,10 @@ public:
 	Error reload(bool p_keep_state = false) override;
 
 	bool has_script_signal(const StringName &p_signal) const override;
-	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	void get_script_signal_list(List<MethodInfo> *r_signals, bool p_no_inheritance = false) const override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
-	void get_script_property_list(List<PropertyInfo> *r_list) const override;
+	void get_script_property_list(List<PropertyInfo> *r_list, bool p_no_inheritance = false) const override;
 	void update_exports() override;
 
 	void get_members(HashSet<StringName> *r_members) override;
@@ -280,7 +278,7 @@ public:
 
 	ScriptLanguage *get_language() const override;
 
-	void get_script_method_list(List<MethodInfo> *p_list) const override;
+	void get_script_method_list(List<MethodInfo> *r_list, bool p_no_inheritance = false) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	MethodInfo get_method_info(const StringName &p_method) const override;


### PR DESCRIPTION
This PR adds optional `no_inheritance` parameter to the following methods:

* `Script.get_script_method_list()`;
* `Script.get_script_property_list()`;
* `Script.get_script_signal_list()`.

Passing `true` returns info about the members of the current class only, no base classes. The `no_inheritance` parameter is already in the corresponding `ClassDB` methods. Also in GDScript there are private methods with the inverted `p_include_base` parameter.

I needed this functionality while working on #80411 ([code](https://github.com/godotengine/godot/blob/206be5dec72a3e67b8bcd758eb86d60b67d46fa2/editor/connections_dialog.cpp#L1286-L1300)). Also I think it can be needed in user code (like plugins) as the alternative is to get the full list for each base class and exclude the items of the parent class.

* Also closes godotengine/godot-proposals#10402.