### PR TITLE
SCons: Add support for detecting MSVC version

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,7 +1,7 @@
 import os
 import platform
 import sys
-from methods import get_compiler_version, using_gcc
+from methods import using_gcc
 from platform_methods import detect_arch
 
 from typing import TYPE_CHECKING
@@ -105,9 +105,7 @@ def configure(env: "Environment"):
     if env["linker"] != "default":
         print("Using linker program: " + env["linker"])
         if env["linker"] == "mold" and using_gcc(env):  # GCC < 12.1 doesn't support -fuse-ld=mold.
-            cc_version = get_compiler_version(env)
-            cc_semver = (int(cc_version["major"]), int(cc_version["minor"]))
-            if cc_semver < (12, 1):
+            if env.compiler_version < (12, 1):
                 found_wrapper = False
                 for path in ["/usr/libexec", "/usr/local/libexec", "/usr/lib", "/usr/local/lib"]:
                     if os.path.isfile(path + "/mold/ld"):

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -9,7 +9,6 @@ from emscripten_helpers import (
     add_js_externs,
     create_template_zip,
 )
-from methods import get_compiler_version
 from SCons.Util import WhereIs
 from typing import TYPE_CHECKING
 
@@ -200,10 +199,8 @@ def configure(env: "Environment"):
     env.Append(LINKFLAGS=["-s", "WASM_MEM_MAX=2048MB"])
 
     if env["dlink_enabled"]:
-        cc_version = get_compiler_version(env)
-        cc_semver = (int(cc_version["major"]), int(cc_version["minor"]), int(cc_version["patch"]))
-        if cc_semver < (3, 1, 14):
-            print("GDExtension support requires emscripten >= 3.1.14, detected: %s.%s.%s" % cc_semver)
+        if env.compiler_version < (3, 1, 14):
+            print("GDExtension support requires emscripten >= 3.1.14, detected: %s.%s.%s" % env.compiler_version)
             sys.exit(255)
 
         env.Append(CCFLAGS=["-s", "SIDE_MODULE=2"])


### PR DESCRIPTION
Add `env.compiler_version` to simplify checks for the compiler version outside SConstruct.

It was pretty hacky, and it's still pretty hacky. Not sure we can make compiler version detection much less of a hack, but at least this should probably be refactored in the future to store all this info in a well-defined object so we can easily query which compiler and which version we're using. But that's for a future PR.

I need MSVC version detection to implement some VS >= 2022 option for https://github.com/godotengine/godot/pull/80375.