### PR TITLE
Fix editor crashing when edited_scene_root is queue freed from tool script

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2978,7 +2978,15 @@ void Node::queue_free() {
 	// There are users which instantiate multiple scene trees for their games.
 	// Use the node's own tree to handle its deletion when relevant.
 	if (is_inside_tree()) {
-		get_tree()->queue_delete(this);
+		SceneTree *tree = get_tree();
+#ifdef TOOLS_ENABLED
+		// Prevent edited_scene_root from being deleted. Would cause editor to crash.
+		Node *edited_scene_root = tree->get_edited_scene_root();
+		if (edited_scene_root && edited_scene_root == this) {
+			ERR_FAIL_MSG("Can't queue free the root node being edited. Check your tool script behavior.");
+		}
+#endif
+		tree->queue_delete(this);
 	} else {
 		SceneTree *tree = SceneTree::get_singleton();
 		ERR_FAIL_NULL_MSG(tree, "Can't queue free a node when no SceneTree is available.");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Resolves #81320