### PR TITLE
Expose `EditorInspector::get_edited_object` to GDScript

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -14,6 +14,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_edited_object">
+			<return type="Object" />
+			<description>
+				Returns the object currently selected in this inspector.
+			</description>
+		</method>
 		<method name="get_selected_path" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4242,6 +4242,7 @@ void EditorInspector::_show_add_meta_dialog() {
 void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
+	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));


### PR DESCRIPTION
I'm making an EditorPlugin for a `Resource` subclass and while it's possible to extract what property has been modified  to using the `property_edited` signal, the plugin needs to know what the new value of the property is in order to set some internal flags. Exposing `EditorInspector::get_edited_object` allows the EditorPlugin to query the value of the property with `Object.get(property)` within a `property_edited` callback.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/7789_