### PR TITLE
Rework AcceptDialog's ok button text

### DIFF
--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -73,8 +73,8 @@
 		</member>
 		<member name="exclusive" type="bool" setter="set_exclusive" getter="is_exclusive" overrides="Window" default="true" />
 		<member name="keep_title_visible" type="bool" setter="set_keep_title_visible" getter="get_keep_title_visible" overrides="Window" default="true" />
-		<member name="ok_button_text" type="String" setter="set_ok_button_text" getter="get_ok_button_text" default="&quot;OK&quot;">
-			The text displayed by the OK button (see [method get_ok_button]).
+		<member name="ok_button_text" type="String" setter="set_ok_button_text" getter="get_ok_button_text" default="&quot;&quot;">
+			The text displayed by the OK button (see [method get_ok_button]). If empty, a default text will be used.
 		</member>
 		<member name="title" type="String" setter="set_title" getter="get_title" overrides="Window" default="&quot;Alert!&quot;" />
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" overrides="Window" default="true" />

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -197,16 +197,12 @@ bool AcceptDialog::has_autowrap() {
 }
 
 void AcceptDialog::set_ok_button_text(String p_ok_button_text) {
-	ok_button->set_text(p_ok_button_text);
-
-	child_controls_changed();
-	if (is_visible()) {
-		_update_child_rects();
-	}
+	ok_text = p_ok_button_text;
+	_update_ok_text();
 }
 
 String AcceptDialog::get_ok_button_text() const {
-	return ok_button->get_text();
+	return ok_text;
 }
 
 void AcceptDialog::register_text_enter(LineEdit *p_line_edit) {
@@ -257,6 +253,25 @@ void AcceptDialog::_update_child_rects() {
 	}
 }
 
+void AcceptDialog::_update_ok_text() {
+	String prev_text = ok_button->get_text();
+	String new_text = internal_ok_text;
+
+	if (!ok_text.is_empty()) {
+		new_text = ok_text;
+	}
+
+	if (new_text == prev_text) {
+		return;
+	}
+	ok_button->set_text(new_text);
+
+	child_controls_changed();
+	if (is_visible()) {
+		_update_child_rects();
+	}
+}
+
 Size2 AcceptDialog::_get_contents_minimum_size() const {
 	// First, we then iterate over the label and any other custom controls
 	// to try and find the size that encompasses all content.
@@ -292,6 +307,11 @@ Size2 AcceptDialog::_get_contents_minimum_size() const {
 	}
 
 	return content_minsize;
+}
+
+void AcceptDialog::set_internal_ok_text(const String &p_text) {
+	internal_ok_text = p_text;
+	_update_ok_text();
 }
 
 void AcceptDialog::_custom_action(const String &p_action) {
@@ -442,7 +462,7 @@ AcceptDialog::AcceptDialog() {
 
 	buttons_hbox->add_spacer();
 	ok_button = memnew(Button);
-	ok_button->set_text(ETR("OK"));
+	set_internal_ok_text(ETR("OK"));
 	buttons_hbox->add_child(ok_button);
 	buttons_hbox->add_spacer();
 

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -51,6 +51,9 @@ class AcceptDialog : public Window {
 	Button *ok_button = nullptr;
 
 	bool popped_up = false;
+	String ok_text;
+	String internal_ok_text;
+
 	bool hide_on_ok = true;
 	bool close_on_escape = true;
 
@@ -64,6 +67,7 @@ class AcceptDialog : public Window {
 	void _custom_action(const String &p_action);
 	void _custom_button_visibility_changed(Button *button);
 	void _update_child_rects();
+	void _update_ok_text();
 
 	static bool swap_cancel_ok;
 
@@ -80,6 +84,8 @@ protected:
 	virtual void ok_pressed() {}
 	virtual void cancel_pressed() {}
 	virtual void custom_action(const String &) {}
+
+	void set_internal_ok_text(const String &p_text);
 
 	// Not private since used by derived classes signal.
 	void _text_submitted(const String &p_text);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -669,10 +669,10 @@ void FileDialog::deselect_all() {
 		switch (mode) {
 			case FILE_MODE_OPEN_FILE:
 			case FILE_MODE_OPEN_FILES:
-				set_ok_button_text(ETR("Open"));
+				set_internal_ok_text(ETR("Open"));
 				break;
 			case FILE_MODE_OPEN_DIR:
-				set_ok_button_text(ETR("Select Current Folder"));
+				set_internal_ok_text(ETR("Select Current Folder"));
 				break;
 			case FILE_MODE_OPEN_ANY:
 				set_ok_button_text(ETR("Open"));
@@ -698,14 +698,14 @@ void FileDialog::_tree_selected() {
 	if (!d["dir"]) {
 		file->set_text(d["name"]);
 		if (mode == FILE_MODE_SAVE_FILE) {
-			set_ok_button_text(ETR("Save"));
+			set_internal_ok_text(ETR("Save"));
 		} else {
-			set_ok_button_text(ETR("Open"));
+			set_internal_ok_text(ETR("Open"));
 		}
 	} else if (mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY || !dir_access->file_exists(file->get_text())) {
 		file->set_text("");
 		if (mode == FILE_MODE_OPEN_DIR || mode == FILE_MODE_OPEN_ANY) {
-			set_ok_button_text(ETR("Select This Folder"));
+			set_internal_ok_text(ETR("Select This Folder"));
 		}
 	}
 
@@ -1235,35 +1235,35 @@ void FileDialog::set_file_mode(FileMode p_mode) {
 	mode = p_mode;
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
-			set_ok_button_text(ETR("Open"));
+			set_internal_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a File"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_FILES:
-			set_ok_button_text(ETR("Open"));
+			set_internal_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open File(s)"));
 			}
 			makedir->hide();
 			break;
 		case FILE_MODE_OPEN_DIR:
-			set_ok_button_text(ETR("Select Current Folder"));
+			set_internal_ok_text(ETR("Select Current Folder"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_OPEN_ANY:
-			set_ok_button_text(ETR("Open"));
+			set_internal_ok_text(ETR("Open"));
 			if (mode_overrides_title) {
 				set_title(ETR("Open a File or Directory"));
 			}
 			makedir->show();
 			break;
 		case FILE_MODE_SAVE_FILE:
-			set_ok_button_text(ETR("Save"));
+			set_internal_ok_text(ETR("Save"));
 			if (mode_overrides_title) {
 				set_title(ETR("Save a File"));
 			}
@@ -1886,6 +1886,7 @@ FileDialog::FileDialog() {
 
 	set_hide_on_ok(false);
 	set_size(Size2(640, 360));
+	set_internal_ok_text(ETR("Save")); // Default mode text.
 
 	if (register_func) {
 		register_func(this);


### PR DESCRIPTION
AcceptDialog's `ok_button_text` was directly operating on the button's text. This might be ok if the text does not change, but it does change. FileDialog was overriding it, making it not editable and causing a translated text to be saved in the scene file.

This PR reworks how the text is used. It's split into 2 properties: one is the user-defined ok text, the other, internal, property is the default ok text. When the user's ok text is empty, the internal text will be used. FileDialog uses now internal text.

https://github.com/godotengine/godot/assets/2223172/1a17df1f-c95a-49a2-a59a-f75cdc48d01c

Fixes #79803
Fixes https://github.com/godotengine/godot/pull/62827#issuecomment-1437762456
Supersedes #79848

This slightly breaks compatibility. Dialogs that previously had ok text defined will not be able to override it internally (affects only FileDialog). Also you can't set empty button text; at best you can put a space.