### PR TITLE
SCons: Carry over the `windows_subsystem` setting to the generated vsproj

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -868,6 +868,9 @@ def generate_vs_project(env, num_jobs, project_name="godot"):
                 if env["custom_modules"]:
                     common_build_postfix.append("custom_modules=%s" % env["custom_modules"])
 
+                if env["windows_subsystem"] == "console":
+                    common_build_postfix.append("windows_subsystem=console")
+
                 if env["precision"] == "double":
                     common_build_postfix.append("precision=double")
 


### PR DESCRIPTION
Even if you specify the subsystem to be the console one, the vsproj doesn't carry over the setting, which makes working with this mode in the IDE a bit annoying since it'll regenerate the vsproj right afterwards. Since there's only two options and 'gui' is the default, we only carry over the 'console' setting.