### PR TITLE
Exit early in `TextEdit::_get_column_pos_of_word` to improve highlight performance

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7000,6 +7000,11 @@ int TextEdit::_get_column_pos_of_word(const String &p_key, const String &p_searc
 				col = p_search.findn(p_key, p_from_column);
 			}
 
+			// If not found, just break early to improve performance.
+			if (col == -1) {
+				break;
+			}
+
 			// Whole words only.
 			if (col != -1 && p_search_flags & SEARCH_WHOLE_WORDS) {
 				p_from_column = col;


### PR DESCRIPTION
This pr fixes #80801
If in the while loop inside `_get_column_pos_of_word`, `string.find` or `findn` can't find any match words, we can just early break the while loop to imporove cpu performance. 
In the origin logic without early break, `p_from_column` will only plus 1 every loop,  this means basically this function will do the `string.find` or `findn` for `p_search.length` times, this is way too slow for a long `p_search` string.
