### PR TITLE
Deprecate `project_settings_changed` signal

### DIFF
--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -149,6 +149,8 @@
 										<xs:element type="xs:string" name="description" />
 									</xs:sequence>
 									<xs:attribute type="xs:string" name="name" use="optional" />
+									<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+									<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
 								</xs:complexType>
 							</xs:element>
 						</xs:sequence>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -749,9 +749,10 @@
 				Emitted when user changes the workspace ([b]2D[/b], [b]3D[/b], [b]Script[/b], [b]AssetLib[/b]). Also works with custom screens defined by plugins.
 			</description>
 		</signal>
-		<signal name="project_settings_changed">
+		<signal name="project_settings_changed" is_deprecated="true">
 			<description>
 				Emitted when any project setting has changed.
+				[i]Deprecated.[/i] Use [signal ProjectSettings.settings_changed] instead.
 			</description>
 		</signal>
 		<signal name="resource_saved">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -431,6 +431,8 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 }
 
 void EditorNode::_update_from_settings() {
+	_update_title();
+
 	int current_filter = GLOBAL_GET("rendering/textures/canvas_textures/default_texture_filter");
 	if (current_filter != scene_root->get_default_canvas_item_texture_filter()) {
 		Viewport::DefaultCanvasItemTextureFilter tf = (Viewport::DefaultCanvasItemTextureFilter)current_filter;
@@ -509,6 +511,8 @@ void EditorNode::_update_from_settings() {
 	tree->set_debug_collisions_color(GLOBAL_GET("debug/shapes/collision/shape_color"));
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
 
+	ResourceImporterTexture::get_singleton()->update_imports();
+
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/edge_connection_color"));
 	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/geometry_edge_color"));
@@ -581,18 +585,6 @@ void EditorNode::_notification(int p_what) {
 			}
 
 			editor_selection->update();
-
-			ResourceImporterTexture::get_singleton()->update_imports();
-
-			if (settings_changed) {
-				_update_title();
-			}
-
-			if (settings_changed) {
-				_update_from_settings();
-				settings_changed = false;
-				emit_signal(SNAME("project_settings_changed"));
-			}
 
 			ResourceImporterTexture::get_singleton()->update_imports();
 
@@ -1146,7 +1138,6 @@ void EditorNode::_reload_modified_scenes() {
 
 void EditorNode::_reload_project_settings() {
 	ProjectSettings::get_singleton()->setup(ProjectSettings::get_singleton()->get_resource_path(), String(), true);
-	settings_changed = true;
 }
 
 void EditorNode::_vp_resized() {
@@ -6724,7 +6715,6 @@ void EditorNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "obj")));
 	ADD_SIGNAL(MethodInfo("scene_saved", PropertyInfo(Variant::STRING, "path")));
-	ADD_SIGNAL(MethodInfo("project_settings_changed"));
 	ADD_SIGNAL(MethodInfo("scene_changed"));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "path")));
 }
@@ -6810,10 +6800,6 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 	return eta.exitcode;
 }
 
-void EditorNode::notify_settings_changed() {
-	settings_changed = true;
-}
-
 EditorNode::EditorNode() {
 	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
 	add_child(epnp);
@@ -6861,6 +6847,7 @@ EditorNode::EditorNode() {
 
 	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
 	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorNode::_update_from_settings));
 
 	TranslationServer::get_singleton()->set_enabled(false);
 	// Load settings.

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -465,7 +465,6 @@ private:
 	bool immediate_dialog_confirmed = false;
 	bool opening_prev = false;
 	bool restoring_scenes = false;
-	bool settings_changed = true; // Make it update settings on first frame.
 	bool unsaved_cache = true;
 	bool waiting_for_first_scan = true;
 
@@ -925,8 +924,6 @@ public:
 	void save_before_run();
 	void try_autosave();
 	void restart_editor();
-
-	void notify_settings_changed();
 
 	void dim_editor(bool p_dimming);
 	bool is_editor_dimmed() const;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -527,19 +527,24 @@ void EditorPlugin::remove_resource_conversion_plugin(const Ref<EditorResourceCon
 	EditorNode::get_singleton()->remove_resource_conversion_plugin(p_plugin);
 }
 
