### PR TITLE
[3.x] mbedtls: Fix UWP arm32 build after 2.28.3 enabled AES-NI intrinsics on MSVC

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -288,7 +288,8 @@ File extracted from upstream release tarball:
 - The `LICENSE` file.
 - Applied the patch in `patches/1453.diff` to fix UWP build (upstream PR:
   https://github.com/ARMmbed/mbedtls/pull/1453).
-  Applied the patch in `patches/windows-arm64-hardclock.diff`
+  Applied the patch in `patches/windows-arm64-hardclock.diff`.
+  Applied the patch in `aesni-no-arm-intrinsics.patch` also to fix UWP build.
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
 

--- a/thirdparty/mbedtls/include/mbedtls/aesni.h
+++ b/thirdparty/mbedtls/include/mbedtls/aesni.h
@@ -54,9 +54,10 @@
  *       macros that may change in future releases.
  */
 #undef MBEDTLS_AESNI_HAVE_INTRINSICS
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_IX86))
 /* Visual Studio supports AESNI intrinsics since VS 2008 SP1. We only support
- * VS 2013 and up for other reasons anyway, so no need to check the version. */
+ * VS 2013 and up for other reasons anyway, so no need to check the version.
+ * Only supported on x64 and x86. */
 #define MBEDTLS_AESNI_HAVE_INTRINSICS
 #endif
 /* GCC-like compilers: currently, we only support intrinsics if the requisite

--- a/thirdparty/mbedtls/patches/aesni-no-arm-intrinsics.patch
+++ b/thirdparty/mbedtls/patches/aesni-no-arm-intrinsics.patch
@@ -1,0 +1,17 @@
+diff --git a/thirdparty/mbedtls/include/mbedtls/aesni.h b/thirdparty/mbedtls/include/mbedtls/aesni.h
+index 6741dead05..6c545bd4a3 100644
+--- a/thirdparty/mbedtls/include/mbedtls/aesni.h
++++ b/thirdparty/mbedtls/include/mbedtls/aesni.h
+@@ -54,9 +54,10 @@
+  *       macros that may change in future releases.
+  */
+ #undef MBEDTLS_AESNI_HAVE_INTRINSICS
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_IX86))
+ /* Visual Studio supports AESNI intrinsics since VS 2008 SP1. We only support
+- * VS 2013 and up for other reasons anyway, so no need to check the version. */
++ * VS 2013 and up for other reasons anyway, so no need to check the version.
++ * Only supported on x64 and x86. */
+ #define MBEDTLS_AESNI_HAVE_INTRINSICS
+ #endif
+ /* GCC-like compilers: currently, we only support intrinsics if the requisite


### PR DESCRIPTION
I'll make a PR to `master` as this might be relevant for Windows "Win32" ARM and ARM64 builds too.

Upstream bug report: https://github.com/Mbed-TLS/mbedtls/issues/8168