### PR TITLE
[3.x] Add check to ensure registered classes are declared

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -170,6 +170,7 @@ public:
 	template <class T>
 	static void register_class() {
 		GLOBAL_LOCK_FUNCTION;
+		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
@@ -182,6 +183,7 @@ public:
 	template <class T>
 	static void register_virtual_class() {
 		GLOBAL_LOCK_FUNCTION;
+		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);
@@ -198,6 +200,7 @@ public:
 	template <class T>
 	static void register_custom_instance_class() {
 		GLOBAL_LOCK_FUNCTION;
+		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);

--- a/core/object.h
+++ b/core/object.h
@@ -269,6 +269,7 @@ private:                                                                        
 	friend class ClassDB;                                                                                                               \
                                                                                                                                         \
 public:                                                                                                                                 \
+	typedef m_class self_type;                                                                                                          \
 	virtual String get_class() const {                                                                                                  \
 		return String(#m_class);                                                                                                        \
 	}                                                                                                                                   \
@@ -407,6 +408,8 @@ class ObjectRC;
 
 class Object {
 public:
+	typedef Object self_type;
+
 	enum ConnectFlags {
 
 		CONNECT_DEFERRED = 1,


### PR DESCRIPTION
Checks that all classes registered to `ClassDB` have been properly declared with `GDCLASS`

* 3.x version of: #81020

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
