### PR TITLE
Prevent creating any type of file with a leading dot

### DIFF
--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -51,13 +51,20 @@ String DirectoryCreateDialog::_validate_path(const String &p_path) const {
 		return TTR("Folder name cannot be empty.");
 	}
 
+	if (p_path.contains("\\") || p_path.contains(":") || p_path.contains("*") ||
+			p_path.contains("|") || p_path.contains(">")) {
+		return TTR("Folder name contains invalid characters.");
+	}
+
 	for (const String &part : p_path.split("/")) {
 		if (part.is_empty()) {
 			return TTR("Folder name cannot be empty.");
 		}
-		if (p_path.contains("\\") || p_path.contains(":") || p_path.contains("*") ||
-				p_path.contains("|") || p_path.contains(">") || p_path.ends_with(".") || p_path.ends_with(" ")) {
-			return TTR("Folder name contains invalid characters.");
+		if (part.ends_with(" ") || part[0] == ' ') {
+			return TTR("Folder name cannot begin or end with a space.");
+		}
+		if (part[0] == '.') {
+			return TTR("Folder name cannot begin with a dot.");
 		}
 	}
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1688,7 +1688,7 @@ void FileSystemDock::_rename_operation_confirm() {
 	} else if (new_name.contains("/") || new_name.contains("\\") || new_name.contains(":")) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
 		rename_error = true;
-	} else if (new_name.begins_with(".")) {
+	} else if (new_name[0] == '.') {
 		EditorNode::get_singleton()->show_warning(TTR("This filename begins with a dot rendering the file invisible to the editor.\nIf you want to rename it anyway, use your operating system's file manager."));
 		rename_error = true;
 	} else if (to_rename.is_file && to_rename.path.get_extension() != new_name.get_extension()) {
@@ -1759,6 +1759,9 @@ void FileSystemDock::_duplicate_operation_confirm() {
 		return;
 	} else if (new_name.contains("/") || new_name.contains("\\") || new_name.contains(":")) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
+		return;
+	} else if (new_name[0] == '.') {
+		EditorNode::get_singleton()->show_warning(TTR("Name begins with a dot."));
 		return;
 	}
 

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -103,6 +103,8 @@ void SceneCreateDialog::update_dialog() {
 
 	if (validation_panel->is_valid() && !scene_name.is_valid_filename()) {
 		validation_panel->set_message(MSG_ID_PATH, TTR("File name invalid."), EditorValidationPanel::MSG_ERROR);
+	} else if (validation_panel->is_valid() && scene_name[0] == '.') {
+		validation_panel->set_message(MSG_ID_PATH, TTR("File name begins with a dot."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	if (validation_panel->is_valid()) {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -243,6 +243,9 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	if (!p.get_file().get_basename().is_valid_filename()) {
 		return TTR("Filename is invalid.");
 	}
+	if (p.get_file().begins_with(".")) {
+		return TTR("Name begins with a dot.");
+	}
 
 	p = ProjectSettings::get_singleton()->localize_path(p);
 	if (!p.begins_with("res://")) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/62497, ports https://github.com/godotengine/godot/pull/62940 to master. Tested with every filesystem dock option, as well as saving resources and scenes from other docks.

Co-authored-by: gotnospirit <gotnospirit@gmail.com>