### PR TITLE
C#: Add abstract class support

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,6 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
+#include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/os/mutex.h"
 #include "core/version.h"
@@ -377,7 +378,14 @@ bool ClassDB::can_instantiate(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 
 	ClassInfo *ti = classes.getptr(p_class);
-	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
+	if (!ti) {
+		if (!ScriptServer::is_global_class(p_class)) {
+			ERR_FAIL_V_MSG(false, "Cannot get class '" + String(p_class) + "'.");
+		}
+		String path = ScriptServer::get_global_class_path(p_class);
+		Ref<Script> scr = ResourceLoader::load(path);
+		return scr.is_valid() && scr->is_valid() && !scr->is_abstract();
+	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
 		return false;
@@ -394,7 +402,9 @@ bool ClassDB::is_virtual(const StringName &p_class) {
 		if (!ScriptServer::is_global_class(p_class)) {
 			ERR_FAIL_V_MSG(false, "Cannot get class '" + String(p_class) + "'.");
 		}
-		return false;
+		String path = ScriptServer::get_global_class_path(p_class);
+		Ref<Script> scr = ResourceLoader::load(path);
+		return scr.is_valid() && scr->is_valid() && scr->is_abstract();
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -880,7 +880,10 @@ void Object::set_script(const Variant &p_script) {
 	}
 
 	Ref<Script> s = p_script;
-	ERR_FAIL_COND_MSG(s.is_null() && !p_script.is_null(), "Invalid parameter, it should be a reference to a valid script (or null).");
+	if (!p_script.is_null()) {
+		ERR_FAIL_COND_MSG(s.is_null(), "Cannot set object script. Parameter should be null or a reference to a valid script.");
+		ERR_FAIL_COND_MSG(s->is_abstract(), vformat("Cannot set object script. Script '%s' should not be abstract.", s->get_path()));
+	}
 
 	script = p_script;
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -146,6 +146,7 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
+	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -150,6 +150,7 @@ public:
 
 	virtual bool is_tool() const = 0;
 	virtual bool is_valid() const = 0;
+	virtual bool is_abstract() const = 0;
 
 	virtual ScriptLanguage *get_language() const = 0;
 

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -59,6 +59,7 @@ void ScriptExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_is_tool);
 	GDVIRTUAL_BIND(_is_valid);
+	GDVIRTUAL_BIND(_is_abstract);
 	GDVIRTUAL_BIND(_get_language);
 
 	GDVIRTUAL_BIND(_has_script_signal, "signal");

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -110,6 +110,12 @@ public:
 	EXBIND0RC(bool, is_tool)
 	EXBIND0RC(bool, is_valid)
 
+	virtual bool is_abstract() const override {
+		bool abst;
+		return GDVIRTUAL_CALL(_is_abstract, abst) && abst;
+	}
+	GDVIRTUAL0RC(bool, _is_abstract)
+
 	EXBIND0RC(ScriptLanguage *, get_language)
 	EXBIND1RC(bool, has_script_signal, const StringName &)
 

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -81,6 +81,12 @@
 				Returns [code]true[/code] if [param base_object] is an instance of this script.
 			</description>
 		</method>
+		<method name="is_abstract" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the script is an abstract script. An abstract script does not have a constructor and cannot be instantiated.
+			</description>
+		</method>
 		<method name="is_tool" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -141,6 +141,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_is_abstract" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the script is an abstract script. An abstract script does not have a constructor and cannot be instantiated.
+			</description>
+		</method>
 		<method name="_is_placeholder_fallback_enabled" qualifiers="virtual const">
 			<return type="bool" />
 			<description>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -279,6 +279,7 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 
 void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String &p_type, const TypeCategory p_type_category) {
 	bool script_type = ScriptServer::is_global_class(p_type);
+	bool is_abstract = false;
 	if (p_type_category == TypeCategory::CPP_TYPE) {
 		r_item->set_text(0, p_type);
 	} else if (p_type_category == TypeCategory::PATH_TYPE) {
@@ -286,14 +287,19 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const String 
 	} else if (script_type) {
 		r_item->set_metadata(0, p_type);
 		r_item->set_text(0, p_type);
-		r_item->set_suffix(0, "(" + ScriptServer::get_global_class_path(p_type).get_file() + ")");
+		String script_path = ScriptServer::get_global_class_path(p_type);
+		r_item->set_suffix(0, "(" + script_path.get_file() + ")");
+
+		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
+		ERR_FAIL_COND(!scr.is_valid());
+		is_abstract = scr->is_abstract();
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);
 		r_item->set_text(0, p_type);
 	}
 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
-			p_type_category == TypeCategory::OTHER_TYPE;
+			(p_type_category == TypeCategory::OTHER_TYPE && !is_abstract);
 	bool instantiable = can_instantiate && !(ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type));
 
 	r_item->set_meta(SNAME("__instantiable"), instantiable);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -510,7 +510,7 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 				}
 			}
 
