### PR TITLE
Add isometric cell shape mode to `AStarGrid2D`.

### DIFF
--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -56,11 +56,19 @@ public:
 		HEURISTIC_MAX,
 	};
 
+	enum CellShape {
+		CELL_SHAPE_SQUARE,
+		CELL_SHAPE_ISOMETRIC_RIGHT,
+		CELL_SHAPE_ISOMETRIC_DOWN,
+		CELL_SHAPE_MAX,
+	};
+
 private:
 	Rect2i region;
 	Vector2 offset;
 	Size2 cell_size = Size2(1, 1);
 	bool dirty = false;
+	CellShape cell_shape = CELL_SHAPE_SQUARE;
 
 	bool jumping_enabled = false;
 	DiagonalMode diagonal_mode = DIAGONAL_MODE_ALWAYS;
@@ -157,6 +165,9 @@ public:
 	void set_cell_size(const Size2 &p_cell_size);
 	Size2 get_cell_size() const;
 
+	void set_cell_shape(CellShape p_cell_shape);
+	CellShape get_cell_shape() const;
+
 	void update();
 
 	bool is_in_bounds(int32_t p_x, int32_t p_y) const;
@@ -193,5 +204,6 @@ public:
 
 VARIANT_ENUM_CAST(AStarGrid2D::DiagonalMode);
 VARIANT_ENUM_CAST(AStarGrid2D::Heuristic);
+VARIANT_ENUM_CAST(AStarGrid2D::CellShape)
 
 #endif // A_STAR_GRID_2D_H

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -157,6 +157,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="cell_shape" type="int" setter="set_cell_shape" getter="get_cell_shape" enum="AStarGrid2D.CellShape" default="0">
+			The cell shape. Affects how the positions are placed in the grid. If changed, [method update] needs to be called before finding the next path.
+		</member>
 		<member name="cell_size" type="Vector2" setter="set_cell_size" getter="get_cell_size" default="Vector2(1, 1)">
 			The size of the point cell which will be applied to calculate the resulting point position returned by [method get_point_path]. If changed, [method update] needs to be called before finding the next path.
 		</member>
@@ -237,6 +240,18 @@
 		</constant>
 		<constant name="DIAGONAL_MODE_MAX" value="4" enum="DiagonalMode">
 			Represents the size of the [enum DiagonalMode] enum.
+		</constant>
+		<constant name="CELL_SHAPE_SQUARE" value="0" enum="CellShape">
+			Rectangular cell shape.
+		</constant>
+		<constant name="CELL_SHAPE_ISOMETRIC_RIGHT" value="1" enum="CellShape">
+			Diamond cell shape (for isometric look). Cell coordinates layout where the horizontal axis goes up-right, and the vertical one goes down-right.
+		</constant>
+		<constant name="CELL_SHAPE_ISOMETRIC_DOWN" value="2" enum="CellShape">
+			Diamond cell shape (for isometric look). Cell coordinates layout where the horizontal axis goes down-right, and the vertical one goes down-left.
+		</constant>
+		<constant name="CELL_SHAPE_MAX" value="3" enum="CellShape">
+			Represents the size of the [enum CellShape] enum.
 		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
I know some users are requesting this. This will ease up to set up this class to work with isometric TileMap's.

![image](https://github.com/godotengine/godot/assets/3036176/ddf2b8cc-30eb-44c3-9dc5-9a637a8004cc)

So I've added a new property `cell_shape` (just like the property in the `TileSet`) and enum for this `CellShape` which has 3 values: `CELL_SHAPE_SQUARE` (default) and `CELL_SHAPE_ISOMETRIC_RIGHT`/`CELL_SHAPE_ISOMETRIC_DOWN` (corresponds to `TILE_LAYOUT_DIAMOND_RIGHT` and `TILE_LAYOUT_DIAMOND_DOWN` enum of the `TileSet` respectively).

This will simply modify the resulted world coordinates and do not affect the id layout of the grid (the `update` method call still required if changed).

 You can check the small demo project which demonstrates this change:  
[IsometricAStarGrid2D.zip](https://github.com/godotengine/godot/files/12505973/IsometricAStarGrid2D.zip)
