### PR TITLE
Improve scene tiles workflow

### DIFF
--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -632,7 +632,7 @@ TileAtlasView::TileAtlasView() {
 	panel->add_child(center_container);
 
 	missing_source_label = memnew(Label);
-	missing_source_label->set_text(TTR("No atlas source with a valid texture selected."));
+	missing_source_label->set_text(TTR("The selected atlas source has no valid texture. Assign a texture in the TileSet bottom tab."));
 	center_container->add_child(missing_source_label);
 
 	margin_container = memnew(MarginContainer);

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -177,7 +177,11 @@ void TileMapEditorTilesPlugin::_update_tile_set_sources_list() {
 		if (scene_collection_source) {
 			texture = tiles_bottom_panel->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 			if (item_text.is_empty()) {
-				item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+				if (scene_collection_source->get_scene_tiles_count() > 0) {
+					item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+				} else {
+					item_text = vformat(TTR("Empty Scene Collection Source (ID: %d)"), source_id);
+				}
 			}
 		}
 
@@ -397,6 +401,10 @@ void TileMapEditorTilesPlugin::_update_scenes_collection_view() {
 		if (tile_set_selection.has(TileMapCell(source_id, Vector2i(), scene_id))) {
 			scene_tiles_list->select(item_index, false);
 		}
+	}
+	if (scene_tiles_list->get_item_count() == 0) {
+		scene_tiles_list->add_item(TTR("The selected scene collection source has no scenes. Add scenes in the TileSet bottom tab."));
+		scene_tiles_list->set_item_disabled(-1, true);
 	}
 
 	// Icon size update.

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -181,7 +181,11 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		if (scene_collection_source) {
 			texture = get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 			if (item_text.is_empty()) {
-				item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+				if (scene_collection_source->get_scene_tiles_count() > 0) {
+					item_text = vformat(TTR("Scene Collection Source (ID: %d)"), source_id);
+				} else {
+					item_text = vformat(TTR("Empty Scene Collection Source (ID: %d)"), source_id);
+				}
 			}
 		}
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.h
@@ -38,6 +38,7 @@
 class Button;
 class ItemList;
 class Label;
+class EditorFileDialog;
 
 class TileSetScenesCollectionSourceEditor : public HBoxContainer {
 	GDCLASS(TileSetScenesCollectionSourceEditor, HBoxContainer);
@@ -114,6 +115,7 @@ private:
 	ItemList *scene_tiles_list = nullptr;
 	Button *scene_tile_add_button = nullptr;
 	Button *scene_tile_delete_button = nullptr;
+	EditorFileDialog *scene_select_dialog = nullptr;
 
 	void _tile_set_scenes_collection_source_changed();
 	void _scenes_collection_source_proxy_object_changed(String p_what);
@@ -121,6 +123,7 @@ private:
 	void _scenes_list_item_activated(int p_index);
 
 	void _source_add_pressed();
+	void _scene_file_selected(const String &p_path);
 	void _source_delete_pressed();
 
 	// Update methods.

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4867,9 +4867,9 @@ void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedSce
 			type = scene_state->get_node_type(0);
 			scene_state = scene_state->get_base_scene_state();
 		}
-		ERR_FAIL_COND_MSG(type.is_empty(), vformat("Invalid PackedScene for TileSetScenesCollectionSource: %s. Could not get the type of the root node.", p_packed_scene->get_path()));
+		ERR_FAIL_COND_EDMSG(type.is_empty(), vformat("Invalid PackedScene for TileSetScenesCollectionSource: %s. Could not get the type of the root node.", p_packed_scene->get_path()));
 		bool extends_correct_class = ClassDB::is_parent_class(type, "CanvasItem");
-		ERR_FAIL_COND_MSG(!extends_correct_class, vformat("Invalid PackedScene for TileSetScenesCollectionSource: %s. Root node should extend CanvasItem. Found %s instead.", p_packed_scene->get_path(), type));
+		ERR_FAIL_COND_EDMSG(!extends_correct_class, vformat("Invalid PackedScene for TileSetScenesCollectionSource: %s. Root node should extend CanvasItem. Found %s instead.", p_packed_scene->get_path(), type));
 
 		scenes[p_id].scene = p_packed_scene;
 	} else {


### PR DESCRIPTION
Misc improvements to scene collection tiles editing, similar to my previous improvements.
- Added hint and a different name when scene source has no tiles in TileMap
![Empty](https://github.com/godotengine/godot/assets/2223172/85689029-78dc-4380-8b11-b5bd2808de36)
- Added hint in TileSet editor how to add scenes
![image](https://github.com/godotengine/godot/assets/2223172/d6211ed6-530d-4d69-be3b-62b276e2596a)
- Pressing Add button opens a file dialog to directly select the scene, instead of adding empty tile

https://github.com/godotengine/godot/assets/2223172/65e83c4c-3bd4-4a2d-b423-76ea0c65f3d5

- If you assign invalid scene, you are informed via editor toaster instead of a hidden error inside the console

https://github.com/godotengine/godot/assets/2223172/0e6ac538-76af-4c3d-a271-f136cade5f5f

