### PR TITLE
Fix a crash when plugin tries to call `make_mesh_previews` on enable

### DIFF
--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -245,7 +245,7 @@ EditorPluginSettings::EditorPluginSettings() {
 	plugin_list->set_column_custom_minimum_width(3, 80 * EDSCALE);
 	plugin_list->set_column_custom_minimum_width(4, 40 * EDSCALE);
 	plugin_list->set_hide_root(true);
-	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed));
+	plugin_list->connect("item_edited", callable_mp(this, &EditorPluginSettings::_plugin_activity_changed), CONNECT_DEFERRED);
 
 	VBoxContainer *mc = memnew(VBoxContainer);
 	mc->add_child(plugin_list);


### PR DESCRIPTION
Fixes #80333
When we update the plugin list, we should check the tree is blocked or not, if blocked, `create_item` will return nullptr and thus cause crash. 