### PR TITLE
Fix overriding `_export_begin`, `_export_file` and `_export_end` from GDExtension

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -498,7 +498,7 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 	//initial export plugin callback
 	for (int i = 0; i < export_plugins.size(); i++) {
 		export_plugins.write[i]->set_export_preset(p_preset);
-		if (export_plugins[i]->get_script_instance()) { //script based
+		if (GDVIRTUAL_IS_OVERRIDDEN_PTR(export_plugins[i], _export_begin)) {
 			PackedStringArray features_psa;
 			for (const String &feature : features) {
 				features_psa.push_back(feature);
@@ -513,7 +513,7 @@ EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_pla
 EditorExportPlatform::ExportNotifier::~ExportNotifier() {
 	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
-		if (export_plugins[i]->get_script_instance()) {
+		if (GDVIRTUAL_IS_OVERRIDDEN_PTR(export_plugins[i], _export_end)) {
 			export_plugins.write[i]->_export_end_script();
 		}
 		export_plugins.write[i]->_export_end();
@@ -1223,7 +1223,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 			bool do_export = true;
 			for (int i = 0; i < export_plugins.size(); i++) {
-				if (export_plugins[i]->get_script_instance()) { //script based
+				if (GDVIRTUAL_IS_OVERRIDDEN_PTR(export_plugins[i], _export_file)) {
 					export_plugins.write[i]->_export_file_script(path, type, features_psa);
 				} else {
 					export_plugins.write[i]->_export_file(path, type, features);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80593

In `EditorExportPlatform`, it's explicitly checking for a script before calling these virtual methods on `EditorExportPlugin`, which prevents them from working correctly when implemented from GDExtension (rather than script).

This PR changes the code to instead check using `GDVIRTUAL_IS_OVERRIDDEN_PTR()` which will check for both script or GDExtension implementations.

Another (possibly better) way this could have been implemented is by making the default implementations of the virtual `_export_begin()` etc functions do `GDVIRTUAL_CALL()` (calling into script or GDExtension), allowing the C++ `EditorExportPlugin`s to override those with custom implementations. It's done this way in a number of other classes. However, when I tried to implement it, there were issues with the fact that the in-engine classes take `HashSet<String> p_features` whereas the script/GDExtension versions take `PackedStringArray`, and this would have been recreating the `PackedStringArray` a lot more times than the current structure. If we changed the in-engine C++ API to take `PackedStringArray` instead, this would not be a problem!

But for now I've gone with the simpler approach.

~~NOTE: Currently marked as a draft, because I haven't actually tested it yet! The issue doesn't have an MRP, and there's a bunch of setup to test, but I will do it as soon as I can.~~