### PR TITLE
Remove leftover debug print in `FileSystemDock`

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1931,7 +1931,6 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			if (!to_move[i].is_file) {
 				new_path = new_path.path_join(old_path.trim_suffix("/").get_file());
-				print_line(new_path);
 			}
 
 			if (old_path != new_path) {


### PR DESCRIPTION
* Fixes: #81404

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
