### PR TITLE
Fix memory access error for `MultiMesh` with GLES3

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -1689,13 +1689,15 @@ void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_b
 		// Color and custom need to be packed so copy buffer to data_cache and pack.
 
 		_multimesh_make_local(multimesh);
-		multimesh->data_cache = p_buffer;
 
-		float *w = multimesh->data_cache.ptrw();
 		uint32_t old_stride = multimesh->xform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12;
 		old_stride += multimesh->uses_colors ? 4 : 0;
 		old_stride += multimesh->uses_custom_data ? 4 : 0;
 		ERR_FAIL_COND(p_buffer.size() != (multimesh->instances * (int)old_stride));
+
+		multimesh->data_cache = p_buffer;
+
+		float *w = multimesh->data_cache.ptrw();
 
 		for (int i = 0; i < multimesh->instances; i++) {
 			{


### PR DESCRIPTION
Buffer was incorrectly assigned when invalid data was provided

Can confirm the data is no longer garbled, but haven't got a sanitiser build to confirm it doesn't crash, as it doesn't crash for me with the original code

Can move it before the "make local" function if safe to save on processing but left it after for now

Edit: Can confirm this fixes memory issues, tested with `set_instance_transform_2d` which crashes on the old code but not the new

* Fixes: #80785

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
