### PR TITLE
Implement a system to contextualize global themes

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -851,6 +851,8 @@ public:
 	void stop_child_process(OS::ProcessID p_pid);
 
 	Ref<Theme> get_editor_theme() const { return theme; }
+	void update_preview_themes(int p_mode);
+
 	Ref<Script> get_object_custom_type_base(const Object *p_object) const;
 	StringName get_object_custom_type_name(const Object *p_object) const;
 	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "Object");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -295,7 +295,6 @@ private:
 	bool is_main_screen_editing = false;
 
 	PanelContainer *scene_root_parent = nullptr;
-	Control *theme_base = nullptr;
 	Control *gui_base = nullptr;
 	VBoxContainer *main_vbox = nullptr;
 	OptionButton *renderer = nullptr;
@@ -525,6 +524,7 @@ private:
 	static void _resource_saved(Ref<Resource> p_resource, const String &p_path);
 	static void _resource_loaded(Ref<Resource> p_resource, const String &p_path);
 
+	void _update_theme(bool p_skip_creation = false);
 	void _build_icon_type_cache();
 	void _enable_pending_addons();
 
@@ -867,7 +867,6 @@ public:
 	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
 
 	Control *get_gui_base() { return gui_base; }
-	Control *get_theme_base() { return gui_base->get_parent_control(); }
 
 	void save_scene_to_path(String p_file, bool p_with_preview = true) {
 		if (p_with_preview) {

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_string_names.h"
 #include "scene/resources/image_texture.h"
 
 bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
@@ -341,7 +342,8 @@ void EditorResourcePreview::_thread() {
 
 void EditorResourcePreview::_update_thumbnail_sizes() {
 	if (small_thumbnail_size == -1) {
-		small_thumbnail_size = EditorNode::get_singleton()->get_theme_base()->get_editor_theme_icon(SNAME("Object"))->get_width(); // Kind of a workaround to retrieve the default icon size
+		// Kind of a workaround to retrieve the default icon size.
+		small_thumbnail_size = EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Object"), EditorStringName(EditorIcons))->get_width();
 	}
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1034,6 +1034,22 @@ void CanvasItemEditor::_on_grid_menu_id_pressed(int p_id) {
 	viewport->queue_redraw();
 }
 
+void CanvasItemEditor::_switch_theme_preview(int p_mode) {
+	view_menu->get_popup()->hide();
+
+	if (theme_preview == p_mode) {
+		return;
+	}
+	theme_preview = (ThemePreviewMode)p_mode;
+	EditorSettings::get_singleton()->set_project_metadata("2d_editor", "theme_preview", theme_preview);
+
+	for (int i = 0; i < THEME_PREVIEW_MAX; i++) {
+		theme_menu->set_item_checked(i, i == theme_preview);
+	}
+
+	EditorNode::get_singleton()->update_preview_themes(theme_preview);
+}
+
 bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_event) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	Ref<InputEventMouseButton> b = p_event;
@@ -5321,6 +5337,20 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/clear_guides", TTR("Clear Guides")), CLEAR_GUIDES);
 	p->add_separator();
 	p->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/preview_canvas_scale", TTR("Preview Canvas Scale")), PREVIEW_CANVAS_SCALE);
+
+	theme_menu = memnew(PopupMenu);
+	theme_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_switch_theme_preview));
+	theme_menu->set_name("ThemeMenu");
+	theme_menu->add_radio_check_item(TTR("Project theme"), THEME_PREVIEW_PROJECT);
+	theme_menu->add_radio_check_item(TTR("Editor theme"), THEME_PREVIEW_EDITOR);
+	theme_menu->add_radio_check_item(TTR("Default theme"), THEME_PREVIEW_DEFAULT);
+	p->add_child(theme_menu);
+	p->add_submenu_item(TTR("Preview Theme"), "ThemeMenu");
+
+	theme_preview = (ThemePreviewMode)(int)EditorSettings::get_singleton()->get_project_metadata("2d_editor", "theme_preview", THEME_PREVIEW_PROJECT);
+	for (int i = 0; i < THEME_PREVIEW_MAX; i++) {
+		theme_menu->set_item_checked(i, i == theme_preview);
+	}
 
 	main_menu_hbox->add_child(memnew(VSeparator));
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -325,6 +325,7 @@ private:
 	Button *override_camera_button = nullptr;
 	MenuButton *view_menu = nullptr;
 	PopupMenu *grid_menu = nullptr;
+	PopupMenu *theme_menu = nullptr;
 	HBoxContainer *animation_hb = nullptr;
 	MenuButton *animation_menu = nullptr;
 
@@ -403,6 +404,19 @@ private:
 	bool _is_grid_visible() const;
 	void _prepare_grid_menu();
 	void _on_grid_menu_id_pressed(int p_id);
+
+public:
+	enum ThemePreviewMode {
+		THEME_PREVIEW_PROJECT,
+		THEME_PREVIEW_EDITOR,
+		THEME_PREVIEW_DEFAULT,
+
+		THEME_PREVIEW_MAX // The number of options for enumerating.
+	};
+
+private:
+	ThemePreviewMode theme_preview = THEME_PREVIEW_PROJECT;
+	void _switch_theme_preview(int p_mode);
 
 	List<CanvasItem *> _get_edited_canvas_items(bool retrieve_locked = false, bool remove_canvas_item_if_parent_in_selection = true) const;
 	Rect2 _get_encompassing_rect_from_list(List<CanvasItem *> p_list);
@@ -557,6 +571,8 @@ public:
 	void center_at(const Point2 &p_pos);
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
+	ThemePreviewMode get_theme_preview() const { return theme_preview; }
 
 	EditorSelection *editor_selection = nullptr;
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1612,6 +1612,8 @@ void ScriptEditor::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
+			tab_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("ScriptEditor"), EditorStringName(EditorStyles)));
+
 			help_search->set_icon(get_editor_theme_icon(SNAME("HelpSearch")));
 			site_search->set_icon(get_editor_theme_icon(SNAME("ExternalLink")));
 
