### PR TITLE
CI: Bump version for `actions/checkout@v4` and `actions/setup-dotnet@v3`

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -18,7 +18,7 @@ jobs:
     name: Template (target=template_release)
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: "ubuntu-20.04"
     name: "Build and test Godot CPP"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
 
       # Checkout godot-cpp
       - name: Checkout godot-cpp
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: godotengine/godot-cpp
           ref: ${{ env.GODOT_CPP_BRANCH }}

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -18,7 +18,7 @@ jobs:
     name: Template (target=template_release)
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -85,7 +85,7 @@ jobs:
             artifact: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Need newer mesa for lavapipe to work properly.
       - name: Linux dependencies for tests
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/godot-deps
 
       - name: Set up .NET Sdk
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         if: ${{ matrix.build-mono }}
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -33,7 +33,7 @@ jobs:
             sconsflags: debug_symbols=no
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -20,7 +20,7 @@ jobs:
     name: Template (target=template_release)
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Emscripten latest
         uses: mymindstorm/setup-emsdk@v12

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -38,7 +38,7 @@ jobs:
             sconsflags: debug_symbols=no
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache


### PR DESCRIPTION
Let's give this a bit before merging, the `actions/checkout@v4` release has just been tagged, and all `@v3` actions seem to have broken: https://github.com/actions/checkout/issues/1448

Let's see if they decide to roll things back or what the resolution will be.

*Edit:* Seems like the incident got resolved, the update should be fine. It's mostly just changing the Node version used, and it doesn't really matter for us.