### PR TITLE
Support alternative UV layers for a handful of texture types

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -31,6 +31,13 @@
 				Returns the [Texture2D] associated with the specified [enum TextureParam].
 			</description>
 		</method>
+		<method name="get_texture_uv" qualifiers="const">
+			<return type="int" enum="BaseMaterial3D.TextureUV" />
+			<param index="0" name="param" type="int" enum="BaseMaterial3D.TextureParam" />
+			<description>
+				Returns the UV layer index for the specified [enum TextureParam].
+			</description>
+		</method>
 		<method name="set_feature">
 			<return type="void" />
 			<param index="0" name="feature" type="int" enum="BaseMaterial3D.Feature" />
@@ -55,6 +62,14 @@
 				Sets the texture for the slot specified by [param param]. See [enum TextureParam] for available slots.
 			</description>
 		</method>
+		<method name="set_texture_uv">
+			<return type="void" />
+			<param index="0" name="param" type="int" enum="BaseMaterial3D.TextureParam" />
+			<param index="1" name="texture_uv" type="int" enum="BaseMaterial3D.TextureUV" />
+			<description>
+				Sets the UV layer index for the slot specified by [param param]. See [enum TextureParam] for available slots.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="albedo_color" type="Color" setter="set_albedo" getter="get_albedo" default="Color(1, 1, 1, 1)">
@@ -71,6 +86,9 @@
 		</member>
 		<member name="albedo_texture_msdf" type="bool" setter="set_flag" getter="get_flag" default="false">
 			Enables multichannel signed distance field rendering shader. Use [member msdf_pixel_range] and [member msdf_outline_size] to configure MSDF parameters.
+		</member>
+		<member name="albedo_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member albedo_texture]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="alpha_antialiasing_edge" type="float" setter="set_alpha_antialiasing_edge" getter="get_alpha_antialiasing_edge">
 			Threshold at which antialiasing will be applied on the alpha channel.
@@ -102,14 +120,14 @@
 		<member name="ao_light_affect" type="float" setter="set_ao_light_affect" getter="get_ao_light_affect" default="0.0">
 			Amount that ambient occlusion affects lighting from lights. If [code]0[/code], ambient occlusion only affects ambient light. If [code]1[/code], ambient occlusion affects lights just as much as it affects ambient light. This can be used to impact the strength of the ambient occlusion effect, but typically looks unrealistic.
 		</member>
-		<member name="ao_on_uv2" type="bool" setter="set_flag" getter="get_flag" default="false">
-			If [code]true[/code], use [code]UV2[/code] coordinates to look up from the [member ao_texture].
-		</member>
 		<member name="ao_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that defines the amount of ambient occlusion for a given point on the object.
 		</member>
 		<member name="ao_texture_channel" type="int" setter="set_ao_texture_channel" getter="get_ao_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member ao_texture] in which the ambient occlusion information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
+		</member>
+		<member name="ao_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member ao_texture]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="backlight" type="Color" setter="set_backlight" getter="get_backlight" default="Color(0, 0, 0, 1)">
 			The color used by the backlight effect. Represents the light passing through an object.
@@ -167,8 +185,8 @@
 			Texture that specifies the per-pixel normal of the detail overlay. The [member detail_normal] texture only uses the red and green channels; the blue and alpha channels are ignored. The normal read from [member detail_normal] is oriented around the surface normal provided by the [Mesh].
 			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
 		</member>
-		<member name="detail_uv_layer" type="int" setter="set_detail_uv" getter="get_detail_uv" enum="BaseMaterial3D.DetailUV" default="0">
-			Specifies whether to use [code]UV[/code] or [code]UV2[/code] for the detail layer. See [enum DetailUV] for options.
+		<member name="detail_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member detail_normal]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="diffuse_mode" type="int" setter="set_diffuse_mode" getter="get_diffuse_mode" enum="BaseMaterial3D.DiffuseMode" default="0">
 			The algorithm used for diffuse light scattering. See [enum DiffuseMode].
@@ -205,14 +223,14 @@
 		<member name="emission_intensity" type="float" setter="set_emission_intensity" getter="get_emission_intensity">
 			Luminance of emitted light, measured in nits (candela per square meter). Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled. The default is roughly equivalent to an indoor lightbulb.
 		</member>
-		<member name="emission_on_uv2" type="bool" setter="set_flag" getter="get_flag" default="false">
-			Use [code]UV2[/code] to read from the [member emission_texture].
-		</member>
 		<member name="emission_operator" type="int" setter="set_emission_operator" getter="get_emission_operator" enum="BaseMaterial3D.EmissionOperator" default="0">
 			Sets how [member emission] interacts with [member emission_texture]. Can either add or multiply. See [enum EmissionOperator] for options.
 		</member>
 		<member name="emission_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies how much surface emits light at a given point.
+		</member>
+		<member name="emission_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member emission_texture]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="fixed_size" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the object is rendered at the same size regardless of distance.
@@ -271,6 +289,9 @@
 		<member name="metallic_texture_channel" type="int" setter="set_metallic_texture_channel" getter="get_metallic_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member metallic_texture] in which the metallic information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
 		</member>
+		<member name="metallic_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member metallic_texture]. See [enum TextureUV] for valid values.
+		</member>
 		<member name="msdf_outline_size" type="float" setter="set_msdf_outline_size" getter="get_msdf_outline_size" default="0.0">
 			The width of the shape outline.
 		</member>