@@ -1628,7 +1630,7 @@ void ScriptEditor::_notification(int p_what) {
 			filter_scripts->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			filter_methods->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 
-			filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+			filename->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 
 			recent_scripts->reset_size();
 
@@ -1639,6 +1641,9 @@ void ScriptEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
+			// Can't set own styles in NOTIFICATION_THEME_CHANGED, so for now this will do.
+			add_theme_style_override("panel", get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+
 			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
 			InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
 			EditorNode::get_singleton()->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
@@ -4138,9 +4143,6 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	convert_indent_on_save = EDITOR_GET("text_editor/behavior/files/convert_indent_on_save");
 
 	ScriptServer::edit_request_func = _open_script_request;
-
-	add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), EditorStringName(EditorStyles)));
-	tab_container->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), EditorStringName(EditorStyles)));
 
 	Ref<EditorJSONSyntaxHighlighter> json_syntax_highlighter;
 	json_syntax_highlighter.instantiate();

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1217,7 +1217,7 @@ void ThemeItemEditorDialog::_dialog_about_to_show() {
 	import_default_theme_items->reset_item_tree();
 
 	import_editor_theme_items->set_edited_theme(edited_theme);
-	import_editor_theme_items->set_base_theme(EditorNode::get_singleton()->get_theme_base()->get_theme());
+	import_editor_theme_items->set_base_theme(EditorNode::get_singleton()->get_editor_theme());
 	import_editor_theme_items->reset_item_tree();
 
 	import_other_theme_items->set_edited_theme(edited_theme);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -202,8 +202,14 @@ void ThemeEditorPreview::_notification(int p_what) {
 			}
 
 			connect("visibility_changed", callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
-			[[fallthrough]];
-		}
+		} break;
+
+		case NOTIFICATION_READY: {
+			List<Ref<Theme>> preview_themes;
+			preview_themes.push_back(ThemeDB::get_singleton()->get_default_theme());
+			ThemeDB::get_singleton()->create_theme_context(preview_root, preview_themes);
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			picker_button->set_icon(get_editor_theme_icon(SNAME("ColorPick")));
 
@@ -247,9 +253,8 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	preview_container = memnew(ScrollContainer);
 	preview_body->add_child(preview_container);
 
-	MarginContainer *preview_root = memnew(MarginContainer);
+	preview_root = memnew(MarginContainer);
 	preview_container->add_child(preview_root);
-	preview_root->set_theme(ThemeDB::get_singleton()->get_default_theme());
 	preview_root->set_clip_contents(true);
 	preview_root->set_custom_minimum_size(Size2(450, 0) * EDSCALE);
 	preview_root->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_preview.h
+++ b/editor/plugins/theme_editor_preview.h
@@ -44,6 +44,7 @@ class ThemeEditorPreview : public VBoxContainer {
 	GDCLASS(ThemeEditorPreview, VBoxContainer);
 
 	ScrollContainer *preview_container = nullptr;
+	MarginContainer *preview_root = nullptr;
 	ColorRect *preview_bg = nullptr;
 	MarginContainer *preview_overlay = nullptr;
 	Control *picker_overlay = nullptr;

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -780,42 +780,31 @@ Ref<Font> Label3D::_get_font_or_default() const {
 		return font_override;
 	}
 
-	// Check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_project_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
+	StringName theme_name = "font";
+	List<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+
+	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_null()) {
+			continue;
+		}
 
 		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_project_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
-				}
-				return f;
+			if (!theme->has_font(theme_name, E)) {
+				continue;
 			}
+
+			Ref<Font> f = theme->get_font(theme_name, E);
+			if (f.is_valid()) {
+				theme_font = f;
+				theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
+			}
+			return f;
 		}
 	}
 
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	{
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_default_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
-
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));
-				}
-				return f;
-			}
-		}
-	}
-
-	// If they don't exist, use any type to return the default/empty value.
-	Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
+	Ref<Font> f = global_context->get_fallback_theme()->get_font(theme_name, StringName());
 	if (f.is_valid()) {
 		theme_font = f;
 		theme_font->connect_changed(callable_mp(const_cast<Label3D *>(this), &Label3D::_font_changed));

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2465,6 +2465,11 @@ bool Control::has_theme_owner_node() const {
 	return data.theme_owner->has_owner_node();
 }
 
+void Control::set_theme_context(ThemeContext *p_context, bool p_propagate) {
+	ERR_MAIN_THREAD_GUARD;
+	data.theme_owner->set_owner_context(p_context, p_propagate);
+}
+
 void Control::set_theme(const Ref<Theme> &p_theme) {
 	ERR_MAIN_THREAD_GUARD;
 	if (data.theme == p_theme) {
@@ -3124,7 +3129,9 @@ void Control::_notification(int p_notification) {
 				notification(NOTIFICATION_TRANSLATION_CHANGED);
 			}
 #endif
-			notification(NOTIFICATION_THEME_CHANGED);
+
+			// Emits NOTIFICATION_THEME_CHANGED internally.
+			set_theme_context(ThemeDB::get_singleton()->get_nearest_theme_context(this));
 		} break;
 
 		case NOTIFICATION_POST_ENTER_TREE: {
@@ -3134,6 +3141,7 @@ void Control::_notification(int p_notification) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			set_theme_context(nullptr, false);
 			release_focus();
 			get_viewport()->_gui_remove_control(this);
 		} break;
@@ -3632,7 +3640,7 @@ void Control::_bind_methods() {
 }
 
 Control::Control() {
-	data.theme_owner = memnew(ThemeOwner);
+	data.theme_owner = memnew(ThemeOwner(this));
 }
 
 Control::~Control() {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -42,6 +42,7 @@ class Viewport;
 class Label;
 class Panel;
 class ThemeOwner;
+class ThemeContext;
 
 class Control : public CanvasItem {
 	GDCLASS(Control, CanvasItem);
@@ -552,6 +553,8 @@ public:
 	void set_theme_owner_node(Node *p_node);
 	Node *get_theme_owner_node() const;
 	bool has_theme_owner_node() const;
+
+	void set_theme_context(ThemeContext *p_context, bool p_propagate = true);
 
 	void set_theme(const Ref<Theme> &p_theme);
 	Ref<Theme> get_theme() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1269,7 +1269,9 @@ void Window::_notification(int p_what) {
 				notification(NOTIFICATION_TRANSLATION_CHANGED);
 			}
 #endif
-			notification(NOTIFICATION_THEME_CHANGED);
+
+			// Emits NOTIFICATION_THEME_CHANGED internally.
+			set_theme_context(ThemeDB::get_singleton()->get_nearest_theme_context(this));
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -1313,6 +1315,8 @@ void Window::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
+			set_theme_context(nullptr, false);
+
 			if (transient) {
 				_clear_transient();
 			}
@@ -1887,6 +1891,11 @@ Node *Window::get_theme_owner_node() const {
 bool Window::has_theme_owner_node() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return theme_owner->has_owner_node();
+}
+
+void Window::set_theme_context(ThemeContext *p_context, bool p_propagate) {
+	ERR_MAIN_THREAD_GUARD;
+	theme_owner->set_owner_context(p_context, p_propagate);
 }
 
 void Window::set_theme(const Ref<Theme> &p_theme) {
@@ -2887,7 +2896,7 @@ Window::Window() {
 		max_size_used = max_size; // Update max_size_used.
 	}
 
-	theme_owner = memnew(ThemeOwner);
+	theme_owner = memnew(ThemeOwner(this));
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_DISABLED);
 }
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -39,6 +39,7 @@ class Font;
 class Shortcut;
 class StyleBox;
 class ThemeOwner;
+class ThemeContext;
 
 class Window : public Viewport {
 	GDCLASS(Window, Viewport)
@@ -364,6 +365,8 @@ public:
 	void set_theme_owner_node(Node *p_node);
 	Node *get_theme_owner_node() const;
 	bool has_theme_owner_node() const;
+
+	void set_theme_context(ThemeContext *p_context, bool p_propagate = true);
 
 	void set_theme(const Ref<Theme> &p_theme);
 	Ref<Theme> get_theme() const;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2779,54 +2779,40 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 		return base_font;
 	}
 
-	// Check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_project_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
+	StringName theme_name = "font";
+	List<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
 
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_project_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f == this) {
-					continue;
-				}
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
-				}
-				return f;
-			}
-		}
-	}
-
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	if (ThemeDB::get_singleton()->get_default_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_default_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
-
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f == this) {
-					continue;
-				}
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
-				}
-				return f;
-			}
+	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_null()) {
+			continue;
 		}
 
