### PR TITLE
Correctly setup tooltip's style as theme variation

### DIFF
--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1025,9 +1025,11 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// TooltipPanel + TooltipLabel
 
+	theme->set_type_variation("TooltipPanel", "PopupPanel");
 	theme->set_stylebox("panel", "TooltipPanel",
 			make_flat_stylebox(Color(0, 0, 0, 0.5), 2 * default_margin, 0.5 * default_margin, 2 * default_margin, 0.5 * default_margin));
 
+	theme->set_type_variation("TooltipLabel", "Label");
 	theme->set_font_size("font_size", "TooltipLabel", -1);
 	theme->set_font("font", "TooltipLabel", Ref<Font>());
 


### PR DESCRIPTION
Sort of a regression from my recent Theme-related changes. Tooltips in the editor started to look strange:

![image](https://github.com/godotengine/godot/assets/11782833/ad6629b4-6faa-4c30-bea6-3841e2187194)

The issue here is that `TooltipPanel` and `TooltipLabel` are used in code as theme variations, but aren't registered as ones. With my latest changes this makes them ignored as a proper dependency chain cannot be created from these types. The fix is to setup them correctly according to their use.