### PR TITLE
Rework MeshLibary previews

### DIFF
--- a/doc/classes/MeshLibrary.xml
+++ b/doc/classes/MeshLibrary.xml
@@ -115,6 +115,13 @@
 				The array consists of each [Shape3D] followed by its [Transform3D].
 			</description>
 		</method>
+		<method name="get_item_use_custom_preview" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns whether the item uses a custom preview.
+			</description>
+		</method>
 		<method name="get_last_unused_item_id" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -210,6 +217,15 @@
 				The array should consist of [Shape3D] objects, each followed by a [Transform3D] that will be applied to it. For shapes that should not have a transform, use [constant Transform3D.IDENTITY].
 			</description>
 		</method>
+		<method name="set_item_use_custom_preview">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="use_custom_preview" type="bool" />
+			<description>
+				If [code]true[/code], the item's preview will be saved with the resource. Use it only if you really need a custom mesh preview and your [MeshLibrary] resource is saved in binary format. The image is intended for editor usage and will get embedded in the library. It also makes the previews not update when the mesh changes.
+				If [code]false[/code], no preview will be stored and the editor will automatically generate them on when needed.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="item/{index}/category" type="String" setter="" getter="" default="&amp;&quot;&quot;">
@@ -237,10 +253,13 @@
 			The transform to apply to the item's navigation mesh.
 		</member>
 		<member name="item/{index}/preview" type="Texture2D" setter="" getter="">
-			The texture to use as the item's preview icon in the editor.
+			The texture to use as the item's preview icon in the editor.  Setting this property automatically enables or disables [member item/{index}/use_custom_preview].
 		</member>
 		<member name="item/{index}/shapes" type="Array" setter="" getter="" default="[]">
 			The item's collision shapes. The array should consist of [Shape3D] objects, each followed by a [Transform3D] that will be applied to it. For shapes that should not have a transform, use [constant Transform3D.IDENTITY].
+		</member>
+		<member name="item/{index}/use_custom_preview" type="bool" setter="" getter="" default="false">
+			If disabled, the preview image is not persistent and instead generated on demand.
 		</member>
 	</members>
 </class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -159,14 +159,12 @@ TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const TypedArray<Mesh
 }
 
 Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size) {
-	int size = p_preview_size;
-
 	RID scenario = RS::get_singleton()->scenario_create();
 
 	RID viewport = RS::get_singleton()->viewport_create();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RSE::VIEWPORT_UPDATE_ALWAYS);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, size, size);
