### PR TITLE
Make Vector4/i properties show in 2x2 layout

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3708,14 +3708,14 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 		} break;
 		case Variant::VECTOR4: {
-			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
+			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
 			editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, p_hint == PROPERTY_HINT_LINK, hint.suffix);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4I: {
-			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
+			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
 			editor->setup(hint.min, hint.max, 1, true, p_hint == PROPERTY_HINT_LINK, hint.suffix);
 			return editor;

--- a/editor/editor_properties_vector.cpp
+++ b/editor/editor_properties_vector.cpp
@@ -188,6 +188,7 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 			break;
 	}
 	bool horizontal = p_force_wide || p_horizontal;
+	bool grid = false;
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -197,10 +198,18 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 	if (p_force_wide) {
 		bc = memnew(HBoxContainer);
 		hb->add_child(bc);
-	} else if (horizontal) {
+	} else if (horizontal && component_count < 4) {
 		bc = memnew(HBoxContainer);
 		hb->add_child(bc);
 		set_bottom_editor(hb);
+	} else if (horizontal) {
+		bc = memnew(VBoxContainer);
+		hb->add_child(bc);
+		set_bottom_editor(hb);
+
+		bc->add_child(memnew(HBoxContainer));
+		bc->add_child(memnew(HBoxContainer));
+		grid = true;
 	} else {
 		bc = memnew(VBoxContainer);
 		hb->add_child(bc);
@@ -212,7 +221,11 @@ EditorPropertyVectorN::EditorPropertyVectorN(Variant::Type p_type, bool p_force_
 
 	for (int i = 0; i < component_count; i++) {
 		spin[i] = memnew(EditorSpinSlider);
-		bc->add_child(spin[i]);
+		if (grid) {
+			bc->get_child(i / 2)->add_child(spin[i]);
+		} else {
+			bc->add_child(spin[i]);
+		}
 		spin[i]->set_flat(true);
 		spin[i]->set_label(String(COMPONENT_LABELS[i]));
 		if (horizontal) {


### PR DESCRIPTION
Vector4 version of #45713

Before:
![image](https://github.com/godotengine/godot/assets/2223172/6648a505-e3dd-4fa5-835e-dfee986f0641)

After:
![image](https://github.com/godotengine/godot/assets/2223172/6b609328-b123-4f88-8291-d446fc9be2d4)

With link:
![image](https://github.com/godotengine/godot/assets/2223172/312b1565-4a61-4508-a407-5e9fe2b490d3)

This is going to be especially relevant for Vector4i properties after #79021
It also allows to unify Rect and Vector editor properties.