### PR TITLE
Fix TileSet with TileMap handling

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -38,7 +38,6 @@
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
-#include "editor/inspector_dock.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 
 #include "scene/2d/tile_map.h"
@@ -326,8 +325,17 @@ void TileMapEditorPlugin::_tile_map_changed() {
 }
 
 void TileMapEditorPlugin::_update_tile_map() {
-	if (tile_map && tile_map->get_tileset().is_valid()) {
-		EditorNode::get_singleton()->edit_item(tile_map->get_tileset().ptr(), InspectorDock::get_inspector_singleton());
+	if (tile_map) {
+		Ref<TileSet> tile_set = tile_map->get_tileset();
+		if (tile_set.is_valid() && edited_tileset != tile_set->get_instance_id()) {
+			tile_set_plugin_singleton->edit(tile_map->get_tileset().ptr());
+			tile_set_plugin_singleton->make_visible(true);
+			edited_tileset = tile_set->get_instance_id();
+		} else if (tile_set.is_null()) {
+			tile_set_plugin_singleton->edit(nullptr);
+			tile_set_plugin_singleton->make_visible(false);
+			edited_tileset = ObjectID();
+		}
 	}
 	tile_map_changed_needs_update = false;
 }
@@ -350,7 +358,9 @@ void TileMapEditorPlugin::edit(Object *p_object) {
 		tile_map->connect("changed", callable_mp(this, &TileMapEditorPlugin::_tile_map_changed));
 
 		if (tile_map->get_tileset().is_valid()) {
-			EditorNode::get_singleton()->edit_item(tile_map->get_tileset().ptr(), InspectorDock::get_inspector_singleton());
+			tile_set_plugin_singleton->edit(tile_map->get_tileset().ptr());
+			tile_set_plugin_singleton->make_visible(true);
+			edited_tileset = tile_map->get_tileset()->get_instance_id();
 		}
 	}
 }

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -118,6 +118,8 @@ class TileMapEditorPlugin : public EditorPlugin {
 	TileMap *tile_map = nullptr;
 
 	bool tile_map_changed_needs_update = false;
+	ObjectID edited_tileset;
+
 	void _tile_map_changed();
 	void _update_tile_map();
 


### PR DESCRIPTION
Fixes #80399
Regression from #74717

The PR force-edited the TileSet when the edited TileMap had one which, aside from still causing the error it tried to fixed, caused also the linked issue + clearing the TileSet in TileMap did not properly close the editor.

This PR makes the TileSet edited without using the standard editor's API. You can still "properly edit" the TileSet when you unfold the inspector property; it does not interfere with what TileMap plugin does.