### PR TITLE
Fix crash on exit where `TileSet` calls destroyed `TileSetAtlasSourceEditor`

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2655,6 +2655,12 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 TileSetAtlasSourceEditor::~TileSetAtlasSourceEditor() {
 	memdelete(tile_proxy_object);
 	memdelete(atlas_source_proxy_object);
+
+	// Remove listener for old objects, so the TileSet doesn't
+	// try to call the destroyed TileSetAtlasSourceEditor.
+	if (tile_set.is_valid()) {
+		tile_set->disconnect_changed(callable_mp(this, &TileSetAtlasSourceEditor::_tile_set_changed));
+	}
 }
 
 ////// EditorPropertyTilePolygon //////


### PR DESCRIPTION
Removes signal from `TileSet` on destroying `TileSetAtlasSourceEditor`, to prevent `TileSet` calling function in destroyed `TileSetAtlasSourceEditor`.

Fixes #80088

## Notes
* See linked issue for more description of the problem.
* I'm not very familiar with master or these classes, but this fixes the crash.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
