### PR TITLE
Improve warnings when running scripts in the editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -254,7 +254,7 @@ bool CanvasItemEditor::_is_node_movable(const Node *p_node, bool p_popup_warning
 	}
 	if (Object::cast_to<Control>(p_node) && Object::cast_to<Container>(p_node->get_parent())) {
 		if (p_popup_warning) {
-			EditorToaster::get_singleton()->popup_str("Children of a container get their position and size determined only by their parent.", EditorToaster::SEVERITY_WARNING);
+			EditorToaster::get_singleton()->popup_str(TTR("Children of a container get their position and size determined only by their parent."), EditorToaster::SEVERITY_WARNING);
 		}
 		return false;
 	}


### PR DESCRIPTION
So I noticed that when a script has errors (caught by the analyzer in case of GDScript), if we try to run it in the editor the reported warning is incorrect and misleading:

<img width="334" alt="godot windows editor dev x86_64_2023-08-25_19-39-34" src="https://github.com/godotengine/godot/assets/11782833/80b7b806-96f9-4607-af88-8537eb3a0972">

That's probably because the tool flag on the script is not set if the script fails the analyzer checks. That may change in the future, but after looking at the code, I think the order of checks in the editor itself is wrong. So I've changed it, and also made these warnings into toasts instead of blocking popups. Seems more appropriate this way, and I adjusted the messages that are shown.

- First we check if it's a script at all (you can run the command for text files, for example).
- Then we try to reload the script and check if that went successfully; we also check if the script is valid.
- Then we check if it's a tool script.
- Then we check if it inherits `EditorScript`.

This order ensures that the latter checks are done on a freshly reloaded version of the script, and before that we actually try to parse it and see if it's valid.

<img width="883" alt="godot windows editor dev x86_64_2023-08-26_20-34-04" src="https://github.com/godotengine/godot/assets/11782833/8f3f1f24-7af6-4ce4-a822-51820847abef">

<img width="883" alt="godot windows editor dev x86_64_2023-08-26_20-34-28" src="https://github.com/godotengine/godot/assets/11782833/7d2720d7-5b0e-44d2-a3a1-043d8f16e806">

<img width="883" alt="godot windows editor dev x86_64_2023-08-26_20-34-59" src="https://github.com/godotengine/godot/assets/11782833/d07b791c-8b74-4434-b119-e385eb096318">

-----

While looking up how to do the toasts I noticed one of them was missing the translation macro, so I added that.