### PR TITLE
Fix `TextEdit.get_rect_at_line_column returning` negative pos even though cursor is in viewable area of the control

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1298,7 +1298,8 @@ void TextEdit::_notification(int p_what) {
 						if (had_glyphs_drawn) {
 							if (first_visible_char > glyphs[j].start) {
 								first_visible_char = glyphs[j].start;
-							} else if (last_visible_char < glyphs[j].end) {
+							}
+							if (last_visible_char < glyphs[j].end) {
 								last_visible_char = glyphs[j].end;
 							}
 						}
@@ -4347,6 +4348,11 @@ Rect2i TextEdit::get_rect_at_line_column(int p_line, int p_column) const {
 	ERR_FAIL_INDEX_V(p_line, text.size(), Rect2i(-1, -1, 0, 0));
 	ERR_FAIL_COND_V(p_column < 0, Rect2i(-1, -1, 0, 0));
 	ERR_FAIL_COND_V(p_column > text[p_line].length(), Rect2i(-1, -1, 0, 0));
+
+	if (text.size() == 1 && text[0].length() == 0) {
+		// The TextEdit is empty.
+		return Rect2i();
+	}
 
 	if (line_drawing_cache.size() == 0 || !line_drawing_cache.has(p_line)) {
 		// Line is not in the cache, which means it's outside of the viewing area.

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -3241,6 +3241,15 @@ TEST_CASE("[SceneTree][TextEdit] mouse") {
 	SceneTree::get_singleton()->get_root()->add_child(text_edit);
 
 	text_edit->set_size(Size2(800, 200));
+
+	CHECK(text_edit->get_rect_at_line_column(0, 0).get_position() == Point2i(0, 0));
+
+	text_edit->set_line(0, "A");
+	MessageQueue::get_singleton()->flush();
+	CHECK(text_edit->get_rect_at_line_column(0, 1).get_position().x > 0);
+
+	text_edit->clear(); // Necessary, otherwise the following test cases fail.
+
 	text_edit->set_line(0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vasius mattis leo, sed porta ex lacinia bibendum. Nunc bibendum pellentesque.");
 	MessageQueue::get_singleton()->flush();
 


### PR DESCRIPTION
Sister PR of https://github.com/godotengine/godot/pull/81352 (for Godot 3.x)

When both are merged, https://github.com/godotengine/godot/issues/81349 can be closed

_Production edit: Fixes https://github.com/godotengine/godot/issues/81349_

Before fix:

[textedit-bug_godot-4.webm](https://github.com/godotengine/godot/assets/6639237/6883919c-69b1-4257-b78b-bbd5f08cf3dd)

After fix:

[after.webm](https://github.com/godotengine/godot/assets/6639237/6dffab26-793e-45f1-a7a5-1cfad7288906)
