### PR TITLE
Fix refresh 'Project Settings' window

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -87,6 +87,23 @@ void ProjectSettingsEditor::update_plugins() {
 	plugin_settings->update_plugins();
 }
 
+void ProjectSettingsEditor::_tab_clicked(int p_tab) {
+	// Tab 'General'
+	if (tab_container->get_tab_idx_from_control(general_editor) == p_tab && settings_last_update > general_editor_last_update) {
+		general_settings_inspector->update_category_list();
+		general_editor_last_update = OS::get_singleton()->get_ticks_msec();
+	}
+	// Tab 'Input Map'
+	else if (tab_container->get_tab_idx_from_control(action_map_editor) == p_tab && settings_last_update > action_map_editor_last_update) {
+		_update_action_map_editor();
+		action_map_editor_last_update = OS::get_singleton()->get_ticks_msec();
+	}
+}
+
+void ProjectSettingsEditor::_settings_changed() {
+	settings_last_update = OS::get_singleton()->get_ticks_msec();
+}
+
 void ProjectSettingsEditor::_setting_edited(const String &p_name) {
 	queue_save();
 }
@@ -591,11 +608,13 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	set_clamp_to_embedder(true);
 
 	ps = ProjectSettings::get_singleton();
+	ps->connect("settings_changed", callable_mp(this, &ProjectSettingsEditor::_settings_changed));
 	data = p_data;
 
 	tab_container = memnew(TabContainer);
 	tab_container->set_use_hidden_tabs_for_min_size(true);
 	tab_container->set_theme_type_variation("TabContainerOdd");
+	tab_container->connect("tab_clicked", callable_mp(this, &ProjectSettingsEditor::_tab_clicked));
 	add_child(tab_container);
 
 	general_editor = memnew(VBoxContainer);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -78,6 +78,13 @@ class ProjectSettingsEditor : public AcceptDialog {
 	ImportDefaultsEditor *import_defaults_editor = nullptr;
 	EditorData *data = nullptr;
 
+	uint64_t general_editor_last_update = 0;
+	uint64_t action_map_editor_last_update = 0;
+	uint64_t settings_last_update = 0;
+
+	void _tab_clicked(int p_tab);
+	void _settings_changed();
+
 	void _advanced_toggled(bool p_button_pressed);
 	void _update_advanced(bool p_is_advanced);
 	void _property_box_changed(const String &p_text);


### PR DESCRIPTION
Fixes #80808, fixes #25865

After clicking on a tab window (`General` or `Input Map`) an update is forced.

Tests: https://github.com/godotengine/godot/issues/80808#issuecomment-1687175715
