### PR TITLE
Assetlib: Fix long plugin names breaking the UI

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -63,6 +63,21 @@ void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, co
 	price->set_text(p_cost);
 }
 
+// TODO: Refactor this method to use the TextServer.
+void EditorAssetLibraryItem::clamp_width(int p_max_width) {
+	int text_pixel_width = title->get_button_font().ptr()->get_string_size(title->get_text()).x * EDSCALE;
+
+	String full_text = title->get_text();
+	title->set_tooltip_text(full_text);
+
+	if (text_pixel_width > p_max_width) {
+		// Truncate title text to within the current column width.
+		int max_length = p_max_width / (text_pixel_width / full_text.length());
+		String truncated_text = full_text.left(max_length - 3) + "...";
+		title->set_text(truncated_text);
+	}
+}
+
 void EditorAssetLibraryItem::set_image(int p_type, int p_index, const Ref<Texture2D> &p_image) {
 	ERR_FAIL_COND(p_type != EditorAssetLibrary::IMAGE_QUEUE_ICON);
 	ERR_FAIL_COND(p_index != 0);
@@ -1007,11 +1022,11 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	}
 
 	//do the mario
-	int from = p_page - 5;
+	int from = p_page - (5 / EDSCALE);
 	if (from < 0) {
 		from = 0;
 	}
-	int to = from + 10;
+	int to = from + (10 / EDSCALE);
 	if (to > p_page_count) {
 		to = p_page_count;
 	}
@@ -1278,6 +1293,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 				EditorAssetLibraryItem *item = memnew(EditorAssetLibraryItem);
 				asset_items->add_child(item);
 				item->configure(r["title"], r["asset_id"], category_map[r["category_id"]], r["category_id"], r["author"], r["author_id"], r["cost"]);
+				item->clamp_width(asset_items_column_width);
 				item->connect("asset_selected", callable_mp(this, &EditorAssetLibrary::_select_asset));
 				item->connect("author_selected", callable_mp(this, &EditorAssetLibrary::_select_author));
 				item->connect("category_selected", callable_mp(this, &EditorAssetLibrary::_select_category));
@@ -1412,6 +1428,8 @@ void EditorAssetLibrary::_update_asset_items_columns() {
 	if (new_columns != asset_items->get_columns()) {
 		asset_items->set_columns(new_columns);
 	}
+
+	asset_items_column_width = (get_size().x / new_columns) - (100 * EDSCALE);
 }
 
 void EditorAssetLibrary::disable_community_support() {

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -80,6 +80,8 @@ protected:
 public:
 	void configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost);
 
+	void clamp_width(int p_max_width);
+
 	EditorAssetLibraryItem();
 };
 
