### PR TITLE
Deselect multi caret when alt clicking on it

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1752,10 +1752,26 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				const int triple_click_tolerance = 5;
 				bool is_triple_click = (!mb->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && mb->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance);
 
-				if (!is_mouse_over_selection() && !mb->is_double_click() && !is_triple_click) {
+				if (!mb->is_double_click() && !is_triple_click) {
 					if (mb->is_alt_pressed()) {
 						prev_line = row;
 						prev_col = col;
+
+						// Remove caret at clicked location.
+						if (carets.size() > 1) {
+							for (int i = 0; i < carets.size(); i++) {
+								// Deselect if clicked on caret or its selection.
+								if ((get_caret_column(i) == col && get_caret_line(i) == row) || is_mouse_over_selection(true, i)) {
+									remove_caret(i);
+									last_dblclk = 0;
+									return;
+								}
+							}
+						}
+
+						if (is_mouse_over_selection()) {
+							return;
+						}
 
 						caret = add_caret(row, col);
 						if (caret == -1) {
@@ -1766,7 +1782,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 						carets.write[caret].selection.selecting_column = col;
 
 						last_dblclk = 0;
-					} else if (!mb->is_shift_pressed()) {
+					} else if (!mb->is_shift_pressed() && !is_mouse_over_selection()) {
 						caret = 0;
 						remove_secondary_carets();
 					}


### PR DESCRIPTION
Fixes #80895

If a caret can't be added it checks if it already exists and then removes it. So now it works similarly to vscode when alt clicking once adds a caret, and alt clicking again removes it.

It does loop through the carets twice but preventing that would require changing the return value of add_caret and therefore break compatibility. The amount of carets are always quite low so the performance impact should be neglectable.