### PR TITLE
[3.x] Make binary resource loader utilize loaded external resources

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -339,7 +339,18 @@ Error ResourceInteractiveLoaderBinary::parse_variant(Variant &r_v) {
 							path = ProjectSettings::get_singleton()->localize_path(res_path.get_base_dir().plus_file(path));
 						}
 
-						RES res = ResourceLoader::load(path, exttype, no_subresource_cache);
+						RES res;
+
+						for (List<RES>::Element *E = resource_cache.front(); E; E = E->next()) {
+							if (E->get()->get_path() == path) {
+								res = E->get();
+								break;
+							}
+						}
+
+						if (res.is_null()) {
+							res = ResourceLoader::load(path, exttype, no_subresource_cache);
+						}
 
 						if (res.is_null()) {
 							WARN_PRINT(String("Couldn't load resource: " + path).utf8().get_data());


### PR DESCRIPTION
The Binary Resource Loader would load external resources, like TSCN files, twice, and basically discard the first one. It always had a `resource_cache` property that got populated, but never actually utilized.

When the no-cache flag wasn't being passed along, that issue wasn't noticeable besides longer loading times. Once it started being taken into account, it became noticeable (though it went under the radar until now.)

Fixes #80783