### PR TITLE
Select node when clicked in AnimationPlayer timeline

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3244,6 +3244,22 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 	}
 }
 
+void AnimationTrackEditGroup::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+		Point2 pos = mb->get_position();
+		Rect2 node_name_rect = Rect2(0, 0, timeline->get_name_limit(), get_size().height);
+
+		if (node_name_rect.has_point(pos)) {
+			EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
+			editor_selection->clear();
+			editor_selection->add_node(root->get_node(node));
+		}
+	}
+}
+
 void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, const String &p_name, const NodePath &p_node) {
 	icon = p_type;
 	node_name = p_name;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -349,6 +349,8 @@ class AnimationTrackEditGroup : public Control {
 protected:
 	void _notification(int p_what);
 
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
 public:
 	void set_type_and_name(const Ref<Texture2D> &p_type, const String &p_name, const NodePath &p_node);
 	virtual Size2 get_minimum_size() const override;


### PR DESCRIPTION
Implements suggestion made in https://github.com/godotengine/godot-proposals/issues/7067. When clicking on the space on the left of the timeline group header that contains the icon & node name, it will select the node corresponding to that group.


https://github.com/godotengine/godot/assets/18225391/a2623908-d717-4940-bce5-3d5eb357578d

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/7067_