### PR TITLE
[3.x] Make `TextureButton` and `Button` update on texture change

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -31,6 +31,7 @@
 #include "button.h"
 
 #include "core/translation.h"
+#include "scene/scene_string_names.h"
 #include "servers/visual_server.h"
 
 Size2 Button::get_minimum_size() const {
@@ -309,7 +310,13 @@ void Button::set_icon(const Ref<Texture> &p_icon) {
 	if (icon == p_icon) {
 		return;
 	}
+	if (icon.is_valid()) {
+		icon->disconnect(SceneStringNames::get_singleton()->changed, this, "_texture_changed");
+	}
 	icon = p_icon;
+	if (icon.is_valid()) {
+		icon->connect(SceneStringNames::get_singleton()->changed, this, "_texture_changed");
+	}
 	update();
 	_change_notify("icon");
 	minimum_size_changed();
@@ -317,6 +324,11 @@ void Button::set_icon(const Ref<Texture> &p_icon) {
 
 Ref<Texture> Button::get_icon() const {
 	return icon;
+}
+
+void Button::_texture_changed() {
+	update();
+	minimum_size_changed();
 }
 
 void Button::set_expand_icon(bool p_expand_icon) {
@@ -383,6 +395,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_icon_align"), &Button::get_icon_align);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
+
+	ClassDB::bind_method(D_METHOD("_texture_changed"), &Button::_texture_changed);
 
 	BIND_ENUM_CONSTANT(ALIGN_LEFT);
 	BIND_ENUM_CONSTANT(ALIGN_CENTER);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -54,6 +54,8 @@ private:
 	TextAlign icon_align;
 	float _internal_margin[4];
 
+	void _texture_changed();
+
 protected:
 	void _set_internal_margin(Margin p_margin, float p_value);
 	void _notification(int p_what);

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -29,7 +29,10 @@
 /**************************************************************************/
 
 #include "texture_button.h"
+
 #include "core/typedefs.h"
+#include "scene/scene_string_names.h"
+
 #include <stdlib.h>
 
 Size2 TextureButton::get_minimum_size() const {
@@ -272,6 +275,8 @@ void TextureButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_expand"), &TextureButton::get_expand);
 	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &TextureButton::get_stretch_mode);
 
+	ClassDB::bind_method(D_METHOD("_texture_changed"), &TextureButton::_texture_changed);
+
 	ADD_GROUP("Textures", "texture_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_normal", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_normal_texture", "get_normal_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture_pressed", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_pressed_texture", "get_pressed_texture");
@@ -294,25 +299,21 @@ void TextureButton::_bind_methods() {
 }
 
 void TextureButton::set_normal_texture(const Ref<Texture> &p_normal) {
-	normal = p_normal;
-	update();
-	minimum_size_changed();
+	_set_texture(&normal, p_normal);
 }
 
 void TextureButton::set_pressed_texture(const Ref<Texture> &p_pressed) {
-	pressed = p_pressed;
-	update();
-	minimum_size_changed();
+	_set_texture(&pressed, p_pressed);
 }
+
 void TextureButton::set_hover_texture(const Ref<Texture> &p_hover) {
-	hover = p_hover;
-	update();
-	minimum_size_changed();
+	_set_texture(&hover, p_hover);
 }
+
 void TextureButton::set_disabled_texture(const Ref<Texture> &p_disabled) {
-	disabled = p_disabled;
-	update();
+	_set_texture(&disabled, p_disabled);
 }
+
 void TextureButton::set_click_mask(const Ref<BitMap> &p_click_mask) {
 	click_mask = p_click_mask;
 	update();
@@ -342,6 +343,27 @@ Ref<Texture> TextureButton::get_focused_texture() const {
 void TextureButton::set_focused_texture(const Ref<Texture> &p_focused) {
 	focused = p_focused;
 };
+
+void TextureButton::_set_texture(Ref<Texture> *p_destination, const Ref<Texture> &p_texture) {
+	DEV_ASSERT(p_destination);
+	Ref<Texture> &destination = *p_destination;
+	if (destination == p_texture) {
+		return;
+	}
+	if (destination.is_valid()) {
+		destination->disconnect(SceneStringNames::get_singleton()->changed, this, "_texture_changed");
+	}
+	destination = p_texture;
+	if (destination.is_valid()) {
+		destination->connect(SceneStringNames::get_singleton()->changed, this, "_texture_changed", varray(), CONNECT_REFERENCE_COUNTED);
+	}
+	_texture_changed();
+}
+
+void TextureButton::_texture_changed() {
+	update();
+	minimum_size_changed();
+}
 
 bool TextureButton::get_expand() const {
 	return expand;

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -64,6 +64,9 @@ private:
 	bool hflip;
 	bool vflip;
 
+	void _set_texture(Ref<Texture> *p_destination, const Ref<Texture> &p_texture);
+	void _texture_changed();
+
 protected:
 	virtual Size2 get_minimum_size() const;
 	virtual bool has_point(const Point2 &p_point) const;


### PR DESCRIPTION
* 3.x version of: #77159

Currently unable to verify functionality on 3.x builds, code should work but would appreciate someone verifying

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
