### PR TITLE
[3.x] Fix TouchScreenButton not redrawn when texture changes

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -33,9 +33,19 @@
 #include "core/input_map.h"
 #include "core/os/input.h"
 #include "core/os/os.h"
+#include "scene/scene_string_names.h"
 
 void TouchScreenButton::set_texture(const Ref<Texture> &p_texture) {
+	if (texture == p_texture) {
+		return;
+	}
+	if (texture.is_valid()) {
+		texture->disconnect(SceneStringNames::get_singleton()->changed, this, "update");
+	}
 	texture = p_texture;
+	if (texture.is_valid()) {
+		texture->connect(SceneStringNames::get_singleton()->changed, this, "update", varray(), CONNECT_REFERENCE_COUNTED);
+	}
 	update();
 }
 
@@ -44,7 +54,16 @@ Ref<Texture> TouchScreenButton::get_texture() const {
 }
 
 void TouchScreenButton::set_texture_pressed(const Ref<Texture> &p_texture_pressed) {
+	if (texture_pressed == p_texture_pressed) {
+		return;
+	}
+	if (texture_pressed.is_valid()) {
+		texture_pressed->disconnect(SceneStringNames::get_singleton()->changed, this, "update");
+	}
 	texture_pressed = p_texture_pressed;
+	if (texture_pressed.is_valid()) {
+		texture_pressed->connect(SceneStringNames::get_singleton()->changed, this, "update", varray(), CONNECT_REFERENCE_COUNTED);
+	}
 	update();
 }
 
@@ -61,16 +80,16 @@ Ref<BitMap> TouchScreenButton::get_bitmask() const {
 }
 
 void TouchScreenButton::set_shape(const Ref<Shape2D> &p_shape) {
-	if (shape.is_valid()) {
-		shape->disconnect("changed", this, "update");
+	if (shape == p_shape) {
+		return;
 	}
-
+	if (shape.is_valid()) {
+		shape->disconnect(SceneStringNames::get_singleton()->changed, this, "update");
+	}
 	shape = p_shape;
-
 	if (shape.is_valid()) {
-		shape->connect("changed", this, "update");
+		shape->connect(SceneStringNames::get_singleton()->changed, this, "update");
 	}
-
 	update();
 }
 


### PR DESCRIPTION
`3.x` version of #75016