### PR TITLE
GDExtension: Allocate `GDExtensionScriptInstanceInfo2` for compatibility on the heap to prevent crash

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1043,35 +1043,35 @@ static void gdextension_ref_set_object(GDExtensionRefPtr p_ref, GDExtensionObjec
 
 #ifndef DISABLE_DEPRECATED
 static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data) {
-	const GDExtensionScriptInstanceInfo2 info_2 = {
-		p_info->set_func,
-		p_info->get_func,
-		p_info->get_property_list_func,
-		p_info->free_property_list_func,
-		p_info->property_can_revert_func,
-		p_info->property_get_revert_func,
-		p_info->get_owner_func,
-		p_info->get_property_state_func,
-		p_info->get_method_list_func,
-		p_info->free_method_list_func,
-		p_info->get_property_type_func,
-		p_info->has_method_func,
-		p_info->call_func,
-		nullptr, // notification_func.
-		p_info->to_string_func,
-		p_info->refcount_incremented_func,
-		p_info->refcount_decremented_func,
-		p_info->get_script_func,
-		p_info->is_placeholder_func,
-		p_info->set_fallback_func,
-		p_info->get_fallback_func,
-		p_info->get_language_func,
-		p_info->free_func,
-	};
+	GDExtensionScriptInstanceInfo2 *info_2 = memnew(GDExtensionScriptInstanceInfo2);
+	info_2->set_func = p_info->set_func;
+	info_2->get_func = p_info->get_func;
+	info_2->get_property_list_func = p_info->get_property_list_func;
+	info_2->free_property_list_func = p_info->free_property_list_func;
+	info_2->property_can_revert_func = p_info->property_can_revert_func;
+	info_2->property_get_revert_func = p_info->property_get_revert_func;
+	info_2->get_owner_func = p_info->get_owner_func;
+	info_2->get_property_state_func = p_info->get_property_state_func;
+	info_2->get_method_list_func = p_info->get_method_list_func;
+	info_2->free_method_list_func = p_info->free_method_list_func;
+	info_2->get_property_type_func = p_info->get_property_type_func;
+	info_2->has_method_func = p_info->has_method_func;
+	info_2->call_func = p_info->call_func;
+	info_2->notification_func = nullptr;
+	info_2->to_string_func = p_info->to_string_func;
+	info_2->refcount_incremented_func = p_info->refcount_incremented_func;
+	info_2->refcount_decremented_func = p_info->refcount_decremented_func;
+	info_2->get_script_func = p_info->get_script_func;
+	info_2->is_placeholder_func = p_info->is_placeholder_func;
+	info_2->set_fallback_func = p_info->set_fallback_func;
+	info_2->get_fallback_func = p_info->get_fallback_func;
+	info_2->get_language_func = p_info->get_language_func;
+	info_2->free_func = p_info->free_func;
 
 	ScriptInstanceExtension *script_instance_extension = memnew(ScriptInstanceExtension);
 	script_instance_extension->instance = p_instance_data;
-	script_instance_extension->native_info = &info_2;
+	script_instance_extension->native_info = info_2;
+	script_instance_extension->free_native_info = true;
 	script_instance_extension->deprecated_native_info.notification_func = p_info->notification_func;
 	return reinterpret_cast<GDExtensionScriptInstancePtr>(script_instance_extension);
 }

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -631,6 +631,7 @@ VARIANT_ENUM_CAST(ScriptLanguageExtension::CodeCompletionLocation)
 class ScriptInstanceExtension : public ScriptInstance {
 public:
 	const GDExtensionScriptInstanceInfo2 *native_info;
+	bool free_native_info = false;
 	struct {
 		GDExtensionClassNotification notification_func;
 	} deprecated_native_info;
@@ -830,6 +831,9 @@ public:
 	virtual ~ScriptInstanceExtension() {
 		if (native_info->free_func) {
 			native_info->free_func(instance);
+		}
+		if (free_native_info) {
+			memfree(const_cast<GDExtensionScriptInstanceInfo2 *>(native_info));
 		}
 	}
 


### PR DESCRIPTION
Alternative approach to fixing crash introduced in https://github.com/godotengine/godot/pull/78634

PR https://github.com/godotengine/godot/pull/81205 is the first approach

~~I'm honestly not sure which approach is better at this point :-)~~

**UPDATE:** Let's go with this one!

This PR has the advantage that there's only the extra copy and memory usage when using the compatibility path.