### PR TITLE
Fix `RDPipelineColorBlendState.attachments` setter

### DIFF
--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -696,7 +696,7 @@ public:
 	RD_SETGET(Color, blend_constant)
 
 	void set_attachments(const TypedArray<RDPipelineColorBlendStateAttachment> &p_attachments) {
-		attachments.push_back(p_attachments);
+		attachments = p_attachments;
 	}
 
 	TypedArray<RDPipelineColorBlendStateAttachment> get_attachments() const {


### PR DESCRIPTION
Fixes the error

```
  Attempted to push_back a variable of type 'Array' into a TypedArray of type 'Object'.
  core/variant/array.cpp:269 - Condition "!_p->typed.validate(value, "push_back")" is true.
```

```gdscript
var pcbs = RDPipelineColorBlendState.new()
var attachment = RDPipelineColorBlendStateAttachment.new()
attachment.enable_blend = true
attachment.alpha_blend_op = RenderingDevice.BLEND_OP_ADD
attachment.color_blend_op = RenderingDevice.BLEND_OP_ADD
attachment.src_color_blend_factor = RenderingDevice.BLEND_FACTOR_SRC_ALPHA
attachment.dst_color_blend_factor = RenderingDevice.BLEND_FACTOR_ONE
attachment.src_alpha_blend_factor = RenderingDevice.BLEND_FACTOR_SRC_ALPHA
attachment.dst_alpha_blend_factor = RenderingDevice.BLEND_FACTOR_ONE
var attachments : Array[RDPipelineColorBlendStateAttachment] = [ attachment ]
pcbs.attachments = attachments
```

* I'm not sure if it's correct to give access to the internal array, user can update array content without calling the setter, see #80950.

CC @BastiaanOlij