### PR TITLE
Add two bake options to Curve3D

### DIFF
--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -207,8 +207,22 @@
 		<member name="point_count" type="int" setter="set_point_count" getter="get_point_count" default="0">
 			The number of points describing the curve.
 		</member>
+		<member name="up_vector_bake_mode" type="int" setter="set_bake_mode" getter="get_bake_mode" enum="Curve3D.BakeMode" default="0">
+			The mode of how to bake local posture on the curve, depending on [enum BakeMode] being used.
+		</member>
 		<member name="up_vector_enabled" type="bool" setter="set_up_vector_enabled" getter="is_up_vector_enabled" default="true">
 			If [code]true[/code], the curve will bake up vectors used for orientation. This is used when [member PathFollow3D.rotation_mode] is set to [constant PathFollow3D.ROTATION_ORIENTED]. Changing it forces the cache to be recomputed.
 		</member>
 	</members>
+	<constants>
+		<constant name="BAKE_PARALLEL_TRANSPORT" value="0" enum="BakeMode">
+			Bake local posture with Parallel Transport frame. It is easier to achieve smooth rotation by default. However, moving control points will change all local posture along the curve, making it harder to tweak together with tilt. This is the default mode.
+		</constant>
+		<constant name="BAKE_FRENET" value="1" enum="BakeMode">
+			Bake local posture with Frenet frame. Moving a control point will only change local posture between the two neighboring control points. However Frenet frame relies on binormal, which is not well defined on straight lines and have abrupt change over saddle points on `S` shaped curves. Avoid these kinds of curves when using this mode.
+		</constant>
+		<constant name="BAKE_PLANAR" value="2" enum="BakeMode">
+			Bake local posture assuming that curves reside almost on a plane, with up vectors in the general direction of Y+. Think of racing tracks or express ways, instead of roller coasters.
+		</constant>
+	</constants>
 </class>

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -72,8 +72,6 @@ public:
 		ROTATION_ORIENTED
 	};
 
-	bool use_model_front = false;
-
 	static Transform3D correct_posture(Transform3D p_transform, PathFollow3D::RotationMode p_rotation_mode);
 
 private:
@@ -84,6 +82,8 @@ private:
 	bool cubic = true;
 	bool loop = true;
 	bool tilt_enabled = true;
