### PR TITLE
Add `getFromFS()` functionality for the web platform

### DIFF
--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -227,6 +227,18 @@ const Engine = (function () {
 			},
 
 			/**
+			 * Get a buffer from the instance's file system at the specified ``path``
+			 * @param {string} path The location where the file is got
+			 * @returns {ArrayBuffer | null} The content of the file, or `null` if no file were found
+			 */
+			getFromFS: function (path) {
+				if (this.rtenv == null) {
+					throw new Error('Engine must be inited before getting files');
+				}
+				return this.rtenv['getFromFS'](path);
+			},
+
+			/**
 			 * Request that the current instance quit.
 			 *
 			 * This is akin the user pressing the close button in the window manager, and will
@@ -247,6 +259,7 @@ const Engine = (function () {
 		Engine.prototype['start'] = Engine.prototype.start;
 		Engine.prototype['startGame'] = Engine.prototype.startGame;
 		Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
+		Engine.prototype['getFromFS'] = Engine.prototype.getFromFS;
 		Engine.prototype['requestQuit'] = Engine.prototype.requestQuit;
 		// Also expose static methods as instance methods
 		Engine.prototype['load'] = Engine.load;

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -110,6 +110,7 @@ const GodotFS = {
 	$GodotFS__postset: [
 		'Module["initFS"] = GodotFS.init;',
 		'Module["copyToFS"] = GodotFS.copy_to_fs;',
+		'Module["getFromFS"] = GodotFS.get_from_fs;',
 	].join(''),
 	$GodotFS: {
 		// ERRNO_CODES works every odd version of emscripten, but this will break too eventually.
@@ -218,6 +219,20 @@ const GodotFS = {
 				FS.mkdirTree(dir);
 			}
 			FS.writeFile(path, new Uint8Array(buffer));
+		},
+
+		/**
+		 * Gets the buffer of a file from the internal file system.
+		 * @param {string} path Path to get file from
+		 * @returns {Uint8Array | null} `Uint8Array` if it found the file, `null` if an error occurred
+		 */
+		get_from_fs: function (path) {
+			try {
+				const array = FS.readFile(path, { encoding: 'binary' });
+				return array.buffer;
+			} catch (e) {
+				return null;
+			}
 		},
 	},
 };


### PR DESCRIPTION
Currently, it is possible to use `copyToFS()` to copy files to the loaded virtual file system. But it is currently impossible to read from that virtual file system.

As emscripten uses an `indexeddb` database for cache purposes, we cannot be certain that the files currently residing in the virtual file system are the ones that have been uploaded by `copyToFS()`.

`getFromFS()` intends to fix that. With that function, you are able to query a file from the file system.

It is not only useful, but essential to get generated files by a game or by the editor.