### PR TITLE
C#: Replace `StringNameCache` with `SNAME`

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -68,8 +68,6 @@
 
 #include <stdint.h>
 
-#define CACHED_STRING_NAME(m_var) (CSharpLanguage::get_singleton()->get_string_names().m_var)
-
 // Types that will be skipped over (in favor of their base types) when setting up instance bindings.
 // This must be a superset of `ignored_types` in bindings_generator.cpp.
 const Vector<String> ignored_types = {};
@@ -1685,7 +1683,7 @@ bool CSharpInstance::property_can_revert(const StringName &p_name) const {
 	Variant ret;
 	Callable::CallError call_error;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &CACHED_STRING_NAME(_property_can_revert), args, 1, &call_error, &ret);
+			gchandle.get_intptr(), &SNAME("_property_can_revert"), args, 1, &call_error, &ret);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
@@ -1703,7 +1701,7 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 	Variant ret;
 	Callable::CallError call_error;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &CACHED_STRING_NAME(_property_get_revert), args, 1, &call_error, &ret);
+			gchandle.get_intptr(), &SNAME("_property_get_revert"), args, 1, &call_error, &ret);
 
 	if (call_error.error != Callable::CallError::CALL_OK) {
 		return false;
@@ -1991,13 +1989,11 @@ void CSharpInstance::notification(int p_notification) {
 void CSharpInstance::_call_notification(int p_notification) {
 	Variant arg = p_notification;
 	const Variant *args[1] = { &arg };
-	StringName method_name = SNAME("_notification");
-
-	Callable::CallError call_error;
 
 	Variant ret;
+	Callable::CallError call_error;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(
-			gchandle.get_intptr(), &method_name, args, 1, &call_error, &ret);
+			gchandle.get_intptr(), &SNAME("_notification"), args, 1, &call_error, &ret);
 }
 
 String CSharpInstance::to_string(bool *r_valid) {
@@ -2221,7 +2217,7 @@ bool CSharpScript::_update_exports(PlaceHolderScriptInstance *p_instance_to_upda
 }
 
 bool CSharpScript::_get(const StringName &p_name, Variant &r_ret) const {
-	if (p_name == CSharpLanguage::singleton->string_names._script_source) {
+	if (p_name == SNAME("script/source")) {
 		r_ret = get_source_code();
 		return true;
 	}
@@ -2230,7 +2226,7 @@ bool CSharpScript::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 bool CSharpScript::_set(const StringName &p_name, const Variant &p_value) {
-	if (p_name == CSharpLanguage::singleton->string_names._script_source) {
+	if (p_name == SNAME("script/source")) {
 		set_source_code(p_value);
 		reload();
 		return true;
@@ -2240,7 +2236,7 @@ bool CSharpScript::_set(const StringName &p_name, const Variant &p_value) {
 }
 
 void CSharpScript::_get_property_list(List<PropertyInfo> *p_properties) const {
-	p_properties->push_back(PropertyInfo(Variant::STRING, CSharpLanguage::singleton->string_names._script_source, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
+	p_properties->push_back(PropertyInfo(Variant::STRING, SNAME("script/source"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 }
 
 void CSharpScript::_bind_methods() {
@@ -2886,10 +2882,4 @@ void ResourceFormatSaverCSharpScript::get_recognized_extensions(const Ref<Resour
 
 bool ResourceFormatSaverCSharpScript::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<CSharpScript>(p_resource.ptr()) != nullptr;
-}
-
-CSharpLanguage::StringNameCache::StringNameCache() {
-	_property_can_revert = StaticCString::create("_property_can_revert");
-	_property_get_revert = StaticCString::create("_property_get_revert");
-	_script_source = StaticCString::create("script/source");
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -331,14 +331,6 @@ class CSharpLanguage : public ScriptLanguage {
 
 	ManagedCallableMiddleman *managed_callable_middleman = memnew(ManagedCallableMiddleman);
 
-	struct StringNameCache {
-		StringName _property_can_revert;
-		StringName _property_get_revert;
-		StringName _script_source;
-
-		StringNameCache();
-	};
-
 	int lang_idx = -1;
 
 	// For debug_break and debug_break_parse
@@ -366,8 +358,6 @@ public:
 	static void set_instance_binding(Object *p_object, void *p_binding);
 	static bool has_instance_binding(Object *p_object);
 
-	StringNameCache string_names;
-
 	const Mutex &get_language_bind_mutex() {
 		return language_bind_mutex;
 	}
@@ -379,10 +369,6 @@ public:
 		return lang_idx;
 	}
 	void set_language_index(int p_idx);
-
-	_FORCE_INLINE_ const StringNameCache &get_string_names() {
-		return string_names;
-	}
 
 	_FORCE_INLINE_ static CSharpLanguage *get_singleton() {
 		return singleton;


### PR DESCRIPTION
`StringNameCache` was a struct that has existed before `SNAME` that seems to have the same purpose, now it's no longer needed.