@@ -291,6 +312,9 @@
 			[b]Note:[/b] The mesh must have both normals and tangents defined in its vertex data. Otherwise, the normal map won't render correctly and will only appear to darken the whole surface. If creating geometry with [SurfaceTool], you can use [method SurfaceTool.generate_normals] and [method SurfaceTool.generate_tangents] to automatically generate normals and tangents respectively.
 			[b]Note:[/b] Godot expects the normal map to use X+, Y+, and Z+ coordinates. See [url=http://wiki.polycount.com/wiki/Normal_Map_Technical_Details#Common_Swizzle_Coordinates]this page[/url] for a comparison of normal map coordinates expected by popular engines.
 			[b]Note:[/b] If [member detail_enabled] is [code]true[/code], the [member detail_albedo] texture is drawn [i]below[/i] the [member normal_texture]. To display a normal map [i]above[/i] the [member detail_albedo] texture, use [member detail_normal] instead.
+		</member>
+		<member name="normal_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member normal_texture]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="orm_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The Occlusion/Roughness/Metallic texture to use. This is a more efficient replacement of [member ao_texture], [member roughness_texture] and [member metallic_texture] in [ORMMaterial3D]. Ambient occlusion is stored in the red channel. Roughness map is stored in the green channel. Metallic map is stored in the blue channel. The alpha channel is ignored.
@@ -346,6 +370,9 @@
 		</member>
 		<member name="roughness_texture_channel" type="int" setter="set_roughness_texture_channel" getter="get_roughness_texture_channel" enum="BaseMaterial3D.TextureChannel" default="0">
 			Specifies the channel of the [member roughness_texture] in which the roughness information is stored. This is useful when you store the information for multiple effects in a single texture. For example if you stored metallic in the red channel, roughness in the blue, and ambient occlusion in the green you could reduce the number of textures you use.
+		</member>
+		<member name="roughness_uv_index" type="int" setter="set_texture_uv" getter="get_texture_uv" enum="BaseMaterial3D.TextureUV" default="0">
+			The index of the UV layer to use for [member roughness_texture]. See [enum TextureUV] for valid values.
 		</member>
 		<member name="shading_mode" type="int" setter="set_shading_mode" getter="get_shading_mode" enum="BaseMaterial3D.ShadingMode" default="1">
 			Sets whether the shading takes place, per-pixel, per-vertex or unshaded. Per-vertex lighting is faster, making it the best choice for mobile applications, however it looks considerably worse than per-pixel. Unshaded rendering is the fastest, but disables all interactions with lights.
@@ -521,11 +548,11 @@
 		<constant name="TEXTURE_FILTER_MAX" value="6" enum="TextureFilter">
 			Represents the size of the [enum TextureFilter] enum.
 		</constant>
-		<constant name="DETAIL_UV_1" value="0" enum="DetailUV">
-			Use [code]UV[/code] with the detail texture.
+		<constant name="TEXTURE_UV_1" value="0" enum="TextureUV">
+			Use [code]UV[/code] with the texture.
 		</constant>
-		<constant name="DETAIL_UV_2" value="1" enum="DetailUV">
-			Use [code]UV2[/code] with the detail texture.
+		<constant name="TEXTURE_UV_2" value="1" enum="TextureUV">
+			Use [code]UV2[/code] with the texture.
 		</constant>
 		<constant name="TRANSPARENCY_DISABLED" value="0" enum="Transparency">
 			The material will not use transparency. This is the fastest to render.
@@ -666,12 +693,6 @@
 		</constant>
 		<constant name="FLAG_UV2_USE_WORLD_TRIPLANAR" value="9" enum="Flags">
 			Use triplanar texture lookup for all texture lookups that would normally use [code]UV2[/code].
-		</constant>
-		<constant name="FLAG_AO_ON_UV2" value="10" enum="Flags">
-			Use [code]UV2[/code] coordinates to look up from the [member ao_texture].
-		</constant>
-		<constant name="FLAG_EMISSION_ON_UV2" value="11" enum="Flags">
-			Use [code]UV2[/code] coordinates to look up from the [member emission_texture].
 		</constant>
 		<constant name="FLAG_ALBEDO_TEXTURE_FORCE_SRGB" value="12" enum="Flags">
 			Forces the shader to convert albedo from sRGB space to linear space. See also [member albedo_texture_force_srgb].

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -287,3 +287,17 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_ge
 Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/commit/arguments/1': meta changed value in new API, from "uint32" to "uint64".
 
 Surface format was increased to 64 bits from 32 bits. Compatibility methods registered. 
+
+
+GH-80522
+--------
+Validate extension JSON: API was removed: classes/BaseMaterial3D/enums/DetailUV
+Validate extension JSON: API was removed: classes/BaseMaterial3D/enums/Flags/values/FLAG_AO_ON_UV2
+Validate extension JSON: API was removed: classes/BaseMaterial3D/enums/Flags/values/FLAG_EMISSION_ON_UV2
+Validate extension JSON: API was removed: classes/BaseMaterial3D/methods/get_detail_uv
+Validate extension JSON: API was removed: classes/BaseMaterial3D/methods/set_detail_uv
+Validate extension JSON: API was removed: classes/BaseMaterial3D/properties/ao_on_uv2
+Validate extension JSON: API was removed: classes/BaseMaterial3D/properties/detail_uv_layer
+Validate extension JSON: API was removed: classes/BaseMaterial3D/properties/emission_on_uv2
+
+Replaced with `TextureUV` enum and `get_texture_uv`/`set_texture_uv` functions.

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3619,11 +3619,12 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			}
 			if (gltf_texture_index != -1) {
 				bct["index"] = gltf_texture_index;
-				Dictionary extensions = _serialize_texture_transform_uv1(material);
+				Dictionary extensions = _serialize_texture_transform(base_material->get_texture_uv(BaseMaterial3D::TEXTURE_ALBEDO), material);
 				if (!extensions.is_empty()) {
 					bct["extensions"] = extensions;
 					p_state->use_khr_texture_transform = true;
 				}
+				bct["texCoord"] = base_material->get_texture_uv(BaseMaterial3D::TEXTURE_ALBEDO);
 				mr["baseColorTexture"] = bct;
 			}
 		}
@@ -3750,15 +3751,17 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			if (has_ao) {
 				Dictionary occt;
 				occt["index"] = orm_texture_index;
+				occt["texCoord"] = base_material->get_texture_uv(BaseMaterial3D::TEXTURE_AMBIENT_OCCLUSION),
 				d["occlusionTexture"] = occt;
 			}
 			if (has_roughness || has_metalness) {
 				mrt["index"] = orm_texture_index;
-				Dictionary extensions = _serialize_texture_transform_uv1(material);
+				Dictionary extensions = _serialize_texture_transform(base_material->get_texture_uv(BaseMaterial3D::TEXTURE_METALLIC), material);
 				if (!extensions.is_empty()) {
 					mrt["extensions"] = extensions;
 					p_state->use_khr_texture_transform = true;
 				}
+				mrt["texCoord"] = base_material->get_texture_uv(BaseMaterial3D::TEXTURE_METALLIC);
 				mr["metallicRoughnessTexture"] = mrt;
 			}
 		}
@@ -3804,6 +3807,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 			nt["scale"] = base_material->get_normal_scale();
 			if (gltf_texture_index != -1) {
 				nt["index"] = gltf_texture_index;
+				nt["texCoord"] = base_material->get_texture_uv(BaseMaterial3D::TEXTURE_NORMAL);
 				d["normalTexture"] = nt;
 			}
 		}
@@ -3828,6 +3832,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 
 			if (gltf_texture_index != -1) {
 				et["index"] = gltf_texture_index;
+				et["texCoord"] = base_material->get_texture_uv(BaseMaterial3D::TEXTURE_EMISSION);
 				d["emissiveTexture"] = et;
 			}
 		}
@@ -3971,7 +3976,11 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 				if (!mr.has("baseColorFactor")) {
 					material->set_albedo(Color(1, 1, 1));
 				}
