### PR TITLE
Editor: Inspector and Signal docks improvements

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -485,7 +485,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	if (_extension) {
 		const ObjectGDExtension *current_extension = _extension;
 		while (current_extension) {
-			p_list->push_back(PropertyInfo(Variant::NIL, current_extension->class_name, PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
+			p_list->push_back(PropertyInfo(Variant::NIL, current_extension->class_name, PROPERTY_HINT_NONE, current_extension->class_name, PROPERTY_USAGE_CATEGORY));
 
 			ClassDB::get_property_list(current_extension->class_name, p_list, true, this);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -489,7 +489,7 @@ protected:                                                                      
 		if (!p_reversed) {                                                                                                                       \
 			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \
 		}                                                                                                                                        \
-		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));                \
+		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY));      \
 		if (!_is_gpl_reversed()) {                                                                                                               \
 			::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                          \
 		}                                                                                                                                        \

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -196,18 +196,27 @@ class ConnectionsDockTree : public Tree {
 class ConnectionsDock : public VBoxContainer {
 	GDCLASS(ConnectionsDock, VBoxContainer);
 
-	// Right-click popup menu options.
-	enum SignalMenuOption {
-		CONNECT,
-		DISCONNECT_ALL,
-		COPY_NAME,
-		OPEN_DOCUMENTATION,
+	enum TreeItemType {
+		TREE_ITEM_TYPE_ROOT,
+		TREE_ITEM_TYPE_CLASS,
+		TREE_ITEM_TYPE_SIGNAL,
+		TREE_ITEM_TYPE_CONNECTION,
 	};
 
+	// Right-click context menu options.
+	enum ClassMenuOption {
+		CLASS_MENU_OPEN_DOCS,
+	};
+	enum SignalMenuOption {
+		SIGNAL_MENU_CONNECT,
+		SIGNAL_MENU_DISCONNECT_ALL,
+		SIGNAL_MENU_COPY_NAME,
+		SIGNAL_MENU_OPEN_DOCS,
+	};
 	enum SlotMenuOption {
-		EDIT,
-		GO_TO_SCRIPT,
-		DISCONNECT,
+		SLOT_MENU_EDIT,
+		SLOT_MENU_GO_TO_METHOD,
+		SLOT_MENU_DISCONNECT,
 	};
 
 	Node *selected_node = nullptr;
@@ -216,6 +225,8 @@ class ConnectionsDock : public VBoxContainer {
 	ConfirmationDialog *disconnect_all_dialog = nullptr;
 	ConnectDialog *connect_dialog = nullptr;
 	Button *connect_button = nullptr;
+	PopupMenu *class_menu = nullptr;
+	String class_menu_doc_class_name;
 	PopupMenu *signal_menu = nullptr;
 	PopupMenu *slot_menu = nullptr;
 	LineEdit *search_box = nullptr;
@@ -231,18 +242,20 @@ class ConnectionsDock : public VBoxContainer {
 
 	void _tree_item_selected();
 	void _tree_item_activated();
-	bool _is_item_signal(TreeItem &p_item);
+	TreeItemType _get_item_type(const TreeItem &p_item) const;
 	bool _is_connection_inherited(Connection &p_connection);
 
 	void _open_connection_dialog(TreeItem &p_item);
 	void _open_edit_connection_dialog(TreeItem &p_item);
-	void _go_to_script(TreeItem &p_item);
+	void _go_to_method(TreeItem &p_item);
 
+	void _handle_class_menu_option(int p_option);
+	void _class_menu_about_to_popup();
 	void _handle_signal_menu_option(int p_option);
 	void _signal_menu_about_to_popup();
 	void _handle_slot_menu_option(int p_option);
 	void _slot_menu_about_to_popup();
-	void _rmb_pressed(Vector2 p_position, MouseButton p_button);
+	void _rmb_pressed(const Ref<InputEvent> &p_event);
 	void _close();
 
 protected:

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -253,11 +253,22 @@ class EditorInspectorCategory : public Control {
 	GDCLASS(EditorInspectorCategory, Control);
 
 	friend class EditorInspector;
+
+	// Right-click context menu options.
+	enum ClassMenuOption {
+		MENU_OPEN_DOCS,
+	};
+
 	Ref<Texture2D> icon;
 	String label;
+	String doc_class_name;
+	PopupMenu *menu = nullptr;
+
+	void _handle_menu_option(int p_option);
 
 protected:
 	void _notification(int p_what);
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	virtual Size2 get_minimum_size() const override;


### PR DESCRIPTION
* Continuation of #81092.
* Fixes #64432.

1\. Fixes a part of #78934 (no description for properties after `@export_category`).

There is now a way (`hint_string`) to distinguish type categories from custom categories. This is consistent with scripts, they already use `hint_string`.

https://github.com/godotengine/godot/blob/549fcce5f8f7beace3e5c90e9bbe4335d4fd1476/core/object/object.h#L492

https://github.com/godotengine/godot/blob/549fcce5f8f7beace3e5c90e9bbe4335d4fd1476/core/object/script_language.cpp#L124

```gdscript
extends Node
@export var a: int
@export_category("Node")
@export var b: int
```

![](https://github.com/godotengine/godot/assets/47700418/f71d211f-a79c-4fda-bec8-bacde1e66bc1)

Also we can make the background a bit less bright than normal categories.

2\. Added a tooltip when hovering a class item in the Signal dock, to be consistent with the Inspector.

![](https://github.com/godotengine/godot/assets/47700418/50f9bf99-4017-43cd-a385-57c78608aac7)

3\. Added "Open Documentation" context menu for classes to Inspector and Signal docks.

![](https://github.com/godotengine/godot/assets/47700418/94bcab1b-1e34-4881-a4fa-11b6e911dfe5)

4\. Fixed a bug with displaying incorrect tooltips for callback items.

Before:
![](https://github.com/godotengine/godot/assets/47700418/d22cd5f7-1c24-4e78-a974-f32d073712e4)

After:
![](https://github.com/godotengine/godot/assets/47700418/1c41332a-3b04-48ba-9649-6613d9b3403e)

5\. Fixed a bug where descriptions could be truncated if they contain `::` (the `maxsplit` argument for `String.split()` is now specified)