### PR TITLE
Ensure methods skipped by `AnimationPlayer::seek` are not called

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -779,7 +779,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 				List<int> indices;
 
 				if (p_seeked) {
-					int found_key = a->track_find_key(i, p_time);
+					int found_key = a->track_find_key(i, p_time, Animation::FIND_MODE_EXACT);
 					if (found_key >= 0) {
 						indices.push_back(found_key);
 					}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #80640
The original code simply picked the key closest to the current time after the animation was seeked. This might accidentally call a method that had been skipped.