### PR TITLE
docs: Fix link to two's complement wiki page

### DIFF
--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -390,7 +390,7 @@
 		<operator name="operator ~">
 			<return type="int" />
 			<description>
-				Performs the bitwise [code]NOT[/code] operation on the [int]. Due to [url=https://en.wikipedia.org/wiki/Two%27s_complement/]2's complement[/url], it's effectively equal to [code]-(int + 1)[/code].
+				Performs the bitwise [code]NOT[/code] operation on the [int]. Due to [url=https://en.wikipedia.org/wiki/Two%27s_complement]2's complement[/url], it's effectively equal to [code]-(int + 1)[/code].
 				[codeblock]
 				print(~4) # Prints -5
 				print(~(-7)) # Prints 6


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
**PR Summary**:
The PR simply fixes the link to the two's complement wiki page (there was an extra `/` at the end of the url, leading to broken link).
