### PR TITLE
[Windows] Fix not applying NVIDIA profile to new executables

### DIFF
--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -88,6 +88,7 @@ typedef int(__cdecl *NvAPI_DRS_CreateApplication_t)(NvDRSSessionHandle, NvDRSPro
 typedef int(__cdecl *NvAPI_DRS_SaveSettings_t)(NvDRSSessionHandle);
 typedef int(__cdecl *NvAPI_DRS_SetSetting_t)(NvDRSSessionHandle, NvDRSProfileHandle, NVDRS_SETTING *);
 typedef int(__cdecl *NvAPI_DRS_FindProfileByName_t)(NvDRSSessionHandle, NvAPI_UnicodeString, NvDRSProfileHandle *);
+typedef int(__cdecl *NvAPI_DRS_FindApplicationByName_t)(NvDRSSessionHandle, NvAPI_UnicodeString, NvDRSProfileHandle *, NVDRS_APPLICATION *);
 NvAPI_GetErrorMessage_t NvAPI_GetErrorMessage__;
 
 static bool nvapi_err_check(const char *msg, int status) {
@@ -138,6 +139,7 @@ void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 	NvAPI_DRS_SaveSettings_t NvAPI_DRS_SaveSettings = (NvAPI_DRS_SaveSettings_t)NvAPI_QueryInterface(0xFCBC7E14);
 	NvAPI_DRS_SetSetting_t NvAPI_DRS_SetSetting = (NvAPI_DRS_SetSetting_t)NvAPI_QueryInterface(0x577DD202);
 	NvAPI_DRS_FindProfileByName_t NvAPI_DRS_FindProfileByName = (NvAPI_DRS_FindProfileByName_t)NvAPI_QueryInterface(0x7E4A9A0B);
+	NvAPI_DRS_FindApplicationByName_t NvAPI_DRS_FindApplicationByName = (NvAPI_DRS_FindApplicationByName_t)NvAPI_QueryInterface(0xEEE566B2);
 
 	if (!nvapi_err_check("NVAPI: Init failed", NvAPI_Initialize())) {
 		return;
@@ -172,9 +174,9 @@ void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 
 	NvDRSProfileHandle profile_handle = 0;
 
-	int status = NvAPI_DRS_FindProfileByName(session_handle, (NvU16 *)(app_profile_name_u16.ptrw()), &profile_handle);
+	int profile_status = NvAPI_DRS_FindProfileByName(session_handle, (NvU16 *)(app_profile_name_u16.ptrw()), &profile_handle);
 
-	if (status != 0) {
+	if (profile_status != 0) {
 		print_verbose("NVAPI: Profile not found, creating....");
 
 		NVDRS_PROFILE profile_info;
@@ -187,9 +189,17 @@ void GLManagerNative_Windows::_nvapi_disable_threaded_optimization() {
 			NvAPI_Unload();
 			return;
 		}
+	}
 
-		NVDRS_APPLICATION_V4 app;
-		app.version = NVDRS_APPLICATION_VER_V4;
+	NvDRSProfileHandle app_profile_handle = 0;
+	NVDRS_APPLICATION_V4 app;
+	app.version = NVDRS_APPLICATION_VER_V4;
+
+	int app_status = NvAPI_DRS_FindApplicationByName(session_handle, (NvU16 *)(app_executable_name_u16.ptrw()), &app_profile_handle, &app);
+
+	if (app_status != 0) {
+		print_verbose("NVAPI: Application not found, adding to profile...");
+
 		app.isPredefined = 0;
 		app.isMetro = 1;
 		app.isCommandLine = 1;


### PR DESCRIPTION
An NVIDIA profile is applied to the current executable to disable threaded OpenGL optimizations on Windows (see #71472). But because the application is only added to the profile upon the profile creation, newer executables won't be added to the profile (e.g. if the profile is created on first launch of `Godot_v4.1-stable_win64.exe`, when users update the editor and launch `Godot_v4.2-stable_win64.exe`, the profile will never be applied to this new executable).

This patch fixes that scenario by splitting creating the profile (if it doesn't exist) and adding the application (if it doesn't have a profile applied) into two separate steps.

Applications that have been manually added to a different profile aren't overriden to avoid confusing users who know what they're doing.