+	RS::get_singleton()->viewport_set_size(viewport, p_preview_size, p_preview_size);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
@@ -187,53 +185,16 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 
 	for (int i = 0; i < p_meshes.size(); i++) {
 		const Ref<Mesh> &mesh = p_meshes[i];
-		if (mesh.is_null()) {
-			textures.push_back(Ref<Texture2D>());
-			continue;
-		}
 
 		Transform3D mesh_xform;
 		if (p_transforms != nullptr) {
 			mesh_xform = (*p_transforms)[i];
 		}
 
-		RID inst = RS::get_singleton()->instance_create2(mesh->get_rid(), scenario);
-		RS::get_singleton()->instance_set_transform(inst, mesh_xform);
-
-		AABB aabb = mesh->get_aabb();
-		Vector3 ofs = aabb.get_center();
-		aabb.position -= ofs;
-		Transform3D xform;
-		xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6);
-		xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI / 6) * xform.basis;
-		AABB rot_aabb = xform.xform(aabb);
-		float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
-		if (m == 0) {
-			textures.push_back(Ref<Texture2D>());
-			continue;
-		}
-		xform.origin = -xform.basis.xform(ofs); //-ofs*m;
-		xform.origin.z -= rot_aabb.size.z * 2;
-		xform.invert();
-		xform = mesh_xform * xform;
-
-		RS::get_singleton()->camera_set_transform(camera, xform * Transform3D(Basis(), Vector3(0, 0, 3)));
-		RS::get_singleton()->camera_set_orthogonal(camera, m * 2, 0.01, 1000.0);
-
-		RS::get_singleton()->instance_set_transform(light_instance, xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
-		RS::get_singleton()->instance_set_transform(light_instance2, xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
-
 		ep.step(TTR("Thumbnail..."), i);
-		DisplayServer::get_singleton()->process_events();
-		Main::iteration();
-		Main::iteration();
-		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
-		ERR_CONTINUE(img.is_null() || img->is_empty());
-		Ref<ImageTexture> it = ImageTexture::create_from_image(img);
 
-		RS::get_singleton()->free_rid(inst);
-
-		textures.push_back(it);
+		Ref<Texture2D> texture = make_mesh_preview_with_environment(scenario, camera, light_instance, light_instance2, viewport_texture, mesh, mesh_xform);
+		textures.push_back(texture);
 	}
 
 	RS::get_singleton()->free_rid(viewport);
@@ -401,6 +362,47 @@ void EditorInterface::add_root_node(Node *p_node) {
 	EditorNode::get_singleton()->set_edited_scene(p_node);
 	EditorUndoRedoManager::get_singleton()->set_history_as_unsaved(EditorNode::get_editor_data().get_current_edited_scene_history_id());
 	EditorSceneTabs::get_singleton()->update_scene_tabs();
+}
+Ref<Texture2D> EditorInterface::make_mesh_preview_with_environment(const RID &p_scenario, const RID &p_camera, const RID &p_light_instance, const RID &p_light_instance2, const RID &p_viewport_texture, const Ref<Mesh> &p_mesh, const Transform3D &p_transform) {
+	if (p_mesh.is_null()) {
+		return Ref<Texture2D>();
+	}
+
+	RID inst = RS::get_singleton()->instance_create2(p_mesh->get_rid(), p_scenario);
+	RS::get_singleton()->instance_set_transform(inst, p_transform);
+
+	AABB aabb = p_mesh->get_aabb();
+	Vector3 ofs = aabb.get_center();
+	aabb.position -= ofs;
+	Transform3D xform;
+	xform.basis = Basis().rotated(Vector3(0, 1, 0), -Math::PI / 6);
+	xform.basis = Basis().rotated(Vector3(1, 0, 0), Math::PI / 6) * xform.basis;
+	AABB rot_aabb = xform.xform(aabb);
+	float m = MAX(rot_aabb.size.x, rot_aabb.size.y) * 0.5;
+	if (m == 0) {
+		return Ref<Texture2D>();
+	}
+	xform.origin = -xform.basis.xform(ofs); //-ofs*m;
+	xform.origin.z -= rot_aabb.size.z * 2;
+	xform.invert();
+	xform = p_transform * xform;
+
+	RS::get_singleton()->camera_set_transform(p_camera, xform * Transform3D(Basis(), Vector3(0, 0, 3)));
+	RS::get_singleton()->camera_set_orthogonal(p_camera, m * 2, 0.01, 1000.0);
+
+	RS::get_singleton()->instance_set_transform(p_light_instance, xform * Transform3D().looking_at(Vector3(-2, -1, -1), Vector3(0, 1, 0)));
+	RS::get_singleton()->instance_set_transform(p_light_instance2, xform * Transform3D().looking_at(Vector3(+1, -1, -2), Vector3(0, 1, 0)));
+
+	DisplayServer::get_singleton()->process_events();
+	Main::iteration();
+	Main::iteration();
+	Ref<Image> img = RS::get_singleton()->texture_2d_get(p_viewport_texture);
+	ERR_FAIL_COND_V(img.is_null() || img->is_empty(), Ref<Texture2D>());
+	Ref<ImageTexture> it = ImageTexture::create_from_image(img);
+
+	RS::get_singleton()->free_rid(inst);
+
+	return it;
 }
 
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -113,6 +113,7 @@ public:
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);
+	Ref<Texture2D> make_mesh_preview_with_environment(const RID &p_scenario, const RID &p_camera, const RID &p_light_instance, const RID &p_light_instance2, const RID &p_viewport_texture, const Ref<Mesh> &p_mesh, const Transform3D &p_transform);
 
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2815,6 +2815,7 @@ void EditorNode::_dialog_action(String p_file) {
 			const Dictionary &fd_options = file_export_lib->get_selected_options();
 			bool merge_with_existing_library = fd_options.get(TTR("Merge With Existing"), true);
 			bool apply_mesh_instance_transforms = fd_options.get(TTR("Apply MeshInstance Transforms"), false);
+			bool bake_previews = fd_options.get(TTR("Bake Mesh Previews"), false);
 
 			Ref<MeshLibrary> ml;
 			if (merge_with_existing_library && FileAccess::exists(p_file)) {
@@ -2830,7 +2831,7 @@ void EditorNode::_dialog_action(String p_file) {
 				ml.instantiate();
 			}
 
-			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, merge_with_existing_library, apply_mesh_instance_transforms);
+			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, merge_with_existing_library, apply_mesh_instance_transforms, bake_previews);
 
 			Error err = ResourceSaver::save(ml, p_file);
 			if (err) {
@@ -9395,6 +9396,7 @@ EditorNode::EditorNode() {
 	file_export_lib->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 	file_export_lib->add_option(TTR("Merge With Existing"), Vector<String>(), true);
 	file_export_lib->add_option(TTR("Apply MeshInstance Transforms"), Vector<String>(), false);
+	file_export_lib->add_option(TTR("Bake Mesh Previews"), Vector<String>(), false);
 	gui_base->add_child(file_export_lib);
 
 	file_pack_zip = memnew(EditorFileDialog);

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -94,7 +94,9 @@ bool MeshLibraryEditor::MeshLibraryItem::_set(const StringName &p_name, const Va
 		mesh_library->_set_item_shapes(mesh_id, p_value);
 #endif // PHYSICS_3D_DISABLED
 	} else if (p_name == "preview") {
-		mesh_library->set_item_preview(mesh_id, p_value);
+		mesh_library->set_item_custom_preview(mesh_id, p_value);
+	} else if (p_name == "use_custom_preview") {
+		mesh_library->set_item_use_custom_preview(mesh_id, p_value);
 	} else if (p_name == "navigation_mesh") {
 		mesh_library->set_item_navigation_mesh(mesh_id, p_value);
 	} else if (p_name == "navigation_mesh_transform") {
@@ -135,6 +137,8 @@ bool MeshLibraryEditor::MeshLibraryItem::_get(const StringName &p_name, Variant 
 		r_ret = mesh_library->get_item_navigation_layers(mesh_id);
 	} else if (p_name == "preview") {
 		r_ret = mesh_library->get_item_preview(mesh_id);
+	} else if (p_name == "custom_preview") {
+		r_ret = mesh_library->get_item_use_custom_preview(mesh_id);
 	} else {
 		return false;
 	}
@@ -185,8 +189,8 @@ void MeshLibraryEditor::edit(const Ref<MeshLibrary> &p_mesh_library) {
 	}
 }
 
-Error MeshLibraryEditor::update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge, bool p_apply_xforms) {
-	_import_scene(p_base_scene, ml, p_merge, p_apply_xforms);
+Error MeshLibraryEditor::update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge, bool p_apply_xforms, bool p_bake_previews) {
+	_import_scene(p_base_scene, ml, p_merge, p_apply_xforms, p_bake_previews);
 	return OK;
 }
 
@@ -461,7 +465,7 @@ void MeshLibraryEditor::_menu_update_confirm(bool p_apply_xforms) {
 	_import_scene_cbk(existing);
 }
 
-void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms) {
+void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms, bool p_bake_previews) {
 	if (!p_merge) {
 		p_library->clear();
 	}
@@ -471,24 +475,26 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 		_import_scene_parse_node(p_library, mesh_instances, p_scene->get_child(i), p_merge, p_apply_xforms);
 	}
 
