### PR TITLE
Fix z-billboard + y to velocity transform alignment to correctly respect non-uniform scale

### DIFF
--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -84,7 +84,6 @@ void main() {
 			} break;
 			case TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY: {
 				vec3 sv = velocity_flags.xyz - sort_direction * dot(sort_direction, velocity_flags.xyz); //screen velocity
-				float s = (length(txform[0]) + length(txform[1]) + length(txform[2])) / 3.0;
 
 				if (length(sv) == 0.0) {
 					sv = align_up;
@@ -92,9 +91,9 @@ void main() {
 
 				sv = normalize(sv);
 
-				txform[0].xyz = normalize(cross(sv, sort_direction)) * s;
-				txform[1].xyz = sv * s;
-				txform[2].xyz = sort_direction * s;
+				txform[0].xyz = normalize(cross(sv, sort_direction)) * length(txform[0]);
+				txform[1].xyz = sv * length(txform[1]);
+				txform[2].xyz = sort_direction * length(txform[2]);
 
 			} break;
 		}

--- a/servers/rendering/renderer_rd/shaders/particles_copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles_copy.glsl
@@ -182,7 +182,6 @@ void main() {
 			case TRANSFORM_ALIGN_Z_BILLBOARD_Y_TO_VELOCITY: {
 				vec3 v = particles.data[particle].velocity;
 				vec3 sv = v - params.sort_direction * dot(params.sort_direction, v); //screen velocity
-				float s = (length(txform[0]) + length(txform[1]) + length(txform[2])) / 3.0;
 
 				if (length(sv) == 0) {
 					sv = params.align_up;
@@ -190,9 +189,9 @@ void main() {
 
 				sv = normalize(sv);
 
-				txform[0].xyz = normalize(cross(sv, params.sort_direction)) * s;
-				txform[1].xyz = sv * s;
-				txform[2].xyz = params.sort_direction * s;
+				txform[0].xyz = normalize(cross(sv, params.sort_direction)) * length(txform[0]);
+				txform[1].xyz = sv * length(txform[1]);
+				txform[2].xyz = params.sort_direction * length(txform[2]);
 
 			} break;
 		}


### PR DESCRIPTION
Adds an alignment option for GPUParticles3D which does not alter the scale of the particle transform. This allows for manipulating the scale of the particle in the particle process material (e.g. being able to stretch it based on the particle's velocity).
