### PR TITLE
Remove too greedy gcov/lcov ignores from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,23 +132,9 @@ cppcheck-cppcheck-build-dir/
 *.pydevproject
 *.launch
 
-# Gcov and Lcov code coverage
-*.gcno
+# GCOV code coverage
 *.gcda
-*.gcov.html
-*.func.html
-*.func-sort-c.html
-*index-sort-f.html
-*index-sort-l.html
-*index.html
-godot.info
-amber.png
-emerald.png
-glass.png
-ruby.png
-snow.png
-updown.png
-gcov.css
+*.gcno
 
 # Geany
 *.geany


### PR DESCRIPTION
This would cause `updown.png` to be ignored in our default theme in 3.x.

These ignores were added in #36800 for #36572 (see that PR for usage
instructions).

From a quick test, using `--output-file` for `lcov` and `--output-directory`
for genhtml let us output the files in a way that won't conflict with the
Git repository (e.g. in `bin/`, or outside the Git repo).

Needed for the `3.x` and `3.5` branch to cherry-pick #78908.

---

Tested locally with:
```
scons -j7 p=linuxbsd dev_build=yes dev_mode=yes linker=mold scu_build=all use_coverage=yes
lcov --directory ./ --capture --output-file bin/godot.info
genhtml bin/godot.info --ignore-errors source --output-directory bin/
```

Output:
```
$ ls bin/*
bin/amber.png    bin/gcov.css   bin/godot.info                         bin/index.html         bin/index-sort-l.html  bin/snow.png
bin/emerald.png  bin/glass.png  bin/godot.linuxbsd.editor.dev.x86_64*  bin/index-sort-f.html  bin/ruby.png           bin/updown.png

bin/godot.git:
core/                                                   hb-buffer-deserialize-text-unicode.hh.gcov.html         hb-ot-shaper-khmer-machine.hh.func-sort-c.html    index.html
drivers/                                                hb-buffer-deserialize-text-unicode.rl.func.html         hb-ot-shaper-khmer-machine.hh.gcov.html           index-sort-f.html
editor/                                                 hb-buffer-deserialize-text-unicode.rl.func-sort-c.html  hb-ot-shaper-khmer-machine.rl.func.html           index-sort-l.html
hb-buffer-deserialize-json.hh.func.html                 hb-buffer-deserialize-text-unicode.rl.gcov.html         hb-ot-shaper-khmer-machine.rl.func-sort-c.html    MachineIndependent/
hb-buffer-deserialize-json.hh.func-sort-c.html          hb-number-parser.hh.func.html                           hb-ot-shaper-khmer-machine.rl.gcov.html           main/
hb-buffer-deserialize-json.hh.gcov.html                 hb-number-parser.hh.func-sort-c.html                    hb-ot-shaper-myanmar-machine.hh.func.html         modules/
hb-buffer-deserialize-json.rl.func.html                 hb-number-parser.hh.gcov.html                           hb-ot-shaper-myanmar-machine.hh.func-sort-c.html  NONE.func.html
hb-buffer-deserialize-json.rl.func-sort-c.html          hb-number-parser.rl.func.html                           hb-ot-shaper-myanmar-machine.hh.gcov.html         NONE.func-sort-c.html
hb-buffer-deserialize-json.rl.gcov.html                 hb-number-parser.rl.func-sort-c.html                    hb-ot-shaper-myanmar-machine.rl.func.html         NONE.gcov.html
hb-buffer-deserialize-text-glyphs.hh.func.html          hb-number-parser.rl.gcov.html                           hb-ot-shaper-myanmar-machine.rl.func-sort-c.html  platform/
hb-buffer-deserialize-text-glyphs.hh.func-sort-c.html   hb-ot-shaper-indic-machine.hh.func.html                 hb-ot-shaper-myanmar-machine.rl.gcov.html         scene/
hb-buffer-deserialize-text-glyphs.hh.gcov.html          hb-ot-shaper-indic-machine.hh.func-sort-c.html          hb-ot-shaper-use-machine.hh.func.html             servers/
hb-buffer-deserialize-text-glyphs.rl.func.html          hb-ot-shaper-indic-machine.hh.gcov.html                 hb-ot-shaper-use-machine.hh.func-sort-c.html      tests/
hb-buffer-deserialize-text-glyphs.rl.func-sort-c.html   hb-ot-shaper-indic-machine.rl.func.html                 hb-ot-shaper-use-machine.hh.gcov.html             thirdparty/
hb-buffer-deserialize-text-glyphs.rl.gcov.html          hb-ot-shaper-indic-machine.rl.func-sort-c.html          hb-ot-shaper-use-machine.rl.func.html
hb-buffer-deserialize-text-unicode.hh.func.html         hb-ot-shaper-indic-machine.rl.gcov.html                 hb-ot-shaper-use-machine.rl.func-sort-c.html
hb-buffer-deserialize-text-unicode.hh.func-sort-c.html  hb-ot-shaper-khmer-machine.hh.func.html                 hb-ot-shaper-use-machine.rl.gcov.html

bin/usr:
include/  lib/
```

All this is in `bin/` which is `.gitignore`d, no untracked file in `git status`.