### PR TITLE
Fix volumetric fog NaN values in textures from starting at a zero Vector2.

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -543,7 +543,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 		if (p_cam_projection.is_orthogonal()) {
 			fog_near_size = fog_far_size;
 		} else {
-			fog_near_size = Vector2();
+			fog_near_size = frustum_near_size.max(Vector2(0.001, 0.001));
 		}
 
 		params.fog_frustum_size_begin[0] = fog_near_size.x;
@@ -1002,7 +1002,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 	if (p_cam_projection.is_orthogonal()) {
 		fog_near_size = fog_far_size;
 	} else {
-		fog_near_size = Vector2();
+		fog_near_size = frustum_near_size.max(Vector2(0.001, 0.001));
 	}
 
 	params.fog_frustum_size_begin[0] = fog_near_size.x;


### PR DESCRIPTION
~~Reported issues: https://github.com/godotengine/godot/issues/78500~~

This attempts to fix these issues in the comments: https://github.com/godotengine/godot/issues/78500#issuecomment-1624167401 and https://github.com/godotengine/godot/issues/78500#issuecomment-1690366785 ~~it might also fix the original issue there but I can't reproduce it on my side and I also couldn't find anyone else who could apart from the OP and Calinou~~.

Details:
At this line: https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl#L308 `fog_unit_pos.z` can be 0 which leads to the mix `mix(params.fog_frustum_size_begin, params.fog_frustum_size_end, vec2(fog_unit_pos.z))` resolving into `params.fog_frustum_size_begin` which comes from this line: https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/servers/rendering/renderer_rd/environment/fog.cpp#L546
Here the `fog_near_size = Vector2();` means it's zero which later on in every light calculation in the shader casues this: `normalize(view_pos)` to yield INF/-INF which is later used for calculations which are then stored in textures and result into NaN in textures. Due to temporal_reprojection's interpolation with previous frame these values are kept and spread more resulting in black artifacts like these in the video I captured here: https://youtu.be/Vz-fKhp5scQ

To reproduce this I needed to up the `Volume Depth` in Project Settings and increase `Detail Spread` in the volumetric fog otherwise it's difficult to reproduce since it can take longer time to happen, since all these result in similar visual glitches as I mentioned earlier this might also fix the original issue, I did manage to kind of reproduce it but had to do some jump arounds so I'm not 100% sure, hopefully @Calinou and @Jonne-G can test this and tell us if this helped the issue as well or if it only helps with the ones I mentioned, please?

As far as I can tell this is as far as the issue can be tracked, so far I've tested on Windows 10, GTX 1660TI and could not reproduce the issues after this fix while before I can reproduce it 100%.

I couldn't find a reason why `Vector2()` needs to be used for the start so if someone else knows better please feel free to let me know I'm not that far into udnerstanding the whole thing so maybe I'm missing some reasoning and this isn't a suitable fix?

The `0.001` is just a safety, currently frustum can't go below this but just in case it changes in the future for some reason.
(we could maybe also just set it as `Vector2(0.01, 0.01);` if the `MAX(frustum_near_size)` is an issue or do a proper calculation whatever that should be (no idea).

This is my first code PR, please have mercy if I'm making any mistakes here, thank you! ^.^

_____________________________________________________________________________________________________
_Side note:
Also I'm not sure about the use of `detail_spread`: https://github.com/godotengine/godot/blob/6758a7f8c07d1f4c8ec4f052ded6d26402967ebe/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl#L305 this power pretty much always results in `0` depending on settings - Volume Depth and Detail Spread - for example spread 2.0 -> 9.53674E-07, spread 6.0 -> 0.0000 (you can get vallues with exponents of E-13 and such), it's not directly related to this but it was part of the chain which made me wonder if these values are ok in general?_