### PR TITLE
Split confusing ERR in `_send_delta/_send_sync`

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -708,7 +708,8 @@ void SceneReplicationInterface::_send_delta(int p_peer, const HashSet<ObjectID> 
 	int ofs = 1;
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
-		ERR_CONTINUE(!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority());
+		ERR_CONTINUE(!sync || !sync->is_multiplayer_authority());
+		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has no replication config.");
 		uint32_t net_id;
 		if (!_verify_synchronizer(p_peer, sync, net_id)) {
 			continue;
@@ -803,7 +804,8 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p
 	// This is a lazy implementation, we could optimize much more here with by grouping by replication config.
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
-		ERR_CONTINUE(!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority());
+		ERR_CONTINUE(!sync || !sync->is_multiplayer_authority());
+		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has no replication config.");
 		if (!sync->update_outbound_sync_time(p_usec)) {
 			continue; // nothing to sync.
 		}

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -709,7 +709,7 @@ void SceneReplicationInterface::_send_delta(int p_peer, const HashSet<ObjectID> 
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
 		ERR_CONTINUE(!sync || !sync->is_multiplayer_authority());
-		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has no replication config.");
+		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has an invalid or non-existent replication configuration.");
 		uint32_t net_id;
 		if (!_verify_synchronizer(p_peer, sync, net_id)) {
 			continue;
@@ -805,7 +805,7 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> p
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
 		ERR_CONTINUE(!sync || !sync->is_multiplayer_authority());
-		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has no replication config.");
+		ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has an invalid or non-existent replication configuration.");
 		if (!sync->update_outbound_sync_time(p_usec)) {
 			continue; // nothing to sync.
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Creating a MultiplayerSynchronizer in code doesn't automatically create an instance of the SceneReplicationConfig (which I assume is by design?)

While that's fine, not having a valid replication config spams a confusing & basic assert-like error in console:
```cpp
!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority()
``` 
I've split it in two:

```cpp
ERR_CONTINUE(!sync || !sync->is_multiplayer_authority());
ERR_CONTINUE_MSG(!sync->get_replication_config().is_valid(), "MultiplayerSynchronizer has no replication config.");
```
