### PR TITLE
Allow comma as a decimal separator for SpinBox

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -534,17 +534,24 @@ String EditorSpinSlider::get_suffix() const {
 }
 
 void EditorSpinSlider::_evaluate_input_text() {
-	// Replace comma with dot to support it as decimal separator (GH-6028).
-	// This prevents using functions like `pow()`, but using functions
-	// in EditorSpinSlider is a barely known (and barely used) feature.
-	// Instead, we'd rather support German/French keyboard layouts out of the box.
-	const String text = TS->parse_number(value_input->get_text().replace(",", "."));
-
 	Ref<Expression> expr;
 	expr.instantiate();
+
+	// Convert commas ',' to dots '.' for French/German etc. keyboard layouts.
+	String text = value_input->get_text().replace(",", ".");
+	text = text.replace(";", ",");
+	text = TS->parse_number(text);
+
 	Error err = expr->parse(text);
 	if (err != OK) {
-		return;
+		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
+		text = value_input->get_text();
+		text = TS->parse_number(text);
+
+		err = expr->parse(text);
+		if (err != OK) {
+			return;
+		}
 	}
 
 	Variant v = expr->execute(Array(), nullptr, false, true);


### PR DESCRIPTION
Fixes #80664
Add support for comma `,` as a decimal separator for SpinBox. This implementation allows for expressions like `pow(2, 3)` to be used as well. If you use comma to separate decimals, use semicolon `;` to separate function parameters.
Change EditorSpinSlider behavior to match (currently EditorSpinSlider accepts commas but not expression with multiple parameters).
![comma](https://github.com/godotengine/godot/assets/1621768/831d3468-9d78-4fbd-92f4-17a7747f2c85)

Caveats: ~~As comma replacing is triggered only in absence of parentheses, there's some cases where replacing doesn't trigger even if it would still make sense for example `(1 + 0,5) * 2`. However, if user needs to write something more complex than what can be inputted via numpad they probably don't mind using dot for decimals.~~ Newer version handles these cases too.
This is also a change to an existing Control, but I can't see anybody relying on input failing whenever commas are present.

*Bugsquad edit:* Fixes #81989