### PR TITLE
Add instance uniforms to particles process shaders (RD only for now)

### DIFF
--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -364,6 +364,7 @@ public:
 
 	virtual void update_particles() override;
 	virtual bool particles_is_inactive(RID p_particles) const override;
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override {}
 
 	_FORCE_INLINE_ RS::ParticlesMode particles_get_mode(RID p_particles) {
 		Particles *particles = particles_owner.get_or_null(p_particles);

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -116,6 +116,7 @@ public:
 	virtual void particles_collision_instance_set_active(RID p_collision_instance, bool p_active) override {}
 
 	virtual bool particles_is_inactive(RID p_particles) const override { return false; }
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override {}
 };
 
 } // namespace RendererDummy

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -182,6 +182,8 @@ layout(push_constant, std430) uniform Params {
 	bool sub_emitter_mode;
 	bool can_emit;
 	bool trail_pass;
+	uvec3 pad;
+	uint instance_uniforms_ofs;
 }
 params;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -118,6 +118,7 @@ ParticlesStorage::ParticlesStorage() {
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
+		actions.instance_uniform_index_variable = "params.instance_uniforms_ofs";
 
 		particles_shader.compiler.initialize(actions);
 	}
@@ -1057,6 +1058,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	push_constant.use_fractional_delta = p_particles->fractional_delta;
 	push_constant.sub_emitter_mode = !p_particles->emitting && p_particles->emission_buffer && (p_particles->emission_buffer->particle_count > 0 || p_particles->force_sub_emit);
 	push_constant.trail_pass = false;
+	push_constant.instance_uniforms_ofs = uint32_t(p_particles->shader_uniforms_offset);
 
 	p_particles->force_sub_emit = false; //reset
 
@@ -1592,6 +1594,13 @@ bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_COND_V(!particles, false);
 	return !particles->emitting && particles->inactive;
+}
+
+void ParticlesStorage::particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_COND(!particles);
+
+	particles->shader_uniforms_offset = p_offset;
 }
 
 /* Particles SHADER */

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -230,6 +230,8 @@ private:
 		uint64_t instance_motion_vectors_last_change = -1;
 		bool instance_motion_vectors_enabled = false;
 
+		int32_t shader_uniforms_offset;
+
 		bool clear = true;
 
 		bool force_sub_emit = false;
@@ -270,6 +272,9 @@ private:
 			uint32_t sub_emitter_mode;
 			uint32_t can_emit;
 			uint32_t trail_pass;
+
+			uint32_t pad[3];
+			uint32_t instance_uniforms_ofs;
 		};
 
 		ParticlesShaderRD shader;
@@ -468,6 +473,8 @@ public:
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override;
 
 	virtual bool particles_is_inactive(RID p_particles) const override;
+
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override;
 
 	_FORCE_INLINE_ RS::ParticlesMode particles_get_mode(RID p_particles) {
 		Particles *particles = particles_owner.get_or_null(p_particles);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3882,6 +3882,13 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 
 					int dp = RSG::particles_storage->particles_get_draw_passes(p_instance->base);
 
+					RID process_material = RSG::particles_storage->particles_get_process_material(p_instance->base);
+					if (process_material.is_valid()) {
+						_update_instance_shader_uniforms_from_material(isparams, p_instance->instance_shader_uniforms, process_material);
+
+						RSG::material_storage->material_update_dependency(process_material, &p_instance->dependency_tracker);
+					}
+
 					for (int i = 0; i < dp; i++) {
 						RID mesh = RSG::particles_storage->particles_get_draw_pass_mesh(p_instance->base, i);
 						if (!mesh.is_valid()) {
@@ -3941,6 +3948,9 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 					p_instance->instance_allocated_shader_uniforms_offset = RSG::material_storage->global_shader_parameters_instance_allocate(p_instance->self);
 					ERR_FAIL_NULL(geom->geometry_instance);
 					geom->geometry_instance->set_instance_shader_uniforms_offset(p_instance->instance_allocated_shader_uniforms_offset);
+					if (p_instance->base_type == RS::INSTANCE_PARTICLES) {
+						RSG::particles_storage->particles_set_instance_uniform_offset(p_instance->base, p_instance->instance_allocated_shader_uniforms_offset);
+					}
 
 					for (const KeyValue<StringName, Instance::InstanceShaderParameter> &E : p_instance->instance_shader_uniforms) {
 						if (E.value.value.get_type() != Variant::NIL) {
@@ -3967,6 +3977,9 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 					p_instance->instance_allocated_shader_uniforms_offset = -1;
 					ERR_FAIL_NULL(geom->geometry_instance);
 					geom->geometry_instance->set_instance_shader_uniforms_offset(-1);
+					if (p_instance->base_type == RS::INSTANCE_PARTICLES) {
+						RSG::particles_storage->particles_set_instance_uniform_offset(p_instance->base, -1);
+					}
 				}
 			}
 		}

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -505,6 +505,7 @@ public:
 	FUNC1R(bool, particles_is_inactive, RID)
 	FUNC3(particles_set_trails, RID, bool, float)
 	FUNC2(particles_set_trail_bind_poses, RID, const Vector<Transform3D> &)
+	FUNC2(particles_set_instance_uniform_offset, RID, int32_t)
 
 	FUNC1(particles_request_process, RID)
 	FUNC1(particles_restart, RID)

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -335,7 +335,7 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 
 	// uniform qualifiers
 
-	{ TK_INSTANCE, "instance", CF_GLOBAL_SPACE | CF_UNIFORM_QUALIFIER, {}, {} },
+	{ TK_INSTANCE, "instance", CF_GLOBAL_SPACE | CF_UNIFORM_QUALIFIER, { "canvas_item", "sky", "fog" }, {} },
 	{ TK_GLOBAL, "global", CF_GLOBAL_SPACE | CF_UNIFORM_QUALIFIER, {}, {} },
 
 	// block keywords
@@ -8333,7 +8333,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						}
 					}
 #endif // DEBUG_ENABLED
-					if (String(shader_type_identifier) != "spatial") {
+					if (String(shader_type_identifier) != "spatial" && String(shader_type_identifier) != "particles") {
 						_set_error(vformat(RTR("Uniform instances are not yet implemented for '%s' shaders."), shader_type_identifier));
 						return ERR_PARSE_ERROR;
 					}

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -75,6 +75,8 @@ public:
 
 	virtual bool particles_is_inactive(RID p_particles) const = 0;
 
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) = 0;
+
 	virtual void particles_set_draw_order(RID p_particles, RS::ParticlesDrawOrder p_order) = 0;
 
 	virtual void particles_set_draw_passes(RID p_particles, int p_count) = 0;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -676,6 +676,8 @@ public:
 	virtual void particles_request_process(RID p_particles) = 0;
 	virtual void particles_restart(RID p_particles) = 0;
 
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) = 0;
+
 	virtual void particles_set_subemitter(RID p_particles, RID p_subemitter_particles) = 0;
 
 	enum ParticlesEmitFlags {


### PR DESCRIPTION
This adds instance uniforms to particles shaders. Most of the infrastructure was already in place because Particles nodes already support instance particles in their spatial shaders. This just extends the same instance uniforms to be accessible in the process material. 

Importantly, this means that the process material shares the same limited number of instance uniform slots with the other materials. 

![Screenshot from 2023-09-08 17-36-08](https://github.com/godotengine/godot/assets/16521339/ce4e4b85-f58d-4ec3-9719-53ff340e077d)

Marking as draft for now as I haven't implemented this in the GL_Compatibility backend yet. But it would be trivial to do so. 