### PR TITLE
Improve readability of `GodotSpace2D::test_body_motion`

### DIFF
--- a/servers/physics_2d/godot_space_2d.h
+++ b/servers/physics_2d/godot_space_2d.h
@@ -67,14 +67,31 @@ public:
 		ELAPSED_TIME_SOLVE_CONSTRAINTS,
 		ELAPSED_TIME_INTEGRATE_VELOCITIES,
 		ELAPSED_TIME_MAX
-
 	};
 
 private:
+	friend class GodotPhysicsDirectSpaceState2D;
+
 	struct ExcludedShapeSW {
 		GodotShape2D *local_shape = nullptr;
 		const GodotCollisionObject2D *against_object = nullptr;
 		int against_shape_index = 0;
+	};
+
+	struct TestBodyMotionData {
+		Rect2 body_aabb;
+		int excluded_shape_pair_count = 0;
+		real_t margin;
+		real_t min_contact_depth;
+		static const int max_excluded_shape_pairs = 32;
+		ExcludedShapeSW excluded_shape_pairs[max_excluded_shape_pairs];
+		Transform2D body_transform;
+		int best_shape = -1;
+		bool recovered = false; // Required in steps 1 and 3.
+		real_t safe_fraction = 1.0; // Required in steps 2 and 3.
+		real_t unsafe_fraction = 1.0;
+		real_t motion_length;
+		Vector2 motion_normal;
 	};
 
 	uint64_t elapsed_time[ELAPSED_TIME_MAX] = {};
@@ -128,7 +145,9 @@ private:
 	Vector<Vector2> contact_debug;
 	int contact_debug_count = 0;
 
-	friend class GodotPhysicsDirectSpaceState2D;
+	void free_stuck_body(GodotBody2D *p_body, const PhysicsServer2D::MotionParameters &p_parameters, TestBodyMotionData *p_test_data);
+	void attempt_body_motion(GodotBody2D *p_body, const PhysicsServer2D::MotionParameters &p_parameters, TestBodyMotionData *p_test_data);
+	bool retrieve_body_motion_data(GodotBody2D *p_body, const PhysicsServer2D::MotionParameters &p_parameters, PhysicsServer2D::MotionResult *r_result, TestBodyMotionData *p_test_data);
 
 public:
 	_FORCE_INLINE_ void set_self(const RID &p_self) { self = p_self; }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Improving the readability of `GodotSpace2D::test_body_motion` by dividing its logic into three distinct helper functions that reflect the stuck, attempt motion and retrieve data steps. These new functions will be called using a `TestBodyMotionData` struct to facilitate their interactions.

The code retains its original functionality, with the sole difference being its division into functions. As a result, this restructuring will not impact the `test_body_motion` callers.

The modified structure is as follows:

```
bool GodotSpace2D::test_body_motion(...) {

	bool did_collide = false;

	free_stuck_body(p_body, p_parameters, &tbmd);

	attempt_body_motion(p_body, p_parameters, &tbmd);

	did_collide = retrieve_body_motion_data(p_body, p_parameters, r_result, &tbmd);

	return did_collide;
}
```
Some local properties have been renamed to align with similar logic in other parts of the code, while others have been renamed for clarity. The local boolean variables of these functions, such as `stuck`, `excluded` and `collided`, have not been renamed.

The members of `TestBodyMotionData` will override the previous properties of the main function. Additionally, two properties (safe and unsafe) have been renamed to resemble the naming conventions used in `PhysicsServer2D::MotionResult` for improved consistency.