### PR TITLE
Fix submenu alignment with parent menu item

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -204,9 +204,9 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 
 	Point2 submenu_pos;
 	if (control->is_layout_rtl()) {
-		submenu_pos = this_pos + Point2(-submenu_size.width, items[p_over]._ofs_cache + scroll_offset);
+		submenu_pos = this_pos + Point2(-submenu_size.width, items[p_over]._ofs_cache + scroll_offset - theme_cache.v_separation / 2);
 	} else {
-		submenu_pos = this_pos + Point2(this_rect.size.width, items[p_over]._ofs_cache + scroll_offset);
+		submenu_pos = this_pos + Point2(this_rect.size.width, items[p_over]._ofs_cache + scroll_offset - theme_cache.v_separation / 2);
 	}
 
 	// Fix pos if going outside parent rect.


### PR DESCRIPTION
Fixes #81467

<table><tr><th>Before</th><td>

![before](https://github.com/godotengine/godot/assets/372476/adbe0917-bc08-49d9-94e0-795e4f09bc6c)

</td></tr>
<tr><th>After</th><td>

![after](https://github.com/godotengine/godot/assets/372476/e71fe0db-18a1-485b-abea-b8c32af7bb47)

</td></tr></table>

The menu item visual (focus rect) is expanded half a `h_separation` on both top and bottom of the menu item itself.