### PR TITLE
Add a note about `SceneTree.create_tween()` method

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -90,6 +90,7 @@
 			<return type="Tween" />
 			<description>
 				Creates and returns a new [Tween]. The Tween will start automatically on the next process frame or physics frame (depending on [enum Tween.TweenProcessMode]).
+				[b]Note:[/b] When creating a [Tween] using this method, the [Tween] will not be tied to the [Node] that called it. It will continue to animate even if the [Node] is freed, but it will automatically finish if there's nothing left to animate. If you want the [Tween] to be automatically killed when the [Node] is freed, use [method Node.create_tween] or [method Tween.bind_node].
 			</description>
 		</method>
 		<method name="get_first_node_in_group">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- I've added a note about `create_tween()` method of `SceneTree` class.

#### Closes: [#7796](https://github.com/godotengine/godot-docs/issues/7796) (issue from godot-docs repo)