### PR TITLE
Remove error print from `XRServer.find_interface`

### DIFF
--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -216,17 +216,12 @@ Ref<XRInterface> XRServer::get_interface(int p_index) const {
 };
 
 Ref<XRInterface> XRServer::find_interface(const String &p_name) const {
-	int idx = -1;
 	for (int i = 0; i < interfaces.size(); i++) {
 		if (interfaces[i]->get_name() == p_name) {
-			idx = i;
-			break;
+			return interfaces[i];
 		};
 	};
-
-	ERR_FAIL_COND_V_MSG(idx == -1, nullptr, "Interface not found.");
-
-	return interfaces[idx];
+	return Ref<XRInterface>();
 };
 
 TypedArray<Dictionary> XRServer::get_interfaces() const {


### PR DESCRIPTION
This PR removes the error print from the `XRServer.find_interface()` method. It is a valid (and expected?) workflow to check if an interface exists by running this method, so we should not print an error, just return null.

Also, this PR simplifies the logic, since `int idx` is not needed.