### PR TITLE
Fix Android input routing logic when using a hardware keyboard

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotEditText.java
@@ -33,6 +33,7 @@ package org.godotengine.godot.input;
 import org.godotengine.godot.*;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Handler;
 import android.os.Message;
 import android.text.InputFilter;
@@ -209,6 +210,13 @@ public class GodotEditText extends EditText {
 			mRenderView.getView().requestFocus();
 		}
 
+		// When a hardware keyboard is connected, all key events come through so we can route them
+		// directly to the engine.
+		// This is not the case when using a soft keyboard, requiring extra processing from this class.
+		if (hasHardwareKeyboard()) {
+			return mRenderView.getInputHandler().onKeyDown(keyCode, keyEvent);
+		}
+
 		// pass event to godot in special cases
 		if (needHandlingInGodot(keyCode, keyEvent) && mRenderView.getInputHandler().onKeyDown(keyCode, keyEvent)) {
 			return true;
@@ -219,6 +227,13 @@ public class GodotEditText extends EditText {
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent keyEvent) {
+		// When a hardware keyboard is connected, all key events come through so we can route them
+		// directly to the engine.
+		// This is not the case when using a soft keyboard, requiring extra processing from this class.
+		if (hasHardwareKeyboard()) {
+			return mRenderView.getInputHandler().onKeyUp(keyCode, keyEvent);
+		}
+
 		if (needHandlingInGodot(keyCode, keyEvent) && mRenderView.getInputHandler().onKeyUp(keyCode, keyEvent)) {
 			return true;
 		} else {
@@ -235,10 +250,20 @@ public class GodotEditText extends EditText {
 				isModifiedKey;
 	}
 
+	boolean hasHardwareKeyboard() {
+		Configuration config = getResources().getConfiguration();
+		return config.keyboard != Configuration.KEYBOARD_NOKEYS &&
+				config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO;
+	}
+
 	// ===========================================================
 	// Methods
 	// ===========================================================
 	public void showKeyboard(String p_existing_text, VirtualKeyboardType p_type, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
+		if (hasHardwareKeyboard()) {
+			return;
+		}
+
 		int maxInputLength = (p_max_input_length <= 0) ? Integer.MAX_VALUE : p_max_input_length;
 		if (p_cursor_start == -1) { // cursor position not given
 			this.mOriginText = p_existing_text;
@@ -262,6 +287,10 @@ public class GodotEditText extends EditText {
 	}
 
 	public void hideKeyboard() {
+		if (hasHardwareKeyboard()) {
+			return;
+		}
+
 		final Message msg = new Message();
 		msg.what = HANDLER_CLOSE_IME_KEYBOARD;
 		msg.obj = this;


### PR DESCRIPTION
When a hardware keyboard is connected, all key events come through so we can route them directly to the engine. This is not the case for soft keyboards, for which the current logic was designed as it requires extra processing.

Addresses https://github.com/godotengine/godot/issues/70751 for hardware keyboards (connected or bluetooth), soft keyboards still have that issue and will be addressed in a separate PR.

[3.x version](https://github.com/godotengine/godot/pull/80935)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
