### PR TITLE
Fix TreeItem range slider not working properly

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3210,7 +3210,7 @@ void Tree::value_editor_changed(double p_value) {
 	TreeItem::Cell &c = popup_edited_item->cells.write[popup_edited_item_col];
 	c.val = p_value;
 
-	text_editor->set_text(String::num(c.val, Math::range_step_decimals(c.step)));
+	line_editor->set_text(String::num(c.val, Math::range_step_decimals(c.step)));
 
 	item_edited(popup_edited_item_col, popup_edited_item);
 	queue_redraw();


### PR DESCRIPTION
Fixes #80556 (partially).

TreeItem's `value_editor_changed` function incorrectly changes the multiline text editor's text when in `CELL_MODE_RANGE`, which relies on the line editor instead.

This PR fixes that issue, but the Action Editor issue still remains as that happens due to the window getting unfocused and losing the reference to `popup_edited_item`.