### PR TITLE
Improve `Object.get_property_list()` method description

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -651,6 +651,7 @@
 				- [code]hint[/code] is [i]how[/i] the property is meant to be edited (see [enum PropertyHint]);
 				- [code]hint_string[/code] depends on the hint (see [enum PropertyHint]);
 				- [code]usage[/code] is a combination of [enum PropertyUsageFlags].
+				[b]Note:[/b] In GDScript, all class members are treated as properties. In C# and GDExtension, it may be necessary to explicitly mark class members as Godot properties using decorators or attributes.
 			</description>
 		</method>
 		<method name="get_script" qualifiers="const">


### PR DESCRIPTION
## What I did 

* Improved the `Object.get_property_list()` method description by making more clear what are the properties returned.
* Closes: godotengine/godot-docs#7533

_Bugsquad edit:_ Fixed method name and formatting.