### PR TITLE
Ensure `joy_connection_changed` is emitted on the main thread

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -475,7 +475,8 @@ void Input::joy_connection_changed(int p_idx, bool p_connected, String p_name, S
 	}
 	joy_names[p_idx] = js;
 
-	emit_signal(SNAME("joy_connection_changed"), p_idx, p_connected);
+	// Ensure this signal is emitted on the main thread, as some platforms (e.g. Linux) call this from a different thread.
+	call_deferred("emit_signal", SNAME("joy_connection_changed"), p_idx, p_connected);
 }
 
 Vector3 Input::get_gravity() const {


### PR DESCRIPTION
Closes #78531 (once cherry-picked for `3.x`)

On Linux, the code for querying joypad status runs in a thread (`JoypadLinux::joypad_events_thread_run`). Therefore, the `joy_connection_changed` signal is not emitted on the main thread, which depending on user code, can lead do a deadlock due to thread-unsafe API.
