### PR TITLE
Prevent axis-based actions from getting stuck

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -104,6 +104,7 @@ private:
 		uint64_t released_physics_frame = UINT64_MAX;
 		uint64_t released_process_frame = UINT64_MAX;
 		int pressed = 0;
+		bool axis_pressed = false;
 		bool exact = true;
 		float strength = 0.0f;
 		float raw_strength = 0.0f;


### PR DESCRIPTION
Fixes #81164

Not sure how much correct is that. This assumes that only InputEventJoypadMotion has this problem and that you have only single axis event assigned to an action (which is true in 99.9% cases). Also a special handler for one event type feels hacky.