### PR TITLE
Avoid text substitution in EditorHelp messages

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -641,7 +641,7 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods)
 	class_desc->add_newline();
 }
 
-void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, const String &p_method_type) {
+void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, MethodType p_method_type) {
 	String link_color_text = theme_cache.title_color.to_html(false);
 
 	class_desc->add_newline();
@@ -699,11 +699,24 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc p_classdoc,
 				class_desc->add_image(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 				class_desc->add_text(" ");
 				class_desc->push_color(theme_cache.comment_color);
+
+				String message;
 				if (p_classdoc.is_script_doc) {
-					class_desc->append_text(vformat(TTR("There is currently no description for this %s."), p_method_type));
+					static const char *messages_by_type[METHOD_TYPE_MAX] = {
+						TTRC("There is currently no description for this method."),
+						TTRC("There is currently no description for this constructor."),
+						TTRC("There is currently no description for this operator."),
+					};
+					message = TTRGET(messages_by_type[p_method_type]);
 				} else {
-					class_desc->append_text(vformat(TTR("There is currently no description for this %s. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"), p_method_type).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text));
+					static const char *messages_by_type[METHOD_TYPE_MAX] = {
+						TTRC("There is currently no description for this method. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
+						TTRC("There is currently no description for this constructor. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
+						TTRC("There is currently no description for this operator. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
+					};
+					message = TTRGET(messages_by_type[p_method_type]).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text);
 				}
+				class_desc->append_text(message);
 				class_desc->pop();
 			}
 
@@ -1842,7 +1855,7 @@ void EditorHelp::_update_doc() {
 		class_desc->add_text(TTR("Constructor Descriptions"));
 		_pop_title_font();
 
-		_update_method_descriptions(cd, cd.constructors, "constructor");
+		_update_method_descriptions(cd, cd.constructors, METHOD_TYPE_CONSTRUCTOR);
 	}
 
 	// Method descriptions
@@ -1852,7 +1865,7 @@ void EditorHelp::_update_doc() {
 		class_desc->add_text(TTR("Method Descriptions"));
 		_pop_title_font();
 
-		_update_method_descriptions(cd, methods, "method");
+		_update_method_descriptions(cd, methods, METHOD_TYPE_METHOD);
 	}
 
 	// Operator descriptions
@@ -1862,7 +1875,7 @@ void EditorHelp::_update_doc() {
 		class_desc->add_text(TTR("Operator Descriptions"));
 		_pop_title_font();
 
-		_update_method_descriptions(cd, cd.operators, "operator");
+		_update_method_descriptions(cd, cd.operators, METHOD_TYPE_OPERATOR);
 	}
 
 	// Free the scroll.

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -86,14 +86,11 @@ public:
 class EditorHelp : public VBoxContainer {
 	GDCLASS(EditorHelp, VBoxContainer);
 
-	enum Page {
-		PAGE_CLASS_LIST,
-		PAGE_CLASS_DESC,
-		PAGE_CLASS_PREV,
-		PAGE_CLASS_NEXT,
-		PAGE_SEARCH,
-		CLASS_SEARCH,
-
+	enum MethodType {
+		METHOD_TYPE_METHOD,
+		METHOD_TYPE_CONSTRUCTOR,
+		METHOD_TYPE_OPERATOR,
+		METHOD_TYPE_MAX
 	};
 
 	bool select_locked = false;
@@ -181,7 +178,7 @@ class EditorHelp : public VBoxContainer {
 	Error _goto_desc(const String &p_class);
 	//void _update_history_buttons();
 	void _update_method_list(const Vector<DocData::MethodDoc> p_methods);
-	void _update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, const String &p_method_type);
+	void _update_method_descriptions(const DocData::ClassDoc p_classdoc, const Vector<DocData::MethodDoc> p_methods, MethodType p_method_type);
 	void _update_doc();
 
 	void _request_help(const String &p_string);


### PR DESCRIPTION
String `There is currently no description for this %s.` exists for different method types. Other types of elements have dedicated versions of this string without substitution.

This substitution may bring difficulties for localization. e.g. For languages that have gender for nouns. So I turned it into individual strings.

p.s. Also removed the unused `EditorHelp::Page` enum.