### PR TITLE
Use godot-cpp 4.1 for the "Godot CPP" CI workflow to prevent circular dependency

### DIFF
--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -4,8 +4,10 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key, and godot-cpp checkout. Add version suffix to force clean build.
+  # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
+  # Used for the godot-cpp checkout.
+  GODOT_CPP_BRANCH: '4.1'
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-cpp-tests
@@ -26,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: godotengine/godot-cpp
-          ref: ${{ env.GODOT_BASE_BRANCH }}
+          ref: ${{ env.GODOT_CPP_BRANCH }}
           submodules: 'recursive'
           path: 'godot-cpp'
 


### PR DESCRIPTION
At the moment, we have an issue where any PR that updates any of the new structs added to `gdextension_interface.h` will fail CI on the "Godot CPP" workflow.

This is because godot-cpp on its `master` branch has already been updated to use the new structs, and so if we change them, we end up with a circular dependency: Godot's CI won't pass without an updated godot-cpp, and godot-cpp's CI won't pass without an updated Godot.

Once Godot 4.2 is release, we won't change these structs any more -- we'll have to start worrying about backward compatibility, and so even newer structs would need to be added in order to make changes. However, until then, we _can_ update these structs - if it weren't for this CI issue :-)

There's a couple of options:

1. We decide it's OK to merge these handful of affected PRs even though tests are failing. This isn't ideal, because until godot-cpp is updated, there is a (probably very short) window of time when other PRs that fork from master at the wrong time will fail too. Given how short this window of time would probably be, maybe that's OK?
2. We ensure that godot-cpp's `master` branch _doesn't_ update to use the new structs until after Godot 4.2 is released. I'm not crazy about this option, though, because we need time to work on the companion Godot 4.2 changes, and I don't want to have to save those PR's until Godot 4.2's release.
3. We switch to using the Godot 4.1 version of godot-cpp. This doesn't have any of the downsides of the previous two options, **and it's what this PR does**, but it does mean we'll have to make some extra PRs around each Godot release to change the version of godot-cpp that's used in the tests. Personally, I think this is the smallest downside - we're making PRs to change stuff everyday, what's one more thing ;-)

But I'd like feedback on what other folks think is the best option, or if there's an option that I didn't consider!