+	bool use_model_front = false;
+
 	RotationMode rotation_mode = ROTATION_XYZ;
 
 	void _update_transform(bool p_update_xyz_rot = true);

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1530,7 +1530,7 @@ void Curve3D::_bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t
 }
 
 Vector3 Curve3D::_calculate_tangent(const Vector3 &p_begin, const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) {
-	// Handle corner cases.
+	// Handle degenerate cases.
 	if (Math::is_zero_approx(p_t - 0.0f) && p_control_1.is_equal_approx(p_begin)) {
 		return (p_end - p_begin).normalized();
 	}
@@ -1540,6 +1540,19 @@ Vector3 Curve3D::_calculate_tangent(const Vector3 &p_begin, const Vector3 &p_con
 	}
 
 	return p_begin.bezier_derivative(p_control_1, p_control_2, p_end, p_t).normalized();
+}
+
+// Static function to avoid code repetition. Internal to this file.
+static inline Vector3 _ensure_valid_up_vector(const Vector3 &p_forward, const Vector3 &p_up_one, const Vector3 &p_up_another) {
+	Basis frame;
+	const Vector3 c = p_forward.cross(p_up_one);
+	if (c.length_squared() < 0.1) {
+		frame = Basis::looking_at(p_forward, p_up_another);
+	} else {
+		frame = Basis::looking_at(p_forward, p_up_one);
+	}
+
+	return frame.get_column(1);
 }
 
 void Curve3D::_bake() const {
@@ -1650,33 +1663,20 @@ void Curve3D::_bake() const {
 	}
 
 	// Step 2: Calculate the up vectors and the whole local reference frame
-	//
-	// See Dougan, Carl. "The parallel transport frame." Game Programming Gems 2 (2001): 215-219.
-	// for an example discussing about why not the Frenet frame.
-	{
-		int point_count = baked_point_cache.size();
+	int point_count = baked_point_cache.size();
+	baked_up_vector_cache.resize(point_count);
+	Vector3 *up_write = baked_up_vector_cache.ptrw();
+	const Vector3 *forward_ptr = baked_forward_vector_cache.ptr();
+	const Vector3 *points_ptr = baked_point_cache.ptr();
 
-		baked_up_vector_cache.resize(point_count);
-		Vector3 *up_write = baked_up_vector_cache.ptrw();
-
-		const Vector3 *forward_ptr = baked_forward_vector_cache.ptr();
-		const Vector3 *points_ptr = baked_point_cache.ptr();
-
-		Basis frame; // X-right, Y-up, -Z-forward.
-		Basis frame_prev;
+	if (bake_mode == BAKE_PARALLEL_TRANSPORT) {
+		// See Dougan, Carl. "The parallel transport frame." Game Programming Gems 2 (2001): 215-219. for a discussing about its difference with Frenet frame.
 
 		// Set the initial frame based on Y-up rule.
-		{
-			Vector3 forward = forward_ptr[0];
+		up_write[0] = _ensure_valid_up_vector(forward_ptr[0], Vector3(0, 1, 0), Vector3(1, 0, 0));
 
-			if (abs(forward.dot(Vector3(0, 1, 0))) > 1.0 - UNIT_EPSILON) {
-				frame_prev = Basis::looking_at(forward, Vector3(1, 0, 0));
-			} else {
-				frame_prev = Basis::looking_at(forward, Vector3(0, 1, 0));
-			}
-
-			up_write[0] = frame_prev.get_column(1);
-		}
+		Basis frame; // X-right, Y-up, -Z-forward.
+		Basis frame_prev = Basis::looking_at(forward_ptr[0], up_write[0]);
 
 		// Calculate the Parallel Transport Frame.
 		for (int idx = 1; idx < point_count; idx++) {
@@ -1685,14 +1685,48 @@ void Curve3D::_bake() const {
 			Basis rotate;
 			rotate.rotate_to_align(-frame_prev.get_column(2), forward);
 			frame = rotate * frame_prev;
-			frame.orthonormalize(); // guard against float error accumulation
+			frame.orthonormalize(); // Guard against float error accumulation.
 
 			up_write[idx] = frame.get_column(1);
 			frame_prev = frame;
 		}
+	} else if (bake_mode == BAKE_FRENET) {
+		// See also Dougan, Carl. "The parallel transport frame." Game Programming Gems 2 (2001): 215-219.
 
+		// Calculate up(binormal) vector.
+		{
+			Vector3 forward;
+			Vector3 side;
+			for (int idx = 0; idx < point_count; idx++) {
+				forward = forward_ptr[idx];
+				if (idx != 0) {
+					side = forward - forward_ptr[idx - 1];
+				} else {
+					side = forward_ptr[idx + 1] - forward;
+				}
+
+				if (side.is_zero_approx()) {
+					up_write[idx] = _ensure_valid_up_vector(forward_ptr[idx], Vector3(0, 1, 0), Vector3(1, 0, 0));
+				} else {
+					const Vector3 up = forward.cross(side).normalized();
+					up_write[idx] = up;
+				}
+			}
+		}
+	} else if (bake_mode == BAKE_PLANAR) {
+		// Simplified case, works great for racing tracks or roads. Not suitable for roller coasters :).
+		for (int idx = 0; idx < point_count; idx++) {
+			Vector3 forward = forward_ptr[idx];
+			Basis frame = Basis::looking_at(forward);
+			up_write[idx] = frame.get_column(1);
+		}
+	} else {
+		ERR_FAIL_MSG("Invalid bake mode.");
+	}
+
+	// Step 3: Smooth rotation for loops, where two ends of a curve share position and tangent.
+	{
 		bool is_loop = true;
-		// Loop smoothing only applies when the curve is a loop, which means two ends meet, and share forward directions.
 		{
 			if (!points_ptr[0].is_equal_approx(points_ptr[point_count - 1])) {
 				is_loop = false;
@@ -2085,6 +2119,15 @@ bool Curve3D::is_up_vector_enabled() const {
 	return up_vector_enabled;
 }
 
+void Curve3D::set_bake_mode(Curve3D::BakeMode p_mode) {
+	bake_mode = p_mode;
+	mark_dirty();
+}
+
+Curve3D::BakeMode Curve3D::get_bake_mode() const {
+	return bake_mode;
+}
+
 Dictionary Curve3D::_get_data() const {
 	Dictionary dc;
 
@@ -2305,6 +2348,8 @@ void Curve3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bake_interval"), &Curve3D::get_bake_interval);
 	ClassDB::bind_method(D_METHOD("set_up_vector_enabled", "enable"), &Curve3D::set_up_vector_enabled);
 	ClassDB::bind_method(D_METHOD("is_up_vector_enabled"), &Curve3D::is_up_vector_enabled);
+	ClassDB::bind_method(D_METHOD("set_bake_mode", "mode"), &Curve3D::set_bake_mode);
+	ClassDB::bind_method(D_METHOD("get_bake_mode"), &Curve3D::get_bake_mode);
 
 	ClassDB::bind_method(D_METHOD("get_baked_length"), &Curve3D::get_baked_length);
 	ClassDB::bind_method(D_METHOD("sample_baked", "offset", "cubic"), &Curve3D::sample_baked, DEFVAL(0.0), DEFVAL(false));
@@ -2327,6 +2372,11 @@ void Curve3D::_bind_methods() {
 
 	ADD_GROUP("Up Vector", "up_vector_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "up_vector_enabled"), "set_up_vector_enabled", "is_up_vector_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "up_vector_bake_mode", PROPERTY_HINT_ENUM, "Parallel Transport,Frenet,Planar"), "set_bake_mode", "get_bake_mode");
+
+	BIND_ENUM_CONSTANT(BAKE_PARALLEL_TRANSPORT);
+	BIND_ENUM_CONSTANT(BAKE_FRENET);
+	BIND_ENUM_CONSTANT(BAKE_PLANAR);
 }
 
 Curve3D::Curve3D() {}

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -250,6 +250,14 @@ public:
 class Curve3D : public Resource {
 	GDCLASS(Curve3D, Resource);
 
+public:
+	enum BakeMode {
+		BAKE_PARALLEL_TRANSPORT,
+		BAKE_FRENET,
+		BAKE_PLANAR
+	};
+
+private:
 	struct Point {
 		Vector3 in;
 		Vector3 out;
@@ -262,6 +270,9 @@ class Curve3D : public Resource {
 	// For Path3DGizmo.
 	mutable Vector<size_t> points_in_cache;
 #endif
+	real_t bake_interval = 0.2;
+	bool up_vector_enabled = true;
+	BakeMode bake_mode = BakeMode::BAKE_PARALLEL_TRANSPORT;
 
 	mutable bool baked_cache_dirty = false;
 	mutable PackedVector3Array baked_point_cache;
@@ -285,9 +296,6 @@ class Curve3D : public Resource {
 	real_t _sample_baked_tilt(Interval p_interval) const;
 	Basis _sample_posture(Interval p_interval, bool p_apply_tilt = false) const;
 	Basis _compose_posture(int p_index) const;
-
-	real_t bake_interval = 0.2;
-	bool up_vector_enabled = true;
 
 	void _bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	void _bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_length) const;
@@ -333,6 +341,8 @@ public:
 	real_t get_bake_interval() const;
 	void set_up_vector_enabled(bool p_enable);
 	bool is_up_vector_enabled() const;
+	void set_bake_mode(BakeMode p_mode);
+	BakeMode get_bake_mode() const;
 
 	real_t get_baked_length() const;
 	Vector3 sample_baked(real_t p_offset, bool p_cubic = false) const;
@@ -350,5 +360,7 @@ public:
 
 	Curve3D();
 };
+
+VARIANT_ENUM_CAST(Curve3D::BakeMode);
 
 #endif // CURVE_H

--- a/tests/scene/test_curve_3d.h
+++ b/tests/scene/test_curve_3d.h
@@ -145,6 +145,34 @@ TEST_CASE("[Curve3D] Baked") {
 			CHECK(curve->get_baked_up_vectors().size() == 0);
 		}
 	}
+
+	SUBCASE("S-shaped Curve") {
+		Vector3 p0(0, 0, 0);
+		Vector3 p1(0, 0, 50);
+		Vector3 p2(0, 0, 100);
+
+		curve->add_point(p0, Vector3(), Vector3(30, 0, 0));
+		curve->add_point(p1, Vector3(30, 0, 0), Vector3(-30, 0, 0));
+		curve->add_point(p2, Vector3(-30, 0, 0), Vector3());
+
+		real_t n_points = curve->get_baked_points().size();
+
+		SUBCASE("Frenet frame") {
+			curve->set_bake_mode(Curve3D::BAKE_FRENET);
+
+			// Frenet frame should have reversed up vectors around saddle point.
+			CHECK(curve->get_baked_up_vectors().get(5).is_equal_approx(Vector3(0, -1, 0)));
+			CHECK(curve->get_baked_up_vectors().get(n_points - 5).is_equal_approx(Vector3(0, 1, 0)));
+		}
+
+		SUBCASE("Planar frame") {
+			curve->set_bake_mode(Curve3D::BAKE_PLANAR);
+
+			// Planar frame should have the same up vectors around saddle point.
+			CHECK(curve->get_baked_up_vectors().get(5).is_equal_approx(Vector3(0, 1, 0)));
+			CHECK(curve->get_baked_up_vectors().get(n_points - 5).is_equal_approx(Vector3(0, 1, 0)));
+		}
+	}
 }
 
 TEST_CASE("[Curve3D] Sampling") {


### PR DESCRIPTION
This PR implements  https://github.com/godotengine/godot-proposals/issues/7462

It gives user more options for different situations, as there is no single best way for all situations.

- Parallel transport frame, the default, produces smooth rotation frames most of the time.
- Frenet frame, globally stable, good for local tweaking of control points.
- Planar frame, simplified case, good for racing track or road type scenarios.

*Bugsquad edit, closes: godotengine/godot-proposals#7462*
