### PR TITLE
Improve usability of the SpriteFramesEditor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -151,6 +151,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	SpinBox *split_sheet_sep_y = nullptr;
 	SpinBox *split_sheet_offset_x = nullptr;
 	SpinBox *split_sheet_offset_y = nullptr;
+	Button *split_sheet_change_spr = nullptr;
 	Button *split_sheet_zoom_out = nullptr;
 	Button *split_sheet_zoom_reset = nullptr;
 	Button *split_sheet_zoom_in = nullptr;
@@ -172,6 +173,8 @@ class SpriteFramesEditor : public HSplitContainer {
 	float sheet_zoom;
 	float max_sheet_zoom;
 	float min_sheet_zoom;
+
+	Dictionary split_data;
 
 	Size2i _get_frame_count() const;
 	Size2i _get_frame_size() const;
@@ -221,14 +224,15 @@ class SpriteFramesEditor : public HSplitContainer {
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
 
-	void _open_sprite_sheet();
+	void _open_sprite_sheet(bool p_force_open = false);
 	void _prepare_sprite_sheet(const String &p_file);
 	int _sheet_preview_position_to_frame_index(const Vector2 &p_position);
 	void _sheet_preview_draw();
-	void _sheet_spin_changed(double p_value, int p_dominant_param);
+	void _sheet_spin_changed(double p_value, int p_dominant_param, const String &p_key);
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);
 	void _sheet_scroll_input(const Ref<InputEvent> &p_event);
 	void _sheet_add_frames();
+	void _sheet_change_sprite();
 	void _sheet_zoom_on_position(float p_zoom, const Vector2 &p_position);
 	void _sheet_zoom_in();
 	void _sheet_zoom_out();


### PR DESCRIPTION
Currently when the user is adding a lot of animations in the SpriteFramesEditor he has to open the sprite everytime and set values all again:

https://github.com/godotengine/godot/assets/58845030/1b487503-4a58-415e-954f-dbddb8d6fed5

with the changes of this PR, I tried to make it as more reliable as possible, the editor will "save" the settings and know the settings and last texture used in the process:


https://github.com/godotengine/godot/assets/58845030/f3f6364c-24d8-475d-98b4-428d77cc43f7


Some info:
* If you close the editor, and open again, it will still know your last configurations
* If you (HOLD SHIFT + Click) on `Add frames from spritesheet` it will open the `Open a file` to select a new texture

*Bugsquad edit:*
* *Closes: https://github.com/godotengine/godot-proposals/issues/7021*