### PR TITLE
Fix `SIGN(NAN)` returning 1

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -109,7 +109,7 @@ constexpr T ABS(T m_v) {
 
 template <typename T>
 constexpr const T SIGN(const T m_v) {
-	return m_v == 0 ? 0.0f : (m_v < 0 ? -1.0f : +1.0f);
+	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
 }
 
 template <typename T, typename T2>

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1168,11 +1168,13 @@
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />
 			<description>
-				Returns the same type of [Variant] as [param x], with [code]-1[/code] for negative values, [code]1[/code] for positive values, and [code]0[/code] for zeros. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
+				Returns the same type of [Variant] as [param x], with [code]-1[/code] for negative values, [code]1[/code] for positive values, and [code]0[/code] for zeros. For [code]nan[/code] values it returns 0.
+				Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				sign(-6.0) # Returns -1
 				sign(0.0)  # Returns 0
 				sign(6.0)  # Returns 1
+				sign(NAN)  # Returns 0
 
 				sign(Vector3(-6.0, 0.0, 6.0)) # Returns (-1, 0, 1)
 				[/codeblock]
@@ -1183,11 +1185,12 @@
 			<return type="float" />
 			<param index="0" name="x" type="float" />
 			<description>
-				Returns [code]-1.0[/code] if [param x] is negative, [code]1.0[/code] if [param x] is positive, and [code]0.0[/code] if [param x] is zero.
+				Returns [code]-1.0[/code] if [param x] is negative, [code]1.0[/code] if [param x] is positive, and [code]0.0[/code] if [param x] is zero. For [code]nan[/code] values of [param x] it returns 0.0.
 				[codeblock]
 				signf(-6.5) # Returns -1.0
 				signf(0.0)  # Returns 0.0
 				signf(6.5)  # Returns 1.0
+				signf(NAN)  # Returns 0.0
 				[/codeblock]
 			</description>
 		</method>

--- a/tests/core/math/test_math_funcs.h
+++ b/tests/core/math/test_math_funcs.h
@@ -54,6 +54,8 @@ TEST_CASE("[Math] C++ macros") {
 	CHECK(SIGN(-5) == -1.0);
 	CHECK(SIGN(0) == 0.0);
 	CHECK(SIGN(5) == 1.0);
+	// Check that SIGN(NAN) returns 0.0.
+	CHECK(SIGN(NAN) == 0.0);
 }
 
 TEST_CASE("[Math] Power of two functions") {


### PR DESCRIPTION
Fixes #79036. sign(NAN) now returns 0.0.
This should not impact performance much in any way.
Adds a test for the NAN case. Updates the documentation to clarify the new behavior.