### PR TITLE
Fix ThemeDB initialization in tests

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -570,8 +570,14 @@ Error Main::test_setup() {
 
 	ResourceLoader::load_path_remaps();
 
+	// Initialize ThemeDB early so that scene types can register their theme items.
+	// Default theme will be initialized later, after modules and ScriptServer are ready.
+	initialize_theme_db();
+
 	register_scene_types();
 	register_driver_types();
+
+	register_scene_singletons();
 
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
 	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
@@ -588,9 +594,7 @@ Error Main::test_setup() {
 	register_platform_apis();
 
 	// Theme needs modules to be initialized so that sub-resources can be loaded.
-	initialize_theme_db();
-	theme_db->initialize_theme();
-	register_scene_singletons();
+	theme_db->initialize_theme_noproject();
 
 	initialize_navigation_server();
 
@@ -2561,8 +2565,14 @@ Error Main::setup2() {
 
 	OS::get_singleton()->benchmark_begin_measure("scene");
 
+	// Initialize ThemeDB early so that scene types can register their theme items.
+	// Default theme will be initialized later, after modules and ScriptServer are ready.
+	initialize_theme_db();
+
 	register_scene_types();
 	register_driver_types();
+
+	register_scene_singletons();
 
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_SCENE);
 	GDExtensionManager::get_singleton()->initialize_extensions(GDExtension::INITIALIZATION_LEVEL_SCENE);
@@ -2580,11 +2590,6 @@ Error Main::setup2() {
 	MAIN_PRINT("Main: Load Modules");
 
 	register_platform_apis();
-
-	// Theme needs modules to be initialized so that sub-resources can be loaded.
-	// Default theme is initialized later, after ScriptServer is ready.
-	initialize_theme_db();
-	register_scene_singletons();
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "display/mouse_cursor/custom_image", PROPERTY_HINT_FILE, "*.png,*.webp"), String());
 	GLOBAL_DEF_BASIC("display/mouse_cursor/custom_image_hotspot", Vector2());

--- a/scene/theme/theme_db.cpp
+++ b/scene/theme/theme_db.cpp
@@ -91,6 +91,18 @@ void ThemeDB::initialize_theme_noproject() {
 	}
 }
 
