### PR TITLE
Unfocus LineEdit when pressing Escape

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -482,6 +482,11 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 
+		if (k->is_action("ui_cancel")) {
+			release_focus();
+			return;
+		}
+
 		if (is_shortcut_keys_enabled()) {
 			if (k->is_action("ui_copy", true)) {
 				copy_text();

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -210,6 +210,11 @@ void SpinBox::_line_edit_focus_exit() {
 	if (line_edit->is_menu_visible()) {
 		return;
 	}
+	// Discontinue because the focus_exit was caused by canceling.
+	if (Input::get_singleton()->is_action_pressed("ui_cancel")) {
+		_update_text();
+		return;
+	}
 
 	_text_submitted(line_edit->get_text());
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7543