### PR TITLE
Ensure the active window gains the keyboard focus

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2893,6 +2893,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 			if (wParam != WA_INACTIVE) {
 				track_mouse_leave_event(hWnd);
+
+				if (!IsIconic(hWnd)) {
+					SetFocus(hWnd);
+				}
 			}
 			return 0; // Return to the message loop.
 		} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #80470
The issue occurred when another window was about to minimize, the currently active window would become inactive temporarily and lose the keyboard focus, and then become active again after the minimizing was complete. However, the active window would not regain the keyboard focus automatically so it would not receive any `WM_CHAR` message.

My solution is based on this [documentation](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-activate#remarks). It mentions the `DefWindowProc` function sets the keyboard focus to the window being activated and not minimized. This mechanism is not found in the current implementation of `DisplayServerWindows::WndProc` function.