### PR TITLE
[MP] Improve SceneReplicationConfig editor UX + optimizations

### DIFF
--- a/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
+++ b/modules/multiplayer/doc_classes/SceneReplicationConfig.xml
@@ -37,6 +37,13 @@
 				Finds the index of the given [param path].
 			</description>
 		</method>
+		<method name="property_get_replication_mode">
+			<return type="int" enum="SceneReplicationConfig.ReplicationMode" />
+			<param index="0" name="path" type="NodePath" />
+			<description>
+				Returns the replication mode for the property identified by the given [param path]. See [enum ReplicationMode].
+			</description>
+		</method>
 		<method name="property_get_spawn">
 			<return type="bool" />
 			<param index="0" name="path" type="NodePath" />
@@ -44,18 +51,28 @@
 				Returns whether the property identified by the given [param path] is configured to be synchronized on spawn.
 			</description>
 		</method>
-		<method name="property_get_sync">
+		<method name="property_get_sync" is_deprecated="true">
 			<return type="bool" />
 			<param index="0" name="path" type="NodePath" />
 			<description>
 				Returns whether the property identified by the given [param path] is configured to be synchronized on process.
+				[i]Deprecated.[/i] Use [method property_get_replication_mode] instead.
 			</description>
 		</method>
-		<method name="property_get_watch">
+		<method name="property_get_watch" is_deprecated="true">
 			<return type="bool" />
 			<param index="0" name="path" type="NodePath" />
 			<description>
 				Returns whether the property identified by the given [param path] is configured to be reliably synchronized when changes are detected on process.
+				[i]Deprecated.[/i] Use [method property_get_replication_mode] instead.
+			</description>
+		</method>
+		<method name="property_set_replication_mode">
+			<return type="void" />
+			<param index="0" name="path" type="NodePath" />
+			<param index="1" name="mode" type="int" enum="SceneReplicationConfig.ReplicationMode" />
+			<description>
+				Sets the synchronization mode for the property identified by the given [param path]. See [enum ReplicationMode].
 			</description>
 		</method>
 		<method name="property_set_spawn">
@@ -66,20 +83,22 @@
 				Sets whether the property identified by the given [param path] is configured to be synchronized on spawn.
 			</description>
 		</method>
-		<method name="property_set_sync">
+		<method name="property_set_sync" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="path" type="NodePath" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets whether the property identified by the given [param path] is configured to be synchronized on process.
+				[i]Deprecated.[/i] Use [method property_set_replication_mode] with [constant REPLICATION_MODE_ALWAYS] instead.
 			</description>
 		</method>
-		<method name="property_set_watch">
+		<method name="property_set_watch" is_deprecated="true">
 			<return type="void" />
 			<param index="0" name="path" type="NodePath" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				Sets whether the property identified by the given [param path] is configured to be reliably synchronized when changes are detected on process.
+				[i]Deprecated.[/i] Use [method property_set_replication_mode] with [constant REPLICATION_MODE_ON_CHANGE] instead.
 			</description>
 		</method>
 		<method name="remove_property">
