### PR TITLE
Consistency for NodePath doc code examples

### DIFF
--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -101,12 +101,12 @@
 				Returns all subnames concatenated with a colon character ([code]:[/code]) as separator, i.e. the right side of the first colon in a node path.
 				[codeblocks]
 				[gdscript]
-				var nodepath = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")
-				print(nodepath.get_concatenated_subnames()) # texture:load_path
+				var node_path = NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path")
+				print(node_path.get_concatenated_subnames()) # texture:load_path
 				[/gdscript]
 				[csharp]
-				var nodepath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
-				GD.Print(nodepath.GetConcatenatedSubnames()); // texture:load_path
+				var nodePath = new NodePath("Path2D/PathFollow2D/Sprite2D:texture:load_path");
+				GD.Print(nodePath.GetConcatenatedSubnames()); // texture:load_path
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
Just makes a code example in NodePath.xml similar to the others

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
