### PR TITLE
Fix setting TabContainer's `font_hovered_color` theme property

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -162,6 +162,7 @@ void TabContainer::_update_theme_item_cache() {
 	theme_cache.drop_mark_color = get_theme_color(SNAME("drop_mark_color"));
 
 	theme_cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
+	theme_cache.font_hovered_color = get_theme_color(SNAME("font_hovered_color"));
 	theme_cache.font_unselected_color = get_theme_color(SNAME("font_unselected_color"));
 	theme_cache.font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
 	theme_cache.font_outline_color = get_theme_color(SNAME("font_outline_color"));
@@ -240,6 +241,7 @@ void TabContainer::_on_theme_changed() {
 	tab_bar->add_theme_color_override(SNAME("drop_mark_color"), theme_cache.drop_mark_color);
 
 	tab_bar->add_theme_color_override(SNAME("font_selected_color"), theme_cache.font_selected_color);
+	tab_bar->add_theme_color_override(SNAME("font_hovered_color"), theme_cache.font_hovered_color);
 	tab_bar->add_theme_color_override(SNAME("font_unselected_color"), theme_cache.font_unselected_color);
 	tab_bar->add_theme_color_override(SNAME("font_disabled_color"), theme_cache.font_disabled_color);
 	tab_bar->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -75,6 +75,7 @@ class TabContainer : public Container {
 		Color drop_mark_color;
 
 		Color font_selected_color;
+		Color font_hovered_color;
 		Color font_unselected_color;
 		Color font_disabled_color;
 		Color font_outline_color;


### PR DESCRIPTION
PRs target `4.x` if the same change was done in `master`, having the same issue in `4.0 stable` as well.
This resolves the issue of not setting the tab's `font_hovered_color` by theme override as mentioned in #80989

* *Bugsquad edit, fixes: #80989* 