### PR TITLE
SCons: Add option for MSVC incremental linking.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -874,6 +874,9 @@ def generate_vs_project(env, num_jobs, project_name="godot"):
                 if env["precision"] == "double":
                     common_build_postfix.append("precision=double")
 
+                if env["incremental_link"]:
+                    common_build_postfix.append("incremental_link=yes")
+
                 result = " ^& ".join(common_build_prefix + [" ".join([commands] + common_build_postfix)])
                 return result
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -185,6 +185,7 @@ def get_opts():
         BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True),
         BoolVariable("use_asan", "Use address sanitizer (ASAN)", False),
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
+        BoolVariable("incremental_link", "Use MSVC incremental linking. May increase or decrease build times.", False),
     ]
 
 
@@ -355,8 +356,9 @@ def configure_msvc(env, vcvars_msvc_config):
         else:
             env.AppendUnique(CCFLAGS=["/MD"])
 
-    # MSVC incremental linking is broken and _increases_ link time (GH-77968).
-    env.Append(LINKFLAGS=["/INCREMENTAL:NO"])
+    # MSVC incremental linking is broken and may _increase_ link time (GH-77968).
+    if not env["incremental_link"]:
+        env.Append(LINKFLAGS=["/INCREMENTAL:NO"])
 
     if env["arch"] == "x86_32":
         env["x86_libtheora_opt_vc"] = True


### PR DESCRIPTION
Build times roughly doubled _for me but not a lot of other people_ without incremental linking with MSVC from an updated Visual Studio Community 2022 with #80482.

Before #80482:
```
1>scons: done building targets.
1>[Time elapsed: 00:00:17.002]
```

After:
```
1>scons: done building targets.
1>[Time elapsed: 00:00:49.474]
```

This PR creates the `incremental_link` option which remains off by default but can be enabled.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
