### PR TITLE
Add PCKReader class

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -134,7 +134,27 @@ public:
 	virtual ~PackSource() {}
 };
 
+class PCKFile {
+	Ref<FileAccess> file;
+	PackedByteArray user_key;
+	HashMap<String, PackedData::PackedFile> files;
+	HashMap<String, String> case_insensitive_filenames;
+	bool process_pck(const String &p_path, Ref<FileAccess> f, uint64_t p_offset, const PackedByteArray &p_key);
+
+public:
+	bool try_open_pack(const String &p_path, uint64_t p_offset, const PackedByteArray &p_key = PackedByteArray());
+	bool try_open_embedded(const String &p_path);
+	Vector<Pair<String, PackedData::PackedFile>> get_files();
+	Ref<FileAccess> get_file(const String &p_path, bool p_case_sensitive);
+	bool file_exists(const String &p_path, bool p_case_sensitive);
+
+	bool is_open();
+	void close();
+};
+
 class PackedSourcePCK : public PackSource {
+	PCKFile file;
+
 public:
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
@@ -185,7 +205,7 @@ public:
 
 	virtual void close() override;
 
-	FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file);
+	FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file, const PackedByteArray &p_key);
 };
 
 Ref<FileAccess> PackedData::try_open_path(const String &p_path) {

--- a/core/io/pck_reader.cpp
+++ b/core/io/pck_reader.cpp
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  pck_reader.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "pck_reader.h"
+
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/io/file_access_pack.h"
+
+Error PCKReader::open(const String &p_path, uint64_t p_offset, const PackedByteArray &p_key) {
+	if (file.is_open()) {
+		close();
+	}
+
+	return file.try_open_pack(p_path, p_offset, p_key) ? OK : FAILED;
+}
+
+Error PCKReader::close() {
+	ERR_FAIL_COND_V_MSG(!file.is_open(), FAILED, "PCKReader cannot be closed because it is not open.");
+
+	file.close();
+	return OK;
+}
+
+PackedStringArray PCKReader::get_files() {
+	ERR_FAIL_COND_V_MSG(!file.is_open(), PackedStringArray(), "PCKReader must be opened before use.");
+
+	PackedStringArray result;
+	for (const Pair<String, PackedData::PackedFile> &pair : file.get_files()) {
+		result.append(pair.first);
+	}
+
+	return result;
+}
+
+PackedByteArray PCKReader::read_file(const String &p_path, bool p_case_sensitive) {
+	ERR_FAIL_COND_V_MSG(!file.is_open(), PackedByteArray(), "PCKReader must be opened before use.");
+
+	Ref<FileAccess> f = file.get_file(p_path, p_case_sensitive);
+	ERR_FAIL_COND_V_MSG(f.is_null(), PackedByteArray(), "Failed to get file from PCK.");
+
+	PackedByteArray res;
+	res.resize(f->get_length());
+	f->get_buffer((uint8_t *)res.ptr(), res.size());
+
+	return res;
+}
+
+bool PCKReader::file_exists(const String &p_path, bool p_case_sensitive) {
+	ERR_FAIL_COND_V_MSG(!file.is_open(), false, "PCKReader must be opened before use.");
+
+	return file.file_exists(p_path, p_case_sensitive);
+}
+
+void PCKReader::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("open", "path", "offset", "key"), &PCKReader::open, DEFVAL(0), DEFVAL(PackedByteArray()));
+	ClassDB::bind_method(D_METHOD("close"), &PCKReader::close);
+	ClassDB::bind_method(D_METHOD("get_files"), &PCKReader::get_files);
+	ClassDB::bind_method(D_METHOD("read_file", "path", "case_sensitive"), &PCKReader::read_file, DEFVAL(Variant(true)));
+	ClassDB::bind_method(D_METHOD("file_exists", "path", "case_sensitive"), &PCKReader::file_exists, DEFVAL(Variant(true)));
+}
+
+PCKReader::PCKReader() {}
+
+PCKReader::~PCKReader() {
+	if (file.is_open()) {
+		close();
+	}
+}

