### PR TITLE
mbedtls: Fix MSVC ARM build after 2.28.3 enabled AES-NI intrinsics

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -441,7 +441,8 @@ File extracted from upstream release tarball:
 - The `LICENSE` file.
 - Applied the patch in `patches/1453.diff` to fix UWP build (upstream PR:
   https://github.com/ARMmbed/mbedtls/pull/1453).
-  Applied the patch in `patches/windows-arm64-hardclock.diff`
+  Applied the patch in `patches/windows-arm64-hardclock.diff`.
+  Applied the patch in `aesni-no-arm-intrinsics.patch` to fix MSVC ARM build.
 - Added 2 files `godot_core_mbedtls_platform.c` and `godot_core_mbedtls_config.h`
   providing configuration for light bundling with core.
 - Added the file `godot_module_mbedtls_config.h` to customize the build configuration when bundling the full library.

--- a/thirdparty/mbedtls/include/mbedtls/aesni.h
+++ b/thirdparty/mbedtls/include/mbedtls/aesni.h
@@ -54,9 +54,10 @@
  *       macros that may change in future releases.
  */
 #undef MBEDTLS_AESNI_HAVE_INTRINSICS
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_IX86))
 /* Visual Studio supports AESNI intrinsics since VS 2008 SP1. We only support
- * VS 2013 and up for other reasons anyway, so no need to check the version. */
+ * VS 2013 and up for other reasons anyway, so no need to check the version.
+ * Only supported on x64 and x86. */
 #define MBEDTLS_AESNI_HAVE_INTRINSICS
 #endif
 /* GCC-like compilers: currently, we only support intrinsics if the requisite

--- a/thirdparty/mbedtls/patches/aesni-no-arm-intrinsics.patch
+++ b/thirdparty/mbedtls/patches/aesni-no-arm-intrinsics.patch
@@ -1,0 +1,17 @@
+diff --git a/thirdparty/mbedtls/include/mbedtls/aesni.h b/thirdparty/mbedtls/include/mbedtls/aesni.h
+index 6741dead05..6c545bd4a3 100644
+--- a/thirdparty/mbedtls/include/mbedtls/aesni.h
++++ b/thirdparty/mbedtls/include/mbedtls/aesni.h
+@@ -54,9 +54,10 @@
+  *       macros that may change in future releases.
+  */
+ #undef MBEDTLS_AESNI_HAVE_INTRINSICS
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) && (defined(_M_AMD64) || defined(_M_IX86))
+ /* Visual Studio supports AESNI intrinsics since VS 2008 SP1. We only support
+- * VS 2013 and up for other reasons anyway, so no need to check the version. */
++ * VS 2013 and up for other reasons anyway, so no need to check the version.
++ * Only supported on x64 and x86. */
+ #define MBEDTLS_AESNI_HAVE_INTRINSICS
+ #endif
+ /* GCC-like compilers: currently, we only support intrinsics if the requisite


### PR DESCRIPTION
`master` counterpart to #81401.

We don't support UWP in 4.0+ anymore, but if we ever fix it this would be needed. More importantly, the Windows builds may be failing on ARM and ARM64 due to the same error (untested).

Upstream bug report: https://github.com/Mbed-TLS/mbedtls/issues/8168