### PR TITLE
Simplify right-click track insertion code

### DIFF
--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -464,6 +464,7 @@ class AnimationTrackEditor : public VBoxContainer {
 		Animation::TrackType type;
 		NodePath path;
 		int track_idx = 0;
+		float time = FLT_MAX; // Defaults to current timeline position.
 		Variant value;
 		String query;
 		bool advance = false;


### PR DESCRIPTION
The code path used for context-menu track insertion hadn't reset logic implemented. This PR refactors it so it uses the already existing code paths and also avoids some repetition even in the code that remains. The only things preventing this PR from being a true refactor are these:
- This lets reset track logic running (the lack thereof is the issue in #55438).
- The cases of `TYPE_BLEND_SHAPE` and `TYPE_VALUE` use to include `_clear_selection_for_anim()` in their undo script. I'm not sure how safe is to stop doing that.

Fixes #55438.

I've smoke-tested this, but this definitely needs more testers.