### PR TITLE
Fixes LSP connection error when launched in a separate thread

### DIFF
--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -73,6 +73,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 }
 
 void GDScriptLanguageServer::thread_main(void *p_userdata) {
+	set_current_thread_safe_for_nodes(true);
 	GDScriptLanguageServer *self = static_cast<GDScriptLanguageServer *>(p_userdata);
 	while (self->thread_running) {
 		// Poll 20 times per second


### PR DESCRIPTION
Fixes #79525 . I went with `set_current_thread_safe_for_nodes(true)` and it fixes the problem but I'm not sure if it doesn't introduce any security issues. But from what I've found out - `GDScriptLanguageServer` has no thread processing (`current_process_thread_group = nullptr`) and here we're left with two choices:

- only access nodes that are not part of a scene tree (that's not happening in out case) and
- mark a current thread as 'safe' (which is what this PR does)

Please, let me know if I'm missing some other possible ways of fixing this.