### PR TITLE
[3.x] Physics Interpolation - automatic resets for Camera2D and TileMap

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -318,6 +318,14 @@ void Camera2D::_notification(int p_what) {
 			first = true;
 			_set_current(current);
 
+			// Note that NOTIFICATION_RESET_PHYSICS_INTERPOLATION
+			// is automatically called before this because Camera2D is inherited
+			// from CanvasItem. However, the camera transform is not up to date
+			// until this point, so we do an extra manual reset.
+			if (is_physics_interpolated_and_enabled()) {
+				_interpolation_data.xform_curr = get_camera_transform();
+				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			const bool viewport_valid = !custom_viewport || ObjectDB::get_instance(custom_viewport_id);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -132,6 +132,17 @@ void TileMap::_notification(int p_what) {
 			}
 
 		} break;
+
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
+				for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
+					Quadrant &q = E->get();
+					for (List<RID>::Element *F = q.canvas_items.front(); F; F = F->next()) {
+						VisualServer::get_singleton()->canvas_item_reset_physics_interpolation(F->get());
+					}
+				}
+			}
+		} break;
 	}
 }
 
@@ -742,6 +753,13 @@ void TileMap::update_dirty_quadrants() {
 
 		if (multirect_started) {
 			VisualServerCanvasHelper::tilemap_end();
+		}
+
+		// Reset physics interpolation for any recreated canvas items.
+		if (is_physics_interpolated_and_enabled() && is_visible_in_tree()) {
+			for (List<RID>::Element *F = q.canvas_items.front(); F; F = F->next()) {
+				VisualServer::get_singleton()->canvas_item_reset_physics_interpolation(F->get());
+			}
 		}
 
 		dirty_quadrant_list.remove(dirty_quadrant_list.first());


### PR DESCRIPTION
Adds physics interpolation resets for `TileMap` and `Camera2D`.

## Notes
* `Camera2D` calls `NOTIFICATION_RESET_PHYSICS_INTERPOLATION` automatically as it inherits this behaviour from `CanvasItem`. However the camera transform is not yet set at that point, so it makes sense to reset after the initialization has occurred in `NOTIFICATION_ENTER_TREE`.
* `TileMap` needs resetting by quadrant, because there are potentially multiple canvas items in each quadrant.
* The quadrants are also reset every time they are renewed after making dirty. This will prevent streaking from the origin, however it could potentially need refinement for the case of moving tilemaps. This should probably be done from an MRP issue in a followup, as this is probably a rare use case.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
