### PR TITLE
Fix Vulkan crash with many Omni/SpotLights, Decals or ReflectionProbes

### DIFF
--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -285,7 +285,7 @@ void ClusterBuilderRD::setup(Size2i p_screen_size, uint32_t p_max_elements, RID 
 	cluster_render_buffer = RD::get_singleton()->storage_buffer_create(cluster_render_buffer_size);
 	cluster_buffer = RD::get_singleton()->storage_buffer_create(cluster_buffer_size);
 
-	render_elements = static_cast<RenderElementData *>(memalloc(sizeof(RenderElementData *) * render_element_max));
+	render_elements = static_cast<RenderElementData *>(memalloc(sizeof(RenderElementData) * render_element_max));
 	render_element_count = 0;
 
 	element_buffer = RD::get_singleton()->storage_buffer_create(sizeof(RenderElementData) * render_element_max);


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/56657

When ClusterBuilderRD attempted to allocate memory for a buffer, it accidentally reserved memory for RenderElementData pointers instead of actual structures. This caused it to allocate much less memory than it thought, so when enough cluster elements were in a scene it overflowed the buffer. Easy to see with ASAN enabled in the issue MRP, if it doesn't crash after some camera movement resizing the window seems to trigger this bug immediately every time.

By default `Max Clustered Elements` in ProjectSettings is 512 items. This times 4 (clustered item types) is 2048 elements. sizeof(RenderElementData) is 80 bytes and pointer size is 8, so only 10% of needed memory is actually allocated. 10% of 2048 elements is roughly 204, and as Calinou and qarmin noted 103 (or 102) OmniLights and SpotLights (total of 206 elements) will start crashing as this is roughly where the buffer overflows the actual allocated size (204 elements) and causes an access violation or memory corruption.
