### PR TITLE
Fix clamping logic in `EditorSpinSlider`

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -203,7 +203,6 @@ void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !is_read_only()) {
 		double step = get_step();
-		double real_step = step;
 		if (step < 1) {
 			double divisor = 1.0 / get_step();
 
@@ -221,30 +220,22 @@ void EditorSpinSlider::_value_input_gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		Key code = k->get_keycode();
+
 		switch (code) {
-			case Key::UP: {
-				_evaluate_input_text();
-
-				double last_value = get_value();
-				set_value(last_value + step);
-				double new_value = get_value();
-
-				if (new_value < CLAMP(last_value + step, get_min(), get_max())) {
-					set_value(last_value + real_step);
-				}
-
-				value_input_dirty = true;
-				set_process_internal(true);
-			} break;
+			case Key::UP:
 			case Key::DOWN: {
 				_evaluate_input_text();
 
 				double last_value = get_value();
-				set_value(last_value - step);
+				if (code == Key::DOWN) {
+					step *= -1;
+				}
+				set_value(last_value + step);
 				double new_value = get_value();
 
-				if (new_value > CLAMP(last_value - step, get_min(), get_max())) {
-					set_value(last_value - real_step);
+				double clamp_value = CLAMP(new_value, get_min(), get_max());
+				if (new_value != clamp_value) {
+					set_value(clamp_value);
 				}
 
 				value_input_dirty = true;


### PR DESCRIPTION
... when arrow keys are pressed `up` or `down`.

Fixes #81272

I have only tried `Inspertor`, I am not sure if the old changes are necessary for something else.
The old version changed the values by 0.001 from time to time.

https://github.com/godotengine/godot/assets/41921395/65962971-c3b8-4374-b03b-9dc596c4bcf3



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
