### PR TITLE
Add XR tracking state-change signals

### DIFF
--- a/doc/classes/XRNode3D.xml
+++ b/doc/classes/XRNode3D.xml
@@ -51,4 +51,12 @@
 			Godot defines a number of standard trackers such as [code]left_hand[/code] and [code]right_hand[/code] but others may be configured within a given [XRInterface].
 		</member>
 	</members>
+	<signals>
+		<signal name="tracking_changed">
+			<param index="0" name="tracking" type="bool" />
+			<description>
+				Emitted when the [member tracker] starts or stops receiving updated tracking data for the [member pose] being tracked. The [param tracking] argument indicates whether the tracker is getting updated tracking data.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -112,6 +112,12 @@
 				Emitted when the state of a pose tracked by this tracker changes.
 			</description>
 		</signal>
+		<signal name="pose_lost_tracking">
+			<param index="0" name="pose" type="XRPose" />
+			<description>
+				Emitted when a pose tracked by this tracker stops getting updated tracking data.
+			</description>
+		</signal>
 		<signal name="profile_changed">
 			<param index="0" name="role" type="String" />
 			<description>

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -78,7 +78,7 @@ class XRNode3D : public Node3D {
 private:
 	StringName tracker_name;
 	StringName pose_name = "default";
-	bool is_active = true;
+	bool has_tracking_data = false;
 
 protected:
 	Ref<XRPositionalTracker> tracker;
@@ -91,6 +91,8 @@ protected:
 	void _removed_tracker(const StringName p_tracker_name, int p_tracker_type);
 
 	void _pose_changed(const Ref<XRPose> &p_pose);
+	void _pose_lost_tracking(const Ref<XRPose> &p_pose);
+	void _set_has_tracking_data(bool p_has_tracking_data);
 
 public:
 	void _validate_property(PropertyInfo &p_property) const;

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -62,6 +62,7 @@ void XRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("invalidate_pose", "name"), &XRPositionalTracker::invalidate_pose);
 	ClassDB::bind_method(D_METHOD("set_pose", "name", "transform", "linear_velocity", "angular_velocity", "tracking_confidence"), &XRPositionalTracker::set_pose);
 	ADD_SIGNAL(MethodInfo("pose_changed", PropertyInfo(Variant::OBJECT, "pose", PROPERTY_HINT_RESOURCE_TYPE, "XRPose")));
+	ADD_SIGNAL(MethodInfo("pose_lost_tracking", PropertyInfo(Variant::OBJECT, "pose", PROPERTY_HINT_RESOURCE_TYPE, "XRPose")));
 
 	ClassDB::bind_method(D_METHOD("get_input", "name"), &XRPositionalTracker::get_input);
 	ClassDB::bind_method(D_METHOD("set_input", "name", "value"), &XRPositionalTracker::set_input);
@@ -146,7 +147,10 @@ void XRPositionalTracker::invalidate_pose(const StringName &p_action_name) {
 	// only update this if we were tracking this pose
 	if (poses.has(p_action_name)) {
 		// We just set tracking data as invalid, we leave our current transform and velocity data as is so controllers don't suddenly jump to origin.
-		poses[p_action_name]->set_has_tracking_data(false);
+		Ref<XRPose> pose = poses[p_action_name];
+		pose->set_has_tracking_data(false);
+
+		emit_signal(SNAME("pose_lost_tracking"), pose);
 	}
 }
 


### PR DESCRIPTION
This pull request adds signals to detect the start and stop of tracking for XR Trackers. Specifically it:
- Adds a `pose_lost_tracking(pose : XRPose)` signal to XRPositionalTracker
- Adds a `tracking_changed(tracking : bool)` signal to XRNode3D

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
