### PR TITLE
SCons: Enable `/WX` on LINKFLAGS for MSVC with `werror=yes`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -752,6 +752,7 @@ if selected_platform in platform_list:
 
         if env["werror"]:
             env.Append(CCFLAGS=["/WX"])
+            env.Append(LINKFLAGS=["/WX"])
     else:  # GCC, Clang
         common_warnings = []
 


### PR DESCRIPTION
~Draft as it should fail due to https://github.com/godotengine/godot/pull/80095#issuecomment-1682066926.~
*Edit:* Fixed by #80713.

For the record, the option is already enabled in godot-cpp, unconditionally: https://github.com/godotengine/godot-cpp/blob/master/tools/windows.py#L35
I guess it makes sense there as we don't want potential linking warnings that would impact loading dynamic libraries.