### PR TITLE
Expose low-processor usage mode for the web platform

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -775,7 +775,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 		LocalVector<ParticleInstanceData3D> particle_vector;
 		particle_vector.resize(particles->amount);
 		particle_array = particle_vector.ptr();
-		glGetBufferSubData(GL_ARRAY_BUFFER, 0, particles->amount * sizeof(ParticleInstanceData3D), particle_array);
+		godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, particles->amount * sizeof(ParticleInstanceData3D), particle_array);
 #endif
 		SortArray<ParticleInstanceData3D, ParticlesViewSort> sorter;
 		sorter.compare.z_dir = axis;
@@ -1133,7 +1133,7 @@ void ParticlesStorage::_particles_reverse_lifetime_sort(Particles *particles) {
 	LocalVector<ParticleInstanceData> particle_vector;
 	particle_vector.resize(particles->amount);
 	particle_array = particle_vector.ptr();
-	glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
+	godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
 #endif
 
 	uint32_t lifetime_split = (MIN(int(particles->amount * particles->sort_buffer_phase), particles->amount - 1) + 1) % particles->amount;

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -113,7 +113,7 @@ Vector<uint8_t> Utilities::buffer_get_data(GLenum p_target, GLuint p_buffer, uin
 #if defined(__EMSCRIPTEN__)
 	{
 		uint8_t *w = ret.ptrw();
-		glGetBufferSubData(p_target, 0, p_buffer_size, w);
+		godot_webgl2_glGetBufferSubData(p_target, 0, p_buffer_size, w);
 	}
 #else
 	void *data = glMapBufferRange(p_target, 0, p_buffer_size, GL_MAP_READ_BIT);

--- a/modules/webrtc/library_godot_webrtc.js
+++ b/modules/webrtc/library_godot_webrtc.js
@@ -90,6 +90,7 @@ const GodotRTCDataChannel = {
 		},
 	},
 
+	godot_js_rtc_datachannel_ready_state_get__proxy: 'sync',
 	godot_js_rtc_datachannel_ready_state_get__sig: 'ii',
 	godot_js_rtc_datachannel_ready_state_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -110,6 +111,7 @@ const GodotRTCDataChannel = {
 		}
 	},
 
+	godot_js_rtc_datachannel_send__proxy: 'sync',
 	godot_js_rtc_datachannel_send__sig: 'iiiii',
 	godot_js_rtc_datachannel_send: function (p_id, p_buffer, p_length, p_raw) {
 		const ref = IDHandler.get(p_id);
@@ -131,16 +133,19 @@ const GodotRTCDataChannel = {
 		return 0;
 	},
 
+	godot_js_rtc_datachannel_is_ordered__proxy: 'sync',
 	godot_js_rtc_datachannel_is_ordered__sig: 'ii',
 	godot_js_rtc_datachannel_is_ordered: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'ordered', true);
 	},
 
+	godot_js_rtc_datachannel_id_get__proxy: 'sync',
 	godot_js_rtc_datachannel_id_get__sig: 'ii',
 	godot_js_rtc_datachannel_id_get: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'id', 65535);
 	},
 
+	godot_js_rtc_datachannel_max_packet_lifetime_get__proxy: 'sync',
 	godot_js_rtc_datachannel_max_packet_lifetime_get__sig: 'ii',
 	godot_js_rtc_datachannel_max_packet_lifetime_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -156,21 +161,25 @@ const GodotRTCDataChannel = {
 		return 65535;
 	},
 
+	godot_js_rtc_datachannel_max_retransmits_get__proxy: 'sync',
 	godot_js_rtc_datachannel_max_retransmits_get__sig: 'ii',
 	godot_js_rtc_datachannel_max_retransmits_get: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'maxRetransmits', 65535);
 	},
 
+	godot_js_rtc_datachannel_is_negotiated__proxy: 'sync',
 	godot_js_rtc_datachannel_is_negotiated__sig: 'ii',
 	godot_js_rtc_datachannel_is_negotiated: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'negotiated', 65535);
 	},
 
+	godot_js_rtc_datachannel_get_buffered_amount__proxy: 'sync',
 	godot_js_rtc_datachannel_get_buffered_amount__sig: 'ii',
 	godot_js_rtc_datachannel_get_buffered_amount: function (p_id) {
 		return GodotRTCDataChannel.get_prop(p_id, 'bufferedAmount', 0);
 	},
 
+	godot_js_rtc_datachannel_label_get__proxy: 'sync',
 	godot_js_rtc_datachannel_label_get__sig: 'ii',
 	godot_js_rtc_datachannel_label_get: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -189,12 +198,14 @@ const GodotRTCDataChannel = {
 		return GodotRuntime.allocString(ref.protocol);
 	},
 
+	godot_js_rtc_datachannel_destroy__proxy: 'sync',
 	godot_js_rtc_datachannel_destroy__sig: 'vi',
 	godot_js_rtc_datachannel_destroy: function (p_id) {
 		GodotRTCDataChannel.close(p_id);
 		IDHandler.remove(p_id);
 	},
 
+	godot_js_rtc_datachannel_connect__proxy: 'sync',
 	godot_js_rtc_datachannel_connect__sig: 'viiiiii',
 	godot_js_rtc_datachannel_connect: function (p_id, p_ref, p_on_open, p_on_message, p_on_error, p_on_close) {
 		const onopen = GodotRuntime.get_func(p_on_open).bind(null, p_ref);
@@ -204,6 +215,7 @@ const GodotRTCDataChannel = {
 		GodotRTCDataChannel.connect(p_id, onopen, onmessage, onerror, onclose);
 	},
 
+	godot_js_rtc_datachannel_close__proxy: 'sync',
 	godot_js_rtc_datachannel_close__sig: 'vi',
 	godot_js_rtc_datachannel_close: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -356,6 +368,7 @@ const GodotRTCPeerConnection = {
 		},
 	},
 
