### PR TITLE
Remove use of `std::string` in test

### DIFF
--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -52,8 +52,7 @@ bool is_variable_char(unsigned char c) {
 }
 
 bool is_operator_char(unsigned char c) {
-	static const std::string operators = "<>=+-*/";
-	return operators.find(c) != std::string::npos;
+	return (c == '*') || (c == '+') || (c == '-') || (c == '/') || ((c >= '<') && (c <= '>'));
 }
 
 // Remove unnecessary spaces from a line.


### PR DESCRIPTION
Can alternatively include `<string>` but since this would be the only place in the source using `std::string` save for the glsl module and the windows platform I'll lean to this

The only other places `std::string` is used are (excluding `thirdparty/`):
* `modules/glslang/register_types.cpp`
* `platform/windows/crash_handler_windows.cpp`

Fixes: #80421

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
