### PR TITLE
Prevent use of resources which are opened in script editor

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -462,7 +462,9 @@ Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path,
 			load_task.use_sub_threads = p_thread_mode == LOAD_THREAD_DISTRIBUTE;
 			if (p_cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				Ref<Resource> existing = ResourceCache::get_ref(local_path);
-				if (existing.is_valid()) {
+				if (p_cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE) {
+					ResourceCache::resources.erase(local_path);
+				} else if (existing.is_valid()) {
 					//referencing is fine
 					load_task.resource = existing;
 					load_task.status = THREAD_LOAD_LOADED;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -134,6 +134,10 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 	Ref<Resource> loaded_resource = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + p_path + "'.");
 
+	if (loaded_resource.ptr()->get_class() == "TextFile") {
+		loaded_resource = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_IGNORE);
+	}
+
 	if (!base_type.is_empty()) {
 		bool any_type_matches = false;
 


### PR DESCRIPTION
Fixes #78075

Added error message for resource picker when it's opened in ScriptEditor 
Added error message for loading scene file when it's opened in ScriptEditor 
Added ScriptEditor::get_open_text_files for detecting errors

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
