### PR TITLE
[3.x] Fix PopupMenu icon and text not having separation

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -495,6 +495,9 @@ void PopupMenu::_draw_items() {
 			has_check = true;
 		}
 	}
+	if (icon_ofs > 0.0) {
+		icon_ofs += hseparation;
+	}
 
 	float check_ofs = 0.0;
 	if (has_check) {


### PR DESCRIPTION
Menu item icon and text were much closer than 3.5.2.

The additional `hseparation` was lost during the PopupMenu rework :P

![image](https://github.com/godotengine/godot/assets/372476/9751d3a8-7fb0-4196-af4b-52e5b85600f3)
