### PR TITLE
[3.x] Silence `Index track = N is out of bounds` error when deleting the last animation track

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1847,7 +1847,9 @@ void AnimationTrackEdit::_notification(int p_what) {
 		if (animation.is_null()) {
 			return;
 		}
-		ERR_FAIL_INDEX(track, animation->get_track_count());
+		if (track >= animation->get_track_count()) {
+			return;
+		}
 
 		type_icon = _get_key_type_icon();
 		selected_icon = get_icon("KeySelected", "EditorIcons");


### PR DESCRIPTION
Instead the method silently returns when the index is out of bounds.

* Fixes #79587 
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
