### PR TITLE
Display custom data layer names in the tile set editor properties

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -5851,7 +5851,7 @@ void TileData::_get_property_list(List<PropertyInfo> *p_list) const {
 			Variant default_val;
 			Callable::CallError error;
 			Variant::construct(custom_data[i].get_type(), default_val, nullptr, 0, error);
-			property_info = PropertyInfo(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d", i), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
+			property_info = PropertyInfo(tile_set->get_custom_data_layer_type(i), vformat("custom_data_%d%s%s", i, tile_set->get_custom_data_layer_name(i).is_empty() ? "" : ": ", tile_set->get_custom_data_layer_name(i)), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 			if (custom_data[i] == default_val) {
 				property_info.usage ^= PROPERTY_USAGE_STORAGE;
 			}


### PR DESCRIPTION
While the custom data layer properties in the tile set editor were listed like this:

<img width="177" alt="image" src="https://github.com/godotengine/godot/assets/260737/4838a224-7f78-47ad-8683-aee9f2345a67">

They are now listed like this, exposing their assigned names:

<img width="272" alt="image" src="https://github.com/godotengine/godot/assets/260737/bddfd162-4378-4e87-ad88-591e8693d183">

This provides a great deal of comfort as opposed to having to perform a manual lookup for the custom data layers in order to determine which is which.

* *Bugsquad edit, fixes: #76733*