-				_set_texture_transform_uv1(bct, material);
+				if (bct.has("texCoord")) {
+					material->set_texture_uv(BaseMaterial3D::TEXTURE_ALBEDO, (BaseMaterial3D::TextureUV)(int)bct["texCoord"]);
+				}
+
+				_set_texture_transform(material->get_texture_uv(BaseMaterial3D::TEXTURE_ALBEDO), bct, material);
 			}
 
 			if (mr.has("metallicFactor")) {
@@ -3987,9 +3996,9 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 			}
 
 			if (mr.has("metallicRoughnessTexture")) {
-				const Dictionary &bct = mr["metallicRoughnessTexture"];
-				if (bct.has("index")) {
-					const Ref<Texture2D> t = _get_texture(p_state, bct["index"], TEXTURE_TYPE_GENERIC);
+				const Dictionary &mrt = mr["metallicRoughnessTexture"];
+				if (mrt.has("index")) {
+					const Ref<Texture2D> t = _get_texture(p_state, mrt["index"], TEXTURE_TYPE_GENERIC);
 					material->set_texture(BaseMaterial3D::TEXTURE_METALLIC, t);
 					material->set_metallic_texture_channel(BaseMaterial3D::TEXTURE_CHANNEL_BLUE);
 					material->set_texture(BaseMaterial3D::TEXTURE_ROUGHNESS, t);
@@ -4001,25 +4010,35 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 						material->set_roughness(1);
 					}
 				}
+				if (mrt.has("texCoord")) {
+					material->set_texture_uv(BaseMaterial3D::TEXTURE_METALLIC, (BaseMaterial3D::TextureUV)(int)mrt["texCoord"]);
+					material->set_texture_uv(BaseMaterial3D::TEXTURE_ROUGHNESS, (BaseMaterial3D::TextureUV)(int)mrt["texCoord"]);
+				}
 			}
 		}
 
 		if (material_dict.has("normalTexture")) {
-			const Dictionary &bct = material_dict["normalTexture"];
-			if (bct.has("index")) {
-				material->set_texture(BaseMaterial3D::TEXTURE_NORMAL, _get_texture(p_state, bct["index"], TEXTURE_TYPE_NORMAL));
+			const Dictionary &nt = material_dict["normalTexture"];
+			if (nt.has("index")) {
+				material->set_texture(BaseMaterial3D::TEXTURE_NORMAL, _get_texture(p_state, nt["index"], TEXTURE_TYPE_NORMAL));
 				material->set_feature(BaseMaterial3D::FEATURE_NORMAL_MAPPING, true);
 			}
-			if (bct.has("scale")) {
-				material->set_normal_scale(bct["scale"]);
+			if (nt.has("texCoord")) {
+				material->set_texture_uv(BaseMaterial3D::TEXTURE_NORMAL, (BaseMaterial3D::TextureUV)(int)nt["texCoord"]);
+			}
+			if (nt.has("scale")) {
+				material->set_normal_scale(nt["scale"]);
 			}
 		}
 		if (material_dict.has("occlusionTexture")) {
-			const Dictionary &bct = material_dict["occlusionTexture"];
-			if (bct.has("index")) {
-				material->set_texture(BaseMaterial3D::TEXTURE_AMBIENT_OCCLUSION, _get_texture(p_state, bct["index"], TEXTURE_TYPE_GENERIC));
+			const Dictionary &ot = material_dict["occlusionTexture"];
+			if (ot.has("index")) {
+				material->set_texture(BaseMaterial3D::TEXTURE_AMBIENT_OCCLUSION, _get_texture(p_state, ot["index"], TEXTURE_TYPE_GENERIC));
 				material->set_ao_texture_channel(BaseMaterial3D::TEXTURE_CHANNEL_RED);
 				material->set_feature(BaseMaterial3D::FEATURE_AMBIENT_OCCLUSION, true);
+			}
+			if (ot.has("texCoord")) {
+				material->set_texture_uv(BaseMaterial3D::TEXTURE_AMBIENT_OCCLUSION, (BaseMaterial3D::TextureUV)(int)ot["texCoord"]);
 			}
 		}
 
@@ -4033,11 +4052,14 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 		}
 
 		if (material_dict.has("emissiveTexture")) {
-			const Dictionary &bct = material_dict["emissiveTexture"];
-			if (bct.has("index")) {
-				material->set_texture(BaseMaterial3D::TEXTURE_EMISSION, _get_texture(p_state, bct["index"], TEXTURE_TYPE_GENERIC));
+			const Dictionary &et = material_dict["emissiveTexture"];
+			if (et.has("index")) {
+				material->set_texture(BaseMaterial3D::TEXTURE_EMISSION, _get_texture(p_state, et["index"], TEXTURE_TYPE_GENERIC));
 				material->set_feature(BaseMaterial3D::FEATURE_EMISSION, true);
 				material->set_emission(Color(0, 0, 0));
+			}
+			if (et.has("texCoord")) {
+				material->set_texture_uv(BaseMaterial3D::TEXTURE_EMISSION, (BaseMaterial3D::TextureUV)(int)et["texCoord"]);
 			}
 		}
 
@@ -4068,7 +4090,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-void GLTFDocument::_set_texture_transform_uv1(const Dictionary &p_dict, Ref<BaseMaterial3D> p_material) {
+void GLTFDocument::_set_texture_transform(BaseMaterial3D::TextureUV p_param, const Dictionary &p_dict, Ref<BaseMaterial3D> p_material) {
 	if (p_dict.has("extensions")) {
 		const Dictionary &extensions = p_dict["extensions"];
 		if (extensions.has("KHR_texture_transform")) {
@@ -4077,13 +4099,21 @@ void GLTFDocument::_set_texture_transform_uv1(const Dictionary &p_dict, Ref<Base
 				const Array &offset_arr = texture_transform["offset"];
 				if (offset_arr.size() == 2) {
 					const Vector3 offset_vector3 = Vector3(offset_arr[0], offset_arr[1], 0.0f);
-					p_material->set_uv1_offset(offset_vector3);
+					if (p_param == BaseMaterial3D::TEXTURE_UV_1) {
+						p_material->set_uv1_offset(offset_vector3);
+					} else {
+						p_material->set_uv2_offset(offset_vector3);
+					}
 				}
 
 				const Array &scale_arr = texture_transform["scale"];
 				if (scale_arr.size() == 2) {
 					const Vector3 scale_vector3 = Vector3(scale_arr[0], scale_arr[1], 1.0f);
-					p_material->set_uv1_scale(scale_vector3);
+					if (p_param == BaseMaterial3D::TEXTURE_UV_1) {
+						p_material->set_uv1_scale(scale_vector3);
+					} else {
+						p_material->set_uv2_scale(scale_vector3);
+					}
 				}
 			}
 		}
@@ -7102,44 +7132,41 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess
 	return OK;
 }
 
-Dictionary _serialize_texture_transform_uv(Vector2 p_offset, Vector2 p_scale) {
-	Dictionary texture_transform;
-	bool is_offset = p_offset != Vector2(0.0, 0.0);
-	if (is_offset) {
-		Array offset;
-		offset.resize(2);
-		offset[0] = p_offset.x;
-		offset[1] = p_offset.y;
-		texture_transform["offset"] = offset;
+Dictionary GLTFDocument::_serialize_texture_transform(BaseMaterial3D::TextureUV p_param, Ref<BaseMaterial3D> p_material) {
+	ERR_FAIL_NULL_V(p_material, Dictionary());
+	Vector3 offset3D, scale3D;
+	if (p_param == BaseMaterial3D::TEXTURE_UV_1) {
+		offset3D = p_material->get_uv1_offset();
+		scale3D = p_material->get_uv1_scale();
+	} else {
+		offset3D = p_material->get_uv2_offset();
+		scale3D = p_material->get_uv2_scale();
 	}
-	bool is_scaled = p_scale != Vector2(1.0, 1.0);
+	Dictionary texture_transform;
+	Vector2 offset(offset3D.x, offset3D.y);
+	Vector2 scale(scale3D.x, scale3D.y);
+	bool is_offset = offset != Vector2(0.0, 0.0);
+	if (is_offset) {
+		Array arr_offset;
+		arr_offset.resize(2);
+		arr_offset[0] = offset.x;
+		arr_offset[1] = offset.y;
+		texture_transform["offset"] = arr_offset;
+	}
+	bool is_scaled = scale != Vector2(1.0, 1.0);
 	if (is_scaled) {
-		Array scale;
-		scale.resize(2);
-		scale[0] = p_scale.x;
-		scale[1] = p_scale.y;
-		texture_transform["scale"] = scale;
+		Array arr_scale;
+		arr_scale.resize(2);
+		arr_scale[0] = scale.x;
+		arr_scale[1] = scale.y;
+		texture_transform["scale"] = arr_scale;
 	}
 	Dictionary extension;
-	// Note: Godot doesn't support texture rotation.
+	// Note: Godot doesn't support texture rotation as it is not widely adopted yet.
 	if (is_offset || is_scaled) {
 		extension["KHR_texture_transform"] = texture_transform;
 	}
 	return extension;
-}
-
-Dictionary GLTFDocument::_serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material) {
-	ERR_FAIL_NULL_V(p_material, Dictionary());
-	Vector3 offset = p_material->get_uv1_offset();
-	Vector3 scale = p_material->get_uv1_scale();
-	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
-}
-
-Dictionary GLTFDocument::_serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material) {
-	ERR_FAIL_NULL_V(p_material, Dictionary());
-	Vector3 offset = p_material->get_uv2_offset();
-	Vector3 scale = p_material->get_uv2_scale();
-	return _serialize_texture_transform_uv(Vector2(offset.x, offset.y), Vector2(scale.x, scale.y));
 }
 
 Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -173,7 +173,7 @@ private:
 	Error _parse_textures(Ref<GLTFState> p_state);
 	Error _parse_texture_samplers(Ref<GLTFState> p_state);
 	Error _parse_materials(Ref<GLTFState> p_state);
-	void _set_texture_transform_uv1(const Dictionary &d, Ref<BaseMaterial3D> p_material);
+	void _set_texture_transform(BaseMaterial3D::TextureUV p_param, const Dictionary &d, Ref<BaseMaterial3D> p_material);
 	void spec_gloss_to_rough_metal(Ref<GLTFSpecGloss> r_spec_gloss,
 			Ref<BaseMaterial3D> p_material);
 	static void spec_gloss_to_metal_base_color(const Color &p_specular_factor,
@@ -286,8 +286,7 @@ private:
 	Error _encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path);
 	Error _encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path);
 	PackedByteArray _serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err);
-	Dictionary _serialize_texture_transform_uv1(Ref<BaseMaterial3D> p_material);
-	Dictionary _serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_material);
+	Dictionary _serialize_texture_transform(BaseMaterial3D::TextureUV p_param, Ref<BaseMaterial3D> p_material);
 	Error _serialize_asset_header(Ref<GLTFState> p_state);
 	Error _serialize_file(Ref<GLTFState> p_state, const String p_path);
 	Error _serialize_gltf_extensions(Ref<GLTFState> p_state) const;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1543,6 +1543,8 @@ Color BaseMaterial3D::get_albedo() const {
 }
 
 void BaseMaterial3D::set_texture_uv(BaseMaterial3D::TextureParam p_param, BaseMaterial3D::TextureUV p_texture_uv) {
+	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
+
 	if (texture_uvs[p_param] == p_texture_uv) {
 		return;
 	}
@@ -1552,6 +1554,8 @@ void BaseMaterial3D::set_texture_uv(BaseMaterial3D::TextureParam p_param, BaseMa
 }
 
 BaseMaterial3D::TextureUV BaseMaterial3D::get_texture_uv(BaseMaterial3D::TextureParam p_param) const {
+	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
+
 	return texture_uvs[p_param];
 }
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -507,6 +507,8 @@ SelfList<BaseMaterial3D>::List BaseMaterial3D::dirty_materials;
 HashMap<BaseMaterial3D::MaterialKey, BaseMaterial3D::ShaderData, BaseMaterial3D::MaterialKey> BaseMaterial3D::shader_map;
 BaseMaterial3D::ShaderNames *BaseMaterial3D::shader_names = nullptr;
 
+static constexpr const char *SHADER_UV_PARAMS[] = { "UV", "UV2" };
+
 void BaseMaterial3D::init_shaders() {
 	shader_names = memnew(ShaderNames);
 
@@ -800,6 +802,7 @@ void BaseMaterial3D::_update_shader() {
 	code += ";\n";
 
 	code += "uniform vec4 albedo : source_color;\n";
+	code += "uniform int albedo_uv;\n";
 	code += "uniform sampler2D texture_albedo : source_color," + texfilter_str + ";\n";
 	if (grow_enabled) {
 		code += "uniform float grow;\n";
@@ -1054,8 +1057,10 @@ void BaseMaterial3D::_update_shader() {
 		code += "	}\n";
 	}
 
-	if (detail_uv == DETAIL_UV_2 && !flags[FLAG_UV2_USE_TRIPLANAR]) {
-		code += "	UV2=UV2*uv2_scale.xy+uv2_offset.xy;\n";
+	if ((texture_uvs[TEXTURE_DETAIL_ALBEDO] == TEXTURE_UV_2 && !flags[FLAG_UV2_USE_TRIPLANAR]) || texture_uvs[TEXTURE_DETAIL_ALBEDO] > TEXTURE_UV_2) {
+		TextureUV detailUV = texture_uvs[TEXTURE_DETAIL_ALBEDO];
+		const char *uvParam = SHADER_UV_PARAMS[detailUV];
+		code += vformat("	%s=%s*uv%i_scale.xy+uv%i_offset.xy;\n", uvParam, uvParam, detailUV + 1, detailUV + 1);
 	}
 	if (flags[FLAG_UV1_USE_TRIPLANAR] || flags[FLAG_UV2_USE_TRIPLANAR]) {
 		//generate tangent and binormal in world space
@@ -1118,14 +1123,6 @@ void BaseMaterial3D::_update_shader() {
 	code += "\n\n";
 	code += "void fragment() {\n";
 
-	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
-		code += "	vec2 base_uv = UV;\n";
-	}
-
-	if ((features[FEATURE_DETAIL] && detail_uv == DETAIL_UV_2) || (features[FEATURE_AMBIENT_OCCLUSION] && flags[FLAG_AO_ON_UV2]) || (features[FEATURE_EMISSION] && flags[FLAG_EMISSION_ON_UV2])) {
-		code += "	vec2 base_uv2 = UV2;\n";
-	}
-
 	if (features[FEATURE_HEIGHT_MAPPING] && flags[FLAG_UV1_USE_TRIPLANAR]) {
 		// Display both resource name and albedo texture name.
 		// Materials are often built-in to scenes, so displaying the resource name alone may not be meaningful.
@@ -1151,7 +1148,7 @@ void BaseMaterial3D::_update_shader() {
 			// Multiply the heightmap scale by 0.01 to improve heightmap scale usability.
 			code += "		vec2 P = view_dir.xy * heightmap_scale * 0.01;\n";
 			code += "		vec2 delta = P / num_layers;\n";
-			code += "		vec2 ofs = base_uv;\n";
+			code += "		vec2 ofs = UV;\n";
 			if (flags[FLAG_INVERT_HEIGHTMAP]) {
 				code += "		float depth = texture(texture_heightmap, ofs).r;\n";
 			} else {
@@ -1179,19 +1176,19 @@ void BaseMaterial3D::_update_shader() {
 
 		} else {
 			if (flags[FLAG_INVERT_HEIGHTMAP]) {
-				code += "		float depth = texture(texture_heightmap, base_uv).r;\n";
+				code += "		float depth = texture(texture_heightmap, UV).r;\n";
 			} else {
-				code += "		float depth = 1.0 - texture(texture_heightmap, base_uv).r;\n";
+				code += "		float depth = 1.0 - texture(texture_heightmap, UV).r;\n";
 			}
 			// Use offset limiting to improve the appearance of non-deep parallax.
 			// This reduces the impression of depth, but avoids visible warping in the distance.
 			// Multiply the heightmap scale by 0.01 to improve heightmap scale usability.
-			code += "		vec2 ofs = base_uv - view_dir.xy * depth * heightmap_scale * 0.01;\n";
+			code += "		vec2 ofs = UV - view_dir.xy * depth * heightmap_scale * 0.01;\n";
 		}
 
-		code += "		base_uv=ofs;\n";
-		if (features[FEATURE_DETAIL] && detail_uv == DETAIL_UV_2) {
-			code += "		base_uv2-=ofs;\n";
+		code += "		UV=ofs;\n";
+		if (features[FEATURE_DETAIL] && texture_uvs[TEXTURE_DETAIL_ALBEDO] > TEXTURE_UV_1) {
+			code += vformat("	%s-=ofs;\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_DETAIL_ALBEDO]]);
 		}
 
 		code += "	}\n";
@@ -1200,10 +1197,13 @@ void BaseMaterial3D::_update_shader() {
 	if (flags[FLAG_USE_POINT_SIZE]) {
 		code += "	vec4 albedo_tex = texture(texture_albedo,POINT_COORD);\n";
 	} else {
-		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
+		if (texture_uvs[TEXTURE_ALBEDO] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec4 albedo_tex = triplanar_texture(texture_albedo,uv1_power_normal,uv1_triplanar_pos);\n";
+		} else if (texture_uvs[TEXTURE_ALBEDO] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+			code += "	vec4 albedo_tex = triplanar_texture(texture_albedo,uv2_power_normal,uv2_triplanar_pos);\n";
 		} else {
-			code += "	vec4 albedo_tex = texture(texture_albedo,base_uv);\n";
+			// GLTF supports up to 8 UV channels
+			code += vformat("	vec4 albedo_tex = texture(texture_albedo,%s);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_ALBEDO]]);
 		}
 	}
 
@@ -1217,7 +1217,7 @@ void BaseMaterial3D::_update_shader() {
 			if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 				code += "		vec2 dest_size = vec2(1.0) / fwidth(uv1_triplanar_pos);\n";
 			} else {
-				code += "		vec2 dest_size = vec2(1.0) / fwidth(base_uv);\n";
+				code += vformat("		vec2 dest_size = vec2(1.0) / fwidth(%s);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_ALBEDO]]);
 			}
 		}
 		code += "		float px_size = max(0.5 * dot(msdf_size, dest_size), 1.0);\n";
@@ -1240,10 +1240,12 @@ void BaseMaterial3D::_update_shader() {
 	code += "	ALBEDO = albedo.rgb * albedo_tex.rgb;\n";
 
 	if (!orm) {
-		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
+		if (texture_uvs[TEXTURE_METALLIC] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	float metallic_tex = dot(triplanar_texture(texture_metallic,uv1_power_normal,uv1_triplanar_pos),metallic_texture_channel);\n";
+		} else if (texture_uvs[TEXTURE_METALLIC] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+			code += "	float metallic_tex = dot(triplanar_texture(texture_metallic,uv2_power_normal,uv2_triplanar_pos),metallic_texture_channel);\n";
 		} else {
-			code += "	float metallic_tex = dot(texture(texture_metallic,base_uv),metallic_texture_channel);\n";
+			code += vformat("	float metallic_tex = dot(texture(texture_metallic,%s),metallic_texture_channel);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_METALLIC]]);
 		}
 		code += "	METALLIC = metallic_tex * metallic;\n";
 
@@ -1267,10 +1269,12 @@ void BaseMaterial3D::_update_shader() {
 				break; // Internal value, skip.
 		}
 
-		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
+		if (texture_uvs[TEXTURE_ROUGHNESS] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	float roughness_tex = dot(triplanar_texture(texture_roughness,uv1_power_normal,uv1_triplanar_pos),roughness_texture_channel);\n";
+		} else if (texture_uvs[TEXTURE_ROUGHNESS] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+			code += "	float roughness_tex = dot(triplanar_texture(texture_roughness,uv2_power_normal,uv2_triplanar_pos),roughness_texture_channel);\n";
 		} else {
-			code += "	float roughness_tex = dot(texture(texture_roughness,base_uv),roughness_texture_channel);\n";
+			code += vformat("	float roughness_tex = dot(texture(texture_roughness,%s),roughness_texture_channel);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_ROUGHNESS]]);
 		}
 		code += "	ROUGHNESS = roughness_tex * roughness;\n";
 		code += "	SPECULAR = specular;\n";
@@ -1278,7 +1282,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec4 orm_tex = triplanar_texture(texture_orm,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 orm_tex = texture(texture_orm,base_uv);\n";
+			code += "	vec4 orm_tex = texture(texture_orm,UV);\n";
 		}
 
 		code += "	ROUGHNESS = orm_tex.g;\n";
@@ -1286,27 +1290,21 @@ void BaseMaterial3D::_update_shader() {
 	}
 
 	if (features[FEATURE_NORMAL_MAPPING]) {
-		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
+		if (texture_uvs[TEXTURE_NORMAL] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	NORMAL_MAP = triplanar_texture(texture_normal,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
 		} else {
-			code += "	NORMAL_MAP = texture(texture_normal,base_uv).rgb;\n";
+			code += vformat("	NORMAL_MAP = texture(texture_normal,%s).rgb;\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_NORMAL]]);
 		}
 		code += "	NORMAL_MAP_DEPTH = normal_scale;\n";
 	}
 
 	if (features[FEATURE_EMISSION]) {
-		if (flags[FLAG_EMISSION_ON_UV2]) {
-			if (flags[FLAG_UV2_USE_TRIPLANAR]) {
-				code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv2_power_normal,uv2_triplanar_pos).rgb;\n";
-			} else {
-				code += "	vec3 emission_tex = texture(texture_emission,base_uv2).rgb;\n";
-			}
+		if (texture_uvs[TEXTURE_EMISSION] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
+			code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
+		} else if (texture_uvs[TEXTURE_EMISSION] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+			code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv2_power_normal,uv2_triplanar_pos).rgb;\n";
 		} else {
-			if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-				code += "	vec3 emission_tex = triplanar_texture(texture_emission,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
-			} else {
-				code += "	vec3 emission_tex = texture(texture_emission,base_uv).rgb;\n";
-			}
+			code += vformat("	vec3 emission_tex = texture(texture_emission,%s).rgb;\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_EMISSION]]);
 		}
 
 		if (emission_op == EMISSION_OP_ADD) {
@@ -1328,7 +1326,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(triplanar_texture(texture_refraction,uv1_power_normal,uv1_triplanar_pos),refraction_texture_channel) * refraction;\n";
 		} else {
-			code += "	vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(texture(texture_refraction,base_uv),refraction_texture_channel) * refraction;\n";
+			code += "	vec2 ref_ofs = SCREEN_UV - ref_normal.xy * dot(texture(texture_refraction,UV),refraction_texture_channel) * refraction;\n";
 		}
 		code += "	float ref_amount = 1.0 - albedo.a * albedo_tex.a;\n";
 		code += "	EMISSION += textureLod(screen_texture,ref_ofs,ROUGHNESS * 8.0).rgb * ref_amount * EXPOSURE;\n";
@@ -1387,7 +1385,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec2 rim_tex = triplanar_texture(texture_rim,uv1_power_normal,uv1_triplanar_pos).xy;\n";
 		} else {
-			code += "	vec2 rim_tex = texture(texture_rim,base_uv).xy;\n";
+			code += "	vec2 rim_tex = texture(texture_rim,UV).xy;\n";
 		}
 		code += "	RIM = rim*rim_tex.x;";
 		code += "	RIM_TINT = rim_tint*rim_tex.y;\n";
@@ -1397,7 +1395,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec2 clearcoat_tex = triplanar_texture(texture_clearcoat,uv1_power_normal,uv1_triplanar_pos).xy;\n";
 		} else {
-			code += "	vec2 clearcoat_tex = texture(texture_clearcoat,base_uv).xy;\n";
+			code += "	vec2 clearcoat_tex = texture(texture_clearcoat,UV).xy;\n";
 		}
 		code += "	CLEARCOAT = clearcoat*clearcoat_tex.x;";
 		code += "	CLEARCOAT_ROUGHNESS = clearcoat_roughness*clearcoat_tex.y;\n";
@@ -1407,7 +1405,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec3 anisotropy_tex = triplanar_texture(texture_flowmap,uv1_power_normal,uv1_triplanar_pos).rga;\n";
 		} else {
-			code += "	vec3 anisotropy_tex = texture(texture_flowmap,base_uv).rga;\n";
+			code += "	vec3 anisotropy_tex = texture(texture_flowmap,UV).rga;\n";
 		}
 		code += "	ANISOTROPY = anisotropy_ratio*anisotropy_tex.b;\n";
 		code += "	ANISOTROPY_FLOW = anisotropy_tex.rg*2.0-1.0;\n";
@@ -1415,18 +1413,12 @@ void BaseMaterial3D::_update_shader() {
 
 	if (features[FEATURE_AMBIENT_OCCLUSION]) {
 		if (!orm) {
-			if (flags[FLAG_AO_ON_UV2]) {
-				if (flags[FLAG_UV2_USE_TRIPLANAR]) {
-					code += "	AO = dot(triplanar_texture(texture_ambient_occlusion,uv2_power_normal,uv2_triplanar_pos),ao_texture_channel);\n";
-				} else {
-					code += "	AO = dot(texture(texture_ambient_occlusion,base_uv2),ao_texture_channel);\n";
-				}
+			if (texture_uvs[TEXTURE_AMBIENT_OCCLUSION] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
+				code += "	AO = dot(triplanar_texture(texture_ambient_occlusion,uv1_power_normal,uv1_triplanar_pos),ao_texture_channel);\n";
+			} else if (texture_uvs[TEXTURE_AMBIENT_OCCLUSION] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+				code += "	AO = dot(triplanar_texture(texture_ambient_occlusion,uv2_power_normal,uv2_triplanar_pos),ao_texture_channel);\n";
 			} else {
-				if (flags[FLAG_UV1_USE_TRIPLANAR]) {
-					code += "	AO = dot(triplanar_texture(texture_ambient_occlusion,uv1_power_normal,uv1_triplanar_pos),ao_texture_channel);\n";
-				} else {
-					code += "	AO = dot(texture(texture_ambient_occlusion,base_uv),ao_texture_channel);\n";
-				}
+				code += vformat("	AO = dot(texture(texture_ambient_occlusion,%s),ao_texture_channel);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_AMBIENT_OCCLUSION]]);
 			}
 		} else {
 			code += "	AO = orm_tex.r;\n";
@@ -1439,7 +1431,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	float sss_tex = triplanar_texture(texture_subsurface_scattering,uv1_power_normal,uv1_triplanar_pos).r;\n";
 		} else {
-			code += "	float sss_tex = texture(texture_subsurface_scattering,base_uv).r;\n";
+			code += "	float sss_tex = texture(texture_subsurface_scattering,UV).r;\n";
 		}
 		code += "	SSS_STRENGTH=subsurface_scattering_strength*sss_tex;\n";
 	}
@@ -1448,7 +1440,7 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec4 trans_color_tex = triplanar_texture(texture_subsurface_transmittance,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 trans_color_tex = texture(texture_subsurface_transmittance,base_uv);\n";
+			code += "	vec4 trans_color_tex = texture(texture_subsurface_transmittance,UV);\n";
 		}
 		code += "	SSS_TRANSMITTANCE_COLOR=transmittance_color*trans_color_tex;\n";
 
@@ -1460,29 +1452,27 @@ void BaseMaterial3D::_update_shader() {
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec3 backlight_tex = triplanar_texture(texture_backlight,uv1_power_normal,uv1_triplanar_pos).rgb;\n";
 		} else {
-			code += "	vec3 backlight_tex = texture(texture_backlight,base_uv).rgb;\n";
+			code += "	vec3 backlight_tex = texture(texture_backlight,UV).rgb;\n";
 		}
 		code += "	BACKLIGHT = (backlight.rgb+backlight_tex);\n";
 	}
 
 	if (features[FEATURE_DETAIL]) {
-		bool triplanar = (flags[FLAG_UV1_USE_TRIPLANAR] && detail_uv == DETAIL_UV_1) || (flags[FLAG_UV2_USE_TRIPLANAR] && detail_uv == DETAIL_UV_2);
-
-		if (triplanar) {
-			String tp_uv = detail_uv == DETAIL_UV_1 ? "uv1" : "uv2";
-			code += "	vec4 detail_tex = triplanar_texture(texture_detail_albedo," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
-			code += "	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal," + tp_uv + "_power_normal," + tp_uv + "_triplanar_pos);\n";
-
+		if (texture_uvs[TEXTURE_DETAIL_ALBEDO] == TEXTURE_UV_1 && flags[FLAG_UV1_USE_TRIPLANAR]) {
+			code += "	vec4 detail_tex = triplanar_texture(texture_detail_albedo,uv1_power_normal,uv1_triplanar_pos);\n";
+			code += "	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal,uv1_power_normal,uv1_triplanar_pos);\n";
+		} else if (texture_uvs[TEXTURE_DETAIL_ALBEDO] == TEXTURE_UV_2 && flags[FLAG_UV2_USE_TRIPLANAR]) {
+			code += "	vec4 detail_tex = triplanar_texture(texture_detail_albedo,uv2_power_normal,uv2_triplanar_pos);\n";
+			code += "	vec4 detail_norm_tex = triplanar_texture(texture_detail_normal,uv2_power_normal,uv2_triplanar_pos);\n";
 		} else {
-			String det_uv = detail_uv == DETAIL_UV_1 ? "base_uv" : "base_uv2";
-			code += "	vec4 detail_tex = texture(texture_detail_albedo," + det_uv + ");\n";
-			code += "	vec4 detail_norm_tex = texture(texture_detail_normal," + det_uv + ");\n";
+			code += vformat("	vec4 detail_tex = texture(texture_detail_albedo,%s);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_DETAIL_ALBEDO]]);
+			code += vformat("	vec4 detail_norm_tex = texture(texture_detail_normal,%s);\n", SHADER_UV_PARAMS[texture_uvs[TEXTURE_DETAIL_ALBEDO]]);
 		}
 
 		if (flags[FLAG_UV1_USE_TRIPLANAR]) {
 			code += "	vec4 detail_mask_tex = triplanar_texture(texture_detail_mask,uv1_power_normal,uv1_triplanar_pos);\n";
 		} else {
-			code += "	vec4 detail_mask_tex = texture(texture_detail_mask,base_uv);\n";
+			code += "	vec4 detail_mask_tex = texture(texture_detail_mask,UV);\n";
 		}
 
 		switch (detail_blend_mode) {
@@ -1550,6 +1540,19 @@ void BaseMaterial3D::set_albedo(const Color &p_albedo) {
 
 Color BaseMaterial3D::get_albedo() const {
 	return albedo;
+}
+
+void BaseMaterial3D::set_texture_uv(BaseMaterial3D::TextureParam p_param, BaseMaterial3D::TextureUV p_texture_uv) {
+	if (texture_uvs[p_param] == p_texture_uv) {
+		return;
+	}
+
+	texture_uvs[p_param] = p_texture_uv;
+	_queue_shader_change();
+}
+
+BaseMaterial3D::TextureUV BaseMaterial3D::get_texture_uv(BaseMaterial3D::TextureParam p_param) const {
+	return texture_uvs[p_param];
 }
 
 void BaseMaterial3D::set_specular(float p_specular) {
@@ -1735,19 +1738,6 @@ void BaseMaterial3D::set_refraction(float p_refraction) {
 
 float BaseMaterial3D::get_refraction() const {
 	return refraction;
-}
-
-void BaseMaterial3D::set_detail_uv(DetailUV p_detail_uv) {
-	if (detail_uv == p_detail_uv) {
-		return;
-	}
-
-	detail_uv = p_detail_uv;
-	_queue_shader_change();
-}
-
-BaseMaterial3D::DetailUV BaseMaterial3D::get_detail_uv() const {
-	return detail_uv;
 }
 
 void BaseMaterial3D::set_blend_mode(BlendMode p_mode) {
@@ -2583,9 +2573,6 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_point_size", "point_size"), &BaseMaterial3D::set_point_size);
 	ClassDB::bind_method(D_METHOD("get_point_size"), &BaseMaterial3D::get_point_size);
 
-	ClassDB::bind_method(D_METHOD("set_detail_uv", "detail_uv"), &BaseMaterial3D::set_detail_uv);
-	ClassDB::bind_method(D_METHOD("get_detail_uv"), &BaseMaterial3D::get_detail_uv);
-
 	ClassDB::bind_method(D_METHOD("set_blend_mode", "blend_mode"), &BaseMaterial3D::set_blend_mode);
 	ClassDB::bind_method(D_METHOD("get_blend_mode"), &BaseMaterial3D::get_blend_mode);
 
@@ -2712,6 +2699,9 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_distance_fade_min_distance", "distance"), &BaseMaterial3D::set_distance_fade_min_distance);
 	ClassDB::bind_method(D_METHOD("get_distance_fade_min_distance"), &BaseMaterial3D::get_distance_fade_min_distance);
 
+	ClassDB::bind_method(D_METHOD("set_texture_uv", "param", "texture_uv"), &BaseMaterial3D::set_texture_uv);
+	ClassDB::bind_method(D_METHOD("get_texture_uv", "param"), &BaseMaterial3D::get_texture_uv);
+
 	ADD_GROUP("Transparency", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transparency", PROPERTY_HINT_ENUM, "Disabled,Alpha,Alpha Scissor,Alpha Hash,Depth Pre-Pass"), "set_transparency", "get_transparency");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_scissor_threshold", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_alpha_scissor_threshold", "get_alpha_scissor_threshold");
@@ -2736,6 +2726,7 @@ void BaseMaterial3D::_bind_methods() {
 
 	ADD_GROUP("Albedo", "albedo_");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "albedo_color"), "set_albedo", "get_albedo");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "albedo_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "albedo_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "albedo_texture_force_srgb"), "set_flag", "get_flag", FLAG_ALBEDO_TEXTURE_FORCE_SRGB);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "albedo_texture_msdf"), "set_flag", "get_flag", FLAG_ALBEDO_TEXTURE_MSDF);
@@ -2746,11 +2737,13 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_GROUP("Metallic", "metallic_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "metallic", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_metallic", "get_metallic");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "metallic_specular", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_specular", "get_specular");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "metallic_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_METALLIC);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "metallic_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_METALLIC);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "metallic_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_metallic_texture_channel", "get_metallic_texture_channel");
 
 	ADD_GROUP("Roughness", "roughness_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "roughness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_roughness", "get_roughness");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "roughness_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_ROUGHNESS);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "roughness_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_ROUGHNESS);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "roughness_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_roughness_texture_channel", "get_roughness_texture_channel");
 
@@ -2761,12 +2754,13 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "emission_intensity", PROPERTY_HINT_RANGE, "0,100000.0,0.01,or_greater,suffix:nt"), "set_emission_intensity", "get_emission_intensity");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "emission_operator", PROPERTY_HINT_ENUM, "Add,Multiply"), "set_emission_operator", "get_emission_operator");
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "emission_on_uv2"), "set_flag", "get_flag", FLAG_EMISSION_ON_UV2);
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "emission_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_EMISSION);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "emission_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_EMISSION);
 
 	ADD_GROUP("Normal Map", "normal_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "normal_enabled"), "set_feature", "get_feature", FEATURE_NORMAL_MAPPING);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "normal_scale", PROPERTY_HINT_RANGE, "-16,16,0.01"), "set_normal_scale", "get_normal_scale");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "normal_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_NORMAL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_NORMAL);
 
 	ADD_GROUP("Rim", "rim_");
@@ -2789,8 +2783,8 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_GROUP("Ambient Occlusion", "ao_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_enabled"), "set_feature", "get_feature", FEATURE_AMBIENT_OCCLUSION);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ao_light_affect", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ao_light_affect", "get_ao_light_affect");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "ao_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_AMBIENT_OCCLUSION);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "ao_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_AMBIENT_OCCLUSION);
-	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "ao_on_uv2"), "set_flag", "get_flag", FLAG_AO_ON_UV2);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ao_texture_channel", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Gray"), "set_ao_texture_channel", "get_ao_texture_channel");
 
 	ADD_GROUP("Height", "heightmap_");
@@ -2832,7 +2826,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "detail_enabled"), "set_feature", "get_feature", FEATURE_DETAIL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_mask", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_MASK);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Subtract,Multiply"), "set_detail_blend_mode", "get_detail_blend_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_uv_layer", PROPERTY_HINT_ENUM, "UV1,UV2"), "set_detail_uv", "get_detail_uv");
+	ADD_PROPERTYI(PropertyInfo(Variant::INT, "detail_uv_index"), "set_texture_uv", "get_texture_uv", TEXTURE_DETAIL_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_albedo", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_normal", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture", TEXTURE_DETAIL_NORMAL);
 
@@ -2914,8 +2908,8 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC);
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_MAX);
 
-	BIND_ENUM_CONSTANT(DETAIL_UV_1);
-	BIND_ENUM_CONSTANT(DETAIL_UV_2);
+	BIND_ENUM_CONSTANT(TEXTURE_UV_1);
+	BIND_ENUM_CONSTANT(TEXTURE_UV_2);
 
 	BIND_ENUM_CONSTANT(TRANSPARENCY_DISABLED);
 	BIND_ENUM_CONSTANT(TRANSPARENCY_ALPHA);
@@ -2970,8 +2964,6 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_UV2_USE_TRIPLANAR);
 	BIND_ENUM_CONSTANT(FLAG_UV1_USE_WORLD_TRIPLANAR);
 	BIND_ENUM_CONSTANT(FLAG_UV2_USE_WORLD_TRIPLANAR);
-	BIND_ENUM_CONSTANT(FLAG_AO_ON_UV2);
-	BIND_ENUM_CONSTANT(FLAG_EMISSION_ON_UV2);
 	BIND_ENUM_CONSTANT(FLAG_ALBEDO_TEXTURE_FORCE_SRGB);
 	BIND_ENUM_CONSTANT(FLAG_DONT_RECEIVE_SHADOWS);
 	BIND_ENUM_CONSTANT(FLAG_DISABLE_AMBIENT_LIGHT);
@@ -3075,6 +3067,14 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_heightmap_deep_parallax_min_layers(8);
 	set_heightmap_deep_parallax_max_layers(32);
 	set_heightmap_deep_parallax_flip_tangent(false); //also sets binormal
+
+	set_texture_uv(TEXTURE_DETAIL_ALBEDO, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_ALBEDO, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_METALLIC, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_ROUGHNESS, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_AMBIENT_OCCLUSION, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_NORMAL, TEXTURE_UV_1);
+	set_texture_uv(TEXTURE_EMISSION, TEXTURE_UV_1);
 
 	flags[FLAG_ALBEDO_TEXTURE_MSDF] = false;
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -154,7 +154,6 @@ public:
 		TEXTURE_DETAIL_NORMAL,
 		TEXTURE_ORM,
 		TEXTURE_MAX
-
 	};
 
 	enum TextureFilter {
@@ -165,12 +164,6 @@ public:
 		TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC,
 		TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC,
 		TEXTURE_FILTER_MAX
-	};
-
-	enum DetailUV {
-		DETAIL_UV_1,
-		DETAIL_UV_2,
-		DETAIL_UV_MAX
 	};
 
 	enum Transparency {
@@ -245,8 +238,8 @@ public:
 		FLAG_UV2_USE_TRIPLANAR,
 		FLAG_UV1_USE_WORLD_TRIPLANAR,
 		FLAG_UV2_USE_WORLD_TRIPLANAR,
-		FLAG_AO_ON_UV2,
-		FLAG_EMISSION_ON_UV2,
+		_RESERVED_0,
+		_RESERVED_1,
 		FLAG_ALBEDO_TEXTURE_FORCE_SRGB,
 		FLAG_DONT_RECEIVE_SHADOWS,
 		FLAG_DISABLE_AMBIENT_LIGHT,
@@ -306,11 +299,16 @@ public:
 		DISTANCE_FADE_MAX
 	};
 
+	enum TextureUV {
+		TEXTURE_UV_1,
+		TEXTURE_UV_2,
+		TEXTURE_UV_MAX
+	};
+
 private:
 	struct MaterialKey {
 		// enum values
 		uint64_t texture_filter : get_num_bits(TEXTURE_FILTER_MAX - 1);
-		uint64_t detail_uv : get_num_bits(DETAIL_UV_MAX - 1);
 		uint64_t transparency : get_num_bits(TRANSPARENCY_MAX - 1);
 		uint64_t alpha_antialiasing_mode : get_num_bits(ALPHA_ANTIALIASING_MAX - 1);
 		uint64_t shading_mode : get_num_bits(SHADING_MODE_MAX - 1);
@@ -324,6 +322,13 @@ private:
 		uint64_t roughness_channel : get_num_bits(TEXTURE_CHANNEL_MAX - 1);
 		uint64_t emission_op : get_num_bits(EMISSION_OP_MAX - 1);
 		uint64_t distance_fade : get_num_bits(DISTANCE_FADE_MAX - 1);
+		uint64_t detail_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t albedo_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t metallic_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t roughness_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t normal_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t ambient_occlusion_uv : get_num_bits(TEXTURE_UV_MAX - 1);
+		uint64_t emissive_uv : get_num_bits(TEXTURE_UV_MAX - 1);
 		// booleans
 		uint64_t deep_parallax : 1;
 		uint64_t grow : 1;
@@ -364,7 +369,6 @@ private:
 	_FORCE_INLINE_ MaterialKey _compute_key() const {
 		MaterialKey mk;
 
-		mk.detail_uv = detail_uv;
 		mk.blend_mode = blend_mode;
 		mk.depth_draw_mode = depth_draw_mode;
 		mk.cull_mode = cull_mode;
@@ -380,6 +384,13 @@ private:
 		mk.grow = grow_enabled;
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
+		mk.detail_uv = texture_uvs[TEXTURE_DETAIL_ALBEDO];
+		mk.albedo_uv = texture_uvs[TEXTURE_ALBEDO];
+		mk.metallic_uv = texture_uvs[TEXTURE_METALLIC];
+		mk.roughness_uv = texture_uvs[TEXTURE_ROUGHNESS];
+		mk.normal_uv = texture_uvs[TEXTURE_NORMAL];
+		mk.ambient_occlusion_uv = texture_uvs[TEXTURE_AMBIENT_OCCLUSION];
+		mk.emissive_uv = texture_uvs[TEXTURE_EMISSION];
 		mk.emission_op = emission_op;
 		mk.alpha_antialiasing_mode = alpha_antialiasing_mode;
 		mk.orm = orm;
@@ -513,8 +524,6 @@ private:
 	Vector3 uv2_offset;
 	float uv2_triplanar_sharpness = 0.0f;
 
-	DetailUV detail_uv = DETAIL_UV_1;
-
 	bool deep_parallax = false;
 	int deep_parallax_min_layers = 0;
 	int deep_parallax_max_layers = 0;
@@ -551,6 +560,7 @@ private:
 	bool features[FEATURE_MAX] = {};
 
 	Ref<Texture2D> textures[TEXTURE_MAX];
+	TextureUV texture_uvs[TEXTURE_MAX];
 
 	_FORCE_INLINE_ void _validate_feature(const String &text, Feature feature, PropertyInfo &property) const;
 
@@ -565,6 +575,9 @@ protected:
 public:
 	void set_albedo(const Color &p_albedo);
 	Color get_albedo() const;
+
+	void set_texture_uv(TextureParam p_param, TextureUV p_texture_uv);
+	TextureUV get_texture_uv(TextureParam p_param) const;
 
 	void set_specular(float p_specular);
 	float get_specular() const;
@@ -655,9 +668,6 @@ public:
 
 	void set_shading_mode(ShadingMode p_shading_mode);
 	ShadingMode get_shading_mode() const;
-
-	void set_detail_uv(DetailUV p_detail_uv);
-	DetailUV get_detail_uv() const;
 
 	void set_blend_mode(BlendMode p_mode);
 	BlendMode get_blend_mode() const;
@@ -786,7 +796,6 @@ VARIANT_ENUM_CAST(BaseMaterial3D::TextureFilter)
 VARIANT_ENUM_CAST(BaseMaterial3D::ShadingMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::Transparency)
 VARIANT_ENUM_CAST(BaseMaterial3D::AlphaAntiAliasing)
-VARIANT_ENUM_CAST(BaseMaterial3D::DetailUV)
 VARIANT_ENUM_CAST(BaseMaterial3D::Feature)
 VARIANT_ENUM_CAST(BaseMaterial3D::BlendMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::DepthDrawMode)
@@ -798,6 +807,7 @@ VARIANT_ENUM_CAST(BaseMaterial3D::BillboardMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::TextureChannel)
 VARIANT_ENUM_CAST(BaseMaterial3D::EmissionOperator)
 VARIANT_ENUM_CAST(BaseMaterial3D::DistanceFadeMode)
+VARIANT_ENUM_CAST(BaseMaterial3D::TextureUV)
 
 class StandardMaterial3D : public BaseMaterial3D {
 	GDCLASS(StandardMaterial3D, BaseMaterial3D)


### PR DESCRIPTION
fixes #80858

The image below shows the current result of importing in 4.1.1-stable on the left for both SheenChair and a custom GLTF that uses UV2 for `baseColorTexture.texCoord`, and the result of doing the same with a build of Godot that includes my changes.

![godot_uv_fix](https://github.com/godotengine/godot/assets/99647234/50d71e78-e2e6-4030-831b-60c08ba364be)

I have added `texCoord` support for all 8 UV layers for albedo, metallic/roughness, normal, ambient occlusion, and emissive material textures. This required a breaking change in the way that alternative UV layers are specified for detail and AO textures.