### PR TITLE
Update folder colors when moving or renaming

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1599,7 +1599,7 @@ void FileSystemDock::_update_dependencies_after_move(const HashMap<String, Strin
 	}
 }
 
-void FileSystemDock::_update_project_settings_after_move(const HashMap<String, String> &p_renames) const {
+void FileSystemDock::_update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames) {
 	// Find all project settings of type FILE and replace them if needed.
 	const HashMap<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
 	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
@@ -1625,6 +1625,14 @@ void FileSystemDock::_update_project_settings_after_move(const HashMap<String, S
 			} else if (autoload.begins_with("*") && p_renames.has(autoload_singleton)) {
 				ProjectSettings::get_singleton()->set_setting(E.name, "*" + p_renames[autoload_singleton]);
 			}
+		}
+	}
+
+	// Update folder colors.
+	for (const KeyValue<String, String> &rename : p_folders_renames) {
+		if (assigned_folder_colors.has(rename.key)) {
+			assigned_folder_colors[rename.value] = assigned_folder_colors[rename.key];
+			assigned_folder_colors.erase(rename.key);
 		}
 	}
 	ProjectSettings::get_singleton()->save();
@@ -1721,6 +1729,11 @@ void FileSystemDock::_folder_removed(String p_folder) {
 		current_path = current_path.get_base_dir();
 	}
 
+	if (assigned_folder_colors.has(p_folder)) {
+		assigned_folder_colors.erase(p_folder);
+		_update_folder_colors_setting();
+	}
+
 	current_path_line_edit->set_text(current_path);
 	EditorFileSystemDirectory *efd = EditorFileSystem::get_singleton()->get_filesystem_path(current_path);
 	if (efd) {
@@ -1796,7 +1809,7 @@ void FileSystemDock::_rename_operation_confirm() {
 	_save_scenes_after_move(file_renames); // save scenes before updating
 	_update_dependencies_after_move(file_renames);
 	_update_resource_paths_after_move(file_renames);
-	_update_project_settings_after_move(file_renames);
+	_update_project_settings_after_move(file_renames, folder_renames);
 	_update_favorites_list_after_move(file_renames, folder_renames);
 
 	EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
@@ -1944,7 +1957,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 			_save_scenes_after_move(file_renames); // Save scenes before updating.
 			_update_dependencies_after_move(file_renames);
 			_update_resource_paths_after_move(file_renames);
-			_update_project_settings_after_move(file_renames);
+			_update_project_settings_after_move(file_renames, folder_renames);
 			_update_favorites_list_after_move(file_renames, folder_renames);
 
 			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
@@ -2764,6 +2777,15 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 	}
 }
 
+void FileSystemDock::_update_folder_colors_setting() {
+	if (!ProjectSettings::get_singleton()->has_setting("file_customization/folder_colors")) {
+		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", assigned_folder_colors);
+	} else if (assigned_folder_colors.is_empty()) {
+		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", Variant());
+	}
+	ProjectSettings::get_singleton()->save();
+}
+
 void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu) {
 	Variant chosen_color_name = p_menu->get_item_metadata(p_index);
 	Vector<String> selected;
@@ -2794,13 +2816,7 @@ void FileSystemDock::_folder_color_index_pressed(int p_index, PopupMenu *p_menu)
 		}
 	}
 
-	if (!ProjectSettings::get_singleton()->has_setting("file_customization/folder_colors")) {
-		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", assigned_folder_colors);
-	} else if (assigned_folder_colors.is_empty()) {
-		ProjectSettings::get_singleton()->set_setting("file_customization/folder_colors", Variant());
-	}
-
-	ProjectSettings::get_singleton()->save();
+	_update_folder_colors_setting();
 
 	_update_tree(get_uncollapsed_paths());
 	_update_file_list(true);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -269,8 +269,10 @@ private:
 	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames) const;
 	void _save_scenes_after_move(const HashMap<String, String> &p_renames) const;
 	void _update_favorites_list_after_move(const HashMap<String, String> &p_files_renames, const HashMap<String, String> &p_folders_renames) const;
-	void _update_project_settings_after_move(const HashMap<String, String> &p_renames) const;
+	void _update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames);
 	String _get_unique_name(const FileOrFolder &p_entry, const String &p_at_path);
+
+	void _update_folder_colors_setting();
 
 	void _resource_removed(const Ref<Resource> &p_resource);
 	void _file_removed(String p_file);


### PR DESCRIPTION
* Followup to: #80440

Ensures that moved and renamed folders transfer their color, and clears the color for removed entries

Currently this does not update anything on moving, renaming, or deleting folders from the OS file manager, could add further logic to handle this but keeping it simple here for these specific cases

This also does not copy the color on duplication, which I think isn't expected, if someone wants that please ask and I can open a dedicated PR for it

* Closes: #81366

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
