### PR TITLE
Fix saving editor folder colors

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2794,6 +2794,12 @@ void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu)
 		}
 	}
 
+	if (!ProjectSettings::get_singleton()->has_setting("file_customization/folder_colors")) {
+		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", assigned_folder_colors);
+	} else if (assigned_folder_colors.is_empty()) {
+		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", Variant());
+	}
+
 	ProjectSettings::get_singleton()->save();
 
 	_update_tree(get_uncollapsed_paths());


### PR DESCRIPTION
Also clears the setting if no folder is configured

If the addition of folder colors are added to the release blog post I think adding a note about it not currently working would be good

* Fixes: #81342

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
