### PR TITLE
Fix incorrectly documented default value for PhysicsServer2D.AREA_PARAM_GRAVITY_VECTOR

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -1026,7 +1026,7 @@
 			Constant to set/get gravity strength in an area. The default value of this parameter is [code]9.80665[/code].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_VECTOR" value="2" enum="AreaParameter">
-			Constant to set/get gravity vector/center in an area. The default value of this parameter is [code]Vector2(0, -1)[/code].
+			Constant to set/get gravity vector/center in an area. The default value of this parameter is [code]Vector2(0, 1)[/code].
 		</constant>
 		<constant name="AREA_PARAM_GRAVITY_IS_POINT" value="3" enum="AreaParameter">
 			Constant to set/get whether the gravity vector of an area is a direction, or a center point. The default value of this parameter is [code]false[/code].


### PR DESCRIPTION
I believe the default 2D gravity vector is `Vector2(0, 1)` (i.e. `Vector2.DOWN`) instead of what the documentation was claiming here (`Vector2(0, -1)`). 