### PR TITLE
Fix "Go to parent folder" in `EditorFileDialog`

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1528,7 +1528,7 @@ void EditorFileDialog::_recent_selected(int p_idx) {
 }
 
 void EditorFileDialog::_go_up() {
-	dir_access->change_dir(get_current_dir().get_base_dir());
+	dir_access->change_dir(get_current_dir().trim_suffix("/").get_base_dir());
 	update_file_list();
 	update_dir();
 	_push_history();


### PR DESCRIPTION
Fixes: #80750

I am not sure if '/' character may be removed in the function `get_base_dir()` as well. (190 results in 80 files)