### PR TITLE
Fix VoxelGI static light pairing

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1805,7 +1805,8 @@ void RendererSceneCull::_update_instance(Instance *p_instance) {
 		pair.pair_mask |= RS::INSTANCE_GEOMETRY_MASK;
 		pair.bvh = &p_instance->scenario->indexers[Scenario::INDEXER_GEOMETRY];
 
-		if (RSG::light_storage->light_get_bake_mode(p_instance->base) == RS::LIGHT_BAKE_DYNAMIC) {
+		RS::LightBakeMode bake_mode = RSG::light_storage->light_get_bake_mode(p_instance->base);
+		if (bake_mode == RS::LIGHT_BAKE_STATIC || bake_mode == RS::LIGHT_BAKE_DYNAMIC) {
 			pair.pair_mask |= (1 << RS::INSTANCE_VOXEL_GI);
 			pair.bvh2 = &p_instance->scenario->indexers[Scenario::INDEXER_VOLUMES];
 		}


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/78373
* Probably fixes https://github.com/godotengine/godot/issues/78569. There is no test project, but considering the issue description I would say it is a duplicate or very similar to the first issue, just using different workarounds.

I tweaked the MRP project from the first issue a bit to make things easier to see (disabling default environment light, ramping up indirect light, changing static light type and position etc.). 

Updated Test Project:
[voxelgi-static-lights-bug.zip](https://github.com/godotengine/godot/files/12464383/voxelgi-static-lights-bug.zip)

Looks like when using lights with static bake mode, the lights are sometimes unpaired from the VoxelGI and not properly paired back. As VoxeGI does support static lights and in optimal conditions they do currently stay paired, I think the way static light are not sometimes paired back is the bug behind those issues. Note that when using VoxelGI and static lights you still need to re-bake VoxelGI if you move static lights around if you want the indirect lighting to stay accurate.

It looks like the issue is with pairing code that unpairs static lights from VoxelGI when updated but doesn't pair them back. Static lights are paired when created, but then lose their pairing after certain node tree transform or visibility change. How and when this happens also depends on node tree structure, which makes this especially nasty. By this I mean the behavior is different depending if the light is "above" or "below" the VoxelGI in the tree sibling node hierarchy. This seems to be caused by transform or visibility notification ordering during scene tree changes, which can invalidate pairing. So depending on order, if the light pairing is invalidated first and then VoxelGI things work out because updating VoxelGI pairs the lights again later. But if it happens the other way around the light stays unpaired until VoxelGI is updated (by baking, toggling its visibility etc.)

We can dig more into the test project now. When you open it without this PR, the VoxelGI indirect light is probably broken for the static spotlight. You can fix this by toggling VoxelGI node visibility off and on again or baking it again, this is where that static light gets paired again to the VoxelGI. Navigating to another scene tab and back also breaks this pairing again (because transform/visibility notification and update unpairs the light). NOTE: You need to save, close and then reopen the scene tab after re-ordering nodes to see the effects. If you try to play the project indirect light is also broken (this is what the workarounds in both projects attempted to fix). For example the first project has this:

`await get_tree().create_timer(0.05).timeout`

to set the data again and the second issue uses toggling visibility to force the light pairing. Interestingly 0.05 timeout value doesn't work for me, I have to use at least 0.1 timeout value on my machine. 

You can experiment by reordering the SpotLight3D so that it is lower than VoxelGI in the sibling hierarchy. Simply doing this fixes the play mode indirect lighting for me (without this PR). Also note that changing order also changes the behavior when navigating to another scene tab and back, but you have to close the tab completely after re-ordering the node.

After this PR, static lights stay paired to VoxelGI even when the tree gets modified (by transform or visibility updates). Still, I'm not all that familiar with the pairing code so feedback is appreciated.

There are also somewhat similar possible pairing/update issues with LightmapGI (like https://github.com/godotengine/godot/issues/77356 and https://github.com/godotengine/godot/issues/77167 and good discussion in https://github.com/godotengine/godot/pull/77089).