### PR TITLE
Assign extension validation files to the GDExtension and .NET teams in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@ doc_classes/*                       @godotengine/documentation
 # Misc
 
 /misc/                              @godotengine/buildsystem
+/misc/extension_api_validation/     @godotengine/gdextension @godotengine/dotnet
 
 # Modules
 


### PR DESCRIPTION
As discussed in Rocket Chat.

I originally also wanted to assign the files that end with `_extension` to the GDExtension team, but I think that would override their current owner unless we explicitly add both which means we can't use a simple regex like `*_extension.*` but instead would have to add one for each area (e.g.: `/modules/openxr/**/*_extension.*`, `/servers/text/**/*_extension.*`).