### PR TITLE
Fix setup of Area2d space override variable

### DIFF
--- a/servers/physics_2d/godot_area_pair_2d.cpp
+++ b/servers/physics_2d/godot_area_pair_2d.cpp
@@ -38,15 +38,17 @@ bool GodotAreaPair2D::setup(real_t p_step) {
 	}
 
 	process_collision = false;
+
 	has_space_override = false;
+	if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_GRAVITY_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
+		has_space_override = true;
+	} else if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
+		has_space_override = true;
+	} else if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
+		has_space_override = true;
+	}
+
 	if (result != colliding) {
-		if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_GRAVITY_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		} else if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_LINEAR_DAMP_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		} else if ((int)area->get_param(PhysicsServer2D::AREA_PARAM_ANGULAR_DAMP_OVERRIDE_MODE) != PhysicsServer2D::AREA_SPACE_OVERRIDE_DISABLED) {
-			has_space_override = true;
-		}
 		process_collision = has_space_override;
 
 		if (area->has_monitor_callback()) {


### PR DESCRIPTION
Ran into an issue where a RigidBody2D was still having an Area2D's forces applied even when the two objects are no longer colliding. I believe it's the issue that others noted here: https://github.com/godotengine/godot/issues/77449

This was due to a variable `has_space_override`, which is initialized in the `setup` method of the AreaPair2D. The setup method sets it to false every time by default, and only runs the logic to change it to true if the collision status has changed (e.g. was colliding before and now isn't, or vice-versa).

When the AreaPair2D is [deallocated](https://github.com/godotengine/godot/blob/0bca4242392992840b0b891acde6422c49712e3e/servers/physics_2d/godot_area_pair_2d.cpp#L107), it checks for `has_space_override` to determine if the area should be removed from the body's list of areas. However, because `setup` will have run again, `has_space_override` will have been set to false, and the area will not be removed. As a result, it will continue to have its effects applied to the RigidBody. 

The fact that it only occurs in some cases suggests that there's some order of operations that theoretically could avoid this, since it'll only occur if `setup` runs again after a collision change and before the constraint is deallocated. But in this case it seems easier just to fix the initialization issue.

*Bugsquad edit:*
- Fixes #81550.
- See also alternative solution in #82470.