-	// Generate previews.
+	// Generate previews!
 
-	Vector<Ref<Mesh>> meshes;
-	Vector<Transform3D> transforms;
-	Vector<int> ids = p_library->get_item_list();
-	for (const int &E : ids) {
-		if (mesh_instances.find(E)) {
-			meshes.push_back(p_library->get_item_mesh(E));
-			transforms.push_back(mesh_instances[E]->get_transform());
+	if (p_bake_previews) {
+		Vector<Ref<Mesh>> meshes;
+		Vector<Transform3D> transforms;
+		Vector<int> ids = p_library->get_item_list();
+		for (int id : ids) {
+			if (mesh_instances.find(id)) {
+				meshes.push_back(p_library->get_item_mesh(id));
+				transforms.push_back(mesh_instances[id]->get_transform());
+			}
 		}
-	}
 
-	Vector<Ref<Texture2D>> textures = EditorInterface::get_singleton()->make_mesh_previews(meshes, &transforms, EDITOR_GET("editors/grid_map/preview_size"));
-	int idx = 0;
-	for (const int &E : ids) {
-		if (mesh_instances.find(E)) {
-			p_library->set_item_preview(E, textures[idx]);
-			idx++;
+		Vector<Ref<Texture2D>> textures = EditorInterface::get_singleton()->make_mesh_previews(meshes, &transforms, EDITOR_GET("editors/grid_map/preview_size"));
+		int i = 0;
+		for (int id : ids) {
+			if (mesh_instances.find(id)) {
+				p_library->set_item_custom_preview(id, textures[i]);
+				i++;
+			}
 		}
 	}
 }
@@ -504,7 +510,7 @@ void MeshLibraryEditor::_import_scene_cbk(const String &p_str) {
 	Ref<MeshLibrary> old_lib;
 	old_lib = mesh_library->duplicate();
 
-	_import_scene(scene, mesh_library, import_update, apply_xforms);
+	_import_scene(scene, mesh_library, import_update, apply_xforms, false);
 
 	memdelete(scene);
 	mesh_library->set_meta("_editor_source_scene", p_str);

--- a/editor/scene/3d/mesh_library_editor_plugin.h
+++ b/editor/scene/3d/mesh_library_editor_plugin.h
@@ -107,7 +107,7 @@ class MeshLibraryEditor : public EditorDock {
 	void _menu_update_confirm(bool p_apply_xforms);
 
 	void _import_scene_cbk(const String &p_str);
-	static void _import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms);
+	static void _import_scene(Node *p_scene, Ref<MeshLibrary> p_library, bool p_merge, bool p_apply_xforms, bool p_bake_previews);
 	static void _import_scene_parse_node(Ref<MeshLibrary> p_library, HashMap<int, MeshInstance3D *> &p_mesh_instances, Node *p_node, bool p_merge, bool p_apply_xforms);
 
 	void _icon_size_changed(float p_value);
@@ -118,7 +118,7 @@ private:
 
 public:
 	void edit(const Ref<MeshLibrary> &p_mesh_library);
-	static Error update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge = true, bool p_apply_xforms = false);
+	static Error update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge = true, bool p_apply_xforms = false, bool p_bake_previews = false);
 
 	MeshLibraryEditor();
 };

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -36,6 +36,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/docks/editor_dock_manager.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -1153,6 +1154,11 @@ void GridMapEditor::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
 }
 
 void GridMapEditor::update_palette() {
+	if (updating) {
+		// Main::iteration() from make_mesh_preview_with_environment() can cause a recursive call.
+		return;
+	}
+
 	float min_size = EDITOR_GET("editors/grid_map/preview_size");
 	min_size *= EDSCALE;
 
@@ -1201,6 +1207,13 @@ void GridMapEditor::update_palette() {
 	}
 	items_sorted.sort();
 
+	int preview_size = EDITOR_GET("editors/grid_map/preview_size");
+	RS::get_singleton()->viewport_set_size(preview_viewport, preview_size, preview_size);
+	RS::get_singleton()->viewport_set_update_mode(preview_viewport, RSE::VIEWPORT_UPDATE_ALWAYS);
+	RID viewport_texture = RS::get_singleton()->viewport_get_texture(preview_viewport);
+
+	mesh_library->set_block_signals(true);
+	updating = true;
 	for (_CGMEItemSort &E : items_sorted) {
 		int item_id = E.id;
 
@@ -1230,15 +1243,13 @@ void GridMapEditor::update_palette() {
 		}
 		mesh_library_palette->set_item_text(list_id, item_name);
 
-		const Ref<Texture2D> &preview = mesh_library->get_item_preview(item_id);
+		Ref<Texture2D> preview = mesh_library->get_item_preview(item_id);
 		if (preview.is_valid()) {
 			mesh_library_palette->set_item_icon(list_id, preview);
 		} else {
-			Ref<Mesh> mesh = mesh_library->get_item_mesh(item_id);
-			if (mesh.is_valid()) {
-				// Fallback to the item's mesh preview.
-				EditorResourcePreview::get_singleton()->queue_edited_resource_preview(mesh, callable_mp(this, &GridMapEditor::_update_resource_preview).bind(list_id));
-			}
+			preview = EditorInterface::get_singleton()->make_mesh_preview_with_environment(
+					preview_scenario, preview_camera, light_instance, light_instance2, viewport_texture, mesh_library->get_item_mesh(item_id), mesh_library->get_item_mesh_transform(item_id));
+			mesh_library->set_item_preview(item_id, preview);
 		}
 
 		mesh_library_palette->set_item_text(list_id, item_name);
@@ -1372,6 +1383,9 @@ void GridMapEditor::_update_resource_preview(const String &p_path, const Ref<Tex
 	if (p_idx < mesh_library_palette->get_item_count()) {
 		mesh_library_palette->set_item_icon(p_idx, p_preview);
 	}
+	mesh_library->set_block_signals(false);
+	updating = false;
+	RS::get_singleton()->viewport_set_update_mode(preview_viewport, RSE::VIEWPORT_UPDATE_DISABLED);
 }
 
 void GridMapEditor::_update_mesh_library() {
@@ -1450,7 +1464,6 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	// Prevent the cursor from being at an incorrect position before any inputs happen.
 	cursor_origin = (Vector3(cursor_gridpos) + Vector3(0.5 * node->get_center_x(), 0.5 * node->get_center_y(), 0.5 * node->get_center_z())) * node->get_cell_size();
 
-	update_palette();
 	_update_cursor_instance();
 	_update_edit_axis();
 
@@ -1480,9 +1493,7 @@ void GridMapEditor::update_grid() {
 		RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], i == edit_axis);
 	}
 
-	updating = true;
-	floor->set_value(edit_floor[edit_axis]);
-	updating = false;
+	floor->set_value_no_signal(edit_floor[edit_axis]);
 }
 
 void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
