### PR TITLE
Core: Add `allow_objects`/`full_objects` parameter to text serialization

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -756,7 +756,7 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			// If we're loading a project.godot from source code, we can operate some
 			// ProjectSettings conversions if need be.
@@ -958,7 +958,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<Str
 			}
 
 			String vstr;
-			VariantWriter::write_to_string(value, vstr);
+			VariantWriter::write_to_string(value, vstr, nullptr, nullptr, true);
 			file->store_string(F.property_name_encode() + "=" + vstr + "\n");
 		}
 	}

--- a/core/io/config_file.compat.inc
+++ b/core/io/config_file.compat.inc
@@ -1,0 +1,79 @@
+/**************************************************************************/
+/*  config_file.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error ConfigFile::_save_bind_compat_80585(const String &p_path) {
+	return save(p_path, false);
+}
+
+Error ConfigFile::_load_bind_compat_80585(const String &p_path) {
+	return load(p_path, false);
+}
+
+Error ConfigFile::_parse_bind_compat_80585(const String &p_path) {
+	return parse(p_path, false);
+}
+
+String ConfigFile::_encode_to_text_bind_compat_80585() const {
+	return encode_to_text(false);
+}
+
+Error ConfigFile::_load_encrypted_bind_compat_80585(const String &p_path, const Vector<uint8_t> &p_key) {
+	return load_encrypted(p_path, p_key, false);
+}
+
+Error ConfigFile::_load_encrypted_pass_bind_compat_80585(const String &p_path, const String &p_pass) {
+	return load_encrypted_pass(p_path, p_pass, false);
+}
+
+Error ConfigFile::_save_encrypted_bind_compat_80585(const String &p_path, const Vector<uint8_t> &p_key) {
+	return save_encrypted(p_path, p_key, false);
+}
+
+Error ConfigFile::_save_encrypted_pass_bind_compat_80585(const String &p_path, const String &p_pass) {
+	return save_encrypted_pass(p_path, p_pass, false);
+}
+
+void ConfigFile::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save", "path"), &ConfigFile::_save_bind_compat_80585);
+	ClassDB::bind_compatibility_method(D_METHOD("load", "path"), &ConfigFile::_load_bind_compat_80585);
+	ClassDB::bind_compatibility_method(D_METHOD("parse", "data"), &ConfigFile::_parse_bind_compat_80585);
+
+	ClassDB::bind_compatibility_method(D_METHOD("encode_to_text"), &ConfigFile::_encode_to_text_bind_compat_80585);
+
+	ClassDB::bind_compatibility_method(D_METHOD("load_encrypted", "path", "key"), &ConfigFile::_load_encrypted_bind_compat_80585);
+	ClassDB::bind_compatibility_method(D_METHOD("load_encrypted_pass", "path", "password"), &ConfigFile::_load_encrypted_pass_bind_compat_80585);
+
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::_save_encrypted_bind_compat_80585);
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::_save_encrypted_pass_bind_compat_80585);
+}
+
+#endif

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -43,13 +43,29 @@ class ConfigFile : public RefCounted {
 
 	PackedStringArray _get_sections() const;
 	PackedStringArray _get_section_keys(const String &p_section) const;
-	Error _internal_load(const String &p_path, Ref<FileAccess> f);
-	Error _internal_save(Ref<FileAccess> file);
+	Error _internal_load(const String &p_path, Ref<FileAccess> f, bool p_allow_objects);
+	Error _internal_save(Ref<FileAccess> file, bool p_full_objects);
 
-	Error _parse(const String &p_path, VariantParser::Stream *p_stream);
+	Error _parse(const String &p_path, VariantParser::Stream *p_stream, bool p_allow_objects);
 
 protected:
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	Error _save_bind_compat_80585(const String &p_path);
+	Error _load_bind_compat_80585(const String &p_path);
+	Error _parse_bind_compat_80585(const String &p_path);
+
+	String _encode_to_text_bind_compat_80585() const;
+
+	Error _load_encrypted_bind_compat_80585(const String &p_path, const Vector<uint8_t> &p_key);
+	Error _load_encrypted_pass_bind_compat_80585(const String &p_path, const String &p_pass);
+
+	Error _save_encrypted_bind_compat_80585(const String &p_path, const Vector<uint8_t> &p_key);
+	Error _save_encrypted_pass_bind_compat_80585(const String &p_path, const String &p_pass);
+
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
@@ -64,19 +80,19 @@ public:
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);
 
-	Error save(const String &p_path);
-	Error load(const String &p_path);
-	Error parse(const String &p_data);
+	Error save(const String &p_path, bool p_full_objects = false);
+	Error load(const String &p_path, bool p_allow_objects = false);
+	Error parse(const String &p_data, bool p_allow_objects = false);
 
-	String encode_to_text() const; // used by exporter
+	String encode_to_text(bool p_full_objects = false) const;
 
 	void clear();
 
-	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
-	Error load_encrypted_pass(const String &p_path, const String &p_pass);
+	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_allow_objects = false);
+	Error load_encrypted_pass(const String &p_path, const String &p_pass, bool p_allow_objects = false);
 
-	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
-	Error save_encrypted_pass(const String &p_path, const String &p_pass);
+	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key, bool p_full_objects = false);
+	Error save_encrypted_pass(const String &p_path, const String &p_pass, bool p_full_objects = false);
 };
 
 #endif // CONFIG_FILE_H

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -69,7 +69,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			return OK;
 		} else if (err != OK) {
@@ -296,7 +296,7 @@ void ResourceFormatImporter::get_internal_resource_path_list(const String &p_pat
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			return;
 		} else if (err != OK) {
@@ -493,12 +493,12 @@ void ResourceImporter::_bind_methods() {
 Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
-	Error err = cf->load(p_path + ".import");
+	Error err = cf->load(p_path + ".import", true);
 	if (err != OK) {
 		return err;
 	}
 	cf->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(p_uid));
-	cf->save(p_path + ".import");
+	cf->save(p_path + ".import", true);
 
 	return OK;
 }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -949,7 +949,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 				next_tag.fields.clear();
 				next_tag.name = String();
 
-				err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+				err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 				if (err == ERR_FILE_EOF) {
 					break;
 				} else if (err != OK) {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3644,7 +3644,7 @@ void Variant::construct_from_string(const String &p_string, Variant &r_value, Ob
 
 String Variant::get_construct_string() const {
 	String vars;
-	VariantWriter::write_to_string(*this, vars);
+	VariantWriter::write_to_string(*this, vars, nullptr, nullptr, true);
 
 	return vars;
 }

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -142,17 +142,17 @@ private:
 	template <class T>
 	static Error _parse_construct(Stream *p_stream, Vector<T> &r_construct, int &line, String &r_err_str);
 	static Error _parse_enginecfg(Stream *p_stream, Vector<String> &strings, int &line, String &r_err_str);
-	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
-	static Error _parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
-	static Error _parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
+	static Error _parse_dictionary(Dictionary &object, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
+	static Error _parse_array(Array &array, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
+	static Error _parse_tag(Token &token, Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
 
 public:
-	static Error parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
-	static Error parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false);
+	static Error parse_tag(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
+	static Error parse_tag_assign_eof(Stream *p_stream, int &line, String &r_err_str, Tag &r_tag, String &r_assign, Variant &r_value, ResourceParser *p_res_parser = nullptr, bool p_simple_tag = false, bool p_allow_objects = false);
 
-	static Error parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr);
+	static Error parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
 	static Error get_token(Stream *p_stream, Token &r_token, int &line, String &r_err_str);
-	static Error parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser = nullptr);
+	static Error parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser = nullptr, bool p_allow_objects = false);
 };
 
 class VariantWriter {
@@ -160,8 +160,8 @@ public:
 	typedef Error (*StoreStringFunc)(void *ud, const String &p_string);
 	typedef String (*EncodeResourceFunc)(void *ud, const Ref<Resource> &p_resource);
 
-	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0);
-	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr);
+	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0, bool p_full_objects = false);
+	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr, bool p_full_objects = false);
 };
 
 #endif // VARIANT_PARSER_H

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1114,7 +1114,13 @@ void VariantUtilityFunctions::push_warning(const Variant **p_args, int p_arg_cou
 
 String VariantUtilityFunctions::var_to_str(const Variant &p_var) {
 	String vars;
-	VariantWriter::write_to_string(p_var, vars);
+	VariantWriter::write_to_string(p_var, vars, nullptr, nullptr, false);
+	return vars;
+}
+
+String VariantUtilityFunctions::var_to_str_with_objects(const Variant &p_var) {
+	String vars;
+	VariantWriter::write_to_string(p_var, vars, nullptr, nullptr, true);
 	return vars;
 }
 
@@ -1123,9 +1129,27 @@ Variant VariantUtilityFunctions::str_to_var(const String &p_var) {
 	ss.s = p_var;
 
 	String errs;
-	int line;
+	int line = 1;
 	Variant ret;
-	(void)VariantParser::parse(&ss, ret, errs, line);
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, false);
+	if (err != OK) {
+		ERR_PRINT("Parse error at line " + itos(line) + ": " + errs + ".");
+	}
+
+	return ret;
+}
+
+Variant VariantUtilityFunctions::str_to_var_with_objects(const String &p_var) {
+	VariantParser::StreamString ss;
+	ss.s = p_var;
+
+	String errs;
+	int line = 1;
+	Variant ret;
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, true);
+	if (err != OK) {
+		ERR_PRINT("Parse error at line " + itos(line) + ": " + errs + ".");
+	}
 
 	return ret;
 }
@@ -1809,6 +1833,9 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(var_to_str, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(str_to_var, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+
+	FUNCBINDR(var_to_str_with_objects, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
+	FUNCBINDR(str_to_var_with_objects, sarray("string"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 
 	FUNCBINDR(var_to_bytes, sarray("variable"), Variant::UTILITY_FUNC_TYPE_GENERAL);
 	FUNCBINDR(bytes_to_var, sarray("bytes"), Variant::UTILITY_FUNC_TYPE_GENERAL);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -142,7 +142,9 @@ struct VariantUtilityFunctions {
 	static void push_error(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static void push_warning(const Variant **p_args, int p_arg_count, Callable::CallError &r_error);
 	static String var_to_str(const Variant &p_var);
+	static String var_to_str_with_objects(const Variant &p_var);
 	static Variant str_to_var(const String &p_var);
+	static Variant str_to_var_with_objects(const String &p_var);
 	static PackedByteArray var_to_bytes(const Variant &p_var);
 	static PackedByteArray var_to_bytes_with_objects(const Variant &p_var);
 	static Variant bytes_to_var(const PackedByteArray &p_arr);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1340,7 +1340,8 @@
 			<return type="Variant" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Converts a formatted [param string] that was returned by [method var_to_str] to the original [Variant].
+				Converts a formatted [param string] that was returned by [method var_to_str] to the equivalent [Variant], without decoding objects.
+				[b]Note:[/b] If you need object deserialization, see [method str_to_var_with_objects].
 				[codeblocks]
 				[gdscript]
 				var data = '{ "a": 1, "b": 2 }' # data is a String
@@ -1353,6 +1354,14 @@
 				GD.Print(dict["a"]);                              // Prints 1
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="str_to_var_with_objects">
+			<return type="Variant" />
+			<param index="0" name="string" type="String" />
+			<description>
+				Converts a formatted [param string] that was returned by [method var_to_str_with_objects] to the equivalent [Variant]. Decoding objects is allowed.
+				[b]Warning:[/b] Deserialized object can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats (remote code execution).
 			</description>
 		</method>
 		<method name="tan">
@@ -1444,7 +1453,8 @@
 			<return type="String" />
 			<param index="0" name="variable" type="Variant" />
 			<description>
-				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var].
+				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var], without encoding objects.
+				[b]Note:[/b] If you need object serialization, see [method var_to_str_with_objects].
 				[codeblocks]
 				[gdscript]
 				var a = { "a": 1, "b": 2 }
@@ -1463,6 +1473,13 @@
 				}
 				[/codeblock]
 				[b]Note:[/b] Converting [Signal] or [Callable] is not supported and will result in an empty value for these types, regardless of their data.
+			</description>
+		</method>
+		<method name="var_to_str_with_objects">
+			<return type="String" />
+			<param index="0" name="variable" type="Variant" />
+			<description>
+				Converts a [Variant] [param variable] to a formatted [String] that can then be parsed using [method str_to_var_with_objects]. Encoding objects is allowed (and can potentially include executable code).
 			</description>
 		</method>
 		<method name="weakref">

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -100,8 +100,11 @@
 		</method>
 		<method name="encode_to_text" qualifiers="const">
 			<return type="String" />
+			<param index="0" name="full_objects" type="bool" default="false" />
 			<description>
-				Obtain the text version of this config file (the same text that would be written to a file).
+				Obtain the text version of this config file (the same text that would be written to a file). If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] and [method @GlobalScope.var_to_str_with_objects] methods.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 		<method name="erase_section">
@@ -161,61 +164,74 @@
 			<returns_error number="0"/>
 			<returns_error number="12"/>
 			<param index="0" name="path" type="String" />
+			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
+				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.str_to_var] and [method @GlobalScope.str_to_var_with_objects] methods.
+				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
 		<method name="load_encrypted">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="allow_objects" type="bool" default="false" />
 			<description>
 				Loads the encrypted config file specified as a parameter, using the provided [param key] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method load] for details.
 			</description>
 		</method>
 		<method name="load_encrypted_pass">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
+			<param index="2" name="allow_objects" type="bool" default="false" />
 			<description>
 				Loads the encrypted config file specified as a parameter, using the provided [param password] to decrypt it. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method load] for details.
 			</description>
 		</method>
 		<method name="parse">
 			<return type="int" enum="Error" />
 			<param index="0" name="data" type="String" />
+			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Parses the passed string as the contents of a config file. The string is parsed and loaded in the ConfigFile object which the method was called on.
+				Parses the passed string as the contents of a config file. The string is parsed and loaded in the ConfigFile object which the method was called on. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.str_to_var] and [method @GlobalScope.str_to_var_with_objects] methods.
+				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure.
+				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] and [method @GlobalScope.var_to_str_with_objects] method.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 		<method name="save_encrypted">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="full_objects" type="bool" default="false" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method save] for details.
 			</description>
 		</method>
 		<method name="save_encrypted_pass">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
+			<param index="2" name="full_objects" type="bool" default="false" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
-				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				See [method save] for details.
 			</description>
 		</method>
 		<method name="set_value">

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -273,7 +273,7 @@
 			<param index="0" name="allow_objects" type="bool" default="false" />
 			<description>
 				Returns the next [Variant] value from the file. If [param allow_objects] is [code]true[/code], decoding objects is allowed.
-				Internally, this uses the same decoding mechanism as the [method @GlobalScope.bytes_to_var] method.
+				Internally, this uses the same decoding mechanism as the [method @GlobalScope.bytes_to_var] and [method @GlobalScope.bytes_to_var_with_objects] methods.
 				[b]Warning:[/b] Deserialized objects can contain code which gets executed. Do not use this option if the serialized object comes from untrusted sources to avoid potential security threats such as remote code execution.
 			</description>
 		</method>
@@ -499,8 +499,8 @@
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
 				Stores any Variant value in the file. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
-				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] method.
-				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object._get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags.
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] and [method @GlobalScope.var_to_bytes_with_objects] methods.
+				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add an usage flag to a property by overriding the [method Object._validate_property] method in your class. In GDScript you can also use the [annotation @GDScript.@export] annotation. See [enum PropertyUsageFlags] for the possible usage flags.
 			</description>
 		</method>
 	</methods>

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -58,7 +58,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 			// Todo the modified times of remapped files should most likely be kept in EditorFileSystem to speed this up in the future.
 			Ref<ConfigFile> cf;
 			cf.instantiate();
-			Error err = cf->load(f + ".import");
+			Error err = cf->load(f + ".import", true);
 
 			ERR_CONTINUE(err != OK);
 			{

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -404,7 +404,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 		if (err == ERR_FILE_EOF) {
 			break;
 		} else if (err != OK) {
@@ -472,7 +472,7 @@ bool EditorFileSystem::_test_for_reimport(const String &p_path, bool p_only_impo
 		next_tag.fields.clear();
 		next_tag.name = String();
 
-		err = VariantParser::parse_tag_assign_eof(&md5_stream, lines, error_text, next_tag, assign, value, nullptr, true);
+		err = VariantParser::parse_tag_assign_eof(&md5_stream, lines, error_text, next_tag, assign, value, nullptr, true, true);
 
 		if (err == ERR_FILE_EOF) {
 			break;
@@ -1832,7 +1832,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 	for (int i = 0; i < p_files.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(p_files[i] + ".import");
+		Error err = config->load(p_files[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 		ERR_CONTINUE(!config->has_section_key("remap", "importer"));
 		String file_importer_name = config->get_value("remap", "importer");
@@ -1959,7 +1959,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 					v = source_file_options[file][base];
 				}
 				String value;
-				VariantWriter::write_to_string(v, value);
+				VariantWriter::write_to_string(v, value, nullptr, nullptr, true);
 				f->store_line(base + "=" + value);
 			}
 		}
@@ -2040,7 +2040,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		//use existing
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		Error err = cf->load(p_file + ".import");
+		Error err = cf->load(p_file + ".import", true);
 		if (err == OK) {
 			if (cf->has_section("params")) {
 				List<String> sk;
@@ -2222,7 +2222,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		for (const ResourceImporter::ImportOption &E : opts) {
 			String base = E.option.name;
 			String value;
-			VariantWriter::write_to_string(params[base], value);
+			VariantWriter::write_to_string(params[base], value, nullptr, nullptr, true);
 			f->store_line(base + "=" + value);
 		}
 	}
@@ -2495,7 +2495,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 			Ref<ConfigFile> config;
 			config.instantiate();
 			String path = efd->get_file_path(i) + ".import";
-			Error err = config->load(path);
+			Error err = config->load(path, true);
 			if (err != OK) {
 				continue;
 			}
@@ -2513,7 +2513,7 @@ void EditorFileSystem::_move_group_files(EditorFileSystemDirectory *efd, const S
 				}
 			}
 
-			config->save(path);
+			config->save(path, true);
 		}
 	}
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -308,7 +308,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 	// Pass the debugger stop shortcut to the running instance(s).
 	String shortcut;
-	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut);
+	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut, nullptr, nullptr, true);
 	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
 
 	if (OS::get_singleton()->is_stdout_verbose()) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1134,7 +1134,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 				Ref<ConfigFile> config;
 				config.instantiate();
-				err = config->load(path + ".import");
+				err = config->load(path + ".import", true);
 				if (err != OK) {
 					ERR_PRINT("Could not parse: '" + path + "', not exported.");
 					continue;
@@ -1156,7 +1156,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				config->erase_section("deps");
 				config->erase_section("params");
 
-				String import_text = config->encode_to_text();
+				String import_text = config->encode_to_text(true);
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());
@@ -1176,7 +1176,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				// File is imported and not customized, replace by what it imports.
 				Ref<ConfigFile> config;
 				config.instantiate();
-				err = config->load(path + ".import");
+				err = config->load(path + ".import", true);
 				if (err != OK) {
 					ERR_PRINT("Could not parse: '" + path + "', not exported.");
 					continue;
@@ -1243,7 +1243,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				config->erase_section("deps");
 				config->erase_section("params");
 
-				String import_text = config->encode_to_text();
+				String import_text = config->encode_to_text(true);
 				CharString cs = import_text.utf8();
 				Vector<uint8_t> sarr;
 				sarr.resize(cs.size());

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1149,7 +1149,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 		if (FileAccess::exists(fpath + ".import")) {
 			Ref<ConfigFile> config;
 			config.instantiate();
-			Error err = config->load(fpath + ".import");
+			Error err = config->load(fpath + ".import", true);
 			if (err == OK) {
 				if (config->has_section_key("remap", "importer")) {
 					String importer = config->get_value("remap", "importer");
@@ -1463,9 +1463,9 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 			// Remove uid from .import file to avoid conflict.
 			Ref<ConfigFile> cfg;
 			cfg.instantiate();
-			cfg->load(old_path + ".import");
+			cfg->load(old_path + ".import", true);
 			cfg->erase_section_key("remap", "uid");
-			err = cfg->save(new_path + ".import");
+			err = cfg->save(new_path + ".import", true);
 			if (err != OK) {
 				EditorNode::get_singleton()->add_io_error(TTR("Error duplicating:") + "\n" + old_path + ".import: " + error_names[err] + "\n");
 				return;
@@ -3537,7 +3537,7 @@ void FileSystemDock::_update_import_dock() {
 		const String &fpath = efiles[i];
 		Ref<ConfigFile> cf;
 		cf.instantiate();
-		Error err = cf->load(fpath + ".import");
+		Error err = cf->load(fpath + ".import", true);
 		if (err != OK) {
 			imports.clear();
 			break;

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -630,7 +630,7 @@ void SceneImportSettingsDialog::open_settings(const String &p_path, bool p_for_a
 
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(p_path + ".import");
+		Error err = config->load(p_path + ".import", true);
 		if (err == OK) {
 			List<String> keys;
 			config->get_section_keys("params", &keys);

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -427,7 +427,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 	if (stream.is_valid()) {
 		Ref<ConfigFile> config_file;
 		config_file.instantiate();
-		Error err = config_file->load(p_path + ".import");
+		Error err = config_file->load(p_path + ".import", true);
 		updating_settings = true;
 		if (err == OK) {
 			double bpm = config_file->get_value("params", "bpm", 0);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1135,7 +1135,7 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	config.instantiate();
 	ERR_FAIL_NULL(config);
 
-	Error err = config->load(p_path + ".import");
+	Error err = config->load(p_path + ".import", true);
 	print_verbose("Loading import settings:");
 	if (err == OK) {
 		List<String> keys;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -103,7 +103,7 @@ void ResourceImporterTexture::update_imports() {
 			cf.instantiate();
 			String src_path = String(E.key) + ".import";
 
-			Error err = cf->load(src_path);
+			Error err = cf->load(src_path, true);
 			ERR_CONTINUE(err != OK);
 
 			bool changed = false;
@@ -150,7 +150,7 @@ void ResourceImporterTexture::update_imports() {
 			}
 
 			if (changed) {
-				cf->save(src_path);
+				cf->save(src_path, true);
 				to_reimport.push_back(E.key);
 			}
 		}

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -101,7 +101,7 @@ ImportDock *ImportDock::singleton = nullptr;
 void ImportDock::set_edit_path(const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
-	Error err = config->load(p_path + ".import");
+	Error err = config->load(p_path + ".import", true);
 	if (err != OK) {
 		clear();
 		return;
@@ -210,7 +210,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 		Ref<ConfigFile> config;
 		config.instantiate();
 		extensions.insert(p_paths[i].get_extension());
-		Error err = config->load(p_paths[i] + ".import");
+		Error err = config->load(p_paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		if (i == 0) {
@@ -381,7 +381,7 @@ void ImportDock::_importer_selected(int i_idx) {
 		if (params->paths.size()) {
 			String path = params->paths[0];
 			config.instantiate();
-			Error err = config->load(path + ".import");
+			Error err = config->load(path + ".import", true);
 			if (err != OK) {
 				config.unref();
 			}
@@ -494,7 +494,7 @@ void ImportDock::_reimport_attempt() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(params->paths[i] + ".import");
+		Error err = config->load(params->paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		String imported_with = config->get_value("remap", "importer");
@@ -569,7 +569,7 @@ void ImportDock::_reimport() {
 	for (int i = 0; i < params->paths.size(); i++) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(params->paths[i] + ".import");
+		Error err = config->load(params->paths[i] + ".import", true);
 		ERR_CONTINUE(err != OK);
 
 		if (params->importer.is_valid()) {
@@ -613,7 +613,7 @@ void ImportDock::_reimport() {
 			config->set_value("remap", "importer", "keep");
 		}
 
-		config->save(params->paths[i] + ".import");
+		config->save(params->paths[i] + ".import", true);
 	}
 
 	EditorFileSystem::get_singleton()->reimport_files(params->paths);

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -150,7 +150,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 
 		config.instantiate();
 		if (FileAccess::exists(p_path + ".import")) {
-			config->load(p_path + ".import");
+			config->load(p_path + ".import", true);
 		}
 
 		config->set_value("remap", "importer", "3d_texture");
@@ -163,7 +163,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 		config->set_value("params", "slices/horizontal", 1);
 		config->set_value("params", "slices/vertical", bake_img->get_meta("depth"));
 
-		config->save(p_path + ".import");
+		config->save(p_path + ".import", true);
 
 		Error err = bake_img->save_exr(p_path, false);
 		ERR_FAIL_COND(err);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -793,7 +793,7 @@ void ProjectManager::_apply_project_tags() {
 
 	ConfigFile cfg;
 	const String project_godot = project_list->get_selected_projects()[0].path.path_join("project.godot");
-	Error err = cfg.load(project_godot);
+	Error err = cfg.load(project_godot, true);
 	if (err != OK) {
 		tag_edit_error->set_text(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err));
 		tag_edit_error->show();
@@ -802,7 +802,7 @@ void ProjectManager::_apply_project_tags() {
 	} else {
 		tags.sort();
 		cfg.set_value("application", "config/tags", tags);
-		err = cfg.save(project_godot);
+		err = cfg.save(project_godot, true);
 		if (err != OK) {
 			tag_edit_error->set_text(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err));
 			tag_edit_error->show();

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -440,12 +440,12 @@ void ProjectDialog::ok_pressed() {
 		// Load project.godot as ConfigFile to set the new name.
 		ConfigFile cfg;
 		String project_godot = dir2.path_join("project.godot");
-		Error err = cfg.load(project_godot);
+		Error err = cfg.load(project_godot, true);
 		if (err != OK) {
 			_set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
 		} else {
 			cfg.set_value("application", "config/name", project_name->get_text().strip_edges());
-			err = cfg.save(project_godot);
+			err = cfg.save(project_godot, true);
 			if (err != OK) {
 				_set_message(vformat(TTR("Couldn't save project at '%s' (error %d)."), project_godot, err), MESSAGE_ERROR);
 			}
@@ -691,7 +691,7 @@ void ProjectDialog::show_dialog() {
 		// Fetch current name from project.godot to prefill the text input.
 		ConfigFile cfg;
 		String project_godot = project_path->get_text().path_join("project.godot");
-		Error err = cfg.load(project_godot);
+		Error err = cfg.load(project_godot, true);
 		if (err != OK) {
 			_set_message(vformat(TTR("Couldn't load project at '%s' (error %d). It may be missing or corrupted."), project_godot, err), MESSAGE_ERROR);
 			status_rect->show();

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -384,7 +384,7 @@ ProjectList::Item ProjectList::load_project_data(const String &p_path, bool p_fa
 	bool missing = false;
 
 	Ref<ConfigFile> cf = memnew(ConfigFile);
-	Error cf_err = cf->load(conf);
+	Error cf_err = cf->load(conf, true);
 
 	int config_version = 0;
 	String project_name = TTR("Unnamed Project");

--- a/editor/surface_upgrade_tool.cpp
+++ b/editor/surface_upgrade_tool.cpp
@@ -141,7 +141,7 @@ void SurfaceUpgradeTool::finish_upgrade() {
 	for (const String &file_path : reimport_paths) {
 		Ref<ConfigFile> config;
 		config.instantiate();
-		Error err = config->load(file_path);
+		Error err = config->load(file_path, true);
 		if (err != OK) {
 			ERR_PRINT("Could not open " + file_path + " for upgrade.");
 			continue;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2395,7 +2395,7 @@ Error Main::setup2() {
 						next_tag.fields.clear();
 						next_tag.name = String();
 
-						err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, true);
+						err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, true, true);
 						if (err == ERR_FILE_EOF) {
 							break;
 						}

--- a/misc/extension_api_validation/4.1-stable_4.2-stable.expected
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable.expected
@@ -98,7 +98,6 @@ Added optional arguments. Compatibility method registered.
 
 GH-80852
 --------
-
 Validate extension JSON: API was removed: classes/GDScriptEditorTranslationParserPlugin
 Validate extension JSON: API was removed: classes/GDScriptNativeClass
 Validate extension JSON: API was removed: classes/GodotPhysicsServer2D
@@ -117,7 +116,6 @@ Excluded unexposed classes from extension_api.json.
 
 GH-79311
 --------
-
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_color
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_count
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_height
@@ -287,6 +285,7 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_ge
 Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/commit/arguments/1': meta changed value in new API, from "uint32" to "uint64".
 
 Surface format was increased to 64 bits from 32 bits. Compatibility methods registered.
+
 
 GH-79527
 --------

--- a/misc/extension_api_validation/4.2-stable.expected
+++ b/misc/extension_api_validation/4.2-stable.expected
@@ -73,3 +73,17 @@ GH-87668
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 8 to 9.
 
 Added optional "baseline_offset" argument. Compatibility method registered.
+
+
+GH-80585
+--------
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load_encrypted/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/load_encrypted_pass/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/parse/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted_pass/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/ConfigFile/methods/encode_to_text': arguments
+
+Added optional argument. Compatibility method registered. Behavior compatibility broken for security and consistency with binary serialization. Object encoding/decoding is now disabled by default.

--- a/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/metatypes.gd
@@ -12,7 +12,7 @@ var test_class := MyClass
 var test_enum := MyEnum
 
 func check_gdscript_native_class(value: Variant) -> void:
-	print(var_to_str(value).get_slice(",", 0).trim_prefix("Object("))
+	print(var_to_str_with_objects(value).get_slice(",", 0).trim_prefix("Object("))
 
 func check_gdscript(value: GDScript) -> void:
 	print(value.get_class())

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3227,7 +3227,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 			if (FileAccess::exists(file_path + ".import")) {
 				Ref<ConfigFile> config;
 				config.instantiate();
-				config->load(file_path + ".import");
+				config->load(file_path + ".import", true);
 				if (config->has_section_key("remap", "generator_parameters")) {
 					generator_parameters = (Dictionary)config->get_value("remap", "generator_parameters");
 				}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -536,12 +536,12 @@ namespace Godot.NativeInterop
 
         internal static partial void godotsharp_weakref(IntPtr p_obj, out godot_ref r_weak_ref);
 
-        internal static partial void godotsharp_str_to_var(in godot_string p_str, out godot_variant r_ret);
+        internal static partial void godotsharp_str_to_var(in godot_string p_str, godot_bool p_allow_objects, out godot_variant r_ret);
 
         internal static partial void godotsharp_var_to_bytes(in godot_variant p_what, godot_bool p_full_objects,
             out godot_packed_byte_array r_bytes);
 
-        internal static partial void godotsharp_var_to_str(in godot_variant p_var, out godot_string r_ret);
+        internal static partial void godotsharp_var_to_str(in godot_variant p_var, godot_bool p_full_objects, out godot_string r_ret);
 
         internal static partial void godotsharp_err_print_error(in godot_string p_function, in godot_string p_file, int p_line, in godot_string p_error, in godot_string p_message = default, godot_bool p_editor_notify = godot_bool.False, godot_error_handler_type p_type = godot_error_handler_type.ERR_HANDLER_ERROR);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1334,21 +1334,21 @@ void godotsharp_err_print_error(const godot_string *p_function, const godot_stri
 			p_editor_notify, p_type);
 }
 
-void godotsharp_var_to_str(const godot_variant *p_var, godot_string *r_ret) {
+void godotsharp_var_to_str(const godot_variant *p_var, bool p_full_objects, godot_string *r_ret) {
 	const Variant &var = *reinterpret_cast<const Variant *>(p_var);
 	String &vars = *memnew_placement(r_ret, String);
-	VariantWriter::write_to_string(var, vars);
+	VariantWriter::write_to_string(var, vars, nullptr, nullptr, p_full_objects);
 }
 
-void godotsharp_str_to_var(const godot_string *p_str, godot_variant *r_ret) {
+void godotsharp_str_to_var(const godot_string *p_str, bool p_allow_objects, godot_variant *r_ret) {
 	Variant ret;
 
 	VariantParser::StreamString ss;
 	ss.s = *reinterpret_cast<const String *>(p_str);
 
 	String errs;
-	int line;
-	Error err = VariantParser::parse(&ss, ret, errs, line);
+	int line = 1;
+	Error err = VariantParser::parse(&ss, ret, errs, line, nullptr, p_allow_objects);
 	if (err != OK) {
 		String err_str = "Parse error at line " + itos(line) + ": " + errs + ".";
 		ERR_PRINT(err_str);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1106,7 +1106,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			config.instantiate();
 
 			if (FileAccess::exists(texture_path + ".import")) {
-				config->load(texture_path + ".import");
+				config->load(texture_path + ".import", true);
 			}
 
 			config->set_value("remap", "importer", "2d_array_texture");
@@ -1120,7 +1120,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			config->set_value("params", "slices/horizontal", 1);
 			config->set_value("params", "slices/vertical", texture_slice_count);
 
-			config->save(texture_path + ".import");
+			config->save(texture_path + ".import", true);
 
 			Error err = texture_image->save_exr(texture_path, false);
 			ERR_FAIL_COND_V(err, BAKE_ERROR_CANT_CREATE_IMAGE);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1584,7 +1584,7 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 				String errs;
 				int line;
-				VariantParser::parse(&ss, shortcut_var, errs, line);
+				VariantParser::parse(&ss, shortcut_var, errs, line, nullptr, true);
 				debugger_stop_shortcut = shortcut_var;
 			}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -275,7 +275,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				String assign;
 				Variant value;
 
-				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &parser);
+				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &parser, false, true);
 
 				if (error) {
 					if (error == ERR_FILE_MISSING_DEPENDENCIES) {
@@ -358,7 +358,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 					unbinds,
 					bind_ints);
 
-			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser);
+			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -381,7 +381,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			packed_scene->get_state()->add_editable_instance(path.simplified());
 
-			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser);
+			error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &parser, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -476,7 +476,7 @@ Error ResourceLoaderText::load() {
 			}
 		}
 
-		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (error) {
 			_printerr();
@@ -589,7 +589,7 @@ Error ResourceLoaderText::load() {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp, false, true);
 
 			if (error) {
 				_printerr();
@@ -702,7 +702,7 @@ Error ResourceLoaderText::load() {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp, false, true);
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
@@ -885,7 +885,7 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 
 		p_dependencies->push_back(path);
 
-		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err) {
 			print_line(error_text + " - " + itos(lines));
@@ -910,7 +910,7 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 	uint64_t tag_end = f->get_position();
 
 	while (true) {
-		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		Error err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err != OK) {
 			error = ERR_FILE_CORRUPT;
@@ -1039,7 +1039,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	resource_current = 0;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		error = err;
@@ -1094,7 +1094,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	}
 
 	if (!p_skip_first_tag) {
-		err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
+		err = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp, false, true);
 
 		if (err) {
 			error_text = "Unexpected end of file";
@@ -1205,7 +1205,7 @@ Error ResourceLoaderText::save_as_binary(const String &p_path) {
 		dummy_read.external_resources[dr] = lindex;
 		dummy_read.rev_external_resources[id] = dr;
 
-		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new);
+		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new, false, true);
 
 		if (error) {
 			_printerr();
@@ -1288,7 +1288,7 @@ Error ResourceLoaderText::save_as_binary(const String &p_path) {
 				String assign;
 				Variant value;
 
-				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new);
+				error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, false, true);
 
 				if (error) {
 					if (main_res && error == ERR_FILE_EOF) {
@@ -1415,7 +1415,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 	rp_new.userdata = &dummy_read;
 
 	while (next_tag.name == "ext_resource") {
-		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new);
+		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new, false, true);
 
 		if (error) {
 			_printerr();
@@ -1442,7 +1442,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, false, true);
 
 			if (error) {
 				if (error == ERR_FILE_EOF) {
@@ -1490,7 +1490,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			String assign;
 			Variant value;
 
-			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new);
+			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp_new, false, true);
 
 			if (error) {
 				if (error == ERR_FILE_MISSING_DEPENDENCIES) {
@@ -1531,7 +1531,7 @@ String ResourceLoaderText::recognize_script_class(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -1569,7 +1569,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -1613,7 +1613,7 @@ ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 	ignore_resource_parsing = true;
 
 	VariantParser::Tag tag;
-	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag, nullptr, false, true);
 
 	if (err) {
 		_printerr();
@@ -2194,7 +2194,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 				}
 
 				String vars;
-				VariantWriter::write_to_string(value, vars, _write_resources, this);
+				VariantWriter::write_to_string(value, vars, _write_resources, this, true);
 				f->store_string(name.property_name_encode() + " = " + vars + "\n");
 			}
 		}
@@ -2258,14 +2258,14 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			if (!instance_placeholder.is_empty()) {
 				String vars;
 				f->store_string(" instance_placeholder=");
-				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this);
+				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this, true);
 				f->store_string(vars);
 			}
 
 			if (instance.is_valid()) {
 				String vars;
 				f->store_string(" instance=");
-				VariantWriter::write_to_string(instance, vars, _write_resources, this);
+				VariantWriter::write_to_string(instance, vars, _write_resources, this, true);
 				f->store_string(vars);
 			}
 
@@ -2273,7 +2273,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
 				String vars;
-				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this);
+				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this, true);
 
 				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
 			}
@@ -2307,7 +2307,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			f->store_string(connstr);
 			if (binds.size()) {
 				String vars;
-				VariantWriter::write_to_string(binds, vars, _write_resources, this);
+				VariantWriter::write_to_string(binds, vars, _write_resources, this, true);
 				f->store_string(" binds= " + vars);
 			}
 

--- a/tests/core/io/test_config_file.h
+++ b/tests/core/io/test_config_file.h
@@ -115,6 +115,27 @@ antialiasing = false ; Duplicate key.
 			"The configuration file shouldn't parse successfully.");
 }
 
+TEST_CASE("[ConfigFile] Parsing object") {
+	const String config_source = R"(
+[test]
+
+test=Object(RefCounted,"script":null)
+)";
+	ConfigFile config_file;
+
+	ERR_PRINT_OFF;
+	Error error = config_file.parse(config_source);
+	ERR_PRINT_ON;
+
+	CHECK(error == ERR_UNAUTHORIZED);
+	CHECK(!config_file.has_section_key("test", "test"));
+
+	error = config_file.parse(config_source, true);
+
+	CHECK(error == OK);
+	CHECK(config_file.get_value("test", "test").get_type() == Variant::OBJECT);
+}
+
 TEST_CASE("[ConfigFile] Saving file") {
 	ConfigFile config_file;
 	config_file.set_value("player", "name", "Unnamed Player");


### PR DESCRIPTION
This PR adds the `allow_objects`/`full_objects` parameter to the `VariantParser`/`VariantWriter` internal API that is used for the `str_to_var()`/`var_to_str()` functions and `ConfigFile` methods.

I think security reason enough to break compatibility in this case. Let me know if you think compatibility is more important and we should provide users with an insecure API by default, even if it's inconsistent with binary serialization.

![](https://github.com/godotengine/godot/assets/47700418/4255b6ae-41fe-45ed-a85d-659a99cbfad8)

* Closes #80562
* See also godotengine/godot-proposals#4925.

_Production edit: closes godotengine/godot-roadmap#69_