### PR TITLE
Fix redundant enter tree notification in project export texture format

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -65,7 +65,6 @@ void ProjectExportTextureFormatError::_bind_methods() {
 
 void ProjectExportTextureFormatError::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			texture_format_error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/78457#discussion_r1304242368

As Yuri correctly noted, [NOTIFICATION_THEME_CHANGED](https://docs.godotengine.org/en/stable/classes/class_control.html#class-control-constant-notification-theme-changed) happens when "The node enters the scene tree".