@@ -1558,22 +1569,22 @@ void GridMapEditor::_update_theme() {
 void GridMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
+			const RID world_scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
 
 			for (int i = 0; i < 3; i++) {
 				grid[i] = RS::get_singleton()->mesh_create();
-				grid_instance[i] = RS::get_singleton()->instance_create2(grid[i], scenario);
+				grid_instance[i] = RS::get_singleton()->instance_create2(grid[i], world_scenario);
 				RenderingServer::get_singleton()->instance_set_layer_mask(grid_instance[i], 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-				selection_level_instance[i] = RenderingServer::get_singleton()->instance_create2(selection_level_mesh[i], scenario);
+				selection_level_instance[i] = RenderingServer::get_singleton()->instance_create2(selection_level_mesh[i], world_scenario);
 				RenderingServer::get_singleton()->instance_set_layer_mask(selection_level_instance[i], 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
 			}
 
-			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, scenario);
+			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, world_scenario);
 			RenderingServer::get_singleton()->instance_set_layer_mask(cursor_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
 			RenderingServer::get_singleton()->instance_set_visible(cursor_instance, false);
-			selection_instance = RenderingServer::get_singleton()->instance_create2(selection_mesh, scenario);
+			selection_instance = RenderingServer::get_singleton()->instance_create2(selection_mesh, world_scenario);
 			RenderingServer::get_singleton()->instance_set_layer_mask(selection_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
-			paste_instance = RenderingServer::get_singleton()->instance_create2(paste_mesh, scenario);
+			paste_instance = RenderingServer::get_singleton()->instance_create2(paste_mesh, world_scenario);
 			RenderingServer::get_singleton()->instance_set_layer_mask(paste_instance, 1 << Node3DEditorViewport::MISC_TOOL_LAYER);
 
 			_update_selection_transform();
@@ -1649,14 +1660,14 @@ void GridMapEditor::_update_cursor_instance() {
 	}
 	cursor_instance = RID();
 
-	const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
+	const RID world_scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
 
 	if (mesh_library.is_valid()) {
 		if (mode_buttons_group->get_pressed_button() == paint_mode_button) {
 			if (selected_palette >= 0 && node && node->get_mesh_library().is_valid()) {
 				Ref<Mesh> mesh = node->get_mesh_library()->get_item_mesh(selected_palette);
 				if (mesh.is_valid() && mesh->get_rid().is_valid()) {
-					cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
+					cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), world_scenario);
 					RSE::ShadowCastingSetting cast_shadows = (RSE::ShadowCastingSetting)node->get_mesh_library()->get_item_mesh_cast_shadow(selected_palette);
 					RS::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, cast_shadows);
 				}
@@ -1664,15 +1675,15 @@ void GridMapEditor::_update_cursor_instance() {
 		} else if (mode_buttons_group->get_pressed_button() == select_mode_button) {
 			cursor_inner_mat->set_albedo(Color(default_color, 0.2));
 			cursor_outer_mat->set_albedo(Color(default_color, 0.8));
-			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, scenario);
+			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, world_scenario);
 		} else if (mode_buttons_group->get_pressed_button() == erase_mode_button) {
 			cursor_inner_mat->set_albedo(Color(erase_color, 0.2));
 			cursor_outer_mat->set_albedo(Color(erase_color, 0.8));
-			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, scenario);
+			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, world_scenario);
 		} else if (mode_buttons_group->get_pressed_button() == pick_mode_button) {
 			cursor_inner_mat->set_albedo(Color(pick_color, 0.2));
 			cursor_outer_mat->set_albedo(Color(pick_color, 0.8));
-			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, scenario);
+			cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, world_scenario);
 		}
 	}
 
