### PR TITLE
SCons: Disable `/EHsc` for MSVC, speeds up build significantly

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -713,7 +713,7 @@ if selected_platform in platform_list:
     # Configure compiler warnings
     if env.msvc:  # MSVC
         if env["warnings"] == "no":
-            env.Append(CCFLAGS=["/w"])
+            env.Append(CCFLAGS=["/w", "/wd4530"])  # Silence "C++ exception handler used without unwind semantics".
         else:
             if env["warnings"] == "extra":
                 env.Append(CCFLAGS=["/W4"])
@@ -734,13 +734,11 @@ if selected_platform in platform_list:
                     "/wd4267",
                     "/wd4305",  # C4305 (truncation): double to float or real_t, too hard to avoid.
                     "/wd4514",  # C4514 (unreferenced inline function has been removed)
+                    "/wd4530",  # C4530 (C++ exception handler used without unwind semantics)
                     "/wd4714",  # C4714 (function marked as __forceinline not inlined)
                     "/wd4820",  # C4820 (padding added after construct)
                 ]
             )
-
-        # Set exception handling model to avoid warnings caused by Windows system headers.
-        env.Append(CCFLAGS=["/EHsc"])
 
         if env["werror"]:
             env.Append(CCFLAGS=["/WX"])

--- a/methods.py
+++ b/methods.py
@@ -123,7 +123,7 @@ def disable_warnings(self):
         self["CCFLAGS"] = [x for x in self["CCFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
         self["CFLAGS"] = [x for x in self["CFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
         self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
-        self.AppendUnique(CCFLAGS=["/w"])
+        self.AppendUnique(CCFLAGS=["/w", "/wd4530"])  # Silence "C++ exception handler used without unwind semantics".
     else:
         self.AppendUnique(CCFLAGS=["-w"])
 

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -13,10 +13,9 @@ env_tests = env.Clone()
 if env_tests["platform"] == "windows":
     env_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
 
-# Increase number of addressable sections in object files
-# due to doctest's heavy use of templates and macros.
+# Doctest uses exceptions for REQUIRE/FAIL checks.
 if env_tests.msvc:
-    env_tests.Append(CCFLAGS=["/bigobj"])
+    env_tests.Append(CCFLAGS=["/EHsc"])
 
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 


### PR DESCRIPTION
As seen in #80513, `/EHsc` seems responsible for extremely long build times for complex files such as `gdscript_vm.cpp` and `variant_call.cpp`, when combined with optimization flags.

On my Windows setup, a clean rebuild of the engine with `scons p=windows` (thus defaulting to `optimize=speed-trace`, i.e. `/O2` on MSVC) went from 35 min down to 16 min with this patch. Incremental rebuilds that would lead to recompiling either `gdscript_vm.cpp` or `variant_call.cpp` will benefit even more.

We were using `/EHsc` to solve warnings in thirdparty code, so instead we silence that warning specifically.

Fixes #80513.

----

I could use help to properly assess the impact of removing `/EHsc` and ignoring the `C4530` warning. I'm not super familiar with exception handling and stack unwinding. Relevant docs: https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170

Patching thirdparty libraries so they don't raise this warning is also an option. In theory, we don't want _any_ exception handling in Godot.