### PR TITLE
Use `ui_text_submit` instead of `ui_accept` to confirm and close text prompts

### DIFF
--- a/editor/editor_layouts_dialog.cpp
+++ b/editor/editor_layouts_dialog.cpp
@@ -42,7 +42,7 @@ void EditorLayoutsDialog::_line_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 
 	if (k.is_valid()) {
-		if (k->is_action_pressed(SNAME("ui_accept"), false, true)) {
+		if (k->is_action_pressed(SNAME("ui_text_submit"), false, true)) {
 			if (get_hide_on_ok()) {
 				hide();
 			}

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1834,7 +1834,7 @@ void ThemeItemEditorDialog::_edit_theme_item_gui_input(const Ref<InputEvent> &p_
 			return;
 		}
 
-		if (k->is_action_pressed(SNAME("ui_accept"), false, true)) {
+		if (k->is_action_pressed(SNAME("ui_text_submit"), false, true)) {
 			_confirm_edit_theme_item();
 			edit_theme_item_dialog->hide();
 			edit_theme_item_dialog->set_input_as_handled();


### PR DESCRIPTION
Fixes #81161
`ui_accept` key map includes key `Space`, should use `ui_text_submit`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
