### PR TITLE
Fix errors when testing `Resource`

### DIFF
--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -139,7 +139,7 @@ TEST_CASE("[Resource] Breaking circular references on save") {
 			loaded_resource_c_binary->get_name() == "C",
 			"The loaded child resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			!loaded_resource_c_binary->get_meta("next"),
+			!loaded_resource_c_binary->has_meta("next"),
 			"The loaded child resource circular reference should be NULL.");
 
 	const Ref<Resource> &loaded_resource_a_text = ResourceLoader::load(save_path_text);
@@ -155,7 +155,7 @@ TEST_CASE("[Resource] Breaking circular references on save") {
 			loaded_resource_c_text->get_name() == "C",
 			"The loaded child resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			!loaded_resource_c_text->get_meta("next"),
+			!loaded_resource_c_text->has_meta("next"),
 			"The loaded child resource circular reference should be NULL.");
 
 	// Break circular reference to avoid memory leak


### PR DESCRIPTION
Using `has_meta` instead of `get_meta` where the result is expected to not exist.

The warning and errors when saving and loading needs to be investigated, it appears that the binary case doesn't identify cycles like the text case does, and the text case errors but without indicating that it's a cyclic error.

* Fixes (partially): #80616

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
