### PR TITLE
Improve `MeshDataTool.get_face_vertex()` method description

### DIFF
--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -137,8 +137,21 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="vertex" type="int" />
 			<description>
-				Returns the specified vertex of the given face.
+				Returns the specified vertex index of the given face.
 				Vertex argument must be either 0, 1, or 2 because faces contain three vertices.
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				var index = mesh_data_tool.get_face_vertex(0, 1) # Gets the index of the second vertex of the first face.
+				var position = mesh_data_tool.get_vertex(index)
+				var normal = mesh_data_tool.get_vertex_normal(index)
+				[/gdscript]
+				[csharp]
+				int index = meshDataTool.GetFaceVertex(0, 1); // Gets the index of the second vertex of the first face.
+				Vector3 position = meshDataTool.GetVertex(index);
+				Vector3 normal = meshDataTool.GetVertexNormal(index);
+				[/csharp]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->

## What I did 

- Improved the `MeshDataTool.get_face_vertex()` method description by making it more clear about what is the data type that is returned and adding a code example.

#### Closes: [#7852](https://github.com/godotengine/godot-docs/issues/7852) (issue from godot-docs repo)