### PR TITLE
Implement center window function

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -351,6 +351,12 @@
 				Returns [code]true[/code] if font oversampling is enabled. See [method set_use_font_oversampling].
 			</description>
 		</method>
+		<method name="move_to_center">
+			<return type="void" />
+			<description>
+				Centers a native window on the current screen and an embedded window on its embedder [Viewport].
+			</description>
+		</method>
 		<method name="move_to_foreground">
 			<return type="void" />
 			<description>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -342,6 +342,25 @@ Point2i Window::get_position() const {
 	return position;
 }
 
+void Window::move_to_center() {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_COND(!is_inside_tree());
+
+	Rect2 parent_rect;
+
+	if (is_embedded()) {
+		parent_rect = get_embedder()->get_visible_rect();
+	} else {
+		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
+		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
+		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);
+	}
+
+	if (parent_rect != Rect2()) {
+		set_position(parent_rect.position + (parent_rect.size - get_size()) / 2);
+	}
+}
+
 void Window::set_size(const Size2i &p_size) {
 	ERR_MAIN_THREAD_GUARD;
 
@@ -2602,6 +2621,7 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &Window::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &Window::get_position);
+	ClassDB::bind_method(D_METHOD("move_to_center"), &Window::move_to_center);
 
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &Window::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &Window::get_size);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -246,6 +246,7 @@ public:
 
 	void set_position(const Point2i &p_position);
 	Point2i get_position() const;
+	void move_to_center();
 
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;


### PR DESCRIPTION
Following the discussion in #65843, implements a `center()` function in `Window`.

Closes https://github.com/godotengine/godot-proposals/issues/5232.

Took inspiration (copied and modified) from the implementation of `Window.popup_centered()`.

Edit: Confused myself from following the popup logic... every non-embedded window will now center itself on it's own screen, while embedded windows will center themselves on the parent window.

Quick and dirty test project (test with embed_subwindows on and off): 
[empty_project.zip](https://github.com/godotengine/godot/files/12444801/empty_project.zip)
