### PR TITLE
Fix Quick Open not opening binary resources

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4025,11 +4025,7 @@ void EditorNode::_quick_opened() {
 	bool open_scene_dialog = quick_open->get_base_type() == "PackedScene";
 	for (int i = 0; i < files.size(); i++) {
 		String res_path = files[i];
-
-		List<String> scene_extensions;
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
-
-		if (open_scene_dialog || scene_extensions.find(files[i].get_extension().to_lower())) {
+		if (open_scene_dialog || ClassDB::is_parent_class(ResourceLoader::get_resource_type(res_path), "PackedScene")) {
 			open_request(res_path);
 		} else {
 			load_resource(res_path);


### PR DESCRIPTION
When you save a Resource with `.res` extension, you won't be able to open it with Quick Open (Shift + Alt + O). There was a bug in opening logic, because it determined what to do based on resource extension. `.res` is one of scene extensions, so the resource was opened as scene, resulting in empty scene tab.
This PR changes it to use actual resource type instead of extension, so scenes and regular resources are properly differentiated.