### PR TITLE
[3.x] GLES2: Make GPU skinning more consistent with GLES3

### DIFF
--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -433,17 +433,44 @@ void main() {
 #else
 	// look up transform from the "pose texture"
 	{
-		for (int i = 0; i < 4; i++) {
-			ivec2 tex_ofs = ivec2(int(bone_ids[i]) * 3, 0);
+		ivec4 bone_indicesi = ivec4(bone_ids); // cast to signed int
 
-			highp mat4 b = mat4(
-					texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(0, 0)),
-					texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
-					texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
-					vec4(0.0, 0.0, 0.0, 1.0));
+		ivec2 tex_ofs = ivec2(bone_indicesi.x * 3, 0);
+		bone_transform = mat4(
+								 texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs),
+								 texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
+								 texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
+								 vec4(0.0, 0.0, 0.0, 1.0)) *
+				bone_weights.x;
 
-			bone_transform += transpose(b) * bone_weights[i];
-		}
+		tex_ofs = ivec2(bone_indicesi.y * 3, 0);
+
+		bone_transform += mat4(
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
+								  vec4(0.0, 0.0, 0.0, 1.0)) *
+				bone_weights.y;
+
+		tex_ofs = ivec2(bone_indicesi.z * 3, 0);
+
+		bone_transform += mat4(
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
+								  vec4(0.0, 0.0, 0.0, 1.0)) *
+				bone_weights.z;
+
+		tex_ofs = ivec2(bone_indicesi.w * 3, 0);
+
+		bone_transform += mat4(
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(1, 0)),
+								  texel2DFetch(bone_transforms, skeleton_texture_size, tex_ofs + ivec2(2, 0)),
+								  vec4(0.0, 0.0, 0.0, 1.0)) *
+				bone_weights.w;
+
+		bone_transform = transpose(bone_transform);
 	}
 
 #endif


### PR DESCRIPTION
My first contribution here! 👋

Aside from consistency, functionally, this may improve performance, with a single ivec4 cast as opposed to 4 separate int casts for bone_ids, plus calling transpose() 1 time instead of 4.

But this change is mainly motivated by the vec4 indexing in the previous implementation causing the following issue on my [Xiaomi Redmi 6A](https://www.gsmarena.com/xiaomi_redmi_6a-9217.php) device on WebGL (a desktop and a high-end mobile device, and a native export on the same device worked, so this is entirely a driver+ANGLE issue):
![Screenshot_2023-08-15-11-07-43-365_com android chrome](https://github.com/godotengine/godot/assets/18270989/d196048c-cb8b-4d84-b309-13804ebf152e)

With the GLES3 implementation ported over, the model renders correctly (the issue with her clothes is common in Makehuman, the rendering is technically correct):
![Screenshot_2023-08-15-11-08-19-569_com android chrome](https://github.com/godotengine/godot/assets/18270989/c0300da9-63a5-4cb7-949a-77c4a3d47f8b)

The minimal fix for the issue would be changing
`bone_transform += transpose(b) * bone_weights[i];`
to:
`bone_transform += transpose(b) * dot(bone_weights, vec4(i == 0 ? 1.0 : 0.0, i == 1 ? 1.0 : 0.0, i == 2 ? 1.0 : 0.0, i == 3 ? 1.0 : 0.0));`
but this would degrade performance, and looks quite ugly.