### PR TITLE
Extract editor scene tabs into their own component

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -56,7 +56,6 @@
 #include "scene/gui/popup.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
-#include "scene/gui/tab_bar.h"
 #include "scene/gui/tab_container.h"
 #include "scene/main/window.h"
 #include "scene/property_utils.h"
@@ -105,6 +104,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_run_bar.h"
+#include "editor/gui/editor_scene_tabs.h"
 #include "editor/gui/editor_title_bar.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/history_dock.h"
@@ -271,90 +271,6 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 	}
 }
 
-// TODO: This REALLY should be done in a better way than replacing all tabs after almost EVERY action.
-void EditorNode::_update_scene_tabs() {
-	bool show_rb = EDITOR_GET("interface/scene_tabs/show_script_button");
-
-	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
-		DisplayServer::get_singleton()->global_menu_clear("_dock");
-	}
-
-	// Get all scene names, which may be ambiguous.
-	Vector<String> disambiguated_scene_names;
-	Vector<String> full_path_names;
-	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		disambiguated_scene_names.append(editor_data.get_scene_title(i));
-		full_path_names.append(editor_data.get_scene_path(i));
-	}
-
-	disambiguate_filenames(full_path_names, disambiguated_scene_names);
-
-	// Workaround to ignore the tab_changed signal from the first added tab.
-	scene_tabs->disconnect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
-
-	scene_tabs->clear_tabs();
-	Ref<Texture2D> script_icon = gui_base->get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
-	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
-		Node *type_node = editor_data.get_edited_scene_root(i);
-		Ref<Texture2D> icon;
-		if (type_node) {
-			icon = EditorNode::get_singleton()->get_object_icon(type_node, "Node");
-		}
-
-		bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(i));
-		scene_tabs->add_tab(disambiguated_scene_names[i] + (unsaved ? "(*)" : ""), icon);
-
-		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
-			DisplayServer::get_singleton()->global_menu_add_item("_dock", editor_data.get_scene_title(i) + (unsaved ? "(*)" : ""), callable_mp(this, &EditorNode::_global_menu_scene), Callable(), i);
-		}
-
-		if (show_rb && editor_data.get_scene_root_script(i).is_valid()) {
-			scene_tabs->set_tab_button_icon(i, script_icon);
-		}
-	}
-
-	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
-		DisplayServer::get_singleton()->global_menu_add_separator("_dock");
-		DisplayServer::get_singleton()->global_menu_add_item("_dock", TTR("New Window"), callable_mp(this, &EditorNode::_global_menu_new_window));
-	}
-
-	if (scene_tabs->get_tab_count() > 0) {
-		scene_tabs->set_current_tab(editor_data.get_edited_scene());
-	}
-
-	const Size2 add_button_size = Size2(scene_tab_add->get_size().x, scene_tabs->get_size().y);
-	if (scene_tabs->get_offset_buttons_visible()) {
-		// Move the add button to a fixed position.
-		if (scene_tab_add->get_parent() == scene_tabs) {
-			scene_tabs->remove_child(scene_tab_add);
-			scene_tab_add_ph->add_child(scene_tab_add);
-			scene_tab_add->set_rect(Rect2(Point2(), add_button_size));
-		}
-	} else {
-		// Move the add button to be after the last tab.
-		if (scene_tab_add->get_parent() == scene_tab_add_ph) {
-			scene_tab_add_ph->remove_child(scene_tab_add);
-			scene_tabs->add_child(scene_tab_add);
-		}
-
-		if (scene_tabs->get_tab_count() == 0) {
-			scene_tab_add->set_rect(Rect2(Point2(), add_button_size));
-			return;
-		}
-
-		Rect2 last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
-		int hsep = scene_tabs->get_theme_constant(SNAME("h_separation"));
-		if (scene_tabs->is_layout_rtl()) {
-			scene_tab_add->set_rect(Rect2(Point2(last_tab.position.x - add_button_size.x - hsep, last_tab.position.y), add_button_size));
-		} else {
-			scene_tab_add->set_rect(Rect2(Point2(last_tab.position.x + last_tab.size.width + hsep, last_tab.position.y), add_button_size));
-		}
-	}
-
-	// Reconnect after everything is done.
-	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
-}
-
 void EditorNode::_version_control_menu_option(int p_idx) {
 	switch (vcs_actions_menu->get_item_id(p_idx)) {
 		case RUN_VCS_METADATA: {
@@ -391,16 +307,6 @@ void EditorNode::shortcut_input(const Ref<InputEvent> &p_event) {
 	if ((k.is_valid() && k->is_pressed() && !k->is_echo()) || Object::cast_to<InputEventShortcut>(*p_event)) {
 		EditorPlugin *old_editor = editor_plugin_screen;
 
-		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
-			int next_tab = editor_data.get_edited_scene() + 1;
-			next_tab %= editor_data.get_edited_scene_count();
-			_scene_tab_changed(next_tab);
-		}
-		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
-			int next_tab = editor_data.get_edited_scene() - 1;
-			next_tab = next_tab >= 0 ? next_tab : editor_data.get_edited_scene_count() - 1;
-			_scene_tab_changed(next_tab);
-		}
 		if (ED_IS_SHORTCUT("editor/filter_files", p_event)) {
 			FileSystemDock::get_singleton()->focus_on_filter();
 		}
@@ -558,7 +464,7 @@ void EditorNode::_notification(int p_what) {
 			}
 
 			if (editor_data.is_scene_changed(-1)) {
-				_update_scene_tabs();
+				scene_tabs->update_scene_tabs();
 			}
 
 			// Update the animation frame of the update spinner.
@@ -715,7 +621,6 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
 			FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 			EditorFileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
 			EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EDITOR_GET("filesystem/file_dialog/display_mode").operator int());
@@ -745,17 +650,10 @@ void EditorNode::_notification(int p_what) {
 				main_vbox->add_theme_constant_override("separation", gui_base->get_theme_constant(SNAME("top_bar_separation"), SNAME("Editor")));
 				scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
 				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanel"), SNAME("EditorStyles")));
-				tabbar_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("tabbar_background"), SNAME("TabContainer")));
-
-				scene_tabs->add_theme_constant_override("icon_max_width", gui_base->get_theme_constant(SNAME("class_icon_size"), SNAME("Editor")));
-				scene_tab_add_ph->set_custom_minimum_size(scene_tab_add->get_minimum_size());
-
 				main_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 			}
 
-			scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
-			_update_scene_tabs();
-
+			scene_tabs->update_scene_tabs();
 			recent_scenes->reset_size();
 
 			// Update debugger area.
