### PR TITLE
GLTF: Move unique name generation code to GLTFState

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -105,7 +105,6 @@ private:
 	Error _parse_nodes(Ref<GLTFState> p_state);
 	String _get_type_name(const GLTFType p_component);
 	String _get_accessor_type_name(const GLTFType p_type);
-	String _gen_unique_name(Ref<GLTFState> p_state, const String &p_name);
 	String _sanitize_animation_name(const String &p_name);
 	String _gen_unique_animation_name(Ref<GLTFState> p_state, const String &p_name);
 	String _sanitize_bone_name(const String &p_name);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -143,6 +143,16 @@ void GLTFState::add_used_extension(const String &p_extension_name, bool p_requir
 	}
 }
 
+String GLTFState::generate_unique_name(const String &p_from_name) {
+	const String start_name = p_from_name.validate_node_name();
+	String unique_name = start_name;
+	for (int i = 2; unique_names.has(unique_name); i++) {
+		unique_name = start_name + itos(i);
+	}
+	unique_names.insert(unique_name);
+	return unique_name;
+}
+
 Dictionary GLTFState::get_json() {
 	return json;
 }

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -105,6 +105,7 @@ protected:
 
 public:
 	void add_used_extension(const String &p_extension, bool p_required = false);
+	String generate_unique_name(const String &p_from_name);
 
 	enum GLTFHandleBinary {
 		HANDLE_BINARY_DISCARD_TEXTURES = 0,


### PR DESCRIPTION
This PR moves the `_gen_unique_name` method from GLTFDocument into GLTFState and renames it to `generate_unique_name`. Without this PR, it is not possible for GLTFDocumentExtension classes to generate unique names, so it's not possible to provide the same uniqueness guarantee as GLTFDocument itself.

This PR also cleans up the code a bit, replacing the `while (true)` and `break;` code with a simple `for` loop. I tested it and it functions exactly the same as before, just now the code is easier to read.

Note: Per Lyuma's request, I have removed the exposing in this PR, so this PR is just moving the method and making it available to in-engine C++ code. We can expose it in a future PR.