### PR TITLE
[3.x] Fix JavaScript callback memory leak

### DIFF
--- a/platform/javascript/js/libs/library_godot_javascript_singleton.js
+++ b/platform/javascript/js/libs/library_godot_javascript_singleton.js
@@ -205,7 +205,9 @@ const GodotJSWrapper = {
 				return;
 			}
 			const args = Array.from(arguments);
-			func(p_ref, GodotJSWrapper.get_proxied(args), args.length);
+			const argsProxy = new GodotJSWrapper.MyProxy(args);
+			func(p_ref, argsProxy.get_id(), args.length);
+			argsProxy.unref();
 		};
 		id = GodotJSWrapper.get_proxied(cb);
 		return id;


### PR DESCRIPTION
This fixes #81005 as I noticed that the original codecase doesn't free up allocated array after use in JS side, hence the issue, and Godot pretty much already copied everything from array to its internal `Array`, rendering the need to keep it intact unnecessary. 