### PR TITLE
Allow implementing `ScriptInstance::validate_property()` from GDExtension

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1055,6 +1055,7 @@ static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDE
 	info_2->get_method_list_func = p_info->get_method_list_func;
 	info_2->free_method_list_func = p_info->free_method_list_func;
 	info_2->get_property_type_func = p_info->get_property_type_func;
+	info_2->validate_property_func = nullptr;
 	info_2->has_method_func = p_info->has_method_func;
 	info_2->call_func = p_info->call_func;
 	info_2->notification_func = nullptr;

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -373,6 +373,7 @@ typedef GDExtensionBool (*GDExtensionScriptInstanceGet)(GDExtensionScriptInstanc
 typedef const GDExtensionPropertyInfo *(*GDExtensionScriptInstanceGetPropertyList)(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count);
 typedef void (*GDExtensionScriptInstanceFreePropertyList)(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo *p_list);
 typedef GDExtensionVariantType (*GDExtensionScriptInstanceGetPropertyType)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid);
+typedef GDExtensionBool (*GDExtensionScriptInstanceValidateProperty)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_property);
 
 typedef GDExtensionBool (*GDExtensionScriptInstancePropertyCanRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name);
 typedef GDExtensionBool (*GDExtensionScriptInstancePropertyGetRevert)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret);
@@ -459,6 +460,7 @@ typedef struct {
 	GDExtensionScriptInstanceGetMethodList get_method_list_func;
 	GDExtensionScriptInstanceFreeMethodList free_method_list_func;
 	GDExtensionScriptInstanceGetPropertyType get_property_type_func;
+	GDExtensionScriptInstanceValidateProperty validate_property_func;
 
 	GDExtensionScriptInstanceHasMethod has_method_func;
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -688,7 +688,24 @@ public:
 		return Variant::NIL;
 	}
 	virtual void validate_property(PropertyInfo &p_property) const override {
-		// TODO
+		if (native_info->validate_property_func) {
+			GDExtensionPropertyInfo gdext_prop = {
+				(GDExtensionVariantType)p_property.type,
+				&p_property.name,
+				&p_property.class_name,
+				(uint32_t)p_property.hint,
+				&p_property.hint_string,
+				p_property.usage,
+			};
+			if (native_info->validate_property_func(instance, &gdext_prop)) {
+				p_property.type = (Variant::Type)gdext_prop.type;
+				p_property.name = *reinterpret_cast<StringName *>(gdext_prop.name);
+				p_property.class_name = *reinterpret_cast<StringName *>(gdext_prop.class_name);
+				p_property.hint = (PropertyHint)gdext_prop.hint;
+				p_property.hint_string = *reinterpret_cast<String *>(gdext_prop.hint_string);
+				p_property.usage = gdext_prop.usage;
+			}
+		}
 	}
 
 	virtual bool property_can_revert(const StringName &p_name) const override {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81119

I haven't had a chance to test this yet.

It adds this function pointer type:

```c++
typedef GDExtensionBool (*GDExtensionScriptInstanceValidateProperty)(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_property);
```

I opted to have it return `GDExtensionBool` (the `ScriptInstance::validate_property()` method doesn't return anything) since we have to copy back and forth between the Godot and GDExtension version of `PropertyInfo`. I figure this could allow the GDExtension to check if the script even implements `validate_property()`, and if it doesn't, just return `false` in order to skip one of the copies. Does that make sense? I'd love some feedback on that.