### PR TITLE
Cleanup some `GLOBAL_DEF`s

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1398,6 +1398,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"), 1);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM, "Disable,Enable,Mirror"), 0);
 
+	GLOBAL_DEF("collada/use_ambient", false);
+
 	// These properties will not show up in the dialog. If you want to exclude whole groups, use add_hidden_prefix().
 	GLOBAL_DEF_INTERNAL("application/config/features", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_remaps", PackedStringArray());

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -400,6 +400,9 @@
 		<member name="audio/video/video_delay_compensation_ms" type="int" setter="" getter="" default="0">
 			Setting to hardcode audio delay when playing video. Best to leave this untouched unless you know what you are doing.
 		</member>
+		<member name="collada/use_ambient" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], ambient lights will be imported from COLLADA models as [DirectionalLight3D]. If [code]false[/code], ambient lights will be ignored.
+		</member>
 		<member name="compression/formats/gzip/compression_level" type="int" setter="" getter="" default="-1">
 			The default compression level for gzip. Affects compressed scenes and resources. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. [code]-1[/code] uses the default gzip compression level, which is identical to [code]6[/code] but could change in the future due to underlying zlib updates.
 		</member>

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -220,7 +220,7 @@ void EditorRunBar::_run_scene(const String &p_scene_path) {
 				return;
 			}
 
-			run_filename = GLOBAL_DEF_BASIC("application/run/main_scene", "");
+			run_filename = GLOBAL_GET("application/run/main_scene");
 		} break;
 	}
 

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -208,7 +208,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 						return OK; //do nothing not needed
 					}
 
-					if (!bool(GLOBAL_DEF("collada/use_ambient", false))) {
+					if (!bool(GLOBAL_GET("collada/use_ambient"))) {
 						return OK;
 					}
 					//well, it's an ambient light..

--- a/modules/webrtc/register_types.cpp
+++ b/modules/webrtc/register_types.cpp
@@ -42,11 +42,7 @@ void initialize_webrtc_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-
-#define SET_HINT(NAME, _VAL_, _MAX_) \
-	GLOBAL_DEF(PropertyInfo(Variant::INT, NAME, PROPERTY_HINT_RANGE, "2," #_MAX_ ",1,or_greater"), _VAL_);
-
-	SET_HINT(WRTC_IN_BUF, 64, 4096);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "network/limits/webrtc/max_channel_in_buffer_kb", PROPERTY_HINT_RANGE, "2,4096,1,or_greater"), 64);
 
 	ClassDB::register_custom_instance_class<WebRTCPeerConnection>();
 	GDREGISTER_CLASS(WebRTCPeerConnectionExtension);
@@ -55,8 +51,6 @@ void initialize_webrtc_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_CLASS(WebRTCDataChannelExtension);
 
 	GDREGISTER_CLASS(WebRTCMultiplayerPeer);
-
-#undef SET_HINT
 }
 
 void uninitialize_webrtc_module(ModuleInitializationLevel p_level) {

--- a/modules/webrtc/webrtc_data_channel.cpp
+++ b/modules/webrtc/webrtc_data_channel.cpp
@@ -61,7 +61,7 @@ void WebRTCDataChannel::_bind_methods() {
 }
 
 WebRTCDataChannel::WebRTCDataChannel() {
-	_in_buffer_shift = nearest_shift((int)GLOBAL_GET(WRTC_IN_BUF) - 1) + 10;
+	_in_buffer_shift = nearest_shift((int)GLOBAL_GET("network/limits/webrtc/max_channel_in_buffer_kb") - 1) + 10;
 }
 
 WebRTCDataChannel::~WebRTCDataChannel() {

--- a/modules/webrtc/webrtc_data_channel.h
+++ b/modules/webrtc/webrtc_data_channel.h
@@ -33,8 +33,6 @@
 
 #include "core/io/packet_peer.h"
 
-#define WRTC_IN_BUF PNAME("network/limits/webrtc/max_channel_in_buffer_kb")
-
 class WebRTCDataChannel : public PacketPeer {
 	GDCLASS(WebRTCDataChannel, PacketPeer);
 


### PR DESCRIPTION
Addresses #55730 (enough to close it?)

Based on https://github.com/godotengine/godot-proposals/issues/4771#issuecomment-1689841315 I experimented a bit with registering settings. Moving setting definitions to `_bind_methods()` sounds like feasible idea, but it has a few problems:
- Some classes are not registered. This means their `_bind_methods()` is not called until a first instance is created. The workaround I found is manually calling `initialize_class()`.
- Some defines may be used in platform-specific code that isn't compiled on other platforms (e.g. `display.iOS/use_cadisplaylink`, which is the only not documented project setting after this PR). This is a bigger problem, because there might be whole platform-specific classes that bind public methods, but aren't documented. I don't think we have any in the official engine though, it's more a problem with custom platforms.
  - btw `display.iOS/use_cadisplaylink` is not even available in the editor. It's basically a dead setting that you can set either in iOS editor build or manually in project.godot.
- Some classes aren't even GDClass. MessageQueue is an example; its setting is registered though, because the class is created early and the define is in the constructor. I think such classes would be exception.
- A whole another problem are editor settings. `register_editor_types()` is called before EditorSettings are created, which means no editor setting can be registered inside `_bind_methods()` of editor classes. This would require Main reorganization.

As for what this PR does:
- remove duplicate setting definition from EditorRunBar
- properly expose `"collada/use_ambient"` and document it
- fix how `"network/limits/webrtc/max_channel_in_buffer_kb"` is defined. The definition did not make sense on many levels, unless you assume that it was some form of code obfuscation 🙃 (although the main reason why I fixed it is that it messed with my setting scanner script)

I might try to do something about the EditorSettings problem next.