-		// If they don't exist, use any type to return the default/empty value.
-		Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
-		if (f != this) {
+		for (const StringName &E : theme_types) {
+			if (!theme->has_font(theme_name, E)) {
+				continue;
+			}
+
+			Ref<Font> f = theme->get_font(theme_name, E);
+			if (f == this) {
+				continue;
+			}
 			if (f.is_valid()) {
 				theme_font = f;
 				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
+	}
+
+	Ref<Font> f = global_context->get_fallback_theme()->get_font(theme_name, StringName());
+	if (f != this) {
+		if (f.is_valid()) {
+			theme_font = f;
+			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+		}
+		return f;
 	}
 
 	return Ref<Font>();
@@ -3131,54 +3117,40 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 		return base_font;
 	}
 
-	// Check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_project_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
+	StringName theme_name = "font";
+	List<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
 
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_project_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f == this) {
-					continue;
-				}
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
-				}
-				return f;
-			}
-		}
-	}
-
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	if (ThemeDB::get_singleton()->get_default_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_default_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
-
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-				if (f == this) {
-					continue;
-				}
-				if (f.is_valid()) {
-					theme_font = f;
-					theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
-				}
-				return f;
-			}
+	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_null()) {
+			continue;
 		}
 
-		// If they don't exist, use any type to return the default/empty value.
-		Ref<Font> f = ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
-		if (f != this) {
+		for (const StringName &E : theme_types) {
+			if (!theme->has_font(theme_name, E)) {
+				continue;
+			}
+
+			Ref<Font> f = theme->get_font(theme_name, E);
+			if (f == this) {
+				continue;
+			}
 			if (f.is_valid()) {
 				theme_font = f;
 				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
+	}
+
+	Ref<Font> f = global_context->get_fallback_theme()->get_font(theme_name, StringName());
+	if (f != this) {
+		if (f.is_valid()) {
+			theme_font = f;
+			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+		}
+		return f;
 	}
 
 	return Ref<Font>();

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -3466,32 +3466,24 @@ Ref<Font> TextMesh::_get_font_or_default() const {
 		return font_override;
 	}
 
-	// Check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_project_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
+	StringName theme_name = "font";
+	List<StringName> theme_types;
+	ThemeDB::get_singleton()->get_native_type_dependencies(get_class_name(), &theme_types);
+
+	ThemeContext *global_context = ThemeDB::get_singleton()->get_default_theme_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_null()) {
+			continue;
+		}
 
 		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				return ThemeDB::get_singleton()->get_project_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
+			if (theme->has_font(theme_name, E)) {
+				return theme->get_font(theme_name, E);
 			}
 		}
 	}
 
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	{
-		List<StringName> theme_types;
-		ThemeDB::get_singleton()->get_default_theme()->get_type_dependencies(get_class_name(), StringName(), &theme_types);
-
-		for (const StringName &E : theme_types) {
-			if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				return ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
-			}
-		}
-	}
-
-	// If they don't exist, use any type to return the default/empty value.
-	return ThemeDB::get_singleton()->get_default_theme()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
+	return global_context->get_fallback_theme()->get_font(theme_name, StringName());
 }
 
 void TextMesh::set_font_size(int p_size) {

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -1263,11 +1263,7 @@ void Theme::get_type_dependencies(const StringName &p_base_type, const StringNam
 	}
 
 	// Continue building the chain using native class hierarchy.
-	StringName class_name = p_base_type;
-	while (class_name != StringName()) {
-		p_list->push_back(class_name);
-		class_name = ClassDB::get_parent_class_nocheck(class_name);
-	}
+	ThemeDB::get_singleton()->get_native_type_dependencies(p_base_type, p_list);
 }
 
 // Internal methods for getting lists as a Vector of String (compatible with public API).

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -272,7 +272,17 @@ void ThemeDB::_init_default_theme_context() {
 	default_theme_context = memnew(ThemeContext);
 
 	List<Ref<Theme>> themes;
+
+	// Only add the project theme to the default context when running projects.
+
+#ifdef TOOLS_ENABLED
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		themes.push_back(project_theme);
+	}
+#else
 	themes.push_back(project_theme);
+#endif
+
 	themes.push_back(default_theme);
 	default_theme_context->set_themes(themes);
 }
@@ -287,6 +297,14 @@ void ThemeDB::_finalize_theme_contexts() {
 		memdelete(E->value);
 		theme_contexts.remove(E);
 	}
