### PR TITLE
Add render mode to use world coordinates in canvas item shader

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -199,6 +199,10 @@ void main() {
 #ifdef USE_POINT_SIZE
 	float point_size = 1.0;
 #endif
+
+#ifdef USE_WORLD_VERTEX_COORDS
+	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
+#endif
 	{
 #CODE : VERTEX
 	}
@@ -207,7 +211,7 @@ void main() {
 	pixel_size_interp = abs(read_draw_data_dst_rect.zw) * vertex_base;
 #endif
 
-#if !defined(SKIP_TRANSFORM_USED)
+#if !defined(SKIP_TRANSFORM_USED) && !defined(USE_WORLD_VERTEX_COORDS)
 	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
 #endif
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1184,6 +1184,7 @@ MaterialStorage::MaterialStorage() {
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";
 		actions.render_mode_defines["light_only"] = "#define MODE_LIGHT_ONLY\n";
+		actions.render_mode_defines["world_vertex_coords"] = "#define USE_WORLD_VERTEX_COORDS\n";
 
 		actions.global_buffer_array_variable = "global_shader_uniforms";
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2480,6 +2480,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";
 		actions.render_mode_defines["light_only"] = "#define MODE_LIGHT_ONLY\n";
+		actions.render_mode_defines["world_vertex_coords"] = "#define USE_WORLD_VERTEX_COORDS\n";
 
 		actions.custom_samplers["TEXTURE"] = "texture_sampler";
 		actions.custom_samplers["NORMAL_TEXTURE"] = "texture_sampler";

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -180,6 +180,10 @@ void main() {
 #ifdef USE_POINT_SIZE
 	float point_size = 1.0;
 #endif
+
+#ifdef USE_WORLD_VERTEX_COORDS
+	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
+#endif
 	{
 #CODE : VERTEX
 	}
@@ -188,7 +192,7 @@ void main() {
 	pixel_size_interp = abs(draw_data.dst_rect.zw) * vertex_base;
 #endif
 
-#if !defined(SKIP_TRANSFORM_USED)
+#if !defined(SKIP_TRANSFORM_USED) && !defined(USE_WORLD_VERTEX_COORDS)
 	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
 #endif
 

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -320,6 +320,7 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "disabled" });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("unshaded") });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("light_only") });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("world_vertex_coords") });
 	}
 
 	/************ PARTICLES **************************/


### PR DESCRIPTION
By using the render mode `world_vertex_coords` you can automatically use the vertex coordinates in world space

Supersedes https://github.com/godotengine/godot/pull/24002
Fixes https://github.com/godotengine/godot-docs/issues/7860
Fixes https://github.com/godotengine/godot/issues/19800
