### PR TITLE
Fix `get_method` from named lambda

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -138,7 +138,7 @@
 		<method name="get_method" qualifiers="const">
 			<return type="StringName" />
 			<description>
-				Returns the name of the method represented by this [Callable]. If the callable is a lambda function, returns the function's name.
+				Returns the name of the method represented by this [Callable]. If the callable is a GDScript lambda function, returns the function's name or [code]"&lt;anonymous lambda&gt;"[/code].
 			</description>
 		</method>
 		<method name="get_object" qualifiers="const">

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -67,6 +67,10 @@ ObjectID GDScriptLambdaCallable::get_object() const {
 	return script->get_instance_id();
 }
 
+StringName GDScriptLambdaCallable::get_method() const {
+	return function->get_name();
+}
+
 void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 	int captures_amount = captures.size();
 

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -56,6 +56,7 @@ public:
 	CompareEqualFunc get_compare_equal_func() const override;
 	CompareLessFunc get_compare_less_func() const override;
 	ObjectID get_object() const override;
+	StringName get_method() const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);

--- a/modules/gdscript/gdscript_rpc_callable.cpp
+++ b/modules/gdscript/gdscript_rpc_callable.cpp
@@ -63,6 +63,10 @@ ObjectID GDScriptRPCCallable::get_object() const {
 	return object->get_instance_id();
 }
 
+StringName GDScriptRPCCallable::get_method() const {
+	return method;
+}
+
 void GDScriptRPCCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 	r_return_value = object->callp(method, p_arguments, p_argcount, r_call_error);
 }

--- a/modules/gdscript/gdscript_rpc_callable.h
+++ b/modules/gdscript/gdscript_rpc_callable.h
@@ -51,6 +51,7 @@ public:
 	CompareEqualFunc get_compare_equal_func() const override;
 	CompareLessFunc get_compare_less_func() const override;
 	ObjectID get_object() const override;
+	StringName get_method() const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 	Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 


### PR DESCRIPTION
Fix #80434 

Snippet used: 
```gdscript
extends Node2D

func _ready():
	var fun = func test(): pass
	print(fun.get_method())
```

Before PR:
![before](https://github.com/godotengine/godot/assets/13846022/c0df640d-50b3-4bad-9767-e71d0f6f39ea)


After PR:
![after](https://github.com/godotengine/godot/assets/13846022/2a1bc2df-b245-4f23-92a5-12bd05abd6a9)
