### PR TITLE
Only allow finite numbers in `Range.value`.

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -94,6 +94,10 @@ void Range::set_value(double p_val) {
 }
 
 void Range::_set_value_no_signal(double p_val) {
+	if (!Math::is_finite(p_val)) {
+		return;
+	}
+
 	if (shared->step > 0) {
 		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
 	}


### PR DESCRIPTION
Fixes #81057.

Since this property represents a number in a range, it doesn't make sense for it to be inf or nan.

*Bugsquad edit:* Fixes #80755