### PR TITLE
GDScript: Fix subclass methods not inheriting RPC info

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1399,22 +1399,6 @@ void GDScript::_save_orphaned_subclasses(ClearData *p_clear_data) {
 	}
 }
 
-void GDScript::_init_rpc_methods_properties() {
-	// Copy the base rpc methods so we don't mask their IDs.
-	rpc_config.clear();
-	if (base.is_valid()) {
-		rpc_config = base->rpc_config.duplicate();
-	}
-
-	// RPC Methods
-	for (KeyValue<StringName, GDScriptFunction *> &E : member_functions) {
-		Variant config = E.value->get_rpc_config();
-		if (config.get_type() != Variant::NIL) {
-			rpc_config[E.value->get_name()] = config;
-		}
-	}
-}
-
 #ifdef DEBUG_ENABLED
 String GDScript::debug_get_script_name(const Ref<Script> &p_script) {
 	if (p_script.is_valid()) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -168,7 +168,6 @@ class GDScript : public Script {
 	bool _update_exports(bool *r_err = nullptr, bool p_recursive_call = false, PlaceHolderScriptInstance *p_instance_to_update = nullptr);
 
 	void _save_orphaned_subclasses(GDScript::ClearData *p_clear_data);
-	void _init_rpc_methods_properties();
 
 	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
 	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2503,7 +2503,10 @@ Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptP
 	return err;
 }
 
-Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {
+// Prepares given script, and inner class scripts, for compilation. It populates class members and initializes method
+// RPC info for its base classes first, then for itself, then for inner classes.
+// Warning: this function cannot initiate compilation of other classes, or it will result in cyclic dependency issues.
+Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state) {
 	if (parsed_classes.has(p_script)) {
 		return OK;
 	}
@@ -2562,6 +2565,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 	p_script->implicit_initializer = nullptr;
 	p_script->implicit_ready = nullptr;
 	p_script->static_initializer = nullptr;
+	p_script->rpc_config.clear();
 
 	p_script->clearing = false;
 
@@ -2592,7 +2596,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 			}
 
 			if (main_script->has_class(base.ptr())) {
-				Error err = _populate_class_members(base.ptr(), p_class->base_type.class_type, p_keep_state);
+				Error err = _prepare_compilation(base.ptr(), p_class->base_type.class_type, p_keep_state);
 				if (err) {
 					return err;
 				}
@@ -2611,7 +2615,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 					return ERR_COMPILATION_FAILED;
 				}
 
-				err = _populate_class_members(base.ptr(), p_class->base_type.class_type, p_keep_state);
+				err = _prepare_compilation(base.ptr(), p_class->base_type.class_type, p_keep_state);
 				if (err) {
 					_set_error(vformat(R"(Could not populate class members of base class "%s" in "%s".)", base->fully_qualified_name, base->path), nullptr);
 					return err;
@@ -2626,6 +2630,12 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 			_set_error("Parser bug: invalid inheritance.", nullptr);
 			return ERR_BUG;
 		} break;
+	}
+
+	// Duplicate RPC information from base GDScript
+	// Base script isn't valid because it should not have been compiled yet, but the reference contains relevant info.
+	if (base_type.kind == GDScriptDataType::GDSCRIPT && p_script->base.is_valid()) {
+		p_script->rpc_config = p_script->base->rpc_config.duplicate();
 	}
 
 	for (int i = 0; i < p_class->members.size(); i++) {
@@ -2746,6 +2756,14 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 				p_script->members.insert(Variant());
 			} break;
 
+			case GDScriptParser::ClassNode::Member::FUNCTION: {
+				const GDScriptParser::FunctionNode *function_n = member.function;
+
+				Variant config = function_n->rpc_config;
+				if (config.get_type() != Variant::NIL) {
+					p_script->rpc_config[function_n->identifier->name] = config;
+				}
+			} break;
 			default:
 				break; // Nothing to do here.
 		}
@@ -2756,7 +2774,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 	parsed_classes.insert(p_script);
 	parsing_classes.erase(p_script);
 
