### PR TITLE
Fix comparison of `Callable`s with binds

### DIFF
--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -88,7 +88,7 @@ ObjectID CallableCustomBind::get_object() const {
 }
 
 const Callable *CallableCustomBind::get_base_comparator() const {
-	return &callable;
+	return callable.get_base_comparator();
 }
 
 int CallableCustomBind::get_bound_arguments_count() const {
@@ -222,7 +222,7 @@ ObjectID CallableCustomUnbind::get_object() const {
 }
 
 const Callable *CallableCustomUnbind::get_base_comparator() const {
-	return &callable;
+	return callable.get_base_comparator();
 }
 
 int CallableCustomUnbind::get_bound_arguments_count() const {


### PR DESCRIPTION
* Fixes: #81118

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
