### PR TITLE
Unedit nodes early when closing scene tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3435,6 +3435,9 @@ bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 }
 
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
+	// When scene gets closed no node is edited anymore, so make sure the editors are notified before nodes are freed.
+	hide_unused_editors(SceneTreeDock::get_singleton());
+
 	int new_index = editor_data.get_edited_scene();
 	int old_index = new_index;
 


### PR DESCRIPTION
Same error as in #80609 also affects GridMap and probably other node-based editors. The reason is that when scene was closed, the editor selection was cleared in a deferred manner, so by the time editors received `edit(nullptr)` to unedit node, the node was already freed. 

This PR ensures that the editors can properly unedit nodes before they are freed.

#80610 is not needed anymore after this change.