### PR TITLE
Add Ctrl + L / Cmd + Shift + G shortcut to focus path bar in FileDialog

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -380,6 +380,10 @@ LineEdit *ActionMapEditor::get_search_box() const {
 	return action_list_search;
 }
 
+LineEdit *ActionMapEditor::get_path_box() const {
+	return add_edit;
+}
+
 InputEventConfigurationDialog *ActionMapEditor::get_configuration_dialog() {
 	return event_config_dialog;
 }

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -118,6 +118,7 @@ protected:
 
 public:
 	LineEdit *get_search_box() const;
+	LineEdit *get_path_box() const;
 	InputEventConfigurationDialog *get_configuration_dialog();
 
 	// Dictionary represents an Action with "events" (Array) and "deadzone" (float) items. Pass with no param to update list from cached action map.

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -587,6 +587,10 @@ void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
 	_autoload_add();
 }
 
+LineEdit *EditorAutoloadSettings::get_path_box() const {
+	return autoload_add_path;
+}
+
 Variant EditorAutoloadSettings::get_drag_data_fw(const Point2 &p_point, Control *p_control) {
 	if (autoload_cache.size() <= 1) {
 		return false;

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -108,6 +108,8 @@ public:
 	bool autoload_add(const String &p_name, const String &p_path);
 	void autoload_remove(const String &p_name);
 
+	LineEdit *get_path_box() const;
+
 	EditorAutoloadSettings();
 	~EditorAutoloadSettings();
 };

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2575,6 +2575,11 @@ void FileSystemDock::fix_dependencies(const String &p_for_file) {
 	deps_editor->edit(p_for_file);
 }
 
+void FileSystemDock::focus_on_path() {
+	current_path_line_edit->grab_focus();
+	current_path_line_edit->select_all();
+}
+
 void FileSystemDock::focus_on_filter() {
 	LineEdit *current_search_box = nullptr;
 	if (display_mode == DISPLAY_MODE_TREE_ONLY) {
@@ -3398,6 +3403,8 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 			_tree_rmb_option(FILE_OPEN_EXTERNAL);
 		} else if (ED_IS_SHORTCUT("filesystem_dock/open_in_terminal", p_event)) {
 			_tree_rmb_option(FILE_OPEN_IN_TERMINAL);
+		} else if (ED_IS_SHORTCUT("file_dialog/focus_path", p_event)) {
+			focus_on_path();
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			focus_on_filter();
 		} else {

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -386,6 +386,7 @@ public:
 	String get_current_directory() const;
 
 	void navigate_to_path(const String &p_path);
+	void focus_on_path();
 	void focus_on_filter();
 
 	ScriptCreateDialog *get_script_create_dialog() const;

--- a/editor/group_settings_editor.cpp
+++ b/editor/group_settings_editor.cpp
@@ -483,6 +483,10 @@ void GroupSettingsEditor::_show_rename_dialog() {
 	rename_group->grab_focus();
 }
 
+LineEdit *GroupSettingsEditor::get_name_box() const {
+	return group_name;
+}
+
 GroupSettingsEditor::GroupSettingsEditor() {
 	ProjectSettings::get_singleton()->add_hidden_prefix("global_group/");
 

--- a/editor/group_settings_editor.h
+++ b/editor/group_settings_editor.h
@@ -90,6 +90,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	LineEdit *get_name_box() const;
 	void show_message(const String &p_message);
 
 	void remove_references(const StringName &p_name);

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -224,6 +224,7 @@ void EditorFileDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 			}
 			if (ED_IS_SHORTCUT("file_dialog/focus_path", p_event)) {
 				dir->grab_focus();
+				dir->select_all();
 				handled = true;
 			}
 			if (ED_IS_SHORTCUT("file_dialog/move_favorite_up", p_event)) {
@@ -1783,7 +1784,10 @@ EditorFileDialog::EditorFileDialog() {
 	ED_SHORTCUT("file_dialog/toggle_mode", TTR("Toggle Mode"), KeyModifierMask::ALT | Key::V);
 	ED_SHORTCUT("file_dialog/create_folder", TTR("Create Folder"), KeyModifierMask::CMD_OR_CTRL | Key::N);
 	ED_SHORTCUT("file_dialog/delete", TTR("Delete"), Key::KEY_DELETE);
-	ED_SHORTCUT("file_dialog/focus_path", TTR("Focus Path"), KeyModifierMask::CMD_OR_CTRL | Key::D);
+	ED_SHORTCUT("file_dialog/focus_path", TTR("Focus Path"), KeyModifierMask::CMD_OR_CTRL | Key::L);
+	// Allow both Cmd + L and Cmd + Shift + G to match Safari's and Finder's shortcuts respectively.
+	ED_SHORTCUT_OVERRIDE_ARRAY("file_dialog/focus_path", "macos",
+			{ int32_t(KeyModifierMask::META | Key::L), int32_t(KeyModifierMask::META | KeyModifierMask::SHIFT | Key::G) });
 	ED_SHORTCUT("file_dialog/move_favorite_up", TTR("Move Favorite Up"), KeyModifierMask::CMD_OR_CTRL | Key::UP);
 	ED_SHORTCUT("file_dialog/move_favorite_down", TTR("Move Favorite Down"), KeyModifierMask::CMD_OR_CTRL | Key::DOWN);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -256,8 +256,13 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 			handled = true;
 		}
 
-		if (k->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F))) {
+		if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			_focus_current_search_box();
+			handled = true;
+		}
+
+		if (ED_IS_SHORTCUT("file_dialog/focus_path", p_event)) {
+			_focus_current_path_box();
 			handled = true;
 		}
 
@@ -344,6 +349,27 @@ void ProjectSettingsEditor::_focus_current_search_box() {
 	if (current_search_box) {
 		current_search_box->grab_focus();
 		current_search_box->select_all();
+	}
+}
+
+void ProjectSettingsEditor::_focus_current_path_box() {
+	Control *tab = tab_container->get_current_tab_control();
+	LineEdit *current_path_box = nullptr;
+	if (tab == general_editor) {
+		current_path_box = property_box;
+	} else if (tab == action_map_editor) {
+		current_path_box = action_map_editor->get_path_box();
+	} else if (tab == autoload_settings) {
+		current_path_box = autoload_settings->get_path_box();
+	} else if (tab == shaders_global_shader_uniforms_editor) {
+		current_path_box = shaders_global_shader_uniforms_editor->get_name_box();
+	} else if (tab == group_settings) {
+		current_path_box = group_settings->get_name_box();
+	}
+
+	if (current_path_box) {
+		current_path_box->grab_focus();
+		current_path_box->select_all();
 	}
 }
 

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -97,6 +97,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 
 	void _tabs_tab_changed(int p_tab);
 	void _focus_current_search_box();
+	void _focus_current_path_box();
 
 	void _editor_restart_request();
 	void _editor_restart();

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -356,6 +356,10 @@ String ShaderGlobalsEditor::_check_new_variable_name(const String &p_variable_na
 	return "";
 }
 
+LineEdit *ShaderGlobalsEditor::get_name_box() const {
+	return variable_name;
+}
+
 void ShaderGlobalsEditor::_variable_name_text_changed(const String &p_variable_name) {
 	const String &warning = _check_new_variable_name(p_variable_name.strip_edges());
 	variable_add->set_tooltip_text(warning);

--- a/editor/shader_globals_editor.h
+++ b/editor/shader_globals_editor.h
@@ -61,6 +61,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	LineEdit *get_name_box() const;
+
 	ShaderGlobalsEditor();
 	~ShaderGlobalsEditor();
 };

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -263,6 +263,27 @@ void FileDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 				case Key::BACKSPACE: {
 					_dir_submitted("..");
 				} break;
+#ifdef MACOS_ENABLED
+				// Cmd + Shift + G (matches Finder's "Go To" shortcut).
+				case Key::G: {
+					if (k->is_command_or_control_pressed() && k->is_shift_pressed()) {
+						dir->grab_focus();
+						dir->select_all();
+					} else {
+						handled = false;
+					}
+				} break;
+#endif
+				// Ctrl + L (matches most Windows/Linux file managers' "focus on path bar" shortcut,
+				// plus macOS Safari's "focus on address bar" shortcut).
+				case Key::L: {
+					if (k->is_command_or_control_pressed()) {
+						dir->grab_focus();
+						dir->select_all();
+					} else {
+						handled = false;
+					}
+				} break;
 				default: {
 					handled = false;
 				}


### PR DESCRIPTION
This also tweaks EditorFileDialog to use the same shortcut, while making it select the path text after focusing (like in most file managers).

<kbd>Ctrl + L</kbd> / <kbd>Cmd + Shift + G</kbd> can also now be used to focus on the     property name in the project settings editor, as well in the Input Map, Autoload, Shader Globals and Global Groups tabs.

**Testing project:** [test_filedialog_focus_shortcut.zip](https://github.com/godotengine/godot/files/12478935/test_filedialog_focus_shortcut.zip)