### PR TITLE
Vertex and attribute compression

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -56,5 +56,7 @@
 		</constant>
 		<constant name="IMPORT_DISCARD_MESHES_AND_MATERIALS" value="32">
 		</constant>
+		<constant name="IMPORT_FORCE_DISABLE_MESH_COMPRESSION" value="64">
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -61,6 +61,7 @@
 		<method name="commit_to_surface">
 			<return type="int" enum="Error" />
 			<param index="0" name="mesh" type="ArrayMesh" />
+			<param index="1" name="compression_flags" type="int" default="0" />
 			<description>
 				Adds a new surface to specified [Mesh] with edited data.
 			</description>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2210,6 +2210,15 @@
 			<param index="0" name="format" type="int" enum="RenderingServer.ArrayFormat" is_bitfield="true" />
 			<param index="1" name="vertex_count" type="int" />
 			<description>
+				Returns the stride of the attribute buffer for a mesh with given [param format].
+			</description>
+		</method>
+		<method name="mesh_surface_get_format_normal_tangent_stride" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="format" type="int" enum="RenderingServer.ArrayFormat" is_bitfield="true" />
+			<param index="1" name="vertex_count" type="int" />
+			<description>
+				Returns the stride of the combined normals and tangents for a mesh with given [param format]. Note importantly that, while normals and tangents are in the vertex buffer with vertices, they are only interleaved with each other and so have a different stride than vertex positions.
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_offset" qualifiers="const">
@@ -2218,6 +2227,7 @@
 			<param index="1" name="vertex_count" type="int" />
 			<param index="2" name="array_index" type="int" />
 			<description>
+				Returns the offset of a given attribute by [param array_index] in the start of its respective buffer.
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_skin_stride" qualifiers="const">
@@ -2225,6 +2235,7 @@
 			<param index="0" name="format" type="int" enum="RenderingServer.ArrayFormat" is_bitfield="true" />
 			<param index="1" name="vertex_count" type="int" />
 			<description>
+				Returns the stride of the skin buffer for a mesh with given [param format].
 			</description>
 		</method>
 		<method name="mesh_surface_get_format_vertex_stride" qualifiers="const">
@@ -2232,6 +2243,7 @@
 			<param index="0" name="format" type="int" enum="RenderingServer.ArrayFormat" is_bitfield="true" />
 			<param index="1" name="vertex_count" type="int" />
 			<description>
+				Returns the stride of the vertex positions for a mesh with given [param format]. Note importantly that vertex positions are stored consecutively and are not interleaved with the other attributes in the vertex buffer (normals and tangents).
 			</description>
 		</method>
 		<method name="mesh_surface_get_material" qualifiers="const">
@@ -4187,6 +4199,28 @@
 			Flag used to mark that the array uses 8 bone weights instead of 4.
 		</constant>
 		<constant name="ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY" value="268435456" enum="ArrayFormat" is_bitfield="true">
+			Flag used to mark that the mesh does not have a vertex array and instead will infer vertex positions in the shader using indices and other information.
+		</constant>
+		<constant name="ARRAY_FLAG_COMPRESS_ATTRIBUTES" value="536870912" enum="ArrayFormat" is_bitfield="true">
+			Flag used to mark that a mesh is using compressed attributes (vertices, normals, tangents, uvs). When this form of compression is enabled, vertex positions will be packed into into an RGBA16UNORM attribute and scaled in the vertex shader. The normal and tangent will be packed into a RG16UNORM representing an axis, and an 16 bit float stored in the A-channel of the vertex. UVs will use 16-bit normalized floats instead of full 32 bit signed floats. When using this compression mode you must either use vertices, normals, and tangents or only vertices. You cannot use normals without tangents. Importers will automatically enable this compression if they can.
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_VERSION_BASE" value="35" enum="ArrayFormat" is_bitfield="true">
+			Flag used to mark the start of the bits used to store the mesh version.
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_VERSION_SHIFT" value="35" enum="ArrayFormat" is_bitfield="true">
+			Flag used to shift a mesh format int to bring the version into the lowest digits.
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_VERSION_1" value="0" enum="ArrayFormat" is_bitfield="true">
+			Flag used to record the format used by prior mesh versions before the introduction of a version.
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_VERSION_2" value="34359738368" enum="ArrayFormat" is_bitfield="true">
+			Flag used to record the second iteration of the mesh version flag. The primary difference between this and [constant ARRAY_FLAG_FORMAT_VERSION_1] is that this version supports [constant ARRAY_FLAG_COMPRESS_ATTRIBUTES] and in this version vertex positions are de-interleaved from normals and tangents.
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_CURRENT_VERSION" value="34359738368" enum="ArrayFormat" is_bitfield="true">
+			Flag used to record the current version that the engine expects. Currently this is the same as [constant ARRAY_FLAG_FORMAT_VERSION_2].
+		</constant>
+		<constant name="ARRAY_FLAG_FORMAT_VERSION_MASK" value="255" enum="ArrayFormat" is_bitfield="true">
+			Flag used to isolate the bits used for mesh version after using [constant ARRAY_FLAG_FORMAT_VERSION_SHIFT] to shift them into place.
 		</constant>
 		<constant name="PRIMITIVE_POINTS" value="0" enum="PrimitiveType">
 			Primitive to draw consists of points.

--- a/doc/classes/ResourceImporterOBJ.xml
+++ b/doc/classes/ResourceImporterOBJ.xml
@@ -11,6 +11,9 @@
 		<link title="Importing 3D scenes">$DOCS_URL/tutorials/assets_pipeline/importing_scenes.html</link>
 	</tutorials>
 	<members>
+		<member name="force_disable_mesh_compression" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], mesh compression will not be used. Consider enabling if you notice blocky artifacts in your mesh normals or UVs, or if you have meshes that are larger than a few thousand meters in each direction.
+		</member>
 		<member name="generate_tangents" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], generate vertex tangents using [url=http://www.mikktspace.com/]Mikktspace[/url] if the source mesh doesn't have tangent data. When possible, it's recommended to let the 3D modeling software generate tangents on export instead on relying on this option. Tangents are required for correct display of normal and height maps, along with any material/shader features that require tangents.
 			If you don't need material features that require tangents, disabling this can reduce output file size and speed up importing if the source 3D file doesn't contain tangents.

--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -37,6 +37,9 @@
 			If [code]true[/code], generate vertex tangents using [url=http://www.mikktspace.com/]Mikktspace[/url] if the input meshes don't have tangent data. When possible, it's recommended to let the 3D modeling software generate tangents on export instead on relying on this option. Tangents are required for correct display of normal and height maps, along with any material/shader features that require tangents.
 			If you don't need material features that require tangents, disabling this can reduce output file size and speed up importing if the source 3D file doesn't contain tangents.
 		</member>
+		<member name="meshes/force_disable_compression" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], mesh compression will not be used. Consider enabling if you notice blocky artifacts in your mesh normals or UVs, or if you have meshes that are larger than a few thousand meters in each direction.
+		</member>
 		<member name="meshes/generate_lods" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], generates lower detail variants of the mesh which will be displayed in the distance to improve rendering performance. Not all meshes benefit from LOD, especially if they are never rendered from far away. Disabling this can reduce output file size and speed up importing. See [url=$DOCS_URL/tutorials/3d/mesh_lod.html#doc-mesh-lod]Mesh level of detail (LOD)[/url] for more information.
 		</member>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1383,7 +1383,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 				GLuint vertex_array_gl = 0;
 				GLuint index_array_gl = 0;
 
-				uint32_t input_mask = 0; // 2D meshes always use the same vertex format
+				uint64_t input_mask = 0; // 2D meshes always use the same vertex format.
 				if (mesh_instance.is_valid()) {
 					mesh_storage->mesh_instance_surface_get_vertex_arrays_and_format(mesh_instance, j, input_mask, vertex_array_gl);
 				} else {

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2908,6 +2908,18 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			}
 
 			material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, world_transform, shader->version, instance_variant, spec_constants);