-			if (!is_custom_resource && !(ScriptServer::is_global_class(t) || ClassDB::can_instantiate(t))) {
+			if (!is_custom_resource && !ClassDB::can_instantiate(t)) {
 				continue;
 			}
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -195,6 +195,7 @@ public:
 	void clear(GDScript::ClearData *p_clear_data = nullptr);
 
 	virtual bool is_valid() const override { return valid; }
+	virtual bool is_abstract() const override { return false; } // GDScript does not support abstract classes.
 
 	bool inherits_script(const Ref<Script> &p_script) const override;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -549,13 +549,13 @@ bool CSharpLanguage::handles_global_class_type(const String &p_type) const {
 
 String CSharpLanguage::get_global_class_name(const String &p_path, String *r_base_type, String *r_icon_path) const {
 	Ref<CSharpScript> scr = ResourceLoader::load(p_path, get_type());
-	if (!scr.is_valid() || !scr->valid || !scr->global_class) {
-		// Invalid script or the script is not a global class.
-		return String();
-	}
+	// Always assign r_base_type and r_icon_path, even if the script
+	// is not a global one. In the case that it is not a global script,
+	// return an empty string AFTER assigning the return parameters.
+	// See GDScriptLanguage::get_global_class_name() in modules/gdscript/gdscript.cpp
 
-	String name = scr->class_name;
-	if (unlikely(name.is_empty())) {
+	if (!scr.is_valid() || !scr->valid) {
+		// Invalid script.
 		return String();
 	}
 
@@ -582,7 +582,8 @@ String CSharpLanguage::get_global_class_name(const String &p_path, String *r_bas
 			*r_base_type = scr->get_instance_base_type();
 		}
 	}
-	return name;
+
+	return scr->global_class ? scr->class_name : String();
 }
 
 String CSharpLanguage::debug_get_error() const {
@@ -2295,6 +2296,7 @@ void CSharpScript::reload_registered_script(Ref<CSharpScript> p_script) {
 void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	bool tool = false;
 	bool global_class = false;
+	bool abstract_class = false;
 
 	// TODO: Use GDExtension godot_dictionary
 	Array methods_array;
@@ -2308,12 +2310,13 @@ void CSharpScript::update_script_class_info(Ref<CSharpScript> p_script) {
 	String icon_path;
 	Ref<CSharpScript> base_script;
 	GDMonoCache::managed_callbacks.ScriptManagerBridge_UpdateScriptClassInfo(
-			p_script.ptr(), &class_name, &tool, &global_class, &icon_path,
+			p_script.ptr(), &class_name, &tool, &global_class, &abstract_class, &icon_path,
 			&methods_array, &rpc_functions_dict, &signals_dict, &base_script);
 
 	p_script->class_name = class_name;
 	p_script->tool = tool;
 	p_script->global_class = global_class;
+	p_script->abstract_class = abstract_class;
 	p_script->icon_path = icon_path;
 
 	p_script->rpc_config.clear();
@@ -2401,7 +2404,7 @@ bool CSharpScript::can_instantiate() const {
 		ERR_FAIL_V_MSG(false, "Cannot instance script because the associated class could not be found. Script: '" + get_path() + "'. Make sure the script exists and contains a class definition with a name that matches the filename of the script exactly (it's case-sensitive).");
 	}
 
-	return valid && extra_cond;
+	return valid && !abstract_class && extra_cond;
 }
 
 StringName CSharpScript::get_instance_base_type() const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -63,6 +63,7 @@ class CSharpScript : public Script {
 
 	bool tool = false;
 	bool global_class = false;
+	bool abstract_class = false;
 	bool valid = false;
 	bool reload_invalidated = false;
 
@@ -187,6 +188,9 @@ public:
 	}
 	bool is_valid() const override {
 		return valid;
+	}
+	bool is_abstract() const override {
+		return abstract_class;
 	}
 
 	bool inherits_script(const Ref<Script> &p_script) const override;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -25,7 +25,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
-        public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
+        public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
         public delegate* unmanaged<IntPtr, IntPtr*, godot_bool, godot_bool> ScriptManagerBridge_SwapGCHandleForType;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, godot_string*, void*, int, void>, void> ScriptManagerBridge_GetPropertyInfoList;
         public delegate* unmanaged<IntPtr, delegate* unmanaged<IntPtr, void*, int, void>, void> ScriptManagerBridge_GetPropertyDefaultValues;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -131,6 +132,8 @@ namespace Godot.Bridge
                 // Performance is not critical here as this will be replaced with source generators.
                 Type scriptType = _scriptTypeBiMap.GetScriptType(scriptPtr);
 
+                Debug.Assert(!scriptType.IsAbstract, $"Cannot create script instance. The class '{scriptType.FullName}' is abstract.");
+
                 var ctor = scriptType
                     .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     .Where(c => c.GetParameters().Length == argCount)
@@ -146,7 +149,7 @@ namespace Godot.Bridge
                     else
                     {
                         throw new MissingMemberException(
-                            $"The class '{scriptType.FullName}' does not define a constructor that takes x parameters.");
+                            $"The class '{scriptType.FullName}' does not define a constructor that takes {argCount} parameters.");
                     }
                 }
 
@@ -597,7 +600,7 @@ namespace Godot.Bridge
 
         [UnmanagedCallersOnly]
         internal static unsafe void UpdateScriptClassInfo(IntPtr scriptPtr, godot_string* outClassName,
-            godot_bool* outTool, godot_bool* outGlobal, godot_string* outIconPath,
+            godot_bool* outTool, godot_bool* outGlobal, godot_bool* outAbstract, godot_string* outIconPath,
             godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest,
             godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript)
         {
@@ -631,8 +634,9 @@ namespace Godot.Bridge
                 var iconAttr = scriptType.GetCustomAttributes(inherit: false)
                     .OfType<IconAttribute>()
                     .FirstOrDefault();
-
                 *outIconPath = Marshaling.ConvertStringToNative(iconAttr?.Path);
+
+                *outAbstract = scriptType.IsAbstract.ToGodotBool();
 
                 // Methods
 
@@ -797,6 +801,7 @@ namespace Godot.Bridge
                 *outClassName = default;
                 *outTool = godot_bool.False;
                 *outGlobal = godot_bool.False;
+                *outAbstract = godot_bool.False;
                 *outIconPath = default;
                 *outMethodsDest = NativeFuncs.godotsharp_array_new();
                 *outRpcFunctionsDest = NativeFuncs.godotsharp_dictionary_new();

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -91,7 +91,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath = void(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
-	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, String *, bool *, bool *, String *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
+	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, String *, bool *, bool *, bool *, String *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_SwapGCHandleForType = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr *, bool);
 	using FuncScriptManagerBridge_GetPropertyInfoList = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyInfoList_Add);
 	using FuncScriptManagerBridge_GetPropertyDefaultValues = void(GD_CLR_STDCALL *)(CSharpScript *, Callback_ScriptManagerBridge_GetPropertyDefaultValues_Add);


### PR DESCRIPTION
At the moment, Godot internally does not support abstract scripts. This poses an issue when trying to create abstract classes in languages such as C#, because it has no way of knowing that trying to instantiate an abstract class is an invalid operation.

Abstract scripts appearing in the create dialog can no longer be instantiated as is the case with built-in classes such as `CanvasItem`. This also allows global abstract classes to remain untouched and functional. Furthermore, non-global C# classes no longer throw an error about an empty inheriting script path.

- Supersedes #80304.
- Fixes #78244.

![image](https://github.com/godotengine/godot/assets/46660281/b1cb319e-7067-4985-91fd-3026c12ad7da)