### PR TITLE
Fix `TileMapEditorPlugin` crash by storing tilemap ID instead of pointer

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -325,6 +325,7 @@ void TileMapEditorPlugin::_tile_map_changed() {
 }
 
 void TileMapEditorPlugin::_update_tile_map() {
+	TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 	if (tile_map) {
 		Ref<TileSet> tile_set = tile_map->get_tileset();
 		if (tile_set.is_valid() && edited_tileset != tile_set->get_instance_id()) {
@@ -347,11 +348,17 @@ void TileMapEditorPlugin::_notification(int p_notification) {
 }
 
 void TileMapEditorPlugin::edit(Object *p_object) {
+	TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 	if (tile_map) {
 		tile_map->disconnect("changed", callable_mp(this, &TileMapEditorPlugin::_tile_map_changed));
 	}
 
 	tile_map = Object::cast_to<TileMap>(p_object);
+	if (tile_map) {
+		tile_map_id = tile_map->get_instance_id();
+	} else {
+		tile_map_id = ObjectID();
+	}
 
 	editor->edit(tile_map);
 	if (tile_map) {

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -115,7 +115,7 @@ class TileMapEditorPlugin : public EditorPlugin {
 
 	TileMapEditor *editor = nullptr;
 	Button *button = nullptr;
-	TileMap *tile_map = nullptr;
+	ObjectID tile_map_id;
 
 	bool tile_map_changed_needs_update = false;
 	ObjectID edited_tileset;


### PR DESCRIPTION
Store the tilemap ObjectID instead of raw pointer, and check it is valid before access.

Fixes #80609 
Alternative to #80537

## Notes
* Stores `ObjectID` for all accesses rather than raw pointer
* Ref counting would have also maybe worked for this, but I don't think `Nodes` are ref counted.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
