### PR TITLE
[3.x] Fix cursor after last character INDEX in line counting as a character outside of the viewing area

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4950,7 +4950,7 @@ Rect2 TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 
 	int first_visible_char = cache_entry.first_visible_char[wrap_index];
 	int last_visible_char = cache_entry.last_visible_char[wrap_index];
-	if (p_column < first_visible_char || p_column > last_visible_char) {
+	if (p_column < first_visible_char || p_column > (last_visible_char + 1)) {
 		// Character is outside of the viewing area, no point calculating its position.
 		return Rect2i(-1, -1, 0, 0);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81349 for Godot 3.x

This fix should be ok like this, because last character and cursor are rendered together (at least on my machine: Ubuntu)

Before fix

[before.webm](https://github.com/godotengine/godot/assets/6639237/5c7da2f5-38a7-4371-b6ef-e11e1898be4a)

After fix

[after.webm](https://github.com/godotengine/godot/assets/6639237/4e377a15-cf74-4af4-8b10-2ab177d3838a)
