### PR TITLE
GLTF: Change "Camera3D" generated node name to "Camera"

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5280,7 +5280,7 @@ void GLTFDocument::_assign_node_names(Ref<GLTFState> p_state) {
 			if (gltf_node->mesh >= 0) {
 				gltf_node_name = "Mesh";
 			} else if (gltf_node->camera >= 0) {
-				gltf_node_name = "Camera3D";
+				gltf_node_name = "Camera";
 			} else {
 				gltf_node_name = "Node";
 			}


### PR DESCRIPTION
This PR was originally a part of #80270, but fire requested that I split this out.

This string [was originally "Camera"](https://github.com/godotengine/godot/blob/8ad0ff8ae5578d92352b63d863e5dcd801458368/editor/import/editor_scene_importer_gltf.cpp#L2566-L2574) but was accidentally renamed to Camera3D during the 4.0 development cycle.

To be clear, this doesn't break compat any more than #80270 does. The names are already changed due to #80270. Before #80270 the names were like "Camera3D2", "Camera3D32", "Camera3D42", etc. As of #80270 they are "Camera3D", "Camera3D2", "Camera3D3", etc. With this PR the names are "Camera", "Camera2", "Camera3", etc. So the names are already changed, this PR just makes it more readable.