### PR TITLE
Fix bindings of `PhysicsServer3DRenderingServerHandler`

### DIFF
--- a/doc/classes/PhysicsServer3DRenderingServerHandler.xml
+++ b/doc/classes/PhysicsServer3DRenderingServerHandler.xml
@@ -12,20 +12,48 @@
 			<return type="void" />
 			<param index="0" name="aabb" type="AABB" />
 			<description>
+				Called by the [PhysicsServer3D] to set the bounding box for the [SoftBody3D].
 			</description>
 		</method>
 		<method name="_set_normal" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
-			<param index="1" name="normals" type="const void*" />
+			<param index="1" name="normal" type="Vector3" />
 			<description>
+				Called by the [PhysicsServer3D] to set the normal for the [SoftBody3D] vertex at the index specified by [param vertex_id].
+				[b]Note:[/b] The [param normal] parameter used to be of type [code]const void*[/code] prior to Godot 4.2.
 			</description>
 		</method>
 		<method name="_set_vertex" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
-			<param index="1" name="vertices" type="const void*" />
+			<param index="1" name="vertex" type="Vector3" />
 			<description>
+				Called by the [PhysicsServer3D] to set the position for the [SoftBody3D] vertex at the index specified by [param vertex_id].
+				[b]Note:[/b] The [param vertex] parameter used to be of type [code]const void*[/code] prior to Godot 4.2.
+			</description>
+		</method>
+		<method name="set_aabb">
+			<return type="void" />
+			<param index="0" name="aabb" type="AABB" />
+			<description>
+				Sets the bounding box for the [SoftBody3D].
+			</description>
+		</method>
+		<method name="set_normal">
+			<return type="void" />
+			<param index="0" name="vertex_id" type="int" />
+			<param index="1" name="normal" type="Vector3" />
+			<description>
+				Sets the normal for the [SoftBody3D] vertex at the index specified by [param vertex_id].
+			</description>
+		</method>
+		<method name="set_vertex">
+			<return type="void" />
+			<param index="0" name="vertex_id" type="int" />
+			<param index="1" name="vertex" type="Vector3" />
+			<description>
+				Sets the position for the [SoftBody3D] vertex at the index specified by [param vertex_id].
 			</description>
 		</method>
 	</methods>

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -176,3 +176,11 @@ Validate extension JSON: API was removed: classes/TileMap/methods/set_quadrant_s
 Validate extension JSON: API was removed: classes/TileMap/properties/cell_quadrant_size
 
 cell_quadrant_size/quadrant_size of the TileMap API was renamed to rendering_quadrant_size.
+
+
+GH-81298
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_vertex/arguments/1': type changed value in new API, from "const void*" to "Vector3".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_normal/arguments/1': type changed value in new API, from "const void*" to "Vector3".
+
+Intentional compatibility breakage to be consistent with the new non-virtual set_vertex/set_normal.

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -78,14 +78,13 @@ void SoftBodyRenderingServerHandler::commit_changes() {
 	RS::get_singleton()->mesh_surface_update_vertex_region(mesh, surface, 0, buffer);
 }
 
-void SoftBodyRenderingServerHandler::set_vertex(int p_vertex_id, const void *p_vector3) {
-	memcpy(&write_buffer[p_vertex_id * stride + offset_vertices], p_vector3, sizeof(float) * 3);
+void SoftBodyRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &p_vertex) {
+	memcpy(&write_buffer[p_vertex_id * stride + offset_vertices], &p_vertex, sizeof(Vector3));
 }
 
