### PR TITLE
CI: Compat checks: Make fetching the reference API more robust

### DIFF
--- a/misc/scripts/validate_extension_api.sh
+++ b/misc/scripts/validate_extension_api.sh
@@ -58,7 +58,7 @@ while read -r file; do
     get_expected_output "$file"
 
     # Download the reference extension_api.json
-    wget -qcO "$reference_file" "https://raw.githubusercontent.com/godotengine/godot-cpp/godot-$reference_tag/gdextension/extension_api.json"
+    wget -nv --retry-on-http-error=503 --tries=5 --timeout=60 -cO "$reference_file" "https://raw.githubusercontent.com/godotengine/godot-cpp/godot-$reference_tag/gdextension/extension_api.json" || has_problems=1
     # Validate the current API against the reference
     "$1" --headless --validate-extension-api "$reference_file" 2>&1 | tee "$validate" | awk '!/^Validate extension JSON:/' - || true
     # Collect the expected and actual validation errors


### PR DESCRIPTION
The GDExtension compat checks have recently been occasionally warning about all entries in the expected file, presumably because the reference API file has failed to download.

Thus:
- Switch wget from quiet to non-verbose mode so that in the future any such failures leave a trail in the log.
- Enable wget's retrying for 503 responses (which presumably was the response from the cache server when the failures occurred)
- Fail the CI step when the download still fails, as in that case the check cannot be executed.