### PR TITLE
Add project settings for `AVAudioSessionCategory` on iOS

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1342,6 +1342,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/3d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/ios/session_category", PROPERTY_HINT_ENUM, "Ambient,Multi Route,Play and Record,Playback,Record,Solo Ambient"), 0);
+	GLOBAL_DEF("audio/general/ios/mix_with_others", false);
+
 	PackedStringArray extensions;
 	extensions.push_back("gd");
 	if (Engine::get_singleton()->has_singleton("GodotSharp")) {

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -392,6 +392,13 @@
 			The base strength of the panning effect for all [AudioStreamPlayer3D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer3D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones. When using speakers, you may find lower values to sound better as speakers have a lower stereo separation compared to headphones.
 		</member>
+		<member name="audio/general/ios/mix_with_others" type="bool" setter="" getter="" default="false">
+			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions/1616611-mixwithothers]mixWithOthers[/url] option for the AVAudioSession on iOS. This will override the mix behavior, if the category is set to [code]Play and Record[/code], [code]Playback[/code], or [code]Multi Route[/code].
+			[code]Ambient[/code] always has this set per default.
+		</member>
+		<member name="audio/general/ios/session_category" type="int" setter="" getter="" default="0">
+			Sets the [url=https://developer.apple.com/documentation/avfaudio/avaudiosessioncategory]AVAudioSessionCategory[/url] on iOS. Use the [code]Playback[/code] category to get sound output, even if the phone is in silent mode.
+		</member>
 		<member name="audio/general/text_to_speech" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text-to-speech support is enabled, see [method DisplayServer.tts_get_voices] and [method DisplayServer.tts_speak].
 			[b]Note:[/b] Enabling TTS can cause addition idle CPU usage and interfere with the sleep mode, so consider disabling it if TTS is not used.

--- a/platform/ios/app_delegate.mm
+++ b/platform/ios/app_delegate.mm
@@ -51,6 +51,15 @@ extern void ios_finish();
 
 @implementation AppDelegate
 
+enum {
+	SESSION_CATEGORY_AMBIENT,
+	SESSION_CATEGORY_MULTI_ROUTE,
+	SESSION_CATEGORY_PLAY_AND_RECORD,
+	SESSION_CATEGORY_PLAYBACK,
+	SESSION_CATEGORY_RECORD,
+	SESSION_CATEGORY_SOLO_AMBIENT
+};
+
 static ViewController *mainViewController = nil;
 
 + (ViewController *)viewController {
@@ -92,8 +101,28 @@ static ViewController *mainViewController = nil;
 
 	mainViewController = viewController;
 
-	// prevent to stop music in another background app
-	[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+	int sessionCategorySetting = GLOBAL_GET("audio/general/ios/session_category");
+
+	// Initialize with default Ambient category.
+	AVAudioSessionCategory category = AVAudioSessionCategoryAmbient;
+
+	if (sessionCategorySetting == SESSION_CATEGORY_MULTI_ROUTE) {
+		category = AVAudioSessionCategoryMultiRoute;
+	} else if (sessionCategorySetting == SESSION_CATEGORY_PLAY_AND_RECORD) {
+		category = AVAudioSessionCategoryPlayAndRecord;
+	} else if (sessionCategorySetting == SESSION_CATEGORY_PLAYBACK) {
+		category = AVAudioSessionCategoryPlayback;
+	} else if (sessionCategorySetting == SESSION_CATEGORY_RECORD) {
+		category = AVAudioSessionCategoryRecord;
+	} else if (sessionCategorySetting == SESSION_CATEGORY_SOLO_AMBIENT) {
+		category = AVAudioSessionCategorySoloAmbient;
+	}
+
+	if (GLOBAL_GET("audio/general/ios/mix_with_others")) {
+		[[AVAudioSession sharedInstance] setCategory:category withOptions:AVAudioSessionCategoryOptionMixWithOthers error:nil];
+	} else {
+		[[AVAudioSession sharedInstance] setCategory:category error:nil];
+	}
 
 	return YES;
 }


### PR DESCRIPTION
Adds project settings for AVAudioSessionCategory on iOS, related to #50638 (does not fix the error log).

![session_category](https://github.com/godotengine/godot/assets/13589801/4e1bea0f-8ac7-406d-a33d-7c6ff34fff7b)

For the setting path I tried to stay consistent with the setting structure in display/window/ios.