### PR TITLE
Fix empty XML tag doc in XMLParser.xml

### DIFF
--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -84,7 +84,7 @@
 		<method name="is_empty" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Check whether the current element is empty (this only works for completely empty tags, e.g. [code]&lt;element \&gt;[/code]).
+				Check whether the current element is empty (this only works for completely empty tags, e.g. [code]&lt;element /&gt;[/code]).
 			</description>
 		</method>
 		<method name="open">


### PR DESCRIPTION
Fix doc to show how an empty XML tag is appropiately closed.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
