### PR TITLE
Haiku: Remove remnants of past WIP platform port

### DIFF
--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -2,7 +2,7 @@
 
 Import("env")
 
-if env["platform"] in ["haiku", "macos", "windows", "linuxbsd"]:
+if env["platform"] in ["macos", "windows", "linuxbsd"]:
     # Thirdparty source files
     thirdparty_dir = "#thirdparty/glad/"
     thirdparty_sources = [

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -3,11 +3,11 @@ import os.path
 
 
 def is_desktop(platform):
-    return platform in ["windows", "macos", "linuxbsd", "haiku"]
+    return platform in ["windows", "macos", "linuxbsd"]
 
 
 def is_unix_like(platform):
-    return platform in ["macos", "linuxbsd", "android", "haiku", "ios"]
+    return platform in ["macos", "linuxbsd", "android", "ios"]
 
 
 def module_supports_tools_on(platform):

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,5 +1,5 @@
-# Prior to .NET Core, we supported these: ["windows", "macos", "linuxbsd", "android", "haiku", "web", "ios"]
-# Eventually support for each them should be added back (except Haiku if not supported by .NET Core)
+# Prior to .NET Core, we supported these: ["windows", "macos", "linuxbsd", "android", "web", "ios"]
+# Eventually support for each them should be added back.
 supported_platforms = ["windows", "macos", "linuxbsd", "android"]
 
 

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -84,7 +84,6 @@
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'windows' ">GODOT_WINDOWS;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'linuxbsd' ">GODOT_LINUXBSD;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'macos' ">GODOT_OSX;GODOT_MACOS;GODOT_PC</GodotPlatformConstants>
-    <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'haiku' ">GODOT_HAIKU;GODOT_PC</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'android' ">GODOT_ANDROID;GODOT_MOBILE</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'ios' ">GODOT_IPHONE;GODOT_IOS;GODOT_MOBILE</GodotPlatformConstants>
     <GodotPlatformConstants Condition=" '$(GodotTargetPlatform)' == 'web' ">GODOT_JAVASCRIPT;GODOT_HTML5;GODOT_WASM;GODOT_WEB</GodotPlatformConstants>

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -603,10 +603,6 @@ MONO_AOT_MODE_LAST = 1000,
                 {
                     return $"linux-{arch}";
                 }
-                case OS.Platforms.Haiku:
-                {
-                    return $"{platform}-{arch}";
-                }
                 default:
                     throw new NotSupportedException($"Platform not supported: {platform}");
             }

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -26,7 +26,6 @@ namespace GodotTools.Utils
             public const string FreeBSD = "FreeBSD";
             public const string NetBSD = "NetBSD";
             public const string BSD = "BSD";
-            public const string Haiku = "Haiku";
             public const string Android = "Android";
             public const string iOS = "iOS";
             public const string Web = "Web";
@@ -40,7 +39,6 @@ namespace GodotTools.Utils
             public const string Windows = "windows";
             public const string MacOS = "macos";
             public const string LinuxBSD = "linuxbsd";
-            public const string Haiku = "haiku";
             public const string Android = "android";
             public const string iOS = "ios";
             public const string Web = "web";
@@ -69,7 +67,6 @@ namespace GodotTools.Utils
             ["Windows"] = Platforms.Windows,
             ["macOS"] = Platforms.MacOS,
             ["Linux"] = Platforms.LinuxBSD,
-            ["Haiku"] = Platforms.Haiku,
             ["Android"] = Platforms.Android,
             ["iOS"] = Platforms.iOS,
             ["Web"] = Platforms.Web
@@ -83,7 +80,6 @@ namespace GodotTools.Utils
             [Names.FreeBSD] = Platforms.LinuxBSD,
             [Names.NetBSD] = Platforms.LinuxBSD,
             [Names.BSD] = Platforms.LinuxBSD,
-            [Names.Haiku] = Platforms.Haiku,
             [Names.Android] = Platforms.Android,
             [Names.iOS] = Platforms.iOS,
             [Names.Web] = Platforms.Web
@@ -127,13 +123,12 @@ namespace GodotTools.Utils
             new[] { Names.Linux, Names.FreeBSD, Names.NetBSD, Names.BSD };
 
         private static readonly IEnumerable<string> UnixLikePlatforms =
-            new[] { Names.MacOS, Names.Haiku, Names.Android, Names.iOS }
+            new[] { Names.MacOS, Names.Android, Names.iOS }
                 .Concat(LinuxBSDPlatforms).ToArray();
 
         private static readonly Lazy<bool> _isWindows = new(() => IsOS(Names.Windows));
         private static readonly Lazy<bool> _isMacOS = new(() => IsOS(Names.MacOS));
         private static readonly Lazy<bool> _isLinuxBSD = new(() => IsAnyOS(LinuxBSDPlatforms));
-        private static readonly Lazy<bool> _isHaiku = new(() => IsOS(Names.Haiku));
         private static readonly Lazy<bool> _isAndroid = new(() => IsOS(Names.Android));
         private static readonly Lazy<bool> _isiOS = new(() => IsOS(Names.iOS));
         private static readonly Lazy<bool> _isWeb = new(() => IsOS(Names.Web));
@@ -144,8 +139,6 @@ namespace GodotTools.Utils
         [SupportedOSPlatformGuard("osx")] public static bool IsMacOS => _isMacOS.Value;
 
         [SupportedOSPlatformGuard("linux")] public static bool IsLinuxBSD => _isLinuxBSD.Value;
-
-        public static bool IsHaiku => _isHaiku.Value;
 
         [SupportedOSPlatformGuard("android")] public static bool IsAndroid => _isAndroid.Value;
 

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -100,7 +100,6 @@ static const char *platform_name_map[][2] = {
 	{ "FreeBSD", "linuxbsd" },
 	{ "NetBSD", "linuxbsd" },
 	{ "BSD", "linuxbsd" },
-	{ "Haiku", "haiku" },
 	{ "Android", "android" },
 	{ "iOS", "ios" },
 	{ "Web", "web" },


### PR DESCRIPTION
The Haiku platform port was never finalized, and moved to a separate repo in
Godot 3.2 days: https://github.com/godotengine/godot-platform-haiku

Sadly it didn't garner more interest there and is bitrotting. It was never
ported to Godot 4 so the bits of Haiku support left in Mono aren't useful.

Includes #81416 as it would conflict otherwise. *Edit:* Merged, so rebased.