### PR TITLE
Differentiate between core and editor-only singletons

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -260,14 +260,21 @@ bool Engine::is_printing_error_messages() const {
 }
 
 void Engine::add_singleton(const Singleton &p_singleton) {
-	ERR_FAIL_COND_MSG(singleton_ptrs.has(p_singleton.name), "Can't register singleton that already exists: " + String(p_singleton.name));
+	ERR_FAIL_COND_MSG(singleton_ptrs.has(p_singleton.name), vformat("Can't register singleton '%s' because it already exists.", p_singleton.name));
 	singletons.push_back(p_singleton);
 	singleton_ptrs[p_singleton.name] = p_singleton.ptr;
 }
 
 Object *Engine::get_singleton_object(const StringName &p_name) const {
 	HashMap<StringName, Object *>::ConstIterator E = singleton_ptrs.find(p_name);
-	ERR_FAIL_COND_V_MSG(!E, nullptr, "Failed to retrieve non-existent singleton '" + String(p_name) + "'.");
+	ERR_FAIL_COND_V_MSG(!E, nullptr, vformat("Failed to retrieve non-existent singleton '%s'.", p_name));
+
+#ifdef TOOLS_ENABLED
+	if (!is_editor_hint() && is_singleton_editor_only(p_name)) {
+		ERR_FAIL_V_MSG(nullptr, vformat("Can't retrieve singleton '%s' outside of editor.", p_name));
+	}
+#endif
+
 	return E->value;
 }
 
@@ -282,6 +289,19 @@ bool Engine::is_singleton_user_created(const StringName &p_name) const {
 
 	return false;
 }
+
+bool Engine::is_singleton_editor_only(const StringName &p_name) const {
+	ERR_FAIL_COND_V(!singleton_ptrs.has(p_name), false);
+
+	for (const Singleton &E : singletons) {
+		if (E.name == p_name && E.editor_only) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Engine::remove_singleton(const StringName &p_name) {
 	ERR_FAIL_COND(!singleton_ptrs.has(p_name));
 
@@ -300,6 +320,12 @@ bool Engine::has_singleton(const StringName &p_name) const {
 
 void Engine::get_singletons(List<Singleton> *p_singletons) {
 	for (const Singleton &E : singletons) {
+#ifdef TOOLS_ENABLED
+		if (!is_editor_hint() && E.editor_only) {
+			continue;
+		}
+#endif
+
 		p_singletons->push_back(E);
 	}
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -44,8 +44,11 @@ public:
 	struct Singleton {
 		StringName name;
 		Object *ptr = nullptr;
-		StringName class_name; //used for binding generation hinting
+		StringName class_name; // Used for binding generation hinting.
+		// Singleton scope flags.
 		bool user_created = false;
+		bool editor_only = false;
+
 		Singleton(const StringName &p_name = StringName(), Object *p_ptr = nullptr, const StringName &p_class_name = StringName());
 	};
 
@@ -129,6 +132,7 @@ public:
 	Object *get_singleton_object(const StringName &p_name) const;
 	void remove_singleton(const StringName &p_name);
 	bool is_singleton_user_created(const StringName &p_name) const;
+	bool is_singleton_editor_only(const StringName &p_name) const;
 
 #ifdef TOOLS_ENABLED
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -275,7 +275,9 @@ void register_editor_types() {
 	GLOBAL_DEF("editor/version_control/autoload_on_startup", false);
 
 	EditorInterface::create();
-	Engine::get_singleton()->add_singleton(Engine::Singleton("EditorInterface", EditorInterface::get_singleton()));
+	Engine::Singleton ei_singleton = Engine::Singleton("EditorInterface", EditorInterface::get_singleton());
+	ei_singleton.editor_only = true;
+	Engine::get_singleton()->add_singleton(ei_singleton);
 
 	OS::get_singleton()->benchmark_end_measure("register_editor_types");
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80704. Supersedes https://github.com/godotengine/godot/pull/80722.

The issues comes from the fact that during debug runs the engine technically has all editor-only classes registered, because we are using the "tools" (editor) version of the executable. In exported games this is not the case, so the reported crash doesn't affect templates. However, this does mean that code that is not guarded with `is_editor_hint` will cause issues when running scenes from the editor, including crashes.

On the one hand, this should've been an issue before, since nothing stops you from writing this in a stable version of Godot:

```gdscript

EditorPlugin.new().get_editor_interface().restart_editor()
```

But it doesn't happen, because `ClassDB` has guards against these situations. GDScript is not very helpful with its error messages (see https://github.com/godotengine/godot/pull/80921), but at least it doesn't crash:

<img width="514" alt="godot windows editor dev x86_64_2023-08-24_16-44-09" src="https://github.com/godotengine/godot/assets/11782833/988a3fe1-10f1-4a01-b660-0b3d63144468">

Unfortunately, `ClassDB` has nothing to do with the engine singletons. So I had to make changes to the `Engine` class. The `Singleton` struct already tracks user-created singletons, so it makes sense to add yet another flag for editor-only singletons, to differentiate between them and normal, always accessible core singletons.

So this no longer causes a crash:

```gdscript

EditorInterface.restart_editor()
```

The error message for GDScript still leaves a lot to be desired, but, once again, it doesn't crash at least.

<img width="389" alt="godot windows editor dev x86_64_2023-08-24_16-43-51" src="https://github.com/godotengine/godot/assets/11782833/a9cb7b59-3a66-4e76-bb8c-59593b40f853">

----

This is a core change, but I think that's something that is justified. `EditorInterface` is the first editor-only singleton that we have, but it may not be the last. We didn't need these checks before, but we do now.