### PR TITLE
Add compatibility methods for RenderingDevice BarrierMask

### DIFF
--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -20,12 +20,9 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/texture_r
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/buffer_update/arguments/4': default_value changed value in new API, from "7" to "32767".
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/buffer_clear/arguments/3': default_value changed value in new API, from "7" to "32767".
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_end/arguments/0': default_value changed value in new API, from "7" to "32767".
-Validate extension JSON: Error: Hash changed for 'classes/RenderingDevice/methods/draw_list_end', from 19365687 to E9B4FA8E. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/compute_list_end/arguments/0': default_value changed value in new API, from "7" to "32767".
-Validate extension JSON: Error: Hash changed for 'classes/RenderingDevice/methods/compute_list_end', from 19365687 to E9B4FA8E. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/barrier/arguments/0': default_value changed value in new API, from "7" to "32767".
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/barrier/arguments/1': default_value changed value in new API, from "7" to "32767".
-Validate extension JSON: Error: Hash changed for 'classes/RenderingDevice/methods/barrier', from 0FE50041 to DD9E8DAB. This means that the function has changed and no compatibility function was provided.
 
 Raster barrier was split into vertex and fragment barriers for use in mobile renderer.
 

--- a/servers/rendering/rendering_device.compat.inc
+++ b/servers/rendering/rendering_device.compat.inc
@@ -34,8 +34,46 @@ RID RenderingDevice::_shader_create_from_bytecode_bind_compat_79606(const Vector
 	return shader_create_from_bytecode(p_shader_binary, RID());
 }
 
+BitField<RenderingDevice::BarrierMask> RenderingDevice::_convert_barrier_mask_81356(BitField<BarrierMask> p_old_barrier) {
+	if (p_old_barrier == 7) {
+		return BARRIER_MASK_ALL_BARRIERS;
+	} else if (p_old_barrier == 16) {
+		return BARRIER_MASK_NO_BARRIER;
+	}
+
+	BitField<BarrierMask> new_barrier;
+	if (p_old_barrier & 1) {
+		new_barrier.set_flag(BARRIER_MASK_VERTEX);
+	}
+	if (p_old_barrier & 2) {
+		new_barrier.set_flag(BARRIER_MASK_FRAGMENT);
+	}
+	if (p_old_barrier & 4) {
+		new_barrier.set_flag(BARRIER_MASK_COMPUTE);
+	}
+	if (p_old_barrier & 8) {
+		new_barrier.set_flag(BARRIER_MASK_TRANSFER);
+	}
+	return new_barrier;
+}
+
+void RenderingDevice::_draw_list_end_bind_compat_81356(BitField<BarrierMask> p_post_barrier) {
+	draw_list_end(_convert_barrier_mask_81356(p_post_barrier));
+}
+
+void RenderingDevice::_compute_list_end_bind_compat_81356(BitField<BarrierMask> p_post_barrier) {
+	compute_list_end(_convert_barrier_mask_81356(p_post_barrier));
+}
+
+void RenderingDevice::_barrier_bind_compat_81356(BitField<BarrierMask> p_from, BitField<BarrierMask> p_to) {
+	barrier(_convert_barrier_mask_81356(p_from), _convert_barrier_mask_81356(p_to));
+}
+
 void RenderingDevice::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("shader_create_from_bytecode", "binary_data"), &RenderingDevice::_shader_create_from_bytecode_bind_compat_79606);
+	ClassDB::bind_compatibility_method(D_METHOD("draw_list_end", "post_barrier"), &RenderingDevice::_draw_list_end_bind_compat_81356, DEFVAL(7));
+	ClassDB::bind_compatibility_method(D_METHOD("compute_list_end", "post_barrier"), &RenderingDevice::_compute_list_end_bind_compat_81356, DEFVAL(7));
+	ClassDB::bind_compatibility_method(D_METHOD("barrier", "from", "to"), &RenderingDevice::_barrier_bind_compat_81356, DEFVAL(7), DEFVAL(7));
 }
 
 #endif

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1383,6 +1383,13 @@ protected:
 	};
 
 	Error _reflect_spirv(const Vector<ShaderStageSPIRVData> &p_spirv, SpirvReflectionData &r_reflection_data);
+
+#ifndef DISABLE_DEPRECATED
+	BitField<BarrierMask> _convert_barrier_mask_81356(BitField<BarrierMask> p_old_barrier);
+	void _draw_list_end_bind_compat_81356(BitField<BarrierMask> p_post_barrier);
+	void _compute_list_end_bind_compat_81356(BitField<BarrierMask> p_post_barrier);
+	void _barrier_bind_compat_81356(BitField<BarrierMask> p_from, BitField<BarrierMask> p_to);
+#endif
 };
 
 VARIANT_ENUM_CAST(RenderingDevice::DeviceType)


### PR DESCRIPTION
PR #79911 changed the values of BarrierMask, which breaks GDExtension compatibility for any method with a default parameter value of `BARRIER_MASK_ALL_BARRIERS`. I added compatibility methods for all of those.

I named everything with _79911, let me know if I should change that to something else.