### PR TITLE
Remove unnecessary validity checks from `Button` and `TextureRect`

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -554,10 +554,8 @@ void Button::set_icon(const Ref<Texture2D> &p_icon) {
 }
 
 void Button::_texture_changed() {
-	if (icon.is_valid()) {
-		queue_redraw();
-		update_minimum_size();
-	}
+	queue_redraw();
+	update_minimum_size();
 }
 
 Ref<Texture2D> Button::get_icon() const {

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -189,10 +189,8 @@ bool TextureRect::_set(const StringName &p_name, const Variant &p_value) {
 #endif
 
 void TextureRect::_texture_changed() {
-	if (texture.is_valid()) {
-		queue_redraw();
-		update_minimum_size();
-	}
+	queue_redraw();
+	update_minimum_size();
 }
 
 void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {


### PR DESCRIPTION
The one in `TextureRect` appears to be a leftover from earlier code, and the one in `Button` was copied from there.

Doing some deep digging this seems to be some code from back when `Texture` had `add_change_receptor`, and derives from `Sprite`, being copied over to `TextureRect`

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
