### PR TITLE
[3.x] GDScript: Don't warn about `RETURN_VALUE_DISCARDED` by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -362,7 +362,7 @@
 		<member name="debug/gdscript/warnings/property_used_as_function" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when using a property as if it was a function.
 		</member>
-		<member name="debug/gdscript/warnings/return_value_discarded" type="bool" setter="" getter="" default="true">
+		<member name="debug/gdscript/warnings/return_value_discarded" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables warnings when calling a function without using its return value (by assigning it to a variable or using it as a function argument). Such return values are sometimes used to denote possible errors using the [enum Error] enum.
 		</member>
 		<member name="debug/gdscript/warnings/shadowed_variable" type="bool" setter="" getter="" default="true">

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2134,7 +2134,7 @@ GDScriptLanguage::GDScriptLanguage() {
 	GLOBAL_DEF("debug/gdscript/completion/autocomplete_setters_and_getters", false);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
 		String warning = GDScriptWarning::get_name_from_code((GDScriptWarning::Code)i).to_lower();
-		bool default_enabled = !warning.begins_with("unsafe_") && i != GDScriptWarning::UNUSED_CLASS_VARIABLE;
+		bool default_enabled = !warning.begins_with("unsafe_") && i != GDScriptWarning::UNUSED_CLASS_VARIABLE && i != GDScriptWarning::RETURN_VALUE_DISCARDED;
 		GLOBAL_DEF("debug/gdscript/warnings/" + warning, default_enabled);
 	}
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Following #69002. Turns out `4.x` has a lot of changes in the GDScript module so cherry-picking it directly is out of question.

I can't really see the reason to keep it enabled by default even with `3.x` especially when more of new features cherry-picked from `4.x` introduce a lot of discarded values. Anyway, this left to be justified by the maintainer since warnings in `3.x` aren't apparent in its own IDE but it's very annoying for users that use external editors.

*This is a re-do pull request from a broken #79077 branch.*