### PR TITLE
FileSystemDock: Don't update current path on rename when file list has focus

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1789,11 +1789,13 @@ void FileSystemDock::_rename_operation_confirm() {
 
 	EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
+	if (tree->has_focus()) {
+		current_path = new_path;
+		current_path_line_edit->set_text(current_path);
+	}
+
 	print_verbose("FileSystem: calling rescan.");
 	_rescan();
-
-	current_path = new_path;
-	current_path_line_edit->set_text(current_path);
 }
 
 void FileSystemDock::_duplicate_operation_confirm() {


### PR DESCRIPTION
fix #80940

FileSystemDock: Don't update current path and path edit when the file list has focus. So that when renaming from the file list, we don't cd into the renamed folder automatically.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
