### PR TITLE
Use `String::resize()` and `CharString` in `text_server_adv` again

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2113,12 +2113,10 @@ Dictionary TextServerAdvanced::_font_get_ot_name_strings(const RID &p_font_rid) 
 				name = vformat("unknown_%d", names[i].name_id);
 			} break;
 		}
+		String text;
 		unsigned int text_size = hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, nullptr, nullptr) + 1;
-		// @todo After godot-cpp#1141 is fixed, use text.resize() and write directly to text.wptr() instead of using a temporary buffer.
-		char32_t *buffer = memnew_arr(char32_t, text_size);
-		hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)buffer);
-		String text(buffer);
-		memdelete_arr(buffer);
+		text.resize(text_size);
+		hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)text.ptrw());
 		if (!text.is_empty()) {
 			Dictionary &id_string = names_for_lang[String(hb_language_to_string(names[i].language))];
 			id_string[name] = text;

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -155,21 +155,10 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 		}
 
 		String xml_code_str = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"" + rtos(min_x) + " " + rtos(min_y) + " " + rtos(new_w) + " " + rtos(new_h) + "\">" + xml_body;
-#ifndef GDEXTENSION
 		gl_state.xml_code = xml_code_str.utf8();
-#else
-		CharString xml_code = xml_code_str.utf8();
-		gl_state.xml_code_length = xml_code.length();
-		gl_state.xml_code = memnew_arr(char, gl_state.xml_code_length);
-		memcpy(gl_state.xml_code, xml_code.get_data(), gl_state.xml_code_length);
-#endif
 
 		picture = tvg::Picture::gen();
-#ifndef GDEXTENSION
 		result = picture->load(gl_state.xml_code.get_data(), gl_state.xml_code.length(), "svg+xml", false);
-#else
-		result = picture->load(gl_state.xml_code, gl_state.xml_code_length, "svg+xml", false);
-#endif
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (glyph metrics).");
 		}
@@ -257,11 +246,7 @@ FT_Error tvg_svg_in_ot_render(FT_GlyphSlot p_slot, FT_Pointer *p_state) {
 	ERR_FAIL_COND_V_MSG(!gl_state.ready, FT_Err_Invalid_SVG_Document, "SVG glyph not ready.");
 
 	std::unique_ptr<tvg::Picture> picture = tvg::Picture::gen();
-#ifndef GDEXTENSION
 	tvg::Result res = picture->load(gl_state.xml_code.get_data(), gl_state.xml_code.length(), "svg+xml", false);
-#else
-	tvg::Result res = picture->load(gl_state.xml_code, gl_state.xml_code_length, "svg+xml", false);
-#endif
 	if (res != tvg::Result::Success) {
 		ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to load SVG document (glyph rendering).");
 	}

--- a/modules/text_server_adv/thorvg_svg_in_ot.h
+++ b/modules/text_server_adv/thorvg_svg_in_ot.h
@@ -66,22 +66,8 @@ struct GL_State {
 	float y = 0;
 	float w = 0;
 	float h = 0;
-#ifndef GDEXTENSION
 	CharString xml_code;
-#else
-	// @todo After godot-cpp#1142 is fixed, use CharString just like when compiled as a Godot module.
-	char *xml_code = nullptr;
-	int xml_code_length = 0;
-#endif
 	tvg::Matrix m;
-
-#ifdef GDEXTENSION
-	~GL_State() {
-		if (xml_code) {
-			memdelete_arr(xml_code);
-		}
-	}
-#endif
 };
 
 struct TVG_State {


### PR DESCRIPTION
Shortly before 4.1 was released, PR https://github.com/godotengine/godot/pull/77532 added some workarounds to allow the `text_server_adv` module to keep compiling as a GDExtension, by avoiding `String::resize()` and `CharString` which were missing or broken in godot-cpp at the time.

However, after PR https://github.com/godotengine/godot-cpp/pull/1166 and PR https://github.com/godotengine/godot-cpp/pull/1150 this should no longer be necessary!

This PR reverts the workaround bits that were in PR https://github.com/godotengine/godot/pull/77532
