### PR TITLE
Fix JavaScript callback memory leak issue

### DIFF
--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -210,7 +210,9 @@ const GodotJSWrapper = {
 			// This is safe! JavaScript is single threaded (and using it in threads is not a good idea anyway).
 			GodotJSWrapper.cb_ret = null;
 			const args = Array.from(arguments);
-			func(p_ref, GodotJSWrapper.get_proxied(args), args.length);
+			const argsProxy = GodotJSWrapper.MyProxy(args);
+			func(p_ref, argsProxy.get_id(), args.length);
+			argsProxy.unref();
 			const ret = GodotJSWrapper.cb_ret;
 			GodotJSWrapper.cb_ret = null;
 			return ret;


### PR DESCRIPTION
Follows #81090 for `master` branch. I noticed that in `master` it supports returning value so I put the `unref` the last until value return occurs.