### PR TITLE
Exclude unexposed classes from the `extension_api.json`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -750,6 +750,9 @@ Dictionary GDExtensionAPIDump::generate_extension_api() {
 		class_list.sort_custom<StringName::AlphCompare>();
 
 		for (const StringName &class_name : class_list) {
+			if (!ClassDB::is_class_exposed(class_name)) {
+				continue;
+			}
 			Dictionary d;
 			d["name"] = String(class_name);
 			d["is_refcounted"] = ClassDB::is_parent_class(class_name, "RefCounted");

--- a/misc/extension_api_validation/4.0-stable.expected
+++ b/misc/extension_api_validation/4.0-stable.expected
@@ -8,15 +8,6 @@ Add new entries at the end of the file.
 
 ========================================================================================================================
 
-Misc
-----
-Validate extension JSON: API was removed: classes/FramebufferCacheRD
-Validate extension JSON: API was removed: classes/UniformSetCacheRD
-
-FIXME: These aren't written when dumping the interface with a headless build
-(since there's no RD backend in use). We need to fix this inconsistency somehow.
-
-
 ## Changes between 4.0-stable and 4.1-stable
 
 GH-78517
@@ -458,3 +449,19 @@ GH-80954
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 4 to 8.
 
 Added optional arguments. Compatibility method registered.
+
+GH-80852
+--------
+
+Validate extension JSON: API was removed: classes/GDScriptEditorTranslationParserPlugin
+Validate extension JSON: API was removed: classes/GDScriptNativeClass
+Validate extension JSON: API was removed: classes/GodotPhysicsServer2D
+Validate extension JSON: API was removed: classes/GodotPhysicsServer3D
+Validate extension JSON: API was removed: classes/IPUnix
+Validate extension JSON: API was removed: classes/MovieWriterMJPEG
+Validate extension JSON: API was removed: classes/MovieWriterPNGWAV
+Validate extension JSON: API was removed: classes/ResourceFormatImporterSaver
+Validate extension JSON: API was removed: classes/FramebufferCacheRD
+Validate extension JSON: API was removed: classes/UniformSetCacheRD
+
+Excluded unexposed classes from extension_api.json.


### PR DESCRIPTION
@Bromeon noticed that `GDScriptNativeClass` was included in the `extension_api.json` but that it wasn't possible to actually get that class at runtime. Looking at the code, it appears that `GDScriptNativeClass` isn't exposed (ie. there's no `GDREGISTER_CLASS(GDScriptNativeClass)` anywhere).

This PR adds a `ClassDB::is_class_exposed()` check in `GDExtensionAPIDump::generate_extension_api()` to ensure that unexposed classes aren't included in the `extension_api.json`.

Up until now, I think unexposed classes were mostly not included in the `extension_api.json` by accident: most simply weren't in `ClassDB` by the time that we were generating the `extension_api.json`.

Aside from `GDScriptNativeClass`, this change also removes the following other unexposed classes (at least for me - I did a diff of the `extension_api.json` with and without this PR):

- `FramebufferCacheRD`
- `GDScriptEditorTranslationParserPlugin`
- `GLTFDocumentExtensionPhysics`
- `GLTFDocumentExtensionTextureWebP`
- `GodotPhysicsServer2D`
- `GodotPhysicsServer3D`
- `IPUnix`
- `MovieWriterMJPEG`
- `MovieWriterPNGWAV`
- `ResourceFormatImporterSaver`
- `UniformSetCacheRD`

I'm not familiar with all of these classes, but I think they are all meant to be internal, and not interacted with directly.