### PR TITLE
GDExtension: Remove DLL copy if it fails to load

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -689,6 +689,12 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 	}
 
 	if (err != OK) {
+#if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
+		// If the DLL fails to load, make sure that temporary DLL copies are cleaned up.
+		if (Engine::get_singleton()->is_editor_hint()) {
+			DirAccess::remove_absolute(lib->get_temp_library_path());
+		}
+#endif
 		// Errors already logged in open_library()
 		return Ref<Resource>();
 	}

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -81,6 +81,7 @@ public:
 
 #if defined(WINDOWS_ENABLED) && defined(TOOLS_ENABLED)
 	void set_temp_library_path(const String &p_path) { temp_lib_path = p_path; }
+	String get_temp_library_path() const { return temp_lib_path; }
 #endif
 
 	enum InitializationLevel {


### PR DESCRIPTION
This is a follow-up to PR https://github.com/godotengine/godot/pull/80188

That PR causes the Godot editor (on Windows) to make a copy of the GDExtension's DLL in order to prevent Windows from locking the original DLL, so the developer can re-compile it without having to stop the editor first. When the editor is shutdown, any DLL copies for loaded GDExtensions will get cleaned up.

But, currently, if the DLL fails to load, the copy _won't_ get cleaned up. I've been testing this by compiling a GDExtension with `scons use_mingw=yes use_static_cpp=no` which will fail to load because it can't find the C++ runtime libraries.

Anyway, with this PR, it will clean up the DLL if it fails to load!