### PR TITLE
SCons: Fix ThorVG build option in TextServers with #80095

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -40,6 +40,8 @@ msdfgen_enabled = "msdfgen" in env.module_list
 
 if "svg" in env.module_list:
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/lib"])
+    # Enable ThorVG static object linking.
+    env_text_server_adv.Append(CPPDEFINES=["TVG_STATIC"])
 
 if env["builtin_harfbuzz"]:
     env_harfbuzz = env_modules.Clone()

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -69,9 +69,6 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/lib/tvgShape.cpp",
         "src/lib/tvgSwCanvas.cpp",
         "src/lib/tvgTaskScheduler.cpp",
-        "src/loaders/external_png/tvgPngLoader.cpp",
-        "src/loaders/jpg/tvgJpgd.cpp",
-        "src/loaders/jpg/tvgJpgLoader.cpp",
         "src/loaders/raw/tvgRawLoader.cpp",
         "src/loaders/svg/tvgSvgCssStyle.cpp",
         "src/loaders/svg/tvgSvgLoader.cpp",
@@ -79,9 +76,6 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/loaders/svg/tvgSvgSceneBuilder.cpp",
         "src/loaders/svg/tvgSvgUtil.cpp",
         "src/loaders/svg/tvgXmlParser.cpp",
-        "src/loaders/tvg/tvgTvgBinInterpreter.cpp",
-        "src/loaders/tvg/tvgTvgLoader.cpp",
-        "src/savers/tvg/tvgTvgSaver.cpp",
     ]
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
@@ -90,15 +84,15 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/lib",
             "../../../thirdparty/thorvg/src/lib/sw_engine",
-            "../../../thirdparty/thorvg/src/loaders/external_png",
-            "../../../thirdparty/thorvg/src/loaders/jpg",
             "../../../thirdparty/thorvg/src/loaders/raw",
             "../../../thirdparty/thorvg/src/loaders/svg",
-            "../../../thirdparty/thorvg/src/loaders/tvg",
-            "../../../thirdparty/thorvg/src/savers/tvg",
             "../../../thirdparty/libpng",
         ]
     )
+
+    # Enable ThorVG static object linking.
+    env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
+
     env.Append(CPPPATH=["../../../thirdparty/thorvg/inc", "../../../thirdparty/thorvg/src/lib"])
     env.Append(CPPDEFINES=["MODULE_SVG_ENABLED"])
 

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -10,6 +10,8 @@ env_text_server_fb = env_modules.Clone()
 
 if "svg" in env.module_list:
     env_text_server_fb.Prepend(CPPPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/lib"])
+    # Enable ThorVG static object linking.
+    env_text_server_fb.Append(CPPDEFINES=["TVG_STATIC"])
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
     # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -64,9 +64,6 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/lib/tvgShape.cpp",
         "src/lib/tvgSwCanvas.cpp",
         "src/lib/tvgTaskScheduler.cpp",
-        "src/loaders/external_png/tvgPngLoader.cpp",
-        "src/loaders/jpg/tvgJpgd.cpp",
-        "src/loaders/jpg/tvgJpgLoader.cpp",
         "src/loaders/raw/tvgRawLoader.cpp",
         "src/loaders/svg/tvgSvgCssStyle.cpp",
         "src/loaders/svg/tvgSvgLoader.cpp",
@@ -74,9 +71,6 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
         "src/loaders/svg/tvgSvgSceneBuilder.cpp",
         "src/loaders/svg/tvgSvgUtil.cpp",
         "src/loaders/svg/tvgXmlParser.cpp",
-        "src/loaders/tvg/tvgTvgBinInterpreter.cpp",
-        "src/loaders/tvg/tvgTvgLoader.cpp",
-        "src/savers/tvg/tvgTvgSaver.cpp",
     ]
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
@@ -85,15 +79,15 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/lib",
             "../../../thirdparty/thorvg/src/lib/sw_engine",
-            "../../../thirdparty/thorvg/src/loaders/external_png",
-            "../../../thirdparty/thorvg/src/loaders/jpg",
             "../../../thirdparty/thorvg/src/loaders/raw",
             "../../../thirdparty/thorvg/src/loaders/svg",
-            "../../../thirdparty/thorvg/src/loaders/tvg",
-            "../../../thirdparty/thorvg/src/savers/tvg",
             "../../../thirdparty/libpng",
         ]
     )
+
+    # Enable ThorVG static object linking.
+    env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
+
     env.Append(CPPPATH=["../../../thirdparty/thorvg/inc", "../../../thirdparty/thorvg/src/lib"])
     env.Append(CPPDEFINES=["MODULE_SVG_ENABLED"])
 


### PR DESCRIPTION
Didn't test the GDExtension changes, I just mirrored what was done in #80095 for `modules/svg/SCsub`.

I'll test that this resolves the MSVC linking error reported in https://github.com/godotengine/godot/pull/80095#issuecomment-1682066926.
*Edit:* Confirmed, that solves it.