### PR TITLE
Fix a crash when built-in script is not saved and have syntax error

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -480,16 +480,18 @@ void ScriptTextEditor::_validate_script() {
 
 	if (!script->get_language()->validate(text, script->get_path(), &fnc, &errors, &warnings, &safe_lines)) {
 		for (List<ScriptLanguage::ScriptError>::Element *E = errors.front(); E; E = E->next()) {
-			if (E->get().path.is_empty() || E->get().path != script->get_path()) {
+			if ((E->get().path.is_empty() && !script->get_path().is_empty()) || E->get().path != script->get_path()) {
 				depended_errors[E->get().path].push_back(E->get());
 				E->erase();
 			}
 		}
 
-		// TRANSLATORS: Script error pointing to a line and column number.
-		String error_text = vformat(TTR("Error at (%d, %d):"), errors[0].line, errors[0].column) + " " + errors[0].message;
-		code_editor->set_error(error_text);
-		code_editor->set_error_pos(errors[0].line - 1, errors[0].column - 1);
+		if (errors.size() > 0) {
+			// TRANSLATORS: Script error pointing to a line and column number.
+			String error_text = vformat(TTR("Error at (%d, %d):"), errors[0].line, errors[0].column) + " " + errors[0].message;
+			code_editor->set_error(error_text);
+			code_editor->set_error_pos(errors[0].line - 1, errors[0].column - 1);
+		}
 		script_is_valid = false;
 	} else {
 		code_editor->set_error("");


### PR DESCRIPTION
Fixes #81149.

When built-in script is not saved, it has empty path, and origin code assumes error with empty path is a depended_error but that's not always the case. When error's path and script's path are both empty, maybe we can believe it is an error caused by a script that's not been saved instead of a depended error.

Also add some protection before access error list's index 0.