### PR TITLE
make non-editor builds less verbose by moving messages for resources …

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -480,8 +480,13 @@ RWLock ResourceCache::path_cache_lock;
 
 void ResourceCache::clear() {
 	if (resources.size()) {
+#ifdef TOOLS_ENABLED
 		ERR_PRINT("Resources still in use at exit (run with --verbose for details).");
+#endif
 		if (OS::get_singleton()->is_stdout_verbose()) {
+#ifndef TOOLS_ENABLED
+			ERR_PRINT("Resources still in use at exit.");
+#endif
 			for (const KeyValue<String, Resource *> &E : resources) {
 				print_line(vformat("Resource still in use: %s (%s)", E.key, E.value->get_class()));
 			}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2046,8 +2046,13 @@ void ObjectDB::cleanup() {
 	if (slot_count > 0) {
 		spin_lock.lock();
 
+#ifdef TOOLS_ENABLED
 		WARN_PRINT("ObjectDB instances leaked at exit (run with --verbose for details).");
+#endif
 		if (OS::get_singleton()->is_stdout_verbose()) {
+#ifndef TOOLS_ENABLED
+			WARN_PRINT("ObjectDB instances leaked at exit.");
+#endif
 			// Ensure calling the native classes because if a leaked instance has a script
 			// that overrides any of those methods, it'd not be OK to call them at this point,
 			// now the scripting languages have already been terminated.


### PR DESCRIPTION
…still in use and ObjectDB instances leak at exit to print only when verbose

In non-editor builds like for export templates, these messages are not actionable for normal use case of export templates especially. Therefore "hide" them behind `--verbose`. Leave them in place for editor builds where those are more useful.

Very similar patches can be applied to 3.x for core/object.cpp and core/resource.cpp if desired.
