### PR TITLE
Expose `EditorExportPlatform::get_os_name()`

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -10,4 +10,12 @@
 	<tutorials>
 		<link title="$DOCS_URL/tutorials/platform/consoles.html">Console support in Godot</link>
 	</tutorials>
+	<methods>
+		<method name="get_os_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the export operating system handled by this [EditorExportPlatform] class, as a friendly string. Possible return values are [code]Windows[/code], [code]Linux[/code], [code]macOS[/code], [code]Android[/code], [code]iOS[/code], and [code]Web[/code].
+			</description>
+		</method>
+	</methods>
 </class>

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1972,5 +1972,9 @@ Error EditorExportPlatform::ssh_push_to_remote(const String &p_host, const Strin
 	return OK;
 }
 
+void EditorExportPlatform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_os_name"), &EditorExportPlatform::get_os_name);
+}
+
 EditorExportPlatform::EditorExportPlatform() {
 }

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -49,6 +49,9 @@ const String ENV_SCRIPT_ENCRYPTION_KEY = "GODOT_SCRIPT_ENCRYPTION_KEY";
 class EditorExportPlatform : public RefCounted {
 	GDCLASS(EditorExportPlatform, RefCounted);
 
+protected:
+	static void _bind_methods();
+
 public:
 	typedef Error (*EditorExportSaveFunction)(void *p_userdata, const String &p_path, const Vector<uint8_t> &p_data, int p_file, int p_total, const Vector<String> &p_enc_in_filters, const Vector<String> &p_enc_ex_filters, const Vector<uint8_t> &p_key);
 	typedef Error (*EditorExportSaveSharedObject)(void *p_userdata, const SharedObject &p_so);


### PR DESCRIPTION
In The Mirror, we need to be able to check what the target operating system of the export is in an EditorExportPlugin script. Turns out, the engine already has a method to do exactly this, but it's just not exposed.

The documentation of possible values was written by looking at the source code. I have tested this for exporting Windows, macOS, and Linux (all from a macOS host) to verify that those are correct.