### PR TITLE
Show doc tooltips when hovering properties in the theme editor

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/templates/hash_set.h"
-#include "editor/doc_tools.h"
 #include "editor/editor_help.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_node.h"

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -187,8 +187,7 @@ public:
 
 //////////////////////////////////////////
 
-// Custom Tree needed to use a RichTextLabel as tooltip control
-// when display signal documentation.
+// Custom `Tree` needed to use `EditorHelpTooltip` to display signal documentation.
 class ConnectionsDockTree : public Tree {
 	virtual Control *make_custom_tooltip(const String &p_text) const;
 };

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -31,6 +31,7 @@
 #include "theme_editor_plugin.h"
 
 #include "core/os/keyboard.h"
+#include "editor/editor_help.h"
 #include "editor/editor_node.h"
 #include "editor/editor_resource_picker.h"
 #include "editor/editor_scale.h"
@@ -2259,6 +2260,10 @@ ThemeTypeDialog::ThemeTypeDialog() {
 
 ///////////////////////
 
+Control *ThemeItemLabel::make_custom_tooltip(const String &p_text) const {
+	return memnew(EditorHelpTooltip(p_text));
+}
+
 VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 	VBoxContainer *items_tab = memnew(VBoxContainer);
 	items_tab->set_custom_minimum_size(Size2(0, 160) * EDSCALE);
@@ -2413,11 +2418,13 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 	item_name_container->set_stretch_ratio(2.0);
 	item_control->add_child(item_name_container);
 
-	Label *item_name = memnew(Label);
+	Label *item_name = memnew(ThemeItemLabel);
 	item_name->set_h_size_flags(SIZE_EXPAND_FILL);
 	item_name->set_clip_text(true);
 	item_name->set_text(p_item_name);
-	item_name->set_tooltip_text(p_item_name);
+	// `|` separators used in `EditorHelpTooltip` for formatting.
+	item_name->set_tooltip_text("theme_item|" + edited_type + "|" + p_item_name + "|");
+	item_name->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	item_name_container->add_child(item_name);
 
 	if (p_editable) {
@@ -2477,7 +2484,6 @@ void ThemeTypeEditor::_add_focusable(Control *p_control) {
 
 void ThemeTypeEditor::_update_type_items() {
 	bool show_default = show_default_items_button->is_pressed();
-	List<StringName> names;
 
 	focusables.clear();
 

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -320,6 +320,11 @@ public:
 	ThemeTypeDialog();
 };
 
+// Custom `Label` needed to use `EditorHelpTooltip` to display theme item documentation.
+class ThemeItemLabel : public Label {
+	virtual Control *make_custom_tooltip(const String &p_text) const;
+};
+
 class ThemeTypeEditor : public MarginContainer {
 	GDCLASS(ThemeTypeEditor, MarginContainer);
 


### PR DESCRIPTION
Just a small QOL thing I wanted to do in a while. I took some inspiration from dalexeev's work in the signal dock on how to implement it.

![image](https://github.com/godotengine/godot/assets/30739239/f038f226-61cb-4a6c-9baf-39853e6908ec)