### PR TITLE
SCons: Make ktx module require basis_universal

### DIFF
--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -11,6 +11,7 @@ thirdparty_obj = []
 
 thirdparty_dir = "#thirdparty/libktx/"
 thirdparty_sources = [
+    "lib/basis_transcode.cpp",
     "lib/checkheader.c",
     "lib/filestream.c",
     "lib/hashlist.c",
@@ -32,10 +33,7 @@ env_ktx.Prepend(CPPPATH=[thirdparty_dir + "include"])
 env_ktx.Prepend(CPPPATH=[thirdparty_dir + "utils"])
 env_ktx.Prepend(CPPPATH=[thirdparty_dir + "lib"])
 env_ktx.Prepend(CPPPATH=[thirdparty_dir + "other_include"])
-
-if env["module_basis_universal_enabled"]:
-    thirdparty_sources += [thirdparty_dir + "lib/basis_transcode.cpp"]
-    env_ktx.Prepend(CPPPATH=["#thirdparty/basis_universal"])
+env_ktx.Prepend(CPPPATH=["#thirdparty/basis_universal"])
 
 if env["vulkan"]:
     env_ktx.Prepend(CPPPATH=["#thirdparty/vulkan/include"])

--- a/modules/ktx/config.py
+++ b/modules/ktx/config.py
@@ -1,4 +1,5 @@
 def can_build(env, platform):
+    env.module_add_dependencies("ktx", ["basis_universal"])
     return True
 
 

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -310,12 +310,11 @@ Files extracted from upstream source:
 - `LICENSE.md`
 - `include/*`
 - `lib/dfdutils/{LICENSES/Apache-2.0.txt,KHR,*.c,*.h,*.inl}`
-- `lib/{basis_sgd.h,basis_transcode.cpp,checkheader.c,filestream.*,formatsize.h,gl_format.h,hashlist.c,ktxint.h,memstream.*,swap.c,texture*,uthash.h,vk_format.h,vkformat_enum.h`
+- `lib/{basis_sgd.h,basis_transcode.cpp,checkheader.c,filestream.*,formatsize.h,gl_format.h,hashlist.c,ktxint.h,memstream.*,swap.c,texture*,uthash.h,vk_format.h,vkformat_enum.h}`
 - `utils/unused.h`
 - `other_include/KHR/*`
-- ifndef-protect NOMINMAX define in `lib/gl_format.h` (see godot.patch)
-- remove `basisu/` prefix from `thirdparty/libktx/lib/basis_transcode.cpp` basisu includes (see godot.patch)
-- comment `VK_FORMAT_ASTC_*x*x*_UNORM_BLOCK_EXT` cases in `lib/dfdutils/vk2dfd.inl` (see godot.patch)
+
+Some Godot-specific changes are applied via `godot.patch`.
 
 
 ## libogg


### PR DESCRIPTION
Fixes #80786.

I gave wrong advice in #76572, ktx depends on basisu's transcoder (at least in our use of it). CC @acazuc