### PR TITLE
Fix empty shader resource loading

### DIFF
--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -239,8 +239,10 @@ Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const Strin
 	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader: " + p_path);
 
 	String str;
-	error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
-	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader: " + p_path);
+	if (buffer.size() > 0) {
+		error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+		ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader: " + p_path);
+	}
 
 	Ref<Shader> shader;
 	shader.instantiate();

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -93,8 +93,10 @@ Ref<Resource> ResourceFormatLoaderShaderInclude::load(const String &p_path, cons
 	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot load shader include: " + p_path);
 
 	String str;
-	error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
-	ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader include: " + p_path);
+	if (buffer.size() > 0) {
+		error = str.parse_utf8((const char *)buffer.ptr(), buffer.size());
+		ERR_FAIL_COND_V_MSG(error, nullptr, "Cannot parse shader include: " + p_path);
+	}
 
 	Ref<ShaderInclude> shader_inc;
 	shader_inc.instantiate();


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/80705. `String.parse_utf8()` returns an error when given string size of 0 and null, so we have to manually check this first. Otherwise, loading a completely empty .gdshader or .gdshaderinc file will fail. The workaround is easy, just add a space or newline to the file using an external text editor and it will load normally again.