@@ -90,4 +109,15 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="REPLICATION_MODE_NEVER" value="0" enum="ReplicationMode">
+			Do not keep the given property synchronized.
+		</constant>
+		<constant name="REPLICATION_MODE_ALWAYS" value="1" enum="ReplicationMode">
+			Replicate the given property on process by constantly sending updates using unreliable transfer mode.
+		</constant>
+		<constant name="REPLICATION_MODE_ON_CHANGE" value="2" enum="ReplicationMode">
+			Replicate the given property on process by sending updates using reliable transfer mode when its value changes.
+		</constant>
+	</constants>
 </class>

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -176,11 +176,6 @@ ReplicationEditor::ReplicationEditor() {
 	delete_dialog->connect("confirmed", callable_mp(this, &ReplicationEditor::_dialog_closed).bind(true));
 	add_child(delete_dialog);
 
-	error_dialog = memnew(AcceptDialog);
-	error_dialog->set_ok_button_text(TTR("Close"));
-	error_dialog->set_title(TTR("Error!"));
-	add_child(error_dialog);
-
 	VBoxContainer *vb = memnew(VBoxContainer);
 	vb->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(vb);
@@ -272,20 +267,17 @@ ReplicationEditor::ReplicationEditor() {
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
-	tree->set_columns(5);
+	tree->set_columns(4);
 	tree->set_column_titles_visible(true);
 	tree->set_column_title(0, TTR("Properties"));
 	tree->set_column_expand(0, true);
 	tree->set_column_title(1, TTR("Spawn"));
 	tree->set_column_expand(1, false);
 	tree->set_column_custom_minimum_width(1, 100);
-	tree->set_column_title(2, TTR("Sync"));
+	tree->set_column_title(2, TTR("Replicate"));
 	tree->set_column_custom_minimum_width(2, 100);
-	tree->set_column_title(3, TTR("Watch"));
-	tree->set_column_custom_minimum_width(3, 100);
 	tree->set_column_expand(2, false);
 	tree->set_column_expand(3, false);
-	tree->set_column_expand(4, false);
 	tree->create_item();
 	tree->connect("button_clicked", callable_mp(this, &ReplicationEditor::_tree_button_pressed));
 	tree->connect("item_edited", callable_mp(this, &ReplicationEditor::_tree_item_edited));
@@ -304,7 +296,7 @@ ReplicationEditor::ReplicationEditor() {
 
 void ReplicationEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_config"), &ReplicationEditor::_update_config);
-	ClassDB::bind_method(D_METHOD("_update_checked", "property", "column", "checked"), &ReplicationEditor::_update_checked);
+	ClassDB::bind_method(D_METHOD("_update_value", "property", "column", "value"), &ReplicationEditor::_update_value);
 }
 
 bool ReplicationEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
@@ -375,20 +367,17 @@ void ReplicationEditor::_notification(int p_what) {
 
 void ReplicationEditor::_add_pressed() {
 	if (!current) {
-		error_dialog->set_text(TTR("Please select a MultiplayerSynchronizer first."));
-		error_dialog->popup_centered();
+		EditorNode::get_singleton()->show_warning(TTR("Please select a MultiplayerSynchronizer first."));
 		return;
 	}
 	if (current->get_root_path().is_empty()) {
-		error_dialog->set_text(TTR("The MultiplayerSynchronizer needs a root path."));
-		error_dialog->popup_centered();
+		EditorNode::get_singleton()->show_warning(TTR("The MultiplayerSynchronizer needs a root path."));
 		return;
 	}
 	String np_text = np_line_edit->get_text();
 
 	if (np_text.is_empty()) {
-		error_dialog->set_text(TTR("Property/path must not be empty."));
-		error_dialog->popup_centered();
+		EditorNode::get_singleton()->show_warning(TTR("Property/path must not be empty."));
 		return;
 	}
 
@@ -399,6 +388,10 @@ void ReplicationEditor::_add_pressed() {
 		np_text = "." + np_text;
 	}
 	NodePath path = NodePath(np_text);
+	if (path.is_empty()) {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Invalid property path: '%s'"), np_text));
+		return;
+	}
 
 	_add_sync_property(path);
 }
@@ -413,36 +406,36 @@ void ReplicationEditor::_tree_item_edited() {
 		return;
 	}
 	int column = tree->get_edited_column();
-	ERR_FAIL_COND(column < 1 || column > 3);
+	ERR_FAIL_COND(column < 1 || column > 2);
 	const NodePath prop = ti->get_metadata(0);
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	bool value = ti->is_checked(column);
 
-	// We have a hard limit of 64 watchable properties per synchronizer.
-	if (column == 3 && value && config->get_watch_properties().size() > 64) {
-		error_dialog->set_text(TTR("Each MultiplayerSynchronizer can have no more than 64 watched properties."));
-		error_dialog->popup_centered();
-		ti->set_checked(column, false);
-		return;
-	}
-	String method;
 	if (column == 1) {
 		undo_redo->create_action(TTR("Set spawn property"));
-		method = "property_set_spawn";
+		bool value = ti->is_checked(column);
+		undo_redo->add_do_method(config.ptr(), "property_set_spawn", prop, value);
+		undo_redo->add_undo_method(config.ptr(), "property_set_spawn", prop, !value);
+		undo_redo->add_do_method(this, "_update_value", prop, column, value ? 1 : 0);
+		undo_redo->add_undo_method(this, "_update_value", prop, column, value ? 1 : 0);
+		undo_redo->commit_action();
 	} else if (column == 2) {
 		undo_redo->create_action(TTR("Set sync property"));
-		method = "property_set_sync";
-	} else if (column == 3) {
-		undo_redo->create_action(TTR("Set watch property"));
-		method = "property_set_watch";
+		int value = ti->get_range(column);
+		int old_value = config->property_get_replication_mode(prop);
+		// We have a hard limit of 64 watchable properties per synchronizer.
+		if (value == SceneReplicationConfig::REPLICATION_MODE_ON_CHANGE && config->get_watch_properties().size() >= 64) {
+			EditorNode::get_singleton()->show_warning(TTR("Each MultiplayerSynchronizer can have no more than 64 watched properties."));
+			ti->set_range(column, old_value);
+			return;
+		}
+		undo_redo->add_do_method(config.ptr(), "property_set_replication_mode", prop, value);
+		undo_redo->add_undo_method(config.ptr(), "property_set_replication_mode", prop, old_value);
+		undo_redo->add_do_method(this, "_update_value", prop, column, value);
+		undo_redo->add_undo_method(this, "_update_value", prop, column, old_value);
+		undo_redo->commit_action();
 	} else {
 		ERR_FAIL();
 	}
-	undo_redo->add_do_method(config.ptr(), method, prop, value);
-	undo_redo->add_undo_method(config.ptr(), method, prop, !value);
-	undo_redo->add_do_method(this, "_update_checked", prop, column, value);
-	undo_redo->add_undo_method(this, "_update_checked", prop, column, !value);
-	undo_redo->commit_action();
 }
 
 void ReplicationEditor::_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button) {
@@ -467,15 +460,13 @@ void ReplicationEditor::_dialog_closed(bool p_confirmed) {
 		const NodePath prop = deleting;
 		int idx = config->property_get_index(prop);
 		bool spawn = config->property_get_spawn(prop);
-		bool sync = config->property_get_sync(prop);
-		bool watch = config->property_get_watch(prop);
+		SceneReplicationConfig::ReplicationMode mode = config->property_get_replication_mode(prop);
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Remove Property"));
 		undo_redo->add_do_method(config.ptr(), "remove_property", prop);
 		undo_redo->add_undo_method(config.ptr(), "add_property", prop, idx);
 		undo_redo->add_undo_method(config.ptr(), "property_set_spawn", prop, spawn);
-		undo_redo->add_undo_method(config.ptr(), "property_set_sync", prop, sync);
-		undo_redo->add_undo_method(config.ptr(), "property_set_watch", prop, watch);
+		undo_redo->add_undo_method(config.ptr(), "property_set_replication_mode", prop, mode);
 		undo_redo->add_do_method(this, "_update_config");
 		undo_redo->add_undo_method(this, "_update_config");
 		undo_redo->commit_action();
@@ -483,14 +474,18 @@ void ReplicationEditor::_dialog_closed(bool p_confirmed) {
 	deleting = NodePath();
 }
 
-void ReplicationEditor::_update_checked(const NodePath &p_prop, int p_column, bool p_checked) {
+void ReplicationEditor::_update_value(const NodePath &p_prop, int p_column, int p_value) {
 	if (!tree->get_root()) {
 		return;
 	}
 	TreeItem *ti = tree->get_root()->get_first_child();
 	while (ti) {
 		if (ti->get_metadata(0).operator NodePath() == p_prop) {
-			ti->set_checked(p_column, p_checked);
+			if (p_column == 1) {
+				ti->set_checked(p_column, p_value != 0);
+			} else if (p_column == 2) {
+				ti->set_range(p_column, p_value);
+			}
 			return;
 		}
 		ti = ti->get_next();
@@ -511,7 +506,7 @@ void ReplicationEditor::_update_config() {
 	}
 	for (int i = 0; i < props.size(); i++) {
 		const NodePath path = props[i];
-		_add_property(path, config->property_get_spawn(path), config->property_get_sync(path), config->property_get_watch(path));
+		_add_property(path, config->property_get_spawn(path), config->property_get_replication_mode(path));
 	}
 }
 
@@ -553,14 +548,13 @@ static bool can_sync(const Variant &p_var) {
 	}
 }
 
-void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, bool p_sync, bool p_watch) {
+void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, SceneReplicationConfig::ReplicationMode p_mode) {
 	String prop = String(p_property);
 	TreeItem *item = tree->create_item();
 	item->set_selectable(0, false);
 	item->set_selectable(1, false);
 	item->set_selectable(2, false);
 	item->set_selectable(3, false);
-	item->set_selectable(4, false);
 	item->set_text(0, prop);
 	item->set_metadata(0, prop);
 	Node *root_node = current && !current->get_root_path().is_empty() ? current->get_node(current->get_root_path()) : nullptr;
@@ -577,22 +571,23 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 		bool valid = false;
 		Variant value = node->get(subpath, &valid);
 		if (valid && !can_sync(value)) {
-			item->set_icon(3, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
-			item->set_tooltip_text(3, TTR("Property of this type not supported."));
+			item->set_icon(0, get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
+			item->set_tooltip_text(0, TTR("Property of this type not supported."));
+		} else {
+			item->set_icon(0, icon);
 		}
+	} else {
+		item->set_icon(0, icon);
 	}
-	item->set_icon(0, icon);
-	item->add_button(4, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+	item->add_button(3, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	item->set_text_alignment(1, HORIZONTAL_ALIGNMENT_CENTER);
 	item->set_cell_mode(1, TreeItem::CELL_MODE_CHECK);
 	item->set_checked(1, p_spawn);
 	item->set_editable(1, true);
 	item->set_text_alignment(2, HORIZONTAL_ALIGNMENT_CENTER);
-	item->set_cell_mode(2, TreeItem::CELL_MODE_CHECK);
-	item->set_checked(2, p_sync);
+	item->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
+	item->set_range_config(2, 0, 2, 1);
+	item->set_text(2, "Never,Always,On Change");
+	item->set_range(2, (int)p_mode);
 	item->set_editable(2, true);
-	item->set_text_alignment(3, HORIZONTAL_ALIGNMENT_CENTER);
-	item->set_cell_mode(3, TreeItem::CELL_MODE_CHECK);
-	item->set_checked(3, p_watch);
-	item->set_editable(3, true);
 }

--- a/modules/multiplayer/editor/replication_editor.h
+++ b/modules/multiplayer/editor/replication_editor.h
@@ -51,7 +51,6 @@ class ReplicationEditor : public VBoxContainer {
 private:
 	MultiplayerSynchronizer *current = nullptr;
 
-	AcceptDialog *error_dialog = nullptr;
 	ConfirmationDialog *delete_dialog = nullptr;
 	Button *add_pick_button = nullptr;
 	Button *add_from_path_button = nullptr;
@@ -75,10 +74,10 @@ private:
 	void _np_text_submitted(const String &p_newtext);
 	void _tree_item_edited();
 	void _tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _update_checked(const NodePath &p_prop, int p_column, bool p_checked);
+	void _update_value(const NodePath &p_prop, int p_column, int p_checked);
 	void _update_config();
 	void _dialog_closed(bool p_confirmed);
-	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true, bool p_watch = false);
+	void _add_property(const NodePath &p_property, bool p_spawn, SceneReplicationConfig::ReplicationMode p_mode);
 
 	void _pick_node_filter_text_changed(const String &p_newtext);
 	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);

--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -47,38 +47,26 @@ bool SceneReplicationConfig::_set(const StringName &p_name, const Variant &p_val
 			add_property(path);
 			return true;
 		}
-		ERR_FAIL_COND_V(p_value.get_type() != Variant::BOOL, false);
 		ERR_FAIL_INDEX_V(idx, properties.size(), false);
 		ReplicationProperty &prop = properties[idx];
-		if (what == "sync") {
-			if ((bool)p_value == prop.sync) {
-				return true;
-			}
-			prop.sync = p_value;
-			if (prop.sync) {
-				sync_props.push_back(prop.name);
-			} else {
-				sync_props.erase(prop.name);
-			}
+		if (what == "replication_mode") {
+			ERR_FAIL_COND_V(p_value.get_type() != Variant::INT, false);
+			ReplicationMode mode = (ReplicationMode)p_value.operator int();
+			ERR_FAIL_COND_V(mode < REPLICATION_MODE_NEVER || mode > REPLICATION_MODE_ON_CHANGE, false);
+			property_set_replication_mode(prop.name, mode);
 			return true;
-		} else if (what == "spawn") {
-			if ((bool)p_value == prop.spawn) {
-				return true;
-			}
-			prop.spawn = p_value;
-			if (prop.spawn) {
-				spawn_props.push_back(prop.name);
-			} else {
-				spawn_props.erase(prop.name);
-			}
+		}
+		ERR_FAIL_COND_V(p_value.get_type() != Variant::BOOL, false);
+		if (what == "spawn") {
+			property_set_spawn(prop.name, p_value);
+			return true;
+		} else if (what == "sync") {
+			// Deprecated.
+			property_set_sync(prop.name, p_value);
 			return true;
 		} else if (what == "watch") {
-			prop.watch = p_value;
-			if (prop.watch) {
-				watch_props.push_back(prop.name);
-			} else {
-				watch_props.erase(prop.name);
-			}
+			// Deprecated.
+			property_set_watch(prop.name, p_value);
 			return true;
 		}
 	}
@@ -96,14 +84,11 @@ bool SceneReplicationConfig::_get(const StringName &p_name, Variant &r_ret) cons
 		if (what == "path") {
 			r_ret = prop.name;
 			return true;
-		} else if (what == "sync") {
-			r_ret = prop.sync;
-			return true;
 		} else if (what == "spawn") {
 			r_ret = prop.spawn;
 			return true;
-		} else if (what == "watch") {
-			r_ret = prop.watch;
+		} else if (what == "replication_mode") {
+			r_ret = prop.mode;
 			return true;
 		}
 	}
@@ -114,8 +99,7 @@ void SceneReplicationConfig::_get_property_list(List<PropertyInfo> *p_list) cons
 	for (int i = 0; i < properties.size(); i++) {
 		p_list->push_back(PropertyInfo(Variant::STRING, "properties/" + itos(i) + "/path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		p_list->push_back(PropertyInfo(Variant::STRING, "properties/" + itos(i) + "/spawn", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::STRING, "properties/" + itos(i) + "/sync", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
-		p_list->push_back(PropertyInfo(Variant::STRING, "properties/" + itos(i) + "/watch", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
+		p_list->push_back(PropertyInfo(Variant::INT, "properties/" + itos(i) + "/replication_mode", PROPERTY_HINT_ENUM, "Never,Always,On Change", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 	}
 }
 
@@ -129,11 +113,11 @@ TypedArray<NodePath> SceneReplicationConfig::get_properties() const {
 
 void SceneReplicationConfig::add_property(const NodePath &p_path, int p_index) {
 	ERR_FAIL_COND(properties.find(p_path));
+	ERR_FAIL_COND(p_path == NodePath());
 
 	if (p_index < 0 || p_index == properties.size()) {
 		properties.push_back(ReplicationProperty(p_path));
-		sync_props.push_back(p_path);
-		spawn_props.push_back(p_path);
+		dirty = true;
 		return;
 	}
 
@@ -146,23 +130,12 @@ void SceneReplicationConfig::add_property(const NodePath &p_path, int p_index) {
 		c++;
 	}
 	properties.insert_before(I, ReplicationProperty(p_path));
-	sync_props.clear();
-	spawn_props.clear();
-	for (const ReplicationProperty &prop : properties) {
-		if (prop.sync) {
-			sync_props.push_back(prop.name);
-		}
-		if (prop.spawn) {
-			spawn_props.push_back(prop.name);
-		}
-	}
+	dirty = true;
 }
 
 void SceneReplicationConfig::remove_property(const NodePath &p_path) {
 	properties.erase(p_path);
-	sync_props.erase(p_path);
-	spawn_props.erase(p_path);
-	watch_props.clear();
+	dirty = true;
 }
 
 bool SceneReplicationConfig::has_property(const NodePath &p_path) const {
@@ -196,54 +169,97 @@ void SceneReplicationConfig::property_set_spawn(const NodePath &p_path, bool p_e
 		return;
 	}
 	E->get().spawn = p_enabled;
-	spawn_props.clear();
-	for (const ReplicationProperty &prop : properties) {
-		if (prop.spawn) {
-			spawn_props.push_back(prop.name);
-		}
-	}
+	dirty = true;
 }
 
 bool SceneReplicationConfig::property_get_sync(const NodePath &p_path) {
 	List<ReplicationProperty>::Element *E = properties.find(p_path);
 	ERR_FAIL_COND_V(!E, false);
-	return E->get().sync;
+	return E->get().mode == REPLICATION_MODE_ALWAYS;
 }
 
 void SceneReplicationConfig::property_set_sync(const NodePath &p_path, bool p_enabled) {
-	List<ReplicationProperty>::Element *E = properties.find(p_path);
-	ERR_FAIL_COND(!E);
-	if (E->get().sync == p_enabled) {
-		return;
-	}
-	E->get().sync = p_enabled;
-	sync_props.clear();
-	for (const ReplicationProperty &prop : properties) {
-		if (prop.sync) {
-			sync_props.push_back(prop.name);
-		}
+	if (p_enabled) {
+		property_set_replication_mode(p_path, REPLICATION_MODE_ALWAYS);
+	} else if (property_get_replication_mode(p_path) == REPLICATION_MODE_ALWAYS) {
+		property_set_replication_mode(p_path, REPLICATION_MODE_NEVER);
 	}
 }
 
 bool SceneReplicationConfig::property_get_watch(const NodePath &p_path) {
 	List<ReplicationProperty>::Element *E = properties.find(p_path);
 	ERR_FAIL_COND_V(!E, false);
-	return E->get().watch;
+	return E->get().mode == REPLICATION_MODE_ON_CHANGE;
 }
 
 void SceneReplicationConfig::property_set_watch(const NodePath &p_path, bool p_enabled) {
+	if (p_enabled) {
+		property_set_replication_mode(p_path, REPLICATION_MODE_ON_CHANGE);
+	} else if (property_get_replication_mode(p_path) == REPLICATION_MODE_ON_CHANGE) {
+		property_set_replication_mode(p_path, REPLICATION_MODE_NEVER);
+	}
+}
+
+SceneReplicationConfig::ReplicationMode SceneReplicationConfig::property_get_replication_mode(const NodePath &p_path) {
+	List<ReplicationProperty>::Element *E = properties.find(p_path);
+	ERR_FAIL_COND_V(!E, REPLICATION_MODE_NEVER);
+	return E->get().mode;
+}
+
+void SceneReplicationConfig::property_set_replication_mode(const NodePath &p_path, ReplicationMode p_mode) {
 	List<ReplicationProperty>::Element *E = properties.find(p_path);
 	ERR_FAIL_COND(!E);
-	if (E->get().watch == p_enabled) {
+	if (E->get().mode == p_mode) {
 		return;
 	}
-	E->get().watch = p_enabled;
+	E->get().mode = p_mode;
+	dirty = true;
+}
+
+void SceneReplicationConfig::_update() {
+	if (!dirty) {
+		return;
+	}
+	dirty = false;
+	sync_props.clear();
+	spawn_props.clear();
 	watch_props.clear();
 	for (const ReplicationProperty &prop : properties) {
-		if (prop.watch) {
-			watch_props.push_back(p_path);
+		if (prop.spawn) {
+			spawn_props.push_back(prop.name);
+		}
+		switch (prop.mode) {
+			case REPLICATION_MODE_ALWAYS:
+				sync_props.push_back(prop.name);
+				break;
+			case REPLICATION_MODE_ON_CHANGE:
+				watch_props.push_back(prop.name);
+				break;
+			default:
+				break;
 		}
 	}
+}
+
+const List<NodePath> &SceneReplicationConfig::get_spawn_properties() {
+	if (dirty) {
+		_update();
+	}
+	return spawn_props;
+}
+
+const List<NodePath> &SceneReplicationConfig::get_sync_properties() {
+	if (dirty) {
+		_update();
+	}
+	return sync_props;
+}
+
+const List<NodePath> &SceneReplicationConfig::get_watch_properties() {
+	if (dirty) {
+		_update();
+	}
+	return watch_props;
 }
 
 void SceneReplicationConfig::_bind_methods() {
@@ -254,6 +270,14 @@ void SceneReplicationConfig::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("property_get_index", "path"), &SceneReplicationConfig::property_get_index);
 	ClassDB::bind_method(D_METHOD("property_get_spawn", "path"), &SceneReplicationConfig::property_get_spawn);
 	ClassDB::bind_method(D_METHOD("property_set_spawn", "path", "enabled"), &SceneReplicationConfig::property_set_spawn);
+	ClassDB::bind_method(D_METHOD("property_get_replication_mode", "path"), &SceneReplicationConfig::property_get_replication_mode);
+	ClassDB::bind_method(D_METHOD("property_set_replication_mode", "path", "mode"), &SceneReplicationConfig::property_set_replication_mode);
+
+	BIND_ENUM_CONSTANT(REPLICATION_MODE_NEVER);
+	BIND_ENUM_CONSTANT(REPLICATION_MODE_ALWAYS);
+	BIND_ENUM_CONSTANT(REPLICATION_MODE_ON_CHANGE);
+
+	// Deprecated.
 	ClassDB::bind_method(D_METHOD("property_get_sync", "path"), &SceneReplicationConfig::property_get_sync);
 	ClassDB::bind_method(D_METHOD("property_set_sync", "path", "enabled"), &SceneReplicationConfig::property_set_sync);
 	ClassDB::bind_method(D_METHOD("property_get_watch", "path"), &SceneReplicationConfig::property_get_watch);

--- a/modules/multiplayer/scene_replication_config.h
+++ b/modules/multiplayer/scene_replication_config.h
@@ -39,12 +39,18 @@ class SceneReplicationConfig : public Resource {
 	OBJ_SAVE_TYPE(SceneReplicationConfig);
 	RES_BASE_EXTENSION("repl");
 
+public:
+	enum ReplicationMode {
+		REPLICATION_MODE_NEVER,
+		REPLICATION_MODE_ALWAYS,
+		REPLICATION_MODE_ON_CHANGE,
+	};
+
 private:
 	struct ReplicationProperty {
 		NodePath name;
 		bool spawn = true;
-		bool sync = true;
-		bool watch = false;
+		ReplicationMode mode = REPLICATION_MODE_ALWAYS;
 
 		bool operator==(const ReplicationProperty &p_to) {
 			return name == p_to.name;
@@ -61,6 +67,9 @@ private:
 	List<NodePath> spawn_props;
 	List<NodePath> sync_props;
 	List<NodePath> watch_props;
+	bool dirty = false;
+
+	void _update();
 
 protected:
 	static void _bind_methods();
@@ -86,11 +95,16 @@ public:
 	bool property_get_watch(const NodePath &p_path);
 	void property_set_watch(const NodePath &p_path, bool p_enabled);
 
-	const List<NodePath> &get_spawn_properties() { return spawn_props; }
-	const List<NodePath> &get_sync_properties() { return sync_props; }
-	const List<NodePath> &get_watch_properties() { return watch_props; }
+	ReplicationMode property_get_replication_mode(const NodePath &p_path);
+	void property_set_replication_mode(const NodePath &p_path, ReplicationMode p_mode);
+
+	const List<NodePath> &get_spawn_properties();
+	const List<NodePath> &get_sync_properties();
+	const List<NodePath> &get_watch_properties();
 
 	SceneReplicationConfig() {}
 };
+
+VARIANT_ENUM_CAST(SceneReplicationConfig::ReplicationMode);
 
 #endif // SCENE_REPLICATION_CONFIG_H


### PR DESCRIPTION
Make "Sync" and "Watch" mutually exclusive by adding an enum (Never/Always/On Change).

Deprecate old methods.

Prevent invalid NodePath from being added to the config.

Optimize the replication config loading by composing the lists on demand.

Fixes #77896

![never_always_change](https://github.com/godotengine/godot/assets/1687918/022da023-13fc-4c78-ba90-2e3cc2a60441)