### PR TITLE
Remove `REDUNDANT_FOR_VARIABLE_TYPE` warning

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -492,9 +492,6 @@
 		<member name="debug/gdscript/warnings/redundant_await" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a function that is not a coroutine is called with await.
 		</member>
-		<member name="debug/gdscript/warnings/redundant_for_variable_type" type="int" setter="" getter="" default="1">
-			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a [code]for[/code] variable type specifier is a supertype of the inferred type.
-		</member>
 		<member name="debug/gdscript/warnings/redundant_static_unload" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when the [code]@static_unload[/code] annotation is used in a script without any static variables.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2142,15 +2142,7 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 					}
 				} else if (!is_type_compatible(specified_type, variable_type)) {
 					p_for->use_conversion_assign = true;
-#ifdef DEBUG_ENABLED
-				} else {
-					parser->push_warning(p_for->datatype_specifier, GDScriptWarning::REDUNDANT_FOR_VARIABLE_TYPE, p_for->variable->name, variable_type.to_string(), specified_type.to_string());
-#endif
 				}
-#ifdef DEBUG_ENABLED
-			} else if (variable_type.is_hard_type()) {
-				parser->push_warning(p_for->datatype_specifier, GDScriptWarning::REDUNDANT_FOR_VARIABLE_TYPE, p_for->variable->name, variable_type.to_string(), specified_type.to_string());
-#endif
 			}
 			p_for->variable->set_datatype(specified_type);
 		} else {

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -119,14 +119,6 @@ String GDScriptWarning::get_message() const {
 			return R"(The "@static_unload" annotation is redundant because the file does not have a class with static variables.)";
 		case REDUNDANT_AWAIT:
 			return R"("await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.)";
-		case REDUNDANT_FOR_VARIABLE_TYPE:
-			CHECK_SYMBOLS(3);
-			if (symbols[1] == symbols[2]) {
-				return vformat(R"(The for loop iterator "%s" already has inferred type "%s", the specified type is redundant.)", symbols[0], symbols[1]);
-			} else {
-				return vformat(R"(The for loop iterator "%s" has inferred type "%s" but its supertype "%s" is specified.)", symbols[0], symbols[1], symbols[2]);
-			}
-			break;
 		case ASSERT_ALWAYS_TRUE:
 			return "Assert statement is redundant because the expression is always true.";
 		case ASSERT_ALWAYS_FALSE:
@@ -224,7 +216,6 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"STATIC_CALLED_ON_INSTANCE",
 		"REDUNDANT_STATIC_UNLOAD",
 		"REDUNDANT_AWAIT",
-		"REDUNDANT_FOR_VARIABLE_TYPE",
 		"ASSERT_ALWAYS_TRUE",
 		"ASSERT_ALWAYS_FALSE",
 		"INTEGER_DIVISION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -74,7 +74,6 @@ public:
 		STATIC_CALLED_ON_INSTANCE, // A static method was called on an instance of a class instead of on the class itself.
 		REDUNDANT_STATIC_UNLOAD, // The `@static_unload` annotation is used but the class does not have static data.
 		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
-		REDUNDANT_FOR_VARIABLE_TYPE, // The for variable type specifier is a supertype of the inferred type.
 		ASSERT_ALWAYS_TRUE, // Expression for assert argument is always true.
 		ASSERT_ALWAYS_FALSE, // Expression for assert argument is always false.
 		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
@@ -123,7 +122,6 @@ public:
 		WARN, // STATIC_CALLED_ON_INSTANCE
 		WARN, // REDUNDANT_STATIC_UNLOAD
 		WARN, // REDUNDANT_AWAIT
-		WARN, // REDUNDANT_FOR_VARIABLE_TYPE
 		WARN, // ASSERT_ALWAYS_TRUE
 		WARN, // ASSERT_ALWAYS_FALSE
 		WARN, // INTEGER_DIVISION

--- a/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_equal_to_inferred.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_equal_to_inferred.gd
@@ -1,4 +1,0 @@
-func test():
-	var a: Array[Node] = []
-	for node: Node in a:
-		print(node)

--- a/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_equal_to_inferred.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_equal_to_inferred.out
@@ -1,5 +1,0 @@
-GDTEST_OK
->> WARNING
->> Line: 3
->> REDUNDANT_FOR_VARIABLE_TYPE
->> The for loop iterator "node" already has inferred type "Node", the specified type is redundant.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_supertype_of_inferred.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_supertype_of_inferred.gd
@@ -1,4 +1,0 @@
-func test():
-	var a: Array[Node2D] = []
-	for node: Node in a:
-		print(node)

--- a/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_supertype_of_inferred.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/for_loop_specified_type_is_supertype_of_inferred.out
@@ -1,5 +1,0 @@
-GDTEST_OK
->> WARNING
->> Line: 3
->> REDUNDANT_FOR_VARIABLE_TYPE
->> The for loop iterator "node" has inferred type "Node2D" but its supertype "Node" is specified.


### PR DESCRIPTION
Remove `REDUNDANT_FOR_VARIABLE_TYPE`
~~Change REDUNDANT_FOR_VARIABLE_TYPE to FOR_LOOP_VARIABLE_SUPERTYPE_SPECIFIED~~

These changes are still open to discussion!

Currently, `REDUNDANT_FOR_VARIABLE_TYPE` warns the user when they explicitly type a for loop variable as the same type as what's inferred by the analyzer. This discourages the user from explicitly typing their for loop variables:

```gdscript
for i: int in range(4): # Emits REDUNDANT_FOR_VARIABLE_TYPE warning
for i: Variant in range(4): #Emits REDUNDANT_FOR_VARIABLE_TYPE warning
```

It is a common convention in statically typed languages to annotate for loop variables, even if the iterator variable can be inferred by the analyzer:
https://www.w3schools.com/cs/cs_foreach_loop.php
https://www.geeksforgeeks.org/g-fact-40-foreach-in-c-and-java/#

Since it is a convention in modern statically typed languages, statically typed GDScript would be the exception to the general concensus. I have no problem with letting the analyzer infer the type of the iterator variable, but I do not think that a warning should be issued when a type annotation is used for a loop and the explicit and inferred types match.

__EDIT 9/12/23:__ The discussion having progressed, seems to be leaning towards removing the `REDUNDANT_FOR_VARIABLE_TYPE` warning in its entirely. For those people behind in the discussion, it was previously discussed whether or not we add a warning for the __strict supertype__ of an inferred variable instead, for example:

```gdscript
for i: A in my_b_list: # Type of my_b_list is Array[B] where B extends A
```

Most people seem to be of the view that no warning should be necessary in any case of explicitly typing a for loop variable.

As always, more discussion is welcomed.

Please let me know your thoughts! 😄 