### PR TITLE
Support other input methods on Popup/Dialogs' `_input_from_window`

### DIFF
--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -38,8 +38,7 @@
 // AcceptDialog
 
 void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
-	Ref<InputEventKey> key = p_event;
-	if (close_on_escape && key.is_valid() && key->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+	if (close_on_escape && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
 		_cancel_pressed();
 	}
 }

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -35,8 +35,7 @@
 #include "scene/gui/panel.h"
 
 void Popup::_input_from_window(const Ref<InputEvent> &p_event) {
-	Ref<InputEventKey> key = p_event;
-	if (get_flag(FLAG_POPUP) && key.is_valid() && key->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+	if (get_flag(FLAG_POPUP) && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
 		_close_pressed();
 	}
 }


### PR DESCRIPTION
The Popup/Dialog's `_input_from_window` callback was only listening for keyboard events. Therefore, other input methods (like game controllers) couldn't be used, notably for closing windows.

Fixes #80425 