### PR TITLE
C#: Fix exporting for Android

### DIFF
--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -33,10 +33,6 @@
 #include "mono_gd/gd_mono.h"
 #include "utils/path_utils.h"
 
-#ifdef ANDROID_ENABLED
-#include "mono_gd/support/android_support.h"
-#endif
-
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2225,16 +2225,14 @@ String EditorExportPlatformAndroid::get_apksigner_path(int p_target_sdk, bool p_
 }
 
 bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug) const {
-#ifdef MODULE_MONO_ENABLED
-	// Don't check for additional errors, as this particular error cannot be resolved.
-	r_error += TTR("Exporting to Android is currently not supported in Godot 4 when using C#/.NET. Use Godot 3 to target Android with C#/Mono instead.") + "\n";
-	r_error += TTR("If this project does not use C#, use a non-C# editor build to export the project.") + "\n";
-	return false;
-#else
-
 	String err;
 	bool valid = false;
 	const bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
+
+#ifdef MODULE_MONO_ENABLED
+	// Android export is still a work in progress, keep a message as a warning.
+	err += TTR("Exporting to Android when using C#/.NET is experimental.") + "\n";
+#endif
 
 	// Look for export templates (first official, and if defined custom templates).
 
@@ -2365,7 +2363,6 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 	}
 
 	return valid;
-#endif // !MODULE_MONO_ENABLED
 }
 
 bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error) const {


### PR DESCRIPTION
You should now be able to compile the C# Android export template properly and export C# Android within the editor.
Only tested the Android export for a small project and it's not clear if this causes any other issues.
![image](https://github.com/godotengine/godot/assets/52148221/46615d8f-bddf-49bd-8673-aabc8e189149)
![image](https://github.com/godotengine/godot/assets/52148221/66904a88-a6a7-4a1a-9ac5-e6bffe24c7c3)
![image](https://github.com/godotengine/godot/assets/52148221/d6a526ad-ca63-42b2-8f10-7ba1ffa2b165)
