### PR TITLE
Flip convention of motion vectors.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -320,7 +320,7 @@ vec3 temporal_antialiasing(uvec2 pos_group_top_left, uvec2 pos_group, uvec2 pos_
 	vec2 velocity = imageLoad(velocity_buffer, ivec2(pos_screen)).xy;
 
 	// Get reprojected uv
-	vec2 uv_reprojected = uv - velocity;
+	vec2 uv_reprojected = uv + velocity;
 
 	// Get input color
 	vec3 color_input = load_color(pos_group);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2293,7 +2293,7 @@ void fragment_shader(in SceneData scene_data) {
 	vec2 position_uv = position_clip * vec2(0.5, 0.5);
 	vec2 prev_position_uv = prev_position_clip * vec2(0.5, 0.5);
 
-	motion_vector = position_uv - prev_position_uv;
+	motion_vector = prev_position_uv - position_uv;
 #endif
 }
 


### PR DESCRIPTION
As seen in PR #80723, the motion vectors used by Godot seem to go against the convention seen in other solutions where the vector of a pixel points towards its position in the previous frame.

While there's no hard rule written about this, the closest thing I can probably cite is what FSR2 expects.

https://github.com/GPUOpen-Effects/FidelityFX-FSR2#providing-motion-vectors

Instead of flipping around the sign of the value sampled from the buffer every time we need it and making FSR2 use a negative scale, it's probably better in the long term to just flip the convention to match. Integrating this should make the vectors go in the correct direction in the video shown in the PR.