### PR TITLE
Fix "Import Defaults" selector not being initialized incorrectly

### DIFF
--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -169,14 +169,12 @@ void ImportDefaultsEditor::_importer_selected(int p_index) {
 
 void ImportDefaultsEditor::clear() {
 	String last_selected;
-	if (importers->get_selected() > 0) {
+
+	if (importers->get_selected() >= 0) {
 		last_selected = importers->get_item_text(importers->get_selected());
 	}
 
 	importers->clear();
-
-	importers->add_item("<" + TTR("Select Importer") + ">");
-	importers->set_item_disabled(0, true);
 
 	List<Ref<ResourceImporter>> importer_list;
 	ResourceFormatImporter::get_singleton()->get_importers(&importer_list);
@@ -187,11 +185,17 @@ void ImportDefaultsEditor::clear() {
 	}
 	names.sort();
 
+	// `last_selected.is_empty()` means it's the first time being called.
+	if (last_selected.is_empty() && !names.is_empty()) {
+		last_selected = names[0];
+	}
+
 	for (int i = 0; i < names.size(); i++) {
 		importers->add_item(names[i]);
 
 		if (names[i] == last_selected) {
-			importers->select(i + 1);
+			importers->select(i);
+			_update_importer();
 		}
 	}
 }


### PR DESCRIPTION
In ImportDefaultsEditor, when first call the function, last_selected can be the first one(`Animation Library`) and directly show the settings for "Animation Library", fix #80867

However, there is another option: show the `<Select Importer>` option, I decided to go with the first option but this one is ok too. Can change my code to impl this one.