+}
+
+ThemeContext *ThemeDB::get_theme_context(Node *p_node) const {
+	if (!theme_contexts.has(p_node)) {
+		return nullptr;
+	}
+
+	return theme_contexts[p_node];
 }
 
 ThemeContext *ThemeDB::get_default_theme_context() const {

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -32,6 +32,9 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
+#include "scene/gui/control.h"
+#include "scene/main/node.h"
+#include "scene/main/window.h"
 #include "scene/resources/font.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
@@ -40,18 +43,18 @@
 #include "servers/text_server.h"
 
 // Default engine theme creation and configuration.
+
 void ThemeDB::initialize_theme() {
+	// Default theme-related project settings.
+
 	// Allow creating the default theme at a different scale to suit higher/lower base resolutions.
 	float default_theme_scale = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "gui/theme/default_theme_scale", PROPERTY_HINT_RANGE, "0.5,8,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 1.0);
 
-	String theme_path = GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
-
-	String font_path = GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.otf,*.ttf,*.woff,*.woff2,*.fnt,*.font,*.pfb,*.pfm", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
+	String project_theme_path = GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "gui/theme/custom", PROPERTY_HINT_FILE, "*.tres,*.res,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
+	String project_font_path = GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "gui/theme/custom_font", PROPERTY_HINT_FILE, "*.tres,*.res,*.otf,*.ttf,*.woff,*.woff2,*.fnt,*.font,*.pfb,*.pfm", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), "");
 
 	TextServer::FontAntialiasing font_antialiasing = (TextServer::FontAntialiasing)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_antialiasing", PROPERTY_HINT_ENUM, "None,Grayscale,LCD Subpixel", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), 1);
-
 	TextServer::Hinting font_hinting = (TextServer::Hinting)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), TextServer::HINTING_LIGHT);
-
 	TextServer::SubpixelPositioning font_subpixel_positioning = (TextServer::SubpixelPositioning)(int)GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/default_font_subpixel_positioning", PROPERTY_HINT_ENUM, "Disabled,Auto,One Half of a Pixel,One Quarter of a Pixel", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED), TextServer::SUBPIXEL_POSITIONING_AUTO);
 
 	const bool font_msdf = GLOBAL_DEF_RST("gui/theme/default_font_multichannel_signed_distance_field", false);
@@ -60,35 +63,42 @@ void ThemeDB::initialize_theme() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "gui/theme/lcd_subpixel_layout", PROPERTY_HINT_ENUM, "Disabled,Horizontal RGB,Horizontal BGR,Vertical RGB,Vertical BGR"), 1);
 	ProjectSettings::get_singleton()->set_restart_if_changed("gui/theme/lcd_subpixel_layout", false);
 
-	Ref<Font> font;
-	if (!font_path.is_empty()) {
-		font = ResourceLoader::load(font_path);
-		if (font.is_valid()) {
-			set_fallback_font(font);
-		} else {
-			ERR_PRINT("Error loading custom font '" + font_path + "'");
-		}
-	}
+	// Attempt to load custom project theme and font.
 
-	// Always make the default theme to avoid invalid default font/icon/style in the given theme.
-	if (RenderingServer::get_singleton()) {
-		make_default_theme(default_theme_scale, font, font_subpixel_positioning, font_hinting, font_antialiasing, font_msdf, font_generate_mipmaps);
-	}
-
-	if (!theme_path.is_empty()) {
-		Ref<Theme> theme = ResourceLoader::load(theme_path);
+	if (!project_theme_path.is_empty()) {
+		Ref<Theme> theme = ResourceLoader::load(project_theme_path);
 		if (theme.is_valid()) {
 			set_project_theme(theme);
 		} else {
-			ERR_PRINT("Error loading custom theme '" + theme_path + "'");
+			ERR_PRINT("Error loading custom project theme '" + project_theme_path + "'");
 		}
 	}
+
+	Ref<Font> project_font;
+	if (!project_font_path.is_empty()) {
+		project_font = ResourceLoader::load(project_font_path);
+		if (project_font.is_valid()) {
+			set_fallback_font(project_font);
+		} else {
+			ERR_PRINT("Error loading custom project font '" + project_font_path + "'");
+		}
+	}
+
+	// Always generate the default theme to serve as a fallback for all required theme definitions.
+
+	if (RenderingServer::get_singleton()) {
+		make_default_theme(default_theme_scale, project_font, font_subpixel_positioning, font_hinting, font_antialiasing, font_msdf, font_generate_mipmaps);
+	}
+
+	_init_default_theme_context();
 }
 
 void ThemeDB::initialize_theme_noproject() {
 	if (RenderingServer::get_singleton()) {
 		make_default_theme(1.0, Ref<Font>());
 	}
+
+	_init_default_theme_context();
 }
 
 void ThemeDB::finalize_theme() {
@@ -96,6 +106,7 @@ void ThemeDB::finalize_theme() {
 		WARN_PRINT("Finalizing theme when there is no RenderingServer is an error; check the order of operations.");
 	}
 
+	_finalize_theme_contexts();
 	default_theme.unref();
 
 	fallback_font.unref();
@@ -103,7 +114,7 @@ void ThemeDB::finalize_theme() {
 	fallback_stylebox.unref();
 }
 
-// Universal fallback Theme resources.
+// Global Theme resources.
 
 void ThemeDB::set_default_theme(const Ref<Theme> &p_default) {
 	default_theme = p_default;
@@ -188,7 +199,117 @@ Ref<StyleBox> ThemeDB::get_fallback_stylebox() {
 	return fallback_stylebox;
 }
 
+void ThemeDB::get_native_type_dependencies(const StringName &p_base_type, List<StringName> *p_list) {
+	ERR_FAIL_NULL(p_list);
+
+	// TODO: It may make sense to stop at Control/Window, because their parent classes cannot be used in
+	// a meaningful way.
+	StringName class_name = p_base_type;
+	while (class_name != StringName()) {
+		p_list->push_back(class_name);
+		class_name = ClassDB::get_parent_class_nocheck(class_name);
+	}
+}
+
+// Global theme contexts.
+
+ThemeContext *ThemeDB::create_theme_context(Node *p_node, List<Ref<Theme>> &p_themes) {
+	ERR_FAIL_COND_V(!p_node->is_inside_tree(), nullptr);
+	ERR_FAIL_COND_V(theme_contexts.has(p_node), nullptr);
+	ERR_FAIL_COND_V(p_themes.is_empty(), nullptr);
+
+	ThemeContext *context = memnew(ThemeContext);
+	context->node = p_node;
+	context->parent = get_nearest_theme_context(p_node);
+	context->set_themes(p_themes);
+
+	theme_contexts[p_node] = context;
+	_propagate_theme_context(p_node, context);
+
+	p_node->connect("tree_exited", callable_mp(this, &ThemeDB::destroy_theme_context).bind(p_node));
+
+	return context;
+}
+
+void ThemeDB::destroy_theme_context(Node *p_node) {
+	ERR_FAIL_COND(!theme_contexts.has(p_node));
+
+	p_node->disconnect("tree_exited", callable_mp(this, &ThemeDB::destroy_theme_context));
+
+	ThemeContext *context = theme_contexts[p_node];
+
+	theme_contexts.erase(p_node);
+	_propagate_theme_context(p_node, context->parent);
+
+	memdelete(context);
+}
+
+void ThemeDB::_propagate_theme_context(Node *p_from_node, ThemeContext *p_context) {
+	Control *from_control = Object::cast_to<Control>(p_from_node);
+	Window *from_window = from_control ? nullptr : Object::cast_to<Window>(p_from_node);
+
+	if (from_control) {
+		from_control->set_theme_context(p_context);
+	} else if (from_window) {
+		from_window->set_theme_context(p_context);
+	}
+
+	for (int i = 0; i < p_from_node->get_child_count(); i++) {
+		Node *child_node = p_from_node->get_child(i);
+
+		// If the child is the root of another global context, stop the propagation
+		// in this branch.
+		if (theme_contexts.has(child_node)) {
+			theme_contexts[child_node]->parent = p_context;
+			continue;
+		}
+
+		_propagate_theme_context(child_node, p_context);
+	}
+}
+
+void ThemeDB::_init_default_theme_context() {
+	default_theme_context = memnew(ThemeContext);
+
+	List<Ref<Theme>> themes;
+	themes.push_back(project_theme);
+	themes.push_back(default_theme);
+	default_theme_context->set_themes(themes);
+}
+
+void ThemeDB::_finalize_theme_contexts() {
+	if (default_theme_context) {
+		memdelete(default_theme_context);
+		default_theme_context = nullptr;
+	}
+	while (theme_contexts.size()) {
+		HashMap<Node *, ThemeContext *>::Iterator E = theme_contexts.begin();
+		memdelete(E->value);
+		theme_contexts.remove(E);
+	}
+}
+
+ThemeContext *ThemeDB::get_default_theme_context() const {
+	return default_theme_context;
+}
+
+ThemeContext *ThemeDB::get_nearest_theme_context(Node *p_for_node) const {
+	ERR_FAIL_COND_V(!p_for_node->is_inside_tree(), nullptr);
+
+	Node *parent_node = p_for_node->get_parent();
+	while (parent_node) {
+		if (theme_contexts.has(parent_node)) {
+			return theme_contexts[parent_node];
+		}
+
+		parent_node = parent_node->get_parent();
+	}
+
+	return nullptr;
+}
+
 // Object methods.
+
 void ThemeDB::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_default_theme"), &ThemeDB::get_default_theme);
 	ClassDB::bind_method(D_METHOD("get_project_theme"), &ThemeDB::get_project_theme);
@@ -214,7 +335,8 @@ void ThemeDB::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("fallback_changed"));
 }
 
