### PR TITLE
Fix an error when dragging nodes into built-in scripts because script does not inherit Node

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -390,6 +390,8 @@ void ScriptCreateDialog::_create_new() {
 
 	if (is_built_in) {
 		scr->set_name(internal_name->get_text());
+		// Make sure the script is compiled to make its type recognizable.
+		scr->reload();
 	} else {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		scr->set_path(lpath);


### PR DESCRIPTION
Fixes #81294 
Reload built_in script after create to allow drag nodes into it. Calling `reload` can compile the script and give it the inheritance info, thus can pass the check in `drop_data_fw`.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