+	godot_js_rtc_pc_create__proxy: 'sync',
 	godot_js_rtc_pc_create__sig: 'iiiiiiii',
 	godot_js_rtc_pc_create: function (p_config, p_ref, p_on_connection_state_change, p_on_ice_gathering_state_change, p_on_signaling_state_change, p_on_ice_candidate, p_on_datachannel) {
 		const wrap = function (p_func) {
@@ -371,6 +384,7 @@ const GodotRTCPeerConnection = {
 		);
 	},
 
+	godot_js_rtc_pc_close__proxy: 'sync',
 	godot_js_rtc_pc_close__sig: 'vi',
 	godot_js_rtc_pc_close: function (p_id) {
 		const ref = IDHandler.get(p_id);
@@ -380,11 +394,13 @@ const GodotRTCPeerConnection = {
 		ref.close();
 	},
 
+	godot_js_rtc_pc_destroy__proxy: 'sync',
 	godot_js_rtc_pc_destroy__sig: 'vi',
 	godot_js_rtc_pc_destroy: function (p_id) {
 		GodotRTCPeerConnection.destroy(p_id);
 	},
 
+	godot_js_rtc_pc_offer_create__proxy: 'sync',
 	godot_js_rtc_pc_offer_create__sig: 'viiii',
 	godot_js_rtc_pc_offer_create: function (p_id, p_obj, p_on_session, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -400,6 +416,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_local_description_set__proxy: 'sync',
 	godot_js_rtc_pc_local_description_set__sig: 'viiiii',
 	godot_js_rtc_pc_local_description_set: function (p_id, p_type, p_sdp, p_obj, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -417,6 +434,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_remote_description_set__proxy: 'sync',
 	godot_js_rtc_pc_remote_description_set__sig: 'viiiiii',
 	godot_js_rtc_pc_remote_description_set: function (p_id, p_type, p_sdp, p_obj, p_session_created, p_on_error) {
 		const ref = IDHandler.get(p_id);
@@ -442,6 +460,7 @@ const GodotRTCPeerConnection = {
 		});
 	},
 
+	godot_js_rtc_pc_ice_candidate_add__proxy: 'sync',
 	godot_js_rtc_pc_ice_candidate_add__sig: 'viiii',
 	godot_js_rtc_pc_ice_candidate_add: function (p_id, p_mid_name, p_mline_idx, p_sdp) {
 		const ref = IDHandler.get(p_id);
@@ -458,6 +477,7 @@ const GodotRTCPeerConnection = {
 	},
 
 	godot_js_rtc_pc_datachannel_create__deps: ['$GodotRTCDataChannel'],
+	godot_js_rtc_pc_datachannel_create__proxy: 'sync',
 	godot_js_rtc_pc_datachannel_create__sig: 'iiii',
 	godot_js_rtc_pc_datachannel_create: function (p_id, p_label, p_config) {
 		try {

--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -144,6 +144,7 @@ const GodotWebSocket = {
 		},
 	},
 
+	godot_js_websocket_create__proxy: 'sync',
 	godot_js_websocket_create__sig: 'iiiiiiii',
 	godot_js_websocket_create: function (p_ref, p_url, p_proto, p_on_open, p_on_message, p_on_error, p_on_close) {
 		const on_open = GodotRuntime.get_func(p_on_open).bind(null, p_ref);
@@ -166,6 +167,7 @@ const GodotWebSocket = {
 		return GodotWebSocket.create(socket, on_open, on_message, on_error, on_close);
 	},
 
+	godot_js_websocket_send__proxy: 'sync',
 	godot_js_websocket_send__sig: 'iiiii',
 	godot_js_websocket_send: function (p_id, p_buf, p_buf_len, p_raw) {
 		const bytes_array = new Uint8Array(p_buf_len);
@@ -180,11 +182,13 @@ const GodotWebSocket = {
 		return GodotWebSocket.send(p_id, out);
 	},
 
+	godot_js_websocket_buffered_amount__proxy: 'sync',
 	godot_js_websocket_buffered_amount__sig: 'ii',
 	godot_js_websocket_buffered_amount: function (p_id) {
 		return GodotWebSocket.bufferedAmount(p_id);
 	},
 
+	godot_js_websocket_close__proxy: 'sync',
 	godot_js_websocket_close__sig: 'viii',
 	godot_js_websocket_close: function (p_id, p_code, p_reason) {
 		const code = p_code;
@@ -192,6 +196,7 @@ const GodotWebSocket = {
 		GodotWebSocket.close(p_id, code, reason);
 	},
 
+	godot_js_websocket_destroy__proxy: 'sync',
 	godot_js_websocket_destroy__sig: 'vi',
 	godot_js_websocket_destroy: function (p_id) {
 		GodotWebSocket.destroy(p_id);

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -88,14 +88,18 @@ private:
 	static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape);
 
 	// events
+	static void _fullscreen_change_callback(int p_fullscreen);
 	static void fullscreen_change_callback(int p_fullscreen);
 	static int mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
 	static void mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers);
 	static int mouse_wheel_callback(double p_delta_x, double p_delta_y);
 	static void touch_callback(int p_type, int p_count);
-	static void key_callback(int p_pressed, int p_repeat, int p_modifiers);
-	static void vk_input_text_callback(const char *p_text, int p_cursor);
-	static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
+	static void _key_callback(int p_pressed, int p_repeat, int p_modifiers);
+	static void key_callback(String p_key_event_code, String p_key_event_key, int p_pressed, int p_repeat, int p_modifiers);
+	static void _vk_input_text_callback(const char *p_text, int p_cursor);
+	static void vk_input_text_callback(const String p_text, int p_cursor);
+	static void _gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
+	static void gamepad_callback(int p_index, int p_connected, const String p_id, const String p_guid);
 	void process_joypads();
 	static void _js_utterance_callback(int p_event, int p_id, int p_pos);
 
@@ -106,10 +110,13 @@ private:
 
 	static void request_quit_callback();
 	static void window_blur_callback();
-	static void update_voices_callback(int p_size, const char **p_voice);
-	static void update_clipboard_callback(const char *p_text);
+	static void _update_voices_callback(int p_size, const char **p_voice);
+	static void update_voices_callback(const Vector<String> &p_voices);
+	static void _update_clipboard_callback(const char *p_text);
+	static void update_clipboard_callback(String p_text);
 	static void send_window_event_callback(int p_notification);
-	static void drop_files_js_callback(char **p_filev, int p_filec);
+	static void _drop_files_js_callback(const char **p_filev, int p_filec);
+	static void drop_files_js_callback(const Vector<String> &p_files);
 
 protected:
 	int get_current_video_driver() const;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 // Config
 extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
@@ -67,7 +68,7 @@ extern int godot_js_input_gamepad_sample();
 extern int godot_js_input_gamepad_sample_count();
 extern int godot_js_input_gamepad_sample_get(int p_idx, float r_btns[16], int32_t *r_btns_num, float r_axes[10], int32_t *r_axes_num, int32_t *r_standard);
 extern void godot_js_input_paste_cb(void (*p_callback)(const char *p_text));
-extern void godot_js_input_drop_files_cb(void (*p_callback)(char **p_filev, int p_filec));
+extern void godot_js_input_drop_files_cb(void (*p_callback)(const char **p_filev, int p_filec));
 
 // TTS
 extern int godot_js_tts_is_speaking();

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -51,6 +51,8 @@ extern int godot_js_os_execute(const char *p_json);
 extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
 extern int godot_js_os_has_feature(const char *p_ftr);
+extern void godot_js_os_low_processor_usage_mode_get_set_cb(int (*p_callback_get)(), void (*p_callback_set)(int p_enabled));
+extern void godot_js_os_low_processor_usage_mode_sleep_usec_get_set_cb(int (*p_callback_get)(), void (*p_callback_set)(int p_sleep_usec));
 extern int godot_js_pwa_cb(void (*p_callback)());
 extern int godot_js_pwa_update();
 

--- a/platform/web/godot_webgl2.h
+++ b/platform/web/godot_webgl2.h
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 void godot_webgl2_glFramebufferTextureMultiviewOVR(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+void godot_webgl2_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
 
 #define glFramebufferTextureMultiviewOVR godot_webgl2_glFramebufferTextureMultiviewOVR
 

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -238,6 +238,58 @@ const Engine = (function () {
 					this.rtenv['request_quit']();
 				}
 			},
+
+			/**
+			 * Getter for {@link https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-property-low-processor-usage-mode | OS.low_processor_usage_mode}.
+			 * @returns {boolean}
+			 */
+			get lowProcessorUsageMode() {
+				if (this.rtenv) {
+					return Boolean(this.rtenv['getLowProcessorUsageMode']());
+				}
+				return false;
+			},
+
+			/**
+			 * Setter for {@link https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-property-low-processor-usage-mode | OS.low_processor_usage_mode}.
+			 * Only works if the engine was compiled using the `do_not_block_main_thread` option.
+			 * @param {boolean | 0 | 1} val Set the low processor mode on or off
+			 */
+			set lowProcessorUsageMode(val) {
+				if (!(typeof val === 'boolean' || typeof val === 'number')) {
+					throw new Error('val must be a boolean or a number');
+				}
+
+				if (this.rtenv) {
+					this.rtenv['setLowProcessorUsageMode'](Number(val));
+				}
+			},
+
+			/**
+			 * Getter for {@link https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-property-low-processor-usage-mode-sleep-usec | OS.low_processor_usage_mode_sleep_usec}.
+			 * @returns {number}
+			 */
+			get lowProcessorUsageModeSleepUsec() {
+				if (this.rtenv) {
+					return this.rtenv['getLowProcessorUsageModeSleepUsec']();
+				}
+				return 6900;
+			},
+
+			/**
+			 * Setter for {@link https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-property-low-processor-usage-mode-sleep-usec | OS.low_processor_usage_mode_sleep_usec}.
+			 * Only works if the engine was compiled using the `do_not_block_main_thread` option.
+			 * @param {number} val Low processor mode sleep usec value
+			 */
+			set lowProcessorUsageModeSleepUsec(val) {
+				if (typeof val !== 'number') {
+					throw new Error('val must be a number');
+				}
+
+				if (this.rtenv) {
+					this.rtenv['setLowProcessorUsageModeSleepUsec'](val);
+				}
+			},
 		};
 
 		Engine.prototype = proto;
@@ -248,6 +300,8 @@ const Engine = (function () {
 		Engine.prototype['startGame'] = Engine.prototype.startGame;
 		Engine.prototype['copyToFS'] = Engine.prototype.copyToFS;
 		Engine.prototype['requestQuit'] = Engine.prototype.requestQuit;
+		Engine.prototype['lowProcessorUsageMode'] = Engine.prototype.lowProcessorUsageMode;
+		Engine.prototype['lowProcessorUsageModeSleepUsec'] = Engine.prototype.lowProcessorUsageModeSleepUsec;
 		// Also expose static methods as instance methods
 		Engine.prototype['load'] = Engine.load;
 		Engine.prototype['unload'] = Engine.unload;

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -159,16 +159,19 @@ const GodotAudio = {
 		return 1;
 	},
 
+	godot_audio_has_worklet__proxy: 'sync',
 	godot_audio_has_worklet__sig: 'i',
 	godot_audio_has_worklet: function () {
 		return (GodotAudio.ctx && GodotAudio.ctx.audioWorklet) ? 1 : 0;
 	},
 
+	godot_audio_has_script_processor__proxy: 'sync',
 	godot_audio_has_script_processor__sig: 'i',
 	godot_audio_has_script_processor: function () {
 		return (GodotAudio.ctx && GodotAudio.ctx.createScriptProcessor) ? 1 : 0;
 	},
 
+	godot_audio_init__proxy: 'sync',
 	godot_audio_init__sig: 'iiiii',
 	godot_audio_init: function (p_mix_rate, p_latency, p_state_change, p_latency_update) {
 		const statechange = GodotRuntime.get_func(p_state_change);
@@ -179,6 +182,7 @@ const GodotAudio = {
 		return channels;
 	},
 
+	godot_audio_resume__proxy: 'sync',
 	godot_audio_resume__sig: 'v',
 	godot_audio_resume: function () {
 		if (GodotAudio.ctx && GodotAudio.ctx.state !== 'running') {
@@ -358,6 +362,7 @@ const GodotAudioWorklet = {
 		},
 	},
 
+	godot_audio_worklet_create__proxy: 'sync',
 	godot_audio_worklet_create__sig: 'ii',
 	godot_audio_worklet_create: function (channels) {
 		try {
@@ -369,6 +374,7 @@ const GodotAudioWorklet = {
 		return 0;
 	},
 
+	godot_audio_worklet_start__proxy: 'sync',
 	godot_audio_worklet_start__sig: 'viiiii',
 	godot_audio_worklet_start: function (p_in_buf, p_in_size, p_out_buf, p_out_size, p_state) {
 		const out_buffer = GodotRuntime.heapSub(HEAPF32, p_out_buf, p_out_size);
@@ -377,6 +383,7 @@ const GodotAudioWorklet = {
 		GodotAudioWorklet.start(in_buffer, out_buffer, state);
 	},
 
+	godot_audio_worklet_start_no_threads__proxy: 'sync',
 	godot_audio_worklet_start_no_threads__sig: 'viiiiii',
 	godot_audio_worklet_start_no_threads: function (p_out_buf, p_out_size, p_out_callback, p_in_buf, p_in_size, p_in_callback) {
 		const out_callback = GodotRuntime.get_func(p_out_callback);
@@ -465,6 +472,7 @@ const GodotAudioScript = {
 		},
 	},
 
+	godot_audio_script_create__proxy: 'sync',
 	godot_audio_script_create__sig: 'iii',
 	godot_audio_script_create: function (buffer_length, channel_count) {
 		const buf_len = GodotRuntime.getHeapValue(buffer_length, 'i32');
@@ -478,6 +486,7 @@ const GodotAudioScript = {
 		return 0;
 	},
 
+	godot_audio_script_start__proxy: 'sync',
 	godot_audio_script_start__sig: 'viiiii',
 	godot_audio_script_start: function (p_in_buf, p_in_size, p_out_buf, p_out_size, p_cb) {
 		const onprocess = GodotRuntime.get_func(p_cb);

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -345,6 +345,7 @@ const GodotDisplay = {
 		},
 	},
 
+	godot_js_display_is_swap_ok_cancel__proxy: 'sync',
 	godot_js_display_is_swap_ok_cancel__sig: 'i',
 	godot_js_display_is_swap_ok_cancel: function () {
 		const win = (['Windows', 'Win64', 'Win32', 'WinCE']);
@@ -355,16 +356,19 @@ const GodotDisplay = {
 		return 0;
 	},
 
+	godot_js_tts_is_speaking__proxy: 'sync',
 	godot_js_tts_is_speaking__sig: 'i',
 	godot_js_tts_is_speaking: function () {
 		return window.speechSynthesis.speaking;
 	},
 
+	godot_js_tts_is_paused__proxy: 'sync',
 	godot_js_tts_is_paused__sig: 'i',
 	godot_js_tts_is_paused: function () {
 		return window.speechSynthesis.paused;
 	},
 
+	godot_js_tts_get_voices__proxy: 'sync',
 	godot_js_tts_get_voices__sig: 'vi',
 	godot_js_tts_get_voices: function (p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
@@ -382,6 +386,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_tts_speak__proxy: 'sync',
 	godot_js_tts_speak__sig: 'viiiffii',
 	godot_js_tts_speak: function (p_text, p_voice, p_volume, p_pitch, p_rate, p_utterance_id, p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
@@ -424,53 +429,63 @@ const GodotDisplay = {
 		window.speechSynthesis.speak(utterance);
 	},
 
+	godot_js_tts_pause__proxy: 'sync',
 	godot_js_tts_pause__sig: 'v',
 	godot_js_tts_pause: function () {
 		window.speechSynthesis.pause();
 	},
 
+	godot_js_tts_resume__proxy: 'sync',
 	godot_js_tts_resume__sig: 'v',
 	godot_js_tts_resume: function () {
 		window.speechSynthesis.resume();
 	},
 
+	godot_js_tts_stop__proxy: 'sync',
 	godot_js_tts_stop__sig: 'v',
 	godot_js_tts_stop: function () {
 		window.speechSynthesis.cancel();
 		window.speechSynthesis.resume();
 	},
 
+	godot_js_display_alert__proxy: 'sync',
 	godot_js_display_alert__sig: 'vi',
 	godot_js_display_alert: function (p_text) {
 		window.alert(GodotRuntime.parseString(p_text)); // eslint-disable-line no-alert
 	},
 
+	godot_js_display_screen_dpi_get__proxy: 'sync',
 	godot_js_display_screen_dpi_get__sig: 'i',
 	godot_js_display_screen_dpi_get: function () {
 		return GodotDisplay.getDPI();
 	},
 
+	godot_js_display_pixel_ratio_get__proxy: 'sync',
 	godot_js_display_pixel_ratio_get__sig: 'f',
 	godot_js_display_pixel_ratio_get: function () {
 		return GodotDisplayScreen.getPixelRatio();
 	},
 
+	godot_js_display_fullscreen_request__proxy: 'sync',
 	godot_js_display_fullscreen_request__sig: 'i',
 	godot_js_display_fullscreen_request: function () {
 		return GodotDisplayScreen.requestFullscreen();
 	},
 
+	godot_js_display_fullscreen_exit__proxy: 'sync',
 	godot_js_display_fullscreen_exit__sig: 'i',
 	godot_js_display_fullscreen_exit: function () {
 		return GodotDisplayScreen.exitFullscreen();
 	},
 
+	godot_js_display_desired_size_set__proxy: 'sync',
 	godot_js_display_desired_size_set__sig: 'vii',
 	godot_js_display_desired_size_set: function (width, height) {
 		GodotDisplayScreen.desired_size = [width, height];
 		GodotDisplayScreen.updateSize();
 	},
 
+	godot_js_display_size_update__proxy: 'sync',
 	godot_js_display_size_update__sig: 'i',
 	godot_js_display_size_update: function () {
 		const updated = GodotDisplayScreen.updateSize();
@@ -480,6 +495,7 @@ const GodotDisplay = {
 		return updated;
 	},
 
+	godot_js_display_screen_size_get__proxy: 'sync',
 	godot_js_display_screen_size_get__sig: 'vii',
 	godot_js_display_screen_size_get: function (width, height) {
 		const scale = GodotDisplayScreen.getPixelRatio();
@@ -487,12 +503,14 @@ const GodotDisplay = {
 		GodotRuntime.setHeapValue(height, window.screen.height * scale, 'i32');
 	},
 
+	godot_js_display_window_size_get__proxy: 'sync',
 	godot_js_display_window_size_get__sig: 'vii',
 	godot_js_display_window_size_get: function (p_width, p_height) {
 		GodotRuntime.setHeapValue(p_width, GodotConfig.canvas.width, 'i32');
 		GodotRuntime.setHeapValue(p_height, GodotConfig.canvas.height, 'i32');
 	},
 
+	godot_js_display_has_webgl__proxy: 'sync',
 	godot_js_display_has_webgl__sig: 'ii',
 	godot_js_display_has_webgl: function (p_version) {
 		if (p_version !== 1 && p_version !== 2) {
@@ -507,11 +525,13 @@ const GodotDisplay = {
 	/*
 	 * Canvas
 	 */
+	godot_js_display_canvas_focus__proxy: 'sync',
 	godot_js_display_canvas_focus__sig: 'v',
 	godot_js_display_canvas_focus: function () {
 		GodotConfig.canvas.focus();
 	},
 
+	godot_js_display_canvas_is_focused__proxy: 'sync',
 	godot_js_display_canvas_is_focused__sig: 'i',
 	godot_js_display_canvas_is_focused: function () {
 		return document.activeElement === GodotConfig.canvas;
@@ -520,6 +540,7 @@ const GodotDisplay = {
 	/*
 	 * Touchscreen
 	 */
+	godot_js_display_touchscreen_is_available__proxy: 'sync',
 	godot_js_display_touchscreen_is_available__sig: 'i',
 	godot_js_display_touchscreen_is_available: function () {
 		return 'ontouchstart' in window;
@@ -528,6 +549,7 @@ const GodotDisplay = {
 	/*
 	 * Clipboard
 	 */
+	godot_js_display_clipboard_set__proxy: 'sync',
 	godot_js_display_clipboard_set__sig: 'ii',
 	godot_js_display_clipboard_set: function (p_text) {
 		const text = GodotRuntime.parseString(p_text);
@@ -541,6 +563,7 @@ const GodotDisplay = {
 		return 0;
 	},
 
+	godot_js_display_clipboard_get__proxy: 'sync',
 	godot_js_display_clipboard_get__sig: 'ii',
 	godot_js_display_clipboard_get: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -560,11 +583,13 @@ const GodotDisplay = {
 	/*
 	 * Window
 	 */
+	godot_js_display_window_title_set__proxy: 'sync',
 	godot_js_display_window_title_set__sig: 'vi',
 	godot_js_display_window_title_set: function (p_data) {
 		document.title = GodotRuntime.parseString(p_data);
 	},
 
+	godot_js_display_window_icon_set__proxy: 'sync',
 	godot_js_display_window_icon_set__sig: 'vii',
 	godot_js_display_window_icon_set: function (p_ptr, p_len) {
 		let link = document.getElementById('-gd-engine-icon');
@@ -593,6 +618,7 @@ const GodotDisplay = {
 	/*
 	 * Cursor
 	 */
+	godot_js_display_cursor_set_visible__proxy: 'sync',
 	godot_js_display_cursor_set_visible__sig: 'vi',
 	godot_js_display_cursor_set_visible: function (p_visible) {
 		const visible = p_visible !== 0;
@@ -607,16 +633,19 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_is_hidden__proxy: 'sync',
 	godot_js_display_cursor_is_hidden__sig: 'i',
 	godot_js_display_cursor_is_hidden: function () {
 		return !GodotDisplayCursor.visible;
 	},
 
+	godot_js_display_cursor_set_shape__proxy: 'sync',
 	godot_js_display_cursor_set_shape__sig: 'vi',
 	godot_js_display_cursor_set_shape: function (p_string) {
 		GodotDisplayCursor.set_shape(GodotRuntime.parseString(p_string));
 	},
 
+	godot_js_display_cursor_set_custom_shape__proxy: 'sync',
 	godot_js_display_cursor_set_custom_shape__sig: 'viiiii',
 	godot_js_display_cursor_set_custom_shape: function (p_shape, p_ptr, p_len, p_hotspot_x, p_hotspot_y) {
 		const shape = GodotRuntime.parseString(p_shape);
@@ -640,6 +669,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_lock_set__proxy: 'sync',
 	godot_js_display_cursor_lock_set__sig: 'vi',
 	godot_js_display_cursor_lock_set: function (p_lock) {
 		if (p_lock) {
@@ -649,6 +679,7 @@ const GodotDisplay = {
 		}
 	},
 
+	godot_js_display_cursor_is_locked__proxy: 'sync',
 	godot_js_display_cursor_is_locked__sig: 'i',
 	godot_js_display_cursor_is_locked: function () {
 		return GodotDisplayCursor.isPointerLocked() ? 1 : 0;
@@ -657,6 +688,7 @@ const GodotDisplay = {
 	/*
 	 * Listeners
 	 */
+	godot_js_display_fullscreen_cb__proxy: 'sync',
 	godot_js_display_fullscreen_cb__sig: 'vi',
 	godot_js_display_fullscreen_cb: function (callback) {
 		const canvas = GodotConfig.canvas;
@@ -671,6 +703,7 @@ const GodotDisplay = {
 		GodotEventListeners.add(document, 'webkitfullscreenchange', change_cb, false);
 	},
 
+	godot_js_display_window_blur_cb__proxy: 'sync',
 	godot_js_display_window_blur_cb__sig: 'vi',
 	godot_js_display_window_blur_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -679,6 +712,7 @@ const GodotDisplay = {
 		}, false);
 	},
 
+	godot_js_display_notification_cb__proxy: 'sync',
 	godot_js_display_notification_cb__sig: 'viiiii',
 	godot_js_display_notification_cb: function (callback, p_enter, p_exit, p_in, p_out) {
 		const canvas = GodotConfig.canvas;
@@ -691,6 +725,7 @@ const GodotDisplay = {
 		});
 	},
 
+	godot_js_display_setup_canvas__proxy: 'sync',
 	godot_js_display_setup_canvas__sig: 'viiii',
 	godot_js_display_setup_canvas: function (p_width, p_height, p_fullscreen, p_hidpi) {
 		const canvas = GodotConfig.canvas;
@@ -725,6 +760,7 @@ const GodotDisplay = {
 	/*
 	 * Virtual Keyboard
 	 */
+	godot_js_display_vk_show__proxy: 'sync',
 	godot_js_display_vk_show__sig: 'viiii',
 	godot_js_display_vk_show: function (p_text, p_type, p_start, p_end) {
 		const text = GodotRuntime.parseString(p_text);
@@ -733,21 +769,25 @@ const GodotDisplay = {
 		GodotDisplayVK.show(text, p_type, start, end);
 	},
 
+	godot_js_display_vk_hide__proxy: 'sync',
 	godot_js_display_vk_hide__sig: 'v',
 	godot_js_display_vk_hide: function () {
 		GodotDisplayVK.hide();
 	},
 
+	godot_js_display_vk_available__proxy: 'sync',
 	godot_js_display_vk_available__sig: 'i',
 	godot_js_display_vk_available: function () {
 		return GodotDisplayVK.available();
 	},
 
+	godot_js_display_tts_available__proxy: 'sync',
 	godot_js_display_tts_available__sig: 'i',
 	godot_js_display_tts_available: function () {
 		return 'speechSynthesis' in window;
 	},
 
+	godot_js_display_vk_cb__proxy: 'sync',
 	godot_js_display_vk_cb__sig: 'vi',
 	godot_js_display_vk_cb: function (p_input_cb) {
 		const input_cb = GodotRuntime.get_func(p_input_cb);

--- a/platform/web/js/libs/library_godot_fetch.js
+++ b/platform/web/js/libs/library_godot_fetch.js
@@ -125,6 +125,7 @@ const GodotFetch = {
 		},
 	},
 
+	godot_js_fetch_create__proxy: 'sync',
 	godot_js_fetch_create__sig: 'iiiiiii',
 	godot_js_fetch_create: function (p_method, p_url, p_headers, p_headers_size, p_body, p_body_size) {
 		const method = GodotRuntime.parseString(p_method);
@@ -145,6 +146,7 @@ const GodotFetch = {
 		}), body);
 	},
 
+	godot_js_fetch_state_get__proxy: 'sync',
 	godot_js_fetch_state_get__sig: 'ii',
 	godot_js_fetch_state_get: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -166,6 +168,7 @@ const GodotFetch = {
 		return -1;
 	},
 
+	godot_js_fetch_http_status_get__proxy: 'sync',
 	godot_js_fetch_http_status_get__sig: 'ii',
 	godot_js_fetch_http_status_get: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -175,6 +178,7 @@ const GodotFetch = {
 		return obj.status;
 	},
 
+	godot_js_fetch_read_headers__proxy: 'sync',
 	godot_js_fetch_read_headers__sig: 'iiii',
 	godot_js_fetch_read_headers: function (p_id, p_parse_cb, p_ref) {
 		const obj = IDHandler.get(p_id);
@@ -192,6 +196,7 @@ const GodotFetch = {
 		return 0;
 	},
 
+	godot_js_fetch_read_chunk__proxy: 'sync',
 	godot_js_fetch_read_chunk__sig: 'iiii',
 	godot_js_fetch_read_chunk: function (p_id, p_buf, p_buf_size) {
 		const obj = IDHandler.get(p_id);
@@ -218,6 +223,7 @@ const GodotFetch = {
 		return p_buf_size - to_read;
 	},
 
+	godot_js_fetch_is_chunked__proxy: 'sync',
 	godot_js_fetch_is_chunked__sig: 'ii',
 	godot_js_fetch_is_chunked: function (p_id) {
 		const obj = IDHandler.get(p_id);
@@ -227,6 +233,7 @@ const GodotFetch = {
 		return obj.chunked ? 1 : 0;
 	},
 
+	godot_js_fetch_free__proxy: 'sync',
 	godot_js_fetch_free__sig: 'vi',
 	godot_js_fetch_free: function (id) {
 		GodotFetch.free(id);

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -356,6 +356,7 @@ const GodotInput = {
 	/*
 	 * Mouse API
 	 */
+	godot_js_input_mouse_move_cb__proxy: 'sync',
 	godot_js_input_mouse_move_cb__sig: 'vi',
 	godot_js_input_mouse_move_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -374,6 +375,7 @@ const GodotInput = {
 		GodotEventListeners.add(window, 'mousemove', move_cb, false);
 	},
 
+	godot_js_input_mouse_wheel_cb__proxy: 'sync',
 	godot_js_input_mouse_wheel_cb__sig: 'vi',
 	godot_js_input_mouse_wheel_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -385,6 +387,7 @@ const GodotInput = {
 		GodotEventListeners.add(GodotConfig.canvas, 'wheel', wheel_cb, false);
 	},
 
+	godot_js_input_mouse_button_cb__proxy: 'sync',
 	godot_js_input_mouse_button_cb__sig: 'vi',
 	godot_js_input_mouse_button_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -409,6 +412,7 @@ const GodotInput = {
 	/*
 	 * Touch API
 	 */
+	godot_js_input_touch_cb__proxy: 'sync',
 	godot_js_input_touch_cb__sig: 'viii',
 	godot_js_input_touch_cb: function (callback, ids, coords) {
 		const func = GodotRuntime.get_func(callback);
@@ -442,6 +446,7 @@ const GodotInput = {
 	/*
 	 * Key API
 	 */
+	godot_js_input_key_cb__proxy: 'sync',
 	godot_js_input_key_cb__sig: 'viii',
 	godot_js_input_key_cb: function (callback, code, key) {
 		const func = GodotRuntime.get_func(callback);
@@ -459,23 +464,27 @@ const GodotInput = {
 	/*
 	 * Gamepad API
 	 */
+	godot_js_input_gamepad_cb__proxy: 'sync',
 	godot_js_input_gamepad_cb__sig: 'vi',
 	godot_js_input_gamepad_cb: function (change_cb) {
 		const onchange = GodotRuntime.get_func(change_cb);
 		GodotInputGamepads.init(onchange);
 	},
 
+	godot_js_input_gamepad_sample_count__proxy: 'sync',
 	godot_js_input_gamepad_sample_count__sig: 'i',
 	godot_js_input_gamepad_sample_count: function () {
 		return GodotInputGamepads.get_samples().length;
 	},
 
+	godot_js_input_gamepad_sample__proxy: 'sync',
 	godot_js_input_gamepad_sample__sig: 'i',
 	godot_js_input_gamepad_sample: function () {
 		GodotInputGamepads.sample();
 		return 0;
 	},
 
+	godot_js_input_gamepad_sample_get__proxy: 'sync',
 	godot_js_input_gamepad_sample_get__sig: 'iiiiiii',
 	godot_js_input_gamepad_sample_get: function (p_index, r_btns, r_btns_num, r_axes, r_axes_num, r_standard) {
 		const sample = GodotInputGamepads.get_sample(p_index);
@@ -502,6 +511,7 @@ const GodotInput = {
 	/*
 	 * Drag/Drop API
 	 */
+	godot_js_input_drop_files_cb__proxy: 'sync',
 	godot_js_input_drop_files_cb__sig: 'vi',
 	godot_js_input_drop_files_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -524,6 +534,7 @@ const GodotInput = {
 	},
 
 	/* Paste API */
+	godot_js_input_paste_cb__proxy: 'sync',
 	godot_js_input_paste_cb__sig: 'vi',
 	godot_js_input_paste_cb: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -535,6 +546,7 @@ const GodotInput = {
 		}, false);
 	},
 
+	godot_js_input_vibrate_handheld__proxy: 'sync',
 	godot_js_input_vibrate_handheld__sig: 'vi',
 	godot_js_input_vibrate_handheld: function (p_duration_ms) {
 		if (typeof navigator.vibrate !== 'function') {

--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -121,6 +121,7 @@ const GodotJSWrapper = {
 		},
 	},
 
+	godot_js_wrapper_interface_get__proxy: 'sync',
 	godot_js_wrapper_interface_get__sig: 'ii',
 	godot_js_wrapper_interface_get: function (p_name) {
 		const name = GodotRuntime.parseString(p_name);
@@ -130,6 +131,7 @@ const GodotJSWrapper = {
 		return 0;
 	},
 
+	godot_js_wrapper_object_get__proxy: 'sync',
 	godot_js_wrapper_object_get__sig: 'iiii',
 	godot_js_wrapper_object_get: function (p_id, p_exchange, p_prop) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -148,6 +150,7 @@ const GodotJSWrapper = {
 		return GodotJSWrapper.js2variant(obj, p_exchange);
 	},
 
+	godot_js_wrapper_object_set__proxy: 'sync',
 	godot_js_wrapper_object_set__sig: 'viiii',
 	godot_js_wrapper_object_set: function (p_id, p_name, p_type, p_exchange) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -162,6 +165,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_call__proxy: 'sync',
 	godot_js_wrapper_object_call__sig: 'iiiiiiiii',
 	godot_js_wrapper_object_call: function (p_id, p_method, p_args, p_argc, p_convert_callback, p_exchange, p_lock, p_free_lock_callback) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -189,6 +193,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_unref__proxy: 'sync',
 	godot_js_wrapper_object_unref__sig: 'vi',
 	godot_js_wrapper_object_unref: function (p_id) {
 		const proxy = IDHandler.get(p_id);
@@ -197,6 +202,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_create_cb__proxy: 'sync',
 	godot_js_wrapper_create_cb__sig: 'iii',
 	godot_js_wrapper_create_cb: function (p_ref, p_func) {
 		const func = GodotRuntime.get_func(p_func);
@@ -221,11 +227,13 @@ const GodotJSWrapper = {
 		return id;
 	},
 
+	godot_js_wrapper_object_set_cb_ret__proxy: 'sync',
 	godot_js_wrapper_object_set_cb_ret__sig: 'vii',
 	godot_js_wrapper_object_set_cb_ret: function (p_val_type, p_val_ex) {
 		GodotJSWrapper.cb_ret = GodotJSWrapper.variant2js(p_val_type, p_val_ex);
 	},
 
+	godot_js_wrapper_object_getvar__proxy: 'sync',
 	godot_js_wrapper_object_getvar__sig: 'iiii',
 	godot_js_wrapper_object_getvar: function (p_id, p_type, p_exchange) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -244,6 +252,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_object_setvar__proxy: 'sync',
 	godot_js_wrapper_object_setvar__sig: 'iiiiii',
 	godot_js_wrapper_object_setvar: function (p_id, p_key_type, p_key_ex, p_val_type, p_val_ex) {
 		const obj = GodotJSWrapper.get_proxied_value(p_id);
@@ -260,6 +269,7 @@ const GodotJSWrapper = {
 		}
 	},
 
+	godot_js_wrapper_create_object__proxy: 'sync',
 	godot_js_wrapper_create_object__sig: 'iiiiiiii',
 	godot_js_wrapper_create_object: function (p_object, p_args, p_argc, p_convert_callback, p_exchange, p_lock, p_free_lock_callback) {
 		const name = GodotRuntime.parseString(p_object);

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -91,11 +91,13 @@ const GodotConfig = {
 		},
 	},
 
+	godot_js_config_canvas_id_get__proxy: 'sync',
 	godot_js_config_canvas_id_get__sig: 'vii',
 	godot_js_config_canvas_id_get: function (p_ptr, p_ptr_max) {
 		GodotRuntime.stringToHeap(`#${GodotConfig.canvas.id}`, p_ptr, p_ptr_max);
 	},
 
+	godot_js_config_locale_get__proxy: 'sync',
 	godot_js_config_locale_get__sig: 'vii',
 	godot_js_config_locale_get: function (p_ptr, p_ptr_max) {
 		GodotRuntime.stringToHeap(GodotConfig.locale, p_ptr, p_ptr_max);
@@ -266,22 +268,26 @@ const GodotOS = {
 		},
 	},
 
+	godot_js_os_finish_async__proxy: 'sync',
 	godot_js_os_finish_async__sig: 'vi',
 	godot_js_os_finish_async: function (p_callback) {
 		const func = GodotRuntime.get_func(p_callback);
 		GodotOS.finish_async(func);
 	},
 
+	godot_js_os_request_quit_cb__proxy: 'sync',
 	godot_js_os_request_quit_cb__sig: 'vi',
 	godot_js_os_request_quit_cb: function (p_callback) {
 		GodotOS.request_quit = GodotRuntime.get_func(p_callback);
 	},
 
+	godot_js_os_fs_is_persistent__proxy: 'sync',
 	godot_js_os_fs_is_persistent__sig: 'i',
 	godot_js_os_fs_is_persistent: function () {
 		return GodotFS.is_persistent();
 	},
 
+	godot_js_os_fs_sync__proxy: 'sync',
 	godot_js_os_fs_sync__sig: 'vi',
 	godot_js_os_fs_sync: function (callback) {
 		const func = GodotRuntime.get_func(callback);
@@ -291,6 +297,7 @@ const GodotOS = {
 		});
 	},
 
+	godot_js_os_has_feature__proxy: 'sync',
 	godot_js_os_has_feature__sig: 'ii',
 	godot_js_os_has_feature: function (p_ftr) {
 		const ftr = GodotRuntime.parseString(p_ftr);
@@ -313,6 +320,7 @@ const GodotOS = {
 		return 0;
 	},
 
+	godot_js_os_execute__proxy: 'sync',
 	godot_js_os_execute__sig: 'ii',
 	godot_js_os_execute: function (p_json) {
 		const json_args = GodotRuntime.parseString(p_json);
@@ -324,11 +332,13 @@ const GodotOS = {
 		return 1;
 	},
 
+	godot_js_os_shell_open__proxy: 'sync',
 	godot_js_os_shell_open__sig: 'vi',
 	godot_js_os_shell_open: function (p_uri) {
 		window.open(GodotRuntime.parseString(p_uri), '_blank');
 	},
 
+	godot_js_os_hw_concurrency_get__proxy: 'sync',
 	godot_js_os_hw_concurrency_get__sig: 'i',
 	godot_js_os_hw_concurrency_get: function () {
 		// TODO Godot core needs fixing to avoid spawning too many threads (> 24).
@@ -336,6 +346,7 @@ const GodotOS = {
 		return concurrency < 2 ? concurrency : 2;
 	},
 
+	godot_js_os_download_buffer__proxy: 'sync',
 	godot_js_os_download_buffer__sig: 'viiii',
 	godot_js_os_download_buffer: function (p_ptr, p_size, p_name, p_mime) {
 		const buf = GodotRuntime.heapSlice(HEAP8, p_ptr, p_size);
@@ -426,6 +437,7 @@ const GodotPWA = {
 		},
 	},
 
+	godot_js_pwa_cb__proxy: 'sync',
 	godot_js_pwa_cb__sig: 'vi',
 	godot_js_pwa_cb: function (p_update_cb) {
 		if ('serviceWorker' in navigator) {
@@ -434,6 +446,7 @@ const GodotPWA = {
 		}
 	},
 
+	godot_js_pwa_update__proxy: 'sync',
 	godot_js_pwa_update__sig: 'i',
 	godot_js_pwa_update: function () {
 		if ('serviceWorker' in navigator && GodotPWA.hasUpdate) {

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -231,11 +231,44 @@ const GodotOS = {
 		'Module["request_quit"] = function() { GodotOS.request_quit() };',
 		'Module["onExit"] = GodotOS.cleanup;',
 		'GodotOS._fs_sync_promise = Promise.resolve();',
+		'Module["getLowProcessorUsageMode"] = GodotOS.low_processor_usage_mode_getter;',
+		'Module["setLowProcessorUsageMode"] = GodotOS.low_processor_usage_mode_setter;',
+		'Module["getLowProcessorUsageModeSleepUsec"] = GodotOS.low_processor_usage_mode_sleep_usec_getter;',
+		'Module["setLowProcessorUsageModeSleepUsec"] = GodotOS.low_processor_usage_mode_sleep_usec_setter;',
 	].join(''),
 	$GodotOS: {
 		request_quit: function () {},
 		_async_cbs: [],
 		_fs_sync_promise: null,
+
+		low_processor_usage_mode_getter: function () {
+			if (GodotOS._low_processor_usage_mode_getter == null) {
+				return null;
+			}
+			return GodotOS._low_processor_usage_mode_getter();
+		},
+		low_processor_usage_mode_setter: function (val) {
+			if (GodotOS._low_processor_usage_mode_setter == null) {
+				return;
+			}
+			GodotOS._low_processor_usage_mode_setter(val);
+		},
+		low_processor_usage_mode_sleep_usec_getter: function () {
+			if (GodotOS._low_processor_usage_mode_sleep_usec_getter == null) {
+				return null;
+			}
+			return GodotOS._low_processor_usage_mode_sleep_usec_getter();
+		},
+		low_processor_usage_mode_sleep_usec_setter: function (val) {
+			if (GodotOS._low_processor_usage_mode_sleep_usec_setter == null) {
+				return;
+			}
+			GodotOS._low_processor_usage_mode_sleep_usec_setter(val);
+		},
+		_low_processor_usage_mode_getter: null,
+		_low_processor_usage_mode_setter: null,
+		_low_processor_usage_mode_sleep_usec_getter: null,
+		_low_processor_usage_mode_sleep_usec_setter: null,
 
 		atexit: function (p_promise_cb) {
 			GodotOS._async_cbs.push(p_promise_cb);
@@ -362,6 +395,36 @@ const GodotOS = {
 		a.click();
 		a.remove();
 		window.URL.revokeObjectURL(url);
+	},
+
+	godot_js_os_low_processor_usage_mode_get_set_cb__proxy: 'sync',
+	godot_js_os_low_processor_usage_mode_get_set_cb__sig: 'vii',
+	godot_js_os_low_processor_usage_mode_get_set_cb: function (p_get_callback, p_set_callback) {
+		const get_func = GodotRuntime.get_func(p_get_callback);
+		const set_func = GodotRuntime.get_func(p_set_callback);
+
+		GodotOS._low_processor_usage_mode_getter = function () {
+			return get_func();
+		};
+
+		GodotOS._low_processor_usage_mode_setter = function (val) {
+			set_func(val);
+		};
+	},
+
+	godot_js_os_low_processor_usage_mode_sleep_usec_get_set_cb__proxy: 'sync',
+	godot_js_os_low_processor_usage_mode_sleep_usec_get_set_cb__sig: 'vii',
+	godot_js_os_low_processor_usage_mode_sleep_usec_get_set_cb: function (p_get_callback, p_set_callback) {
+		const get_func = GodotRuntime.get_func(p_get_callback);
+		const set_func = GodotRuntime.get_func(p_set_callback);
+
+		GodotOS._low_processor_usage_mode_sleep_usec_getter = function () {
+			return get_func();
+		};
+
+		GodotOS._low_processor_usage_mode_sleep_usec_setter = function (val) {
+			set_func(val);
+		};
 	},
 };
 

--- a/platform/web/js/libs/library_godot_webgl2.js
+++ b/platform/web/js/libs/library_godot_webgl2.js
@@ -32,6 +32,19 @@ const GodotWebGL2 = {
 	$GodotWebGL2__deps: ['$GL', '$GodotRuntime'],
 	$GodotWebGL2: {},
 
+	// This is implemented as "glGetBufferSubData" in new emscripten versions.
+	// Since we have to support older (pre 2.0.17) emscripten versions, we add this wrapper function instead.
+	godot_webgl2_glGetBufferSubData__proxy: 'sync',
+	godot_webgl2_glGetBufferSubData__sig: 'vippp',
+	godot_webgl2_glGetBufferSubData__deps: ['$GL', 'emscripten_webgl_get_current_context'],
+	godot_webgl2_glGetBufferSubData: function (target, offset, size, data) {
+		const gl_context_handle = _emscripten_webgl_get_current_context(); // eslint-disable-line no-undef
+		const gl = GL.getContext(gl_context_handle);
+		if (gl) {
+			gl.GLctx['getBufferSubData'](target, offset, HEAPU8, data, size);
+		}
+	},
+
 	godot_webgl2_glFramebufferTextureMultiviewOVR__deps: ['emscripten_webgl_get_current_context'],
 	godot_webgl2_glFramebufferTextureMultiviewOVR__proxy: 'sync',
 	godot_webgl2_glFramebufferTextureMultiviewOVR__sig: 'viiiiii',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -215,6 +215,26 @@ void OS_Web::update_pwa_state_callback() {
 	}
 }
 
+void OS_Web::low_processor_usage_mode_set_callback(int p_enabled) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	OS::get_singleton()->set_low_processor_usage_mode(p_enabled > 0);
+#endif
+}
+
+int OS_Web::low_processor_usage_mode_get_callback() {
+	return OS::get_singleton()->is_in_low_processor_usage_mode();
+}
+
+void OS_Web::low_processor_usage_mode_sleep_usec_set_callback(int p_sleep_usec) {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(p_sleep_usec);
+#endif
+}
+
+int OS_Web::low_processor_usage_mode_sleep_usec_get_callback() {
+	return OS::get_singleton()->get_low_processor_usage_mode_sleep_usec();
+}
+
 void OS_Web::force_fs_sync() {
 	if (is_userfs_persistent()) {
 		idb_needs_sync = true;
@@ -263,6 +283,9 @@ OS_Web::OS_Web() {
 	}
 
 	idb_available = godot_js_os_fs_is_persistent();
+
+	godot_js_os_low_processor_usage_mode_get_set_cb(&OS_Web::low_processor_usage_mode_get_callback, &OS_Web::low_processor_usage_mode_set_callback);
+	godot_js_os_low_processor_usage_mode_sleep_usec_get_set_cb(&OS_Web::low_processor_usage_mode_sleep_usec_get_callback, &OS_Web::low_processor_usage_mode_sleep_usec_set_callback);
 
 	Vector<Logger *> loggers;
 	loggers.push_back(memnew(StdLogger));

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -88,9 +88,12 @@ public:
 	String get_executable_path() const override;
 	Error shell_open(String p_uri) override;
 	String get_name() const override;
+
+#ifndef PROXY_TO_PTHREAD_ENABLED
 	// Override default OS implementation which would block the main thread with delay_usec.
 	// Implemented in web_main.cpp loop callback instead.
 	void add_frame_delay(bool p_can_draw) override {}
+#endif
 
 	void vibrate_handheld(int p_duration_ms) override;
 

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -54,6 +54,11 @@ class OS_Web : public OS_Unix {
 	static void fs_sync_callback();
 	static void update_pwa_state_callback();
 
+	static int low_processor_usage_mode_get_callback();
+	static void low_processor_usage_mode_set_callback(int p_enabled);
+	static int low_processor_usage_mode_sleep_usec_get_callback();
+	static void low_processor_usage_mode_sleep_usec_set_callback(int p_sleep_usec);
+
 protected:
 	void initialize() override;
 


### PR DESCRIPTION
**Depends on #79711**

This PR exposes `lowProcessorUsageMode` and `lowProcessorUsageModeSleepUsec` getters/setters to edit `OS.low_processor_usage_mode` and `OS.low_processor_usage_mode_sleep_usec` respectively.

Please see godotengine/godot-proposals#7546 for more details on the why of the PR.

Fixes godotengine/godot-proposals#7546