### PR TITLE
Add export setting to control whether to show the Godot app in the app library

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -110,6 +110,10 @@
 		<member name="package/show_in_android_tv" type="bool" setter="" getter="">
 			If [code]true[/code], this app will show in Android TV launcher UI.
 		</member>
+		<member name="package/show_in_app_library" type="bool" setter="" getter="">
+			If [code]true[/code], this app will show in the device's app library.
+			[b]Note:[/b] This is [code]true[/code] by default.
+		</member>
 		<member name="package/signed" type="bool" setter="" getter="">
 			If [code]true[/code], package signing is enabled.
 		</member>

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1838,6 +1838,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/exclude_from_recents"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_in_android_tv"), false));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_in_app_library"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_as_launcher_app"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, launcher_icon_option, PROPERTY_HINT_FILE, "*.png"), ""));

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -269,7 +269,12 @@ String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, con
 
 	manifest_activity_text += "            <intent-filter>\n"
 							  "                <action android:name=\"android.intent.action.MAIN\" />\n"
-							  "                <category android:name=\"android.intent.category.LAUNCHER\" />\n";
+							  "                <category android:name=\"android.intent.category.DEFAULT\" />\n";
+
+	bool show_in_app_library = p_preset->get("package/show_in_app_library");
+	if (show_in_app_library) {
+		manifest_activity_text += "                <category android:name=\"android.intent.category.LAUNCHER\" />\n";
+	}
 
 	bool uses_leanback_category = p_preset->get("package/show_in_android_tv");
 	if (uses_leanback_category) {
@@ -279,7 +284,6 @@ String _get_activity_tag(const Ref<EditorExportPlatform> &p_export_platform, con
 	bool uses_home_category = p_preset->get("package/show_as_launcher_app");
 	if (uses_home_category) {
 		manifest_activity_text += "                <category android:name=\"android.intent.category.HOME\" />\n";
-		manifest_activity_text += "                <category android:name=\"android.intent.category.DEFAULT\" />\n";
 	}
 
 	manifest_activity_text += "            </intent-filter>\n";

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -45,6 +45,7 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/pull/78958#issuecomment-1676128296

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
