### PR TITLE
SCons: Disable C++ exception handling

### DIFF
--- a/modules/denoise/SCsub
+++ b/modules/denoise/SCsub
@@ -109,6 +109,15 @@ env_oidn.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds
 
 env_thirdparty = env_oidn.Clone()
 env_thirdparty.disable_warnings()
+
+if env["disable_exceptions"]:
+    # OIDN hard-requires exceptions, so we re-enable them here.
+    if env.msvc and ("_HAS_EXCEPTIONS", 0) in env_thirdparty["CPPDEFINES"]:
+        env_thirdparty["CPPDEFINES"].remove(("_HAS_EXCEPTIONS", 0))
+        env_thirdparty.AppendUnique(CCFLAGS=["/EHsc"])
+    elif not env.msvc and "-fno-exceptions" in env_thirdparty["CCFLAGS"]:
+        env_thirdparty["CCFLAGS"].remove("-fno-exceptions")
+
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -52,10 +52,11 @@ if env["builtin_openxr"]:
 
     env_thirdparty = env_openxr.Clone()
     env_thirdparty.disable_warnings()
-    env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
 
-    if "-fno-exceptions" in env_thirdparty["CXXFLAGS"]:
-        env_thirdparty["CXXFLAGS"].remove("-fno-exceptions")
+    env_thirdparty.AppendUnique(CPPDEFINES=["DISABLE_STD_FILESYSTEM"])
+    if env["disable_exceptions"]:
+        env_thirdparty.AppendUnique(CPPDEFINES=["XRLOADER_DISABLE_EXCEPTION_HANDLING", ("JSON_USE_EXCEPTION", 0)])
+
     env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
 
     # add in external jsoncpp dependency

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -170,10 +170,6 @@ def configure(env: "Environment"):
     env["RANLIB"] = compiler_path + "/llvm-ranlib"
     env["AS"] = compiler_path + "/clang"
 
-    # Disable exceptions on template builds
-    if not env.editor_build:
-        env.Append(CXXFLAGS=["-fno-exceptions"])
-
     env.Append(
         CCFLAGS=(
             "-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing".split()

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -30,7 +30,6 @@ def get_opts():
         ),
         ("IOS_SDK_PATH", "Path to the iOS SDK", ""),
         BoolVariable("ios_simulator", "Build for iOS Simulator", False),
-        BoolVariable("ios_exceptions", "Enable exceptions", False),
         ("ios_triple", "Triple for ios toolchain", ""),
     ]
 
@@ -137,11 +136,6 @@ def configure(env: "Environment"):
         )
         env.Append(ASFLAGS=["-arch", "arm64"])
         env.Append(CPPDEFINES=["NEED_LONG_INT"])
-
-    if env["ios_exceptions"]:
-        env.Append(CCFLAGS=["-fexceptions"])
-    else:
-        env.Append(CCFLAGS=["-fno-exceptions"])
 
     # Temp fix for ABS/MAX/MIN macros in iOS SDK blocking compilation
     env.Append(CCFLAGS=["-Wno-ambiguous-macro"])

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -97,12 +97,9 @@ def configure(env: "Environment"):
     if env["use_assertions"]:
         env.Append(LINKFLAGS=["-s", "ASSERTIONS=1"])
 
-    if env.editor_build:
-        if env["initial_memory"] < 64:
-            print('Note: Forcing "initial_memory=64" as it is required for the web editor.')
-            env["initial_memory"] = 64
-    else:
-        env.Append(CPPFLAGS=["-fno-exceptions"])
+    if env.editor_build and env["initial_memory"] < 64:
+        print('Note: Forcing "initial_memory=64" as it is required for the web editor.')
+        env["initial_memory"] = 64
 
     env.Append(LINKFLAGS=["-s", "INITIAL_MEMORY=%sMB" % env["initial_memory"]])
 

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -13,10 +13,8 @@ env_tests = env.Clone()
 if env_tests["platform"] == "windows":
     env_tests.Append(CPPDEFINES=[("DOCTEST_THREAD_LOCAL", "")])
 
