### PR TITLE
Fix `TileMapEditorPlugin` crash where deleted tile_map accessed

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -347,14 +347,16 @@ void TileMapEditorPlugin::_notification(int p_notification) {
 }
 
 void TileMapEditorPlugin::edit(Object *p_object) {
-	if (tile_map) {
+	if (tile_map && ObjectDB::get_instance(tile_map_id)) {
 		tile_map->disconnect("changed", callable_mp(this, &TileMapEditorPlugin::_tile_map_changed));
 	}
 
 	tile_map = Object::cast_to<TileMap>(p_object);
+	tile_map_id = ObjectID();
 
 	editor->edit(tile_map);
 	if (tile_map) {
+		tile_map_id = tile_map->get_instance_id();
 		tile_map->connect("changed", callable_mp(this, &TileMapEditorPlugin::_tile_map_changed));
 
 		if (tile_map->get_tileset().is_valid()) {

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -116,6 +116,7 @@ class TileMapEditorPlugin : public EditorPlugin {
 	TileMapEditor *editor = nullptr;
 	Button *button = nullptr;
 	TileMap *tile_map = nullptr;
+	ObjectID tile_map_id;
 
 	bool tile_map_changed_needs_update = false;
 	ObjectID edited_tileset;


### PR DESCRIPTION
Store the ObjectID and check it is valid before access.

Fixes #80609

## Notes
* I'm not super familiar with this code so this is just a 2 minute example fix, it might be ok or something more in depth might be needed.
* There's a number of other ways of doing this, e.g. calling a signal in the plugin on `TileMap` deletion etc. 
* First mentioned in #80088 but worth a unique issue.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
