### PR TITLE
Core: Fix `VariantWriter::write()` encodes all script properties

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1918,7 +1918,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 			obj->get_property_list(&props);
 			bool first = true;
 			for (const PropertyInfo &E : props) {
-				if (E.usage & PROPERTY_USAGE_STORAGE || E.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) {
+				if (E.usage & PROPERTY_USAGE_STORAGE) {
 					//must be serialized
 
 					if (first) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1393,6 +1393,7 @@
 			<param index="0" name="variable" type="Variant" />
 			<description>
 				Encodes a [Variant] value to a byte array. Encoding objects is allowed (and can potentially include executable code). Deserialization can be done with [method bytes_to_var_with_objects].
+				[b]Note:[/b] When serializing objects, not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object.get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags. In GDScript, [code]@export[/code]ed variables automatically have the [constant PROPERTY_USAGE_STORAGE] flag.
 			</description>
 		</method>
 		<method name="var_to_str">
@@ -1418,6 +1419,7 @@
 				}
 				[/codeblock]
 				[b]Note:[/b] Converting [Signal] or [Callable] is not supported and will result in an empty value for these types, regardless of their data.
+				[b]Note:[/b] When serializing objects, not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object.get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags. In GDScript, [code]@export[/code]ed variables automatically have the [constant PROPERTY_USAGE_STORAGE] flag.
 			</description>
 		</method>
 		<method name="weakref">

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -102,6 +102,8 @@
 			<return type="String" />
 			<description>
 				Obtain the text version of this config file (the same text that would be written to a file).
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] method.
+				[b]Note:[/b] When serializing objects, not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object.get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags. In GDScript, [code]@export[/code]ed variables automatically have the [constant PROPERTY_USAGE_STORAGE] flag.
 			</description>
 		</method>
 		<method name="erase_section">
@@ -198,6 +200,8 @@
 			<description>
 				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure.
 				Returns one of the [enum Error] code constants ([constant OK] on success).
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_str] method.
+				[b]Note:[/b] When serializing objects, not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object.get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags. In GDScript, [code]@export[/code]ed variables automatically have the [constant PROPERTY_USAGE_STORAGE] flag.
 			</description>
 		</method>
 		<method name="save_encrypted">
@@ -205,8 +209,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure.
-				Returns one of the [enum Error] code constants ([constant OK] on success).
+				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure. See [method save] for details.
 			</description>
 		</method>
 		<method name="save_encrypted_pass">
@@ -214,8 +217,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
 			<description>
-				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
-				Returns one of the [enum Error] code constants ([constant OK] on success).
+				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure. See [method save] for details.
 			</description>
 		</method>
 		<method name="set_value">

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -496,8 +496,8 @@
 			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
 				Stores any Variant value in the file. If [param full_objects] is [code]true[/code], encoding objects is allowed (and can potentially include code).
-				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] method.
-				[b]Note:[/b] Not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object._get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags.
+				Internally, this uses the same encoding mechanism as the [method @GlobalScope.var_to_bytes] and [method @GlobalScope.var_to_bytes_with_objects] methods.
+				[b]Note:[/b] When serializing objects, not all properties are included. Only properties that are configured with the [constant PROPERTY_USAGE_STORAGE] flag set will be serialized. You can add a new usage flag to a property by overriding the [method Object._get_property_list] method in your class. You can also check how property usage is configured by calling [method Object.get_property_list]. See [enum PropertyUsageFlags] for the possible usage flags. In GDScript, [code]@export[/code]ed variables automatically have the [constant PROPERTY_USAGE_STORAGE] flag.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
* See godotengine/godot-proposals#7457.

It looks like a bug, it is inconsistent with binary serialization and `*.tscn`/`*.tres`.

https://github.com/godotengine/godot/blob/bceac8c34f2cd6f9f156b3b1b9cbd012bc45d928/core/variant/variant_parser.cpp#L1917-L1922

https://github.com/godotengine/godot/blob/bceac8c34f2cd6f9f156b3b1b9cbd012bc45d928/core/io/marshalls.cpp#L1495-L1502

This was added in bb20f230ad307a2a5f18c03bece3793d29ae208a, I don't think it's intentional, it's part of another big change.