### PR TITLE
Web: Workaround Emscripten 3.1.42+ LTO regression

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -7,7 +7,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 3.1.18
+  EM_VERSION: 3.1.45
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   web-template:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     name: Template (target=template_release)
 
     steps:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -118,6 +118,11 @@ def configure(env: "Environment"):
         else:
             env.Append(CCFLAGS=["-flto"])
             env.Append(LINKFLAGS=["-flto"])
+        # Workaround https://github.com/emscripten-core/emscripten/issues/19781.
+        cc_version = get_compiler_version(env)
+        cc_semver = (int(cc_version["major"]), int(cc_version["minor"]), int(cc_version["patch"]))
+        if cc_semver >= (3, 1, 42):
+            env.Append(LINKFLAGS=["-Wl,-u,scalbnf"])
 
     # Sanitizers
     if env["use_ubsan"]:


### PR DESCRIPTION
Fixes #80010.

Tested with Emscripten 3.1.45 and `scons p=web target=template_release production=yes verbose=yes`.