### PR TITLE
Check if any global script class is shadowed by a variable

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5036,7 +5036,11 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "built-in function");
 			return;
 		} else if (ClassDB::class_exists(name)) {
-			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global class");
+			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "native class");
+			return;
+		} else if (ScriptServer::is_global_class(name)) {
+			String class_path = ScriptServer::get_global_class_path(name).get_file();
+			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, vformat(R"(global class defined in "%s")", class_path));
 			return;
 		} else if (GDScriptParser::get_builtin_type(name) != Variant::VARIANT_MAX) {
 			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "built-in type");

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.gd
@@ -1,3 +1,5 @@
+class_name ShadowedClass
+
 var member: int = 0
 
 var print_debug := 'print_debug'
@@ -12,5 +14,6 @@ func test():
 	var sqrt := 'sqrt'
 	var member := 'member'
 	var reference := 'reference'
+	var ShadowedClass := 'ShadowedClass'
 
 	print('warn')

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowning.out
@@ -1,30 +1,34 @@
 GDTEST_OK
 >> WARNING
->> Line: 3
+>> Line: 5
 >> SHADOWED_GLOBAL_IDENTIFIER
 >> The variable "print_debug" has the same name as a built-in function.
 >> WARNING
->> Line: 9
+>> Line: 11
 >> SHADOWED_GLOBAL_IDENTIFIER
 >> The variable "Array" has the same name as a built-in type.
 >> WARNING
->> Line: 10
+>> Line: 12
 >> SHADOWED_GLOBAL_IDENTIFIER
->> The variable "Node" has the same name as a global class.
+>> The variable "Node" has the same name as a native class.
 >> WARNING
->> Line: 11
+>> Line: 13
 >> SHADOWED_GLOBAL_IDENTIFIER
 >> The variable "is_same" has the same name as a built-in function.
 >> WARNING
->> Line: 12
+>> Line: 14
 >> SHADOWED_GLOBAL_IDENTIFIER
 >> The variable "sqrt" has the same name as a built-in function.
 >> WARNING
->> Line: 13
+>> Line: 15
 >> SHADOWED_VARIABLE
->> The local variable "member" is shadowing an already-declared variable at line 1.
+>> The local variable "member" is shadowing an already-declared variable at line 3.
 >> WARNING
->> Line: 14
+>> Line: 16
 >> SHADOWED_VARIABLE_BASE_CLASS
 >> The local variable "reference" is shadowing an already-declared method at the base class "RefCounted".
+>> WARNING
+>> Line: 17
+>> SHADOWED_GLOBAL_IDENTIFIER
+>> The variable "ShadowedClass" has the same name as a global class defined in "shadowning.gd".
 warn


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Related to #80003

* *Bugsquad edit, fixes: #80003*