### PR TITLE
Improve visual feedback when using the motion vectors debug view option

### DIFF
--- a/servers/rendering/renderer_rd/effects/debug_effects.h
+++ b/servers/rendering/renderer_rd/effects/debug_effects.h
@@ -32,6 +32,7 @@
 #define DEBUG_EFFECTS_RD_H
 
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
+#include "servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/shadow_frustum.glsl.gen.h"
 #include "servers/rendering/renderer_scene_render.h"
 
@@ -70,6 +71,18 @@ private:
 		PipelineCacheRD pipelines[SFP_MAX];
 	} shadow_frustum;
 
+	struct MotionVectorsPushConstant {
+		float velocity_resolution[2];
+		float pad[2];
+	};
+
+	struct {
+		MotionVectorsShaderRD shader;
+		RID shader_version;
+		PipelineCacheRD pipeline;
+		MotionVectorsPushConstant push_constant;
+	} motion_vectors;
+
 	void _create_frustum_arrays();
 
 protected:
@@ -78,6 +91,7 @@ public:
 	~DebugEffects();
 
 	void draw_shadow_frustum(RID p_light, const Projection &p_cam_projection, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect);
+	void draw_motion_vectors(RID p_velocity, RID p_dest_fb, Size2i p_velocity_size);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -745,8 +745,7 @@ void RendererSceneRenderRD::_render_buffers_debug_draw(const RenderDataRD *p_ren
 	}
 
 	if (debug_draw == RS::VIEWPORT_DEBUG_DRAW_MOTION_VECTORS && _render_buffers_get_velocity_texture(rb).is_valid()) {
-		Size2i rtsize = texture_storage->render_target_get_size(render_target);
-		copy_effects->copy_to_fb_rect(_render_buffers_get_velocity_texture(rb), texture_storage->render_target_get_rd_framebuffer(render_target), Rect2(Vector2(), rtsize), false, false);
+		debug_effects->draw_motion_vectors(_render_buffers_get_velocity_texture(rb), texture_storage->render_target_get_rd_framebuffer(render_target), rb->get_internal_size());
 	}
 }
 

--- a/servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl
@@ -1,0 +1,80 @@
+#[vertex]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(location = 0) out vec2 uv_interp;
+
+void main() {
+	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
+	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+}
+
+#[fragment]
+
+#version 450
+
+#VERSION_DEFINES
+
+layout(location = 0) in vec2 uv_interp;
+
+layout(set = 0, binding = 0) uniform sampler2D source_velocity;
+
+layout(location = 0) out vec4 frag_color;
+
+layout(push_constant, std430) uniform Params {
+	vec2 resolution;
+}
+params;
+
+// Based on distance to line segment from https://www.shadertoy.com/view/3tdSDj
+
+float line_segment(in vec2 p, in vec2 a, in vec2 b) {
+	vec2 aspect = vec2(params.resolution.x / params.resolution.y, 1.0f);
+	vec2 ba = (b - a) * aspect;
+	vec2 pa = (p - a) * aspect;
+	float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0f, 1.0f);
+	return length(pa - h * ba) * (params.resolution.y / 2.0f);
+}
+
+void main() {
+	// Retrieve motion vector data.
+	float cell_size = 32.0f;
+	float circle_radius = 2.0f;
+	vec3 nan_color = vec3(1.0f, 0.0f, 0.0f);
+	vec3 active_color = vec3(1.0f, 0.8f, 0.1f);
+	vec3 inactive_color = vec3(0.5f, 0.5f, 0.5f);
+	vec2 pos_pixel = uv_interp * params.resolution;
+	vec2 cell_pos_pixel = floor(pos_pixel / cell_size) * cell_size + (cell_size * 0.5f);
+	vec2 cell_pos_uv = cell_pos_pixel / params.resolution;
+	vec2 cell_pos_previous_uv = cell_pos_uv + textureLod(source_velocity, cell_pos_uv, 0.0f).xy;
+
+	// Draw the shapes.
+	float epsilon = 1e-6f;
+	vec2 cell_pos_delta_uv = cell_pos_uv - cell_pos_previous_uv;
+	bool motion_active = length(cell_pos_delta_uv) > epsilon;
+	vec3 color;
+	if (any(isnan(cell_pos_delta_uv))) {
+		color = nan_color;
+	} else if (motion_active) {
+		color = active_color;
+	} else {
+		color = inactive_color;
+	}
+
+	float alpha;
+	if (length(cell_pos_pixel - pos_pixel) <= circle_radius) {
+		// Circle center.
+		alpha = 1.0f;
+	} else if (motion_active) {
+		// Motion vector line.
+		alpha = 1.0f - line_segment(uv_interp, cell_pos_uv, cell_pos_previous_uv);
+	} else {
+		// Ignore pixel.
+		alpha = 0.0f;
+	}
+
+	frag_color = vec4(color, alpha);
+}


### PR DESCRIPTION
Replaces the current method of showing the raw values of the motion vectors buffer to display a grid of lines instead with a new shader. This should help make debugging motion vectors much easier.

**This currently replaces the current method of viewing motion vectors.** It should be decided whether to keep the old one as an option or not. Personally I don't see much use of it as if I want the raw values, I'd much rather inspect the texture on RenderDoc than look at RGB values that can't properly display the low range they usually have.

https://github.com/godotengine/godot/assets/538504/10255bb5-7d44-47f7-a7da-88fb2dec12f1

Side note: @clayjohn and I couldn't agree on what direction the vectors should point, so we'll let the people decide. :)