+void ThemeDB::finalize_theme() {
+	if (!RenderingServer::get_singleton()) {
+		WARN_PRINT("Finalizing theme when there is no RenderingServer is an error; check the order of operations.");
+	}
+
+	default_theme.unref();
+
+	fallback_font.unref();
+	fallback_icon.unref();
+	fallback_stylebox.unref();
+}
+
 // Universal fallback Theme resources.
 
 void ThemeDB::set_default_theme(const Ref<Theme> &p_default) {

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -61,6 +61,7 @@ protected:
 public:
 	void initialize_theme();
 	void initialize_theme_noproject();
+	void finalize_theme();
 
 	// Universal Theme resources
 

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -43,8 +43,8 @@
 
 namespace TestViewport {
 
-class NotificationControl : public Control {
-	GDCLASS(NotificationControl, Control);
+class NotificationControlViewport : public Control {
+	GDCLASS(NotificationControlViewport, Control);
 
 protected:
 	void _notification(int p_what) {
@@ -63,11 +63,11 @@ public:
 	bool mouse_over = false;
 };
 
-// `NotificationControl`-derived class that additionally
+// `NotificationControlViewport`-derived class that additionally
 // - allows start Dragging
 // - stores mouse information of last event
-class DragStart : public NotificationControl {
-	GDCLASS(DragStart, NotificationControl);
+class DragStart : public NotificationControlViewport {
+	GDCLASS(DragStart, NotificationControlViewport);
 
 public:
 	MouseButton last_mouse_button;
@@ -93,9 +93,9 @@ public:
 	}
 };
 
-// `NotificationControl`-derived class that acts as a Drag and Drop target.
-class DragTarget : public NotificationControl {
-	GDCLASS(DragTarget, NotificationControl);
+// `NotificationControlViewport`-derived class that acts as a Drag and Drop target.
+class DragTarget : public NotificationControlViewport {
+	GDCLASS(DragTarget, NotificationControlViewport);
 
 public:
 	Variant drag_data;

--- a/tests/scene/test_window.h
+++ b/tests/scene/test_window.h
@@ -38,8 +38,8 @@
 
 namespace TestWindow {
 
-class NotificationControl : public Control {
-	GDCLASS(NotificationControl, Control);
+class NotificationControlWindow : public Control {
+	GDCLASS(NotificationControlWindow, Control);
 
 protected:
 	void _notification(int p_what) {
@@ -69,7 +69,7 @@ TEST_CASE("[SceneTree][Window]") {
 		w->set_content_scale_size(Size2i(200, 200));
 		w->set_content_scale_mode(Window::CONTENT_SCALE_MODE_CANVAS_ITEMS);
 		w->set_content_scale_aspect(Window::CONTENT_SCALE_ASPECT_KEEP);
-		NotificationControl *c = memnew(NotificationControl);
+		NotificationControlWindow *c = memnew(NotificationControlWindow);
 		w->add_child(c);
 		c->set_size(Size2i(100, 100));
 		c->set_position(Size2i(-50, -50));

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -212,7 +212,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 	PhysicsServer2D *physics_server_2d = nullptr;
 	NavigationServer3D *navigation_server_3d = nullptr;
 	NavigationServer2D *navigation_server_2d = nullptr;
-	ThemeDB *theme_db = nullptr;
 
 	void test_case_start(const doctest::TestCaseData &p_in) override {
 		reinitialize();
@@ -238,6 +237,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			RenderingServerDefault::get_singleton()->init();
 			RenderingServerDefault::get_singleton()->set_render_loop_enabled(false);
 
+			// ThemeDB requires RenderingServer to initialize the default theme.
+			// So we have to do this for each test case.
+			ThemeDB::get_singleton()->initialize_theme_noproject();
+
 			physics_server_3d = PhysicsServer3DManager::get_singleton()->new_default_server();
 			physics_server_3d->init();
 
@@ -251,9 +254,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 			memnew(InputMap);
 			InputMap::get_singleton()->load_default();
-
-			theme_db = memnew(ThemeDB);
-			theme_db->initialize_theme_noproject();
 
 			memnew(SceneTree);
 			SceneTree::get_singleton()->initialize();
@@ -294,11 +294,6 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			memdelete(SceneTree::get_singleton());
 		}
 
-		if (theme_db) {
-			memdelete(theme_db);
-			theme_db = nullptr;
-		}
-
 		if (navigation_server_3d) {
 			memdelete(navigation_server_3d);
 			navigation_server_3d = nullptr;
@@ -326,6 +321,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		}
 
 		if (RenderingServer::get_singleton()) {
+			// ThemeDB requires RenderingServer to finalize the default theme.
+			// So we have to do this for each test case.
+			ThemeDB::get_singleton()->finalize_theme();
+
 			RenderingServer::get_singleton()->sync();
 			RenderingServer::get_singleton()->global_shader_parameters_clear();
 			RenderingServer::get_singleton()->finish();


### PR DESCRIPTION
While working on another PR I ran into issues with tests because of how we work with `ThemeDB` in tests. Basically, each test cases initializes its own `ThemeDB` instance, which overrides the singleton pointer. This means that interactions with the singleton instance become unreliable. It doesn't cause any visible problems at the moment, but it does with my PR, because I need `Control` and `Window` classes to statically interact with the singleton.

So I'm fixing that, and also slightly changing the order of initialization for `ThemeDB`. Now it's initialized before scene types, so that they can work with it. I also added an explicit way to finalize default resources in `ThemeDB`, which is needed for test cases which destroy and recreate the theme constantly.

Unfortunately, we have to do it this way, because test cases also create and destroy the `RenderingServer` instance, which themes need for textures to work. Otherwise I'd just use the singleton.

-----

Also noticed that `Viewport` and `Window` tests used the same name for the registered class, causing a warning from `ClassDB` when running tests. So fixed that as well.