-// Memory management, reference, and initialization
+// Memory management, reference, and initialization.
+
 ThemeDB *ThemeDB::singleton = nullptr;
 
 ThemeDB *ThemeDB::get_singleton() {
@@ -223,13 +345,15 @@ ThemeDB *ThemeDB::get_singleton() {
 
 ThemeDB::ThemeDB() {
 	singleton = this;
-
-	// Universal default values, final fallback for every theme.
-	fallback_base_scale = 1.0;
-	fallback_font_size = 16;
 }
 
 ThemeDB::~ThemeDB() {
+	// For technical reasons unit tests recreate and destroy the default
+	// theme over and over again. Make sure that finalize_theme() also
+	// frees any objects that can be recreated by initialize_theme*().
+
+	_finalize_theme_contexts();
+
 	default_theme.unref();
 	project_theme.unref();
 
@@ -238,4 +362,44 @@ ThemeDB::~ThemeDB() {
 	fallback_stylebox.unref();
 
 	singleton = nullptr;
+}
+
+void ThemeContext::_emit_changed() {
+	emit_signal(SNAME("changed"));
+}
+
+void ThemeContext::set_themes(List<Ref<Theme>> &p_themes) {
+	for (const Ref<Theme> &theme : themes) {
+		theme->disconnect_changed(callable_mp(this, &ThemeContext::_emit_changed));
+	}
+
+	themes.clear();
+
+	for (const Ref<Theme> &theme : p_themes) {
+		if (theme.is_null()) {
+			continue;
+		}
+
+		themes.push_back(theme);
+		theme->connect_changed(callable_mp(this, &ThemeContext::_emit_changed));
+	}
+
+	_emit_changed();
+}
+
+List<Ref<Theme>> ThemeContext::get_themes() const {
+	return themes;
+}
+
+Ref<Theme> ThemeContext::get_fallback_theme() const {
+	// We expect all contexts to be valid and non-empty, but just in case...
+	if (themes.size() == 0) {
+		return ThemeDB::get_singleton()->get_default_theme();
+	}
+
+	return themes.back()->get();
+}
+
+void ThemeContext::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("changed"));
 }

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -35,25 +35,38 @@
 #include "core/object/ref_counted.h"
 
 class Font;
+class Node;
 class StyleBox;
 class Texture2D;
 class Theme;
+class ThemeContext;
 
 class ThemeDB : public Object {
 	GDCLASS(ThemeDB, Object);
 
 	static ThemeDB *singleton;
 
-	// Universal Theme resources used when no other theme has the item.
+	// Global Theme resources used by the default theme context.
+
 	Ref<Theme> default_theme;
 	Ref<Theme> project_theme;
 
 	// Universal default values, final fallback for every theme.
-	float fallback_base_scale;
+
+	float fallback_base_scale = 1.0;
 	Ref<Font> fallback_font;
-	int fallback_font_size;
+	int fallback_font_size = 16;
 	Ref<Texture2D> fallback_icon;
 	Ref<StyleBox> fallback_stylebox;
+
+	// Global theme contexts used to scope global Theme resources.
+
+	ThemeContext *default_theme_context = nullptr;
+	HashMap<Node *, ThemeContext *> theme_contexts;
+
+	void _propagate_theme_context(Node *p_from_node, ThemeContext *p_context);
+	void _init_default_theme_context();
+	void _finalize_theme_contexts();
 
 protected:
 	static void _bind_methods();
@@ -63,7 +76,7 @@ public:
 	void initialize_theme_noproject();
 	void finalize_theme();
 
-	// Universal Theme resources
+	// Global Theme resources.
 
 	void set_default_theme(const Ref<Theme> &p_default);
 	Ref<Theme> get_default_theme();
@@ -71,7 +84,7 @@ public:
 	void set_project_theme(const Ref<Theme> &p_project_default);
 	Ref<Theme> get_project_theme();
 
-	// Universal default values.
+	// Universal fallback values.
 
 	void set_fallback_base_scale(float p_base_scale);
 	float get_fallback_base_scale();
@@ -88,9 +101,45 @@ public:
 	void set_fallback_stylebox(const Ref<StyleBox> &p_stylebox);
 	Ref<StyleBox> get_fallback_stylebox();
 
+	void get_native_type_dependencies(const StringName &p_base_type, List<StringName> *p_list);
+
+	// Global theme contexts.
+
+	ThemeContext *create_theme_context(Node *p_node, List<Ref<Theme>> &p_themes);
+	void destroy_theme_context(Node *p_node);
+
+	ThemeContext *get_default_theme_context() const;
+	ThemeContext *get_nearest_theme_context(Node *p_for_node) const;
+
+	// Memory management, reference, and initialization.
+
 	static ThemeDB *get_singleton();
 	ThemeDB();
 	~ThemeDB();
+};
+
+class ThemeContext : public Object {
+	GDCLASS(ThemeContext, Object);
+
+	friend class ThemeDB;
+
+	Node *node = nullptr;
+	ThemeContext *parent = nullptr;
+
+	// Themes are stacked in the order of relevance, for easy iteration.
+	// This means that the first theme is the one you should check first,
+	// and the last theme is the fallback theme where every lookup ends.
+	List<Ref<Theme>> themes;
+
+	void _emit_changed();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_themes(List<Ref<Theme>> &p_themes);
+	List<Ref<Theme>> get_themes() const;
+	Ref<Theme> get_fallback_theme() const;
 };
 
 #endif // THEME_DB_H

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -108,6 +108,7 @@ public:
 	ThemeContext *create_theme_context(Node *p_node, List<Ref<Theme>> &p_themes);
 	void destroy_theme_context(Node *p_node);
 
+	ThemeContext *get_theme_context(Node *p_node) const;
 	ThemeContext *get_default_theme_context() const;
 	ThemeContext *get_nearest_theme_context(Node *p_for_node) const;
 

--- a/scene/theme/theme_owner.cpp
+++ b/scene/theme/theme_owner.cpp
@@ -66,6 +66,52 @@ bool ThemeOwner::has_owner_node() const {
 	return bool(owner_control || owner_window);
 }
 
+void ThemeOwner::set_owner_context(ThemeContext *p_context, bool p_propagate) {
+	ThemeContext *default_context = ThemeDB::get_singleton()->get_default_theme_context();
+
+	if (owner_context && owner_context->is_connected("changed", callable_mp(this, &ThemeOwner::_owner_context_changed))) {
+		owner_context->disconnect("changed", callable_mp(this, &ThemeOwner::_owner_context_changed));
+	} else if (default_context->is_connected("changed", callable_mp(this, &ThemeOwner::_owner_context_changed))) {
+		default_context->disconnect("changed", callable_mp(this, &ThemeOwner::_owner_context_changed));
+	}
+
+	owner_context = p_context;
+
+	if (owner_context) {
+		owner_context->connect("changed", callable_mp(this, &ThemeOwner::_owner_context_changed));
+	} else {
+		default_context->connect("changed", callable_mp(this, &ThemeOwner::_owner_context_changed));
+	}
+
+	if (p_propagate) {
+		_owner_context_changed();
+	}
+}
+
+void ThemeOwner::_owner_context_changed() {
+	if (!holder->is_inside_tree()) {
+		// We ignore theme changes outside of tree, because NOTIFICATION_ENTER_TREE covers everything.
+		return;
+	}
+
+	Control *c = Object::cast_to<Control>(holder);
+	Window *w = c == nullptr ? Object::cast_to<Window>(holder) : nullptr;
+
+	if (c) {
+		c->notification(Control::NOTIFICATION_THEME_CHANGED);
+	} else if (w) {
+		w->notification(Window::NOTIFICATION_THEME_CHANGED);
+	}
+}
+
+ThemeContext *ThemeOwner::_get_active_owner_context() const {
+	if (owner_context) {
+		return owner_context;
+	}
+
+	return ThemeDB::get_singleton()->get_default_theme_context();
+}
+
 // Theme propagation.
 
 void ThemeOwner::assign_theme_on_parented(Node *p_for_node) {
@@ -158,9 +204,7 @@ void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const Strin
 	const Window *for_w = Object::cast_to<Window>(p_for_node);
 	ERR_FAIL_COND_MSG(!for_c && !for_w, "Only Control and Window nodes and derivatives can be polled for theming.");
 
-	Ref<Theme> default_theme = ThemeDB::get_singleton()->get_default_theme();
-	Ref<Theme> project_theme = ThemeDB::get_singleton()->get_project_theme();
-
+	StringName type_name = p_for_node->get_class_name();
 	StringName type_variation;
 	if (for_c) {
 		type_variation = for_c->get_theme_type_variation();
@@ -168,31 +212,23 @@ void ThemeOwner::get_theme_type_dependencies(const Node *p_for_node, const Strin
 		type_variation = for_w->get_theme_type_variation();
 	}
 
-	if (p_theme_type == StringName() || p_theme_type == p_for_node->get_class_name() || p_theme_type == type_variation) {
-		if (project_theme.is_valid() && project_theme->get_type_variation_base(type_variation) != StringName()) {
-			project_theme->get_type_dependencies(p_for_node->get_class_name(), type_variation, r_list);
-		} else {
-			default_theme->get_type_dependencies(p_for_node->get_class_name(), type_variation, r_list);
+	// If we are looking for dependencies of the current class (or a variantion of it), check themes from the context.
+	if (p_theme_type == StringName() || p_theme_type == type_name || p_theme_type == type_variation) {
+		ThemeContext *global_context = _get_active_owner_context();
+		for (const Ref<Theme> &theme : global_context->get_themes()) {
+			if (theme.is_valid() && theme->get_type_variation_base(type_variation) != StringName()) {
+				theme->get_type_dependencies(type_name, type_variation, r_list);
+				return;
+			}
 		}
-	} else {
-		default_theme->get_type_dependencies(p_theme_type, StringName(), r_list);
-	}
-}
 
-Node *ThemeOwner::_get_next_owner_node(Node *p_from_node) const {
-	Node *parent = p_from_node->get_parent();
-
-	Control *parent_c = Object::cast_to<Control>(parent);
-	if (parent_c) {
-		return parent_c->get_theme_owner_node();
-	} else {
-		Window *parent_w = Object::cast_to<Window>(parent);
-		if (parent_w) {
-			return parent_w->get_theme_owner_node();
-		}
+		// If nothing was found, get the native dependencies for the current class.
+		ThemeDB::get_singleton()->get_native_type_dependencies(type_name, r_list);
+		return;
 	}
 
-	return nullptr;
+	// Otherwise, get the native dependencies for the provided theme type.
+	ThemeDB::get_singleton()->get_native_type_dependencies(p_theme_type, r_list);
 }
 
 Variant ThemeOwner::get_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, List<StringName> p_theme_types) {
@@ -215,24 +251,20 @@ Variant ThemeOwner::get_theme_item_in_types(Theme::DataType p_data_type, const S
 		owner_node = _get_next_owner_node(owner_node);
 	}
 
-	// Secondly, check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		for (const StringName &E : p_theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(p_data_type, p_name, E)) {
-				return ThemeDB::get_singleton()->get_project_theme()->get_theme_item(p_data_type, p_name, E);
+	// Second, check global themes from the appropriate context.
+	ThemeContext *global_context = _get_active_owner_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_valid()) {
+			for (const StringName &E : p_theme_types) {
+				if (theme->has_theme_item(p_data_type, p_name, E)) {
+					return theme->get_theme_item(p_data_type, p_name, E);
+				}
 			}
 		}
 	}
 
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	for (const StringName &E : p_theme_types) {
-		if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(p_data_type, p_name, E)) {
-			return ThemeDB::get_singleton()->get_default_theme()->get_theme_item(p_data_type, p_name, E);
-		}
-	}
-
-	// If they don't exist, use any type to return the default/empty value.
-	return ThemeDB::get_singleton()->get_default_theme()->get_theme_item(p_data_type, p_name, p_theme_types[0]);
+	// Finally, if no match exists, use any type to return the default/empty value.
+	return global_context->get_fallback_theme()->get_theme_item(p_data_type, p_name, StringName());
 }
 
 bool ThemeOwner::has_theme_item_in_types(Theme::DataType p_data_type, const StringName &p_name, List<StringName> p_theme_types) {
@@ -255,22 +287,19 @@ bool ThemeOwner::has_theme_item_in_types(Theme::DataType p_data_type, const Stri
 		owner_node = _get_next_owner_node(owner_node);
 	}
 
-	// Secondly, check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		for (const StringName &E : p_theme_types) {
-			if (ThemeDB::get_singleton()->get_project_theme()->has_theme_item(p_data_type, p_name, E)) {
-				return true;
+	// Second, check global themes from the appropriate context.
+	ThemeContext *global_context = _get_active_owner_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_valid()) {
+			for (const StringName &E : p_theme_types) {
+				if (theme->has_theme_item(p_data_type, p_name, E)) {
+					return true;
+				}
 			}
 		}
 	}
 
