### PR TITLE
Fix VoxelGI CameraAttributes exposure normalization handling

### DIFF
--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -131,6 +131,8 @@ private:
 	void _find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes);
 	void _debug_bake();
 
+	float _get_camera_exposure_normalization();
+
 protected:
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/74134

Exposure value is used both when baking and during runtime, but currently VoxelGI only sets the runtime exposure normalization value when it is baked. This means that when the resource is freed and reloaded later, this setting is not updated properly and the normalization is not applied. This PR updates the normalization value when either voxel data or camera data is changed.