### PR TITLE
Remove some dead declarations in `audio_stream_player.h`

### DIFF
--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -60,15 +60,10 @@ private:
 
 	MixTarget mix_target = MIX_TARGET_STEREO;
 
-	void _mix_internal(bool p_fadeout);
-	void _mix_audio();
-	static void _mix_audios(void *self) { reinterpret_cast<AudioStreamPlayer *>(self)->_mix_audio(); }
-
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
 	void _bus_layout_changed();
-	void _mix_to_bus(const AudioFrame *p_frames, int p_amount);
 
 	Vector<AudioFrame> _get_volume_vector();
 


### PR DESCRIPTION
There were a few function declarations in `audio_stream_player.h` that actually had no definition, and of course were never used, because that should have revealed the issue in the form of linker errors. Probably just a left-over from a refactoring.
