### PR TITLE
Fix version check for GDExtension

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -607,12 +607,13 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 	}
 
 	bool compatible = true;
-	if (VERSION_MAJOR < compatibility_minimum[0]) {
-		compatible = false;
-	} else if (VERSION_MINOR < compatibility_minimum[1]) {
-		compatible = false;
-	} else if (VERSION_PATCH < compatibility_minimum[2]) {
-		compatible = false;
+	// Check version lexicographically.
+	if (VERSION_MAJOR != compatibility_minimum[0]) {
+		compatible = VERSION_MAJOR > compatibility_minimum[0];
+	} else if (VERSION_MINOR != compatibility_minimum[1]) {
+		compatible = VERSION_MINOR > compatibility_minimum[1];
+	} else {
+		compatible = VERSION_PATCH >= compatibility_minimum[2];
 	}
 	if (!compatible) {
 		if (r_error) {


### PR DESCRIPTION
The version check only checks individual entries, not lexicographical comparison, this would cause a plugin requiring at least "4.1.1" to fail if you are on "4.2.0"

(Not technically needed for 4.1 as the condition won't be true there)

Could alternatively be written as:
```cpp
if (VERSION_MAJOR != compatibility_minimum[0]) {
	compatible = VERSION_MAJOR > compatibility_minimum[0];
} else if (VERSION_MINOR != compatibility_minimum[1]) {
	compatible = VERSION_MINOR > compatibility_minimum[1];
} else {
	compatible = VERSION_PATCH >= compatibility_minimum[2];
}
```

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
