### PR TITLE
Fix Vulkan texture update

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -2622,7 +2622,7 @@ Error RenderingDeviceVulkan::_texture_update(RID p_texture, uint32_t p_layer, co
 
 					vkCmdCopyBufferToImage(command_buffer, staging_buffer_blocks[staging_buffer_current].buffer, texture->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_image_copy);
 
-					staging_buffer_blocks.write[staging_buffer_current].fill_amount += alloc_size;
+					staging_buffer_blocks.write[staging_buffer_current].fill_amount = alloc_offset + alloc_size;
 				}
 			}
 		}


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/78445

For some non-4 byte aligned or compressed image formats (like FORMAT_RH, FORMAT_RG8 or COMPRESS_S3TC with USED_CHANNELS_RG etc.) the staging buffer calculation was off because possible alignment adjustment offset was not taken into account. This sometimes made the last pixel in an image corrupt when uploaded to GPU. Also see `RenderingDeviceVulkan::_buffer_update()` which does this same calculation correctly.

**edit:**

This fix proably needs to be done in https://github.com/godotengine/godot/pull/80164 `RenderingDeviceVulkan::_texture_update_partial()` too. Interestingly, this issue is fixed in Direct3D 12 PR https://github.com/godotengine/godot/pull/70315 in `RenderingDeviceD3D12::_texture_update()`.