### PR TITLE
Fixed editor filesystem/import properties not being caught by the doctool.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -477,6 +477,22 @@
 		<member name="filesystem/file_dialog/thumbnail_size" type="int" setter="" getter="">
 			The thumbnail size to use in the editor's file dialogs (in pixels). See also [member docks/filesystem/thumbnail_size].
 		</member>
+		<member name="filesystem/import/blender/blender3_path" type="String" setter="" getter="">
+			The path to the directory containing the Blender executable used for converting the Blender 3D scene files [code].blend[/code] to glTF 2.0 format during import. Blender 3.0 or later is required.
+			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/blender/enabled].
+		</member>
+		<member name="filesystem/import/blender/rpc_port" type="int" setter="" getter="">
+			The port number used for Remote Procedure Call (RPC) communication with Godot's created process of the blender executable.
+			Setting this to 0 effectively disables communication with Godot and the blender process, making performance slower.
+		</member>
+		<member name="filesystem/import/blender/rpc_server_uptime" type="float" setter="" getter="">
+			The maximum idle uptime (in seconds) of the Blender process.
+			This prevents Godot from having to create a new process for each import within the given seconds.
+		</member>
+		<member name="filesystem/import/fbx/fbx2gltf_path" type="String" setter="" getter="">
+			The path to the FBX2glTF executable used for converting Autodesk FBX 3D scene files [code].fbx[/code] to glTF 2.0 format during import.
+			To enable this feature for your specific project, use [member ProjectSettings.filesystem/import/fbx/enabled].
+		</member>
 		<member name="filesystem/on_save/compress_binary_resources" type="bool" setter="" getter="">
 			If [code]true[/code], uses lossless compression for binary resources.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -513,6 +513,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/file_dialog/display_mode", 0, "Thumbnails,List")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/file_dialog/thumbnail_size", 64, "32,128,16")
 
+	// Import (for glft module)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/import/blender/blender3_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_port", 6011, "0,65535,1", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_server_uptime", 5, "0,300,1,or_greater,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+
 	/* Docks */
 
 	// SceneTree

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -55,18 +55,7 @@ static void _editor_init() {
 	// Blend to glTF importer.
 
 	bool blend_enabled = GLOBAL_GET("filesystem/import/blender/enabled");
-	// Defined here because EditorSettings doesn't exist in `register_gltf_types` yet.
-	EDITOR_DEF_RST("filesystem/import/blender/rpc_port", 6011);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT,
-			"filesystem/import/blender/rpc_port", PROPERTY_HINT_RANGE, "0,65535,1"));
-
-	EDITOR_DEF_RST("filesystem/import/blender/rpc_server_uptime", 5);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT,
-			"filesystem/import/blender/rpc_server_uptime", PROPERTY_HINT_RANGE, "0,300,1,or_greater,suffix:s"));
-
-	String blender3_path = EDITOR_DEF_RST("filesystem/import/blender/blender3_path", "");
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,
-			"filesystem/import/blender/blender3_path", PROPERTY_HINT_GLOBAL_DIR));
+	String blender3_path = EDITOR_GET("filesystem/import/blender/blender3_path");
 	if (blend_enabled) {
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		if (blender3_path.is_empty()) {
@@ -89,10 +78,6 @@ static void _editor_init() {
 	// FBX to glTF importer.
 
 	bool fbx_enabled = GLOBAL_GET("filesystem/import/fbx/enabled");
-	// Defined here because EditorSettings doesn't exist in `register_gltf_types` yet.
-	String fbx2gltf_path = EDITOR_DEF_RST("filesystem/import/fbx/fbx2gltf_path", "");
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING,
-			"filesystem/import/fbx/fbx2gltf_path", PROPERTY_HINT_GLOBAL_FILE));
 	if (fbx_enabled) {
 		Ref<EditorSceneFormatImporterFBX> importer;
 		importer.instantiate();


### PR DESCRIPTION
So in this [issue](https://github.com/godotengine/godot/issues/63695) it was mentioned that some editor settings properties were not being caught by the doctool. And after running it myself, the properties for filesystem/import in the editor settings wouldn't show up in the docs.

I found a solution where adding the Editor Setting configs to the editor_settings.cpp and taking the now-not-needed editor setting configs out of modules/gltf/register_types.cpp fixes this issue after running the doctool now, hopefully in a preferred manner.

Addresses #63695

* *Bugsquad edit, fixes: #63695*