### PR TITLE
Fix sign(NAN) returning 1.

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -109,7 +109,8 @@ constexpr T ABS(T m_v) {
 
 template <typename T>
 constexpr const T SIGN(const T m_v) {
-	return m_v == 0 ? 0.0f : (m_v < 0 ? -1.0f : +1.0f);
+	// Sign of NAN is NAN.
+	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : (m_v == 0 ? 0.0f : m_v));
 }
 
 template <typename T, typename T2>

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1168,11 +1168,12 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the same type of [Variant] as [param x], with [code]-1[/code] for negative values, [code]1[/code] for positive values, and [code]0[/code] for zeros. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
+				Returns the same type of [Variant] as [param x], with [code]-1[/code] for negative values, [code]1[/code] for positive values, [code]0[/code] for zeros, and [code]nan[/code] for NaN values. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				sign(-6.0) # Returns -1
 				sign(0.0)  # Returns 0
 				sign(6.0)  # Returns 1
+				sign(NAN)  # Returns NaN
 
 				sign(Vector3(-6.0, 0.0, 6.0)) # Returns (-1, 0, 1)
 				[/codeblock]
@@ -1183,11 +1184,12 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns [code]-1.0[/code] if [param x] is negative, [code]1.0[/code] if [param x] is positive, and [code]0.0[/code] if [param x] is zero.
+				Returns [code]-1.0[/code] if [param x] is negative, [code]1.0[/code] if [param x] is positive, [code]0.0[/code] if [param x] is zero, and [code]nan[/code] if [param x] is NaN.
 				[codeblock]
 				signf(-6.5) # Returns -1.0
 				signf(0.0)  # Returns 0.0
 				signf(6.5)  # Returns 1.0
+				sign(NAN)  # Returns NaN
 				[/codeblock]
 			</description>
 		</method>

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -54,6 +54,8 @@ TEST_CASE("[Math] C++ macros") {
 	CHECK(SIGN(-5) == -1.0);
 	CHECK(SIGN(0) == 0.0);
 	CHECK(SIGN(5) == 1.0);
+	// check that SIGN(NAN) returns NAN.
+	CHECK(Math::is_nan(SIGN(NAN)));
 }
 
 TEST_CASE("[Math] Power of two functions") {


### PR DESCRIPTION
Fixes godotengine#79036 by using the same implementation for SIGN() as numpy does.
Adds a test for the NAN case. Updates the documentation to clarify the new behavior.