### PR TITLE
Fixup special case of cluster render

### DIFF
--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -58,6 +58,7 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 			afs.push_back(RD::AttachmentFormat());
 			afs.write[0].usage_flags = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT;
 			fb_format = RD::get_singleton()->framebuffer_format_create(afs);
+			blend_state = RD::PipelineColorBlendState::create_blend();
 			defines = "\n#define USE_ATTACHMENT\n";
 		}
 


### PR DESCRIPTION
This is a fixup for #76832. Either something has changed that requires this change or it shouldn't have worked at all without it (weird, because it did work). In any case, it makes a lot of sense to add this code line and things work as expected again with it.