-	// Populate sub-classes.
+	// Populate inner classes.
 	for (int i = 0; i < p_class->members.size(); i++) {
 		const GDScriptParser::ClassNode::Member &member = p_class->members[i];
 		if (member.type != member.CLASS) {
@@ -2769,7 +2787,7 @@ Error GDScriptCompiler::_populate_class_members(GDScript *p_script, const GDScri
 
 		// Subclass might still be parsing, just skip it
 		if (!parsing_classes.has(subclass_ptr)) {
-			Error err = _populate_class_members(subclass_ptr, inner_class, p_keep_state);
+			Error err = _prepare_compilation(subclass_ptr, inner_class, p_keep_state);
 			if (err) {
 				return err;
 			}
@@ -2905,8 +2923,6 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 		has_static_data = has_static_data || inner_class->has_static_data;
 	}
 
-	p_script->_init_rpc_methods_properties();
-
 	p_script->valid = true;
 	return OK;
 }
@@ -2979,7 +2995,7 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	make_scripts(p_script, root, p_keep_state);
 
 	main_script->_owner = nullptr;
-	Error err = _populate_class_members(main_script, parser->get_tree(), p_keep_state);
+	Error err = _prepare_compilation(main_script, parser->get_tree(), p_keep_state);
 
 	if (err) {
 		return err;

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -135,7 +135,7 @@ class GDScriptCompiler {
 	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
 	GDScriptFunction *_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
-	Error _populate_class_members(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
+	Error _prepare_compilation(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	Error _compile_class(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	int err_line = 0;
 	int err_column = 0;


### PR DESCRIPTION
Fixes #80087, which has an excellent explanation of the origins of the issue thanks to @Dragoncraft89.

UPDATED

### General issue description

The way that RPC configurations were populated required the full compilation of the base class. Specifically, the order of operations is the following:
```
GDScriptCompiler::compile() // Compiles the main class
|-> GDScriptCompiler::_populate_class_members() // Prepares base class member info, followed by current & inner classes
|-> GDScriptCompiler::_compile_class() // Actually compiles the class to byte code
    |-> GDScript::_init_rpc_methods_properties() // At the end of compilation, obtains RPC information from base classes
|-> GDScriptCache::finish_compiling() // Finally compiles dependencies, which includes base classes
```

So notice that since RPC information requires the base class to be _compiled_, that information isn't available until after, when `GDScriptCache::finish_compiling()` is called. However, the core issue of #78146 was that `_populate_class_members()` was calling for the compilation of the base class, which introduced fundamental cyclic dependency problems during compilation.

We _cannot_ cause the compilation of another class during compilation of the current class. Specifically, `_compile_class()` cannot cause another `compile()` or `get_full_script()` call to anywhere else.

### Solution

The solution is to populate RPC information in a similar manner to how `_populate_class_members()` currently works, after #79205. In essence, RPC configuration should only depend on:

1. Information available from _shallow_ scripts, i.e. parsed & analyzed (but not compiled) scripts,
2. The base class

Crucially, it cannot depend on data obtained from the compilation (meaning `_compile_class()`) of another class. Current code requires `GDScriptFunctions`, which result from compilation.

### Implementation

All the RPC information was actually from simple parsing of the annotation and stored in `FunctionNode`. It turns out `_populate_class_members()` was already using `GDScripts` and their associated `ClassNode`, which contains members, including functions.

All RPC logic was moved into `_populate_class_members()`, which was already recursively being called for base scripts, traversing its `ClassNode` members, and continuing with inner scripts. In essence, doing everything we needed it to do.

The function was also renamed to `_prepare_compilation()`, which is more descriptive of all it does now. Comments were added indicating that the function cannot cause compilation to occur. It's strictly a pre-compilation step. The order is now:

```
GDScriptCompiler::compile() // Compiles the main class
|-> GDScriptCompiler::_prepare_compilation() // Prepares base class member info & RPC info, followed by current & inner classes
|-> GDScriptCompiler::_compile_class() // Actually compiles the class to byte code
|-> GDScriptCache::finish_compiling() // Finally compiles dependencies, which includes base classes
```

### MRP

[Here](https://github.com/godotengine/godot/files/12562953/godot-test.zip) is a project that fails before this PR and is fixed after, and which uses inner class RPCs. Basically a copy of the original issue report. To run it, you can use the following commands from the appropriate directories:

```
godot-binary --path ./godot-test/ server.tscn
godot-binary --path ./godot-test/ client.tscn
```



I doubt it addresses #80597 since that one is present in 4.1.1 but this regression was introduced by #79205, which isn't in 4.1.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
