### PR TITLE
[3.x] Core: Add recursion level check for `VariantWriter::write()`

### DIFF
--- a/core/variant_parser.h
+++ b/core/variant_parser.h
@@ -166,7 +166,7 @@ public:
 	typedef Error (*StoreStringFunc)(void *ud, const String &p_string);
 	typedef String (*EncodeResourceFunc)(void *ud, const RES &p_resource);
 
-	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud);
+	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int p_recursion_count = 0);
 	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr);
 };
 


### PR DESCRIPTION
Fixes a crash on the following code:

```gdscript
var a = []
a.append(a)
print(var2str(a))
```

See https://github.com/godotengine/godot/pull/79370#issuecomment-1697080762.