-# Increase number of addressable sections in object files
-# due to doctest's heavy use of templates and macros.
-if env_tests.msvc:
-    env_tests.Append(CCFLAGS=["/bigobj"])
+if env["disable_exceptions"]:
+    env_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
 
 env_tests.add_source_files(env.tests_sources, "*.cpp")
 

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -262,9 +262,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 
 		for (const Rect2i &rect : rects) {
 			Ref<Image> img = memnew(Image(img_width, img_height, false, Image::FORMAT_RGBA8));
-			CHECK_NOTHROW_MESSAGE(
-					img->fill_rect(rect, Color(1, 1, 1, 1)),
-					"fill_rect() shouldn't throw for any rect.");
+			img->fill_rect(rect, Color(1, 1, 1, 1));
 			for (int y = 0; y < img->get_height(); y++) {
 				for (int x = 0; x < img->get_width(); x++) {
 					if (rect.abs().has_point(Point2(x, y))) {
@@ -317,7 +315,7 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 	// Pre-multiply Alpha then Convert from RGBA to L8, checking alpha
 	{
 		Ref<Image> gray_image = memnew(Image(3, 3, false, Image::FORMAT_RGBA8));
-		CHECK_NOTHROW_MESSAGE(gray_image->fill_rect(Rect2i(0, 0, 3, 3), Color(1, 1, 1, 0)), "fill_rect() shouldn't throw for any rect.");
+		gray_image->fill_rect(Rect2i(0, 0, 3, 3), Color(1, 1, 1, 0));
 		gray_image->set_pixel(1, 1, Color(1, 1, 1, 1));
 		gray_image->set_pixel(1, 2, Color(0.5, 0.5, 0.5, 0.5));
 		gray_image->set_pixel(2, 1, Color(0.25, 0.05, 0.5, 1.0));

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -226,7 +226,7 @@ TEST_CASE("[SceneTree][Viewport] Controls and InputEvent handling") {
 
 	SUBCASE("[Viewport][GuiInputEvent] nullptr as argument doesn't lead to a crash.") {
 		ERR_PRINT_OFF;
-		CHECK_NOTHROW(root->push_input(nullptr));
+		root->push_input(nullptr);
 		ERR_PRINT_ON;
 	}
 


### PR DESCRIPTION
Upon investigating the extremely slow MSVC build times in #80513, I noticed that while Godot policy is to never use exceptions, we weren't enforcing it with compiler flags, and thus still included exception handling code and stack unwinding.

This is wasteful on multiple aspects:

- Binary size: Around 20% binary size reduction with exceptions disabled for both MSVC and GCC binaries.
- Compile time:
  * More than 50% build time reduction with MSVC.
  * 10% to 25% build time reduction with GCC + LTO.
- Performance: Possibly, needs to be benchmarked.

Since users may want to re-enable exceptions in their own thirdparty code or the libraries they compile with Godot, this behavior can be toggled with the `disable_exceptions` SCons option, which defaults to true.

Alternative to #80516.
Fixes #80513.

Could be considered for a `4.1` cherry-pick, but this will require significant testing to make sure it behaves as expected, and it may be a welcome but surprising change for existing 4.1.x users, so we might opt for not including it.

----

## Test builds

**Edit:** New test builds for all platforms made with the official buildsystem: https://downloads.tuxfamily.org/godotengine/testing/4.2-dev-pr80612/

To help validate this PR, I've done some builds of the before and after states (from this PR, so on top of 0308422f461dce11339896249e23ff02d978bfa0), for Linux (GCC on our official buildsystem) and Windows (VS 2022 on my laptop, unsigned).

You'll find zips here:
https://downloads.tuxfamily.org/godotengine/testing/4.2.dev.no-exceptions/

#### Linux builds

```
-rwxr-xr-x. 1 akien akien 116M Aug 14 13:11 godot.linuxbsd.editor.x86_64.exceptions-with-oidn
-rwxr-xr-x. 1 akien akien 110M Aug 14 11:02 godot.linuxbsd.editor.x86_64.exceptions-without-oidn
-rwxr-xr-x. 1 akien akien  97M Aug 14 13:11 godot.linuxbsd.editor.x86_64.no-exceptions-with-oidn
-rwxr-xr-x. 1 akien akien  90M Aug 14 11:02 godot.linuxbsd.editor.x86_64.no-exceptions-without-oidn
-rwxr-xr-x. 1 akien akien  68M Aug 14 13:11 godot.linuxbsd.template_release.x86_64.exceptions
-rwxr-xr-x. 1 akien akien  57M Aug 14 13:11 godot.linuxbsd.template_release.x86_64.no-exceptions
```

`exceptions` are the same as we currently use for official builds, and `no-exceptions` use the new option to disable exception handling.

OIDN is special cased as I couldn't disable exception handling for it yet, so the `with-oidn` builds actually still have exceptions enabled for OIDN's build environment only. `without-oidn` builds were made with `module_denoise_enabled=no`. It's an editor-only dependency so it doesn't affect the template build.

I didn't include the `without-oidn` builds in the above ZIPs to save your bandwidth, I mostly build them to see the impact on size and build time.

These builds were made on the official buildsystem with the same options as official releases, so with full optimizations and LTO enabled (`scons p=linuxbsd target=editor warnings=no production=yes`)

#### Windows builds

```
-rwxr-xr-x 1 Remi 197121 118M Aug 14 11:17 godot.windows.editor.x86_64.exceptions.exe*
-rwxr-xr-x 1 Remi 197121 101M Aug 14 13:50 godot.windows.editor.x86_64.no-exceptions.exe*
-rwxr-xr-x 1 Remi 197121  54M Aug 14 12:17 godot.windows.template_release.x86_64.exceptions.exe*
-rwxr-xr-x 1 Remi 197121  51M Aug 14 11:52 godot.windows.template_release.x86_64.no-exceptions.exe*
```

## Impact on size

As seen above, for Linux builds with GCC 10, we get a 16% size reduction for the editor build (or said otherwise, enabling exceptions added 20% size), and a similar ratio for the release template.

With LTO disabled, both build types are around 3M bigger, so the ratio doesn't change much.

Dev build: 758M to 736M on Linux, so 3% size reduction. Less than I expected.

On Windows, there's a similar 15% size reduction for the editor build, and only 5% size reduction for the release template (but it was already significantly smaller than the Linux one, now they have a comparable size).

## Impact on compile time

#### Linux with GCC 10

**Production builds with LTO enabled.**

`scons p=linuxbsd target=editor warnings=no production=yes`

```
==> ../logs/godot-editor-exceptions-with-oidn.log <==
[Time elapsed: 00:09:19.461]

==> ../logs/godot-editor-exceptions-without-oidn.log <==
[Time elapsed: 00:09:09.282]

==> ../logs/godot-editor-no-exceptions-with-oidn.log <==
[Time elapsed: 00:08:51.862]

==> ../logs/godot-editor-no-exceptions-without-oidn.log <==
[Time elapsed: 00:07:55.473]

==> ../logs/godot-template_release-exceptions.log <==
[Time elapsed: 00:06:10.944]

==> ../logs/godot-template_release-no-exceptions.log <==
[Time elapsed: 00:04:34.993]
```

The differences aren't huge, because LTO still takes a while, and it seems like having to compile OIDN with exceptions enabled adds a whole minute to the build time.

If we compare the builds without OIDN, there's a 13% build time reduction for the editor, and a 26% build time reduction for the release template.

**Builds without LTO enabled.**

`no-lto` is `scons p=linuxbsd target=editor warnings=no`, while `dev-build` is `scons p=linuxbsd target=editor dev_build=yes`.

```
==> ../ext/logs/godot-editor-dev-build-exceptions.log <==
[Time elapsed: 00:05:47.942]

==> ../ext/logs/godot-editor-dev-build-exceptions.log <==
[Time elapsed: 00:06:00.398]

==> ../ext/logs/godot-editor-no-lto-exceptions.log <==
[Time elapsed: 00:10:02.207]

==> ../ext/logs/godot-editor-no-lto-no-exceptions.log <==
[Time elapsed: 00:07:35.507]
```

For an optimized build without LTO (so not paying a disproportionate amount of time for linking), there's a significant 25% build time speedup.

For the dev builds, I actually got a 2% build time increase, though I don't know if it's representative, I ran the test only once.

Sizes for these builds for those interested:
```
-rwxr-xr-x. 1 root root 758M Aug 14 11:45 godot.linuxbsd.editor.dev.x86_64.exceptions-dev-build
-rwxr-xr-x. 1 root root 736M Aug 14 12:01 godot.linuxbsd.editor.dev.x86_64.no-exceptions-dev-build
-rwxr-xr-x. 1 root root 119M Aug 14 11:34 godot.linuxbsd.editor.x86_64.exceptions-no-lto
-rwxr-xr-x. 1 root root 100M Aug 14 11:19 godot.linuxbsd.editor.x86_64.no-exceptions-no-lto
```

#### Windows with MSVC from VS 2022

```
scons p=windows target=editor scu_build=yes verbose=yes

- exceptions
[Time elapsed: 00:34:24.411]

- no-exceptions
[Time elapsed: 00:12:18.504]


scons p=windows target=template_release scu_build=yes verbose=yes

- exceptions
[Time elapsed: 00:19:28.350]

- no-exceptions
[Time elapsed: 00:09:20.439]
```

I used `scu_build` to speed things up, so this exacerbates issues like #80513 since the parallel build goes faster, but we'll still get stuck a long time on `gdscript_vm.cpp` for the `exceptions` build.

The results are pretty impressive though, with the build time divided by 3 for the editor (34m to 12m) and divided by 2 for the template (19m to 9m).

## Impact on performance

Help welcome to run some benchmarks! You can use the builds linked above.

## Impact on tests

I had to disable exceptions in doctest, which downgrades our `REQUIRE`/`FAIL` macros to the `CHECK` level (which marks the test as failed but doesn't rage quit). We need to see if that impacts our test suites negatively, and if we should clarify this behavior by changing our existing `REQUIRE`/`FAIL` uses to `CHECK`.

This is work for a follow-up PR where I'd welcome a volunteer - for this PR we should just ensure that the tests still work properly.

## Further work

`godot-cpp` could likely reuse the same logic to build without extensions by default, with a command line option to override that behavior for users who want to compile with a library that needs exceptions (or their own code).

`3.x` backport: #80622