-void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const void *p_vector3) {
+void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {
 	// Store normal vector in A2B10G10R10 format.
-	Vector3 n;
-	memcpy(&n, p_vector3, sizeof(Vector3));
+	Vector3 n = p_normal;
 	n *= Vector3(0.5, 0.5, 0.5);
 	n += Vector3(0.5, 0.5, 0.5);
 	Vector2 res = n.octahedron_encode();

--- a/scene/3d/soft_body_3d.h
+++ b/scene/3d/soft_body_3d.h
@@ -59,8 +59,8 @@ private:
 	void commit_changes();
 
 public:
-	void set_vertex(int p_vertex_id, const void *p_vector3) override;
-	void set_normal(int p_vertex_id, const void *p_vector3) override;
+	void set_vertex(int p_vertex_id, const Vector3 &p_vertex) override;
+	void set_normal(int p_vertex_id, const Vector3 &p_normal) override;
 	void set_aabb(const AABB &p_aabb) override;
 };
 

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -155,11 +155,9 @@ void GodotSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHand
 	for (uint32_t i = 0; i < vertex_count; ++i) {
 		const uint32_t node_index = map_visual_to_physics[i];
 		const Node &node = nodes[node_index];
-		const Vector3 &vertex_position = node.x;
-		const Vector3 &vertex_normal = node.n;
 
-		p_rendering_server_handler->set_vertex(i, &vertex_position);
-		p_rendering_server_handler->set_normal(i, &vertex_normal);
+		p_rendering_server_handler->set_vertex(i, node.x);
+		p_rendering_server_handler->set_normal(i, node.n);
 	}
 
 	p_rendering_server_handler->set_aabb(bounds);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -34,20 +34,24 @@
 #include "core/string/print_string.h"
 #include "core/variant/typed_array.h"
 
-void PhysicsServer3DRenderingServerHandler::set_vertex(int p_vertex_id, const void *p_vector3) {
-	GDVIRTUAL_REQUIRED_CALL(_set_vertex, p_vertex_id, p_vector3);
+void PhysicsServer3DRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &p_vertex) {
+	GDVIRTUAL_REQUIRED_CALL(_set_vertex, p_vertex_id, p_vertex);
 }
-void PhysicsServer3DRenderingServerHandler::set_normal(int p_vertex_id, const void *p_vector3) {
-	GDVIRTUAL_REQUIRED_CALL(_set_normal, p_vertex_id, p_vector3);
+void PhysicsServer3DRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {
+	GDVIRTUAL_REQUIRED_CALL(_set_normal, p_vertex_id, p_normal);
 }
 void PhysicsServer3DRenderingServerHandler::set_aabb(const AABB &p_aabb) {
 	GDVIRTUAL_REQUIRED_CALL(_set_aabb, p_aabb);
 }
 
 void PhysicsServer3DRenderingServerHandler::_bind_methods() {
-	GDVIRTUAL_BIND(_set_vertex, "vertex_id", "vertices");
-	GDVIRTUAL_BIND(_set_normal, "vertex_id", "normals");
+	GDVIRTUAL_BIND(_set_vertex, "vertex_id", "vertex");
+	GDVIRTUAL_BIND(_set_normal, "vertex_id", "normal");
 	GDVIRTUAL_BIND(_set_aabb, "aabb");
+
+	ClassDB::bind_method(D_METHOD("set_vertex", "vertex_id", "vertex"), &PhysicsServer3DRenderingServerHandler::set_vertex);
+	ClassDB::bind_method(D_METHOD("set_normal", "vertex_id", "normal"), &PhysicsServer3DRenderingServerHandler::set_normal);
+	ClassDB::bind_method(D_METHOD("set_aabb", "aabb"), &PhysicsServer3DRenderingServerHandler::set_aabb);
 }
 
 PhysicsServer3D *PhysicsServer3D::singleton = nullptr;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -211,15 +211,15 @@ public:
 class PhysicsServer3DRenderingServerHandler : public Object {
 	GDCLASS(PhysicsServer3DRenderingServerHandler, Object)
 protected:
-	GDVIRTUAL2(_set_vertex, int, GDExtensionConstPtr<void>)
-	GDVIRTUAL2(_set_normal, int, GDExtensionConstPtr<void>)
+	GDVIRTUAL2(_set_vertex, int, const Vector3 &)
+	GDVIRTUAL2(_set_normal, int, const Vector3 &)
 	GDVIRTUAL1(_set_aabb, const AABB &)
 
 	static void _bind_methods();
 
 public:
-	virtual void set_vertex(int p_vertex_id, const void *p_vector3);
-	virtual void set_normal(int p_vertex_id, const void *p_vector3);
+	virtual void set_vertex(int p_vertex_id, const Vector3 &p_vertex);
+	virtual void set_normal(int p_vertex_id, const Vector3 &p_normal);
 	virtual void set_aabb(const AABB &p_aabb);
 
 	virtual ~PhysicsServer3DRenderingServerHandler() {}


### PR DESCRIPTION
It's currently impossible to implement `SoftBody3D` from a GDExtension, due to the `set_vertex`, `set_normal` and `set_aabb` methods of `PhysicsServer3DRenderingServerHandler` not being bound, which need to be called in order to update the rendered positions of each particle/vertex, as seen in the Godot Physics implementation here:

https://github.com/godotengine/godot/blob/75de1ca76871fdf7f5a9e081aa57ec0e33061107/servers/physics_3d/godot_soft_body_3d.cpp#L154-L165

It's also impossible to bind `set_vertex` and `set_normal` with the interface they have currently, as they (for some reason) take a `void*` to a `Vector3` rather than just a `const Vector3&`.

This PR addresses both of these problems by changing these methods to take `const Vector3&` and then binding all the relevant methods.