### PR TITLE
Trigger zoom from pan gestures when pressing ctrl

### DIFF
--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -125,6 +125,17 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
+		if (pan_gesture->is_ctrl_pressed()) {
+			// Zoom gesture.
+			float pan_zoom_factor = 1.02f;
+			float zoom_direction = pan_gesture->get_delta().x - pan_gesture->get_delta().y;
+			if (zoom_direction == 0.f) {
+				return true;
+			}
+			float zoom = zoom_direction < 0 ? 1.0 / pan_zoom_factor : pan_zoom_factor;
+			zoom_callback.call(zoom, pan_gesture->get_position(), p_event);
+			return true;
+		}
 		pan_callback.call(-pan_gesture->get_delta() * scroll_speed, p_event);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/72609

After the gestures refactor in https://github.com/godotengine/godot/pull/71685, zooming with ctrl + trackpad panning in macOS stopped working (4.0 beta16).

This PR aims at recovering that behavior, and extending it to other UI elements exposing zoom callbacks (pre-beta16, only `CanvasItemEditor` had this functionality hardcoded).

Panning up or right zooms in, down or left zooms out.

Zoom speed is tricky, as there is no `factor` in `InputEventPanGesture` we can leverage, and I haven’t found a way to consistently calculate one from `delta`s. I’ve decided to mimic the `delta` to `factor` logic in `platform/macos/godot_content_view.mm`, multiplying the default scroll zoom factor increase ratio by 0.3. Seems to work well for some UI elements (e.g. tilemaps), but is still too fast for others (e.g. animation tracks).

To keep things simple and avoid breaking existing user expectations, I’m not honoring the scroll pans/zooms toggle. I think it makes sense for panning to… pan by default (if this is deemed as potentially confusing to users who expect pan to behave like scroll, it’s an easy fix though).

EDIT: slightly reduced zoom speed, still feels good and natural in the canvas editor, and makes it a bit more precise in animation track editor.