### PR TITLE
GDScript: Don't make array literal typed in weak type context

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2591,7 +2591,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 	}
 
 	// Check if assigned value is an array literal, so we can make it a typed array too if appropriate.
-	if (p_assignment->assigned_value->type == GDScriptParser::Node::ARRAY && assignee_type.has_container_element_type()) {
+	if (p_assignment->assigned_value->type == GDScriptParser::Node::ARRAY && assignee_type.is_hard_type() && assignee_type.has_container_element_type()) {
 		update_array_literal_element_type(static_cast<GDScriptParser::ArrayNode *>(p_assignment->assigned_value), assignee_type.get_container_element_type());
 	}
 
@@ -3189,7 +3189,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		// If the function require typed arrays we must make literals be typed.
 		for (const KeyValue<int, GDScriptParser::ArrayNode *> &E : arrays) {
 			int index = E.key;
-			if (index < par_types.size() && par_types[index].has_container_element_type()) {
+			if (index < par_types.size() && par_types[index].is_hard_type() && par_types[index].has_container_element_type()) {
 				update_array_literal_element_type(E.value, par_types[index].get_container_element_type());
 			}
 		}

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_dont_make_literal_typed_with_weak_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_dont_make_literal_typed_with_weak_type.gd
@@ -1,0 +1,22 @@
+var _typed_array: Array[int]
+
+func weak_param_func(weak_param = _typed_array):
+	weak_param = [11] # Don't treat the literal as typed!
+	return weak_param
+
+func hard_param_func(hard_param := _typed_array):
+	hard_param = [12]
+	return hard_param
+
+func test():
+	var weak_var = _typed_array
+	print(weak_var.is_typed())
+	weak_var = [21] # Don't treat the literal as typed!
+	print(weak_var.is_typed())
+	print(weak_param_func().is_typed())
+
+	var hard_var := _typed_array
+	print(hard_var.is_typed())
+	hard_var = [22]
+	print(hard_var.is_typed())
+	print(hard_param_func().is_typed())

--- a/modules/gdscript/tests/scripts/analyzer/features/typed_array_dont_make_literal_typed_with_weak_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/typed_array_dont_make_literal_typed_with_weak_type.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+true
+false
+false
+true
+true
+true


### PR DESCRIPTION
We have an implicit treatment of an array literal as typed in a typed context. For example:

```gdscript
var a: Array
a = [1, 2, 3] # Untyped array.

var b: Array[int]
b = [1, 2, 3] # Typed array.
```

However, I noticed that this also happens in the case of a weak type:

```gdscript
var a: Array[int]
var b = a # b is "weak Array[int]".
b = [1, 2, 3] # Typed array.
```

**Note:** This may break code for users relying on this behavior, but I believe it's worth it, the current behavior is weird.