### PR TITLE
GDScript: Fix "Identifier not found" error when accessing inner class from inside

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3469,6 +3469,9 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 	for (GDScriptParser::ClassNode *script_class : script_classes) {
 		if (p_base == nullptr && script_class->identifier && script_class->identifier->name == name) {
 			reduce_identifier_from_base_set_class(p_identifier, script_class->get_datatype());
+			if (script_class->outer != nullptr) {
+				p_identifier->source = GDScriptParser::IdentifierNode::MEMBER_CLASS;
+			}
 			return;
 		}
 

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_access_from_inside.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_access_from_inside.gd
@@ -1,0 +1,21 @@
+# GH-80508
+
+class A:
+	func a():
+		return A.new()
+	func b():
+		return B.new()
+
+class B:
+	func a():
+		return A.new()
+	func b():
+		return B.new()
+
+func test():
+	var a := A.new()
+	var b := B.new()
+	print(a.a() is A)
+	print(a.b() is B)
+	print(b.a() is A)
+	print(b.b() is B)

--- a/modules/gdscript/tests/scripts/analyzer/features/inner_class_access_from_inside.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/inner_class_access_from_inside.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+true
+true
+true
+true


### PR DESCRIPTION
* Closes #80508.
* Fixes regression from #79880.