### PR TITLE
Fix TextEdit/CodeEdit crash with invalid caret position.

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -623,7 +623,7 @@ void TextEdit::_notification(int p_what) {
 						}
 					}
 
-					if (get_caret_column(caret) > 0) {
+					if (get_caret_column(caret) > 0 && get_caret_column(caret) <= text[get_caret_line(caret)].length()) {
 						char32_t c = text[get_caret_line(caret)][get_caret_column(caret) - 1];
 						char32_t closec = 0;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/73202
