### PR TITLE
Recurse into resources to check for changed node paths

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1682,6 +1682,32 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 			}
 		} break;
 
+		case Variant::OBJECT: {
+			Resource *resource = Object::cast_to<Resource>(r_variant);
+			if (!resource) {
+				break;
+			}
+
+			List<PropertyInfo> properties;
+			resource->get_property_list(&properties);
+
+			for (const PropertyInfo &E : properties) {
+				if (!(E.usage & (PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR))) {
+					continue;
+				}
+				String propertyname = E.name;
+				Variant old_variant = resource->get(propertyname);
+				Variant updated_variant = old_variant;
+				if (_check_node_path_recursive(p_root_node, updated_variant, p_renames)) {
+					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+					undo_redo->add_do_property(resource, propertyname, updated_variant);
+					undo_redo->add_undo_property(resource, propertyname, old_variant);
+					resource->set(propertyname, updated_variant);
+				}
+			}
+			break;
+		};
+
 		default: {
 		}
 	}


### PR DESCRIPTION
Fixes #74155 by recursing into resources when checking for changed `NodePath`s. Also verified to work with custom resources.

The added code follows the same pattern as [the code that handles `Node` subclasses](https://github.com/godotengine/godot/blob/0511f9d9a7d56c742d87fafdcea8785d40ad14b3/editor/scene_tree_dock.cpp#L1716). For `Node` subclasses, however, the existing code does some extra work we don't need for resources, such as recursing into the Node's children and scanning for related AnimationPlayers.