### PR TITLE
Add global parameter to EditorPlugin.add_autoload_singleton

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -397,8 +397,9 @@
 			<return type="void" />
 			<param index="0" name="name" type="String" />
 			<param index="1" name="path" type="String" />
+			<param index="2" name="global" type="bool" default="true" />
 			<description>
-				Adds a script at [param path] to the Autoload list as [param name].
+				Adds a script at [param path] to the Autoload list as [param name]. If [param global] is [code]true[/code], the Autoload will be globally accessible by its name.
 			</description>
 		</method>
 		<method name="add_context_menu_plugin">

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -776,7 +776,7 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 	undo_redo->commit_action();
 }
 
-bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_path) {
+bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_path, const bool &p_singleton) {
 	String name = p_name;
 
 	String error;
@@ -801,7 +801,7 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 
 	undo_redo->create_action(TTR("Add Autoload"));
 	// Singleton autoloads are represented with a leading "*" in their path.
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, "*" + p_path);
+	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, (p_singleton ? "*" : "") + p_path);
 
 	if (ProjectSettings::get_singleton()->has_setting(name)) {
 		undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, GLOBAL_GET(name));

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -105,7 +105,7 @@ protected:
 public:
 	void init_autoloads();
 	void update_autoload();
-	bool autoload_add(const String &p_name, const String &p_path);
+	bool autoload_add(const String &p_name, const String &p_path, const bool &p_singleton = true);
 	void autoload_remove(const String &p_name);
 
 	LineEdit *get_path_box() const;

--- a/editor/plugins/editor_plugin.compat.inc
+++ b/editor/plugins/editor_plugin.compat.inc
@@ -38,9 +38,15 @@ void EditorPlugin::_add_control_to_dock_compat_88081(DockSlot p_slot, Control *p
 	return add_control_to_dock(p_slot, p_control, nullptr);
 }
 
+void EditorPlugin::_add_autoload_singleton_compat_80519(const String &p_name, const String &p_path) {
+	add_autoload_singleton(p_name, p_path);
+}
+
 void EditorPlugin::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_bottom_panel", "control", "title"), &EditorPlugin::_add_control_to_bottom_panel_compat_88081);
 	ClassDB::bind_compatibility_method(D_METHOD("add_control_to_dock", "slot", "control"), &EditorPlugin::_add_control_to_dock_compat_88081);
+
+	ClassDB::bind_compatibility_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::_add_autoload_singleton_compat_80519);
 }
 
 #endif

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -64,14 +64,14 @@ void EditorPlugin::remove_custom_type(const String &p_type) {
 	EditorNode::get_editor_data().remove_custom_type(p_type);
 }
 
-void EditorPlugin::add_autoload_singleton(const String &p_name, const String &p_path) {
+void EditorPlugin::add_autoload_singleton(const String &p_name, const String &p_path, const bool &p_singleton) {
 	if (p_path.begins_with("res://")) {
-		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, p_path);
+		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, p_path, p_singleton);
 	} else {
 		const Ref<Script> plugin_script = static_cast<Ref<Script>>(get_script());
 		ERR_FAIL_COND(plugin_script.is_null());
 		const String script_base_path = plugin_script->get_path().get_base_dir();
-		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, script_base_path.path_join(p_path));
+		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, script_base_path.path_join(p_path), p_singleton);
 	}
 }
 
@@ -602,7 +602,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_custom_type", "type", "base", "script", "icon"), &EditorPlugin::add_custom_type);
 	ClassDB::bind_method(D_METHOD("remove_custom_type", "type"), &EditorPlugin::remove_custom_type);
 
-	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
+	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path", "global"), &EditorPlugin::add_autoload_singleton, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("remove_autoload_singleton", "name"), &EditorPlugin::remove_autoload_singleton);
 
 	ClassDB::bind_method(D_METHOD("update_overlays"), &EditorPlugin::update_overlays);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -106,6 +106,7 @@ protected:
 	void _notification(int p_what);
 
 	static void _bind_methods();
+
 	EditorUndoRedoManager *get_undo_redo();
 
 	void add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon);
@@ -139,6 +140,7 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	Button *_add_control_to_bottom_panel_compat_88081(Control *p_control, const String &p_title);
 	void _add_control_to_dock_compat_88081(DockSlot p_slot, Control *p_control);
+	void _add_autoload_singleton_compat_80519(const String &p_name, const String &p_path);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -240,7 +242,7 @@ public:
 	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
 
-	void add_autoload_singleton(const String &p_name, const String &p_path);
+	void add_autoload_singleton(const String &p_name, const String &p_path, const bool &p_singleton = true);
 	void remove_autoload_singleton(const String &p_name);
 
 	void add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -321,3 +321,10 @@ Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/a
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-80519
+--------
+Validate extension JSON: Error: Field 'classes/EditorPlugin/methods/add_autoload_singleton/arguments': size changed value in new API, from 2 to 3.
+
+Added optional argument. Compatibility method registered.


### PR DESCRIPTION
Usefull for `EditorPlugins` that need to do some background stuff in an autoload but don't want to concern the user with it.
