### PR TITLE
Increase h separation of editor's PopupMenu

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1188,6 +1188,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const int vsep_base = extra_spacing + default_margin_size + 6;
 	const int force_even_vsep = vsep_base + (vsep_base % 2);
 	theme->set_constant("v_separation", "PopupMenu", force_even_vsep * EDSCALE);
+	theme->set_constant("h_separation", "PopupMenu", 8 * EDSCALE);
 	theme->set_constant("outline_size", "PopupMenu", 0);
 	theme->set_constant("item_start_padding", "PopupMenu", default_margin_size * 1.5 * EDSCALE);
 	theme->set_constant("item_end_padding", "PopupMenu", default_margin_size * 1.5 * EDSCALE);


### PR DESCRIPTION
Before:
![](https://chat.godotengine.org/file-upload/64e26a6dc74bb96ce288ebad/Clipboard%20-%2020%20sierpnia%202023%2021:32.png)
After:
![image](https://github.com/godotengine/godot/assets/2223172/89bddff6-e58b-4069-929f-dd39ecc77458)
(this is scene dock's ⋮ menu)

Closes #81964