@@ -780,7 +678,6 @@ void EditorNode::_notification(int p_what) {
 
 			prev_scene->set_icon(gui_base->get_theme_icon(SNAME("PrevScene"), SNAME("EditorIcons")));
 			distraction_free->set_icon(gui_base->get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
-			scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 
 			bottom_panel_raise->set_icon(gui_base->get_theme_icon(SNAME("ExpandBottomDock"), SNAME("EditorIcons")));
 
@@ -1139,8 +1036,8 @@ void EditorNode::_reload_modified_scenes() {
 		}
 	}
 
-	set_current_scene(current_idx);
-	_update_scene_tabs();
+	_set_current_scene(current_idx);
+	scene_tabs->update_scene_tabs();
 	disk_changed->hide();
 }
 
@@ -1385,6 +1282,10 @@ void EditorNode::_menu_option(int p_option) {
 
 void EditorNode::_menu_confirm_current() {
 	_menu_option_confirm(current_menu_option, true);
+}
+
+void EditorNode::trigger_menu_option(int p_option, bool p_confirmed) {
+	_menu_option_confirm(p_option, p_confirmed);
 }
 
 void EditorNode::_dialog_display_save_error(String p_file, Error p_error) {
@@ -1822,7 +1723,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		editor_folding.save_scene_folding(scene, p_file);
 
 		_update_title();
-		_update_scene_tabs();
+		scene_tabs->update_scene_tabs();
 	} else {
 		_dialog_display_save_error(p_file, err);
 	}
@@ -1937,7 +1838,7 @@ void EditorNode::_mark_unsaved_scenes() {
 	}
 
 	_update_title();
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 }
 
 void EditorNode::_dialog_action(String p_file) {
@@ -2277,7 +2178,8 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 
 	Ref<Resource> res = Object::cast_to<Resource>(current_obj);
 	if (p_skip_foreign && res.is_valid()) {
-		if (res->get_path().find("::") > -1 && res->get_path().get_slice("::", 0) != editor_data.get_scene_path(get_current_tab())) {
+		const int current_tab = scene_tabs->get_current_tab();
+		if (res->get_path().find("::") > -1 && res->get_path().get_slice("::", 0) != editor_data.get_scene_path(current_tab)) {
 			// Trying to edit resource that belongs to another scene; abort.
 			current_obj = nullptr;
 		}
@@ -3110,7 +3012,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 			// Don't close tabs when exiting the editor (required for "restore_scenes_on_load" setting).
 			if (!_is_closing_editor()) {
 				_remove_scene(tab_closing_idx);
-				_update_scene_tabs();
+				scene_tabs->update_scene_tabs();
 			}
 			_proceed_closing_scene_tabs();
 		} break;
@@ -3448,11 +3350,11 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 	}
 
 	if (p_change_tab) {
-		_scene_tab_changed(new_index);
+		_set_current_scene(new_index);
 	}
 	editor_data.remove_scene(old_index);
 	_update_title();
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 }
 
 void EditorNode::_remove_scene(int index, bool p_change_tab) {
@@ -3574,7 +3476,15 @@ bool EditorNode::is_changing_scene() const {
 	return changing_scene;
 }
 
-void EditorNode::set_current_scene(int p_idx) {
+void EditorNode::_set_current_scene(int p_idx) {
+	if (p_idx == editor_data.get_edited_scene()) {
+		return; // Pointless.
+	}
+
+	_set_current_scene_nocheck(p_idx);
+}
+
+void EditorNode::_set_current_scene_nocheck(int p_idx) {
 	// Save the folding in case the scene gets reloaded.
 	if (editor_data.get_scene_path(p_idx) != "" && editor_data.get_edited_scene_root(p_idx)) {
 		editor_folding.save_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
@@ -3621,7 +3531,7 @@ void EditorNode::set_current_scene(int p_idx) {
 	_edit_current(true);
 
 	_update_title();
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 
 	if (tabs_to_close.is_empty()) {
 		call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.
@@ -3664,9 +3574,9 @@ int EditorNode::new_scene() {
 	}
 	idx = MAX(idx, 0);
 
-	_scene_tab_changed(idx);
+	_set_current_scene(idx);
 	editor_data.clear_editor_states();
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 	return idx;
 }
 
@@ -3679,7 +3589,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	if (!p_set_inherited) {
 		for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 			if (editor_data.get_scene_path(i) == p_scene) {
-				_scene_tab_changed(i);
+				_set_current_scene(i);
 				return OK;
 			}
 		}
@@ -3710,10 +3620,10 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	if (!editor_data.get_edited_scene_root() && editor_data.get_edited_scene_count() == 2) {
 		_remove_edited_scene();
-	} else if (!p_silent_change_tab) {
-		_scene_tab_changed(idx);
+	} else if (p_silent_change_tab) {
+		_set_current_scene_nocheck(idx);
 	} else {
-		set_current_scene(idx);
+		_set_current_scene(idx);
 	}
 
 	dependency_errors.clear();
@@ -3725,7 +3635,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		opening_prev = false;
 
 		if (prev != -1) {
-			set_current_scene(prev);
+			_set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
 		return ERR_FILE_NOT_FOUND;
@@ -3741,7 +3651,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		opening_prev = false;
 
 		if (prev != -1) {
-			set_current_scene(prev);
+			_set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
 		return ERR_FILE_MISSING_DEPENDENCIES;
@@ -3777,7 +3687,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		_dialog_display_load_error(lpath, ERR_FILE_CORRUPT);
 		opening_prev = false;
 		if (prev != -1) {
-			set_current_scene(prev);
+			_set_current_scene(prev);
 			editor_data.remove_scene(idx);
 		}
 		return ERR_FILE_CORRUPT;
@@ -3803,7 +3713,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	_update_title();
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 	_add_to_recent_scenes(lpath);
 
 	if (editor_folding.has_folding_data(lpath)) {
@@ -3996,6 +3906,10 @@ void EditorNode::open_request(const String &p_path) {
 	}
 
 	load_scene(p_path); // As it will be opened in separate tab.
+}
+
+bool EditorNode::has_previous_scenes() const {
+	return !previous_scenes.is_empty();
 }
 
 void EditorNode::edit_foreign_resource(Ref<Resource> p_resource) {
@@ -5408,7 +5322,7 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 		String current_scene = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "current_scene");
 		int current_scene_idx = scenes.find(current_scene);
 		if (current_scene_idx >= 0) {
-			set_current_scene(current_scene_idx);
+			_set_current_scene(current_scene_idx);
 		}
 	}
 
@@ -5500,14 +5414,6 @@ void EditorNode::cleanup() {
 	_init_callbacks.clear();
 }
 
-int EditorNode::get_current_tab() {
-	return scene_tabs->get_current_tab();
-}
-
-void EditorNode::set_current_tab(int p_tab) {
-	scene_tabs->set_current_tab(p_tab);
-}
-
 void EditorNode::_update_layouts_menu() {
 	editor_layouts->clear();
 	overridden_default_layout = -1;
@@ -5572,13 +5478,6 @@ void EditorNode::_layout_menu_option(int p_id) {
 	}
 }
 
-void EditorNode::_scene_tab_script_edited(int p_tab) {
-	Ref<Script> scr = editor_data.get_scene_root_script(p_tab);
-	if (scr.is_valid()) {
-		InspectorDock::get_singleton()->edit_resource(scr);
-	}
-}
-
 void EditorNode::_proceed_closing_scene_tabs() {
 	List<String>::Element *E = tabs_to_close.front();
 	if (!E) {
@@ -5610,8 +5509,8 @@ bool EditorNode::_is_closing_editor() const {
 	return tab_closing_menu_option == FILE_QUIT || tab_closing_menu_option == RUN_PROJECT_MANAGER || tab_closing_menu_option == RELOAD_CURRENT_PROJECT;
 }
 
-void EditorNode::_scene_tab_closed(int p_tab, int p_option) {
-	current_menu_option = p_option;
+void EditorNode::_scene_tab_closed(int p_tab) {
+	current_menu_option = SCENE_TAB_CLOSE;
 	tab_closing_idx = p_tab;
 	Node *scene = editor_data.get_edited_scene_root(p_tab);
 	if (!scene) {
@@ -5639,17 +5538,12 @@ void EditorNode::_scene_tab_closed(int p_tab, int p_option) {
 	}
 
 	if (!unsaved_message.is_empty()) {
-		if (get_current_tab() != p_tab) {
-			set_current_scene(p_tab);
+		if (scene_tabs->get_current_tab() != p_tab) {
+			_set_current_scene(p_tab);
 		}
 
-		if (current_menu_option == RELOAD_CURRENT_PROJECT) {
-			save_confirmation->set_ok_button_text(TTR("Save & Reload"));
-			save_confirmation->set_text(unsaved_message + "\n\n" + TTR("Save before reloading?"));
-		} else {
-			save_confirmation->set_ok_button_text(TTR("Save & Close"));
-			save_confirmation->set_text(unsaved_message + "\n\n" + TTR("Save before closing?"));
-		}
+		save_confirmation->set_ok_button_text(TTR("Save & Close"));
+		save_confirmation->set_text(unsaved_message + "\n\n" + TTR("Save before closing?"));
 		save_confirmation->reset_size();
 		save_confirmation->popup_centered();
 	} else {
@@ -5657,113 +5551,7 @@ void EditorNode::_scene_tab_closed(int p_tab, int p_option) {
 	}
 
 	save_editor_layout_delayed();
-	_update_scene_tabs();
-}
-
-void EditorNode::_scene_tab_hovered(int p_tab) {
-	if (!bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover"))) {
-		return;
-	}
-	int current_tab = scene_tabs->get_current_tab();
-
-	if (p_tab == current_tab || p_tab < 0) {
-		tab_preview_panel->hide();
-	} else {
-		String path = editor_data.get_scene_path(p_tab);
-		if (!path.is_empty()) {
-			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_thumbnail_done", p_tab);
-		}
-	}
-}
-
-void EditorNode::_scene_tab_exit() {
-	tab_preview_panel->hide();
-}
-
-void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
-	int tab_id = scene_tabs->get_hovered_tab();
-	Ref<InputEventMouseButton> mb = p_input;
-
-	if (mb.is_valid()) {
-		if (tab_id >= 0) {
-			if (mb->get_button_index() == MouseButton::MIDDLE && mb->is_pressed()) {
-				_scene_tab_closed(tab_id);
-			}
-		} else if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
-			int tab_buttons = 0;
-			if (scene_tabs->get_offset_buttons_visible()) {
-				tab_buttons = theme->get_icon(SNAME("increment"), SNAME("TabBar"))->get_width() + theme->get_icon(SNAME("decrement"), SNAME("TabBar"))->get_width();
-			}
-
-			if ((gui_base->is_layout_rtl() && mb->get_position().x > tab_buttons) || (!gui_base->is_layout_rtl() && mb->get_position().x < scene_tabs->get_size().width - tab_buttons)) {
-				_menu_option_confirm(FILE_NEW_SCENE, true);
-			}
-		}
-
-		if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-			// Context menu.
-			scene_tabs_context_menu->clear();
-			scene_tabs_context_menu->reset_size();
-
-			scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/new_scene"), FILE_NEW_SCENE);
-			if (tab_id >= 0) {
-				scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_scene"), FILE_SAVE_SCENE);
-				scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_scene_as"), FILE_SAVE_AS_SCENE);
-			}
-			scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_all_scenes"), FILE_SAVE_ALL_SCENES);
-			if (tab_id >= 0) {
-				scene_tabs_context_menu->add_separator();
-				scene_tabs_context_menu->add_item(TTR("Show in FileSystem"), FILE_SHOW_IN_FILESYSTEM);
-				scene_tabs_context_menu->add_item(TTR("Play This Scene"), FILE_RUN_SCENE);
-
-				scene_tabs_context_menu->add_separator();
-				scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/close_scene"), FILE_CLOSE);
-				scene_tabs_context_menu->set_item_text(scene_tabs_context_menu->get_item_index(FILE_CLOSE), TTR("Close Tab"));
-				scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/reopen_closed_scene"), FILE_OPEN_PREV);
-				scene_tabs_context_menu->set_item_text(scene_tabs_context_menu->get_item_index(FILE_OPEN_PREV), TTR("Undo Close Tab"));
-				if (previous_scenes.is_empty()) {
-					scene_tabs_context_menu->set_item_disabled(scene_tabs_context_menu->get_item_index(FILE_OPEN_PREV), true);
-				}
-				scene_tabs_context_menu->add_item(TTR("Close Other Tabs"), FILE_CLOSE_OTHERS);
-				if (editor_data.get_edited_scene_count() <= 1) {
-					scene_tabs_context_menu->set_item_disabled(file_menu->get_item_index(FILE_CLOSE_OTHERS), true);
-				}
-				scene_tabs_context_menu->add_item(TTR("Close Tabs to the Right"), FILE_CLOSE_RIGHT);
-				if (editor_data.get_edited_scene_count() == tab_id + 1) {
-					scene_tabs_context_menu->set_item_disabled(file_menu->get_item_index(FILE_CLOSE_RIGHT), true);
-				}
-				scene_tabs_context_menu->add_item(TTR("Close All Tabs"), FILE_CLOSE_ALL);
-			}
-			scene_tabs_context_menu->set_position(scene_tabs->get_screen_position() + mb->get_position());
-			scene_tabs_context_menu->reset_size();
-			scene_tabs_context_menu->popup();
-		}
-	}
-}
-
-void EditorNode::_reposition_active_tab(int idx_to) {
-	editor_data.move_edited_scene_to_index(idx_to);
-	_update_scene_tabs();
-}
-
-void EditorNode::_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
-	int p_tab = p_udata.operator signed int();
-	if (p_preview.is_valid()) {
-		Rect2 rect = scene_tabs->get_tab_rect(p_tab);
-		rect.position += scene_tabs->get_global_position();
-		tab_preview->set_texture(p_preview);
-		tab_preview_panel->set_position(rect.position + Vector2(0, rect.size.height));
-		tab_preview_panel->show();
-	}
-}
-
-void EditorNode::_scene_tab_changed(int p_tab) {
-	tab_preview_panel->hide();
-
-	if (p_tab == editor_data.get_edited_scene()) {
-		return; // Pointless.
-	}
-	set_current_scene(p_tab);
+	scene_tabs->update_scene_tabs();
 }
 
 Button *EditorNode::add_bottom_panel_item(String p_text, Control *p_item) {
@@ -6076,19 +5864,6 @@ void EditorNode::remove_tool_menu_item(const String &p_name) {
 
 PopupMenu *EditorNode::get_export_as_menu() {
 	return export_as_menu;
-}
-
-void EditorNode::_global_menu_scene(const Variant &p_tag) {
-	int idx = (int)p_tag;
-	scene_tabs->set_current_tab(idx);
-}
-
-void EditorNode::_global_menu_new_window(const Variant &p_tag) {
-	if (OS::get_singleton()->get_main_loop()) {
-		List<String> args;
-		args.push_back("-p");
-		OS::get_singleton()->create_instance(args);
-	}
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files) {
@@ -6708,9 +6483,6 @@ void EditorNode::_feature_profile_changed() {
 }
 
 void EditorNode::_bind_methods() {
-	ClassDB::bind_method("edit_current", &EditorNode::edit_current);
-	ClassDB::bind_method("edit_node", &EditorNode::edit_node);
-
 	ClassDB::bind_method(D_METHOD("push_item", "object", "property", "inspector_only"), &EditorNode::push_item, DEFVAL(""), DEFVAL(false));
 
 	ClassDB::bind_method("set_edited_scene", &EditorNode::set_edited_scene);
@@ -6720,12 +6492,8 @@ void EditorNode::_bind_methods() {
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
 
-	ClassDB::bind_method("set_current_scene", &EditorNode::set_current_scene);
-	ClassDB::bind_method("_thumbnail_done", &EditorNode::_thumbnail_done);
 	ClassDB::bind_method("_set_main_scene_state", &EditorNode::_set_main_scene_state);
 	ClassDB::bind_method("_update_recent_scenes", &EditorNode::_update_recent_scenes);
-
-	ClassDB::bind_method(D_METHOD("get_gui_base"), &EditorNode::get_gui_base);
 
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
@@ -7268,62 +7036,13 @@ EditorNode::EditorNode() {
 
 	VBoxContainer *srt = memnew(VBoxContainer);
 	srt->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	top_split->add_child(srt);
 	srt->add_theme_constant_override("separation", 0);
+	top_split->add_child(srt);
 
-	tab_preview_panel = memnew(Panel);
-	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
-	tab_preview_panel->hide();
-	tab_preview_panel->set_self_modulate(Color(1, 1, 1, 0.7));
-	gui_base->add_child(tab_preview_panel);
-
-	tab_preview = memnew(TextureRect);
-	tab_preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	tab_preview->set_size(Size2(96, 96) * EDSCALE);
-	tab_preview->set_position(Point2(2, 2) * EDSCALE);
-	tab_preview_panel->add_child(tab_preview);
-
-	tabbar_panel = memnew(PanelContainer);
-	tabbar_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("tabbar_background"), SNAME("TabContainer")));
-	srt->add_child(tabbar_panel);
-	tabbar_container = memnew(HBoxContainer);
-	tabbar_panel->add_child(tabbar_container);
-
-	scene_tabs = memnew(TabBar);
-	scene_tabs->set_select_with_rmb(true);
-	scene_tabs->add_tab("unsaved");
-	scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
-	scene_tabs->add_theme_constant_override("icon_max_width", gui_base->get_theme_constant(SNAME("class_icon_size"), SNAME("Editor")));
-	scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
-	scene_tabs->set_drag_to_rearrange_enabled(true);
-	scene_tabs->set_auto_translate(false);
-	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
-	scene_tabs->connect("tab_button_pressed", callable_mp(this, &EditorNode::_scene_tab_script_edited));
-	scene_tabs->connect("tab_close_pressed", callable_mp(this, &EditorNode::_scene_tab_closed).bind(SCENE_TAB_CLOSE));
-	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorNode::_scene_tab_hovered));
-	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorNode::_scene_tab_exit));
-	scene_tabs->connect("gui_input", callable_mp(this, &EditorNode::_scene_tab_input));
-	scene_tabs->connect("active_tab_rearranged", callable_mp(this, &EditorNode::_reposition_active_tab));
-	scene_tabs->connect("resized", callable_mp(this, &EditorNode::_update_scene_tabs));
-	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	tabbar_container->add_child(scene_tabs);
-
-	scene_tabs_context_menu = memnew(PopupMenu);
-	tabbar_container->add_child(scene_tabs_context_menu);
-	scene_tabs_context_menu->connect("id_pressed", callable_mp(this, &EditorNode::_menu_option));
-
-	scene_tab_add = memnew(Button);
-	scene_tab_add->set_flat(true);
-	scene_tab_add->set_tooltip_text(TTR("Add a new scene."));
-	scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-	scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
-	scene_tabs->add_child(scene_tab_add);
-	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option).bind(FILE_NEW_SCENE));
-
-	scene_tab_add_ph = memnew(Control);
-	scene_tab_add_ph->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	scene_tab_add_ph->set_custom_minimum_size(scene_tab_add->get_minimum_size());
-	tabbar_container->add_child(scene_tab_add_ph);
+	scene_tabs = memnew(EditorSceneTabs);
+	srt->add_child(scene_tabs);
+	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_set_current_scene));
+	scene_tabs->connect("tab_closed", callable_mp(this, &EditorNode::_scene_tab_closed));
 
 	distraction_free = memnew(Button);
 	distraction_free->set_flat(true);
@@ -7331,10 +7050,10 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT_OVERRIDE("editor/distraction_free_mode", "macos", KeyModifierMask::META | KeyModifierMask::CTRL | Key::D);
 	distraction_free->set_shortcut(ED_GET_SHORTCUT("editor/distraction_free_mode"));
 	distraction_free->set_tooltip_text(TTR("Toggle distraction-free mode."));
-	distraction_free->connect("pressed", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
 	distraction_free->set_icon(gui_base->get_theme_icon(SNAME("DistractionFree"), SNAME("EditorIcons")));
 	distraction_free->set_toggle_mode(true);
-	tabbar_container->add_child(distraction_free);
+	scene_tabs->add_extra_button(distraction_free);
+	distraction_free->connect("pressed", callable_mp(this, &EditorNode::_toggle_distraction_free_mode));
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
@@ -8157,7 +7876,7 @@ EditorNode::EditorNode() {
 
 	editor_data.add_edited_scene(-1);
 	editor_data.set_edited_scene(0);
-	_update_scene_tabs();
+	scene_tabs->update_scene_tabs();
 
 	ImportDock::get_singleton()->initialize_import_options();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -93,6 +93,7 @@ class EditorResourcePreview;
 class EditorResourceConversionPlugin;
 class EditorRunBar;
 class EditorRunNative;
+class EditorSceneTabs;
 class EditorSelectionHistory;
 class EditorSettingsDialog;
 class EditorTitleBar;
@@ -154,6 +155,8 @@ public:
 	};
 
 private:
+	friend class EditorSceneTabs;
+
 	enum MenuOptions {
 		FILE_NEW_SCENE,
 		FILE_NEW_INHERITED_SCENE,
@@ -216,6 +219,7 @@ private:
 		SETTINGS_PICK_MAIN_SCENE,
 		SETTINGS_TOGGLE_FULLSCREEN,
 		SETTINGS_HELP,
+
 		SCENE_TAB_CLOSE,
 
 		EDITOR_SCREENSHOT,
@@ -234,9 +238,6 @@ private:
 		HELP_SUPPORT_GODOT_DEVELOPMENT,
 
 		SET_RENDERER_NAME_SAVE_AND_RESTART,
-
-		GLOBAL_NEW_WINDOW,
-		GLOBAL_SCENE,
 
 		IMPORT_PLUGIN_BASE = 100,
 
@@ -319,10 +320,7 @@ private:
 	Vector<HSplitContainer *> hsplits;
 
 	// Main tabs.
-	TabBar *scene_tabs = nullptr;
-	PopupMenu *scene_tabs_context_menu = nullptr;
-	Panel *tab_preview_panel = nullptr;
-	TextureRect *tab_preview = nullptr;
+	EditorSceneTabs *scene_tabs = nullptr;
 
 	int tab_closing_idx = 0;
 	List<String> tabs_to_close;
@@ -437,11 +435,7 @@ private:
 	int dock_popup_selected_idx = -1;
 	int dock_select_rect_over_idx = -1;
 
-	PanelContainer *tabbar_panel = nullptr;
-	HBoxContainer *tabbar_container = nullptr;
 	Button *distraction_free = nullptr;
-	Button *scene_tab_add = nullptr;
-	Control *scene_tab_add_ph = nullptr;
 
 	Vector<BottomPanelItem> bottom_panel_items;
 	PanelContainer *bottom_panel = nullptr;
@@ -567,7 +561,6 @@ private:
 	void _save_editor_states(const String &p_file, int p_idx = -1);
 	void _load_editor_plugin_states_from_config(const Ref<ConfigFile> &p_config_file);
 	void _update_title();
-	void _update_scene_tabs();
 	void _version_control_menu_option(int p_idx);
 	void _close_messages();
 	void _show_messages();
@@ -579,11 +572,14 @@ private:
 
 	int _save_external_resources();
 
+	void _set_current_scene(int p_idx);
+	void _set_current_scene_nocheck(int p_idx);
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
 	void _save_scene(String p_file, int idx = -1);
 	void _save_all_scenes();
 	int _next_unsaved_scene(bool p_valid_filename, int p_start = 0);
 	void _discard_changes(const String &p_str = String());
+	void _scene_tab_closed(int p_tab);
 
 	void _inherit_request(String p_file);
 	void _instantiate_request(const Vector<String> &p_files);
@@ -597,8 +593,6 @@ private:
 	void _add_to_recent_scenes(const String &p_scene);
 	void _update_recent_scenes();
 	void _open_recent_scene(int p_idx);
-	void _global_menu_scene(const Variant &p_tag);
-	void _global_menu_new_window(const Variant &p_tag);
 	void _dropped_files(const Vector<String> &p_files);
 	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 
@@ -637,16 +631,9 @@ private:
 	void _dock_floating_close_request(WindowWrapper *p_wrapper);
 	void _dock_make_selected_float();
 	void _dock_make_float(Control *p_control, int p_slot_index, bool p_show_window = true);
-	void _scene_tab_changed(int p_tab);
+
 	void _proceed_closing_scene_tabs();
 	bool _is_closing_editor() const;
-	void _scene_tab_closed(int p_tab, int p_option = SCENE_TAB_CLOSE);
-	void _scene_tab_hovered(int p_tab);
-	void _scene_tab_exit();
-	void _scene_tab_input(const Ref<InputEvent> &p_input);
-	void _reposition_active_tab(int idx_to);
-	void _thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
-	void _scene_tab_script_edited(int p_tab);
 
 	Dictionary _get_main_scene_state();
 	void _set_main_scene_state(Dictionary p_state, Node *p_for_scene);
@@ -706,9 +693,6 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	int get_current_tab();
-	void set_current_tab(int p_tab);
-
 public:
 	// Public for use with callable_mp.
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
@@ -764,6 +748,9 @@ public:
 	EditorSelectionHistory *get_editor_selection_history() { return &editor_history; }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
+
+	void trigger_menu_option(int p_option, bool p_confirmed);
+	bool has_previous_scenes() const;
 
 	void new_inherited_scene() { _menu_option_confirm(FILE_NEW_INHERITED_SCENE, false); }
 
@@ -849,8 +836,6 @@ public:
 			List<AdditiveNodeEntry> &p_addition_list);
 
 	bool is_scene_open(const String &p_path);
-
-	void set_current_scene(int p_idx);
 
 	void setup_color_picker(ColorPicker *p_picker);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -45,6 +45,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/gui/editor_dir_dialog.h"
+#include "editor/gui/editor_scene_tabs.h"
 #include "editor/import/resource_importer_scene.h"
 #include "editor/import_dock.h"
 #include "editor/plugins/editor_resource_tooltip_plugins.h"
@@ -1732,14 +1733,14 @@ void FileSystemDock::_rename_operation_confirm() {
 	HashMap<String, String> folder_renames;
 	_try_move_item(to_rename, new_path, file_renames, folder_renames);
 
-	int current_tab = EditorNode::get_singleton()->get_current_tab();
+	int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 	_save_scenes_after_move(file_renames); // save scenes before updating
 	_update_dependencies_after_move(file_renames);
 	_update_resource_paths_after_move(file_renames);
 	_update_project_settings_after_move(file_renames);
 	_update_favorites_list_after_move(file_renames, folder_renames);
 
-	EditorNode::get_singleton()->set_current_tab(current_tab);
+	EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
 	print_verbose("FileSystem: calling rescan.");
 	_rescan();
@@ -1881,14 +1882,14 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 		}
 
 		if (is_moved) {
-			int current_tab = EditorNode::get_singleton()->get_current_tab();
+			int current_tab = EditorSceneTabs::get_singleton()->get_current_tab();
 			_save_scenes_after_move(file_renames); // Save scenes before updating.
 			_update_dependencies_after_move(file_renames);
 			_update_resource_paths_after_move(file_renames);
 			_update_project_settings_after_move(file_renames);
 			_update_favorites_list_after_move(file_renames, folder_renames);
 
-			EditorNode::get_singleton()->set_current_tab(current_tab);
+			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
 			print_verbose("FileSystem: calling rescan.");
 			_rescan();

--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -1,0 +1,384 @@
+/**************************************************************************/
+/*  editor_scene_tabs.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_scene_tabs.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_resource_preview.h"
+#include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/inspector_dock.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/panel.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/popup_menu.h"
+#include "scene/gui/tab_bar.h"
+#include "scene/gui/texture_rect.h"
+
+EditorSceneTabs *EditorSceneTabs::singleton = nullptr;
+
+void EditorSceneTabs::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			tabbar_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("tabbar_background"), SNAME("TabContainer")));
+			scene_tabs->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), SNAME("Editor")));
+
+			scene_tab_add->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
+
+			scene_tab_add_ph->set_custom_minimum_size(scene_tab_add->get_minimum_size());
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
+			scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
+		} break;
+	}
+}
+
+void EditorSceneTabs::_scene_tab_changed(int p_tab) {
+	tab_preview_panel->hide();
+
+	emit_signal("tab_changed", p_tab);
+}
+
+void EditorSceneTabs::_scene_tab_script_edited(int p_tab) {
+	Ref<Script> scr = EditorNode::get_editor_data().get_scene_root_script(p_tab);
+	if (scr.is_valid()) {
+		InspectorDock::get_singleton()->edit_resource(scr);
+	}
+}
+
+void EditorSceneTabs::_scene_tab_closed(int p_tab) {
+	emit_signal("tab_closed", p_tab);
+}
+
+void EditorSceneTabs::_scene_tab_hovered(int p_tab) {
+	if (!bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover"))) {
+		return;
+	}
+	int current_tab = scene_tabs->get_current_tab();
+
+	if (p_tab == current_tab || p_tab < 0) {
+		tab_preview_panel->hide();
+	} else {
+		String path = EditorNode::get_editor_data().get_scene_path(p_tab);
+		if (!path.is_empty()) {
+			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_tab_preview_done", p_tab);
+		}
+	}
+}
+
+void EditorSceneTabs::_scene_tab_exit() {
+	tab_preview_panel->hide();
+}
+
+void EditorSceneTabs::_scene_tab_input(const Ref<InputEvent> &p_input) {
+	int tab_id = scene_tabs->get_hovered_tab();
+	Ref<InputEventMouseButton> mb = p_input;
+
+	if (mb.is_valid()) {
+		if (tab_id >= 0) {
+			if (mb->get_button_index() == MouseButton::MIDDLE && mb->is_pressed()) {
+				_scene_tab_closed(tab_id);
+			}
+		} else if (mb->get_button_index() == MouseButton::LEFT && mb->is_double_click()) {
+			int tab_buttons = 0;
+			if (scene_tabs->get_offset_buttons_visible()) {
+				tab_buttons = get_theme_icon(SNAME("increment"), SNAME("TabBar"))->get_width() + get_theme_icon(SNAME("decrement"), SNAME("TabBar"))->get_width();
+			}
+
+			if ((is_layout_rtl() && mb->get_position().x > tab_buttons) || (!is_layout_rtl() && mb->get_position().x < scene_tabs->get_size().width - tab_buttons)) {
+				EditorNode::get_singleton()->trigger_menu_option(EditorNode::FILE_NEW_SCENE, true);
+			}
+		}
+		if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
+			// Context menu.
+			_update_context_menu();
+
+			scene_tabs_context_menu->set_position(scene_tabs->get_screen_position() + mb->get_position());
+			scene_tabs_context_menu->reset_size();
+			scene_tabs_context_menu->popup();
+		}
+	}
+}
+
+void EditorSceneTabs::_reposition_active_tab(int p_to_index) {
+	EditorNode::get_editor_data().move_edited_scene_to_index(p_to_index);
+	update_scene_tabs();
+}
+
+void EditorSceneTabs::_update_context_menu() {
+	scene_tabs_context_menu->clear();
+	scene_tabs_context_menu->reset_size();
+
+	int tab_id = scene_tabs->get_hovered_tab();
+
+	scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/new_scene"), EditorNode::FILE_NEW_SCENE);
+	if (tab_id >= 0) {
+		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_scene"), EditorNode::FILE_SAVE_SCENE);
+		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_scene_as"), EditorNode::FILE_SAVE_AS_SCENE);
+	}
+	scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/save_all_scenes"), EditorNode::FILE_SAVE_ALL_SCENES);
+	if (tab_id >= 0) {
+		scene_tabs_context_menu->add_separator();
+		scene_tabs_context_menu->add_item(TTR("Show in FileSystem"), EditorNode::FILE_SHOW_IN_FILESYSTEM);
+		scene_tabs_context_menu->add_item(TTR("Play This Scene"), EditorNode::FILE_RUN_SCENE);
+
+		scene_tabs_context_menu->add_separator();
+		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/close_scene"), EditorNode::FILE_CLOSE);
+		scene_tabs_context_menu->set_item_text(scene_tabs_context_menu->get_item_index(EditorNode::FILE_CLOSE), TTR("Close Tab"));
+		scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/reopen_closed_scene"), EditorNode::FILE_OPEN_PREV);
+		scene_tabs_context_menu->set_item_text(scene_tabs_context_menu->get_item_index(EditorNode::FILE_OPEN_PREV), TTR("Undo Close Tab"));
+		if (!EditorNode::get_singleton()->has_previous_scenes()) {
+			scene_tabs_context_menu->set_item_disabled(scene_tabs_context_menu->get_item_index(EditorNode::FILE_OPEN_PREV), true);
+		}
+		scene_tabs_context_menu->add_item(TTR("Close Other Tabs"), EditorNode::FILE_CLOSE_OTHERS);
+		if (EditorNode::get_editor_data().get_edited_scene_count() <= 1) {
+			scene_tabs_context_menu->set_item_disabled(scene_tabs_context_menu->get_item_index(EditorNode::FILE_CLOSE_OTHERS), true);
+		}
+		scene_tabs_context_menu->add_item(TTR("Close Tabs to the Right"), EditorNode::FILE_CLOSE_RIGHT);
+		if (EditorNode::get_editor_data().get_edited_scene_count() == tab_id + 1) {
+			scene_tabs_context_menu->set_item_disabled(scene_tabs_context_menu->get_item_index(EditorNode::FILE_CLOSE_RIGHT), true);
+		}
+		scene_tabs_context_menu->add_item(TTR("Close All Tabs"), EditorNode::FILE_CLOSE_ALL);
+	}
+}
+
+// TODO: This REALLY should be done in a better way than replacing all tabs after almost EVERY action.
+void EditorSceneTabs::update_scene_tabs() {
+	tab_preview_panel->hide();
+
+	bool show_rb = EDITOR_GET("interface/scene_tabs/show_script_button");
+
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		DisplayServer::get_singleton()->global_menu_clear("_dock");
+	}
+
+	// Get all scene names, which may be ambiguous.
+	Vector<String> disambiguated_scene_names;
+	Vector<String> full_path_names;
+	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
+		disambiguated_scene_names.append(EditorNode::get_editor_data().get_scene_title(i));
+		full_path_names.append(EditorNode::get_editor_data().get_scene_path(i));
+	}
+
+	EditorNode::disambiguate_filenames(full_path_names, disambiguated_scene_names);
+
+	// Workaround to ignore the tab_changed signal from the first added tab.
+	scene_tabs->disconnect("tab_changed", callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
+
+	scene_tabs->clear_tabs();
+	Ref<Texture2D> script_icon = get_theme_icon(SNAME("Script"), SNAME("EditorIcons"));
+	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
+		Node *type_node = EditorNode::get_editor_data().get_edited_scene_root(i);
+		Ref<Texture2D> icon;
+		if (type_node) {
+			icon = EditorNode::get_singleton()->get_object_icon(type_node, "Node");
+		}
+
+		bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(EditorNode::get_editor_data().get_scene_history_id(i));
+		scene_tabs->add_tab(disambiguated_scene_names[i] + (unsaved ? "(*)" : ""), icon);
+
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+			DisplayServer::get_singleton()->global_menu_add_item("_dock", EditorNode::get_editor_data().get_scene_title(i) + (unsaved ? "(*)" : ""), callable_mp(this, &EditorSceneTabs::_global_menu_scene), Callable(), i);
+		}
+
+		if (show_rb && EditorNode::get_editor_data().get_scene_root_script(i).is_valid()) {
+			scene_tabs->set_tab_button_icon(i, script_icon);
+		}
+	}
+
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_GLOBAL_MENU)) {
+		DisplayServer::get_singleton()->global_menu_add_separator("_dock");
+		DisplayServer::get_singleton()->global_menu_add_item("_dock", TTR("New Window"), callable_mp(this, &EditorSceneTabs::_global_menu_new_window));
+	}
+
+	if (scene_tabs->get_tab_count() > 0) {
+		scene_tabs->set_current_tab(EditorNode::get_editor_data().get_edited_scene());
+	}
+
+	const Size2 add_button_size = Size2(scene_tab_add->get_size().x, scene_tabs->get_size().y);
+	if (scene_tabs->get_offset_buttons_visible()) {
+		// Move the add button to a fixed position.
+		if (scene_tab_add->get_parent() == scene_tabs) {
+			scene_tabs->remove_child(scene_tab_add);
+			scene_tab_add_ph->add_child(scene_tab_add);
+			scene_tab_add->set_rect(Rect2(Point2(), add_button_size));
+		}
+	} else {
+		// Move the add button to be after the last tab.
+		if (scene_tab_add->get_parent() == scene_tab_add_ph) {
+			scene_tab_add_ph->remove_child(scene_tab_add);
+			scene_tabs->add_child(scene_tab_add);
+		}
+
+		if (scene_tabs->get_tab_count() == 0) {
+			scene_tab_add->set_rect(Rect2(Point2(), add_button_size));
+			return;
+		}
+
+		Rect2 last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
+		int hsep = scene_tabs->get_theme_constant(SNAME("h_separation"));
+		if (scene_tabs->is_layout_rtl()) {
+			scene_tab_add->set_rect(Rect2(Point2(last_tab.position.x - add_button_size.x - hsep, last_tab.position.y), add_button_size));
+		} else {
+			scene_tab_add->set_rect(Rect2(Point2(last_tab.position.x + last_tab.size.width + hsep, last_tab.position.y), add_button_size));
+		}
+	}
+
+	// Reconnect after everything is done.
+	scene_tabs->connect("tab_changed", callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
+}
+
+void EditorSceneTabs::_tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
+	int p_tab = p_udata;
+	if (p_preview.is_valid()) {
+		tab_preview->set_texture(p_preview);
+
+		Rect2 rect = scene_tabs->get_tab_rect(p_tab);
+		rect.position += scene_tabs->get_global_position();
+		tab_preview_panel->set_global_position(rect.position + Vector2(0, rect.size.height));
+		tab_preview_panel->show();
+	}
+}
+
+void EditorSceneTabs::_global_menu_scene(const Variant &p_tag) {
+	int idx = (int)p_tag;
+	scene_tabs->set_current_tab(idx);
+}
+
+void EditorSceneTabs::_global_menu_new_window(const Variant &p_tag) {
+	if (OS::get_singleton()->get_main_loop()) {
+		List<String> args;
+		args.push_back("-p");
+		OS::get_singleton()->create_instance(args);
+	}
+}
+
+void EditorSceneTabs::shortcut_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventKey> k = p_event;
+	if ((k.is_valid() && k->is_pressed() && !k->is_echo()) || Object::cast_to<InputEventShortcut>(*p_event)) {
+		if (ED_IS_SHORTCUT("editor/next_tab", p_event)) {
+			int next_tab = EditorNode::get_editor_data().get_edited_scene() + 1;
+			next_tab %= EditorNode::get_editor_data().get_edited_scene_count();
+			_scene_tab_changed(next_tab);
+		}
+		if (ED_IS_SHORTCUT("editor/prev_tab", p_event)) {
+			int next_tab = EditorNode::get_editor_data().get_edited_scene() - 1;
+			next_tab = next_tab >= 0 ? next_tab : EditorNode::get_editor_data().get_edited_scene_count() - 1;
+			_scene_tab_changed(next_tab);
+		}
+	}
+}
+
+void EditorSceneTabs::add_extra_button(Button *p_button) {
+	tabbar_container->add_child(p_button);
+}
+
+void EditorSceneTabs::set_current_tab(int p_tab) {
+	scene_tabs->set_current_tab(p_tab);
+}
+
+int EditorSceneTabs::get_current_tab() const {
+	return scene_tabs->get_current_tab();
+}
+
+void EditorSceneTabs::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab_index")));
+	ADD_SIGNAL(MethodInfo("tab_closed", PropertyInfo(Variant::INT, "tab_index")));
+
+	ClassDB::bind_method("_tab_preview_done", &EditorSceneTabs::_tab_preview_done);
+}
+
+EditorSceneTabs::EditorSceneTabs() {
+	singleton = this;
+
+	tabbar_panel = memnew(PanelContainer);
+	add_child(tabbar_panel);
+	tabbar_container = memnew(HBoxContainer);
+	tabbar_panel->add_child(tabbar_container);
+
+	scene_tabs = memnew(TabBar);
+	scene_tabs->set_select_with_rmb(true);
+	scene_tabs->add_tab("unsaved");
+	scene_tabs->set_tab_close_display_policy((TabBar::CloseButtonDisplayPolicy)EDITOR_GET("interface/scene_tabs/display_close_button").operator int());
+	scene_tabs->set_max_tab_width(int(EDITOR_GET("interface/scene_tabs/maximum_width")) * EDSCALE);
+	scene_tabs->set_drag_to_rearrange_enabled(true);
+	scene_tabs->set_auto_translate(false);
+	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	tabbar_container->add_child(scene_tabs);
+
+	scene_tabs->connect("tab_changed", callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
+	scene_tabs->connect("tab_button_pressed", callable_mp(this, &EditorSceneTabs::_scene_tab_script_edited));
+	scene_tabs->connect("tab_close_pressed", callable_mp(this, &EditorSceneTabs::_scene_tab_closed));
+	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorSceneTabs::_scene_tab_hovered));
+	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorSceneTabs::_scene_tab_exit));
+	scene_tabs->connect("gui_input", callable_mp(this, &EditorSceneTabs::_scene_tab_input));
+	scene_tabs->connect("active_tab_rearranged", callable_mp(this, &EditorSceneTabs::_reposition_active_tab));
+	scene_tabs->connect("resized", callable_mp(this, &EditorSceneTabs::update_scene_tabs));
+
+	scene_tabs_context_menu = memnew(PopupMenu);
+	tabbar_container->add_child(scene_tabs_context_menu);
+	scene_tabs_context_menu->connect("id_pressed", callable_mp(EditorNode::get_singleton(), &EditorNode::trigger_menu_option).bind(false));
+
+	scene_tab_add = memnew(Button);
+	scene_tab_add->set_flat(true);
+	scene_tab_add->set_tooltip_text(TTR("Add a new scene."));
+	scene_tabs->add_child(scene_tab_add);
+	scene_tab_add->connect("pressed", callable_mp(EditorNode::get_singleton(), &EditorNode::trigger_menu_option).bind(EditorNode::FILE_NEW_SCENE, false));
+
+	scene_tab_add_ph = memnew(Control);
+	scene_tab_add_ph->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	scene_tab_add_ph->set_custom_minimum_size(scene_tab_add->get_minimum_size());
+	tabbar_container->add_child(scene_tab_add_ph);
+
+	// On-hover tab preview.
+
+	Control *tab_preview_anchor = memnew(Control);
+	tab_preview_anchor->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+	add_child(tab_preview_anchor);
+
+	tab_preview_panel = memnew(Panel);
+	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
+	tab_preview_panel->hide();
+	tab_preview_panel->set_self_modulate(Color(1, 1, 1, 0.7));
+	tab_preview_anchor->add_child(tab_preview_panel);
+
+	tab_preview = memnew(TextureRect);
+	tab_preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+	tab_preview->set_size(Size2(96, 96) * EDSCALE);
+	tab_preview->set_position(Point2(2, 2) * EDSCALE);
+	tab_preview_panel->add_child(tab_preview);
+}

--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  editor_scene_tabs.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_SCENE_TABS_H
+#define EDITOR_SCENE_TABS_H
+
+#include "scene/gui/margin_container.h"
+
+class Button;
+class HBoxContainer;
+class Panel;
+class PanelContainer;
+class PopupMenu;
+class TabBar;
+class TextureRect;
+
+class EditorSceneTabs : public MarginContainer {
+	GDCLASS(EditorSceneTabs, MarginContainer);
+
+	static EditorSceneTabs *singleton;
+
+	PanelContainer *tabbar_panel = nullptr;
+	HBoxContainer *tabbar_container = nullptr;
+
+	TabBar *scene_tabs = nullptr;
+	PopupMenu *scene_tabs_context_menu = nullptr;
+	Button *scene_tab_add = nullptr;
+	Control *scene_tab_add_ph = nullptr;
+
+	Panel *tab_preview_panel = nullptr;
+	TextureRect *tab_preview = nullptr;
+
+	void _scene_tab_changed(int p_tab);
+	void _scene_tab_script_edited(int p_tab);
+	void _scene_tab_closed(int p_tab);
+	void _scene_tab_hovered(int p_tab);
+	void _scene_tab_exit();
+	void _scene_tab_input(const Ref<InputEvent> &p_input);
+
+	void _reposition_active_tab(int p_to_index);
+	void _update_context_menu();
+
+	void _tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
+
+	void _global_menu_scene(const Variant &p_tag);
+	void _global_menu_new_window(const Variant &p_tag);
+
+	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	static EditorSceneTabs *get_singleton() { return singleton; }
+
+	void add_extra_button(Button *p_button);
+
+	void set_current_tab(int p_tab);
+	int get_current_tab() const;
+
+	void update_scene_tabs();
+
+	EditorSceneTabs();
+};
+
+#endif // EDITOR_SCENE_TABS_H

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -458,7 +458,7 @@ void OccluderInstance3D::set_occluder(const Ref<Occluder3D> &p_occluder) {
 #ifdef TOOLS_ENABLED
 	// PolygonOccluder3D is edited via an editor plugin, this ensures the plugin is shown/hidden when necessary
 	if (Engine::get_singleton()->is_editor_hint()) {
-		EditorNode::get_singleton()->call_deferred(SNAME("edit_current"));
+		callable_mp(EditorNode::get_singleton(), &EditorNode::edit_current).call_deferred();
 	}
 #endif
 }


### PR DESCRIPTION
Another one of my extraction PRs for a part of `EditorNode`. It's not a huge part, but it's still worthwhile to properly abstract it.

There should be no behavioral changes after this PR. As an extra, I noticed a couple of methods were bound for no reason and removed their binds. One was used in a deferred call, so I reworked it. Others don't seem to be used in deferred calls or UndoRedo, so this should be safe.