### PR TITLE
Fix `_get_debug_tooltip` crash if tooltip string is too large

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -433,7 +433,11 @@ ScriptEditor *ScriptEditor::script_editor = nullptr;
 
 String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
 	String val = EditorDebuggerNode::get_singleton()->get_var_value(p_text);
+	const int display_limit = 300;
 	if (!val.is_empty()) {
+		if (val.size() > display_limit) {
+			val = val.left(display_limit) + " [...] truncated!";
+		}
 		return p_text + ": " + val;
 	} else {
 		return String();


### PR DESCRIPTION
This pr solves part of https://github.com/godotengine/godot/issues/80959

There are three problems raised from this issue, this pr only deals with the problem that if the stack variable's tooltip string is smaller than 1Mb ( if bigger than 1Mb, the case is addressed by another pr) but still very big, vulkan will crash at creating the buffer for the tooltip's flat style box since it's too long.

I choose to truncate the string at position 200 and append a ' [...] overflowed!' at the end of the string. The number is arbitrary but I dont think it's necessary to expose the value for user to config. 