### PR TITLE
Keep `_export_begin()`'s `path` argument always consistent

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -1070,7 +1070,7 @@ void ProjectExportDialog::_export_project_to_path(const String &p_path) {
 	current->set_export_path(p_path);
 
 	platform->clear_messages();
-	Error err = platform->export_project(current, export_debug->is_pressed(), p_path, 0);
+	Error err = platform->export_project(current, export_debug->is_pressed(), current->get_export_path(), 0);
 	result_dialog_log->clear();
 	if (err != ERR_SKIP) {
 		if (platform->fill_log_messages(result_dialog_log, err)) {


### PR DESCRIPTION
Currently, the `path` argument given by `_export_begin()` will show a simplified path if exporting a single preset, or an absolute one if exporting them all at once. This PR makes sure that in both cases the simplified one is given.