### PR TITLE
[TextServer] Pass Dictionary properties by value and check property values instead of references.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2383,8 +2383,10 @@ void TextServerAdvanced::_font_set_variation_coordinates(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	_font_clear_cache(fd);
-	fd->variation_coordinates = p_variation_coordinates;
+	if (!fd->variation_coordinates.recursive_equal(p_variation_coordinates, 1)) {
+		_font_clear_cache(fd);
+		fd->variation_coordinates = p_variation_coordinates.duplicate();
+	}
 }
 
 Dictionary TextServerAdvanced::_font_get_variation_coordinates(const RID &p_font_rid) const {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1376,8 +1376,10 @@ void TextServerFallback::_font_set_variation_coordinates(const RID &p_font_rid, 
 	ERR_FAIL_COND(!fd);
 
 	MutexLock lock(fd->mutex);
-	_font_clear_cache(fd);
-	fd->variation_coordinates = p_variation_coordinates;
+	if (!fd->variation_coordinates.recursive_equal(p_variation_coordinates, 1)) {
+		_font_clear_cache(fd);
+		fd->variation_coordinates = p_variation_coordinates.duplicate();
+	}
 }
 
 Dictionary TextServerFallback::_font_get_variation_coordinates(const RID &p_font_rid) const {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -2833,12 +2833,14 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 }
 
 void FontVariation::set_variation_opentype(const Dictionary &p_coords) {
-	variation.opentype = p_coords;
-	_invalidate_rids();
+	if (!variation.opentype.recursive_equal(p_coords, 1)) {
+		variation.opentype = p_coords.duplicate();
+		_invalidate_rids();
+	}
 }
 
 Dictionary FontVariation::get_variation_opentype() const {
-	return variation.opentype;
+	return variation.opentype.duplicate();
 }
 
 void FontVariation::set_variation_embolden(float p_strength) {
@@ -2875,12 +2877,14 @@ int FontVariation::get_variation_face_index() const {
 }
 
 void FontVariation::set_opentype_features(const Dictionary &p_features) {
-	opentype_features = p_features;
-	_invalidate_rids();
+	if (!opentype_features.recursive_equal(p_features, 1)) {
+		opentype_features = p_features.duplicate();
+		_invalidate_rids();
+	}
 }
 
 Dictionary FontVariation::get_opentype_features() const {
-	return opentype_features;
+	return opentype_features.duplicate();
 }
 
 void FontVariation::set_spacing(TextServer::SpacingType p_spacing, int p_value) {


### PR DESCRIPTION
- Since there's no way to track changes in the Dictionary, pass it by value (duplicate).
- Instead of matching references, match Dictionary fields. 

Fixes regression from https://github.com/godotengine/godot/pull/79166 (see https://github.com/godotengine/godot/issues/81397, it seems like something wrong theme propagation, and it just uncovered excessive theme fonts updates).