### PR TITLE
Fix CanvasItem notification thread guard

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -424,14 +424,17 @@ Point2 Node2D::to_global(Point2 p_local) const {
 }
 
 void Node2D::_notification(int p_notification) {
-	ERR_THREAD_GUARD;
 	switch (p_notification) {
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_MAIN_THREAD_GUARD;
+
 			if (get_viewport()) {
 				get_parent()->connect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::gui_set_root_order_dirty), CONNECT_REFERENCE_COUNTED);
 			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_MAIN_THREAD_GUARD;
+
 			if (get_viewport()) {
 				get_parent()->disconnect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::gui_set_root_order_dirty));
 			}

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -131,10 +131,9 @@ void Node3D::_propagate_transform_changed(Node3D *p_origin) {
 }
 
 void Node3D::_notification(int p_what) {
-	ERR_THREAD_GUARD;
-
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_MAIN_THREAD_GUARD;
 			ERR_FAIL_NULL(get_tree());
 
 			Node *p = get_parent();
@@ -163,6 +162,8 @@ void Node3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_MAIN_THREAD_GUARD;
+
 			notification(NOTIFICATION_EXIT_WORLD, true);
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
@@ -176,6 +177,8 @@ void Node3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_WORLD: {
+			ERR_MAIN_THREAD_GUARD;
+
 			data.inside_world = true;
 			data.viewport = nullptr;
 			Node *parent = get_parent();
@@ -198,6 +201,8 @@ void Node3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_WORLD: {
+			ERR_MAIN_THREAD_GUARD;
+
 #ifdef TOOLS_ENABLED
 			clear_gizmos();
 #endif
@@ -211,6 +216,8 @@ void Node3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
+			ERR_THREAD_GUARD;
+
 #ifdef TOOLS_ENABLED
 			for (int i = 0; i < data.gizmos.size(); i++) {
 				data.gizmos.write[i]->transform();

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -273,10 +273,9 @@ void CanvasItem::_exit_canvas() {
 }
 
 void CanvasItem::_notification(int p_what) {
-	ERR_MAIN_THREAD_GUARD;
-
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			ERR_MAIN_THREAD_GUARD;
 			ERR_FAIL_COND(!is_inside_tree());
 
 			Node *parent = get_parent();
@@ -336,6 +335,8 @@ void CanvasItem::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			ERR_MAIN_THREAD_GUARD;
+
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
 			}
@@ -357,14 +358,20 @@ void CanvasItem::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
+			ERR_MAIN_THREAD_GUARD;
+
 			emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 		} break;
 		case NOTIFICATION_WORLD_2D_CHANGED: {
+			ERR_MAIN_THREAD_GUARD;
+
 			_exit_canvas();
 			_enter_canvas();
 		} break;
 		case NOTIFICATION_PARENTED: {
 			// The node is not inside the tree during this notification.
+			ERR_MAIN_THREAD_GUARD;
+
 			_notify_transform();
 		} break;
 	}


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/80412

Seems like simple fix, most other nodes like Node2D and Node3D also use `ERR_THREAD_GUARD` instead of `ERR_MAIN_THREAD_GUARD` in their notification callback. Looks like CanvasItem should also use `ERR_THREAD_GUARD` unless there is some specific reason why CanvasItem can't be used with subthread groups.