### PR TITLE
Fixes Scene corruption when child scene is renamed in another directory

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1745,7 +1745,6 @@ void FileSystemDock::_rename_operation_confirm() {
 	_rescan();
 
 	print_verbose("FileSystem: saving moved scenes.");
-	_save_scenes_after_move(file_renames);
 
 	current_path = new_path;
 	current_path_line_edit->set_text(current_path);


### PR DESCRIPTION
Fixes [#80379](https://github.com/godotengine/godot/issues/80379)
The issue was that _save_scenes_after_move(..) is used both before, and after updating the file, so on the second save it tries to access a file that no longer exists, because it was renamed.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
