### PR TITLE
Clarify the behavior of CSGMesh using ArrayMesh

### DIFF
--- a/modules/csg/doc_classes/CSGMesh3D.xml
+++ b/modules/csg/doc_classes/CSGMesh3D.xml
@@ -16,7 +16,8 @@
 		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource to use as a CSG shape.
-			[b]Note:[/b] When using an [ArrayMesh], avoid meshes with vertex normals unless a flat shader is required. By default, CSGMesh will ignore the mesh's vertex normals and use a smooth shader calculated using the faces' normals. If a flat shader is required, ensure that all faces' vertex normals are parallel.
+			[b]Note:[/b] When using an [ArrayMesh], all vertex attributes except [constant Mesh.ARRAY_VERTEX], [constant Mesh.ARRAY_NORMAL] and [constant Mesh.ARRAY_TEX_UV] are left unused. Only [constant Mesh.ARRAY_VERTEX] and [constant Mesh.ARRAY_TEX_UV] will be passed to the GPU.
+			[constant Mesh.ARRAY_NORMAL] is only used to determine which faces require the use of flat shading. By default, CSGMesh will ignore the mesh's vertex normals, recalculate them for each vertex and use a smooth shader. If a flat shader is required for a face, ensure that all vertex normals of the face are approximately equal.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
The docs for CSGMesh/CSGMesh3D should say that it ignores all vertex attribute arrays of ArrayMesh except position, uv1 and normal. I tried to use per-vertex color in a shader only to realise that it is not even used when creating the brush.

Compatible with 3.x.

https://github.com/godotengine/godot/blob/9435c38b95407b668b88ed4a724b2b7e4ce8cd26/modules/csg/csg_shape.cpp#L740
https://github.com/godotengine/godot/blob/9435c38b95407b668b88ed4a724b2b7e4ce8cd26/modules/csg/csg_shape.cpp#L888-L889