### PR TITLE
C#: Replace usage of deprecated `project_settings_changed` signal

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -440,7 +440,7 @@ namespace GodotTools
         {
             base._EnablePlugin();
 
-            ProjectSettingsChanged += GodotSharpDirs.DetermineProjectLocation;
+            ProjectSettings.SettingsChanged += GodotSharpDirs.DetermineProjectLocation;
 
             if (Instance != null)
                 throw new InvalidOperationException();


### PR DESCRIPTION
Replace usage of `EditorPlugin::project_settings_changed` signal with `ProjectSettings::settings_changed`.

- Follow-up to https://github.com/godotengine/godot/pull/80450.