### PR TITLE
Document `RenderingServer.get_video_adapter_name()` may report a fixed name

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1450,6 +1450,7 @@
 			<description>
 				Returns the name of the video adapter (e.g. "GeForce GTX 1080/PCIe/SSE2").
 				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
+				[b]Note:[/b] On the web platform, some browsers such as Firefox may report a different, fixed GPU name such as "GeForce GTX 980" (regardless of the user's actual GPU model). This is done to make fingerprinting more difficult.
 			</description>
 		</method>
 		<method name="get_video_adapter_type" qualifiers="const">


### PR DESCRIPTION
Firefox may[^1] report the user's GPU as a GeForce GTX 980 in an attempt to make fingerprinting more difficult. This is not the case in Chromium-based browsers though.

[^1]: I've noticed this on 3 different setups (GTX 1080, RX 6900 XT, RTX 4090). I don't know if GPUs older than the GTX 980 are affected by this (probably not).