### PR TITLE
Fix 2D/3D viewport context switching issues when script editor is floating

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2357,7 +2357,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			SceneTreeDock::get_singleton()->set_selected(current_node);
 			InspectorDock::get_singleton()->update(current_node);
 			if (!inspector_only && !skip_main_plugin) {
-				skip_main_plugin = stay_in_script_editor_on_node_selected && ScriptEditor::get_singleton()->is_visible_in_tree();
+				skip_main_plugin = stay_in_script_editor_on_node_selected && !ScriptEditor::get_singleton()->is_editor_floating() && ScriptEditor::get_singleton()->is_visible_in_tree();
 			}
 		} else {
 			NodeDock::get_singleton()->set_node(nullptr);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1791,6 +1791,10 @@ void ScriptEditor::ensure_select_current() {
 	_update_selected_editor_menu();
 }
 
+bool ScriptEditor::is_editor_floating() {
+	return is_floating;
+}
+
 void ScriptEditor::_find_scripts(Node *p_base, Node *p_current, HashSet<Ref<Script>> &used) {
 	if (p_current != p_base && p_current->get_owner() != p_base) {
 		return;
@@ -3747,6 +3751,7 @@ void ScriptEditor::_on_find_in_files_modified_files(PackedStringArray paths) {
 
 void ScriptEditor::_window_changed(bool p_visible) {
 	make_floating->set_visible(!p_visible);
+	is_floating = p_visible;
 }
 
 void ScriptEditor::_filter_scripts_text_changed(const String &p_newtext) {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -274,6 +274,7 @@ class ScriptEditor : public PanelContainer {
 	Button *help_search = nullptr;
 	Button *site_search = nullptr;
 	Button *make_floating = nullptr;
+	bool is_floating = false;
 	EditorHelpSearch *help_search_dialog = nullptr;
 
 	ItemList *script_list = nullptr;
@@ -506,6 +507,8 @@ public:
 	Ref<Resource> open_file(const String &p_file);
 
 	void ensure_select_current();
+
+	bool is_editor_floating();
 
 	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
 	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);


### PR DESCRIPTION
This pr solves issue #80588.
I added a simple function to tell whether the script editor is floating or not, and when script editor is floating, skip_main_plugin should be false so the plugin will draw itself's gizmos.

*Bugsquad edit:*
- Fixes #80015
- Fixes #80588