@@ -304,6 +306,8 @@ class EditorAssetLibrary : public PanelContainer {
 	void _support_toggled(int p_support);
 
 	void _install_external_asset(String p_zip_path, String p_title);
+
+	int asset_items_column_width = 0;
 
 	void _update_asset_items_columns();
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -129,6 +129,10 @@ LinkButton::UnderlineMode LinkButton::get_underline_mode() const {
 	return underline_mode;
 }
 
+Ref<Font> LinkButton::get_button_font() const {
+	return theme_cache.font;
+}
+
 void LinkButton::pressed() {
 	if (uri.is_empty()) {
 		return;

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -104,6 +104,8 @@ public:
 	void set_underline_mode(UnderlineMode p_underline_mode);
 	UnderlineMode get_underline_mode() const;
 
+	Ref<Font> get_button_font() const;
+
 	LinkButton(const String &p_text = String());
 };
 


### PR DESCRIPTION
Edit:
I think I have this fixed now.

Assets should have their titles truncated with an ellipsis to within the column width now, and I added a tooltip with the full asset title to the ones that get truncated, so that the user can still see the full title without opening the asset page.

I also changed the pagination from having 10 fixed page buttons to using the `EDSCALE` to dynamically choose a number of nav buttons to display so that it won't cause the horizontal overflow issue on large scales but will still show more page buttons on smaller scales.

It works on my machine at all scales up to 200%. At custom scales above 200% it starts to overflow again, but this happens regardless of the title and nav buttons. I tested this by truncating all titles to three characters and removing the nav buttons completely, and it still overflows at over 200% scale, so I think that is a separate issue and probably affects other parts of the engine UI as well.

I haven't written a unit test for this yet, but I can add one if needed. It will likely be next Saturday before I am able to get to it though.

Here are the updated screenshots:

<details>
<summary>
75% scale:
</summary>

![75percent](https://github.com/godotengine/godot/assets/35282898/75d5dc90-f9a2-4e39-9809-a3f606439d99)

</details>

<details>
<summary>
100% scale:
</summary>

![100percent](https://github.com/godotengine/godot/assets/35282898/03225be2-c910-42b0-bdea-c278433fe56d)

</details>

<details>
<summary>
125% scale:
</summary>

![125percent_top](https://github.com/godotengine/godot/assets/35282898/04d7c7a6-9a0f-415a-823c-0c462fe554e6)

![125percent_longtitle](https://github.com/godotengine/godot/assets/35282898/f3d819ae-c62f-4140-9406-51921f4a5ad0)

</details>

<details>
<summary>
150% scale:
</summary>

![150percent_top](https://github.com/godotengine/godot/assets/35282898/f3b390a5-70a5-4dd3-b552-3968cdabaee0)

![150percent_longtitle](https://github.com/godotengine/godot/assets/35282898/c2296b19-28ec-42f2-b629-86f02893d171)

</details>

<details>
<summary>
175% scale:
</summary>

![175percent_top](https://github.com/godotengine/godot/assets/35282898/c4a96993-b0cf-4a35-be6f-b074aecfda71)

![175percent_longtitle](https://github.com/godotengine/godot/assets/35282898/85023530-bdd1-4532-b6b0-c829276f3a3a)

</details>

<details>
<summary>
200% scale:
</summary>

![200percent_top](https://github.com/godotengine/godot/assets/35282898/e7a599ec-d391-4569-810e-106542824a80)

![200percent_longtitle](https://github.com/godotengine/godot/assets/35282898/aed0864a-3c8f-409c-b0a5-9791a9f385bd)

</details>

Original PR:
I removed the line that disables horizontal scrolling in the AssetLib plugin. This fixes the screen overflow issue on my machine, but I am not sure if this is an appropriate solution since there was probably a reason why scroll was disabled in the first place, and I was unable to reproduce the column alignment issues seen in the screenshots posted in #80507 on either the current master or 4.1.1 stable, so I think there may be something platform specific going on here.

My system:
- Linux version 6.4.8-arch1-1 (linux@archlinux) (gcc (GCC) 13.2.1 20230801, GNU ld (GNU Binutils) 2.41.0) Thu, 03 Aug 2023 16:02:01 +0000

Please advise if enabling horizontal scroll in the AssetLib is a problem, and I will look for another solution.

Additionally, I wanted to write a unit test for this that would basically just check that the editor window size didn't exceed the size of the screen, but I wasn't sure which classes to use for that, and I wanted to get feedback on this solution early, so I'm submitting this now, but if someone can point me in the right direction for where to look for methods related to overall editor window size and screen size, that would be much appreciated!

Here's some screenshots of the AssetLib on my local machine with this fix in place at different editor scales:
<details>
<summary>100%</summary>
<br/>

![assetlib_100percent](https://github.com/godotengine/godot/assets/35282898/63377e71-9c1b-45cd-ba21-c9211228a4ed)

</details>
<details>
<summary>125%</summary>
<br/>

![assetlib_125percent](https://github.com/godotengine/godot/assets/35282898/980aefee-e0c4-48be-82c6-3a0d815baad4)

</details>
<details>
<summary>150%</summary>
<br/>

![assetlib_150percent](https://github.com/godotengine/godot/assets/35282898/e0b87142-644a-4549-8689-18ff298f37a6)
</details>

<details>
<summary>175%</summary>
<br/>

![assetlib_175percent](https://github.com/godotengine/godot/assets/35282898/d997779c-b6b4-4764-8194-3f0204f8f1c2)

</details>
<details>
<summary>200%</summary>
<br/>

![assetlib_200percent](https://github.com/godotengine/godot/assets/35282898/995e27de-2013-4493-adf8-723d06cc4bff)

</details>

* *Bugsquad edit, fixes: #80507*