### PR TITLE
Fix `EditorFileDialog` clears the file name on changing directory

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -264,17 +264,17 @@ void EditorFileDialog::update_dir() {
 	}
 	dir->set_text(dir_access->get_current_dir(false));
 
-	file->set_text("");
-
 	// Disable "Open" button only when selecting file(s) mode.
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 	switch (mode) {
 		case FILE_MODE_OPEN_FILE:
 		case FILE_MODE_OPEN_FILES:
+			file->set_text("");
 			set_ok_button_text(TTR("Open"));
 			break;
 		case FILE_MODE_OPEN_ANY:
 		case FILE_MODE_OPEN_DIR:
+			file->set_text("");
 			set_ok_button_text(TTR("Select Current Folder"));
 			break;
 		case FILE_MODE_SAVE_FILE:


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/51478, the change in that PR will clear the file when changing directory (which is undesirable, for example if you want to save the same name in a different directory), can't find any clear justification for the change in the PR, but I might have missed something, but in any case it breaks correct behavior relatively seriously, so what ever the reason for that change it has to be re-implemented with these effects in mind.

Might work correctly by moving the change to the cases below, but think this needs a dedicated investigation into what we actually want to accomplish here:
```diff
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -264,17 +264,17 @@ void EditorFileDialog::update_dir() {
        }
        dir->set_text(dir_access->get_current_dir(false));

-       file->set_text("");
-
        // Disable "Open" button only when selecting file(s) mode.
        get_ok_button()->set_disabled(_is_open_should_be_disabled());
        switch (mode) {
                case FILE_MODE_OPEN_FILE:
                case FILE_MODE_OPEN_FILES:
+                       file->set_text("");
                        set_ok_button_text(TTR("Open"));
                        break;
                case FILE_MODE_OPEN_ANY:
                case FILE_MODE_OPEN_DIR:
+                       file->set_text("");
                        set_ok_button_text(TTR("Select Current Folder"));
                        break;
                case FILE_MODE_SAVE_FILE:
```

* Fixes: #81225

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
