### PR TITLE
Enchancement: to_raw_bytes(Variant) ->PackedByteArray: in GlobalScope

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1814,6 +1814,82 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 	return OK;
 }
 
+Error to_raw_bytes(const Variant &p_variant, PackedByteArray &out) {
+	switch (p_variant.get_type()) {
+		case Variant::INT: {
+			int32_t v = p_variant;
+			size_t offset = out.size();
+			out.resize(out.size() + sizeof(v));
+			memcpy(out.ptrw() + offset, &v, sizeof(v));
+		} break;
+		case Variant::BOOL: {
+			bool v = p_variant;
+			size_t offset = out.size();
+			out.resize(out.size() + sizeof(v));
+			memcpy(out.ptrw() + offset, &v, sizeof(v));
+		} break;
+		case Variant::FLOAT: {
+#ifdef REAL_T_IS_DOUBLE
+			double v = p_variant;
+			size_t offset = out.size();
+			out.resize(out.size() + sizeof(v));
+			memcpy(out.ptrw() + offset, &v, sizeof(v));
+#else
+			float v = p_variant;
+			size_t offset = out.size();
+			out.resize(out.size() + sizeof(v));
+			memcpy(out.ptrw() + offset, &v, sizeof(v));
+#endif
+		} break;
+		case Variant::VECTOR2: {
+			Vector2 v = p_variant;
+			for (size_t elements = 0; elements < 2; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::VECTOR3: {
+			Vector3 v = p_variant;
+			for (size_t elements = 0; elements < 3; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::VECTOR4: {
+			Vector4 v = p_variant;
+			for (size_t elements = 0; elements < 4; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::VECTOR2I: {
+			Vector2i v = p_variant;
+			for (size_t elements = 0; elements < 2; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::VECTOR3I: {
+			Vector3i v = p_variant;
+			for (size_t elements = 0; elements < 3; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::VECTOR4I: {
+			Vector4i v = p_variant;
+			for (size_t elements = 0; elements < 4; elements++) {
+				to_raw_bytes(v[elements], out);
+			}
+		} break;
+		case Variant::ARRAY: {
+			Array v = p_variant;
+			for (int i = 0; i < v.size(); i++) {
+				to_raw_bytes(v[i], out);
+			}
+		} break;
+		default: {
+			ERR_FAIL_V(ERR_UNAVAILABLE);
+		}
+	};
+	return OK;
+}
+
 Vector<float> vector3_to_float32_array(const Vector3 *vecs, size_t count) {
 	// We always allocate a new array, and we don't memcpy.
 	// We also don't consider returning a pointer to the passed vectors when sizeof(real_t) == 4.

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1829,17 +1829,14 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 			memcpy(out.ptrw() + offset, &v, sizeof(v));
 		} break;
 		case Variant::FLOAT: {
-#ifdef REAL_T_IS_DOUBLE
-			double v = p_variant;
-			size_t offset = out.size();
-			out.resize(out.size() + sizeof(v));
-			memcpy(out.ptrw() + offset, &v, sizeof(v));
-#else
+			// always convert to float at a cost of precision
+			// while 64 bit values are inpractical in shaders
+			// and there is no easy way to know what precision
+			// a programmer needs in GDScript.
 			float v = p_variant;
 			size_t offset = out.size();
 			out.resize(out.size() + sizeof(v));
 			memcpy(out.ptrw() + offset, &v, sizeof(v));
-#endif
 		} break;
 		case Variant::VECTOR2: {
 			Vector2 v = p_variant;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1830,7 +1830,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		} break;
 		case Variant::FLOAT: {
 			// always convert to float at a cost of precision
-			// while 64 bit values are inpractical in shaders
+			// while 64 bit values are impractical in shaders
 			// and there is no easy way to know what precision
 			// a programmer needs in GDScript.
 			float v = p_variant;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1844,43 +1844,64 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR2: {
 			Vector2 v = p_variant;
 			for (size_t elements = 0; elements < 2; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::VECTOR3: {
 			Vector3 v = p_variant;
 			for (size_t elements = 0; elements < 3; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::VECTOR4: {
 			Vector4 v = p_variant;
 			for (size_t elements = 0; elements < 4; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::VECTOR2I: {
 			Vector2i v = p_variant;
 			for (size_t elements = 0; elements < 2; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::VECTOR3I: {
 			Vector3i v = p_variant;
 			for (size_t elements = 0; elements < 3; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::VECTOR4I: {
 			Vector4i v = p_variant;
 			for (size_t elements = 0; elements < 4; elements++) {
-				to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		case Variant::ARRAY: {
 			Array v = p_variant;
 			for (int i = 0; i < v.size(); i++) {
-				to_raw_bytes(v[i], out);
+				Error err = to_raw_bytes(v[i], out);
+				if (err != OK) {
+					return err;
+				}
 			}
 		} break;
 		default: {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1814,7 +1814,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 	return OK;
 }
 
-Error to_raw_bytes(const Variant &p_variant, PackedByteArray &out) {
+Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 	switch (p_variant.get_type()) {
 		case Variant::INT: {
 			int32_t v = p_variant;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1818,15 +1818,15 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 	switch (p_variant.get_type()) {
 		case Variant::INT: {
 			int32_t v = p_variant;
-			size_t offset = out.size();
-			out.resize(out.size() + sizeof(v));
-			memcpy(out.ptrw() + offset, &v, sizeof(v));
+			size_t offset = r_out_sink.size();
+			r_out_sink.resize(r_out_sink.size() + sizeof(v));
+			memcpy(r_out_sink.ptrw() + offset, &v, sizeof(v));
 		} break;
 		case Variant::BOOL: {
 			bool v = p_variant;
-			size_t offset = out.size();
-			out.resize(out.size() + sizeof(v));
-			memcpy(out.ptrw() + offset, &v, sizeof(v));
+			size_t offset = r_out_sink.size();
+			r_out_sink.resize(r_out_sink.size() + sizeof(v));
+			memcpy(r_out_sink.ptrw() + offset, &v, sizeof(v));
 		} break;
 		case Variant::FLOAT: {
 			// always convert to float at a cost of precision
@@ -1834,14 +1834,14 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 			// and there is no easy way to know what precision
 			// a programmer needs in GDScript.
 			float v = p_variant;
-			size_t offset = out.size();
-			out.resize(out.size() + sizeof(v));
-			memcpy(out.ptrw() + offset, &v, sizeof(v));
+			size_t offset = r_out_sink.size();
+			r_out_sink.resize(r_out_sink.size() + sizeof(v));
+			memcpy(r_out_sink.ptrw() + offset, &v, sizeof(v));
 		} break;
 		case Variant::VECTOR2: {
 			Vector2 v = p_variant;
 			for (size_t elements = 0; elements < 2; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1850,7 +1850,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR3: {
 			Vector3 v = p_variant;
 			for (size_t elements = 0; elements < 3; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1859,7 +1859,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR4: {
 			Vector4 v = p_variant;
 			for (size_t elements = 0; elements < 4; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1868,7 +1868,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR2I: {
 			Vector2i v = p_variant;
 			for (size_t elements = 0; elements < 2; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1877,7 +1877,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR3I: {
 			Vector3i v = p_variant;
 			for (size_t elements = 0; elements < 3; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1886,7 +1886,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::VECTOR4I: {
 			Vector4i v = p_variant;
 			for (size_t elements = 0; elements < 4; elements++) {
-				Error err = to_raw_bytes(v[elements], out);
+				Error err = to_raw_bytes(v[elements], r_out_sink);
 				if (err != OK) {
 					return err;
 				}
@@ -1895,7 +1895,7 @@ Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink) {
 		case Variant::ARRAY: {
 			Array v = p_variant;
 			for (int i = 0; i < v.size(); i++) {
-				Error err = to_raw_bytes(v[i], out);
+				Error err = to_raw_bytes(v[i], r_out_sink);
 				if (err != OK) {
 					return err;
 				}

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -217,7 +217,7 @@ public:
 Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false, int p_depth = 0);
 Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bool p_full_objects = false, int p_depth = 0);
 
-Error to_raw_bytes(const Variant &p_variant, PackedByteArray &out_sink);
+Error to_raw_bytes(const Variant &p_variant, PackedByteArray &r_out_sink);
 
 Vector<float> vector3_to_float32_array(const Vector3 *vecs, size_t count);
 

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -36,6 +36,8 @@
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
+#include <vector>
+
 // uintr_t is only for pairing with real_t, and we only need it in here.
 #ifdef REAL_T_IS_DOUBLE
 typedef uint64_t uintr_t;
@@ -214,6 +216,8 @@ public:
 
 Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len = nullptr, bool p_allow_objects = false, int p_depth = 0);
 Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bool p_full_objects = false, int p_depth = 0);
+
+Error to_raw_bytes(const Variant &p_variant, PackedByteArray &out_sink);
 
 Vector<float> vector3_to_float32_array(const Vector3 *vecs, size_t count);
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -962,6 +962,15 @@ PackedByteArray VariantUtilityFunctions::var_to_bytes(const Variant &p_var) {
 	return barr;
 }
 
+PackedByteArray VariantUtilityFunctions::to_raw_bytes(const Variant &p_variant) {
+	PackedByteArray packed;
+	Error err = ::to_raw_bytes(p_variant, packed);
+	if (err != OK) {
+		ERR_FAIL_V_MSG(packed, "to_raw_bytes(), an attempt to convert unsupported type");
+	}
+	return packed;
+}
+
 PackedByteArray VariantUtilityFunctions::var_to_bytes_with_objects(const Variant &p_var) {
 	int len;
 	Error err = encode_variant(p_var, nullptr, len, true);
@@ -1616,6 +1625,8 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(var_to_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(bytes_to_var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+
+	FUNCBINDR(to_raw_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
 	FUNCBINDR(var_to_bytes_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(bytes_to_var_with_objects, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -139,6 +139,7 @@ struct VariantUtilityFunctions {
 	static Variant str_to_var(const String &p_var);
 	static PackedByteArray var_to_bytes(const Variant &p_var);
 	static PackedByteArray var_to_bytes_with_objects(const Variant &p_var);
+	static PackedByteArray to_raw_bytes(const Variant &p_var);
 	static Variant bytes_to_var(const PackedByteArray &p_arr);
 	static Variant bytes_to_var_with_objects(const PackedByteArray &p_arr);
 	static int64_t hash(const Variant &p_arr);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1325,6 +1325,30 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="to_raw_bytes">
+			<return type="PackedByteArray" />
+			<param index="0" name="variable" type="Variant" />
+			<description>
+				Endodes a limited amount of [Variant] sub-types to a raw byte array ([PackedByteArray] without type information)
+				[b]Note:[/b] No deserialization is possible. Using [method bytes_to_var] on resulting [PackedByteArray] will return garbage or may crash the engine.
+				Following [Variant] sub-types are supported: [float], [int], [bool], [Vector2], [Vector3], [Vector4], [Vector2i], [Vector3i], [Vector4i], [Array].
+				Usage scenario: Convert values from [Array] to a raw bytes PackedByteArray, to use with [method RenderingDevice.compute_list_set_push_constant] or with Shader Storage Buffer Object of the compute shaders ([method RenderingDevice.buffer_update]).
+				[codeblock]
+				# Vectors are aligned to 16 bytes, so we need to pad vectors with some other 4 byte value like float, int or bool
+				var array = [
+				    Vector3(camera_pos.x,camera_pos.y,camera_pos.z),
+				    float(seed),                                                    # padded for 16 byte alignment of the camera_position above
+				    Vector3(light_direction.x,light_direction.y,light_direction.z),
+				    float(scale),                                                   # padded for 16 byte alignment of the light_direction above
+				    [ 0, 1, true, 33.17, Vector3(0.1,0.2,0.3), false ]              # some other array values, Vector3 is padded for 16 byte alignment
+				                                                                    # by bool value, and before Vector3 there are 4 four-byte values
+				]
+
+				var bytes:PackedByteArray = to_raw_bytes(array)                     # convert to raw bytes
+				_rd.buffer_update(_buffer_rid, 0, bytes.size(), bytes)              # update existing SSBO
+				[/codeblock]
+			</description>
+		</method>
 		<method name="typeof">
 			<return type="int" />
 			<param index="0" name="variable" type="Variant" />

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1332,7 +1332,7 @@
 				Endodes a limited amount of [Variant] sub-types to a raw byte array ([PackedByteArray] without type information)
 				[b]Note:[/b] No deserialization is possible. Using [method bytes_to_var] on resulting [PackedByteArray] will return garbage or may crash the engine.
 				Following [Variant] sub-types are supported: [float], [int], [bool], [Vector2], [Vector3], [Vector4], [Vector2i], [Vector3i], [Vector4i], [Array].
-				[b]Note:[/b] int will be semantically converted into 32 bit signed integer, even if the value is in the range of 64 bit signed integer.
+				[b]Note:[/b] int and float will be semantically converted into 32 bit signed integer and 32 bit float, even if the value is out of range and at the cost of precision for GDScript float values.
 
 				Usage scenario: Convert values from [Array] to a raw bytes PackedByteArray, to use with [method RenderingDevice.compute_list_set_push_constant] or with Shader Storage Buffer Object of the compute shaders ([method RenderingDevice.buffer_update]).
 				[codeblock]

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1332,6 +1332,8 @@
 				Endodes a limited amount of [Variant] sub-types to a raw byte array ([PackedByteArray] without type information)
 				[b]Note:[/b] No deserialization is possible. Using [method bytes_to_var] on resulting [PackedByteArray] will return garbage or may crash the engine.
 				Following [Variant] sub-types are supported: [float], [int], [bool], [Vector2], [Vector3], [Vector4], [Vector2i], [Vector3i], [Vector4i], [Array].
+				[b]Note:[/b] int will be semantically converted into 32 bit signed integer, even if the value is in the range of 64 bit signed integer.
+
 				Usage scenario: Convert values from [Array] to a raw bytes PackedByteArray, to use with [method RenderingDevice.compute_list_set_push_constant] or with Shader Storage Buffer Object of the compute shaders ([method RenderingDevice.buffer_update]).
 				[codeblock]
 				# Vectors are aligned to 16 bytes, so we need to pad vectors with some other 4 byte value like float, int or bool


### PR DESCRIPTION
### What  
```GDScript
 to_raw_bytes(Variant) -> PackedByteArray
 ```
A new function in a GlobalScope to convert a Variant into PackedByteArray which does not include an encoding information (no type information is encoded, no possibility to de-serialize from result)

### Why
There is no simple way to prepare a byte stream for push constants or for SSBO updates of the compute shaders in GDScript.  It is inconvenient, slow and error prone.

Here is a simple function that convert limited range of Variants (Array, int, float, bool, Vector2, Vector3,Vector4,Vector2i,Vector3i,Vector4i) into byte stream and returns it as PackedByteArray.

Nope, this function does not control the alignment if vec2,vec3 types, this is still responsibility of the user.

Here how it looks like:

```GDScript
    # Vectors are aligned to 16 bytes, so we need to pad vectors with some other 4 byte value like float, int or bool
    var array = [
        Vector3(camera_pos.x,camera_pos.y,camera_pos.z),
        float(seed),                                                    # padded for 16 byte alignment of the camera_position above
        Vector3(light_direction.x,light_direction.y,light_direction.z),
        float(scale),                                                   # padded for 16 byte alignment of the light_direction above
        [ 0, 1, true, 33.17, Vector3(0.1,0.2,0.3), false ]              # some other array values, Vector3 is padded for 16 byte alignment
                                                                            # by bool value, and before Vector3 there are 4 four-byte values
    ]
    
    var bytes:PackedByteArray = to_raw_bytes(array)                     # convert to raw bytes
    _rd.buffer_update(_buffer_rid, 0, bytes.size(), bytes)                # update existing SSBO
```

### Bad

One should avoid using the result of this function with bytes_to_vars() function, because of the obvious possibility to not only get a garbage in return or impossibility to convert, but a danger of engine crash.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/7478*