-	// Lastly, fall back on the items defined in the default Theme, if they exist.
-	for (const StringName &E : p_theme_types) {
-		if (ThemeDB::get_singleton()->get_default_theme()->has_theme_item(p_data_type, p_name, E)) {
-			return true;
-		}
-	}
-
+	// Finally, if no match exists, return false.
 	return false;
 }
 
@@ -290,17 +319,17 @@ float ThemeOwner::get_theme_default_base_scale() {
 		owner_node = _get_next_owner_node(owner_node);
 	}
 
-	// Secondly, check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		if (ThemeDB::get_singleton()->get_project_theme()->has_default_base_scale()) {
-			return ThemeDB::get_singleton()->get_project_theme()->get_default_base_scale();
+	// Second, check global themes from the appropriate context.
+	ThemeContext *global_context = _get_active_owner_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_valid()) {
+			if (theme->has_default_base_scale()) {
+				return theme->get_default_base_scale();
+			}
 		}
 	}
 
-	// Lastly, fall back on the default Theme.
-	if (ThemeDB::get_singleton()->get_default_theme()->has_default_base_scale()) {
-		return ThemeDB::get_singleton()->get_default_theme()->get_default_base_scale();
-	}
+	// Finally, if no match exists, return the universal default.
 	return ThemeDB::get_singleton()->get_fallback_base_scale();
 }
 
