### PR TITLE
Reset SDFGI when changing editor scene tabs

### DIFF
--- a/drivers/gles3/environment/gi.cpp
+++ b/drivers/gles3/environment/gi.cpp
@@ -137,4 +137,7 @@ uint32_t GI::voxel_gi_get_version(RID p_voxel_gi) const {
 	return 0;
 }
 
+void GI::sdfgi_reset() {
+}
+
 #endif // GLES3_ENABLED

--- a/drivers/gles3/environment/gi.h
+++ b/drivers/gles3/environment/gi.h
@@ -90,6 +90,8 @@ public:
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const override;
 
 	virtual uint32_t voxel_gi_get_version(RID p_voxel_gi) const override;
+
+	virtual void sdfgi_reset() override;
 };
 
 }; // namespace GLES3

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -65,6 +65,7 @@
 #include "servers/display_server.h"
 #include "servers/navigation_server_3d.h"
 #include "servers/physics_server_2d.h"
+#include "servers/rendering_server.h"
 
 #include "editor/audio_stream_preview.h"
 #include "editor/debugger/editor_debugger_node.h"
@@ -3463,6 +3464,9 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	ScriptEditor::get_singleton()->set_scene_root_script(editor_data.get_scene_root_script(editor_data.get_edited_scene()));
 	editor_data.notify_edited_scene_changed();
 	emit_signal(SNAME("scene_changed"));
+
+	// Reset SDFGI after everything else so that any last-second scene modifications will be processed.
+	RenderingServer::get_singleton()->sdfgi_reset();
 }
 
 bool EditorNode::is_changing_scene() const {

--- a/servers/rendering/dummy/environment/gi.h
+++ b/servers/rendering/dummy/environment/gi.h
@@ -78,6 +78,8 @@ public:
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const override { return false; }
 
 	virtual uint32_t voxel_gi_get_version(RID p_voxel_gi) const override { return 0; }
+
+	virtual void sdfgi_reset() override {}
 };
 
 } // namespace RendererDummy

--- a/servers/rendering/environment/renderer_gi.h
+++ b/servers/rendering/environment/renderer_gi.h
@@ -79,6 +79,8 @@ public:
 	virtual bool voxel_gi_is_using_two_bounces(RID p_voxel_gi) const = 0;
 
 	virtual uint32_t voxel_gi_get_version(RID p_probe) const = 0;
+
+	virtual void sdfgi_reset() = 0;
 };
 
 #endif // RENDERER_GI_H

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -392,6 +392,10 @@ Dependency *GI::voxel_gi_get_dependency(RID p_voxel_gi) const {
 	return &voxel_gi->dependency;
 }
 
+void GI::sdfgi_reset() {
+	sdfgi_current_version++;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // SDFGI
 
@@ -416,6 +420,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 	y_scale_mode = RendererSceneRenderRD::get_singleton()->environment_get_sdfgi_y_scale(p_env);
 	static const float y_scale[3] = { 2.0, 1.5, 1.0 };
 	y_mult = y_scale[y_scale_mode];
+	version = gi->sdfgi_current_version;
 	cascades.resize(num_cascades);
 	probe_axis_count = SDFGI::PROBE_DIVISOR + 1;
 	solid_cell_ratio = gi->sdfgi_solid_cell_ratio;

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -667,6 +667,7 @@ public:
 
 		float y_mult = 1.0;
 
+		uint32_t version = 0;
 		uint32_t render_pass = 0;
 
 		int32_t cascade_dynamic_light_count[SDFGI::MAX_CASCADES]; //used dynamically
@@ -701,10 +702,13 @@ public:
 	Vector3 sdfgi_debug_probe_dir;
 	bool sdfgi_debug_probe_enabled = false;
 	Vector3i sdfgi_debug_probe_index;
+	uint32_t sdfgi_current_version = 0;
 
 	/* SDFGI UPDATE */
 
 	int sdfgi_get_lightprobe_octahedron_size() const { return SDFGI::LIGHTPROBE_OCT_SIZE; }
+
+	virtual void sdfgi_reset() override;
 
 	struct SDFGIData {
 		float grid_size[3];

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3323,14 +3323,18 @@ void RenderForwardClustered::sdfgi_update(const Ref<RenderSceneBuffers> &p_rende
 	}
 
 	bool needs_sdfgi = p_environment.is_valid() && environment_get_sdfgi_enabled(p_environment);
+	bool needs_reset = sdfgi.is_valid() ? sdfgi->version != gi.sdfgi_current_version : false;
 
-	if (!needs_sdfgi) {
+	if (!needs_sdfgi || needs_reset) {
 		if (sdfgi.is_valid()) {
 			// delete it
 			sdfgi.unref();
 			rb->set_custom_data(RB_SCOPE_SDFGI, sdfgi);
 		}
-		return;
+
+		if (!needs_sdfgi) {
+			return;
+		}
 	}
 
 	// Ensure advanced shaders are available if SDFGI is used.

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -476,6 +476,8 @@ public:
 	FUNC2(voxel_gi_set_interior, RID, bool)
 	FUNC2(voxel_gi_set_use_two_bounces, RID, bool)
 
+	FUNC0(sdfgi_reset)
+
 	/* PARTICLES */
 
 #undef ServerName

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -617,6 +617,8 @@ public:
 
 	virtual void voxel_gi_set_quality(VoxelGIQuality) = 0;
 
+	virtual void sdfgi_reset() = 0;
+
 	/* LIGHTMAP */
 
 	virtual RID lightmap_create() = 0;


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/81028. The other issues mentioned (including view not updating) are already tracked in separate issues.

Resets SDFGI when user changes scenes in the editor. Previously, users could sometimes see reflections, occlusion or GI from another, completely unrelated scene. This is well shown in the issue video or MRP (use the third project, `sdfgi test3.zip`). The issue project is an extreme case, but it explains some issues people have been complaining about. For example, after tuning and adjusting a scene lighting and coming back later the scene can look completely different (because back then it was partially or completely using SDFGI data from another scene).

This also adds `RenderingServer::sdfgi_reset()` to perform this reset. I'm not completely familiar with RenderingServer internals, so feedback is welcome. I implemented a simple a I think robust way to reset SDFGI, but I can see a few other ways it could be implemented.

Also, it would be useful to expose this to scripting too as people have to do this when changing their game scenes. I can do that now or in another PR if we want to think about the public API more (related issue https://github.com/godotengine/godot/issues/39961, although in this PR we only add complete reset functionality). Currently, doing the reset in GDScript is pretty tricky and looking for the right, active WorldEnvironment node and its resource can be hard for general tools scripts. Then you have to do a double wait (process+render) for cover all cases (like if the Gogot window is minimized or if the node gets freed during the wait etc.), so you have to do something like this:

```gdscript
world.environment.sdfgi_enabled = false

await get_tree().process_frame
await RenderingServer.frame_post_draw

world.environment.sdfgi_enabled = true
```