### PR TITLE
Fix a editor restart crash when custom_display_scale is set to NAN

### DIFF
--- a/editor/editor_scale.cpp
+++ b/editor/editor_scale.cpp
@@ -29,11 +29,16 @@
 /**************************************************************************/
 
 #include "editor_scale.h"
+#include "core/typedefs.h"
 
 float EditorScale::_scale = 1.0f;
 
 void EditorScale::set_scale(float p_scale) {
-	_scale = p_scale;
+	if (p_scale >= 0.5) {
+		_scale = MIN(p_scale, 3);
+	} else {
+		_scale = 0.5f;
+	}
 }
 
 float EditorScale::get_scale() {


### PR DESCRIPTION
Fixes #81041. Add some protection in EditorScale::set_scale.
It's better to add some limit when assign the value `interface/editor/custom_display_scale` but it will require more work. But I'm happy to apply your suggestions as well.
