### PR TITLE
Limit mesh complexity in LOD generation to prevent crashing

### DIFF
--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -475,6 +475,14 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 			if (new_index_count == 0 || (new_index_count >= (index_count * 0.75f))) {
 				break;
 			}
+			if (new_index_count > 5000000) {
+				// This limit theoretically shouldn't be needed, but it's here
+				// as an ad-hoc fix to prevent a crash with complex meshes.
+				// The crash still happens with limit of 6000000, but 5000000 works.
+				// In the future, identify what's causing that crash and fix it.
+				WARN_PRINT("Mesh LOD generation failed for mesh " + get_name() + " surface " + itos(i) + ", mesh is too complex. Some automatic LODs were not generated.");
+				break;
+			}
 
 			new_indices.resize(new_index_count);
 


### PR DESCRIPTION
This PR fixes the crash in #80431. Instead of crashing, Godot will now print this message:

```
WARNING: Mesh LOD generation failed for mesh grass_Plane_009 surface 0, mesh is too complex. Some automatic LODs were not generated.
     at: generate_lods (scene/resources/importer_mesh.cpp:479)
```

I set the limit to `5000000` (5 million). I'm not certain what the limit should be, but a limit of 6 million crashes.

Note: I suspect that there is a bug in the LOD generator and that the limit should be higher than this. However, even if the limit should be higher, it's still good to have some kind of limit that prints a meaningful message instead of crashing. Also, this mesh lags Godot, so LODs are not the only problem with a mesh this big.