### PR TITLE
Fix int's C# documentation

### DIFF
--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -17,7 +17,7 @@
 		[/gdscript]
 		[csharp]
 		int x = 1; // x is 1
-		x = 4.2; // x is 4, because 4.2 gets truncated
+		x = (int)4.2; // x is 4, because 4.2 gets truncated
 		// We use long below, because GDScript's int is 64-bit while C#'s int is 32-bit.
 		long maxLong = 9223372036854775807; // Biggest value a long can store
 		maxLong++; // maxLong is now -9223372036854775808, because it wrapped around.
@@ -27,12 +27,19 @@
 		maxInt++; // maxInt is now -2147483648, because it wrapped around
 		[/csharp]
 		[/codeblocks]
-		In GDScript, you can use the [code]0b[/code] literal for binary representation, the [code]0x[/code] literal for hexadecimal representation, and the [code]_[/code] symbol to separate long numbers and improve readability.
-		[codeblock]
+		You can use the [code]0b[/code] literal for binary representation, the [code]0x[/code] literal for hexadecimal representation, and the [code]_[/code] symbol to separate long numbers and improve readability.
+		[codeblocks]
+		[gdscript]
 		var x = 0b1001 # x is 9
 		var y = 0xF5 # y is 245
 		var z = 10_000_000 # z is 10000000
-		[/codeblock]
+		[/gdscript]
+		[csharp]
+		int x = 0b1001; // x is 9
+		int y = 0xF5; // y is 245
+		int z = 10_000_000; // z is 10000000
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
- There's no implicit conversion from `double` to `int`, a cast was missing.
- The example about literals in GDScript also applies to C# (with the same syntax even).

This documentation was added in https://github.com/godotengine/godot/pull/70046 which was merged in 4.1 and cherry-picked to 4.0 so I added the cherry-pick labels accordingly.