### PR TITLE
Optimize GDScript VM codegen for MSVC

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -397,7 +397,13 @@ void (*type_init_function_table[])(Variant *) = {
 #define OPCODES_END
 #define OPCODES_OUT
 #define DISPATCH_OPCODE continue
+#ifdef _MSC_VER
+#define OPCODE_SWITCH(m_test)       \
+	__assume(m_test <= OPCODE_END); \
+	switch (m_test)
+#else
 #define OPCODE_SWITCH(m_test) switch (m_test)
+#endif
 #define OPCODE_BREAK break
 #define OPCODE_OUT break
 #endif


### PR DESCRIPTION
This allegedly leads to less optimal code than in the case of GCC/Clang's computed gotos, but is an improvement for those building with MSVC. I haven't benchmarked myself, so TIWAGOS.