+#ifndef DISABLE_DEPRECATED
 void EditorPlugin::_editor_project_settings_changed() {
 	emit_signal(SNAME("project_settings_changed"));
 }
+#endif
+
 void EditorPlugin::_notification(int p_what) {
+#ifndef DISABLE_DEPRECATED
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			EditorNode::get_singleton()->disconnect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+			ProjectSettings::get_singleton()->disconnect("settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
 		} break;
 	}
+#endif
 }
 
 void EditorPlugin::_bind_methods() {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -63,7 +63,9 @@ class EditorPlugin : public Node {
 	String last_main_screen_name;
 	String plugin_version;
 
+#ifndef DISABLE_DEPRECATED
 	void _editor_project_settings_changed();
+#endif
 
 protected:
 	void _notification(int p_what);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1287,7 +1287,7 @@ EditorPropertyLayers::EditorPropertyLayers() {
 	layers->set_hide_on_checkable_item_selection(false);
 	layers->connect("id_pressed", callable_mp(this, &EditorPropertyLayers::_menu_pressed));
 	layers->connect("popup_hide", callable_mp((BaseButton *)button, &BaseButton::set_pressed).bind(false));
-	EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &EditorPropertyLayers::_refresh_names));
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorPropertyLayers::_refresh_names));
 }
 
 ///////////////////// INT /////////////////////////

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -109,8 +109,6 @@ void ImportDefaultsEditor::_save() {
 		} else {
 			ProjectSettings::get_singleton()->set("importer_defaults/" + settings->importer->get_importer_name(), Variant());
 		}
-
-		emit_signal(SNAME("project_settings_changed"));
 	}
 }
 
@@ -194,10 +192,6 @@ void ImportDefaultsEditor::clear() {
 			importers->select(i + 1);
 		}
 	}
-}
-
-void ImportDefaultsEditor::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("project_settings_changed"));
 }
 
 ImportDefaultsEditor::ImportDefaultsEditor() {

--- a/editor/import_defaults_editor.h
+++ b/editor/import_defaults_editor.h
@@ -57,7 +57,6 @@ class ImportDefaultsEditor : public VBoxContainer {
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
 	void clear();

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2687,7 +2687,7 @@ void Node3DEditorViewport::_project_settings_changed() {
 void Node3DEditorViewport::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &Node3DEditorViewport::_project_settings_changed));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditorViewport::_project_settings_changed));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -7562,7 +7562,7 @@ void Node3DEditor::_notification(int p_what) {
 			sun_state->set_custom_minimum_size(sun_vb->get_combined_minimum_size());
 			environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
 
-			EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1076,7 +1076,7 @@ TextShaderEditor::TextShaderEditor() {
 	shader_editor->connect("show_warnings_panel", callable_mp(this, &TextShaderEditor::_show_warnings_panel));
 	shader_editor->connect("script_changed", callable_mp(this, &TextShaderEditor::apply_shaders));
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextShaderEditor::_editor_settings_changed));
-	ProjectSettingsEditor::get_singleton()->connect("confirmed", callable_mp(this, &TextShaderEditor::_project_settings_changed));
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextShaderEditor::_project_settings_changed));
 
 	shader_editor->get_text_editor()->set_code_hint_draw_below(EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"));
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -70,7 +70,6 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 }
 
 void ProjectSettingsEditor::queue_save() {
-	EditorNode::get_singleton()->notify_settings_changed();
 	timer->start();
 }
 
@@ -734,7 +733,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	import_defaults_editor = memnew(ImportDefaultsEditor);
 	import_defaults_editor->set_name(TTR("Import Defaults"));
 	tab_container->add_child(import_defaults_editor);
-	import_defaults_editor->connect("project_settings_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 
 	MovieWriter::set_extensions_hint(); // ensure extensions are properly displayed.
 }


### PR DESCRIPTION
Follow-up to #62038

- deprecate `project_settings_changed` in EditorPlugin
- remove the signal from EditorNode

Builds on top of #62038