### PR TITLE
Add `global_basis` property to `Node3D`

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -271,6 +271,9 @@
 		<member name="basis" type="Basis" setter="set_basis" getter="get_basis">
 			Direct access to the 3x3 basis of the [member transform] property.
 		</member>
+		<member name="global_basis" type="Basis" setter="set_global_basis" getter="get_global_basis">
+			Global basis of this node. This is equivalent to [code]global_transform.basis[/code].
+		</member>
 		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position">
 			Global position of this node. This is equivalent to [code]global_transform.origin[/code].
 		</member>

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -250,10 +250,22 @@ Vector3 Node3D::get_global_position() const {
 	return get_global_transform().get_origin();
 }
 
+Basis Node3D::get_global_basis() const {
+	ERR_READ_THREAD_GUARD_V(Basis());
+	return get_global_transform().get_basis();
+}
+
 void Node3D::set_global_position(const Vector3 &p_position) {
 	ERR_THREAD_GUARD;
 	Transform3D transform = get_global_transform();
 	transform.set_origin(p_position);
+	set_global_transform(transform);
+}
+
+void Node3D::set_global_basis(const Basis &p_basis) {
+	ERR_THREAD_GUARD;
+	Transform3D transform = get_global_transform();
+	transform.set_basis(p_basis);
 	set_global_transform(transform);
 }
 
@@ -1110,6 +1122,8 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_global_transform"), &Node3D::get_global_transform);
 	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Node3D::set_global_position);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Node3D::get_global_position);
+	ClassDB::bind_method(D_METHOD("set_global_basis", "basis"), &Node3D::set_global_basis);
+	ClassDB::bind_method(D_METHOD("get_global_basis"), &Node3D::get_global_basis);
 	ClassDB::bind_method(D_METHOD("set_global_rotation", "euler_radians"), &Node3D::set_global_rotation);
 	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node3D::get_global_rotation);
 	ClassDB::bind_method(D_METHOD("set_global_rotation_degrees", "euler_degrees"), &Node3D::set_global_rotation_degrees);
@@ -1191,6 +1205,7 @@ void Node3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_position", "get_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "global_basis", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_basis", "get_global_basis");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation", "get_global_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_global_rotation_degrees", "get_global_rotation_degrees");
 	ADD_GROUP("Visibility", "");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -182,6 +182,7 @@ public:
 	void set_scale(const Vector3 &p_scale);
 
 	void set_global_position(const Vector3 &p_position);
+	void set_global_basis(const Basis &p_basis);
 	void set_global_rotation(const Vector3 &p_euler_rad);
 	void set_global_rotation_degrees(const Vector3 &p_euler_degrees);
 
@@ -193,6 +194,7 @@ public:
 	Vector3 get_scale() const;
 
 	Vector3 get_global_position() const;
+	Basis get_global_basis() const;
 	Vector3 get_global_rotation() const;
 	Vector3 get_global_rotation_degrees() const;
 


### PR DESCRIPTION
Resolves godotengine/godot-proposals#6229.

This adds a `global_basis` property to `Node3D`, which is similar to the `global_position` property in that it's just a shorthand for `global_transform.basis`.

Useful for things like `intersect_ray`, since physics queries are all done in global-space.

If nothing else it makes the `global_*` part of the `Node3D` API more consistent with the non-global one.