### PR TITLE
GDScript: Fix some methods still can use multi-level calls

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -154,6 +154,7 @@
 				[/codeblocks]
 				[b]Note:[/b] This method is intended for advanced purposes. For most common use cases, the scripting languages offer easier ways to handle properties. See [annotation @GDScript.@export], [annotation @GDScript.@export_enum], [annotation @GDScript.@export_group], etc.
 				[b]Note:[/b] If the object's script is not [annotation @GDScript.@tool], this method will not be called in the editor.
+				[b]Note:[/b] [code]_get_property_list()[/code] is automatically called for [b]all[/b] base classes. Unlike most other methods, you don't need to call [code]super()[/code] (in GDScript).
 			</description>
 		</method>
 		<method name="_init" qualifiers="virtual">
@@ -185,6 +186,7 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] The base [Object] defines a few notifications ([constant NOTIFICATION_POSTINITIALIZE] and [constant NOTIFICATION_PREDELETE]). Inheriting classes such as [Node] define a lot more notifications, which are also received by this method.
+				[b]Note:[/b] [code]_notification()[/code] is automatically called for [b]all[/b] base classes. Unlike most other methods, you don't need to call [code]super()[/code] (in GDScript).
 			</description>
 		</method>
 		<method name="_property_can_revert" qualifiers="virtual">

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -147,6 +147,25 @@ public:
 		return false;
 	}
 
+	Variant get_default_value() const {
+		if (has_type && kind == BUILTIN) {
+			if (builtin_type == Variant::ARRAY) {
+				Array array;
+				if (has_container_element_type()) {
+					array.set_typed(container_element_type->builtin_type, container_element_type->native_type, container_element_type->script_type);
+				}
+				return array;
+			} else {
+				Variant variant;
+				Callable::CallError call_error;
+				Variant::construct(builtin_type, variant, nullptr, 0, call_error);
+				ERR_FAIL_COND_V(call_error.error != Callable::CallError::CALL_OK, Variant());
+				return variant;
+			}
+		}
+		return Variant();
+	}
+
 	void set_container_element_type(const GDScriptDataType &p_element_type) {
 		container_element_type = memnew(GDScriptDataType(p_element_type));
 	}
@@ -513,7 +532,6 @@ private:
 #endif
 
 	_FORCE_INLINE_ String _get_call_error(const Callable::CallError &p_err, const String &p_where, const Variant **argptrs) const;
-	Variant _get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
 
 public:
 	static constexpr int MAX_CALL_DEPTH = 2048; // Limit to try to avoid crash because of a stack overflow.

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -86,31 +86,6 @@ static String _get_var_type(const Variant *p_var) {
 }
 #endif // DEBUG_ENABLED
 
-Variant GDScriptFunction::_get_default_variant_for_data_type(const GDScriptDataType &p_data_type) {
-	if (p_data_type.kind == GDScriptDataType::BUILTIN) {
-		if (p_data_type.builtin_type == Variant::ARRAY) {
-			Array array;
-			// Typed array.
-			if (p_data_type.has_container_element_type()) {
-				const GDScriptDataType &element_type = p_data_type.get_container_element_type();
-				array.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
-			}
-
-			return array;
-		} else {
-			Callable::CallError ce;
-			Variant variant;
-			Variant::construct(p_data_type.builtin_type, variant, nullptr, 0, ce);
-
-			ERR_FAIL_COND_V(ce.error != Callable::CallError::CALL_OK, Variant());
-
-			return variant;
-		}
-	}
-
-	return Variant();
-}
-
 String GDScriptFunction::_get_call_error(const Callable::CallError &p_err, const String &p_where, const Variant **argptrs) const {
 	String err_text;
 
@@ -447,7 +422,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	OPCODES_TABLE;
 
 	if (!_code_ptr) {
-		return _get_default_variant_for_data_type(return_type);
+		return return_type.get_default_value();
 	}
 
 	r_err.error = Callable::CallError::CALL_OK;
@@ -476,7 +451,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 			_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text, false, ERR_HANDLER_SCRIPT);
 		}
 #endif
-		return _get_default_variant_for_data_type(return_type);
+		return return_type.get_default_value();
 	}
 
 	Variant retvalue;
@@ -514,12 +489,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				r_err.argument = _argument_count;
 
 				call_depth--;
-				return _get_default_variant_for_data_type(return_type);
+				return return_type.get_default_value();
 			} else if (p_argcount < _argument_count - _default_arg_count) {
 				r_err.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 				r_err.argument = _argument_count - _default_arg_count;
 				call_depth--;
-				return _get_default_variant_for_data_type(return_type);
+				return return_type.get_default_value();
 			} else {
 				defarg = _argument_count - p_argcount;
 			}
@@ -547,7 +522,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				r_err.argument = i;
 				r_err.expected = argument_types[i].builtin_type;
 				call_depth--;
-				return _get_default_variant_for_data_type(return_type);
+				return return_type.get_default_value();
 			}
 			if (argument_types[i].kind == GDScriptDataType::BUILTIN) {
 				Variant arg;
@@ -3664,7 +3639,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 
 		// Get a default return type in case of failure
-		retvalue = _get_default_variant_for_data_type(return_type);
+		retvalue = return_type.get_default_value();
 #endif
 
 		OPCODE_OUT;


### PR DESCRIPTION
In 4.0 we [removed](https://godotengine.org/article/gdscript-progress-report-new-gdscript-now-merged/#remove-multi-level-calls) multi-level calls, users must now always explicitly use `super()` to call a base class method.

However, some methods are not implemented correctly, and a base class method _may_ be implicitly called (if child class method returns `false`, `null`, or an error occurs). ~~This is most apparent in `_get_property_list()` and `_notification()`, which are always multi-level called.~~

<details>
<summary>Outdated example</summary>

```gdscript
# 1.gd
extends Node

func _get_property_list() -> Array[Dictionary]:
    print("1.gd")
    return []
```

```gdscript
# 2.gd
extends "1.gd"

func _ready() -> void:
    var _t = get_property_list()

func _get_property_list() -> Array[Dictionary]:
    print("2.gd")
    # No `super()` here!
    return []
```

Prints:

```
2.gd
1.gd
```

</details>

Method list:

* `_set()`
* `_get()`
* `_validate_property()`
* ~~`_get_property_list()`~~ **(!)**
* `_property_can_revert()`
* `_property_get_revert()`
* ~~`_notification()`~~ **(!)**
* `_to_string()`

**EDIT 1.** Formally, this doesn't break compatibility, it's a bug fix. But some users can rely on this wrong behavior (I believe this is a bug), so it definitely deserves a mention in the release notes if this PR gets merged.

**EDIT 2.** `_notification()` looks problematic, since `notification()` is essentially intended for multi-level calls. See comment below.