### PR TITLE
Fix compiling with 3D disabled due to unused navigation variable

### DIFF
--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -56,7 +56,9 @@
 	void MERGE(_cmd_, F_NAME)(T_0 D_0, T_1 D_1)
 
 class GodotNavigationServer;
+#ifndef _3D_DISABLED
 class NavMeshGenerator3D;
+#endif // _3D_DISABLED
 
 struct SetCommand {
 	virtual ~SetCommand() {}
@@ -80,7 +82,9 @@ class GodotNavigationServer : public NavigationServer3D {
 	LocalVector<NavMap *> active_maps;
 	LocalVector<uint32_t> active_maps_update_id;
 
+#ifndef _3D_DISABLED
 	NavMeshGenerator3D *navmesh_generator_3d = nullptr;
+#endif // _3D_DISABLED
 
 	// Performance Monitor
 	int pm_region_count = 0;


### PR DESCRIPTION
In the current master, Godot does not compile with 3D disabled `scons target=template_debug disable_3d=yes`, at least it fails with Clang, due to an unused variable. This PR fixes that.

```
[ 51%] In file included from modules/navigation/godot_navigation_server.cpp:31:
modules/navigation/godot_navigation_server.h:83:22: error: private field 'navmesh_generator_3d' is not used [-Werror,-Wunused-private-field]
        NavMeshGenerator3D *navmesh_generator_3d = nullptr;
                            ^
1 error generated.
```