### PR TITLE
Fix gizmo for `BoxShape3D`

### DIFF
--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -301,7 +301,7 @@ void CollisionShape3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo
 		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 		ur->create_action(TTR("Change Box Shape Size"));
 		ur->add_do_method(ss.ptr(), "set_size", ss->get_size());
-		ur->add_do_method(cs, "set_position", cs->get_global_position());
+		ur->add_do_method(cs, "set_global_position", cs->get_global_position());
 		ur->add_undo_method(ss.ptr(), "set_size", p_restore);
 		ur->add_undo_method(cs, "set_global_position", initial_transform.get_origin());
 		ur->commit_action();


### PR DESCRIPTION
Typo causing a bug due to using local, not global, position

(Not relevant to 4.1, as the PR introducing this, #71092, has not been cherry picked)

* Fixes: #80685
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
