### PR TITLE
Fix action state when multiple events are assigned

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -103,7 +103,7 @@ private:
 		uint64_t pressed_process_frame = UINT64_MAX;
 		uint64_t released_physics_frame = UINT64_MAX;
 		uint64_t released_process_frame = UINT64_MAX;
-		bool pressed = false;
+		int pressed = 0;
 		bool exact = true;
 		float strength = 0.0f;
 		float raw_strength = 0.0f;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -215,7 +215,7 @@
 			<param index="0" name="action" type="StringName" />
 			<param index="1" name="exact_match" type="bool" default="false" />
 			<description>
-				Returns [code]true[/code] if you are pressing the action event. Note that if an action has multiple buttons assigned and more than one of them is pressed, releasing one button will release the action, even if some other button assigned to this action is still pressed.
+				Returns [code]true[/code] if you are pressing the action event.
 				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>


### PR DESCRIPTION
Fixes #45628

This PR simply changes `Action.pressed` (internal struct) from bool to int and increments it when action is pressed and decrements when it's released. `Input.is_action_pressed()` and related actions return true when at least one even is pressed.

There is some weirdness when releasing actions with modifier keys. They can be released without being pressed. I added a small workaround, but the changes need some testing in general.