### PR TITLE
Updated C# example of AddPropertyInfo

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -43,8 +43,8 @@
 				var propertyInfo = new Godot.Collections.Dictionary
 				{
 				    {"name", "category/propertyName"},
-				    {"type", Variant.Type.Int},
-				    {"hint", PropertyHint.Enum},
+				    {"type", (int)Variant.Type.Int},
+				    {"hint", (int)PropertyHint.Enum},
 				    {"hint_string", "one,two,three"},
 				};
 


### PR DESCRIPTION
Currently, the C# example of the method `AddPropertyInfo` looks like this:

```c#
var propertyInfo = new Godot.Collections.Dictionary
		{
			{"name", "category/propertyName"},
			{"type", Variant.Type.Int},
			{"hint", PropertyHint.Enum},
			{"hint_string", "one,two,three"},
		};
```

![image](https://github.com/godotengine/godot/assets/49737868/e1912bca-6acd-4813-84fe-fd2bf9a0effd)


However, the code above produces an error if copied exactly, because Godot cannot convert a `Variant.Type` or a `PropertyHint` variable into a `Variant` one. Casting both variables to `int` fixes the issue:

```c#
var propertyInfo = new Godot.Collections.Dictionary
		{
			{"name", "category/propertyName"},
			{"type", (int)Variant.Type.Int},
			{"hint", (int)PropertyHint.Enum},
			{"hint_string", "one,two,three"},
		};
```

![image](https://github.com/godotengine/godot/assets/49737868/a91bdb35-b216-48e4-9c10-3141929a585b)
