### PR TITLE
Fix for non-deterministic behavior in PCKPacker

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -205,7 +205,7 @@ Error PCKPacker::flush(bool p_verbose) {
 
 	int header_padding = _get_pad(alignment, file->get_position());
 	for (int i = 0; i < header_padding; i++) {
-		file->store_8(Math::rand() % 256);
+		file->store_8(0);
 	}
 
 	int64_t file_base = file->get_position();
@@ -244,7 +244,7 @@ Error PCKPacker::flush(bool p_verbose) {
 
 		int pad = _get_pad(alignment, file->get_position());
 		for (int j = 0; j < pad; j++) {
-			file->store_8(Math::rand() % 256);
+			file->store_8(0);
 		}
 
 		count += 1;

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -236,7 +236,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 
 	int pad = _get_pad(PCK_PADDING, pd->f->get_position());
 	for (int i = 0; i < pad; i++) {
-		pd->f->store_8(Math::rand() % 256);
+		pd->f->store_8(0);
 	}
 
 	// Store MD5 of original file.
@@ -1659,7 +1659,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	int header_padding = _get_pad(PCK_PADDING, f->get_position());
 	for (int i = 0; i < header_padding; i++) {
-		f->store_8(Math::rand() % 256);
+		f->store_8(0);
 	}
 
 	uint64_t file_base = f->get_position();


### PR DESCRIPTION
PCK files (like other build products) should be deterministic based on their inputs. This fix removes calls to Math::rand() that are being used to fill in padding (0-padding is preferred).

It looks like these lines were introduced as part of adding encryption support, but the padding being random does not have any cryptographic significance. This can be trivially inferred since file blocks that happen to be aligned don't get padding at all and would receive no contribution to their entropy. 

If there's a desire to indroduce something that functions as a nonce it should probably be added explicitly and only if encryption is enabled. That said, such a feature would probably be more simply implemented (with no additional code) by just changing the encrypted assets or cycling the keys used for the pck file, so I've made no attempt to address it with this fix.
