### PR TITLE
Unify make dir and duplicate dialogs

### DIFF
--- a/editor/directory_create_dialog.h
+++ b/editor/directory_create_dialog.h
@@ -40,23 +40,31 @@ class LineEdit;
 class DirectoryCreateDialog : public ConfirmationDialog {
 	GDCLASS(DirectoryCreateDialog, ConfirmationDialog);
 
-	String base_dir;
+public:
+	enum Mode {
+		MODE_FILE,
+		MODE_DIRECTORY,
+	};
 
-	Label *label = nullptr;
+private:
+	String base_dir;
+	Callable accept_callback;
+	int mode = MODE_FILE;
+
+	Label *base_path_label = nullptr;
 	LineEdit *dir_path = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 
+	String _sanitize_input(const String &p_input) const;
 	String _validate_path(const String &p_path) const;
 	void _on_dir_path_changed();
 
 protected:
-	static void _bind_methods();
-
 	virtual void ok_pressed() override;
 	virtual void _post_popup() override;
 
 public:
-	void config(const String &p_base_dir);
+	void config(const String &p_base_dir, const Callable &p_accept_callback, int p_mode, const String &p_title, const String &p_default_name = "");
 
 	DirectoryCreateDialog();
 };

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -183,8 +183,6 @@ private:
 	DependencyRemoveDialog *remove_dialog = nullptr;
 
 	EditorDirDialog *move_dialog = nullptr;
-	ConfirmationDialog *duplicate_dialog = nullptr;
-	LineEdit *duplicate_dialog_text = nullptr;
 	DirectoryCreateDialog *make_dir_dialog = nullptr;
 
 	ConfirmationDialog *overwrite_dialog = nullptr;
@@ -291,7 +289,7 @@ private:
 	void _resource_created();
 	void _make_scene_confirm();
 	void _rename_operation_confirm();
-	void _duplicate_operation_confirm();
+	void _duplicate_operation_confirm(const String &p_path);
 	void _overwrite_dialog_action(bool p_overwrite);
 	void _convert_dialog_action();
 	Vector<String> _check_existing();
@@ -384,6 +382,7 @@ public:
 	void navigate_to_path(const String &p_path);
 	void focus_on_path();
 	void focus_on_filter();
+	void create_directory(const String &p_path, const String &p_base_dir);
 
 	ScriptCreateDialog *get_script_create_dialog() const;
 

--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -175,11 +175,14 @@ void EditorDirDialog::ok_pressed() {
 void EditorDirDialog::_make_dir() {
 	TreeItem *ti = tree->get_selected();
 	ERR_FAIL_NULL(ti);
-	makedialog->config(ti->get_metadata(0));
+	const String &directory = ti->get_metadata(0);
+	makedialog->config(directory, callable_mp(this, &EditorDirDialog::_make_dir_confirm).bind(directory), DirectoryCreateDialog::MODE_DIRECTORY, "new folder");
 	makedialog->popup_centered();
 }
 
-void EditorDirDialog::_make_dir_confirm(const String &p_path) {
+void EditorDirDialog::_make_dir_confirm(const String &p_path, const String &p_base_dir) {
+	FileSystemDock::get_singleton()->create_directory(p_path, p_base_dir);
+
 	// Multiple level of directories can be created at once.
 	String base_dir = p_path.get_base_dir();
 	while (true) {
@@ -228,5 +231,4 @@ EditorDirDialog::EditorDirDialog() {
 
 	makedialog = memnew(DirectoryCreateDialog);
 	add_child(makedialog);
-	makedialog->connect("dir_created", callable_mp(this, &EditorDirDialog::_make_dir_confirm));
 }

--- a/editor/gui/editor_dir_dialog.h
+++ b/editor/gui/editor_dir_dialog.h
@@ -56,7 +56,7 @@ class EditorDirDialog : public ConfirmationDialog {
 	void _update_dir(const Color &p_default_folder_color, const Dictionary &p_assigned_folder_colors, const HashMap<String, Color> &p_folder_colors, bool p_is_dark_theme, TreeItem *p_item, EditorFileSystemDirectory *p_dir, const String &p_select_path = String());
 
 	void _make_dir();
-	void _make_dir_confirm(const String &p_path);
+	void _make_dir_confirm(const String &p_path, const String &p_base_dir);
 
 	void _copy_pressed();
 	void ok_pressed() override;


### PR DESCRIPTION
When duplicating a file/folder, there is this bare-bones dialog with just name input. I wanted to enhance it a bit, but noticed that DirectoryCreateDialog is very similar, so I just unified them.

- DirectoryCreateDialog (name pending) now supports file and directory mode and 
- the dialog now takes a callback, which is called after accepting. It sends the validated path as argument
- creating new directory was adapted to the new dialog
- when you duplicate file, the new DirectoryCreateDialog will be used for validation (instead of validating after accepting 🤦‍♂️)
- you can now duplicate the file into another directory, which will be created if it doesn't exist

https://github.com/godotengine/godot/assets/2223172/add86683-0946-4f1c-b41d-a86c16e1be1e

This will also allow to unhack #79966

Note that the PR is ready for review, but I still need to rename DirectoryCreateDialog into something that makes more sense with the new functionality.