### PR TITLE
Check the native base of scripts when resolving icons

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4208,10 +4208,10 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 		}
 
 		if (p_fallback_script_to_theme) {
-			// Look for the base type in the editor theme.
-			// This is only relevant for built-in classes.
-			String base_type;
-			p_script->get_language()->get_global_class_name(p_script->get_path(), &base_type);
+			// Look for the native base type in the editor theme. This is relevant for
+			// scripts extending other scripts and for built-in classes.
+			String script_class_name = p_script->get_language()->get_global_class_name(p_script->get_path());
+			String base_type = ScriptServer::get_global_class_native_base(script_class_name);
 			if (gui_base && gui_base->has_theme_icon(base_type, EditorStringName(EditorIcons))) {
 				return gui_base->get_editor_theme_icon(base_type);
 			}


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/80184#issuecomment-1704673358. This is not a regression from https://github.com/godotengine/godot/pull/80184, though. The issue was present before as well, but it manifested differently:

![image](https://github.com/godotengine/godot/assets/11782833/80d80002-d7a7-452a-801b-9f27fba17717)

The issue is that we only check the direct base class of script classes. This means that if your class extends another script class, we won't be able to find the fallback icon for it correctly. Before https://github.com/godotengine/godot/pull/80184 we would simply fall back onto the `Node` or `Object`, or whatever else was supplied as the common fallback icon. With https://github.com/godotengine/godot/pull/80184 the common fallback defaults to an empty string, so we end up with no icon whatsoever.

The fix is to find the first native base class instead of the direct base class and use its icon.

![image](https://github.com/godotengine/godot/assets/11782833/cc9a5fd4-d003-4f3e-9768-0806d641cba5)

Fixes https://github.com/godotengine/godot/issues/79979.

-----

PS. This PR touches code around the same lines as https://github.com/godotengine/godot/pull/81130, so it may lead to conflicts when one of them is merged. While this one is small and simple, I'd prefer https://github.com/godotengine/godot/pull/81130 to be merged first, if we're okay with it.