@@ -1705,10 +1716,6 @@ void GridMapEditor::_item_selected_cbk(int idx) {
 }
 
 void GridMapEditor::_floor_changed(float p_value) {
-	if (updating) {
-		return;
-	}
-
 	edit_floor[_get_edit_axis()] = p_value;
 	node->set_meta("_editor_floor_", Vector3(edit_floor[0], edit_floor[1], edit_floor[2]));
 	update_grid();
@@ -2184,6 +2191,23 @@ GridMapEditor::GridMapEditor() {
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	indicator_mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 	indicator_mat->set_albedo(EDITOR_GET("editors/3d_gizmos/gizmo_colors/gridmap_grid"));
+
+	preview_scenario = RS::get_singleton()->scenario_create();
+
+	preview_viewport = RS::get_singleton()->viewport_create();
+	RS::get_singleton()->viewport_set_scenario(preview_viewport, preview_scenario);
+	RS::get_singleton()->viewport_set_transparent_background(preview_viewport, true);
+	RS::get_singleton()->viewport_set_active(preview_viewport, true);
+
+	preview_camera = RS::get_singleton()->camera_create();
+	RS::get_singleton()->viewport_attach_camera(preview_viewport, preview_camera);
+
+	light = RS::get_singleton()->directional_light_create();
+	light_instance = RS::get_singleton()->instance_create2(light, preview_scenario);
+
+	light2 = RS::get_singleton()->directional_light_create();
+	RS::get_singleton()->light_set_color(light2, Color(0.7, 0.7, 0.7));
+	light_instance2 = RS::get_singleton()->instance_create2(light2, preview_scenario);
 }
 
 GridMapEditor::~GridMapEditor() {
@@ -2219,6 +2243,14 @@ GridMapEditor::~GridMapEditor() {
 	if (paste_instance.is_valid()) {
 		RenderingServer::get_singleton()->free_rid(paste_instance);
 	}
+
+	RS::get_singleton()->free_rid(preview_viewport);
+	RS::get_singleton()->free_rid(light);
+	RS::get_singleton()->free_rid(light_instance);
+	RS::get_singleton()->free_rid(light2);
+	RS::get_singleton()->free_rid(light_instance2);
+	RS::get_singleton()->free_rid(preview_camera);
+	RS::get_singleton()->free_rid(preview_scenario);
 }
 
 void GridMapEditorPlugin::_notification(int p_what) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -143,6 +143,15 @@ class GridMapEditor : public EditorDock {
 	RID paste_mesh;
 	RID paste_instance;
 
+	// Mesh preview generation.
+	RID preview_viewport;
+	RID light;
+	RID light_instance;
+	RID light2;
+	RID light_instance2;
+	RID preview_camera;
+	RID preview_scenario;
+
 	struct ClipboardItem {
 		int cell_item = 0;
 		Vector3 grid_offset;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -30,6 +30,7 @@
 
 #include "mesh_library.h"
 
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/resources/texture.h"
 #include "servers/rendering/rendering_server.h" // IWYU pragma: keep // Needed to bind RSE enums.
@@ -46,6 +47,13 @@ bool MeshLibrary::_validate_index(int p_idx) {
 		create_item(p_idx);
 	}
 
+	return true;
+}
+
+bool MeshLibrary::_filter_property(const String &p_name, int p_index) const {
+	if (p_name == "preview") {
+		return get_item_use_custom_preview(p_index);
+	}
 	return true;
 }
 
@@ -142,10 +150,17 @@ void MeshLibrary::set_item_category(int p_item, const StringName &p_category) {
 }
 
 void MeshLibrary::set_item_mesh(int p_item, const Ref<Mesh> &p_mesh) {
-	if (_validate_index(p_item)) {
-		item_map[p_item].mesh = p_mesh;
-		emit_changed();
+	if (!_validate_index(p_item)) {
+		return;
 	}
+	if (item_map[p_item].mesh.is_valid()) {
+		item_map[p_item].mesh->disconnect_changed(callable_mp(this, &MeshLibrary::_mesh_changed));
+	}
+	item_map[p_item].mesh = p_mesh;
+	if (p_mesh.is_valid()) {
+		p_mesh->connect_changed(callable_mp(this, &MeshLibrary::_mesh_changed).bind(p_item));
+	}
+	emit_changed();
 }
 
 void MeshLibrary::set_item_mesh_transform(int p_item, const Transform3D &p_transform) {
@@ -202,6 +217,19 @@ void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) 
 	}
 }
 
+void MeshLibrary::set_item_custom_preview(int p_item, const Ref<Texture2D> &p_preview) {
+	if (_validate_index(p_item)) {
+		set_item_preview(p_item, p_preview);
+		item_map[p_item].use_custom_preview = p_preview.is_valid();
+	}
+}
+
+void MeshLibrary::set_item_use_custom_preview(int p_item, bool p_use_custom_preview) {
+	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	print_line(p_use_custom_preview);
+	item_map[p_item].use_custom_preview = p_use_custom_preview;
+}
+
 String MeshLibrary::get_item_name(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), "", "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].name;
@@ -254,6 +282,11 @@ uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].preview;
+}
+
+bool MeshLibrary::get_item_use_custom_preview(int p_item) const {
+	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), false, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
+	return item_map[p_item].use_custom_preview;
 }
 
 bool MeshLibrary::has_item(int p_item) const {
@@ -353,6 +386,14 @@ Array MeshLibrary::_get_item_shapes(int p_item) const {
 }
 #endif // PHYSICS_3D_DISABLED
 
+void MeshLibrary::_mesh_changed(int p_idx) {
+	ERR_FAIL_COND(!item_map.has(p_idx));
+	if (!item_map[p_idx].use_custom_preview) {
+		item_map[p_idx].preview = Ref<Texture2D>();
+		callable_mp((Resource *)this, &Resource::emit_changed).call_deferred();
+	}
+}
+
 void MeshLibrary::reset_state() {
 	clear();
 }
@@ -375,7 +416,8 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 #endif // PHYSICS_3D_DISABLED
 
-	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
+	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_custom_preview);
+	ClassDB::bind_method(D_METHOD("set_item_use_custom_preview", "id", "use_custom_preview"), &MeshLibrary::set_item_use_custom_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_category", "id"), &MeshLibrary::get_item_category);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
@@ -393,6 +435,7 @@ void MeshLibrary::_bind_methods() {
 #endif // PHYSICS_3D_DISABLED
 
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
+	ClassDB::bind_method(D_METHOD("get_item_use_custom_preview", "id"), &MeshLibrary::get_item_use_custom_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);
 	ClassDB::bind_method(D_METHOD("find_item_by_name", "name"), &MeshLibrary::find_item_by_name);
 
@@ -405,6 +448,7 @@ void MeshLibrary::_bind_methods() {
 
 	base_property_helper.set_prefix("item/");
 	base_property_helper.set_array_length_getter(&MeshLibrary::get_item_count);
+	base_property_helper.set_property_filter(&MeshLibrary::_filter_property);
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), defaults.name, &MeshLibrary::set_item_name, &MeshLibrary::get_item_name);
 	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("category"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), defaults.category, &MeshLibrary::set_item_category, &MeshLibrary::get_item_category);
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("mesh"), PROPERTY_HINT_RESOURCE_TYPE, Mesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.mesh, &MeshLibrary::set_item_mesh, &MeshLibrary::get_item_mesh);
@@ -422,6 +466,7 @@ void MeshLibrary::_bind_methods() {
 #endif // NAVIGATION_3D_DISABLED
 
 	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NO_EDITOR), defaults.preview, &MeshLibrary::set_item_preview, &MeshLibrary::get_item_preview);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("use_custom_preview"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), defaults.use_custom_preview, &MeshLibrary::set_item_use_custom_preview, &MeshLibrary::get_item_use_custom_preview);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -50,6 +50,7 @@ class MeshLibrary : public Resource {
 	bool init_property = false;
 
 	bool _validate_index(int p_idx);
+	bool _filter_property(const String &p_name, int p_index) const;
 
 public:
 #ifndef PHYSICS_3D_DISABLED
@@ -69,6 +70,7 @@ public:
 		Vector<ShapeData> shapes;
 #endif // PHYSICS_3D_DISABLED
 		Ref<Texture2D> preview;
+		bool use_custom_preview = false;
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
@@ -79,6 +81,7 @@ public:
 	void _set_item_shapes(int p_item, const Array &p_shapes);
 	Array _get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
+	void _mesh_changed(int p_idx);
 
 private:
 	RBMap<int, Item> item_map;
@@ -110,6 +113,8 @@ public:
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
+	void set_item_custom_preview(int p_item, const Ref<Texture2D> &p_preview);
+	void set_item_use_custom_preview(int p_item, bool p_use_custom_preview);
 
 	String get_item_name(int p_item) const;
 	StringName get_item_category(int p_item) const;
@@ -123,6 +128,7 @@ public:
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
 	Ref<Texture2D> get_item_preview(int p_item) const;
+	bool get_item_use_custom_preview(int p_item) const;
 
 	void remove_item(int p_item);
 	bool has_item(int p_item) const;


### PR DESCRIPTION
Fixes #76429
Closes https://github.com/godotengine/godot-proposals/issues/12784

This PR adds a new property to MeshLibrary items: `use_custom_preview`. If disabled (default), the `preview` will not be saved with the resource. Instead the editor will auto-generate the previews every time the library is loaded and when it changes. This makes MeshLibrary resources much smaller, as the preview textures no longer get embedded 😬

https://github.com/godotengine/godot/assets/2223172/b2292fca-6f6b-4d4c-a7ae-b9712d47f664

It's not perfect, because when you change the mesh's material, not the mesh itself, the change will not be detected. You can however clear the preview manually and it will get auto-generated again.

https://github.com/godotengine/godot/assets/2223172/a36f23ae-122e-450f-b64a-9a1dbcb5a2c6

Using `set_item_preview()` (bound) will automatically enable the `use_custom_preview`. Also I added an option that preserves the previous behavior of embedding previews:

![image](https://github.com/godotengine/godot/assets/2223172/20e77606-943a-4a09-8362-70093b31b41a)

While this PR preserves API compatibility, if someone had custom previews in their MeshLibrary they need to enable `use_custom_preview` property for each item, otherwise the previews will be lost.

Also this PR needs testing with large MeshLibrary with complex meshes. I reworked preview generation to be much faster, but I don't know if it's sufficiently fast.