### PR TITLE
Add Texture2D and Texture3D icons

### DIFF
--- a/editor/icons/Texture2D.svg
+++ b/editor/icons/Texture2D.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="#808080"><path d="M2 1a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zm1 2h10v8H3z"/><path d="M3.5 3.5h9v7h-9" fill-opacity=".2"/></g></svg>

--- a/editor/icons/Texture3D.svg
+++ b/editor/icons/Texture3D.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><g fill="gray"><path d="M1 14a1 1 0 0 0 1 1h9.5a1 1 0 0 0 .707-.293l2.5-2.5A1 1 0 0 0 15 11.5V2a1 1 0 0 0-1-1H4.5a1 1 0 0 0-.707.293l-2.5 2.5A1 1 0 0 0 1 4.5zm1.25-9H11v7H2.25zm10 6.25v-6.5L14 3v6.5zm-1-7.5H3L4.75 2H13z"/><path d="M2.75 5.5h7.75v6H2.75" fill-opacity=".2"/></g></svg>


### PR DESCRIPTION
Texture2D and Texture3D have quite established shapes, so I think we should make use of it for the abstract classes, to help with visual grepping when they're folded in the Create dialog.

![image](https://github.com/godotengine/godot/assets/85438892/a9d36257-d098-4a1b-b7c8-a39247a04c2b)
