### PR TITLE
Fix `PathFollow2D` does not update child `AnimatableBody2D`'s collision

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_object_2d.h"
 
+#include "scene/2d/path_2d.h"
 #include "scene/resources/world_2d.h"
 #include "scene/scene_string_names.h"
 
@@ -78,6 +79,10 @@ void CollisionObject2D::_notification(int p_what) {
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (only_update_transform_changes) {
+				PathFollow2D *synchronized_body_parent = Object::cast_to<PathFollow2D>(get_parent());
+				if (synchronized_body_parent) {
+					call_deferred("set_global_position", synchronized_body_parent->get_global_position());
+				}
 				return;
 			}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes:

Edit: It's not the proper fix.