### PR TITLE
Fix animation keyframes being skipped when played backwards

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2782,7 +2782,7 @@ void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double
 			p_indices->push_back(i);
 		}
 	} else {
-		for (int i = to; i >= to; i--) {
+		for (int i = to; i >= from; i--) {
 			p_indices->push_back(i);
 		}
 	}


### PR DESCRIPTION
Fixes #57271.

Currently, if an animation playing backwards passes by multiple keyframes in a single frame, only the first of the keyframes (last in forwards-order) takes effect. The others are skipped. The cause appears to be a simple typo.