### PR TITLE
Prevent errors if Tween callback's object is freed

### DIFF
--- a/doc/classes/CallbackTweener.xml
+++ b/doc/classes/CallbackTweener.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[CallbackTweener] is used to call a method in a tweening sequence. See [method Tween.tween_callback] for more usage information.
+		The tweener will finish automatically if the callback's target object is freed.
 		[b]Note:[/b] [method Tween.tween_callback] is the only correct way to create [CallbackTweener]. Any [CallbackTweener] created manually will not function correctly.
 	</description>
 	<tutorials>

--- a/doc/classes/MethodTweener.xml
+++ b/doc/classes/MethodTweener.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[MethodTweener] is similar to a combination of [CallbackTweener] and [PropertyTweener]. It calls a method providing an interpolated value as a parameter. See [method Tween.tween_method] for more usage information.
+		The tweener will finish automatically if the callback's target object is freed.
 		[b]Note:[/b] [method Tween.tween_method] is the only correct way to create [MethodTweener]. Any [MethodTweener] created manually will not function correctly.
 	</description>
 	<tutorials>

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -675,6 +675,10 @@ bool CallbackTweener::step(double &r_delta) {
 		return false;
 	}
 
+	if (!callback.get_object()) {
+		return false;
+	}
+
 	elapsed_time += r_delta;
 	if (elapsed_time >= delay) {
 		Variant result;
@@ -733,6 +737,10 @@ void MethodTweener::start() {
 
 bool MethodTweener::step(double &r_delta) {
 	if (finished) {
+		return false;
+	}
+
+	if (!callback.get_object()) {
 		return false;
 	}
 


### PR DESCRIPTION
This PR prevents errors when the callback target of CallbackTweener or MethodTweener is freed. This is consistent with PropertyTweener.

Related: #81087 and the linked issue.