### PR TITLE
Use a different mouse cursor when hovering EditorSpinSlider

### DIFF
--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -19,6 +19,7 @@
 		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
 			The text that displays to the left of the value.
 		</member>
+		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="10" />
 		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false">
 			If [code]true[/code], the slider can't be interacted with.
 		</member>

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -701,6 +701,8 @@ void EditorSpinSlider::_ensure_input_popup() {
 }
 
 EditorSpinSlider::EditorSpinSlider() {
+	// Provide a visual hint that EditorSpinSlider can be dragged to adjust the value (like in Blender).
+	set_default_cursor_shape(CURSOR_HSIZE);
 	set_focus_mode(FOCUS_ALL);
 	grabber = memnew(TextureRect);
 	add_child(grabber);


### PR DESCRIPTION
This makes it more obvious that the value can be dragged, similar to Blender. This modified cursor is not displayed when hovering the draggable point on floating-point values, as you drag the point directly instead of the slider.

Alternatively, we could use a I-beam cursor like SpinBox already does.

- See https://github.com/godotengine/godot/issues/81045.

## Preview

https://github.com/godotengine/godot/assets/180032/47b8681c-6044-43a5-9b83-e6bc520a933a