--- a/core/io/pck_reader.h
+++ b/core/io/pck_reader.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  pck_reader.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PCK_READER_H
+#define PCK_READER_H
+
+#include "core/io/file_access_pack.h"
+#include "core/object/ref_counted.h"
+
+class PCKReader : public RefCounted {
+	GDCLASS(PCKReader, RefCounted)
+
+	PCKFile file;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Error open(const String &p_path, uint64_t p_offset, const PackedByteArray &p_key = PackedByteArray());
+	Error close();
+
+	PackedStringArray get_files();
+	PackedByteArray read_file(const String &p_path, bool p_case_sensitive = true);
+	bool file_exists(const String &p_path, bool p_case_sensitive = true);
+
+	PCKReader();
+	~PCKReader();
+};
+
+#endif // PCK_READER_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -56,6 +56,7 @@
 #include "core/io/packet_peer_dtls.h"
 #include "core/io/packet_peer_udp.h"
 #include "core/io/pck_packer.h"
+#include "core/io/pck_reader.h"
 #include "core/io/resource_format_binary.h"
 #include "core/io/resource_importer.h"
 #include "core/io/resource_uid.h"
@@ -249,6 +250,7 @@ void register_core_types() {
 	GDREGISTER_CLASS(ConfigFile);
 
 	GDREGISTER_CLASS(PCKPacker);
+	GDREGISTER_CLASS(PCKReader);
 
 	GDREGISTER_CLASS(PackedDataContainer);
 	GDREGISTER_ABSTRACT_CLASS(PackedDataContainerRef);

--- a/doc/classes/PCKReader.xml
+++ b/doc/classes/PCKReader.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PCKReader" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Allows reading the content of a pck file.
+	</brief_description>
+	<description>
+		This class implements a reader that can extract the content of individual files inside a pack file.
+		[codeblock]
+		func read_pck_file():
+		    var reader := PCKReader.new()
+		    var err := reader.open("user://pack.pck")
+		    if err != OK:
+		        return PackedByteArray()
+		    var res := reader.read_file("hello.txt")
+		    reader.close()
+		    return res
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="close">
+			<return type="int" enum="Error" />
+			<description>
+				Closes the underlying resources used by this instance.
+			</description>
+		</method>
+		<method name="file_exists">
+			<return type="bool" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="case_sensitive" type="bool" default="true" />
+			<description>
+				Returns [code]true[/code] if the file exists in the loaded pack file.
+				Must be called after [method open].
+			</description>
+		</method>
+		<method name="get_files">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of names of all files in the loaded pack file.
+				Must be called after [method open].
+			</description>
+		</method>
+		<method name="open">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="offset" type="int" default="0" />
+			<param index="2" name="key" type="PackedByteArray" default="PackedByteArray()" />
+			<description>
+				Opens the pack file at the given [param path] and [param offset] within the file and reads its file list.
+				If the pack file has encrypted contents, you can specify a custom [param key] for decryption. If not supplied, [method open] uses the default encryption key.
+			</description>
+		</method>
+		<method name="read_file">
+			<return type="PackedByteArray" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="case_sensitive" type="bool" default="true" />
+			<description>
+				Loads the whole content of a file in the loaded pack file into memory and returns it.
+				Must be called after [method open].
+			</description>
+		</method>
+	</methods>
+</class>


### PR DESCRIPTION
Adds a `PCKReader` class to read the contents of pck files without loading them.

This class exposes the same interface as the `ZipReader` class. Therefore we now have the same interface as `ZIPPacker`/`ZIPReader` for dealing with pck files.

To do so, the PCK implementation of PackedSourcePCK has been extracted into a new `PCKFile` class. I also split the loading of normal pck files and the loading of embedded pck files. This seemed clearer to me. If you have any issues regarding this, feel free to tell me.

Something to note would be that you cannot load the pck file embedded in the binary, as the `PCKReader` does not try to open the embedded file. But I'm not sure whether this should be supported as it feels quite hacky.

Furthermore, the current implementation loads the file list to memory when opening. This way we do not need to parse the file list on each access.

Resolves https://github.com/godotengine/godot-proposals/issues/1212