@@ -320,17 +349,17 @@ Ref<Font> ThemeOwner::get_theme_default_font() {
 		owner_node = _get_next_owner_node(owner_node);
 	}
 
-	// Secondly, check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		if (ThemeDB::get_singleton()->get_project_theme()->has_default_font()) {
-			return ThemeDB::get_singleton()->get_project_theme()->get_default_font();
+	// Second, check global themes from the appropriate context.
+	ThemeContext *global_context = _get_active_owner_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_valid()) {
+			if (theme->has_default_font()) {
+				return theme->get_default_font();
+			}
 		}
 	}
 
-	// Lastly, fall back on the default Theme.
-	if (ThemeDB::get_singleton()->get_default_theme()->has_default_font()) {
-		return ThemeDB::get_singleton()->get_default_theme()->get_default_font();
-	}
+	// Finally, if no match exists, return the universal default.
 	return ThemeDB::get_singleton()->get_fallback_font();
 }
 
@@ -350,17 +379,17 @@ int ThemeOwner::get_theme_default_font_size() {
 		owner_node = _get_next_owner_node(owner_node);
 	}
 
-	// Secondly, check the project-defined Theme resource.
-	if (ThemeDB::get_singleton()->get_project_theme().is_valid()) {
-		if (ThemeDB::get_singleton()->get_project_theme()->has_default_font_size()) {
-			return ThemeDB::get_singleton()->get_project_theme()->get_default_font_size();
+	// Second, check global themes from the appropriate context.
+	ThemeContext *global_context = _get_active_owner_context();
+	for (const Ref<Theme> &theme : global_context->get_themes()) {
+		if (theme.is_valid()) {
+			if (theme->has_default_font_size()) {
+				return theme->get_default_font_size();
+			}
 		}
 	}
 
-	// Lastly, fall back on the default Theme.
-	if (ThemeDB::get_singleton()->get_default_theme()->has_default_font_size()) {
-		return ThemeDB::get_singleton()->get_default_theme()->get_default_font_size();
-	}
+	// Finally, if no match exists, return the universal default.
 	return ThemeDB::get_singleton()->get_fallback_font_size();
 }
 
@@ -376,4 +405,20 @@ Ref<Theme> ThemeOwner::_get_owner_node_theme(Node *p_owner_node) const {
 	}
 
 	return Ref<Theme>();
+}
+
+Node *ThemeOwner::_get_next_owner_node(Node *p_from_node) const {
+	Node *parent = p_from_node->get_parent();
+
+	Control *parent_c = Object::cast_to<Control>(parent);
+	if (parent_c) {
+		return parent_c->get_theme_owner_node();
+	} else {
+		Window *parent_w = Object::cast_to<Window>(parent);
+		if (parent_w) {
+			return parent_w->get_theme_owner_node();
+		}
+	}
+
+	return nullptr;
 }