+			{
+				GLES3::Mesh::Surface *s = reinterpret_cast<GLES3::Mesh::Surface *>(surf->surface);
+				if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, s->aabb.position, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, s->aabb.size, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::UV_SCALE, s->uv_scale, shader->version, instance_variant, spec_constants);
+				} else {
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, Vector3(0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, Vector3(1.0, 1.0, 1.0), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::UV_SCALE, Vector4(0.0, 0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
+				}
+			}
 
 			// Can be index count or vertex count
 			uint32_t count = 0;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2944,7 +2944,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	cull_mode = Cull(cull_modei);
 	blend_mode = BlendMode(blend_modei);
 	alpha_antialiasing_mode = AlphaAntiAliasing(alpha_antialiasing_modei);
-	vertex_input_mask = uint32_t(uses_normal);
+	vertex_input_mask = uint64_t(uses_normal);
 	vertex_input_mask |= uses_tangent << 1;
 	vertex_input_mask |= uses_color << 2;
 	vertex_input_mask |= uses_uv << 3;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -316,7 +316,7 @@ struct SceneShaderData : public ShaderData {
 	bool uses_bones;
 	bool uses_weights;
 
-	uint32_t vertex_input_mask = 0;
+	uint64_t vertex_input_mask = 0;
 
 	uint64_t last_pass = 0;
 	uint32_t index = 0;

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -117,34 +117,40 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		uint32_t skin_stride = 0;
 
 		for (int i = 0; i < RS::ARRAY_WEIGHTS; i++) {
-			if ((p_surface.format & (1 << i))) {
+			if ((p_surface.format & (1ULL << i))) {
 				switch (i) {
 					case RS::ARRAY_VERTEX: {
-						if (p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
+						if ((p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) || (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 							stride += sizeof(float) * 2;
 						} else {
 							stride += sizeof(float) * 3;
 						}
-
 					} break;
 					case RS::ARRAY_NORMAL: {
 						stride += sizeof(uint16_t) * 2;
 
 					} break;
 					case RS::ARRAY_TANGENT: {
-						stride += sizeof(uint16_t) * 2;
-
+						if (!(p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+							stride += sizeof(uint16_t) * 2;
+						}
 					} break;
 					case RS::ARRAY_COLOR: {
 						attrib_stride += sizeof(uint32_t);
 					} break;
 					case RS::ARRAY_TEX_UV: {
-						attrib_stride += sizeof(float) * 2;
-
+						if (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+							attrib_stride += sizeof(uint16_t) * 2;
+						} else {
+							attrib_stride += sizeof(float) * 2;
+						}
 					} break;
 					case RS::ARRAY_TEX_UV2: {
-						attrib_stride += sizeof(float) * 2;
-
+						if (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+							attrib_stride += sizeof(uint16_t) * 2;
+						} else {
+							attrib_stride += sizeof(float) * 2;
+						}
 					} break;
 					case RS::ARRAY_CUSTOM0:
 					case RS::ARRAY_CUSTOM1:
@@ -185,92 +191,121 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 
 #endif
 
+	uint64_t surface_version = p_surface.format & (uint64_t(RS::ARRAY_FLAG_FORMAT_VERSION_MASK) << RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT);
+	RS::SurfaceData new_surface = p_surface;
+#ifdef DISABLE_DEPRECATED
+
+	ERR_FAIL_COND_MSG(surface_version != RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION, "Surface version provided (" + itos(int(surface_version >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT)) + ") does not match current version (" + itos(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) + ")");
+
+#else
+
+	if (surface_version != uint64_t(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION)) {
+		RS::_fix_surface_compatibility(new_surface);
+		surface_version = new_surface.format & (uint64_t(RS::ARRAY_FLAG_FORMAT_VERSION_MASK) << RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT);
+		ERR_FAIL_COND_MSG(surface_version != uint64_t(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION),
+				"Surface version provided (" +
+						itos((surface_version >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) & RS::ARRAY_FLAG_FORMAT_VERSION_MASK) +
+						") does not match current version (" +
+						itos((uint64_t(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION) >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) & RS::ARRAY_FLAG_FORMAT_VERSION_MASK) +
+						")");
+	}
+#endif
+
 	Mesh::Surface *s = memnew(Mesh::Surface);
 
-	s->format = p_surface.format;
-	s->primitive = p_surface.primitive;
+	s->format = new_surface.format;
+	s->primitive = new_surface.primitive;
 
-	if (p_surface.vertex_data.size()) {
+	if (new_surface.vertex_data.size()) {
 		glGenBuffers(1, &s->vertex_buffer);
 		glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->vertex_buffer, p_surface.vertex_data.size(), p_surface.vertex_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh vertex buffer");
-		s->vertex_buffer_size = p_surface.vertex_data.size();
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->vertex_buffer, new_surface.vertex_data.size(), new_surface.vertex_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh vertex buffer");
+		s->vertex_buffer_size = new_surface.vertex_data.size();
 	}
 
-	if (p_surface.attribute_data.size()) {
+	if (new_surface.attribute_data.size()) {
 		glGenBuffers(1, &s->attribute_buffer);
 		glBindBuffer(GL_ARRAY_BUFFER, s->attribute_buffer);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->attribute_buffer, p_surface.attribute_data.size(), p_surface.attribute_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh attribute buffer");
-		s->attribute_buffer_size = p_surface.attribute_data.size();
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->attribute_buffer, new_surface.attribute_data.size(), new_surface.attribute_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh attribute buffer");
+		s->attribute_buffer_size = new_surface.attribute_data.size();
 	}
 
-	if (p_surface.skin_data.size()) {
+	if (new_surface.skin_data.size()) {
 		glGenBuffers(1, &s->skin_buffer);
 		glBindBuffer(GL_ARRAY_BUFFER, s->skin_buffer);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->skin_buffer, p_surface.skin_data.size(), p_surface.skin_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh skin buffer");
-		s->skin_buffer_size = p_surface.skin_data.size();
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->skin_buffer, new_surface.skin_data.size(), new_surface.skin_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh skin buffer");
+		s->skin_buffer_size = new_surface.skin_data.size();
 	}
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	s->vertex_count = p_surface.vertex_count;
+	s->vertex_count = new_surface.vertex_count;
 
-	if (p_surface.format & RS::ARRAY_FORMAT_BONES) {
+	if (new_surface.format & RS::ARRAY_FORMAT_BONES) {
 		mesh->has_bone_weights = true;
 	}
 
-	if (p_surface.index_count) {
-		bool is_index_16 = p_surface.vertex_count <= 65536 && p_surface.vertex_count > 0;
+	if (new_surface.index_count) {
+		bool is_index_16 = new_surface.vertex_count <= 65536 && new_surface.vertex_count > 0;
 		glGenBuffers(1, &s->index_buffer);
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_buffer);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ELEMENT_ARRAY_BUFFER, s->index_buffer, p_surface.index_data.size(), p_surface.index_data.ptr(), GL_STATIC_DRAW, "Mesh index buffer");
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ELEMENT_ARRAY_BUFFER, s->index_buffer, new_surface.index_data.size(), new_surface.index_data.ptr(), GL_STATIC_DRAW, "Mesh index buffer");
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); //unbind
-		s->index_count = p_surface.index_count;
-		s->index_buffer_size = p_surface.index_data.size();
+		s->index_count = new_surface.index_count;
+		s->index_buffer_size = new_surface.index_data.size();
 
-		if (p_surface.lods.size()) {
-			s->lods = memnew_arr(Mesh::Surface::LOD, p_surface.lods.size());
-			s->lod_count = p_surface.lods.size();
+		if (new_surface.lods.size()) {
+			s->lods = memnew_arr(Mesh::Surface::LOD, new_surface.lods.size());
+			s->lod_count = new_surface.lods.size();
 
-			for (int i = 0; i < p_surface.lods.size(); i++) {
+			for (int i = 0; i < new_surface.lods.size(); i++) {
 				glGenBuffers(1, &s->lods[i].index_buffer);
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->lods[i].index_buffer);
-				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ELEMENT_ARRAY_BUFFER, s->lods[i].index_buffer, p_surface.lods[i].index_data.size(), p_surface.lods[i].index_data.ptr(), GL_STATIC_DRAW, "Mesh index buffer LOD[" + itos(i) + "]");
+				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ELEMENT_ARRAY_BUFFER, s->lods[i].index_buffer, new_surface.lods[i].index_data.size(), new_surface.lods[i].index_data.ptr(), GL_STATIC_DRAW, "Mesh index buffer LOD[" + itos(i) + "]");
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); //unbind
-				s->lods[i].edge_length = p_surface.lods[i].edge_length;
-				s->lods[i].index_count = p_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
-				s->lods[i].index_buffer_size = p_surface.lods[i].index_data.size();
+				s->lods[i].edge_length = new_surface.lods[i].edge_length;
+				s->lods[i].index_count = new_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
+				s->lods[i].index_buffer_size = new_surface.lods[i].index_data.size();
 			}
 		}
 	}
 
-	ERR_FAIL_COND_MSG(!p_surface.index_count && !p_surface.vertex_count, "Meshes must contain a vertex array, an index array, or both");
+	ERR_FAIL_COND_MSG(!new_surface.index_count && !new_surface.vertex_count, "Meshes must contain a vertex array, an index array, or both");
 
-	s->aabb = p_surface.aabb;
-	s->bone_aabbs = p_surface.bone_aabbs; //only really useful for returning them.
+	s->aabb = new_surface.aabb;
+	s->bone_aabbs = new_surface.bone_aabbs; //only really useful for returning them.
 
-	if (p_surface.skin_data.size() || mesh->blend_shape_count > 0) {
+	s->uv_scale = new_surface.uv_scale;
+
+	if (new_surface.skin_data.size() || mesh->blend_shape_count > 0) {
 		// Size must match the size of the vertex array.
-		int size = p_surface.vertex_data.size();
+		int size = new_surface.vertex_data.size();
 		int vertex_size = 0;
-		int stride = 0;
+		int position_stride = 0;
+		int normal_tangent_stride = 0;
 		int normal_offset = 0;
 		int tangent_offset = 0;
-		if ((p_surface.format & (1 << RS::ARRAY_VERTEX))) {
-			if (p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
+		if ((new_surface.format & (1ULL << RS::ARRAY_VERTEX))) {
+			if (new_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
 				vertex_size = 2;
+				position_stride = sizeof(float) * vertex_size;
 			} else {
-				vertex_size = 3;
+				if (new_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+					vertex_size = 4;
+					position_stride = sizeof(uint16_t) * vertex_size;
+				} else {
+					vertex_size = 3;
+					position_stride = sizeof(float) * vertex_size;
+				}
 			}
-			stride = sizeof(float) * vertex_size;
 		}
-		if ((p_surface.format & (1 << RS::ARRAY_NORMAL))) {
-			normal_offset = stride;
-			stride += sizeof(uint16_t) * 2;
+		if ((new_surface.format & (1ULL << RS::ARRAY_NORMAL))) {
+			normal_offset = position_stride * s->vertex_count;
+			normal_tangent_stride += sizeof(uint16_t) * 2;
 		}
-		if ((p_surface.format & (1 << RS::ARRAY_TANGENT))) {
-			tangent_offset = stride;
-			stride += sizeof(uint16_t) * 2;
+		if ((new_surface.format & (1ULL << RS::ARRAY_TANGENT))) {
+			tangent_offset = normal_offset + normal_tangent_stride;
+			normal_tangent_stride += sizeof(uint16_t) * 2;
 		}
 
 		if (mesh->blend_shape_count > 0) {
@@ -282,54 +317,38 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 				glBindVertexArray(s->blend_shapes[i].vertex_array);
 				glGenBuffers(1, &s->blend_shapes[i].vertex_buffer);
 				glBindBuffer(GL_ARRAY_BUFFER, s->blend_shapes[i].vertex_buffer);
-				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->blend_shapes[i].vertex_buffer, size, p_surface.blend_shape_data.ptr() + i * size, (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh blend shape buffer");
+				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->blend_shapes[i].vertex_buffer, size, new_surface.blend_shape_data.ptr() + i * size, (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh blend shape buffer");
 
-				if ((p_surface.format & (1 << RS::ARRAY_VERTEX))) {
+				if ((new_surface.format & (1ULL << RS::ARRAY_VERTEX))) {
 					glEnableVertexAttribArray(RS::ARRAY_VERTEX + 3);
-					glVertexAttribPointer(RS::ARRAY_VERTEX + 3, vertex_size, GL_FLOAT, GL_FALSE, stride, CAST_INT_TO_UCHAR_PTR(0));
+					glVertexAttribPointer(RS::ARRAY_VERTEX + 3, vertex_size, GL_FLOAT, GL_FALSE, position_stride, CAST_INT_TO_UCHAR_PTR(0));
 				}
-				if ((p_surface.format & (1 << RS::ARRAY_NORMAL))) {
+				if ((new_surface.format & (1ULL << RS::ARRAY_NORMAL))) {
+					// Normal and tangent are packed into the same attribute.
 					glEnableVertexAttribArray(RS::ARRAY_NORMAL + 3);
-					glVertexAttribPointer(RS::ARRAY_NORMAL + 3, 2, GL_UNSIGNED_SHORT, GL_TRUE, stride, CAST_INT_TO_UCHAR_PTR(normal_offset));
+					glVertexAttribPointer(RS::ARRAY_NORMAL + 3, 2, GL_UNSIGNED_SHORT, GL_TRUE, normal_tangent_stride, CAST_INT_TO_UCHAR_PTR(normal_offset));
 				}
-				if ((p_surface.format & (1 << RS::ARRAY_TANGENT))) {
+				if ((p_surface.format & (1ULL << RS::ARRAY_TANGENT))) {
 					glEnableVertexAttribArray(RS::ARRAY_TANGENT + 3);
-					glVertexAttribPointer(RS::ARRAY_TANGENT + 3, 2, GL_UNSIGNED_SHORT, GL_TRUE, stride, CAST_INT_TO_UCHAR_PTR(tangent_offset));
+					glVertexAttribPointer(RS::ARRAY_TANGENT + 3, 2, GL_UNSIGNED_SHORT, GL_TRUE, normal_tangent_stride, CAST_INT_TO_UCHAR_PTR(tangent_offset));
 				}
 			}
 			glBindVertexArray(0);
 			glBindBuffer(GL_ARRAY_BUFFER, 0);
 		}
 
-		// Create a vertex array to use for skeleton/blend shapes.
-		glGenVertexArrays(1, &s->skeleton_vertex_array);
-		glBindVertexArray(s->skeleton_vertex_array);
-		glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
-
-		if ((p_surface.format & (1 << RS::ARRAY_VERTEX))) {
-			glEnableVertexAttribArray(RS::ARRAY_VERTEX);
-			glVertexAttribPointer(RS::ARRAY_VERTEX, vertex_size, GL_FLOAT, GL_FALSE, stride, CAST_INT_TO_UCHAR_PTR(0));
-		}
-		if ((p_surface.format & (1 << RS::ARRAY_NORMAL))) {
-			glEnableVertexAttribArray(RS::ARRAY_NORMAL);
-			glVertexAttribPointer(RS::ARRAY_NORMAL, 2, GL_UNSIGNED_SHORT, GL_TRUE, stride, CAST_INT_TO_UCHAR_PTR(normal_offset));
-		}
-		if ((p_surface.format & (1 << RS::ARRAY_TANGENT))) {
-			glEnableVertexAttribArray(RS::ARRAY_TANGENT);
-			glVertexAttribPointer(RS::ARRAY_TANGENT, 2, GL_UNSIGNED_SHORT, GL_TRUE, stride, CAST_INT_TO_UCHAR_PTR(tangent_offset));
-		}
 		glBindVertexArray(0);
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 
 	if (mesh->surface_count == 0) {
-		mesh->aabb = p_surface.aabb;
+		mesh->aabb = new_surface.aabb;
 	} else {
-		mesh->aabb.merge_with(p_surface.aabb);
+		mesh->aabb.merge_with(new_surface.aabb);
 	}
 	mesh->skeleton_aabb_version = 0;
 
-	s->material = p_surface.material;
+	s->material = new_surface.material;
 
 	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count + 1));
 	mesh->surfaces[mesh->surface_count] = s;
@@ -478,6 +497,8 @@ RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 			sd.blend_shape_data.append_array(Utilities::buffer_get_data(GL_ARRAY_BUFFER, s.blend_shapes[i].vertex_buffer, s.vertex_buffer_size));
 		}
 	}
+
+	sd.uv_scale = s.uv_scale;
 
 	return sd;
 }
@@ -696,10 +717,6 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 			}
 			memdelete_arr(s.blend_shapes);
 		}
-		if (s.skeleton_vertex_array != 0) {
-			glDeleteVertexArrays(1, &s.skeleton_vertex_array);
-			s.skeleton_vertex_array = 0;
-		}
 
 		memdelete(mesh->surfaces[i]);
 	}
@@ -720,15 +737,16 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 	}
 }
 
-void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, MeshInstance::Surface *mis) {
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, MeshInstance::Surface *mis) {
 	Mesh::Surface::Attrib attribs[RS::ARRAY_MAX];
 
+	int position_stride = 0; // Vertex position only.
+	int normal_tangent_stride = 0;
 	int attributes_stride = 0;
-	int vertex_stride = 0;
 	int skin_stride = 0;
 
 	for (int i = 0; i < RS::ARRAY_INDEX; i++) {
-		if (!(s->format & (1 << i))) {
+		if (!(s->format & (1ULL << i))) {
 			attribs[i].enabled = false;
 			attribs[i].integer = false;
 			continue;
@@ -739,29 +757,55 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 		switch (i) {
 			case RS::ARRAY_VERTEX: {
-				attribs[i].offset = vertex_stride;
+				attribs[i].offset = 0;
+				attribs[i].type = GL_FLOAT;
+				attribs[i].normalized = GL_FALSE;
 				if (s->format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
 					attribs[i].size = 2;
+					position_stride = attribs[i].size * sizeof(float);
 				} else {
-					attribs[i].size = 3;
+					if (!mis && (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+						attribs[i].size = 4;
+						position_stride = attribs[i].size * sizeof(uint16_t);
+						attribs[i].type = GL_UNSIGNED_SHORT;
+						attribs[i].normalized = GL_TRUE;
+					} else {
+						attribs[i].size = 3;
+						position_stride = attribs[i].size * sizeof(float);
+					}
 				}
-				attribs[i].type = GL_FLOAT;
-				vertex_stride += attribs[i].size * sizeof(float);
-				attribs[i].normalized = GL_FALSE;
 			} break;
 			case RS::ARRAY_NORMAL: {
-				attribs[i].offset = vertex_stride;
-				attribs[i].size = 2;
+				if (!mis && (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+					attribs[i].size = 2;
+					normal_tangent_stride += 2 * attribs[i].size;
+				} else {
+					attribs[i].size = 4;
+					// A small trick here: if we are uncompressed and we have normals, but no tangents. We need
+					// the shader to think there are 4 components to "axis_tangent_attrib". So we give a size of 4,
+					// but a stride based on only having 2 elements.
+					if (!(s->format & RS::ARRAY_FORMAT_TANGENT)) {
+						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 2;
+					} else {
+						normal_tangent_stride += (mis ? sizeof(float) : sizeof(uint16_t)) * 4;
+					}
+				}
+
+				if (mis) {
+					// Transform feedback has interleave all or no attributes. It can't mix interleaving.
+					attribs[i].offset = position_stride;
+					normal_tangent_stride += position_stride;
+					position_stride = normal_tangent_stride;
+				} else {
+					attribs[i].offset = position_stride * s->vertex_count;
+				}
 				attribs[i].type = (mis ? GL_FLOAT : GL_UNSIGNED_SHORT);
-				vertex_stride += sizeof(uint16_t) * 2 * (mis ? 2 : 1);
 				attribs[i].normalized = GL_TRUE;
 			} break;
 			case RS::ARRAY_TANGENT: {
-				attribs[i].offset = vertex_stride;
-				attribs[i].size = 2;
-				attribs[i].type = (mis ? GL_FLOAT : GL_UNSIGNED_SHORT);
-				vertex_stride += sizeof(uint16_t) * 2 * (mis ? 2 : 1);
-				attribs[i].normalized = GL_TRUE;
+				// We never use the tangent attribute. It is always packed in ARRAY_NORMAL, or ARRAY_VERTEX.
+				attribs[i].enabled = false;
+				attribs[i].integer = false;
 			} break;
 			case RS::ARRAY_COLOR: {
 				attribs[i].offset = attributes_stride;
@@ -773,16 +817,28 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			case RS::ARRAY_TEX_UV: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				attribs[i].type = GL_FLOAT;
-				attributes_stride += 2 * sizeof(float);
-				attribs[i].normalized = GL_FALSE;
+				if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+					attribs[i].type = GL_UNSIGNED_SHORT;
+					attributes_stride += 2 * sizeof(uint16_t);
+					attribs[i].normalized = GL_TRUE;
+				} else {
+					attribs[i].type = GL_FLOAT;
+					attributes_stride += 2 * sizeof(float);
+					attribs[i].normalized = GL_FALSE;
+				}
 			} break;
 			case RS::ARRAY_TEX_UV2: {
 				attribs[i].offset = attributes_stride;
 				attribs[i].size = 2;
-				attribs[i].type = GL_FLOAT;
-				attributes_stride += 2 * sizeof(float);
-				attribs[i].normalized = GL_FALSE;
+				if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+					attribs[i].type = GL_UNSIGNED_SHORT;
+					attributes_stride += 2 * sizeof(uint16_t);
+					attribs[i].normalized = GL_TRUE;
+				} else {
+					attribs[i].type = GL_FLOAT;
+					attributes_stride += 2 * sizeof(float);
+					attribs[i].normalized = GL_FALSE;
+				}
 			} break;
 			case RS::ARRAY_CUSTOM0:
 			case RS::ARRAY_CUSTOM1:
@@ -828,7 +884,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			continue;
 		}
 		if (i <= RS::ARRAY_TANGENT) {
-			attribs[i].stride = vertex_stride;
+			attribs[i].stride = (i == RS::ARRAY_VERTEX) ? position_stride : normal_tangent_stride;
 			if (mis) {
 				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffer);
 			} else {
@@ -946,7 +1002,7 @@ void MeshStorage::_mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint3
 	if ((mesh->blend_shape_count > 0 || (mesh->surfaces[p_surface]->format & RS::ARRAY_FORMAT_BONES)) && mesh->surfaces[p_surface]->vertex_buffer_size > 0) {
 		// Cache surface properties
 		s.format_cache = mesh->surfaces[p_surface]->format;
-		if ((s.format_cache & (1 << RS::ARRAY_VERTEX))) {
+		if ((s.format_cache & (1ULL << RS::ARRAY_VERTEX))) {
 			if (s.format_cache & RS::ARRAY_FLAG_USE_2D_VERTICES) {
 				s.vertex_size_cache = 2;
 			} else {
@@ -954,25 +1010,27 @@ void MeshStorage::_mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint3
 			}
 			s.vertex_stride_cache = sizeof(float) * s.vertex_size_cache;
 		}
-		if ((s.format_cache & (1 << RS::ARRAY_NORMAL))) {
+		if ((s.format_cache & (1ULL << RS::ARRAY_NORMAL))) {
 			s.vertex_normal_offset_cache = s.vertex_stride_cache;
 			s.vertex_stride_cache += sizeof(uint32_t) * 2;
 		}
-		if ((s.format_cache & (1 << RS::ARRAY_TANGENT))) {
+		if ((s.format_cache & (1ULL << RS::ARRAY_TANGENT))) {
 			s.vertex_tangent_offset_cache = s.vertex_stride_cache;
 			s.vertex_stride_cache += sizeof(uint32_t) * 2;
 		}
 
+		int buffer_size = s.vertex_stride_cache * mesh->surfaces[p_surface]->vertex_count;
+
 		// Buffer to be used for rendering. Final output of skeleton and blend shapes.
 		glGenBuffers(1, &s.vertex_buffer);
 		glBindBuffer(GL_ARRAY_BUFFER, s.vertex_buffer);
-		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s.vertex_buffer, s.vertex_stride_cache * mesh->surfaces[p_surface]->vertex_count, nullptr, GL_DYNAMIC_DRAW, "MeshInstance vertex buffer");
+		GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s.vertex_buffer, buffer_size, nullptr, GL_DYNAMIC_DRAW, "MeshInstance vertex buffer");
 		if (mesh->blend_shape_count > 0) {
 			// Ping-Pong buffers for processing blendshapes.
 			glGenBuffers(2, s.vertex_buffers);
 			for (uint32_t i = 0; i < 2; i++) {
 				glBindBuffer(GL_ARRAY_BUFFER, s.vertex_buffers[i]);
-				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s.vertex_buffers[i], s.vertex_stride_cache * mesh->surfaces[p_surface]->vertex_count, nullptr, GL_DYNAMIC_DRAW, "MeshInstance process buffer[" + itos(i) + "]");
+				GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s.vertex_buffers[i], buffer_size, nullptr, GL_DYNAMIC_DRAW, "MeshInstance process buffer[" + itos(i) + "]");
 			}
 		}
 		glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
@@ -1011,19 +1069,19 @@ void MeshStorage::mesh_instance_set_canvas_item_transform(RID p_mesh_instance, c
 void MeshStorage::_blend_shape_bind_mesh_instance_buffer(MeshInstance *p_mi, uint32_t p_surface) {
 	glBindBuffer(GL_ARRAY_BUFFER, p_mi->surfaces[p_surface].vertex_buffers[0]);
 
-	if ((p_mi->surfaces[p_surface].format_cache & (1 << RS::ARRAY_VERTEX))) {
+	if ((p_mi->surfaces[p_surface].format_cache & (1ULL << RS::ARRAY_VERTEX))) {
 		glEnableVertexAttribArray(RS::ARRAY_VERTEX);
 		glVertexAttribPointer(RS::ARRAY_VERTEX, p_mi->surfaces[p_surface].vertex_size_cache, GL_FLOAT, GL_FALSE, p_mi->surfaces[p_surface].vertex_stride_cache, CAST_INT_TO_UCHAR_PTR(0));
 	} else {
 		glDisableVertexAttribArray(RS::ARRAY_VERTEX);
 	}
-	if ((p_mi->surfaces[p_surface].format_cache & (1 << RS::ARRAY_NORMAL))) {
+	if ((p_mi->surfaces[p_surface].format_cache & (1ULL << RS::ARRAY_NORMAL))) {
 		glEnableVertexAttribArray(RS::ARRAY_NORMAL);
 		glVertexAttribIPointer(RS::ARRAY_NORMAL, 2, GL_UNSIGNED_INT, p_mi->surfaces[p_surface].vertex_stride_cache, CAST_INT_TO_UCHAR_PTR(p_mi->surfaces[p_surface].vertex_normal_offset_cache));
 	} else {
 		glDisableVertexAttribArray(RS::ARRAY_NORMAL);
 	}
-	if ((p_mi->surfaces[p_surface].format_cache & (1 << RS::ARRAY_TANGENT))) {
+	if ((p_mi->surfaces[p_surface].format_cache & (1ULL << RS::ARRAY_TANGENT))) {
 		glEnableVertexAttribArray(RS::ARRAY_TANGENT);
 		glVertexAttribIPointer(RS::ARRAY_TANGENT, 2, GL_UNSIGNED_INT, p_mi->surfaces[p_surface].vertex_stride_cache, CAST_INT_TO_UCHAR_PTR(p_mi->surfaces[p_surface].vertex_tangent_offset_cache));
 	} else {
@@ -1091,7 +1149,7 @@ void MeshStorage::update_mesh_instances() {
 		}
 
 		for (uint32_t i = 0; i < mi->surfaces.size(); i++) {
-			if (mi->surfaces[i].vertex_buffer == 0 || mi->mesh->surfaces[i]->skeleton_vertex_array == 0) {
+			if (mi->surfaces[i].vertex_buffer == 0) {
 				continue;
 			}
 
@@ -1106,10 +1164,10 @@ void MeshStorage::update_mesh_instances() {
 				specialization |= array_is_2d ? SkeletonShaderGLES3::MODE_2D : 0;
 				specialization |= SkeletonShaderGLES3::USE_BLEND_SHAPES;
 				if (!array_is_2d) {
-					if ((mi->surfaces[i].format_cache & (1 << RS::ARRAY_NORMAL))) {
+					if ((mi->surfaces[i].format_cache & (1ULL << RS::ARRAY_NORMAL))) {
 						specialization |= SkeletonShaderGLES3::USE_NORMAL;
 					}
-					if ((mi->surfaces[i].format_cache & (1 << RS::ARRAY_TANGENT))) {
+					if ((mi->surfaces[i].format_cache & (1ULL << RS::ARRAY_TANGENT))) {
 						specialization |= SkeletonShaderGLES3::USE_TANGENT;
 					}
 				}
@@ -1123,7 +1181,12 @@ void MeshStorage::update_mesh_instances() {
 				skeleton_shader.shader.version_set_uniform(SkeletonShaderGLES3::BLEND_SHAPE_COUNT, float(mi->mesh->blend_shape_count), skeleton_shader.shader_version, variant, specialization);
 
 				glBindBuffer(GL_ARRAY_BUFFER, 0);
-				glBindVertexArray(mi->mesh->surfaces[i]->skeleton_vertex_array);
+				GLuint vertex_array_gl = 0;
+				uint64_t mask = ((1 << 10) - 1) << 3; // Mask from ARRAY_FORMAT_COLOR to ARRAY_FORMAT_INDEX.
+				mask = ~mask;
+				uint64_t format = mi->surfaces[i].format_cache & mask; // Format should only have vertex, normal, tangent (as necessary) + compressions.
+				mesh_surface_get_vertex_arrays_and_format(mi->mesh->surfaces[i], format, vertex_array_gl);
+				glBindVertexArray(vertex_array_gl);
 				glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, mi->surfaces[i].vertex_buffers[0]);
 				glBeginTransformFeedback(GL_POINTS);
 				glDrawArrays(GL_POINTS, 0, mi->mesh->surfaces[i]->vertex_count);
@@ -1210,10 +1273,10 @@ void MeshStorage::update_mesh_instances() {
 				specialization |= SkeletonShaderGLES3::FINAL_PASS;
 				specialization |= use_8_weights ? SkeletonShaderGLES3::USE_EIGHT_WEIGHTS : 0;
 				if (!array_is_2d) {
-					if ((mi->surfaces[i].format_cache & (1 << RS::ARRAY_NORMAL))) {
+					if ((mi->surfaces[i].format_cache & (1ULL << RS::ARRAY_NORMAL))) {
 						specialization |= SkeletonShaderGLES3::USE_NORMAL;
 					}
-					if ((mi->surfaces[i].format_cache & (1 << RS::ARRAY_TANGENT))) {
+					if ((mi->surfaces[i].format_cache & (1ULL << RS::ARRAY_TANGENT))) {
 						specialization |= SkeletonShaderGLES3::USE_TANGENT;
 					}
 				}
@@ -1233,7 +1296,12 @@ void MeshStorage::update_mesh_instances() {
 				skeleton_shader.shader.version_set_uniform(SkeletonShaderGLES3::INVERSE_TRANSFORM_Y, inverse_transform[1], skeleton_shader.shader_version, variant, specialization);
 				skeleton_shader.shader.version_set_uniform(SkeletonShaderGLES3::INVERSE_TRANSFORM_OFFSET, inverse_transform[2], skeleton_shader.shader_version, variant, specialization);
 
-				glBindVertexArray(mi->mesh->surfaces[i]->skeleton_vertex_array);
+				GLuint vertex_array_gl = 0;
+				uint64_t mask = ((1 << 10) - 1) << 3; // Mask from ARRAY_FORMAT_COLOR to ARRAY_FORMAT_INDEX.
+				mask = ~mask;
+				uint64_t format = mi->surfaces[i].format_cache & mask; // Format should only have vertex, normal, tangent (as necessary) + compressions.
+				mesh_surface_get_vertex_arrays_and_format(mi->mesh->surfaces[i], format, vertex_array_gl);
+				glBindVertexArray(vertex_array_gl);
 				_compute_skeleton(mi, sk, i);
 			}
 		}

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -58,7 +58,7 @@ struct Mesh {
 			uint32_t offset;
 		};
 		RS::PrimitiveType primitive = RS::PRIMITIVE_POINTS;
-		uint32_t format = 0;
+		uint64_t format = 0;
 
 		GLuint vertex_buffer = 0;
 		GLuint attribute_buffer = 0;
@@ -97,6 +97,8 @@ struct Mesh {
 		AABB aabb;
 
 		Vector<AABB> bone_aabbs;
+
+		Vector4 uv_scale;
 
 		struct BlendShape {
 			GLuint vertex_buffer = 0;
@@ -144,7 +146,7 @@ struct MeshInstance {
 		int vertex_size_cache = 0;
 		int vertex_normal_offset_cache = 0;
 		int vertex_tangent_offset_cache = 0;
-		uint32_t format_cache = 0;
+		uint64_t format_cache = 0;
 
 		Mesh::Surface::Version *versions = nullptr; //allocated on demand
 		uint32_t version_count = 0;
@@ -221,7 +223,7 @@ private:
 
 	mutable RID_Owner<Mesh, true> mesh_owner;
 
-	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, MeshInstance::Surface *mis = nullptr);
+	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, MeshInstance::Surface *mis = nullptr);
 
 	/* Mesh Instance API */
 
@@ -381,18 +383,18 @@ public:
 	}
 
 	// Use this to cache Vertex Array Objects so they are only generated once
-	_FORCE_INLINE_ void mesh_surface_get_vertex_arrays_and_format(void *p_surface, uint32_t p_input_mask, GLuint &r_vertex_array_gl) {
+	_FORCE_INLINE_ void mesh_surface_get_vertex_arrays_and_format(void *p_surface, uint64_t p_input_mask, GLuint &r_vertex_array_gl) {
 		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
 
 		s->version_lock.lock();
 
-		//there will never be more than, at much, 3 or 4 versions, so iterating is the fastest way
+		// There will never be more than 3 or 4 versions, so iterating is the fastest way.
 
 		for (uint32_t i = 0; i < s->version_count; i++) {
 			if (s->versions[i].input_mask != p_input_mask) {
 				continue;
 			}
-			//we have this version, hooray
+			// We have this version, hooray.
 			r_vertex_array_gl = s->versions[i].vertex_array;
 			s->version_lock.unlock();
 			return;
@@ -424,7 +426,7 @@ public:
 
 	// TODO: considering hashing versions with multimesh buffer RID.
 	// Doing so would allow us to avoid specifying multimesh buffer pointers every frame and may improve performance.
-	_FORCE_INLINE_ void mesh_instance_surface_get_vertex_arrays_and_format(RID p_mesh_instance, uint32_t p_surface_index, uint32_t p_input_mask, GLuint &r_vertex_array_gl) {
+	_FORCE_INLINE_ void mesh_instance_surface_get_vertex_arrays_and_format(RID p_mesh_instance, uint32_t p_surface_index, uint64_t p_input_mask, GLuint &r_vertex_array_gl) {
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -4499,6 +4499,7 @@ RID RenderingDeviceVulkan::vertex_array_create(uint32_t p_vertex_count, VertexFo
 			if (atf.frequency == VERTEX_FREQUENCY_VERTEX) {
 				// Validate size for regular drawing.
 				uint64_t total_size = uint64_t(atf.stride) * (p_vertex_count - 1) + atf.offset + element_size;
+
 				ERR_FAIL_COND_V_MSG(total_size > buffer->size, RID(),
 						"Attachment (" + itos(i) + ") will read past the end of the buffer.");
 
@@ -4665,7 +4666,7 @@ struct RenderingDeviceVulkanShaderBinarySpecializationConstant {
 };
 
 struct RenderingDeviceVulkanShaderBinaryData {
-	uint32_t vertex_input_mask;
+	uint64_t vertex_input_mask;
 	uint32_t fragment_output_mask;
 	uint32_t specialization_constants_count;
 	uint32_t is_compute;
@@ -4881,7 +4882,7 @@ RID RenderingDeviceVulkan::shader_create_from_bytecode(const Vector<uint8_t> &p_
 	push_constant.size = binary_data.push_constant_size;
 	push_constant.vk_stages_mask = binary_data.push_constant_vk_stages_mask;
 
-	uint32_t vertex_input_mask = binary_data.vertex_input_mask;
+	uint64_t vertex_input_mask = binary_data.vertex_input_mask;
 
 	uint32_t fragment_output_mask = binary_data.fragment_output_mask;
 
@@ -5209,7 +5210,7 @@ RID RenderingDeviceVulkan::shader_create_placeholder() {
 	return shader_owner.make_rid(shader);
 }
 
-uint32_t RenderingDeviceVulkan::shader_get_vertex_input_attribute_mask(RID p_shader) {
+uint64_t RenderingDeviceVulkan::shader_get_vertex_input_attribute_mask(RID p_shader) {
 	_THREAD_SAFE_METHOD_
 
 	const Shader *shader = shader_owner.get_or_null(p_shader);
@@ -6152,8 +6153,8 @@ RID RenderingDeviceVulkan::render_pipeline_create(RID p_shader, FramebufferForma
 		pipeline_vertex_input_state_create_info = vd.create_info;
 
 		// Validate with inputs.
-		for (uint32_t i = 0; i < 32; i++) {
-			if (!(shader->vertex_input_mask & (1UL << i))) {
+		for (uint64_t i = 0; i < 64; i++) {
+			if (!(shader->vertex_input_mask & (1ULL << i))) {
 				continue;
 			}
 			bool found = false;

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -621,7 +621,7 @@ class RenderingDeviceVulkan : public RenderingDevice {
 			VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
 		};
 
-		uint32_t vertex_input_mask = 0; // Inputs used, this is mostly for validation.
+		uint64_t vertex_input_mask = 0; // Inputs used, this is mostly for validation.
 		uint32_t fragment_output_mask = 0;
 
 		struct PushConstant {
@@ -1140,7 +1140,7 @@ public:
 	virtual RID shader_create_from_bytecode(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID());
 	virtual RID shader_create_placeholder();
 
-	virtual uint32_t shader_get_vertex_input_attribute_mask(RID p_shader);
+	virtual uint64_t shader_get_vertex_input_attribute_mask(RID p_shader);
 
 	/*****************/
 	/**** UNIFORM ****/

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -919,6 +919,12 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				}
 			}
 
+			uint64_t mesh_flags = 0;
+
+			if (p_use_compression) {
+				mesh_flags = RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+			}
+
 			Ref<SurfaceTool> surftool;
 			surftool.instantiate();
 			surftool->begin(Mesh::PRIMITIVE_TRIANGLES);
@@ -969,12 +975,19 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 			}
 
 			if (!normal_src) {
-				//should always be normals
+				// Should always have normals.
 				surftool->generate_normals();
 			}
 
-			if ((!binormal_src || !tangent_src) && normal_src && uv_src && force_make_tangents) {
+			bool generate_tangents = (!binormal_src || !tangent_src) && uv_src && force_make_tangents;
+
+			if (generate_tangents) {
 				surftool->generate_tangents();
+			}
+
+			if (!binormal_src || !(tangent_src || generate_tangents) || p_mesh->get_blend_shape_count() != 0 || p_skin_controller) {
+				// Can't compress if attributes missing or if using vertex weights.
+				mesh_flags &= ~RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
 			}
 
 			////////////////////////////
@@ -996,7 +1009,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 
 				// Enforce blend shape mask array format
 				for (int mj = 0; mj < Mesh::ARRAY_MAX; mj++) {
-					if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1 << mj))) {
+					if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1ULL << mj))) {
 						a[mj] = Variant();
 					}
 				}
@@ -1011,7 +1024,7 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				}
 				surface_name = material->get_name();
 			}
-			p_mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, d, mr, Dictionary(), mat, surface_name);
+			p_mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, d, mr, Dictionary(), mat, surface_name, mesh_flags);
 		}
 
 		/*****************/
@@ -1773,7 +1786,7 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 	state.use_mesh_builtin_materials = true;
 	state.bake_fps = (float)p_options["animation/fps"];
 
-	Error err = state.load(p_path, flags, p_flags & EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS, false);
+	Error err = state.load(p_path, flags, p_flags & EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS, !bool(p_flags & EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION));
 
 	if (r_err) {
 		*r_err = err;

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -112,6 +112,7 @@ void EditorSceneFormatImporter::_bind_methods() {
 	BIND_CONSTANT(IMPORT_GENERATE_TANGENT_ARRAYS);
 	BIND_CONSTANT(IMPORT_USE_NAMED_SKIN_BINDS);
 	BIND_CONSTANT(IMPORT_DISCARD_MESHES_AND_MATERIALS);
+	BIND_CONSTANT(IMPORT_FORCE_DISABLE_MESH_COMPRESSION);
 }
 
 /////////////////////////////////
@@ -1934,6 +1935,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/create_shadow_meshes"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/light_baking", PROPERTY_HINT_ENUM, "Disabled,Static (VoxelGI/SDFGI),Static Lightmaps (VoxelGI/SDFGI/LightmapGI),Dynamic (VoxelGI only)", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "meshes/lightmap_texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.2));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/force_disable_compression"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "skins/use_named_skins"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 30));
@@ -2426,6 +2428,11 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	bool ensure_tangents = p_options["meshes/ensure_tangents"];
 	if (ensure_tangents) {
 		import_flags |= EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS;
+	}
+
+	bool force_disable_compression = p_options["meshes/force_disable_compression"];
+	if (force_disable_compression) {
+		import_flags |= EditorSceneFormatImporter::IMPORT_FORCE_DISABLE_MESH_COMPRESSION;
 	}
 
 	Error err = OK;

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -71,6 +71,7 @@ public:
 		IMPORT_GENERATE_TANGENT_ARRAYS = 8,
 		IMPORT_USE_NAMED_SKIN_BINDS = 16,
 		IMPORT_DISCARD_MESHES_AND_MATERIALS = 32, //used for optimizing animation import
+		IMPORT_FORCE_DISABLE_MESH_COMPRESSION = 64,
 	};
 
 	virtual uint32_t get_import_flags() const;

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -365,6 +365,13 @@ def build_gles3_header(
             + ") { _FU GLfloat vec3[3]={float(p_vec3.x),float(p_vec3.y),float(p_vec3.z)}; glUniform3fv(version_get_uniform(p_uniform,p_version,p_variant,p_specialization),1,vec3); }\n\n"
         )
         fd.write(
+            "\t_FORCE_INLINE_ void version_set_uniform(Uniforms p_uniform, const Vector4& p_vec4,RID p_version,ShaderVariant p_variant"
+            + defvariant
+            + ",uint64_t p_specialization="
+            + str(defspec)
+            + ") { _FU GLfloat vec4[4]={float(p_vec4.x),float(p_vec4.y),float(p_vec4.z),float(p_vec4.w)}; glUniform4fv(version_get_uniform(p_uniform,p_version,p_variant,p_specialization),1,vec4); }\n\n"
+        )
+        fd.write(
             "\t_FORCE_INLINE_ void version_set_uniform(Uniforms p_uniform, float p_a, float p_b,RID p_version,ShaderVariant p_variant"
             + defvariant
             + ",uint64_t p_specialization="

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -274,3 +274,16 @@ Validate extension JSON: API was removed: classes/GraphEdit/methods/set_arrange_
 Validate extension JSON: API was removed: classes/GraphEdit/properties/arrange_nodes_button_hidden
 
 Make GraphEdit toolbar more customizable
+
+
+GH-81138
+--------
+
+Validate extension JSON: Error: Field 'classes/ImporterMesh/methods/add_surface/arguments/6': meta changed value in new API, from "uint32" to "uint64".
+Validate extension JSON: Error: Field 'classes/ImporterMesh/methods/get_surface_format/return_value': meta changed value in new API, from "uint32" to "uint64".
+Validate extension JSON: Error: Field 'classes/MeshDataTool/methods/commit_to_surface/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/MeshDataTool/methods/get_format/return_value': meta changed value in new API, from "int32" to "uint64".
+Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_get_vertex_input_attribute_mask/return_value': meta changed value in new API, from "uint32" to "uint64".
+Validate extension JSON: Error: Field 'classes/SurfaceTool/methods/commit/arguments/1': meta changed value in new API, from "uint32" to "uint64".
+
+Surface format was increased to 64 bits from 32 bits. Compatibility methods registered. 

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -58,7 +58,9 @@ class GLTFState : public Resource {
 	bool use_named_skin_binds = false;
 	bool use_khr_texture_transform = false;
 	bool discard_meshes_and_materials = false;
+	bool force_generate_tangents = false;
 	bool create_animations = true;
+	bool force_disable_compression = false;
 
 	int handle_binary_image = HANDLE_BINARY_EXTRACT_TEXTURES;
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
@@ -128,6 +128,16 @@ partial class GraphNode
         remove => DeleteRequest -= value;
     }
 }
+partial class ImporterMesh
+{
+    /// <inheritdoc cref="AddSurface(Mesh.PrimitiveType, Godot.Collections.Array, Godot.Collections.Array{Godot.Collections.Array}, Godot.Collections.Dictionary, Material, string, ulong)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void AddSurface(Mesh.PrimitiveType primitive, Godot.Collections.Array arrays, Godot.Collections.Array<Godot.Collections.Array> blendShapes, Godot.Collections.Dictionary lods, Material material, string name, uint flags)
+    {
+        AddSurface(primitive, arrays, blendShapes, lods, material, name, (ulong)flags);
+    }
+}
+
 
 partial class MeshInstance3D
 {
@@ -190,6 +200,13 @@ partial class SurfaceTool
     public void AddTriangleFan(Vector3[] vertices, Vector2[] uvs, Color[] colors, Vector2[] uv2S, Vector3[] normals, Godot.Collections.Array tangents)
     {
         AddTriangleFan(vertices, uvs, colors, uv2S, normals, new Godot.Collections.Array<Plane>(tangents));
+    }
+
+    /// <inheritdoc cref="Commit(ArrayMesh, ulong)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public ArrayMesh Commit(ArrayMesh existing, uint flags)
+    {
+        return Commit(existing, (ulong)flags);
     }
 }
 

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -46,12 +46,14 @@ void SoftBodyRenderingServerHandler::prepare(RID p_mesh, int p_surface) {
 
 	uint32_t surface_offsets[RS::ARRAY_MAX];
 	uint32_t vertex_stride;
+	uint32_t normal_tangent_stride;
 	uint32_t attrib_stride;
 	uint32_t skin_stride;
-	RS::get_singleton()->mesh_surface_make_offsets_from_format(surface_data.format, surface_data.vertex_count, surface_data.index_count, surface_offsets, vertex_stride, attrib_stride, skin_stride);
+	RS::get_singleton()->mesh_surface_make_offsets_from_format(surface_data.format, surface_data.vertex_count, surface_data.index_count, surface_offsets, vertex_stride, normal_tangent_stride, attrib_stride, skin_stride);
 
 	buffer = surface_data.vertex_data;
 	stride = vertex_stride;
+	normal_stride = normal_tangent_stride;
 	offset_vertices = surface_offsets[RS::ARRAY_VERTEX];
 	offset_normal = surface_offsets[RS::ARRAY_NORMAL];
 }
@@ -59,6 +61,7 @@ void SoftBodyRenderingServerHandler::prepare(RID p_mesh, int p_surface) {
 void SoftBodyRenderingServerHandler::clear() {
 	buffer.resize(0);
 	stride = 0;
+	normal_stride = 0;
 	offset_vertices = 0;
 	offset_normal = 0;
 
@@ -83,15 +86,11 @@ void SoftBodyRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &
 }
 
 void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {
-	// Store normal vector in A2B10G10R10 format.
-	Vector3 n = p_normal;
-	n *= Vector3(0.5, 0.5, 0.5);
-	n += Vector3(0.5, 0.5, 0.5);
-	Vector2 res = n.octahedron_encode();
+	Vector2 res = p_normal.octahedron_encode();
 	uint32_t value = 0;
 	value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
 	value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;
-	memcpy(&write_buffer[p_vertex_id * stride + offset_normal], &value, sizeof(uint32_t));
+	memcpy(&write_buffer[p_vertex_id * normal_stride + offset_normal], &value, sizeof(uint32_t));
 }
 
 void SoftBodyRenderingServerHandler::set_aabb(const AABB &p_aabb) {

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -44,6 +44,7 @@ class SoftBodyRenderingServerHandler : public PhysicsServer3DRenderingServerHand
 	int surface = 0;
 	Vector<uint8_t> buffer;
 	uint32_t stride = 0;
+	uint32_t normal_stride = 0;
 	uint32_t offset_vertices = 0;
 	uint32_t offset_normal = 0;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -234,8 +234,8 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		float v_vertex[3] = { (float)vtx.x, (float)vtx.y, (float)vtx.z };
 
 		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_VERTEX]], &v_vertex, sizeof(float) * 3);
-		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
-		memcpy(&vertex_write_buffer[i * vertex_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
+		memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_NORMAL]], &v_normal, 4);
+		memcpy(&vertex_write_buffer[i * normal_tangent_stride + mesh_surface_offsets[RS::ARRAY_TANGENT]], &v_tangent, 4);
 		memcpy(&attribute_write_buffer[i * attrib_stride + mesh_surface_offsets[RS::ARRAY_COLOR]], v_color, 4);
 	}
 
@@ -682,7 +682,7 @@ SpriteBase3D::SpriteBase3D() {
 
 	sd.material = material;
 
-	RS::get_singleton()->mesh_surface_make_offsets_from_format(sd.format, sd.vertex_count, sd.index_count, mesh_surface_offsets, vertex_stride, attrib_stride, skin_stride);
+	RS::get_singleton()->mesh_surface_make_offsets_from_format(sd.format, sd.vertex_count, sd.index_count, mesh_surface_offsets, vertex_stride, normal_tangent_stride, attrib_stride, skin_stride);
 	RS::get_singleton()->mesh_add_surface(mesh, sd);
 	set_base(mesh);
 }

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -112,6 +112,7 @@ protected:
 	PackedByteArray vertex_buffer;
 	PackedByteArray attribute_buffer;
 	uint32_t vertex_stride = 0;
+	uint32_t normal_tangent_stride = 0;
 	uint32_t attrib_stride = 0;
 	uint32_t skin_stride = 0;
 	uint32_t mesh_surface_format = 0;

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -156,7 +156,7 @@ Mesh::BlendShapeMode ImporterMesh::get_blend_shape_mode() const {
 	return blend_shape_mode;
 }
 
-void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_name, const uint32_t p_flags) {
+void ImporterMesh::add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes, const Dictionary &p_lods, const Ref<Material> &p_material, const String &p_name, const uint64_t p_flags) {
 	ERR_FAIL_COND(p_blend_shapes.size() != blend_shapes.size());
 	ERR_FAIL_COND(p_arrays.size() != Mesh::ARRAY_MAX);
 	Surface s;
@@ -240,7 +240,7 @@ float ImporterMesh::get_surface_lod_size(int p_surface, int p_lod) const {
 	return surfaces[p_surface].lods[p_lod].distance;
 }
 
-uint32_t ImporterMesh::get_surface_format(int p_surface) const {
+uint64_t ImporterMesh::get_surface_format(int p_surface) const {
 	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), 0);
 	return surfaces[p_surface].flags;
 }
@@ -1105,7 +1105,7 @@ struct EditorSceneFormatImporterMeshLightmapSurface {
 	Ref<Material> material;
 	LocalVector<SurfaceTool::Vertex> vertices;
 	Mesh::PrimitiveType primitive = Mesh::PrimitiveType::PRIMITIVE_MAX;
-	uint32_t format = 0;
+	uint64_t format = 0;
 	String name;
 };
 

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -61,7 +61,7 @@ class ImporterMesh : public Resource {
 		Vector<LOD> lods;
 		Ref<Material> material;
 		String name;
-		uint32_t flags = 0;
+		uint64_t flags = 0;
 
 		struct LODComparator {
 			_FORCE_INLINE_ bool operator()(const LOD &l, const LOD &r) const {
@@ -93,7 +93,7 @@ public:
 	int get_blend_shape_count() const;
 	String get_blend_shape_name(int p_blend_shape) const;
 
-	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint32_t p_flags = 0);
+	void add_surface(Mesh::PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = Array(), const Dictionary &p_lods = Dictionary(), const Ref<Material> &p_material = Ref<Material>(), const String &p_name = String(), const uint64_t p_flags = 0);
 	int get_surface_count() const;
 
 	void set_blend_shape_mode(Mesh::BlendShapeMode p_blend_shape_mode);
@@ -108,7 +108,7 @@ public:
 	Vector<int> get_surface_lod_indices(int p_surface, int p_lod) const;
 	float get_surface_lod_size(int p_surface, int p_lod) const;
 	Ref<Material> get_surface_material(int p_surface) const;
-	uint32_t get_surface_format(int p_surface) const;
+	uint64_t get_surface_format(int p_surface) const;
 
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -350,6 +350,8 @@ private:
 		}
 	};
 
+	size_t sss = sizeof(MaterialKey);
+
 	struct ShaderData {
 		RID shader;
 		int users = 0;

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -119,7 +119,7 @@ public:
 		ARRAY_CUSTOM_MAX
 	};
 
-	enum ArrayFormat {
+	enum ArrayFormat : uint64_t {
 		ARRAY_FORMAT_VERTEX = RS::ARRAY_FORMAT_VERTEX,
 		ARRAY_FORMAT_NORMAL = RS::ARRAY_FORMAT_NORMAL,
 		ARRAY_FORMAT_TANGENT = RS::ARRAY_FORMAT_TANGENT,
@@ -151,6 +151,14 @@ public:
 		ARRAY_FLAG_USE_8_BONE_WEIGHTS = RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS,
 
 		ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY = RS::ARRAY_FLAG_USES_EMPTY_VERTEX_ARRAY,
+		ARRAY_FLAG_COMPRESS_ATTRIBUTES = RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES,
+
+		ARRAY_FLAG_FORMAT_VERSION_BASE = RS::ARRAY_FLAG_FORMAT_VERSION_BASE,
+		ARRAY_FLAG_FORMAT_VERSION_SHIFT = RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT,
+		ARRAY_FLAG_FORMAT_VERSION_1 = RS::ARRAY_FLAG_FORMAT_VERSION_1,
+		ARRAY_FLAG_FORMAT_VERSION_2 = (uint64_t)RS::ARRAY_FLAG_FORMAT_VERSION_2,
+		ARRAY_FLAG_FORMAT_CURRENT_VERSION = (uint64_t)RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION,
+		ARRAY_FLAG_FORMAT_VERSION_MASK = RS::ARRAY_FLAG_FORMAT_VERSION_MASK,
 	};
 
 	virtual int get_surface_count() const;
@@ -328,7 +336,7 @@ protected:
 public:
 	void add_surface_from_arrays(PrimitiveType p_primitive, const Array &p_arrays, const TypedArray<Array> &p_blend_shapes = TypedArray<Array>(), const Dictionary &p_lods = Dictionary(), BitField<ArrayFormat> p_flags = 0);
 
-	void add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RS::SurfaceData::LOD> &p_lods = Vector<RS::SurfaceData::LOD>());
+	void add_surface(BitField<ArrayFormat> p_format, PrimitiveType p_primitive, const Vector<uint8_t> &p_array, const Vector<uint8_t> &p_attribute_array, const Vector<uint8_t> &p_skin_array, int p_vertex_count, const Vector<uint8_t> &p_index_array, int p_index_count, const AABB &p_aabb, const Vector<uint8_t> &p_blend_shape_data = Vector<uint8_t>(), const Vector<AABB> &p_bone_aabbs = Vector<AABB>(), const Vector<RS::SurfaceData::LOD> &p_lods = Vector<RS::SurfaceData::LOD>(), const Vector4 p_uv_scale = Vector4());
 
 	Array surface_get_arrays(int p_surface) const override;
 	TypedArray<Array> surface_get_blend_shape_arrays(int p_surface) const override;

--- a/scene/resources/mesh_data_tool.compat.inc
+++ b/scene/resources/mesh_data_tool.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  mesh_data_tool.compat.inc                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error MeshDataTool::commit_to_surface_bind_compat_81138(const Ref<ArrayMesh> &p_mesh) {
+	return commit_to_surface(p_mesh, 0);
+}
+
+void MeshDataTool::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("commit_to_surface", "mesh"), &MeshDataTool::commit_to_surface_bind_compat_81138);
+}
+
+#endif

--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "mesh_data_tool.h"
+#include "mesh_data_tool.compat.inc"
 
 void MeshDataTool::clear() {
 	vertices.clear();
@@ -190,7 +191,7 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 	return OK;
 }
 
-Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh) {
+Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh, uint64_t p_compression_flags) {
 	ERR_FAIL_COND_V(p_mesh.is_null(), ERR_INVALID_PARAMETER);
 	Array arr;
 	arr.resize(Mesh::ARRAY_MAX);
@@ -327,13 +328,13 @@ Error MeshDataTool::commit_to_surface(const Ref<ArrayMesh> &p_mesh) {
 
 	Ref<ArrayMesh> ncmesh = p_mesh;
 	int sc = ncmesh->get_surface_count();
-	ncmesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arr);
+	ncmesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arr, TypedArray<Array>(), Dictionary(), p_compression_flags);
 	ncmesh->surface_set_material(sc, material);
 
 	return OK;
 }
 
-int MeshDataTool::get_format() const {
+uint64_t MeshDataTool::get_format() const {
 	return format;
 }
 
@@ -521,7 +522,7 @@ void MeshDataTool::set_material(const Ref<Material> &p_material) {
 void MeshDataTool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &MeshDataTool::clear);
 	ClassDB::bind_method(D_METHOD("create_from_surface", "mesh", "surface"), &MeshDataTool::create_from_surface);
-	ClassDB::bind_method(D_METHOD("commit_to_surface", "mesh"), &MeshDataTool::commit_to_surface);
+	ClassDB::bind_method(D_METHOD("commit_to_surface", "mesh", "compression_flags"), &MeshDataTool::commit_to_surface, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("get_format"), &MeshDataTool::get_format);
 

--- a/scene/resources/mesh_data_tool.h
+++ b/scene/resources/mesh_data_tool.h
@@ -36,7 +36,7 @@
 class MeshDataTool : public RefCounted {
 	GDCLASS(MeshDataTool, RefCounted);
 
-	int format = 0;
+	uint64_t format = 0;
 	struct Vertex {
 		Vector3 vertex;
 		Color color;
@@ -74,12 +74,17 @@ class MeshDataTool : public RefCounted {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error commit_to_surface_bind_compat_81138(const Ref<ArrayMesh> &p_mesh);
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	void clear();
 	Error create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surface);
-	Error commit_to_surface(const Ref<ArrayMesh> &p_mesh);
+	Error commit_to_surface(const Ref<ArrayMesh> &p_mesh, uint64_t p_compression_flags = 0);
 
-	int get_format() const;
+	uint64_t get_format() const;
 
 	int get_vertex_count() const;
 	int get_edge_count() const;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -422,7 +422,7 @@ Array SurfaceTool::commit_to_arrays() {
 	a.resize(Mesh::ARRAY_MAX);
 
 	for (int i = 0; i < Mesh::ARRAY_MAX; i++) {
-		if (!(format & (1 << i))) {
+		if (!(format & (1ULL << i))) {
 			continue; //not in format
 		}
 
@@ -711,7 +711,7 @@ Array SurfaceTool::commit_to_arrays() {
 	return a;
 }
 
-Ref<ArrayMesh> SurfaceTool::commit(const Ref<ArrayMesh> &p_existing, uint32_t p_compress_flags) {
+Ref<ArrayMesh> SurfaceTool::commit(const Ref<ArrayMesh> &p_existing, uint64_t p_compress_flags) {
 	Ref<ArrayMesh> mesh;
 	if (p_existing.is_valid()) {
 		mesh = p_existing;
@@ -787,7 +787,7 @@ void SurfaceTool::deindex() {
 	index_array.clear();
 }
 
-void SurfaceTool::_create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat) {
+void SurfaceTool::_create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
 	ERR_FAIL_NULL_MSG(p_existing, "First argument in SurfaceTool::_create_list() must be a valid object of type Mesh");
 
 	Array arr = p_existing->surface_get_arrays(p_surface);
@@ -798,7 +798,7 @@ void SurfaceTool::_create_list(const Ref<Mesh> &p_existing, int p_surface, Local
 const uint32_t SurfaceTool::custom_mask[RS::ARRAY_CUSTOM_COUNT] = { Mesh::ARRAY_FORMAT_CUSTOM0, Mesh::ARRAY_FORMAT_CUSTOM1, Mesh::ARRAY_FORMAT_CUSTOM2, Mesh::ARRAY_FORMAT_CUSTOM3 };
 const uint32_t SurfaceTool::custom_shift[RS::ARRAY_CUSTOM_COUNT] = { Mesh::ARRAY_FORMAT_CUSTOM0_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM1_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM2_SHIFT, Mesh::ARRAY_FORMAT_CUSTOM3_SHIFT };
 
-void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<SurfaceTool::Vertex> &ret, uint32_t *r_format) {
+void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<SurfaceTool::Vertex> &ret, uint64_t *r_format) {
 	ret.clear();
 
 	Vector<Vector3> varr = p_arrays[RS::ARRAY_VERTEX];
@@ -927,7 +927,7 @@ void SurfaceTool::create_vertex_array_from_triangle_arrays(const Array &p_arrays
 	}
 }
 
-void SurfaceTool::_create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat) {
+void SurfaceTool::_create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat) {
 	create_vertex_array_from_triangle_arrays(arr, *r_vertex, &lformat);
 	ERR_FAIL_COND(r_vertex->size() == 0);
 
@@ -1020,7 +1020,7 @@ void SurfaceTool::append_from(const Ref<Mesh> &p_existing, int p_surface, const 
 		format = 0;
 	}
 
-	uint32_t nformat = 0;
+	uint64_t nformat = 0;
 	LocalVector<Vertex> nvertices;
 	LocalVector<int> nindices;
 	_create_list(p_existing, p_surface, &nvertices, &nindices, nformat);

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -136,7 +136,7 @@ private:
 	bool begun = false;
 	bool first = false;
 	Mesh::PrimitiveType primitive = Mesh::PRIMITIVE_LINES;
-	uint32_t format = 0;
+	uint64_t format = 0;
 	Ref<Material> material;
 	//arrays
 	LocalVector<Vertex> vertex_array;
@@ -158,8 +158,8 @@ private:
 
 	CustomFormat last_custom_format[RS::ARRAY_CUSTOM_COUNT];
 
-	void _create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat);
-	void _create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint32_t &lformat);
+	void _create_list_from_arrays(Array arr, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat);
+	void _create_list(const Ref<Mesh> &p_existing, int p_surface, LocalVector<Vertex> *r_vertex, LocalVector<int> *r_index, uint64_t &lformat);
 
 	//mikktspace callbacks
 	static int mikktGetNumFaces(const SMikkTSpaceContext *pContext);
@@ -219,12 +219,12 @@ public:
 	LocalVector<Vertex> &get_vertex_array() { return vertex_array; }
 
 	void create_from_triangle_arrays(const Array &p_arrays);
-	static void create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<Vertex> &ret, uint32_t *r_format = nullptr);
+	static void create_vertex_array_from_triangle_arrays(const Array &p_arrays, LocalVector<Vertex> &ret, uint64_t *r_format = nullptr);
 	Array commit_to_arrays();
 	void create_from(const Ref<Mesh> &p_existing, int p_surface);
 	void create_from_blend_shape(const Ref<Mesh> &p_existing, int p_surface, const String &p_blend_shape_name);
 	void append_from(const Ref<Mesh> &p_existing, int p_surface, const Transform3D &p_xform);
-	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint32_t p_compress_flags = 0);
+	Ref<ArrayMesh> commit(const Ref<ArrayMesh> &p_existing = Ref<ArrayMesh>(), uint64_t p_compress_flags = 0);
 
 	SurfaceTool();
 };

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -298,6 +298,9 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 			uint32_t gi_offset; //GI information when using lightmapping (VCT or lightmap index)
 			uint32_t layer_mask;
 			float lightmap_uv_scale[4];
+			float compressed_aabb_position[4];
+			float compressed_aabb_size[4];
+			float uv_scale[4];
 		};
 
 		UBO ubo;
@@ -479,7 +482,7 @@ class RenderForwardClustered : public RendererSceneRenderRD {
 
 		virtual void _mark_dirty() override;
 
-		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabbb) override;
+		virtual void set_transform(const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabb) override;
 		virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;
 		virtual void set_lightmap_capture(const Color *p_sh9) override;
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -142,7 +142,7 @@ public:
 
 		bool valid = false;
 		RID version;
-		uint32_t vertex_input_mask = 0;
+		uint64_t vertex_input_mask = 0;
 		PipelineCacheRD pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][PIPELINE_VERSION_MAX];
 		PipelineCacheRD color_pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][PIPELINE_COLOR_PASS_FLAG_COUNT];
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -202,9 +202,9 @@ private:
 
 	void _update_render_base_uniform_set(const RendererRD::MaterialStorage::Samplers &p_samplers);
 
+	void _update_instance_data_buffer(RenderListType p_render_list);
+	void _fill_instance_data(RenderListType p_render_list, uint32_t p_offset = 0, int32_t p_max_elements = -1, bool p_update_buffer = true);
 	void _fill_render_list(RenderListType p_render_list, const RenderDataRD *p_render_data, PassMode p_pass_mode, bool p_append = false);
-	void _fill_element_info(RenderListType p_render_list, uint32_t p_offset = 0, int32_t p_max_elements = -1);
-	// void _update_instance_data_buffer(RenderListType p_render_list);
 
 	void _setup_environment(const RenderDataRD *p_render_data, bool p_no_fog, const Size2i &p_screen_size, bool p_flip_y, const Color &p_default_bg_color, bool p_opaque_render_buffers = false, bool p_pancake_shadows = false, int p_index = 0);
 	void _setup_lightmaps(const RenderDataRD *p_render_data, const PagedArray<RID> &p_lightmaps, const Transform3D &p_cam_transform);
@@ -228,6 +228,32 @@ private:
 
 	struct SceneState {
 		LocalVector<RID> uniform_buffers;
+
+		struct PushConstant {
+			float uv_offset[2];
+			uint32_t base_index;
+			uint32_t pad;
+		};
+
+		struct InstanceData {
+			float transform[16];
+			uint32_t flags;
+			uint32_t instance_uniforms_ofs; // Base offset in global buffer for instance variables.
+			uint32_t gi_offset; // GI information when using lightmapping (VCT or lightmap index).
+			uint32_t layer_mask = 1;
+			float lightmap_uv_scale[4]; // Doubles as uv_offset when needed.
+			uint32_t reflection_probes[2]; // Packed reflection probes.
+			uint32_t omni_lights[2]; // Packed omni lights.
+			uint32_t spot_lights[2]; // Packed spot lights.
+			uint32_t decals[2]; // Packed spot lights.
+			float compressed_aabb_position[4];
+			float compressed_aabb_size[4];
+			float uv_scale[4];
+		};
+
+		RID instance_buffer[RENDER_LIST_MAX];
+		uint32_t instance_buffer_size[RENDER_LIST_MAX] = { 0, 0, 0 };
+		LocalVector<InstanceData> instance_data[RENDER_LIST_MAX];
 
 		// !BAS! We need to change lightmaps, we're not going to do this with a buffer but pushing the used lightmap in
 		LightmapData lightmaps[MAX_LIGHTMAPS];
@@ -447,27 +473,11 @@ protected:
 
 	class GeometryInstanceForwardMobile : public RenderGeometryInstanceBase {
 	public:
-		// this structure maps to our push constant in our shader and is populated right before our draw call
-		struct PushConstant {
-			float transform[16];
-			uint32_t flags;
-			uint32_t instance_uniforms_ofs; //base offset in global buffer for instance variables
-			uint32_t gi_offset; //GI information when using lightmapping (VCT or lightmap index)
-			uint32_t layer_mask = 1;
-			float lightmap_uv_scale[4]; // doubles as uv_offset when needed
-			uint32_t reflection_probes[2]; // packed reflection probes
-			uint32_t omni_lights[2]; // packed omni lights
-			uint32_t spot_lights[2]; // packed spot lights
-			uint32_t decals[2]; // packed spot lights
-		};
-
-		// PushConstant push_constant; // we populate this from our instance data
-
 		//used during rendering
 		RID transforms_uniform_set;
 		bool use_projector = false;
 		bool use_soft_shadow = false;
-		bool store_transform_cache = true; // if true we copy our transform into our PushConstant, if false we use our transforms UBO and clear our PushConstants transform
+		bool store_transform_cache = true; // If true we copy our transform into our per-draw buffer, if false we use our transforms UBO and clear our per-draw transform.
 		uint32_t instance_count = 0;
 		uint32_t trail_steps = 1;
 
@@ -534,11 +544,11 @@ protected:
 		virtual void free_forward_id(RendererRD::ForwardIDType p_type, RendererRD::ForwardID p_id) override;
 		virtual void map_forward_id(RendererRD::ForwardIDType p_type, RendererRD::ForwardID p_id, uint32_t p_index) override;
 		virtual bool uses_forward_ids() const override { return true; }
-
-		void fill_push_constant_instance_indices(GeometryInstanceForwardMobile::PushConstant *p_push_constant, uint32_t &spec_constants, const GeometryInstanceForwardMobile *p_instance);
 	};
 
 	ForwardIDStorageMobile *forward_id_storage_mobile = nullptr;
+
+	void fill_push_constant_instance_indices(SceneState::InstanceData *p_instance_data, const GeometryInstanceForwardMobile *p_instance);
 
 	virtual RendererRD::ForwardIDStorage *create_forward_id_storage() override {
 		forward_id_storage_mobile = memnew(ForwardIDStorageMobile);

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -620,7 +620,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
-		actions.instance_uniform_index_variable = "draw_call.instance_uniforms_ofs";
+		actions.instance_uniform_index_variable = "instances.data[instance_index].instance_uniforms_ofs";
 
 		actions.apply_luminance_multiplier = true; // apply luminance multiplier to screen texture
 		actions.check_multiview_samplers = RendererCompositorRD::get_singleton()->is_xr_enabled(); // Make sure we check sampling multiview textures.

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -97,7 +97,7 @@ public:
 
 		bool valid = false;
 		RID version;
-		uint32_t vertex_input_mask = 0;
+		uint64_t vertex_input_mask = 0;
 		PipelineCacheRD pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][SHADER_VERSION_MAX];
 
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.h
@@ -91,7 +91,7 @@ public:
 		return result;
 	}
 
-	_FORCE_INLINE_ uint32_t get_vertex_input_mask() {
+	_FORCE_INLINE_ uint64_t get_vertex_input_mask() {
 		if (input_mask == 0) {
 			ERR_FAIL_COND_V(shader.is_null(), 0);
 			input_mask = RD::get_singleton()->shader_get_vertex_input_attribute_mask(shader);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -894,7 +894,7 @@ void RendererCanvasRenderRD::_render_item(RD::DrawListID p_draw_list, RID p_rend
 					RS::PrimitiveType primitive = mesh_storage->mesh_surface_get_primitive(surface);
 					ERR_CONTINUE(primitive < 0 || primitive >= RS::PRIMITIVE_MAX);
 
-					uint32_t input_mask = pipeline_variants->variants[light_mode][variant[primitive]].get_vertex_input_mask();
+					uint64_t input_mask = pipeline_variants->variants[light_mode][variant[primitive]].get_vertex_input_mask();
 
 					RID vertex_array;
 					RD::VertexFormatID vertex_format = RD::INVALID_FORMAT_ID;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -10,21 +10,17 @@
 
 /* INPUT ATTRIBS */
 
-layout(location = 0) in vec3 vertex_attrib;
+// Always contains vertex position in XYZ, can contain tangent angle in W.
+layout(location = 0) in vec4 vertex_angle_attrib;
 
 //only for pure render depth when normal is not used
 
-#ifdef NORMAL_USED
-layout(location = 1) in vec2 normal_attrib;
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+// Contains Normal/Axis in RG, can contain tangent in BA.
+layout(location = 1) in vec4 axis_tangent_attrib;
 #endif
 
-#if !defined(TANGENT_USED) && (defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED))
-#define TANGENT_USED
-#endif
-
-#ifdef TANGENT_USED
-layout(location = 2) in vec2 tangent_attrib;
-#endif
+// Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
@@ -63,15 +59,12 @@ layout(location = 11) in vec4 weight_attrib;
 #endif
 
 #ifdef MOTION_VECTORS
-layout(location = 12) in vec3 previous_vertex_attrib;
+layout(location = 12) in vec4 previous_vertex_attrib;
 
-#ifdef NORMAL_USED
-layout(location = 13) in vec2 previous_normal_attrib;
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+layout(location = 13) in vec4 previous_normal_attrib;
 #endif
 
-#ifdef TANGENT_USED
-layout(location = 14) in vec2 previous_tangent_attrib;
-#endif
 #endif // MOTION_VECTORS
 
 vec3 oct_to_vec3(vec2 e) {
@@ -79,6 +72,16 @@ vec3 oct_to_vec3(vec2 e) {
 	float t = max(-v.z, 0.0);
 	v.xy += t * -sign(v.xy);
 	return normalize(v);
+}
+
+void axis_angle_to_tbn(vec3 axis, float angle, out vec3 tangent, out vec3 binormal, out vec3 normal) {
+	float c = cos(angle);
+	float s = sin(angle);
+	vec3 omc_axis = (1.0 - c) * axis;
+	vec3 s_axis = s * axis;
+	tangent = omc_axis.xxx * axis + vec3(c, -s_axis.z, s_axis.y);
+	binormal = omc_axis.yyy * axis + vec3(s_axis.z, c, -s_axis.x);
+	normal = omc_axis.zzz * axis + vec3(-s_axis.y, s_axis.x, c);
 }
 
 /* Varyings */
@@ -179,10 +182,11 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 
 void vertex_shader(vec3 vertex_input,
 #ifdef NORMAL_USED
-		in vec2 normal_input,
+		in vec3 normal_input,
 #endif
 #ifdef TANGENT_USED
-		in vec2 tangent_input,
+		in vec3 tangent_input,
+		in vec3 binormal_input,
 #endif
 		in uint instance_index, in bool is_multimesh, in uint multimesh_offset, in SceneData scene_data, in mat4 model_matrix, out vec4 screen_pos) {
 	vec4 instance_custom = vec4(0.0);
@@ -314,14 +318,12 @@ void vertex_shader(vec3 vertex_input,
 
 	vec3 vertex = vertex_input;
 #ifdef NORMAL_USED
-	vec3 normal = oct_to_vec3(normal_input * 2.0 - 1.0);
+	vec3 normal = normal_input;
 #endif
 
 #ifdef TANGENT_USED
-	vec2 signed_tangent_input = tangent_input * 2.0 - 1.0;
-	vec3 tangent = oct_to_vec3(vec2(signed_tangent_input.x, abs(signed_tangent_input.y) * 2.0 - 1.0));
-	float binormalf = sign(signed_tangent_input.y);
-	vec3 binormal = normalize(cross(normal, tangent) * binormalf);
+	vec3 tangent = tangent_input;
+	vec3 binormal = binormal_input;
 #endif
 
 #ifdef UV_USED
@@ -331,6 +333,17 @@ void vertex_shader(vec3 vertex_input,
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
 #endif
+
+	vec4 uv_scale = instances.data[instance_index].uv_scale;
+
+	if (uv_scale != vec4(0.0)) { // Compression enabled
+#ifdef UV_USED
+		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
+#endif
+#if defined(UV2_USED) || defined(USE_LIGHTMAP)
+		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
+#endif
+	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position;
@@ -484,6 +497,46 @@ void vertex_shader(vec3 vertex_input,
 #endif
 }
 
+void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position, vec3 p_compressed_aabb_size,
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+		vec4 p_normal_in,
+#ifdef NORMAL_USED
+		out vec3 r_normal,
+#endif
+		out vec3 r_tangent,
+		out vec3 r_binormal,
+#endif
+		out vec3 r_vertex) {
+
+	r_vertex = p_vertex_in.xyz * p_compressed_aabb_size + p_compressed_aabb_position;
+#ifdef NORMAL_USED
+	r_normal = oct_to_vec3(p_normal_in.xy * 2.0 - 1.0);
+#endif
+
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+
+	float binormal_sign;
+
+	// This works because the oct value (0, 1) maps onto (0, 0, -1) which encodes to (1, 1).
+	// Accordingly, if p_normal_in.z contains octahedral values, it won't equal (0, 1).
+	if (p_normal_in.z > 0.0 || p_normal_in.w < 1.0) {
+		// Uncompressed format.
+		vec2 signed_tangent_attrib = p_normal_in.zw * 2.0 - 1.0;
+		r_tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
+		binormal_sign = sign(signed_tangent_attrib.y);
+		r_binormal = normalize(cross(r_normal, r_tangent) * binormal_sign);
+	} else {
+		// Compressed format.
+		float angle = p_vertex_in.w;
+		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
+		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
+		vec3 axis = r_normal;
+		axis_angle_to_tbn(axis, angle, r_tangent, r_binormal, r_normal);
+		r_binormal *= binormal_sign;
+	}
+#endif
+}
+
 void main() {
 	uint instance_index = draw_call.instance_index;
 
@@ -498,13 +551,38 @@ void main() {
 
 #ifdef MOTION_VECTORS
 	// Previous vertex.
-	global_time = scene_data_block.prev_data.time;
-	vertex_shader(previous_vertex_attrib,
+	vec3 prev_vertex;
 #ifdef NORMAL_USED
+	vec3 prev_normal;
+#endif
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+	vec3 prev_tangent;
+	vec3 prev_binormal;
+#endif
+
+	_unpack_vertex_attributes(
+			previous_vertex_attrib,
+			instances.data[instance_index].compressed_aabb_position_pad.xyz,
+			instances.data[instance_index].compressed_aabb_size_pad.xyz,
+
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
 			previous_normal_attrib,
+#ifdef NORMAL_USED
+			prev_normal,
+#endif
+			prev_tangent,
+			prev_binormal,
+#endif
+			prev_vertex);
+
+	global_time = scene_data_block.prev_data.time;
+	vertex_shader(prev_vertex,
+#ifdef NORMAL_USED
+			prev_normal,
 #endif
 #ifdef TANGENT_USED
-			previous_tangent_attrib,
+			prev_tangent,
+			prev_binormal,
 #endif
 			instance_index, is_multimesh, draw_call.multimesh_motion_vectors_previous_offset, scene_data_block.prev_data, instances.data[instance_index].prev_transform, prev_screen_position);
 #else
@@ -512,14 +590,38 @@ void main() {
 	vec4 screen_position;
 #endif
 
+	vec3 vertex;
+#ifdef NORMAL_USED
+	vec3 normal;
+#endif
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+	vec3 tangent;
+	vec3 binormal;
+#endif
+
+	_unpack_vertex_attributes(
+			vertex_angle_attrib,
+			instances.data[instance_index].compressed_aabb_position_pad.xyz,
+			instances.data[instance_index].compressed_aabb_size_pad.xyz,
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+			axis_tangent_attrib,
+#ifdef NORMAL_USED
+			normal,
+#endif
+			tangent,
+			binormal,
+#endif
+			vertex);
+
 	// Current vertex.
 	global_time = scene_data_block.data.time;
-	vertex_shader(vertex_attrib,
+	vertex_shader(vertex,
 #ifdef NORMAL_USED
-			normal_attrib,
+			normal,
 #endif
 #ifdef TANGENT_USED
-			tangent_attrib,
+			tangent,
+			binormal,
 #endif
 			instance_index, is_multimesh, draw_call.multimesh_motion_vectors_current_offset, scene_data_block.data, model_matrix, screen_position);
 }
@@ -573,10 +675,6 @@ layout(location = 3) in vec2 uv_interp;
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) in vec2 uv2_interp;
-#endif
-
-#if !defined(TANGENT_USED) && (defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED))
-#define TANGENT_USED
 #endif
 
 #ifdef TANGENT_USED

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -28,6 +28,10 @@
 #endif
 #endif
 
+#if !defined(TANGENT_USED) && (defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED))
+#define TANGENT_USED
+#endif
+
 layout(push_constant, std430) uniform DrawCall {
 	uint instance_index;
 	uint uv_offset;
@@ -211,6 +215,9 @@ struct InstanceData {
 	uint gi_offset; //GI information when using lightmapping (VCT or lightmap index)
 	uint layer_mask;
 	vec4 lightmap_uv_scale;
+	vec4 compressed_aabb_position_pad; // Only .xyz is used. .w is padding.
+	vec4 compressed_aabb_size_pad; // Only .xyz is used. .w is padding.
+	vec4 uv_scale;
 };
 
 layout(set = 1, binding = 2, std430) buffer restrict readonly InstanceDataBuffer {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -11,17 +11,17 @@
 
 /* INPUT ATTRIBS */
 
-layout(location = 0) in vec3 vertex_attrib;
+// Always contains vertex position in XYZ, can contain tangent angle in W.
+layout(location = 0) in vec4 vertex_angle_attrib;
 
 //only for pure render depth when normal is not used
 
 #ifdef NORMAL_USED
-layout(location = 1) in vec2 normal_attrib;
+// Contains Normal/Axis in RG, can contain tangent in BA.
+layout(location = 1) in vec4 axis_tangent_attrib;
 #endif
 
-#if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-layout(location = 2) in vec2 tangent_attrib;
-#endif
+// Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
@@ -64,6 +64,16 @@ vec3 oct_to_vec3(vec2 e) {
 	float t = max(-v.z, 0.0);
 	v.xy += t * -sign(v.xy);
 	return normalize(v);
+}
+
+void axis_angle_to_tbn(vec3 axis, float angle, out vec3 tangent, out vec3 binormal, out vec3 normal) {
+	float c = cos(angle);
+	float s = sin(angle);
+	vec3 omc_axis = (1.0 - c) * axis;
+	vec3 s_axis = s * axis;
+	tangent = omc_axis.xxx * axis + vec3(c, -s_axis.z, s_axis.y);
+	binormal = omc_axis.yyy * axis + vec3(s_axis.z, c, -s_axis.x);
+	normal = omc_axis.zzz * axis + vec3(-s_axis.y, s_axis.x, c);
 }
 
 /* Varyings */
@@ -162,9 +172,9 @@ void main() {
 	color_interp = color_attrib;
 #endif
 
-	bool is_multimesh = bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH);
+	bool is_multimesh = bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH);
 
-	mat4 model_matrix = draw_call.transform;
+	mat4 model_matrix = instances.data[draw_call.instance_index].transform;
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
 #ifdef USE_DOUBLE_PRECISION
 	vec3 model_precision = vec3(model_matrix[0][3], model_matrix[1][3], model_matrix[2][3]);
@@ -178,7 +188,7 @@ void main() {
 #endif
 
 	mat3 model_normal_matrix;
-	if (bool(draw_call.flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
+	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
 		model_normal_matrix = transpose(inverse(mat3(model_matrix)));
 	} else {
 		model_normal_matrix = mat3(model_matrix);
@@ -191,7 +201,7 @@ void main() {
 		//multimesh, instances are for it
 
 #ifdef USE_PARTICLE_TRAILS
-		uint trail_size = (draw_call.flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
+		uint trail_size = (instances.data[draw_call.instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
 		uint stride = 3 + 1 + 1; //particles always uses this format
 
 		uint offset = trail_size * stride * gl_InstanceIndex;
@@ -238,22 +248,22 @@ void main() {
 		uint stride = 0;
 		{
 			//TODO implement a small lookup table for the stride
-			if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_FORMAT_2D)) {
+			if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_FORMAT_2D)) {
 				stride += 2;
 			} else {
 				stride += 3;
 			}
-			if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_HAS_COLOR)) {
+			if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_HAS_COLOR)) {
 				stride += 1;
 			}
-			if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA)) {
+			if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA)) {
 				stride += 1;
 			}
 		}
 
 		uint offset = stride * gl_InstanceIndex;
 
-		if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_FORMAT_2D)) {
+		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_FORMAT_2D)) {
 			matrix = mat4(transforms.data[offset + 0], transforms.data[offset + 1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
 			offset += 2;
 		} else {
@@ -261,14 +271,14 @@ void main() {
 			offset += 3;
 		}
 
-		if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_HAS_COLOR)) {
+		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_HAS_COLOR)) {
 #ifdef COLOR_USED
 			color_interp *= transforms.data[offset];
 #endif
 			offset += 1;
 		}
 
-		if (bool(draw_call.flags & INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA)) {
+		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA)) {
 			instance_custom = transforms.data[offset];
 		}
 
@@ -287,16 +297,31 @@ void main() {
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
-	vec3 vertex = vertex_attrib;
+	vec3 vertex = vertex_angle_attrib.xyz * instances.data[draw_call.instance_index].compressed_aabb_size_pad.xyz + instances.data[draw_call.instance_index].compressed_aabb_position_pad.xyz;
 #ifdef NORMAL_USED
-	vec3 normal = oct_to_vec3(normal_attrib * 2.0 - 1.0);
+	vec3 normal = oct_to_vec3(axis_tangent_attrib.xy * 2.0 - 1.0);
 #endif
 
-#if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	vec2 signed_tangent_attrib = tangent_attrib * 2.0 - 1.0;
-	vec3 tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
-	float binormalf = sign(signed_tangent_attrib.y);
-	vec3 binormal = normalize(cross(normal, tangent) * binormalf);
+#if defined(NORMAL_USED) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
+
+	vec3 binormal;
+	float binormal_sign;
+	vec3 tangent;
+	if (axis_tangent_attrib.z > 0.0 || axis_tangent_attrib.w < 1.0) {
+		// Uncompressed format.
+		vec2 signed_tangent_attrib = axis_tangent_attrib.zw * 2.0 - 1.0;
+		tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
+		binormal_sign = sign(signed_tangent_attrib.y);
+		binormal = normalize(cross(normal, tangent) * binormal_sign);
+	} else {
+		// Compressed format.
+		float angle = vertex_angle_attrib.w;
+		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
+		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
+		vec3 axis = normal;
+		axis_angle_to_tbn(axis, angle, tangent, binormal, normal);
+		binormal *= binormal_sign;
+	}
 #endif
 
 #ifdef UV_USED
@@ -306,6 +331,17 @@ void main() {
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
 #endif
+
+	vec4 uv_scale = instances.data[draw_call.instance_index].uv_scale;
+
+	if (uv_scale != vec4(0.0)) { // Compression enabled
+#ifdef UV_USED
+		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
+#endif
+#if defined(UV2_USED) || defined(USE_LIGHTMAP)
+		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
+#endif
+	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position;
@@ -441,8 +477,7 @@ void main() {
 #endif // MODE_RENDER_DEPTH
 #ifdef MODE_RENDER_MATERIAL
 	if (scene_data.material_uv2_mode) {
-		vec2 uv_offset = draw_call.lightmap_uv_scale.xy; // we are abusing lightmap_uv_scale here, we shouldn't have a lightmap during a depth pass...
-		gl_Position.xy = (uv2_attrib.xy + uv_offset) * 2.0 - 1.0;
+		gl_Position.xy = (uv2_attrib.xy + draw_call.uv_offset) * 2.0 - 1.0;
 		gl_Position.z = 0.00001;
 		gl_Position.w = 1.0;
 	}
@@ -765,7 +800,7 @@ void main() {
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
-	mat4 read_model_matrix = draw_call.transform;
+	mat4 read_model_matrix = instances.data[draw_call.instance_index].transform;
 #ifdef USE_DOUBLE_PRECISION
 	read_model_matrix[0][3] = 0.0;
 	read_model_matrix[1][3] = 0.0;
@@ -890,11 +925,11 @@ void main() {
 	if (!sc_disable_decals) { //Decals
 		// must implement
 
-		uint decal_indices = draw_call.decals.x;
+		uint decal_indices = instances.data[draw_call.instance_index].decals.x;
 		for (uint i = 0; i < 8; i++) {
 			uint decal_index = decal_indices & 0xFF;
 			if (i == 3) {
-				decal_indices = draw_call.decals.y;
+				decal_indices = instances.data[draw_call.instance_index].decals.y;
 			} else {
 				decal_indices = decal_indices >> 8;
 			}
@@ -903,7 +938,7 @@ void main() {
 				break;
 			}
 
-			if (!bool(decals.data[decal_index].mask & draw_call.layer_mask)) {
+			if (!bool(decals.data[decal_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
 				continue; //not masked
 			}
 
@@ -1097,8 +1132,8 @@ void main() {
 #ifdef USE_LIGHTMAP
 
 	//lightmap
-	if (bool(draw_call.flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
-		uint index = draw_call.gi_offset;
+	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
+		uint index = instances.data[draw_call.instance_index].gi_offset;
 
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
 		const float c1 = 0.429043;
@@ -1118,12 +1153,12 @@ void main() {
 								 2.0 * c2 * lightmap_captures.data[index].sh[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 
-	} else if (bool(draw_call.flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
-		bool uses_sh = bool(draw_call.flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
-		uint ofs = draw_call.gi_offset & 0xFFFF;
-		uint slice = draw_call.gi_offset >> 16;
+	} else if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
+		bool uses_sh = bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
+		uint ofs = instances.data[draw_call.instance_index].gi_offset & 0xFFFF;
+		uint slice = instances.data[draw_call.instance_index].gi_offset >> 16;
 		vec3 uvw;
-		uvw.xy = uv2 * draw_call.lightmap_uv_scale.zw + draw_call.lightmap_uv_scale.xy;
+		uvw.xy = uv2 * instances.data[draw_call.instance_index].lightmap_uv_scale.zw + instances.data[draw_call.instance_index].lightmap_uv_scale.xy;
 		uvw.z = float(slice);
 
 		if (uses_sh) {
@@ -1162,7 +1197,7 @@ void main() {
 		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
 		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
 
-		uint reflection_indices = draw_call.reflection_probes.x;
+		uint reflection_indices = instances.data[draw_call.instance_index].reflection_probes.x;
 
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1179,7 +1214,7 @@ void main() {
 		for (uint i = 0; i < 8; i++) {
 			uint reflection_index = reflection_indices & 0xFF;
 			if (i == 3) {
-				reflection_indices = draw_call.reflection_probes.y;
+				reflection_indices = instances.data[draw_call.instance_index].reflection_probes.y;
 			} else {
 				reflection_indices = reflection_indices >> 8;
 			}
@@ -1260,7 +1295,7 @@ void main() {
 				break;
 			}
 
-			if (!bool(directional_lights.data[i].mask & draw_call.layer_mask)) {
+			if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
 				continue; //not masked
 			}
 
@@ -1532,7 +1567,7 @@ void main() {
 				break;
 			}
 
-			if (!bool(directional_lights.data[i].mask & draw_call.layer_mask)) {
+			if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
 				continue; //not masked
 			}
 
@@ -1601,11 +1636,11 @@ void main() {
 	} //directional light
 
 	if (!sc_disable_omni_lights) { //omni lights
-		uint light_indices = draw_call.omni_lights.x;
+		uint light_indices = instances.data[draw_call.instance_index].omni_lights.x;
 		for (uint i = 0; i < 8; i++) {
 			uint light_index = light_indices & 0xFF;
 			if (i == 3) {
-				light_indices = draw_call.omni_lights.y;
+				light_indices = instances.data[draw_call.instance_index].omni_lights.y;
 			} else {
 				light_indices = light_indices >> 8;
 			}
@@ -1646,11 +1681,11 @@ void main() {
 
 	if (!sc_disable_spot_lights) { //spot lights
 
-		uint light_indices = draw_call.spot_lights.x;
+		uint light_indices = instances.data[draw_call.instance_index].spot_lights.x;
 		for (uint i = 0; i < 8; i++) {
 			uint light_index = light_indices & 0xFF;
 			if (i == 3) {
-				light_indices = draw_call.spot_lights.y;
+				light_indices = instances.data[draw_call.instance_index].spot_lights.y;
 			} else {
 				light_indices = light_indices >> 8;
 			}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -15,20 +15,11 @@
 #endif
 
 #define USING_MOBILE_RENDERER
-/* don't exceed 128 bytes!! */
-/* put instance data into our push content, not a array */
-layout(push_constant, std430) uniform DrawCall {
-	highp mat4 transform; // 64 - 64
-	uint flags; // 04 - 68
-	uint instance_uniforms_ofs; //base offset in global buffer for instance variables	// 04 - 72
-	uint gi_offset; //GI information when using lightmapping (VCT or lightmap index)    // 04 - 76
-	uint layer_mask; // 04 - 80
-	highp vec4 lightmap_uv_scale; // 16 - 96 doubles as uv_offset when needed
 
-	uvec2 reflection_probes; // 08 - 104
-	uvec2 omni_lights; // 08 - 112
-	uvec2 spot_lights; // 08 - 120
-	uvec2 decals; // 08 - 128
+layout(push_constant, std430) uniform DrawCall {
+	vec2 uv_offset;
+	uint instance_index;
+	uint pad;
 }
 draw_call;
 
@@ -122,6 +113,29 @@ layout(set = 1, binding = 0, std140) uniform SceneDataBlock {
 	SceneData prev_data;
 }
 scene_data_block;
+
+struct InstanceData {
+	highp mat4 transform; // 64 - 64
+	uint flags; // 04 - 68
+	uint instance_uniforms_ofs; // Base offset in global buffer for instance variables.	// 04 - 72
+	uint gi_offset; // GI information when using lightmapping (VCT or lightmap index).    // 04 - 76
+	uint layer_mask; // 04 - 80
+	highp vec4 lightmap_uv_scale; // 16 - 96 Doubles as uv_offset when needed.
+
+	uvec2 reflection_probes; // 08 - 104
+	uvec2 omni_lights; // 08 - 112
+	uvec2 spot_lights; // 08 - 120
+	uvec2 decals; // 08 - 128
+
+	vec4 compressed_aabb_position_pad; // 16 - 144 // Only .xyz is used. .w is padding.
+	vec4 compressed_aabb_size_pad; // 16 - 160 // Only .xyz is used. .w is padding.
+	vec4 uv_scale; // 16 - 176
+};
+
+layout(set = 1, binding = 1, std430) buffer restrict readonly InstanceDataBuffer {
+	InstanceData data[];
+}
+instances;
 
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -71,7 +71,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	mat4 inv_view_matrix = scene_data_block.data.inv_view_matrix;
 
 #ifdef USING_MOBILE_RENDERER
-	mat4 read_model_matrix = draw_call.transform;
+	mat4 read_model_matrix = instances.data[draw_call.instance_index].transform;
 #else
 	mat4 read_model_matrix = instances.data[instance_index_interp].transform;
 #endif

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -270,10 +270,10 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 		uint32_t skin_stride = 0;
 
 		for (int i = 0; i < RS::ARRAY_WEIGHTS; i++) {
-			if ((p_surface.format & (1 << i))) {
+			if ((p_surface.format & (1ULL << i))) {
 				switch (i) {
 					case RS::ARRAY_VERTEX: {
-						if (p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
+						if ((p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) || (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
 							stride += sizeof(float) * 2;
 						} else {
 							stride += sizeof(float) * 3;
@@ -281,22 +281,31 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 
 					} break;
 					case RS::ARRAY_NORMAL: {
-						stride += sizeof(int32_t);
+						stride += sizeof(uint16_t) * 2;
 
 					} break;
 					case RS::ARRAY_TANGENT: {
-						stride += sizeof(int32_t);
-
+						if (!(p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+							stride += sizeof(uint16_t) * 2;
+						}
 					} break;
 					case RS::ARRAY_COLOR: {
 						attrib_stride += sizeof(uint32_t);
 					} break;
 					case RS::ARRAY_TEX_UV: {
-						attrib_stride += sizeof(float) * 2;
+						if (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+							attrib_stride += sizeof(uint16_t) * 2;
+						} else {
+							attrib_stride += sizeof(float) * 2;
+						}
 
 					} break;
 					case RS::ARRAY_TEX_UV2: {
-						attrib_stride += sizeof(float) * 2;
+						if (p_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+							attrib_stride += sizeof(uint16_t) * 2;
+						} else {
+							attrib_stride += sizeof(float) * 2;
+						}
 
 					} break;
 					case RS::ARRAY_CUSTOM0:
@@ -338,59 +347,96 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 
 #endif
 
+	uint64_t surface_version = p_surface.format & (uint64_t(RS::ARRAY_FLAG_FORMAT_VERSION_MASK) << RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT);
+	RS::SurfaceData new_surface = p_surface;
+#ifdef DISABLE_DEPRECATED
+
+	ERR_FAIL_COND_MSG(surface_version != RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION, "Surface version provided (" + itos(int(surface_version >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT)) + ") does not match current version (" + itos(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) + ")");
+
+#else
+
+	if (surface_version != uint64_t(RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION)) {
+		RS::_fix_surface_compatibility(new_surface);
+		surface_version = new_surface.format & (RS::ARRAY_FLAG_FORMAT_VERSION_MASK << RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT);
+		ERR_FAIL_COND_MSG(surface_version != RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION,
+				"Surface version provided (" +
+						itos((surface_version >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) & RS::ARRAY_FLAG_FORMAT_VERSION_MASK) +
+						") does not match current version (" +
+						itos((RS::ARRAY_FLAG_FORMAT_CURRENT_VERSION >> RS::ARRAY_FLAG_FORMAT_VERSION_SHIFT) & RS::ARRAY_FLAG_FORMAT_VERSION_MASK) +
+						")");
+	}
+#endif
+
 	Mesh::Surface *s = memnew(Mesh::Surface);
 
-	s->format = p_surface.format;
-	s->primitive = p_surface.primitive;
+	s->format = new_surface.format;
+	s->primitive = new_surface.primitive;
 
-	bool use_as_storage = (p_surface.skin_data.size() || mesh->blend_shape_count > 0);
+	bool use_as_storage = (new_surface.skin_data.size() || mesh->blend_shape_count > 0);
 
-	if (p_surface.vertex_data.size()) {
-		s->vertex_buffer = RD::get_singleton()->vertex_buffer_create(p_surface.vertex_data.size(), p_surface.vertex_data, use_as_storage);
-		s->vertex_buffer_size = p_surface.vertex_data.size();
+	if (new_surface.vertex_data.size()) {
+		// If we have an uncompressed surface that contains normals, but not tangents, we need to differentiate the array
+		// from a compressed array in the shader. To do so, we allow the the normal to read 4 components out of the buffer
+		// But only give it 2 components per normal. So essentially, each vertex reads the next normal in normal.zw.
+		// This allows us to avoid adding a shader permutation, and avoid passing dummy tangents. Since the stride is kept small
+		// this should still be a net win for bandwidth.
+		// If we do this, then the last normal will read past the end of the array. So we need to pad the array with dummy data.
+		if (!(new_surface.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && (new_surface.format & RS::ARRAY_FORMAT_NORMAL) && !(new_surface.format & RS::ARRAY_FORMAT_TANGENT)) {
+			// Unfortunately, we need to copy the buffer, which is fine as doing a resize triggers a CoW anyway.
+			Vector<uint8_t> new_vertex_data;
+			new_vertex_data.resize_zeroed(new_surface.vertex_data.size() + sizeof(uint16_t) * 2);
+			memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
+			s->vertex_buffer = RD::get_singleton()->vertex_buffer_create(new_vertex_data.size(), new_vertex_data, use_as_storage);
+			s->vertex_buffer_size = new_vertex_data.size();
+		} else {
+			s->vertex_buffer = RD::get_singleton()->vertex_buffer_create(new_surface.vertex_data.size(), new_surface.vertex_data, use_as_storage);
+			s->vertex_buffer_size = new_surface.vertex_data.size();
+		}
 	}
 
-	if (p_surface.attribute_data.size()) {
-		s->attribute_buffer = RD::get_singleton()->vertex_buffer_create(p_surface.attribute_data.size(), p_surface.attribute_data);
+	if (new_surface.attribute_data.size()) {
+		s->attribute_buffer = RD::get_singleton()->vertex_buffer_create(new_surface.attribute_data.size(), new_surface.attribute_data);
 	}
-	if (p_surface.skin_data.size()) {
-		s->skin_buffer = RD::get_singleton()->vertex_buffer_create(p_surface.skin_data.size(), p_surface.skin_data, use_as_storage);
-		s->skin_buffer_size = p_surface.skin_data.size();
+	if (new_surface.skin_data.size()) {
+		s->skin_buffer = RD::get_singleton()->vertex_buffer_create(new_surface.skin_data.size(), new_surface.skin_data, use_as_storage);
+		s->skin_buffer_size = new_surface.skin_data.size();
 	}
 
-	s->vertex_count = p_surface.vertex_count;
+	s->vertex_count = new_surface.vertex_count;
 
-	if (p_surface.format & RS::ARRAY_FORMAT_BONES) {
+	if (new_surface.format & RS::ARRAY_FORMAT_BONES) {
 		mesh->has_bone_weights = true;
 	}
 
-	if (p_surface.index_count) {
-		bool is_index_16 = p_surface.vertex_count <= 65536 && p_surface.vertex_count > 0;
+	if (new_surface.index_count) {
+		bool is_index_16 = new_surface.vertex_count <= 65536 && new_surface.vertex_count > 0;
 
-		s->index_buffer = RD::get_singleton()->index_buffer_create(p_surface.index_count, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, p_surface.index_data, false);
-		s->index_count = p_surface.index_count;
+		s->index_buffer = RD::get_singleton()->index_buffer_create(new_surface.index_count, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, new_surface.index_data, false);
+		s->index_count = new_surface.index_count;
 		s->index_array = RD::get_singleton()->index_array_create(s->index_buffer, 0, s->index_count);
-		if (p_surface.lods.size()) {
-			s->lods = memnew_arr(Mesh::Surface::LOD, p_surface.lods.size());
-			s->lod_count = p_surface.lods.size();
+		if (new_surface.lods.size()) {
+			s->lods = memnew_arr(Mesh::Surface::LOD, new_surface.lods.size());
+			s->lod_count = new_surface.lods.size();
 
-			for (int i = 0; i < p_surface.lods.size(); i++) {
-				uint32_t indices = p_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
-				s->lods[i].index_buffer = RD::get_singleton()->index_buffer_create(indices, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, p_surface.lods[i].index_data);
+			for (int i = 0; i < new_surface.lods.size(); i++) {
+				uint32_t indices = new_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
+				s->lods[i].index_buffer = RD::get_singleton()->index_buffer_create(indices, is_index_16 ? RD::INDEX_BUFFER_FORMAT_UINT16 : RD::INDEX_BUFFER_FORMAT_UINT32, new_surface.lods[i].index_data);
 				s->lods[i].index_array = RD::get_singleton()->index_array_create(s->lods[i].index_buffer, 0, indices);
-				s->lods[i].edge_length = p_surface.lods[i].edge_length;
+				s->lods[i].edge_length = new_surface.lods[i].edge_length;
 				s->lods[i].index_count = indices;
 			}
 		}
 	}
 
-	ERR_FAIL_COND_MSG(!p_surface.index_count && !p_surface.vertex_count, "Meshes must contain a vertex array, an index array, or both");
+	ERR_FAIL_COND_MSG(!new_surface.index_count && !new_surface.vertex_count, "Meshes must contain a vertex array, an index array, or both");
 
-	s->aabb = p_surface.aabb;
-	s->bone_aabbs = p_surface.bone_aabbs; //only really useful for returning them.
+	s->aabb = new_surface.aabb;
+	s->bone_aabbs = new_surface.bone_aabbs; //only really useful for returning them.
+
+	s->uv_scale = new_surface.uv_scale;
 
 	if (mesh->blend_shape_count > 0) {
-		s->blend_shape_buffer = RD::get_singleton()->storage_buffer_create(p_surface.blend_shape_data.size(), p_surface.blend_shape_data);
+		s->blend_shape_buffer = RD::get_singleton()->storage_buffer_create(new_surface.blend_shape_data.size(), new_surface.blend_shape_data);
 	}
 
 	if (use_as_storage) {
@@ -433,13 +479,13 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface)
 	}
 
 	if (mesh->surface_count == 0) {
-		mesh->aabb = p_surface.aabb;
+		mesh->aabb = new_surface.aabb;
 	} else {
-		mesh->aabb.merge_with(p_surface.aabb);
+		mesh->aabb.merge_with(new_surface.aabb);
 	}
 	mesh->skeleton_aabb_version = 0;
 
-	s->material = p_surface.material;
+	s->material = new_surface.material;
 
 	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count + 1));
 	mesh->surfaces[mesh->surface_count] = s;
@@ -545,6 +591,11 @@ RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 	sd.format = s.format;
 	if (s.vertex_buffer.is_valid()) {
 		sd.vertex_data = RD::get_singleton()->buffer_get_data(s.vertex_buffer);
+		// When using an uncompressed buffer with normals, but without tangents, we have to trim the padding.
+		if (!(s.format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && (s.format & RS::ARRAY_FORMAT_NORMAL) && !(s.format & RS::ARRAY_FORMAT_TANGENT)) {
+			Vector<uint8_t> new_vertex_data;
+			sd.vertex_data.resize(sd.vertex_data.size() - sizeof(uint16_t) * 2);
+		}
 	}
 	if (s.attribute_buffer.is_valid()) {
 		sd.attribute_data = RD::get_singleton()->buffer_get_data(s.attribute_buffer);
@@ -560,6 +611,7 @@ RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 		sd.index_data = RD::get_singleton()->buffer_get_data(s.index_buffer);
 	}
 	sd.aabb = s.aabb;
+	sd.uv_scale = s.uv_scale;
 	for (uint32_t i = 0; i < s.lod_count; i++) {
 		RS::SurfaceData::LOD lod;
 		lod.edge_length = s.lods[i].edge_length;
@@ -1016,8 +1068,10 @@ void MeshStorage::update_mesh_instances() {
 			push_constant.has_skeleton = sk != nullptr && sk->use_2d == array_is_2d && (mi->mesh->surfaces[i]->format & RS::ARRAY_FORMAT_BONES);
 			push_constant.has_blend_shape = mi->mesh->blend_shape_count > 0;
 
+			push_constant.normal_tangent_stride = (push_constant.has_normal ? 1 : 0) + (push_constant.has_tangent ? 1 : 0);
+
 			push_constant.vertex_count = mi->mesh->surfaces[i]->vertex_count;
-			push_constant.vertex_stride = (mi->mesh->surfaces[i]->vertex_buffer_size / mi->mesh->surfaces[i]->vertex_count) / 4;
+			push_constant.vertex_stride = ((mi->mesh->surfaces[i]->vertex_buffer_size / mi->mesh->surfaces[i]->vertex_count) / 4) - push_constant.normal_tangent_stride;
 			push_constant.skin_stride = (mi->mesh->surfaces[i]->skin_buffer_size / mi->mesh->surfaces[i]->vertex_count) / 4;
 			push_constant.skin_weight_offset = (mi->mesh->surfaces[i]->format & RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 4 : 2;
 
@@ -1042,7 +1096,6 @@ void MeshStorage::update_mesh_instances() {
 
 			push_constant.blend_shape_count = mi->mesh->blend_shape_count;
 			push_constant.normalized_blend_shapes = mi->mesh->blend_shape_mode == RS::BLEND_SHAPE_MODE_NORMALIZED;
-			push_constant.pad0 = 0;
 			push_constant.pad1 = 0;
 
 			RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SkeletonShader::PushConstant));
@@ -1061,11 +1114,13 @@ void MeshStorage::update_mesh_instances() {
 	RD::get_singleton()->compute_list_end();
 }
 
-void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, bool p_input_motion_vectors, MeshInstance::Surface *mis, uint32_t p_current_buffer, uint32_t p_previous_buffer) {
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_input_motion_vectors, MeshInstance::Surface *mis, uint32_t p_current_buffer, uint32_t p_previous_buffer) {
 	Vector<RD::VertexAttribute> attributes;
 	Vector<RID> buffers;
+	Vector<uint64_t> offsets;
 
-	uint32_t stride = 0;
+	uint32_t position_stride = 0;
+	uint32_t normal_tangent_stride = 0;
 	uint32_t attribute_stride = 0;
 	uint32_t skin_stride = 0;
 
@@ -1073,8 +1128,9 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 		RD::VertexAttribute vd;
 		RID buffer;
 		vd.location = i;
+		uint64_t offset = 0;
 
-		if (!(s->format & (1 << i))) {
+		if (!(s->format & (1ULL << i))) {
 			// Not supplied by surface, use default value
 			buffer = mesh_default_rd_buffers[i];
 			vd.stride = 0;
@@ -1123,14 +1179,19 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 			switch (i) {
 				case RS::ARRAY_VERTEX: {
-					vd.offset = stride;
+					vd.offset = position_stride;
 
 					if (s->format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
 						vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
-						stride += sizeof(float) * 2;
+						position_stride = sizeof(float) * 2;
 					} else {
-						vd.format = RD::DATA_FORMAT_R32G32B32_SFLOAT;
-						stride += sizeof(float) * 3;
+						if (!mis && (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+							vd.format = RD::DATA_FORMAT_R16G16B16A16_UNORM;
+							position_stride = sizeof(uint16_t) * 4;
+						} else {
+							vd.format = RD::DATA_FORMAT_R32G32B32_SFLOAT;
+							position_stride = sizeof(float) * 3;
+						}
 					}
 
 					if (mis) {
@@ -1141,10 +1202,22 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 				} break;
 				case RS::ARRAY_NORMAL: {
-					vd.offset = stride;
-					vd.format = RD::DATA_FORMAT_R16G16_UNORM;
-					stride += sizeof(uint16_t) * 2;
-
+					vd.offset = 0;
+					offset = position_stride * s->vertex_count;
+					if (!mis && (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES)) {
+						vd.format = RD::DATA_FORMAT_R16G16_UNORM;
+						normal_tangent_stride += sizeof(uint16_t) * 2;
+					} else {
+						vd.format = RD::DATA_FORMAT_R16G16B16A16_UNORM;
+						// A small trick here: if we are uncompressed and we have normals, but no tangents. We need
+						// the shader to think there are 4 components to "axis_tangent_attrib". So we give a size of 4,
+						// but a stride based on only having 2 elements.
+						if (!(s->format & RS::ARRAY_FORMAT_TANGENT)) {
+							normal_tangent_stride += sizeof(uint16_t) * 2;
+						} else {
+							normal_tangent_stride += sizeof(uint16_t) * 4;
+						}
+					}
 					if (mis) {
 						buffer = mis->vertex_buffer[p_current_buffer];
 					} else {
@@ -1152,15 +1225,9 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 					}
 				} break;
 				case RS::ARRAY_TANGENT: {
-					vd.offset = stride;
-					vd.format = RD::DATA_FORMAT_R16G16_UNORM;
-					stride += sizeof(uint16_t) * 2;
-
-					if (mis) {
-						buffer = mis->vertex_buffer[p_current_buffer];
-					} else {
-						buffer = s->vertex_buffer;
-					}
+					buffer = mesh_default_rd_buffers[i];
+					vd.stride = 0;
+					vd.format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
 				} break;
 				case RS::ARRAY_COLOR: {
 					vd.offset = attribute_stride;
@@ -1171,17 +1238,25 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 				} break;
 				case RS::ARRAY_TEX_UV: {
 					vd.offset = attribute_stride;
-
-					vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
-					attribute_stride += sizeof(float) * 2;
+					if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+						vd.format = RD::DATA_FORMAT_R16G16_UNORM;
+						attribute_stride += sizeof(uint16_t) * 2;
+					} else {
+						vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
+						attribute_stride += sizeof(float) * 2;
+					}
 					buffer = s->attribute_buffer;
 
 				} break;
 				case RS::ARRAY_TEX_UV2: {
 					vd.offset = attribute_stride;
-
-					vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
-					attribute_stride += sizeof(float) * 2;
+					if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
+						vd.format = RD::DATA_FORMAT_R16G16_UNORM;
+						attribute_stride += sizeof(uint16_t) * 2;
+					} else {
+						vd.format = RD::DATA_FORMAT_R32G32_SFLOAT;
+						attribute_stride += sizeof(float) * 2;
+					}
 					buffer = s->attribute_buffer;
 				} break;
 				case RS::ARRAY_CUSTOM0:
@@ -1216,12 +1291,13 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			}
 		}
 
-		if (!(p_input_mask & (1 << i))) {
+		if (!(p_input_mask & (1ULL << i))) {
 			continue; // Shader does not need this, skip it (but computing stride was important anyway)
 		}
 
 		attributes.push_back(vd);
 		buffers.push_back(buffer);
+		offsets.push_back(offset);
 
 		if (p_input_motion_vectors) {
 			// Since the previous vertex, normal and tangent can't be part of the vertex format but they are required when motion
@@ -1246,6 +1322,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 
 				attributes.push_back(vd);
 				buffers.push_back(buffer);
+				offsets.push_back(offset);
 			}
 		}
 	}
@@ -1256,9 +1333,10 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 			continue; //default location
 		}
 		int loc = attributes[i].location;
-
-		if ((loc < RS::ARRAY_COLOR) || ((loc >= ATTRIBUTE_LOCATION_PREV_VERTEX) && (loc <= ATTRIBUTE_LOCATION_PREV_TANGENT))) {
-			attributes.write[i].stride = stride;
+		if (loc == RS::ARRAY_VERTEX || loc == ATTRIBUTE_LOCATION_PREV_VERTEX) {
+			attributes.write[i].stride = position_stride;
+		} else if ((loc < RS::ARRAY_COLOR) || ((loc >= ATTRIBUTE_LOCATION_PREV_NORMAL) && (loc <= ATTRIBUTE_LOCATION_PREV_TANGENT))) {
+			attributes.write[i].stride = normal_tangent_stride;
 		} else if (loc < RS::ARRAY_BONES) {
 			attributes.write[i].stride = attribute_stride;
 		} else {
@@ -1271,7 +1349,7 @@ void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::V
 	v.previous_buffer = p_previous_buffer;
 	v.input_motion_vectors = p_input_motion_vectors;
 	v.vertex_format = RD::get_singleton()->vertex_format_create(attributes);
-	v.vertex_array = RD::get_singleton()->vertex_array_create(s->vertex_count, v.vertex_format, buffers);
+	v.vertex_array = RD::get_singleton()->vertex_array_create(s->vertex_count, v.vertex_format, buffers, offsets);
 }
 
 ////////////////// MULTIMESH

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -73,7 +73,7 @@ private:
 	struct Mesh {
 		struct Surface {
 			RS::PrimitiveType primitive = RS::PRIMITIVE_POINTS;
-			uint32_t format = 0;
+			uint64_t format = 0;
 
 			RID vertex_buffer;
 			RID attribute_buffer;
@@ -90,7 +90,7 @@ private:
 			// cache-efficient structure.
 
 			struct Version {
-				uint32_t input_mask = 0;
+				uint64_t input_mask = 0;
 				uint32_t current_buffer = 0;
 				uint32_t previous_buffer = 0;
 				bool input_motion_vectors = false;
@@ -119,6 +119,8 @@ private:
 			AABB aabb;
 
 			Vector<AABB> bone_aabbs;
+
+			Vector4 uv_scale;
 
 			RID blend_shape_buffer;
 
@@ -190,7 +192,7 @@ private:
 				weight_update_list(this), array_update_list(this) {}
 	};
 
-	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, bool p_input_motion_vectors, MeshInstance::Surface *mis = nullptr, uint32_t p_current_buffer = 0, uint32_t p_previous_buffer = 0);
+	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint64_t p_input_mask, bool p_input_motion_vectors, MeshInstance::Surface *mis = nullptr, uint32_t p_current_buffer = 0, uint32_t p_previous_buffer = 0);
 
 	void _mesh_instance_clear(MeshInstance *mi);
 	void _mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint32_t p_surface);
@@ -265,7 +267,7 @@ private:
 
 			uint32_t blend_shape_count;
 			uint32_t normalized_blend_shapes;
-			uint32_t pad0;
+			uint32_t normal_tangent_stride;
 			uint32_t pad1;
 			float skeleton_transform_x[2];
 			float skeleton_transform_y[2];
@@ -422,6 +424,21 @@ public:
 		return s->index_count ? s->index_count : s->vertex_count;
 	}
 
+	_FORCE_INLINE_ AABB mesh_surface_get_aabb(void *p_surface) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->aabb;
+	}
+
+	_FORCE_INLINE_ uint64_t mesh_surface_get_format(void *p_surface) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->format;
+	}
+
+	_FORCE_INLINE_ Vector4 mesh_surface_get_uv_scale(void *p_surface) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->uv_scale;
+	}
+
 	_FORCE_INLINE_ uint32_t mesh_surface_get_lod(void *p_surface, float p_model_scale, float p_distance_threshold, float p_mesh_lod_threshold, uint32_t &r_index_count) const {
 		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
 
@@ -484,7 +501,7 @@ public:
 		s->version_lock.unlock();
 	}
 
-	_FORCE_INLINE_ void mesh_instance_surface_get_vertex_arrays_and_format(RID p_mesh_instance, uint32_t p_surface_index, uint32_t p_input_mask, bool p_input_motion_vectors, RID &r_vertex_array_rd, RD::VertexFormatID &r_vertex_format) {
+	_FORCE_INLINE_ void mesh_instance_surface_get_vertex_arrays_and_format(RID p_mesh_instance, uint64_t p_surface_index, uint32_t p_input_mask, bool p_input_motion_vectors, RID &r_vertex_array_rd, RD::VertexFormatID &r_vertex_format) {
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -643,7 +643,7 @@ Error RenderingDevice::_reflect_spirv(const Vector<ShaderStageSPIRVData> &p_spir
 
 					for (uint32_t j = 0; j < iv_count; j++) {
 						if (input_vars[j] && input_vars[j]->decoration_flags == 0) { // Regular input.
-							r_reflection_data.vertex_input_mask |= (1 << uint32_t(input_vars[j]->location));
+							r_reflection_data.vertex_input_mask |= (1ULL << uint32_t(input_vars[j]->location));
 						}
 					}
 				}

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -758,7 +758,7 @@ public:
 	virtual RID shader_create_from_bytecode(const Vector<uint8_t> &p_shader_binary, RID p_placeholder = RID()) = 0;
 	virtual RID shader_create_placeholder() = 0;
 
-	virtual uint32_t shader_get_vertex_input_attribute_mask(RID p_shader) = 0;
+	virtual uint64_t shader_get_vertex_input_attribute_mask(RID p_shader) = 0;
 
 	/******************/
 	/**** UNIFORMS ****/
@@ -1371,7 +1371,7 @@ protected:
 
 	struct SpirvReflectionData {
 		BitField<ShaderStage> stages_mask;
-		uint32_t vertex_input_mask;
+		uint64_t vertex_input_mask;
 		uint32_t fragment_output_mask;
 		bool is_compute;
 		uint32_t compute_local_size[3];


### PR DESCRIPTION
This scheme is backwards compatible so old meshes will continue to work.

Users can get a performance boost by reimporting assets

The rationale behind this PR can be found here: https://files.godot.foundation/s/259N9YQEPcBZwMx

In short, the main reason behind making this PR is bandwidth reduction (passing less data around the GPU per draw call). Bandwidth reduction is valuable in two cases:
1. If the scene is bandwidth limited, reducing bandwidth can improve performance
2. Reducing bandwidth reduces power consumption on mobile and power-constrained devices. 

From our perspective, reducing bandwidth also has the added benefit that we can now confirm that we are not generally bandwidth bound (i.e. we aren't boundwidth bound in _all_ scenes) which means we can focus our next performance improvements elsewhere (VGPRs / instructions).

### Usage notes

After merging this PR all meshes will automatically start using a slightly different vertex attribute layout:
```
P = Vertex position
N = normal
T = tangent

// Before this PR
PNTPNTPNTPNT

// After this PR
PPPPNTNTNTNT
```

This is the recommended layout for mobile devices as it means that shadow passes and tiling passes only ever have to read vertex positions and it doesn't hurt performance on Desktop. 

The renderer will automatically use this layout even if the mesh doesn't. To accommodate that, I have added a mesh format version number so we can perform automatic upgrades between versions. This avoids the issue we had last summer when integrating octahedral compression. Three things to note about this though:
1. When running scenes with the old mesh format, users will get warnings for each mesh that needs to be upgraded
2. Meshes need to save the new mesh format to stop getting the warning. In some cases this means they will have to reimport the mesh. Upon saving a mesh though, the new format will be used. 
3. Once the new format is used, users can't go back to an earlier version without re-importing their mesh. 

In addition to the vertex layout change, we also introduced optional compression for vertices, normals, tangents, and UVs. The importers will automatically detect if the mesh is a candidate for compression and apply the appropriate flags. For UVs, we can compress them as long as they are all within the 0-1 range. While this is technically a lossy compression, there won't be a visible difference on textures with a size smaller than 65536 pixels, so it is safe to apply). For vertices we do two things:
1. Scale the vertices into the 0-1 range using the surface's AABB (this allows us to store the meshes in RGB16 instead of RGB32
2. Store Normal (vec3) + Tangent (vec4) as Axis (vec3)+ Angle (float). The Axis replaces the normal and tangent fits into the A channel of the vertex. 

I implemented this compression scheme in a way that does not require additional shader variants, so there will be no effect on shader compile time. However, this means that there are more calculations in the shader, and VGPR usage may be affected on some compilers. 

When the compression flags are not used, the vertex format remains the same as it was before this PR. 

### Performance

So far I have tested on my laptop using an integrated GPU and an NVidia 3050m. There is no difference when using the forward+ renderer, a slight improvement when using the compatibility renderer, and about a 10% improvement when using the mobile renderer. This is likely due to the fact that I had to refactor the mobile renderer to pass the necessary data. 

On the TPS demo on integrated graphics, I am seeing an improvement from ~17 FPS to ~20FPS (Forward+). 
Using the [Synty Vikings demo](https://syntystore.com/products/polygon-vikings-pack) When using the mobile renderer, I get an increase from 40 ms per frame to 37 ms per frame. 

Running the TPS demo on mobile (Pixel 7 and Pixel 1) I see no performance difference (likely because both are instruction bound, not bandwidth bound).

~More performance testing is needed before merging. But so far, in all cases the performance is either the exact same or slightly better.~

Todos:
1. ~Add additional optimization by de-interleaving vertex positions (this won't be backwards compatible and so we need to add version identifiers to mesh data~
2. ~Add a setting to force disable optimization on an imported mesh. Generally, the auto-detection works quite well. But it relies on the mesh having both proper normals and tangents. If the mesh has improper tangents, the result is also bad.~ In the end this setting wasn't needed. The issue came from a scene with non-continuous UVs, so the generated tangents were bogus. The solution was to allow GLTFs to respect the "ensure tangents" setting. Previously tangents were always generated if not supplied. 
3. ~more performance testing with heavier scenes on mobile devices (especially scenes with more shadows).~
