### PR TITLE
[3.x] [macOS] Disable live resize in multithreaded rendering mode.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -478,7 +478,7 @@ static NSCursor *cursorFromSelector(SEL selector, SEL fallback = nil) {
 @implementation GodotContentView
 
 - (void)drawRect:(NSRect)dirtyRect {
-	if (OS_OSX::singleton->get_main_loop() && OS_OSX::singleton->is_resizing) {
+	if (OS_OSX::singleton->get_main_loop() && (OS_OSX::singleton->get_render_thread_mode() != OS::RENDER_SEPARATE_THREAD) && OS_OSX::singleton->is_resizing) {
 		Main::force_redraw();
 		if (!Main::is_iterating()) { // Avoid cyclic loop.
 			Main::iteration();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81402

Irrelevant for 4.x / Vulkan, 4.x / OpenGL multithreaded mode is crashing in the rasterizer init.