### PR TITLE
CI: Bump Emscripten version to 3.1.36

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.18
+  EM_VERSION: 3.1.36
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:


### PR DESCRIPTION
That's the last working version for LTO builds based on #80010, but aside from this we should be able to upgrade.

This goes together with https://github.com/godotengine/build-containers/pull/128 which updates the version used for official builds similarly. For now I'm only planning to use those containers for 4.2+, so this shouldn't be cherry-picked.