### PR TITLE
Fix misleading description of `MeshDataTool.get_vertex()` method

### DIFF
--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -171,7 +171,7 @@
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the vertex at given index.
+				Returns the position of the given vertex.
 			</description>
 		</method>
 		<method name="get_vertex_bones" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

## What I did

- Adjusted the description of `MeshDataTool.get_vertex()` method. 

##### Closes: #80244