### PR TITLE
Display time of last save in the unsaved changes confirmation editor dialog

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -355,6 +355,8 @@ private:
 
 	Timer *screenshot_timer = nullptr;
 
+	uint64_t started_timestamp = 0;
+
 	PluginConfigDialog *plugin_config_dialog = nullptr;
 
 	RichTextLabel *load_errors = nullptr;


### PR DESCRIPTION
When multitasking, this makes it clearer whether closing a window with unsaved changes is potentially dangerous or not.

This is inspired by various games which display such a message when quitting, but I've seen various apps do it as well (I can't remember exactly which ones though).

## Preview

![Screenshot_20230825_201328](https://github.com/godotengine/godot/assets/180032/4f5558b3-fb1c-4370-b51f-9577d40ecca2)