### PR TITLE
GLES3: Fix `glMapBufferRange` return null when `r_index + last_item_index > max_instance`

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1451,7 +1451,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broken) {
 	state.canvas_instance_batches[state.current_batch_index].instance_count++;
 	r_index++;
-	if (r_index >= data.max_instances_per_buffer) {
+	if (r_index + state.last_item_index >= data.max_instances_per_buffer) {
 		// Copy over all data needed for rendering right away
 		// then go back to recording item commands.
 		glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index]);


### PR DESCRIPTION
fixes #80986.
The origin code has bug because when `r_index == data.max_instances_per_buffer`, glMapBufferRange trys to map length = `data.max_instances_per_buffer * sizeof(InstanceData)`  range from offset `state.last_item_index * sizeof(InstanceData)`, but array buffer size is equal to `data.max_instances_per_buffer * sizeof(InstanceData)`, smaller than length + offset, so the glMapBufferRange failed and returned null instead, and thus caused the crash.
```
r_index++;
if (r_index >= data.max_instances_per_buffer) {
...
void *buffer = glMapBufferRange(GL_ARRAY_BUFFER, state.last_item_index * sizeof(InstanceData), r_index * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_UNSYNCHRONIZED_BIT);
memcpy(buffer, state.instance_data_array, r_index * sizeof(InstanceData));
```