### PR TITLE
Fix GCC `-Wmaybe-uninitialized` warnings

### DIFF
--- a/core/io/remote_filesystem_client.h
+++ b/core/io/remote_filesystem_client.h
@@ -44,8 +44,8 @@ protected:
 	String _get_cache_path() { return cache_path; }
 	struct FileCache {
 		String path; // Local path (as in "folder/to/file.png")
-		uint64_t server_modified_time; // MD5 checksum.
-		uint64_t modified_time;
+		uint64_t server_modified_time = 0; // MD5 checksum.
+		uint64_t modified_time = 0;
 	};
 	virtual bool _is_configured() { return !cache_path.is_empty(); }
 	// Can be re-implemented per platform. If so, feel free to ignore get_cache_path()

--- a/platform/linuxbsd/x11/gl_manager_x11.h
+++ b/platform/linuxbsd/x11/gl_manager_x11.h
@@ -74,17 +74,17 @@ private:
 	};
 
 	struct GLDisplay {
-		GLDisplay() { context = nullptr; }
+		GLDisplay() {}
 		~GLDisplay();
 		GLManager_X11_Private *context = nullptr;
-		::Display *x11_display;
-		XVisualInfo x_vi;
+		::Display *x11_display = nullptr;
+		XVisualInfo x_vi = {};
 	};
 
 	// just for convenience, window and display struct
 	struct XWinDisp {
 		::Window x11_window;
-		::Display *x11_display;
+		::Display *x11_display = nullptr;
 	} _x_windisp;
 
 	LocalVector<GLWindow> _windows;

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -423,6 +423,7 @@ TEST_SUITE("[Navigation]") {
 		navigation_server->free(map);
 	}
 
+#ifndef DISABLE_DEPRECATED
 	// This test case uses only public APIs on purpose - other test cases use simplified baking.
 	// FIXME: Remove once deprecated `region_bake_navigation_mesh()` is removed.
 	TEST_CASE("[NavigationServer3D][SceneTree][DEPRECATED] Server should be able to bake map correctly") {
@@ -470,6 +471,7 @@ TEST_SUITE("[Navigation]") {
 		memdelete(mesh_instance);
 		memdelete(node_3d);
 	}
+#endif // DISABLE_DEPRECATED
 
 	// This test case uses only public APIs on purpose - other test cases use simplified baking.
 	TEST_CASE("[NavigationServer3D][SceneTree] Server should be able to bake map correctly") {


### PR DESCRIPTION
Raised while working on #80612, not sure if it's because disabling exception handling lets GCC find different warnings, or if it's just due to trigger a full codebase rebuild from scratch and thus not reusing already compiled objects.