### PR TITLE
Fix FindReplaceBar losing focus too early

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -483,7 +483,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (k->is_action("ui_cancel")) {
-			release_focus();
+			callable_mp((Control *)this, &Control::release_focus).call_deferred();
 			return;
 		}
 


### PR DESCRIPTION
Fixes #81441

It doesn't matter if the focus is released immediately or later, so if it fixes the issue... 🤷‍♂️