### PR TITLE
Fix Shader and ShaderInclude resource loading

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -234,13 +234,16 @@ Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const Strin
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
 
-	Ref<Shader> shader;
-	shader.instantiate();
-
-	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path);
+	Error error = OK;
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path, &error);
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader: " + p_path);
 
 	String str;
-	str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+	error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader: " + p_path);
+
+	Ref<Shader> shader;
+	shader.instantiate();
 
 	shader->set_include_path(p_path);
 	shader->set_code(str);

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -88,13 +88,16 @@ Ref<Resource> ResourceFormatLoaderShaderInclude::load(const String &p_path, cons
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
 
-	Ref<ShaderInclude> shader_inc;
-	shader_inc.instantiate();
-
-	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path);
+	Error error = OK;
+	Vector<uint8_t> buffer = FileAccess::get_file_as_bytes(p_path, &error);
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader include: " + p_path);
 
 	String str;
-	str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+	error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader include: " + p_path);
+
+	Ref<ShaderInclude> shader_inc;
+	shader_inc.instantiate();
 
 	shader_inc->set_include_path(p_path);
 	shader_inc->set_code(str);


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/76183

Possibly also helps with some other issues like https://github.com/godotengine/godot/issues/79324. There have been several reports of deleted or renamed Shader resources somehow "haunting" a project, reappearing or otherwise causing some strange issues. These are possibly caused by the Shader resource loading logic which never fails even if you try to load a completely nonexistent Shader or ShaderInclude file, see https://github.com/godotengine/godot/pull/73975 for more details.

This PR adds error checking when loading these resources. In the linked issue MRP the crash happens because the scene file contains invalid references to a deleted `.gdshader` file:

`[ext_resource type="Shader" path="res://Shaders/planetShader.gdshader" id="1_3kkjf"]`

and

`shader = ExtResource("1_3kkjf")`

Because currently loading this invalid resource actually succeeds it also makes the editor think that `Shaders` directory exists and when it tries to scan this invalid directory Godot crashes (because `DirAccess:open()` return value is not checked).

After this PR, trying to open the scene will correctly fail with an error message pointing to the missing file instead of silently creating invalid resources and then crashing Godot when trying to save the scene. If people have similar dangling resource references in their projects, they can no longer open and edit these scenes in the editor as the loading will fail. To fix this, they can either manually edit the .tscn file using an external text editor or create a temporary shader file where the missing one should be, then edit and adjust the scene inside the Godot editor. _edit: Turns out there is also a scene dependency fixer functionality in the editor that can be used to fix this, live and learn._

This PR will also trigger some relatively untested code branches because previously Shader resource loading never failed. There are some conditions in the codebase that never failed previously, but after some testing they seem to work okay. Still, it's something to keep an eye out for.