### PR TITLE
Fix `JavaScriptBridge.eval()` never returning PackedByteArray

### DIFF
--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -109,7 +109,7 @@ const GodotJSWrapper = {
 					return 2; // INT
 				}
 				GodotRuntime.setHeapValue(p_exchange, p_val, 'double');
-				return 3; // REAL
+				return 3; // FLOAT
 			} else if (type === 'string') {
 				const c_str = GodotRuntime.allocString(p_val);
 				GodotRuntime.setHeapValue(p_exchange, c_str, '*');
@@ -313,7 +313,7 @@ const GodotEval = {
 
 		case 'number':
 			GodotRuntime.setHeapValue(p_union_ptr, eval_ret, 'double');
-			return 3; // REAL
+			return 3; // FLOAT
 
 		case 'string':
 			GodotRuntime.setHeapValue(p_union_ptr, GodotRuntime.allocString(eval_ret), '*');
@@ -333,7 +333,7 @@ const GodotEval = {
 				const func = GodotRuntime.get_func(p_callback);
 				const bytes_ptr = func(p_byte_arr, p_byte_arr_write, eval_ret.length);
 				HEAPU8.set(eval_ret, bytes_ptr);
-				return 20; // POOL_BYTE_ARRAY
+				return 29; // PACKED_BYTE_ARRAY
 			}
 			break;
 


### PR DESCRIPTION
JavaScriptBridge.eval() currently returns 20 on array buffers, which used to be the enumerator value of Godot 3.x's TYPE_POOL_BYTE_ARRAY (and now is the value of TYPE_COLOR in 4.x), while it should return 29 which is the enumerator value of [TYPE_PACKED_BYTE_ARRAY](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#enum-globalscope-variant-type).

The rest of the enumerator values of the file seem OK, but feel free to let me know if you see anything else that needs to be updated.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
