### PR TITLE
Codestyle: Don't use auto where not warranted

### DIFF
--- a/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_fb_passthrough_extension_wrapper.cpp
@@ -71,7 +71,7 @@ Viewport *OpenXRFbPassthroughExtensionWrapper::get_main_viewport() {
 		return nullptr;
 	}
 
-	auto *scene_tree = Object::cast_to<SceneTree>(main_loop);
+	SceneTree *scene_tree = Object::cast_to<SceneTree>(main_loop);
 	if (!scene_tree) {
 		print_error("Unable to retrieve scene tree");
 		return nullptr;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -300,32 +300,31 @@ bool OpenXRAPI::create_instance() {
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		const HashMap<String, bool *> &wrapper_request_extensions = wrapper->get_requested_extensions();
 
-		// requested_extensions.insert(wrapper_request_extensions.begin(), wrapper_request_extensions.end());
-		for (auto &requested_extension : wrapper_request_extensions) {
+		for (const KeyValue<String, bool *> &requested_extension : wrapper_request_extensions) {
 			requested_extensions[requested_extension.key] = requested_extension.value;
 		}
 	}
 
-	// Check which extensions are supported
+	// Check which extensions are supported.
 	enabled_extensions.clear();
 
-	for (auto &requested_extension : requested_extensions) {
+	for (KeyValue<String, bool *> &requested_extension : requested_extensions) {
 		if (!is_extension_supported(requested_extension.key)) {
 			if (requested_extension.value == nullptr) {
-				// nullptr means this is a manditory extension so we fail
+				// Null means this is a manditory extension so we fail.
 				ERR_FAIL_V_MSG(false, String("OpenXR: OpenXR Runtime does not support ") + requested_extension.key + String(" extension!"));
 			} else {
-				// set this extension as not supported
+				// Set this extension as not supported.
 				*requested_extension.value = false;
 			}
 		} else if (requested_extension.value != nullptr) {
-			// set this extension as supported
+			// Set this extension as supported.
 			*requested_extension.value = true;
 
-			// and record that we want to enable it
+			// And record that we want to enable it.
 			enabled_extensions.push_back(requested_extension.key.ascii());
 		} else {
-			// record that we want to enable this
+			// Record that we want to enable this.
 			enabled_extensions.push_back(requested_extension.key.ascii());
 		}
 	}
@@ -2077,7 +2076,7 @@ XRPose::TrackingConfidence _transform_from_location(const T &p_location, Transfo
 	Basis basis;
 	Vector3 origin;
 	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
-	const auto &pose = p_location.pose;
+	const XrPosef &pose = p_location.pose;
 
 	// Check orientation
 	if (p_location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) {

--- a/modules/openxr/scene/openxr_hand.cpp
+++ b/modules/openxr/scene/openxr_hand.cpp
@@ -213,8 +213,8 @@ void OpenXRHand::_update_skeleton() {
 			quaternions[i] = Quaternion();
 			positions[i] = Vector3();
 
-			const auto &location = hand_tracker->joint_locations[i];
-			const auto &pose = location.pose;
+			const XrHandJointLocationEXT &location = hand_tracker->joint_locations[i];
+			const XrPosef &pose = location.pose;
 
 			if (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) {
 				if (pose.orientation.x != 0 || pose.orientation.y != 0 || pose.orientation.z != 0 || pose.orientation.w != 0) {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -90,7 +90,7 @@ TEST_CASE("[Dictionary] Assignment using bracket notation ([])") {
 	CHECK(int(map[false]) == 128);
 
 	// Ensure read-only maps aren't modified by non-existing keys.
-	const auto length = map.size();
+	const int length = map.size();
 	map.make_read_only();
 	CHECK(int(map["This key does not exist"].get_type()) == Variant::NIL);
 	CHECK(map.size() == length);

--- a/tests/scene/test_arraymesh.h
+++ b/tests/scene/test_arraymesh.h
@@ -195,7 +195,7 @@ TEST_CASE("[SceneTree][ArrayMesh] Surface metadata tests.") {
 	}
 
 	SUBCASE("Returns correct format for the mesh") {
-		auto format = RS::ARRAY_FORMAT_BLEND_SHAPE_MASK | RS::ARRAY_FORMAT_TEX_UV | RS::ARRAY_FORMAT_INDEX;
+		int format = RS::ARRAY_FORMAT_BLEND_SHAPE_MASK | RS::ARRAY_FORMAT_TEX_UV | RS::ARRAY_FORMAT_INDEX;
 		CHECK((mesh->surface_get_format(0) & format) != 0);
 		CHECK((mesh->surface_get_format(1) & format) != 0);
 	}

--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -66,7 +66,7 @@ String remove_spaces(String &p_str) {
 
 	for (int n = 0; n < p_str.size(); n++) {
 		// These test cases only use ASCII.
-		auto c = static_cast<unsigned char>(p_str[n]);
+		unsigned char c = static_cast<unsigned char>(p_str[n]);
 		if (std::isblank(c)) {
 			has_removed = true;
 		} else {
@@ -92,7 +92,7 @@ String remove_spaces(String &p_str) {
 String compact_spaces(String &p_str) {
 	Vector<String> lines = p_str.split("\n", false);
 	erase_all_empty(lines);
-	for (auto &line : lines) {
+	for (String &line : lines) {
 		line = remove_spaces(line);
 	}
 	return String("\n").join(lines);


### PR DESCRIPTION
We allow using auto for lambdas or complex macros where a return type may change based on the parameters. But where the type is clear, we should be explicit.

https://www.youtube.com/watch?v=z87g8IQTVjw