### PR TITLE
Make DDS loading code only check for R channel bitmask when loading grayscale images

### DIFF
--- a/modules/dds/image_loader_dds.cpp
+++ b/modules/dds/image_loader_dds.cpp
@@ -196,9 +196,9 @@ Error ImageLoaderDDS::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 		dds_format = DDS_BGR10A2;
 	} else if (format_flags & DDPF_RGB && !(format_flags & DDPF_ALPHAPIXELS) && format_rgb_bits == 16 && format_red_mask == 0x0000f800 && format_green_mask == 0x000007e0 && format_blue_mask == 0x0000001f) {
 		dds_format = DDS_BGR565;
-	} else if (!(format_flags & DDPF_ALPHAPIXELS) && format_rgb_bits == 8 && format_red_mask == 0xff && format_green_mask == 0xff && format_blue_mask == 0xff) {
+	} else if (!(format_flags & DDPF_ALPHAPIXELS) && format_rgb_bits == 8 && format_red_mask == 0xff) {
 		dds_format = DDS_LUMINANCE;
-	} else if ((format_flags & DDPF_ALPHAPIXELS) && format_rgb_bits == 16 && format_red_mask == 0xff && format_green_mask == 0xff && format_blue_mask == 0xff && format_alpha_mask == 0xff00) {
+	} else if ((format_flags & DDPF_ALPHAPIXELS) && format_rgb_bits == 16 && format_red_mask == 0xff && format_alpha_mask == 0xff00) {
 		dds_format = DDS_LUMINANCE_ALPHA;
 	} else if (format_flags & DDPF_INDEXED && format_rgb_bits == 8) {
 		dds_format = DDS_BGR565;


### PR DESCRIPTION
I've encountered this issue while working on another PR. Here's an MRP: [dds_lumi_import.zip](https://github.com/godotengine/godot/files/12402365/dds_lumi_import.zip)

The DDS loading code currently checks for all color channel masks to be set to 0xFF when loading grayscale/luminance images. However, many DDS grayscale images only set the R channel mask, meaning the engine fails to import them. Additionally, the [official Microsoft DDS documentation](https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide) states that only the R bitmask has to be set.

According to the documentation, an additional flag in the file should be specified to discern l8/l8a8 images from r8/r8g8 ones, however, Godot's DDS module currently does not support the latter. If there is demand to implement those formats in the future, we could add a check for that flag.

This PR removes the check for G and B bitmasks, making it possible to import all L8 and L8A8 files correctly. This change shouldn't have any impact on currently imported textures, so it doesn't break compatibility.