### PR TITLE
Fix scaling last bone length with negative scales

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -325,7 +325,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 		rel = rel.rotated(-get_global_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	} else {
 		real_t angle_to_use = get_rotation() + bone_angle;
-		rel = Vector2(cos(angle_to_use), sin(angle_to_use)) * (length * MIN(get_global_scale().x, get_global_scale().y));
+		rel = Vector2(cos(angle_to_use), sin(angle_to_use)) * length * get_global_scale().abs();
 		rel = rel.rotated(-get_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	}
 


### PR DESCRIPTION
Fixes: #80643 

Change to use absolute value.  

**EDIT**:
I was trying to maintain the logic "use the lower value to define the length of the last bone", but I don't think this the right way.  
The user always want to see how much the bone is scaled in any direction, so why use the lower value?  

No change to scale:
![Bones with all scales 1](https://github.com/godotengine/godot/assets/9352894/debcc54a-eea5-4a2e-9138-ec791314edf0)  

Current behaviour when scaling X to 3:
![Bones with X scaled to 3, current behavior](https://github.com/godotengine/godot/assets/9352894/407ecb90-296b-4bc7-887f-fe5c350d8b7a)  

Propose change:
![Bones with X scaled to 3, propose behavior](https://github.com/godotengine/godot/assets/9352894/11094488-de93-40bf-8ada-5ecdbdbf089a)  

This also helps with #76087, in this issue we can see that saving calls this functions to redraw bones. Current behavior:  

- Before the user save, they are scaled using both X and Y axis.  
- After the user save, it redraw only using the lower value from scale.  

Note: Changing this would only help with the **last** bone.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
