### PR TITLE
Fix `NodePath` property assignments when reparenting nodes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1639,7 +1639,7 @@ bool SceneTreeDock::_update_node_path(Node *p_root_node, NodePath &r_node_path, 
 	return false;
 }
 
-bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_variant, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource) const {
+bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_variant, Variant &r_cleared_variant, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource) const {
 	switch (r_variant.get_type()) {
 		case Variant::NODE_PATH: {
 			NodePath node_path = r_variant;
@@ -1650,44 +1650,56 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 
 			if (!node_path.is_empty() && _update_node_path(p_root_node, node_path, p_renames)) {
 				r_variant = node_path;
+				r_cleared_variant = NodePath();
 				return true;
 			}
 		} break;
 
 		case Variant::ARRAY: {
 			Array a = r_variant;
+			Array cleared_a = r_variant;
 			bool updated = false;
 			for (int i = 0; i < a.size(); i++) {
 				Variant value = a[i];
-				if (_check_node_path_recursive(p_root_node, value, p_renames, p_inside_resource)) {
+				Variant cleared_value;
+				if (_check_node_path_recursive(p_root_node, value, cleared_value, p_renames, p_inside_resource)) {
 					if (!updated) {
 						a = a.duplicate(); // Need to duplicate for undo-redo to work.
+						cleared_a = cleared_a.duplicate();
 						updated = true;
 					}
 					a[i] = value;
+					cleared_a[i] = cleared_value;
 				}
 			}
 			if (updated) {
 				r_variant = a;
+				r_cleared_variant = cleared_a;
 				return true;
 			}
 		} break;
 
 		case Variant::DICTIONARY: {
 			Dictionary d = r_variant;
+			Dictionary cleared_d = r_variant;
 			bool updated = false;
 			for (int i = 0; i < d.size(); i++) {
 				Variant value = d.get_value_at_index(i);
-				if (_check_node_path_recursive(p_root_node, value, p_renames, p_inside_resource)) {
+				Variant cleared_value;
+				if (_check_node_path_recursive(p_root_node, value, cleared_value, p_renames, p_inside_resource)) {
 					if (!updated) {
 						d = d.duplicate(); // Need to duplicate for undo-redo to work.
+						cleared_d = cleared_d.duplicate();
 						updated = true;
 					}
-					d[d.get_key_at_index(i)] = value;
+					Variant key = d.get_key_at_index(i);
+					d[key] = value;
+					cleared_d[key] = cleared_value;
 				}
 			}
 			if (updated) {
 				r_variant = d;
+				r_cleared_variant = cleared_d;
 				return true;
 			}
 		} break;
@@ -1708,11 +1720,12 @@ bool SceneTreeDock::_check_node_path_recursive(Node *p_root_node, Variant &r_var
 				String propertyname = E.name;
 				Variant old_variant = resource->get(propertyname);
 				Variant updated_variant = old_variant;
-				if (_check_node_path_recursive(p_root_node, updated_variant, p_renames, true)) {
+				Variant cleared_variant;
+				if (_check_node_path_recursive(p_root_node, updated_variant, cleared_variant, p_renames, true)) {
 					EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 					undo_redo->add_do_property(resource, propertyname, updated_variant);
 					undo_redo->add_undo_property(resource, propertyname, old_variant);
-					resource->set(propertyname, updated_variant);
+					resource->set(propertyname, cleared_variant);
 				}
 			}
 			break;
@@ -1756,11 +1769,13 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 		String propertyname = E.name;
 		Variant old_variant = p_base->get(propertyname);
 		Variant updated_variant = old_variant;
-		if (_check_node_path_recursive(p_base, updated_variant, p_renames)) {
+		Variant cleared_variant;
+		if (_check_node_path_recursive(p_base, updated_variant, cleared_variant, p_renames)) {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->add_do_property(p_base, propertyname, updated_variant);
 			undo_redo->add_undo_property(p_base, propertyname, old_variant);
-			p_base->set(propertyname, updated_variant);
+			// Remove old node paths temporarily to avoid triggering errors.
+			p_base->set(propertyname, cleared_variant);
 		}
 	}
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -281,7 +281,7 @@ class SceneTreeDock : public VBoxContainer {
 	static void _update_configuration_warning();
 
 	bool _update_node_path(Node *p_root_node, NodePath &r_node_path, HashMap<Node *, NodePath> *p_renames) const;
-	bool _check_node_path_recursive(Node *p_root_node, Variant &r_variant, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource = false) const;
+	bool _check_node_path_recursive(Node *p_root_node, Variant &r_variant, Variant &r_cleared_variant, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource = false) const;
 	bool _check_node_recursive(Variant &r_variant, Node *p_node, Node *p_by_node, const String type_hint, String &r_warn_message);
 	void _replace_node(Node *p_node, Node *p_by_node, bool p_keep_properties = true, bool p_remove_old = true);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #80589
The skeleton path is updated with a new relative path before node reparenting completes so `MeshInstance3D` tries to find the skeleton before moving to the expected position. Base on my observation, the skeleton path will be resolved after `MeshInstance3D` enters the tree again after the node reparenting.
