### PR TITLE
Expose CharacterBody3D methods to C++

### DIFF
--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -435,6 +435,7 @@ private:
 	Vector<PhysicsServer3D::MotionResult> motion_results;
 	Vector<Ref<KinematicCollision3D>> slide_colliders;
 
+public:
 	void set_safe_margin(real_t p_margin);
 	real_t get_safe_margin() const;
 
@@ -474,14 +475,16 @@ private:
 	void set_platform_on_leave(PlatformOnLeave p_on_leave_velocity);
 	PlatformOnLeave get_platform_on_leave() const;
 
+	void set_up_direction(const Vector3 &p_up_direction);
+	const Vector3 &get_up_direction() const;
+
+private:
 	void _move_and_slide_floating(double p_delta);
 	void _move_and_slide_grounded(double p_delta, bool p_was_on_floor);
 
 	Ref<KinematicCollision3D> _get_slide_collision(int p_bounce);
 	Ref<KinematicCollision3D> _get_last_slide_collision();
-	const Vector3 &get_up_direction() const;
 	bool _on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_facing_up);
-	void set_up_direction(const Vector3 &p_up_direction);
 	void _set_collision_direction(const PhysicsServer3D::MotionResult &p_result, CollisionState &r_state, CollisionState p_apply_state = CollisionState(true, true, true));
 	void _set_platform_data(const PhysicsServer3D::MotionCollision &p_collision);
 	void _snap_on_floor(bool p_was_on_floor, bool p_vel_dir_facing_up);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


For some reason CharacterBody3D methods that are exposed to GDScript and GDExtension aren't being exposed to C++ code. This PR makes all methods that are bound to scripting also be public in C++