### PR TITLE
Add placeholder RID to GradientTexture1D

### DIFF
--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -64,11 +64,11 @@ void GradientTexture1D::set_gradient(Ref<Gradient> p_gradient) {
 		return;
 	}
 	if (gradient.is_valid()) {
-		gradient->disconnect_changed(callable_mp(this, &GradientTexture1D::_update));
+		gradient->disconnect_changed(callable_mp(this, &GradientTexture1D::_queue_update));
 	}
 	gradient = p_gradient;
 	if (gradient.is_valid()) {
-		gradient->connect_changed(callable_mp(this, &GradientTexture1D::_update));
+		gradient->connect_changed(callable_mp(this, &GradientTexture1D::_queue_update));
 	}
 	_queue_update();
 	emit_changed();
@@ -162,6 +162,13 @@ void GradientTexture1D::set_use_hdr(bool p_enabled) {
 
 bool GradientTexture1D::is_using_hdr() const {
 	return use_hdr;
+}
+
+RID GradientTexture1D::get_rid() const {
+	if (!texture.is_valid()) {
+		texture = RS::get_singleton()->texture_2d_placeholder_create();
+	}
+	return texture;
 }
 
 Ref<Image> GradientTexture1D::get_image() const {

--- a/scene/resources/gradient_texture.h
+++ b/scene/resources/gradient_texture.h
@@ -39,7 +39,7 @@ class GradientTexture1D : public Texture2D {
 private:
 	Ref<Gradient> gradient;
 	bool update_pending = false;
-	RID texture;
+	mutable RID texture;
 	int width = 256;
 	bool use_hdr = false;
 
@@ -59,7 +59,7 @@ public:
 	void set_use_hdr(bool p_enabled);
 	bool is_using_hdr() const;
 
-	virtual RID get_rid() const override { return texture; }
+	virtual RID get_rid() const override;
 	virtual int get_height() const override { return 1; }
 	virtual bool has_alpha() const override { return true; }
 


### PR DESCRIPTION
Fixes #81166
My previous PR made assigning RID deferred, so the material used invalid value. This PR ensures that the RID does not change during the lifetime of the texture (same as in GradientTexture2D).

I also made Gradient `changed` connect to deferred update, for consistency (it doesn't have obvious detrimental effects).