### PR TITLE
Add buttons to reorder inspector array items without dragging

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1852,6 +1852,10 @@ void EditorInspectorArray::_move_element(int p_element_index, int p_to_pos) {
 		if (page == max_page && (MAX(0, count - 1) / page_length != max_page)) {
 			emit_signal(SNAME("page_change_request"), max_page - 1);
 		}
+	} else if (p_to_pos == begin_array_index - 1) {
+		emit_signal(SNAME("page_change_request"), page - 1);
+	} else if (p_to_pos > end_array_index) {
+		emit_signal(SNAME("page_change_request"), page + 1);
 	}
 	begin_array_index = page * page_length;
 	end_array_index = MIN(count, (page + 1) * page_length);
@@ -2112,6 +2116,19 @@ void EditorInspectorArray::_setup() {
 
 		// Move button.
 		if (movable) {
+			int element_position = begin_array_index + i;
+			VBoxContainer *move_vbox = memnew(VBoxContainer);
+			move_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
+			move_vbox->set_alignment(BoxContainer::ALIGNMENT_CENTER);
+			ae.hbox->add_child(move_vbox);
+
+			if (element_position > 0) {
+				ae.move_up = memnew(Button);
+				ae.move_up->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+				ae.move_up->connect("pressed", callable_mp(this, &EditorInspectorArray::_move_element).bind(element_position, element_position - 1));
+				move_vbox->add_child(ae.move_up);
+			}
+
 			ae.move_texture_rect = memnew(TextureRect);
 			ae.move_texture_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
 			ae.move_texture_rect->set_default_cursor_shape(Control::CURSOR_MOVE);
@@ -2119,7 +2136,14 @@ void EditorInspectorArray::_setup() {
 			if (is_inside_tree()) {
 				ae.move_texture_rect->set_texture(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 			}
-			ae.hbox->add_child(ae.move_texture_rect);
+			move_vbox->add_child(ae.move_texture_rect);
+
+			if (element_position < _get_array_count() - 1) {
+				ae.move_down = memnew(Button);
+				ae.move_down->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+				ae.move_down->connect("pressed", callable_mp(this, &EditorInspectorArray::_move_element).bind(element_position, element_position + 2));
+				move_vbox->add_child(ae.move_down);
+			}
 		}
 
 		if (numbered) {
@@ -2220,7 +2244,12 @@ void EditorInspectorArray::_notification(int p_what) {
 				if (ae.move_texture_rect) {
 					ae.move_texture_rect->set_texture(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 				}
-
+				if (ae.move_up) {
+					ae.move_up->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+				}
+				if (ae.move_down) {
+					ae.move_down->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+				}
 				Size2 min_size = get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->get_minimum_size();
 				ae.margin->add_theme_constant_override("margin_left", min_size.x / 2);
 				ae.margin->add_theme_constant_override("margin_top", min_size.y / 2);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -361,7 +361,9 @@ class EditorInspectorArray : public EditorInspectorSection {
 		PanelContainer *panel = nullptr;
 		MarginContainer *margin = nullptr;
 		HBoxContainer *hbox = nullptr;
+		Button *move_up = nullptr;
 		TextureRect *move_texture_rect = nullptr;
+		Button *move_down = nullptr;
 		Label *number = nullptr;
 		VBoxContainer *vbox = nullptr;
 		Button *erase = nullptr;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7495https://github.com/godotengine/godot-proposals/issues/7495
Fix #80524

# Issue fix

As @markopolojorgensen explains in issue https://github.com/godotengine/godot/issues/80524, array items in editor inspector can be reordered by dragging with mouse. But if the number of item is above 5, a pagination system is used. As a consequence, there is no way to move an item from a page to another via editor.

# Fix proposal / feature enhancement

This PR implements the proposal https://github.com/godotengine/godot-proposals/issues/7495 to add two buttons in order to move an item one step up or down.

If down button is used on an item at the bottom of a page, it will send it at the top of the following page.
If top button is used on an item at the top of a page, it will send it at the bottom of the previous page.

It will allow to use drag move inside a page and button move inside and across page.

The up and down button system is already used in some part of the editor (eg. autoload panel to reoreder autoload script/scenes) so it seems to be consistent to add one here.

# Preview

![move_array](https://github.com/godotengine/godot-proposals/assets/3649998/0d3ee091-f21f-476f-b207-ab3e34d196c3)
