### PR TITLE
Fix integer value for `GL_MAX_UNIFORM_BLOCK_SIZE` overflowing

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -771,7 +771,7 @@ void ShaderGLES3::initialize(const String &p_general_defines, int p_base_texture
 		print_verbose("Shader '" + name + "' SHA256: " + base_sha256);
 	}
 
-	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_image_units);
+	glGetInteger64v(GL_MAX_TEXTURE_IMAGE_UNITS, &max_image_units);
 }
 
 void ShaderGLES3::set_shader_cache_dir(const String &p_dir) {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -154,7 +154,7 @@ private:
 	static bool shader_cache_save_debug;
 	bool shader_cache_dir_valid = false;
 
-	GLint max_image_units = 0;
+	int64_t max_image_units = 0;
 
 	enum StageType {
 		STAGE_TYPE_VERTEX,

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -53,9 +53,9 @@ Config::Config() {
 	singleton = this;
 
 	{
-		GLint max_extensions = 0;
-		glGetIntegerv(GL_NUM_EXTENSIONS, &max_extensions);
-		for (int i = 0; i < max_extensions; i++) {
+		int64_t max_extensions = 0;
+		glGetInteger64v(GL_NUM_EXTENSIONS, &max_extensions);
+		for (int64_t i = 0; i < max_extensions; i++) {
 			const GLubyte *s = glGetStringi(GL_EXTENSIONS, i);
 			if (!s) {
 				break;
@@ -88,11 +88,11 @@ Config::Config() {
 	rgtc_supported = extensions.has("GL_EXT_texture_compression_rgtc") || extensions.has("GL_ARB_texture_compression_rgtc") || extensions.has("EXT_texture_compression_rgtc");
 #endif
 
-	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &max_vertex_texture_image_units);
-	glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_image_units);
-	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
-	glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &max_uniform_buffer_size);
-	glGetIntegerv(GL_MAX_VIEWPORT_DIMS, max_viewport_size);
+	glGetInteger64v(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &max_vertex_texture_image_units);
+	glGetInteger64v(GL_MAX_TEXTURE_IMAGE_UNITS, &max_texture_image_units);
+	glGetInteger64v(GL_MAX_TEXTURE_SIZE, &max_texture_size);
+	glGetInteger64v(GL_MAX_UNIFORM_BLOCK_SIZE, &max_uniform_buffer_size);
+	glGetInteger64v(GL_MAX_VIEWPORT_DIMS, max_viewport_size);
 
 	support_anisotropic_filter = extensions.has("GL_EXT_texture_filter_anisotropic");
 	if (support_anisotropic_filter) {

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -58,14 +58,14 @@ public:
 	bool use_nearest_mip_filter = false;
 	bool use_depth_prepass = true;
 
-	int max_vertex_texture_image_units = 0;
-	int max_texture_image_units = 0;
-	int max_texture_size = 0;
-	int max_viewport_size[2] = { 0, 0 };
-	int max_uniform_buffer_size = 0;
-	int max_renderable_elements = 0;
-	int max_renderable_lights = 0;
-	int max_lights_per_object = 0;
+	int64_t max_vertex_texture_image_units = 0;
+	int64_t max_texture_image_units = 0;
+	int64_t max_texture_size = 0;
+	int64_t max_viewport_size[2] = { 0, 0 };
+	int64_t max_uniform_buffer_size = 0;
+	int64_t max_renderable_elements = 0;
+	int64_t max_renderable_lights = 0;
+	int64_t max_lights_per_object = 0;
 
 	// TODO implement wireframe in OpenGL
 	// bool generate_wireframes;


### PR DESCRIPTION
This PR fixes the issue of shader compilation on the web platform.
![Capture d’écran du 2023-08-22 11-36-25](https://github.com/godotengine/godot/assets/270928/fe6eed53-3093-430d-9417-46444b054a03)

It happens that the following line (on my PC, at least) makes the `int Config::max_uniform_buffer_size` to overflow to `-2147483648`, which is exactly `INT_MIN` (or `INT_MAX + 1`).
https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/drivers/gles3/storage/config.cpp#L94

Then, `int Config::max_renderable_lights` (defaults to `32`) is set to the minimum value of itself or our `Config::max_uniform_buffer_size`, which we remember is `-2147483648`. Then the same thing happens for `int Config::max_lights_per_object` (defaults to `8`).
https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/drivers/gles3/rasterizer_scene_gles3.cpp#L2626-L2627

This makes two [scene.glsl](https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/drivers/gles3/shaders/scene.glsl) "#defines" with `INT_MIN` value. It's pretty easy to understand then why the shader can't compile.

https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/drivers/gles3/rasterizer_scene_gles3.cpp#L2664-L2673

~My PR is quite simple. If the value of `Config::max_uniform_buffer_size` is negative, it means that it overflowed. So `INT_MAX` is set as the value.~

Edit: used `glGetInteger64v()` and `int64_t` for `Config` instead.

Fixes #68180