### PR TITLE
Refactor disabling scene tab context menu options

### DIFF
--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -66,6 +66,7 @@ class EditorSceneTabs : public MarginContainer {
 
 	void _reposition_active_tab(int p_to_index);
 	void _update_context_menu();
+	void _disable_menu_option_if(int p_option, bool p_condition);
 
 	void _tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
 


### PR DESCRIPTION
Follow-up to #79382
I was going to disable one more option, but then noticed another option should also be disabled and eventually I refactored the whole thing 🤷‍♂️

- disable Show In FileSystem when the scene file does not exist (either empty scene or file was deleted)
- disable Save Scene, Save Scene As... and Play This Scene if root node does not exist
- disable Save All Scenes if there are no scenes that can be saved
- add a helper method to conditionally disable an option, to make code cleaner

![image](https://github.com/godotengine/godot/assets/2223172/9cecd881-85de-4614-9f43-55b7bb3b9a5c)