--- a/scene/theme/theme_owner.h
+++ b/scene/theme/theme_owner.h
@@ -36,11 +36,18 @@
 
 class Control;
 class Node;
+class ThemeContext;
 class Window;
 
 class ThemeOwner : public Object {
+	Node *holder = nullptr;
+
 	Control *owner_control = nullptr;
 	Window *owner_window = nullptr;
+	ThemeContext *owner_context = nullptr;
+
+	void _owner_context_changed();
+	ThemeContext *_get_active_owner_context() const;
 
 	Node *_get_next_owner_node(Node *p_from_node) const;
 	Ref<Theme> _get_owner_node_theme(Node *p_owner_node) const;
@@ -51,6 +58,8 @@ public:
 	void set_owner_node(Node *p_node);
 	Node *get_owner_node() const;
 	bool has_owner_node() const;
+
+	void set_owner_context(ThemeContext *p_context, bool p_propagate = true);
 
 	// Theme propagation.
 
@@ -69,7 +78,7 @@ public:
 	Ref<Font> get_theme_default_font();
 	int get_theme_default_font_size();
 
-	ThemeOwner() {}
+	ThemeOwner(Node *p_holder) { holder = p_holder; }
 	~ThemeOwner() {}
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -238,7 +238,9 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			RenderingServerDefault::get_singleton()->set_render_loop_enabled(false);
 
 			// ThemeDB requires RenderingServer to initialize the default theme.
-			// So we have to do this for each test case.
+			// So we have to do this for each test case. Also make sure there is
+			// no residual theme from something else.
+			ThemeDB::get_singleton()->finalize_theme();
 			ThemeDB::get_singleton()->initialize_theme_noproject();
 
 			physics_server_3d = PhysicsServer3DManager::get_singleton()->new_default_server();


### PR DESCRIPTION
This PR introduces a concept of global theme contexts.

### Global themes we have now

For the purposes of this change I define as a global theme any theme that we use as a fallback when looking up items, regardless of the scene tree structure. This means that currently we have 2 global themes: the default one (`scene/theme/default_theme.cpp`, previously `scene/resources/default_theme/default_theme.cpp`), and the custom project one (if it is defined by the user).

Whenever we cannot find a theme item, we first check in the project theme, and then in the default theme. This works regardless of what other themes affect the node and what parents of the node look like (i.e. if they can affect theming or not). Thus these two are global.

In the editor we have the editor theme, but it's not global. It applies directly to Control/Window nodes, just like you would do in your project. Thus the editor theme must have an uninterrupted chain of themable nodes between its holder node and any GUI node in the editor UI that needs to respect it. If the chain breaks, or if the target node is not in a branch that has one of the themed node in it, then styling break.

At the same time, in the editor we don't need nor want to have the project theme applied as global. If there are missing definitions in the editor theme, the project theme will leak into the editor UI. Historically we've patched many such holes on the case-by-case basis. And vice versa, the editor theme can leak into the 2D preview viewport or the theme editor preview tabs, if the default theme has missing definitions.

⛔⛔⛔ **THIS HAS TO STOP** ⛔⛔⛔

### Global themes, but contextualized

I propose a new feature, with a sidenote that it's currently not exposed to users, but it may be made public in the future. The feature is **Theme Contexts** (maybe a better name exists).

The idea is simple: define areas/branches in the scene tree that have their own sets of global themes. By default, in the running project you would have the same two themes as you have now, the project one and the default one. However, in the editor, we would define several areas.

The default context would only contain the default theme, and no project theme, to prevent it leaking into the editor. Then the editor window and the `EditorNode` root of all would have a custom context consisting of the editor theme and the default theme. The editor theme would not be applied to nodes directly, instead it would become one of the fallback themes for the entire editor GUI.

To help users we would also add a custom context for the 2D viewport (project + default) and the theme editor tabs (just default). As a cherry on top we can also make the 2D viewport context controllable from the toolbar and add a way to switch between the project, the editor, and the default theme. The editor theme preview is very powerful for the editor plugin developers.


https://github.com/godotengine/godot/assets/11782833/c663872c-e4bd-47ae-b533-717de9cc91d4


Each theme context replaces any previous context. Unlike themes themselves, contexts do not propagate and merge. They are authoritative and act as the final say in their controlled branch. This prevents theme leaks completely. To use contexts safely, you need to always add the default theme to each of them, or a theme that is equally complete. Otherwise things would turn unstyled.

Contexts can be attached to any node, not just GUI/Window nodes. This allows to put them before any themable node, and it also makes them truly global. Despite that, contexts are capable of propagating changes in their stored themes to the affected nodes (ignoring non-themable nodes). This means that with theme contexts GUI can react to global theme changes in real time. This is very useful when editing the project theme and looking at the 2D viewport to preview the changes.


https://github.com/godotengine/godot/assets/11782833/dcc11411-c39b-4288-91ad-8efd6ed1734a


### In short (TL;DR)

This PR does the following changes:

- Adds scopes for global themes called **Theme Contexts**.
- Keeps global themes for running project the same as before this PR.
- Adjusts global themes in the editor using contexts to prevent themes leaking.
- Adds `NOTIFICATION_THEME_CHANGED` propagation when relevant global themes change.
- Adds a switch to preview different themes in the 2D viewport (the setting is remembered and stored per project).
- Does a bit of theming related cleanup in `EditorNode` and non-themable nodes that also use global themes (cc @bruvzg).

There are many issues that this addresses, though most of them are probably closed with fixes to themes and workarounds. Here are some that I can find:

Fixes (for real) the 4.x part of https://github.com/godotengine/godot/issues/60930 (not sure if we want to keep it open for 3.x).
Fixes https://github.com/godotengine/godot/issues/79753 (the other linked PR may still have merits).
Fixes https://github.com/godotengine/godot/issues/74762.
Fixes https://github.com/godotengine/godot/issues/73154.
Fixes https://github.com/godotengine/godot/issues/63889 (aside from the requirement to restart the editor, this can be reworked, but it's not a bug per se).
Fixes https://github.com/godotengine/godot/issues/33902 (duplicates with https://github.com/godotengine/godot/issues/63889, same note).
Fixes https://github.com/godotengine/godot/issues/81146.