### PR TITLE
Document GradientTexture updates being deferred

### DIFF
--- a/doc/classes/GradientTexture1D.xml
+++ b/doc/classes/GradientTexture1D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A 1D texture that obtains colors from a [Gradient] to fill the texture data. The texture is filled by sampling the gradient for each pixel. Therefore, the texture does not necessarily represent an exact copy of the gradient, as it may miss some colors if there are not enough pixels. See also [GradientTexture2D], [CurveTexture] and [CurveXYZTexture].
+		[b]Note:[/b] [GradientTexture1D] updates are deferred, which means that the result of changing a property such as [member width] is only guaranteed to be visible after 2 frames have passed. To use [method Texture2D.get_image] correctly on a [GradientTexture1D] with non-default values, wait for 2 frames using [code]await get_tree().process_frame[/code] [i]twice[/i] before calling [method Texture2D.get_image].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A 2D texture that obtains colors from a [Gradient] to fill the texture data. This texture is able to transform a color transition into different patterns such as a linear or a radial gradient. The gradient is sampled individually for each pixel so it does not necessarily represent an exact copy of the gradient(see [member width] and [member height]). See also [GradientTexture1D], [CurveTexture] and [CurveXYZTexture].
+		[b]Note:[/b] [GradientTexture2D] updates are deferred, which means that the result of changing a property such as [member width] or [member height] is only guaranteed to be visible after 2 frames have passed. To use [method Texture2D.get_image] correctly on a [GradientTexture2D] with non-default values, wait for 2 frames using [code]await get_tree().process_frame[/code] [i]twice[/i] before calling [method Texture2D.get_image].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
I don't know if a new `force_update()` method could be added, but that's proposal territory.

- This closes https://github.com/godotengine/godot/issues/66627.
