### PR TITLE
Fix shader language preprocessor include marker handling

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -910,6 +910,7 @@ private:
 	int error_line = 0;
 
 	Vector<FilePosition> include_positions;
+	HashSet<String> include_markers_handled;
 
 #ifdef DEBUG_ENABLED
 	struct Usage {

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -747,7 +747,7 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 	processor.preprocess(state, included, result);
 	add_to_output("@@>" + real_path + "\n"); // Add token for enter include path
 	add_to_output(result);
-	add_to_output("\n@@<\n"); // Add token for exit include path
+	add_to_output("\n@@<" + real_path + "\n"); // Add token for exit include path.
 
 	// Reset to last include if there are no errors. We want to use this as context.
 	if (state->error.is_empty()) {


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/81215

When the shader preprocessor handles include directives, it adds enter and exit markers to the shader code, like this:

```glsl
@@>some_file.gdshaderinc
//Included shader code goes here.
@@<
```

The actual shader compiler tokenizer then handles these markers and pushes and pops line and file remapping (`include_positions`). These are used for better file and line number error reporting. However, in some specific circumstances the tokenizer can backtrack the current statement and process same code multiple times. In this case, it happens when an include is used inside a function code block immediately followed by an assignment. In that case, it also processes the include marker multiple times and makes the remapping stack unbalanced.

This PR makes each include marker unique by also adding the file name after the `@@<` marker and only manipulates the `include_positions` stack once per marker. This makes sure the stack stays balanced.