### PR TITLE
[Core] Replace `ERR_FAIL_COND` with `ERR_FAIL_NULL` where applicable

### DIFF
--- a/core/crypto/crypto_core.cpp
+++ b/core/crypto/crypto_core.cpp
@@ -73,7 +73,7 @@ Error CryptoCore::RandomGenerator::init() {
 }
 
 Error CryptoCore::RandomGenerator::get_random_bytes(uint8_t *r_buffer, size_t p_bytes) {
-	ERR_FAIL_COND_V(!ctx, ERR_UNCONFIGURED);
+	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	int ret = mbedtls_ctr_drbg_random((mbedtls_ctr_drbg_context *)ctx, r_buffer, p_bytes);
 	ERR_FAIL_COND_V_MSG(ret, FAILED, " failed\n  ! mbedtls_ctr_drbg_seed returned an error" + itos(ret));
 	return OK;

--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -35,7 +35,7 @@
 Error HashingContext::start(HashType p_type) {
 	ERR_FAIL_COND_V(ctx != nullptr, ERR_ALREADY_IN_USE);
 	_create_ctx(p_type);
-	ERR_FAIL_COND_V(ctx == nullptr, ERR_UNAVAILABLE);
+	ERR_FAIL_NULL_V(ctx, ERR_UNAVAILABLE);
 	switch (type) {
 		case HASH_MD5:
 			return ((CryptoCore::MD5Context *)ctx)->start();
@@ -48,7 +48,7 @@ Error HashingContext::start(HashType p_type) {
 }
 
 Error HashingContext::update(PackedByteArray p_chunk) {
-	ERR_FAIL_COND_V(ctx == nullptr, ERR_UNCONFIGURED);
+	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	size_t len = p_chunk.size();
 	ERR_FAIL_COND_V(len == 0, FAILED);
 	const uint8_t *r = p_chunk.ptr();
@@ -64,7 +64,7 @@ Error HashingContext::update(PackedByteArray p_chunk) {
 }
 
 PackedByteArray HashingContext::finish() {
-	ERR_FAIL_COND_V(ctx == nullptr, PackedByteArray());
+	ERR_FAIL_NULL_V(ctx, PackedByteArray());
 	PackedByteArray out;
 	Error err = FAILED;
 	switch (type) {

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -415,7 +415,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	Array msg;
 	msg.push_back(p_can_continue);
 	msg.push_back(error_str);
-	ERR_FAIL_COND(!script_lang);
+	ERR_FAIL_NULL(script_lang);
 	msg.push_back(script_lang->debug_get_stack_level_count() > 0);
 	msg.push_back(Thread::get_caller_id() == Thread::get_main_id() ? String(RTR("Main Thread")) : itos(Thread::get_caller_id()));
 	if (allow_focus_steal_fn) {
@@ -485,7 +485,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			} else if (command == "get_stack_frame_vars") {
 				ERR_FAIL_COND(data.size() != 1);
-				ERR_FAIL_COND(!script_lang);
+				ERR_FAIL_NULL(script_lang);
 				int lv = data[0];
 
 				List<String> members;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -491,7 +491,7 @@ void GDExtension::register_interface_function(StringName p_function_name, GDExte
 
 GDExtensionInterfaceFunctionPtr GDExtension::get_interface_function(StringName p_function_name) {
 	GDExtensionInterfaceFunctionPtr *function = gdextension_interface_functions.getptr(p_function_name);
-	ERR_FAIL_COND_V_MSG(function == nullptr, nullptr, "Attempt to get non-existent interface function: " + p_function_name);
+	ERR_FAIL_NULL_V_MSG(function, nullptr, "Attempt to get non-existent interface function: " + String(p_function_name) + ".");
 	return *function;
 }
 
@@ -525,7 +525,7 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 }
 
 void GDExtension::close_library() {
-	ERR_FAIL_COND(library == nullptr);
+	ERR_FAIL_NULL(library);
 	OS::get_singleton()->close_dynamic_library(library);
 
 #if defined(TOOLS_ENABLED) && defined(WINDOWS_ENABLED)
@@ -543,12 +543,12 @@ bool GDExtension::is_library_open() const {
 }
 
 GDExtension::InitializationLevel GDExtension::get_minimum_library_initialization_level() const {
-	ERR_FAIL_COND_V(library == nullptr, INITIALIZATION_LEVEL_CORE);
+	ERR_FAIL_NULL_V(library, INITIALIZATION_LEVEL_CORE);
 	return InitializationLevel(initialization.minimum_initialization_level);
 }
 
 void GDExtension::initialize_library(InitializationLevel p_level) {
-	ERR_FAIL_COND(library == nullptr);
+	ERR_FAIL_NULL(library);
 	ERR_FAIL_COND_MSG(p_level <= int32_t(level_initialized), vformat("Level '%d' must be higher than the current level '%d'", p_level, level_initialized));
 
 	level_initialized = int32_t(p_level);
@@ -558,7 +558,7 @@ void GDExtension::initialize_library(InitializationLevel p_level) {
 	initialization.initialize(initialization.userdata, GDExtensionInitializationLevel(p_level));
 }
 void GDExtension::deinitialize_library(InitializationLevel p_level) {
-	ERR_FAIL_COND(library == nullptr);
+	ERR_FAIL_NULL(library);
 	ERR_FAIL_COND(p_level > int32_t(level_initialized));
 
 	level_initialized = int32_t(p_level) - 1;

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1097,7 +1097,7 @@ static GDExtensionScriptInstancePtr gdextension_placeholder_script_instance_crea
 
 static void gdextension_placeholder_script_instance_update(GDExtensionScriptInstancePtr p_placeholder, GDExtensionConstTypePtr p_properties, GDExtensionConstTypePtr p_values) {
 	PlaceHolderScriptInstance *placeholder = dynamic_cast<PlaceHolderScriptInstance *>(reinterpret_cast<ScriptInstance *>(p_placeholder));
-	ERR_FAIL_COND_MSG(!placeholder, "Unable to update placeholder, expected a PlaceHolderScriptInstance but received an invalid type.");
+	ERR_FAIL_NULL_MSG(placeholder, "Unable to update placeholder, expected a PlaceHolderScriptInstance but received an invalid type.");
 
 	const Array &properties = *reinterpret_cast<const Array *>(p_properties);
 	const Dictionary &values = *reinterpret_cast<const Dictionary *>(p_values);
@@ -1148,7 +1148,7 @@ static GDExtensionMethodBindPtr gdextension_classdb_get_method_bind(GDExtensionC
 		ERR_PRINT("Method '" + classname + "." + methodname + "' has changed and no compatibility fallback has been provided. Please open an issue.");
 		return nullptr;
 	}
-	ERR_FAIL_COND_V(!mb, nullptr);
+	ERR_FAIL_NULL_V(mb, nullptr);
 	if (mb->get_hash() != p_hash) {
 		ERR_PRINT("Hash mismatch for method '" + classname + "." + methodname + "'.");
 		return nullptr;

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -215,7 +215,7 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 #ifdef BROTLI_ENABLED
 		BrotliDecoderResult ret;
 		BrotliDecoderState *state = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
-		ERR_FAIL_COND_V(state == nullptr, Z_DATA_ERROR);
+		ERR_FAIL_NULL_V(state, Z_DATA_ERROR);
 
 		// Setup the stream inputs.
 		const uint8_t *next_in = p_src;

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -79,7 +79,7 @@ Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 }
 
 Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags) {
-	ERR_FAIL_COND_V(!files, ERR_FILE_NOT_FOUND);
+	ERR_FAIL_NULL_V(files, ERR_FILE_NOT_FOUND);
 
 	String name = fix_path(p_path);
 	//name = DirAccess::normalize_path(name);
@@ -99,22 +99,22 @@ bool FileAccessMemory::is_open() const {
 }
 
 void FileAccessMemory::seek(uint64_t p_position) {
-	ERR_FAIL_COND(!data);
+	ERR_FAIL_NULL(data);
 	pos = p_position;
 }
 
 void FileAccessMemory::seek_end(int64_t p_position) {
-	ERR_FAIL_COND(!data);
+	ERR_FAIL_NULL(data);
 	pos = length + p_position;
 }
 
 uint64_t FileAccessMemory::get_position() const {
-	ERR_FAIL_COND_V(!data, 0);
+	ERR_FAIL_NULL_V(data, 0);
 	return pos;
 }
 
 uint64_t FileAccessMemory::get_length() const {
-	ERR_FAIL_COND_V(!data, 0);
+	ERR_FAIL_NULL_V(data, 0);
 	return length;
 }
 
@@ -134,7 +134,7 @@ uint8_t FileAccessMemory::get_8() const {
 
 uint64_t FileAccessMemory::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
-	ERR_FAIL_COND_V(!data, -1);
+	ERR_FAIL_NULL_V(data, -1);
 
 	uint64_t left = length - pos;
 	uint64_t read = MIN(p_length, left);
@@ -154,11 +154,11 @@ Error FileAccessMemory::get_error() const {
 }
 
 void FileAccessMemory::flush() {
-	ERR_FAIL_COND(!data);
+	ERR_FAIL_NULL(data);
 }
 
 void FileAccessMemory::store_8(uint8_t p_byte) {
-	ERR_FAIL_COND(!data);
+	ERR_FAIL_NULL(data);
 	ERR_FAIL_COND(pos >= length);
 	data[pos++] = p_byte;
 }

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -239,7 +239,7 @@ Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags) {
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, FAILED);
 	ZipArchive *arch = ZipArchive::get_singleton();
-	ERR_FAIL_COND_V(!arch, FAILED);
+	ERR_FAIL_NULL_V(arch, FAILED);
 	zfile = arch->get_file_handle(p_path);
 	ERR_FAIL_COND_V(!zfile, FAILED);
 
@@ -255,7 +255,7 @@ void FileAccessZip::_close() {
 	}
 
 	ZipArchive *arch = ZipArchive::get_singleton();
-	ERR_FAIL_COND(!arch);
+	ERR_FAIL_NULL(arch);
 	arch->close_handle(zfile);
 	zfile = nullptr;
 }

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2356,7 +2356,7 @@ void Image::initialize_data(const char **p_xpm) {
 					}
 
 					Color *colorptr = colormap.getptr(pixelstr);
-					ERR_FAIL_COND(!colorptr);
+					ERR_FAIL_NULL(colorptr);
 					uint8_t pixel[4];
 					for (uint32_t i = 0; i < pixel_size; i++) {
 						pixel[i] = CLAMP((*colorptr)[i] * 255, 0, 255);
@@ -2646,23 +2646,23 @@ Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels
 
 	switch (p_mode) {
 		case COMPRESS_S3TC: {
-			ERR_FAIL_COND_V(!_image_compress_bc_func, ERR_UNAVAILABLE);
+			ERR_FAIL_NULL_V(_image_compress_bc_func, ERR_UNAVAILABLE);
 			_image_compress_bc_func(this, p_channels);
 		} break;
 		case COMPRESS_ETC: {
-			ERR_FAIL_COND_V(!_image_compress_etc1_func, ERR_UNAVAILABLE);
+			ERR_FAIL_NULL_V(_image_compress_etc1_func, ERR_UNAVAILABLE);
 			_image_compress_etc1_func(this);
 		} break;
 		case COMPRESS_ETC2: {
-			ERR_FAIL_COND_V(!_image_compress_etc2_func, ERR_UNAVAILABLE);
+			ERR_FAIL_NULL_V(_image_compress_etc2_func, ERR_UNAVAILABLE);
 			_image_compress_etc2_func(this, p_channels);
 		} break;
 		case COMPRESS_BPTC: {
-			ERR_FAIL_COND_V(!_image_compress_bptc_func, ERR_UNAVAILABLE);
+			ERR_FAIL_NULL_V(_image_compress_bptc_func, ERR_UNAVAILABLE);
 			_image_compress_bptc_func(this, p_channels);
 		} break;
 		case COMPRESS_ASTC: {
-			ERR_FAIL_COND_V(!_image_compress_astc_func, ERR_UNAVAILABLE);
+			ERR_FAIL_NULL_V(_image_compress_astc_func, ERR_UNAVAILABLE);
 			_image_compress_astc_func(this, p_astc_format);
 		} break;
 		case COMPRESS_MAX: {
@@ -3655,7 +3655,7 @@ void Image::bump_map_to_normal_map(float bump_scale) {
 		const uint8_t *rp = data.ptr();
 		uint8_t *wp = result_image.ptrw();
 
-		ERR_FAIL_COND(!rp);
+		ERR_FAIL_NULL(rp);
 
 		unsigned char *write_ptr = wp;
 		float *read_ptr = (float *)rp;
@@ -3916,7 +3916,7 @@ Error Image::_load_from_buffer(const Vector<uint8_t> &p_array, ImageMemLoadFunc 
 	int buffer_size = p_array.size();
 
 	ERR_FAIL_COND_V(buffer_size == 0, ERR_INVALID_PARAMETER);
-	ERR_FAIL_COND_V(!p_loader, ERR_INVALID_PARAMETER);
+	ERR_FAIL_NULL_V(p_loader, ERR_INVALID_PARAMETER);
 
 	const uint8_t *r = p_array.ptr();
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -333,7 +333,7 @@ IP *(*IP::_create)() = nullptr;
 
 IP *IP::create() {
 	ERR_FAIL_COND_V_MSG(singleton, nullptr, "IP singleton already exist.");
-	ERR_FAIL_COND_V(!_create, nullptr);
+	ERR_FAIL_NULL_V(_create, nullptr);
 	return _create();
 }
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -640,7 +640,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 				} else {
 					Object *obj = ClassDB::instantiate(str);
 
-					ERR_FAIL_COND_V(!obj, ERR_UNAVAILABLE);
+					ERR_FAIL_NULL_V(obj, ERR_UNAVAILABLE);
 					ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
 
 					int32_t count = decode_uint32(buf);
@@ -1576,7 +1576,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 					buf += len;
 				}
 				Variant *v = d.getptr(E);
-				ERR_FAIL_COND_V(!v, ERR_BUG);
+				ERR_FAIL_NULL_V(v, ERR_BUG);
 				err = encode_variant(*v, buf, len, p_full_objects, p_depth + 1);
 				ERR_FAIL_COND_V(err, err);
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -125,7 +125,7 @@ Variant PackedDataContainer::_get_at_ofs(uint32_t p_ofs, const uint8_t *p_buf, b
 uint32_t PackedDataContainer::_type_at_ofs(uint32_t p_ofs) const {
 	ERR_FAIL_COND_V(p_ofs + 4 > (uint32_t)data.size(), 0);
 	const uint8_t *rd = data.ptr();
-	ERR_FAIL_COND_V(!rd, 0);
+	ERR_FAIL_NULL_V(rd, 0);
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);
 
@@ -135,7 +135,7 @@ uint32_t PackedDataContainer::_type_at_ofs(uint32_t p_ofs) const {
 int PackedDataContainer::_size(uint32_t p_ofs) const {
 	ERR_FAIL_COND_V(p_ofs + 4 > (uint32_t)data.size(), 0);
 	const uint8_t *rd = data.ptr();
-	ERR_FAIL_COND_V(!rd, 0);
+	ERR_FAIL_NULL_V(rd, 0);
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);
 
@@ -156,7 +156,7 @@ Variant PackedDataContainer::_key_at_ofs(uint32_t p_ofs, const Variant &p_key, b
 	const uint8_t *rd = data.ptr();
 	if (!rd) {
 		err = true;
-		ERR_FAIL_COND_V(!rd, Variant());
+		ERR_FAIL_NULL_V(rd, Variant());
 	}
 	const uint8_t *r = &rd[p_ofs];
 	uint32_t type = decode_uint32(r);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1114,7 +1114,7 @@ bool ResourceLoader::add_custom_resource_format_loader(String script_path) {
 
 	Object *obj = ClassDB::instantiate(ibt);
 
-	ERR_FAIL_COND_V_MSG(obj == nullptr, false, "Cannot instance script as custom resource loader, expected 'ResourceFormatLoader' inheritance, got: " + String(ibt) + ".");
+	ERR_FAIL_NULL_V_MSG(obj, false, "Cannot instance script as custom resource loader, expected 'ResourceFormatLoader' inheritance, got: " + String(ibt) + ".");
 
 	Ref<ResourceFormatLoader> crl = Object::cast_to<ResourceFormatLoader>(obj);
 	crl->set_script(s);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -241,7 +241,7 @@ bool ResourceSaver::add_custom_resource_format_saver(String script_path) {
 
 	Object *obj = ClassDB::instantiate(ibt);
 
-	ERR_FAIL_COND_V_MSG(obj == nullptr, false, "Cannot instance script as custom resource saver, expected 'ResourceFormatSaver' inheritance, got: " + String(ibt) + ".");
+	ERR_FAIL_NULL_V_MSG(obj, false, "Cannot instance script as custom resource saver, expected 'ResourceFormatSaver' inheritance, got: " + String(ibt) + ".");
 
 	Ref<ResourceFormatSaver> crl = Object::cast_to<ResourceFormatSaver>(obj);
 	crl->set_script(s);

--- a/core/io/stream_peer_gzip.cpp
+++ b/core/io/stream_peer_gzip.cpp
@@ -102,7 +102,7 @@ Error StreamPeerGZIP::_start(bool p_compress, bool p_is_deflate, int buffer_size
 }
 
 Error StreamPeerGZIP::_process(uint8_t *p_dst, int p_dst_size, const uint8_t *p_src, int p_src_size, int &r_consumed, int &r_out, bool p_close) {
-	ERR_FAIL_COND_V(!ctx, ERR_UNCONFIGURED);
+	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	z_stream &strm = *(z_stream *)ctx;
 	strm.avail_in = p_src_size;
 	strm.avail_out = p_dst_size;
@@ -132,7 +132,7 @@ Error StreamPeerGZIP::put_data(const uint8_t *p_data, int p_bytes) {
 }
 
 Error StreamPeerGZIP::put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) {
-	ERR_FAIL_COND_V(!ctx, ERR_UNCONFIGURED);
+	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(p_bytes < 0, ERR_INVALID_PARAMETER);
 
 	// Ensure we have enough space in temporary buffer.

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -336,7 +336,7 @@ uint64_t XMLParser::get_node_offset() const {
 }
 
 Error XMLParser::seek(uint64_t p_pos) {
-	ERR_FAIL_COND_V(!data, ERR_FILE_EOF);
+	ERR_FAIL_NULL_V(data, ERR_FILE_EOF);
 	ERR_FAIL_COND_V(p_pos >= length, ERR_FILE_EOF);
 
 	P = data + p_pos;
@@ -474,7 +474,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 
 Error XMLParser::_open_buffer(const uint8_t *p_buffer, size_t p_size) {
 	ERR_FAIL_COND_V(p_size == 0, ERR_INVALID_DATA);
-	ERR_FAIL_COND_V(!p_buffer, ERR_INVALID_DATA);
+	ERR_FAIL_NULL_V(p_buffer, ERR_INVALID_DATA);
 
 	if (data_copy) {
 		memdelete_arr(data_copy);

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -74,7 +74,7 @@ int godot_unzip_locate_file(unzFile p_zip_file, String p_filepath, bool p_case_s
 
 void *zipio_open(voidpf opaque, const char *p_fname, int mode) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, nullptr);
+	ERR_FAIL_NULL_V(fa, nullptr);
 
 	String fname;
 	fname.parse_utf8(p_fname);
@@ -100,7 +100,7 @@ void *zipio_open(voidpf opaque, const char *p_fname, int mode) {
 
 uLong zipio_read(voidpf opaque, voidpf stream, void *buf, uLong size) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 0);
+	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	return (*fa)->get_buffer((uint8_t *)buf, size);
@@ -108,7 +108,7 @@ uLong zipio_read(voidpf opaque, voidpf stream, void *buf, uLong size) {
 
 uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong size) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 0);
+	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	(*fa)->store_buffer((uint8_t *)buf, size);
@@ -117,7 +117,7 @@ uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong size) {
 
 long zipio_tell(voidpf opaque, voidpf stream) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 0);
+	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	return (*fa)->get_position();
@@ -125,7 +125,7 @@ long zipio_tell(voidpf opaque, voidpf stream) {
 
 long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 0);
+	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	uint64_t pos = offset;
@@ -146,7 +146,7 @@ long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 
 int zipio_close(voidpf opaque, voidpf stream) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 0);
+	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	fa->unref();
@@ -155,7 +155,7 @@ int zipio_close(voidpf opaque, voidpf stream) {
 
 int zipio_testerror(voidpf opaque, voidpf stream) {
 	Ref<FileAccess> *fa = reinterpret_cast<Ref<FileAccess> *>(opaque);
-	ERR_FAIL_COND_V(fa == nullptr, 1);
+	ERR_FAIL_NULL_V(fa, 1);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
 	return (fa->is_valid() && (*fa)->get_error() != OK) ? 1 : 0;

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -134,7 +134,7 @@ void DisjointSet<T, H, C, AL>::get_representatives(Vector<T> &out_representative
 template <typename T, class H, class C, class AL>
 void DisjointSet<T, H, C, AL>::get_members(Vector<T> &out_members, T representative) {
 	typename MapT::Iterator rep_itr = elements.find(representative);
-	ERR_FAIL_COND(rep_itr == nullptr);
+	ERR_FAIL_NULL(rep_itr);
 
 	Element *rep_element = rep_itr->value;
 	ERR_FAIL_COND(rep_element->parent != rep_element);

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -190,7 +190,7 @@ private:
 		_FORCE_INLINE_ bool is_internal() const { return (!is_leaf()); }
 
 		_FORCE_INLINE_ int get_index_in_parent() const {
-			ERR_FAIL_COND_V(!parent, 0);
+			ERR_FAIL_NULL_V(parent, 0);
 			return (parent->children[1] == this) ? 1 : 0;
 		}
 		void get_max_depth(int depth, int &maxdepth) {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -144,7 +144,7 @@ StringName ClassDB::get_compatibility_remapped_class(const StringName &p_class) 
 
 StringName ClassDB::_get_parent_class(const StringName &p_class) {
 	ClassInfo *ti = classes.getptr(p_class);
-	ERR_FAIL_COND_V_MSG(!ti, StringName(), "Cannot get class '" + String(p_class) + "'.");
+	ERR_FAIL_NULL_V_MSG(ti, StringName(), "Cannot get class '" + String(p_class) + "'.");
 	return ti->inherits;
 }
 
@@ -159,7 +159,7 @@ ClassDB::APIType ClassDB::get_api_type(const StringName &p_class) {
 
 	ClassInfo *ti = classes.getptr(p_class);
 
-	ERR_FAIL_COND_V_MSG(!ti, API_NONE, "Cannot get class '" + String(p_class) + "'.");
+	ERR_FAIL_NULL_V_MSG(ti, API_NONE, "Cannot get class '" + String(p_class) + "'.");
 	return ti->api;
 }
 
@@ -180,7 +180,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 	for (const StringName &E : class_list) {
 		ClassInfo *t = classes.getptr(E);
-		ERR_FAIL_COND_V_MSG(!t, 0, "Cannot get class '" + String(E) + "'.");
+		ERR_FAIL_NULL_V_MSG(t, 0, "Cannot get class '" + String(E) + "'.");
 		if (t->api != p_api || !t->exposed) {
 			continue;
 		}
@@ -278,7 +278,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 			for (const StringName &F : snames) {
 				PropertySetGet *psg = t->property_setget.getptr(F);
-				ERR_FAIL_COND_V(!psg, 0);
+				ERR_FAIL_NULL_V(psg, 0);
 
 				hash = hash_murmur3_one_64(F.hash(), hash);
 				hash = hash_murmur3_one_64(psg->setter.hash(), hash);
@@ -336,9 +336,9 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 				ti = classes.getptr(compat_classes[p_class]);
 			}
 		}
-		ERR_FAIL_COND_V_MSG(!ti, nullptr, "Cannot get class '" + String(p_class) + "'.");
+		ERR_FAIL_NULL_V_MSG(ti, nullptr, "Cannot get class '" + String(p_class) + "'.");
 		ERR_FAIL_COND_V_MSG(ti->disabled, nullptr, "Class '" + String(p_class) + "' is disabled.");
-		ERR_FAIL_COND_V_MSG(!ti->creation_func, nullptr, "Class '" + String(p_class) + "' or its base class cannot be instantiated.");
+		ERR_FAIL_NULL_V_MSG(ti->creation_func, nullptr, "Class '" + String(p_class) + "' or its base class cannot be instantiated.");
 	}
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
@@ -354,7 +354,7 @@ Object *ClassDB::instantiate(const StringName &p_class) {
 }
 
 void ClassDB::set_object_extension_instance(Object *p_object, const StringName &p_class, GDExtensionClassInstancePtr p_instance) {
-	ERR_FAIL_COND(!p_object);
+	ERR_FAIL_NULL(p_object);
 	ClassInfo *ti;
 	{
 		OBJTYPE_RLOCK;
@@ -364,9 +364,9 @@ void ClassDB::set_object_extension_instance(Object *p_object, const StringName &
 				ti = classes.getptr(compat_classes[p_class]);
 			}
 		}
-		ERR_FAIL_COND_MSG(!ti, "Cannot get class '" + String(p_class) + "'.");
+		ERR_FAIL_NULL_MSG(ti, "Cannot get class '" + String(p_class) + "'.");
 		ERR_FAIL_COND_MSG(ti->disabled, "Class '" + String(p_class) + "' is disabled.");
-		ERR_FAIL_COND_MSG(!ti->gdextension, "Class '" + String(p_class) + "' has no native extension.");
+		ERR_FAIL_NULL_MSG(ti->gdextension, "Class '" + String(p_class) + "' has no native extension.");
 	}
 
 	p_object->_extension = ti->gdextension;
@@ -377,7 +377,7 @@ bool ClassDB::can_instantiate(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 
 	ClassInfo *ti = classes.getptr(p_class);
-	ERR_FAIL_COND_V_MSG(!ti, false, "Cannot get class '" + String(p_class) + "'.");
+	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
 #ifdef TOOLS_ENABLED
 	if (ti->api == API_EDITOR && !Engine::get_singleton()->is_editor_hint()) {
 		return false;
@@ -621,7 +621,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 
 	ClassInfo *type = classes.getptr(p_class);
 
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	if (type->constant_map.has(p_name)) {
 		ERR_FAIL();
@@ -790,7 +790,7 @@ void ClassDB::set_method_error_return_values(const StringName &p_class, const St
 #ifdef DEBUG_METHODS_ENABLED
 	ClassInfo *type = classes.getptr(p_class);
 
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	type->method_error_values[p_method] = p_values;
 #endif
@@ -800,7 +800,7 @@ Vector<Error> ClassDB::get_method_error_return_values(const StringName &p_class,
 #ifdef DEBUG_METHODS_ENABLED
 	ClassInfo *type = classes.getptr(p_class);
 
-	ERR_FAIL_COND_V(!type, Vector<Error>());
+	ERR_FAIL_NULL_V(type, Vector<Error>());
 
 	if (!type->method_error_values.has(p_method)) {
 		return Vector<Error>();
@@ -853,7 +853,7 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 	OBJTYPE_WLOCK;
 
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	StringName sname = p_signal.name;
 
@@ -872,7 +872,7 @@ void ClassDB::get_signal_list(const StringName &p_class, List<MethodInfo> *p_sig
 	OBJTYPE_RLOCK;
 
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	ClassInfo *check = type;
 
@@ -926,7 +926,7 @@ bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, 
 void ClassDB::add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix, int p_indent_depth) {
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	String prefix = p_prefix;
 	if (p_indent_depth > 0) {
@@ -939,7 +939,7 @@ void ClassDB::add_property_group(const StringName &p_class, const String &p_name
 void ClassDB::add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix, int p_indent_depth) {
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	String prefix = p_prefix;
 	if (p_indent_depth > 0) {
@@ -956,7 +956,7 @@ void ClassDB::add_property_array_count(const StringName &p_class, const String &
 void ClassDB::add_property_array(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix) {
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	type->property_list.push_back(PropertyInfo(Variant::NIL, p_path, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, p_array_element_prefix));
 }
@@ -967,14 +967,14 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 	ClassInfo *type = classes.getptr(p_class);
 	lock.read_unlock();
 
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	MethodBind *mb_set = nullptr;
 	if (p_setter) {
 		mb_set = get_method(p_class, p_setter);
 #ifdef DEBUG_METHODS_ENABLED
 
-		ERR_FAIL_COND_MSG(!mb_set, "Invalid setter '" + p_class + "::" + p_setter + "' for property '" + p_pinfo.name + "'.");
+		ERR_FAIL_NULL_MSG(mb_set, "Invalid setter '" + p_class + "::" + p_setter + "' for property '" + p_pinfo.name + "'.");
 
 		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, "Invalid function for setter '" + p_class + "::" + p_setter + " for property '" + p_pinfo.name + "'.");
@@ -986,7 +986,7 @@ void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinf
 		mb_get = get_method(p_class, p_getter);
 #ifdef DEBUG_METHODS_ENABLED
 
-		ERR_FAIL_COND_MSG(!mb_get, "Invalid getter '" + p_class + "::" + p_getter + "' for property '" + p_pinfo.name + "'.");
+		ERR_FAIL_NULL_MSG(mb_get, "Invalid getter '" + p_class + "::" + p_getter + "' for property '" + p_pinfo.name + "'.");
 
 		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, "Invalid function for getter '" + p_class + "::" + p_getter + "' for property: '" + p_pinfo.name + "'.");
@@ -1031,7 +1031,7 @@ void ClassDB::add_linked_property(const StringName &p_class, const String &p_pro
 #ifdef TOOLS_ENABLED
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
-	ERR_FAIL_COND(!type);
+	ERR_FAIL_NULL(type);
 
 	ERR_FAIL_COND(!type->property_map.has(p_property));
 	ERR_FAIL_COND(!type->property_map.has(p_linked_property));
@@ -1306,7 +1306,7 @@ void ClassDB::set_method_flags(const StringName &p_class, const StringName &p_me
 	OBJTYPE_WLOCK;
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
-	ERR_FAIL_COND(!check);
+	ERR_FAIL_NULL(check);
 	ERR_FAIL_COND(!check->method_map.has(p_method));
 	check->method_map[p_method]->set_hint_flags(p_flags);
 }
@@ -1374,7 +1374,7 @@ MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p
 	ClassInfo *type = classes.getptr(instance_type);
 	if (!type) {
 		memdelete(bind);
-		ERR_FAIL_COND_V(!type, nullptr);
+		ERR_FAIL_NULL_V(type, nullptr);
 	}
 
 	if (p_compatibility) {
@@ -1406,7 +1406,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 #endif
 
 	OBJTYPE_WLOCK;
-	ERR_FAIL_COND_V(!p_bind, nullptr);
+	ERR_FAIL_NULL_V(p_bind, nullptr);
 	p_bind->set_name(mdname);
 
 	String instance_type = p_bind->get_instance_class();
@@ -1532,7 +1532,7 @@ bool ClassDB::is_class_enabled(const StringName &p_class) {
 		}
 	}
 
-	ERR_FAIL_COND_V_MSG(!ti, false, "Cannot get class '" + String(p_class) + "'.");
+	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
 	return !ti->disabled;
 }
 
@@ -1540,7 +1540,7 @@ bool ClassDB::is_class_exposed(const StringName &p_class) {
 	OBJTYPE_RLOCK;
 
 	ClassInfo *ti = classes.getptr(p_class);
-	ERR_FAIL_COND_V_MSG(!ti, false, "Cannot get class '" + String(p_class) + "'.");
+	ERR_FAIL_NULL_V_MSG(ti, false, "Cannot get class '" + String(p_class) + "'.");
 	return ti->exposed;
 }
 
@@ -1688,7 +1688,7 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 
 void ClassDB::unregister_extension_class(const StringName &p_class) {
 	ClassInfo *c = classes.getptr(p_class);
-	ERR_FAIL_COND_MSG(!c, "Class " + p_class + "does not exist");
+	ERR_FAIL_NULL_MSG(c, "Class '" + String(p_class) + "' does not exist.");
 	for (KeyValue<StringName, MethodBind *> &F : c->method_map) {
 		memdelete(F.value);
 	}

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -190,7 +190,7 @@ public:
 		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
 		t->exposed = true;
 		t->is_virtual = p_virtual;
@@ -205,7 +205,7 @@ public:
 		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_NULL(t);
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();
 		t->api = current_api;
@@ -218,7 +218,7 @@ public:
 		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
 		t->exposed = false;
 		t->is_virtual = false;
@@ -241,7 +241,7 @@ public:
 		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
-		ERR_FAIL_COND(!t);
+		ERR_FAIL_NULL(t);
 		t->creation_func = &_create_ptr_func<T>;
 		t->exposed = true;
 		t->class_ptr = T::get_class_ptr_static();
@@ -347,7 +347,7 @@ public:
 		GLOBAL_LOCK_FUNCTION;
 
 		MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
-		ERR_FAIL_COND_V(!bind, nullptr);
+		ERR_FAIL_NULL_V(bind, nullptr);
 
 		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
 			bind->set_return_type_is_raw_object_ptr(true);
@@ -360,7 +360,7 @@ public:
 		GLOBAL_LOCK_FUNCTION;
 
 		MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
-		ERR_FAIL_COND_V(!bind, nullptr);
+		ERR_FAIL_NULL_V(bind, nullptr);
 
 		if constexpr (std::is_same<typename member_function_traits<M>::return_type, Object *>::value) {
 			bind->set_return_type_is_raw_object_ptr(true);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -867,7 +867,7 @@ String Object::to_string() {
 void Object::set_script_and_instance(const Variant &p_script, ScriptInstance *p_instance) {
 	//this function is not meant to be used in any of these ways
 	ERR_FAIL_COND(p_script.is_null());
-	ERR_FAIL_COND(!p_instance);
+	ERR_FAIL_NULL(p_instance);
 	ERR_FAIL_COND(script_instance != nullptr || !script.is_null());
 
 	script = p_script;
@@ -1300,7 +1300,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 	ERR_FAIL_COND_V_MSG(p_callable.is_null(), ERR_INVALID_PARAMETER, "Cannot connect to '" + p_signal + "': the provided callable is null.");
 
 	Object *target_object = p_callable.get_object();
-	ERR_FAIL_COND_V_MSG(!target_object, ERR_INVALID_PARAMETER, "Cannot connect to '" + p_signal + "' to callable '" + p_callable + "': the callable object is null.");
+	ERR_FAIL_NULL_V_MSG(target_object, ERR_INVALID_PARAMETER, "Cannot connect to '" + p_signal + "' to callable '" + p_callable + "': the callable object is null.");
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
@@ -1385,7 +1385,7 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 	ERR_FAIL_COND_V_MSG(p_callable.is_null(), false, "Cannot disconnect from '" + p_signal + "': the provided callable is null.");
 
 	Object *target_object = p_callable.get_object();
-	ERR_FAIL_COND_V_MSG(!target_object, false, "Cannot disconnect '" + p_signal + "' from callable '" + p_callable + "': the callable object is null.");
+	ERR_FAIL_NULL_V_MSG(target_object, false, "Cannot disconnect '" + p_signal + "' from callable '" + p_callable + "': the callable object is null.");
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
@@ -1393,7 +1393,7 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 				(!script.is_null() && Ref<Script>(script)->has_script_signal(p_signal));
 		ERR_FAIL_COND_V_MSG(signal_is_valid, false, "Attempt to disconnect a nonexistent connection from '" + to_string() + "'. Signal: '" + p_signal + "', callable: '" + p_callable + "'.");
 	}
-	ERR_FAIL_COND_V_MSG(!s, false, vformat("Disconnecting nonexistent signal '%s' in %s.", p_signal, to_string()));
+	ERR_FAIL_NULL_V_MSG(s, false, vformat("Disconnecting nonexistent signal '%s' in %s.", p_signal, to_string()));
 
 	ERR_FAIL_COND_V_MSG(!s->slot_map.has(*p_callable.get_base_comparator()), false, "Attempt to disconnect a nonexistent connection from '" + to_string() + "'. Signal: '" + p_signal + "', callable: '" + p_callable + "'.");
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -71,7 +71,7 @@ class Ref {
 	}
 
 	void ref_pointer(T *p_ref) {
-		ERR_FAIL_COND(!p_ref);
+		ERR_FAIL_NULL(p_ref);
 
 		if (p_ref->init_ref()) {
 			reference = p_ref;

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -178,7 +178,7 @@ void UndoRedo::add_undo_method(const Callable &p_callable) {
 }
 
 void UndoRedo::add_do_property(Object *p_object, const StringName &p_property, const Variant &p_value) {
-	ERR_FAIL_COND(p_object == nullptr);
+	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
@@ -194,7 +194,7 @@ void UndoRedo::add_do_property(Object *p_object, const StringName &p_property, c
 }
 
 void UndoRedo::add_undo_property(Object *p_object, const StringName &p_property, const Variant &p_value) {
-	ERR_FAIL_COND(p_object == nullptr);
+	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 
@@ -217,7 +217,7 @@ void UndoRedo::add_undo_property(Object *p_object, const StringName &p_property,
 }
 
 void UndoRedo::add_do_reference(Object *p_object) {
-	ERR_FAIL_COND(p_object == nullptr);
+	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
@@ -231,7 +231,7 @@ void UndoRedo::add_do_reference(Object *p_object) {
 }
 
 void UndoRedo::add_undo_reference(Object *p_object) {
-	ERR_FAIL_COND(p_object == nullptr);
+	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -34,8 +34,8 @@
 #include "core/os/thread_safe.h"
 
 void WorkerThreadPool::Task::free_template_userdata() {
-	ERR_FAIL_COND(!template_userdata);
-	ERR_FAIL_COND(native_func_userdata == nullptr);
+	ERR_FAIL_NULL(template_userdata);
+	ERR_FAIL_NULL(native_func_userdata);
 	BaseTemplateUserdata *btu = (BaseTemplateUserdata *)native_func_userdata;
 	memdelete(btu);
 }

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -74,7 +74,7 @@ void *Memory::alloc_static(size_t p_bytes, bool p_pad_align) {
 
 	void *mem = malloc(p_bytes + (prepad ? PAD_ALIGN : 0));
 
-	ERR_FAIL_COND_V(!mem, nullptr);
+	ERR_FAIL_NULL_V(mem, nullptr);
 
 	alloc_count.increment();
 
@@ -127,7 +127,7 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 			*s = p_bytes;
 
 			mem = (uint8_t *)realloc(mem, p_bytes + PAD_ALIGN);
-			ERR_FAIL_COND_V(!mem, nullptr);
+			ERR_FAIL_NULL_V(mem, nullptr);
 
 			s = (uint64_t *)mem;
 
@@ -145,7 +145,7 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 }
 
 void Memory::free_static(void *p_ptr, bool p_pad_align) {
-	ERR_FAIL_COND(p_ptr == nullptr);
+	ERR_FAIL_NULL(p_ptr);
 
 	uint8_t *mem = (uint8_t *)p_ptr;
 

--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -144,7 +144,7 @@ T *memnew_arr_template(size_t p_elements) {
 	size_t len = sizeof(T) * p_elements;
 	uint64_t *mem = (uint64_t *)Memory::alloc_static(len, true);
 	T *failptr = nullptr; //get rid of a warning
-	ERR_FAIL_COND_V(!mem, failptr);
+	ERR_FAIL_NULL_V(mem, failptr);
 	*(mem - 1) = p_elements;
 
 	if (!std::is_trivially_constructible<T>::value) {

--- a/core/os/pool_allocator.cpp
+++ b/core/os/pool_allocator.cpp
@@ -305,7 +305,7 @@ Error PoolAllocator::resize(ID p_mem, int p_new_size) {
 
 	if (!e) {
 		mt_unlock();
-		ERR_FAIL_COND_V(!e, ERR_INVALID_PARAMETER);
+		ERR_FAIL_NULL_V(e, ERR_INVALID_PARAMETER);
 	}
 
 	if (needs_locking && e->lock) {
@@ -431,7 +431,7 @@ bool PoolAllocator::is_locked(ID p_mem) const {
 const void *PoolAllocator::get(ID p_mem) const {
 	if (!needs_locking) {
 		const Entry *e = get_entry(p_mem);
-		ERR_FAIL_COND_V(!e, nullptr);
+		ERR_FAIL_NULL_V(e, nullptr);
 		return &pool[e->pos];
 	}
 
@@ -440,7 +440,7 @@ const void *PoolAllocator::get(ID p_mem) const {
 
 	if (!e) {
 		mt_unlock();
-		ERR_FAIL_COND_V(!e, nullptr);
+		ERR_FAIL_NULL_V(e, nullptr);
 	}
 	if (e->lock == 0) {
 		mt_unlock();
@@ -463,7 +463,7 @@ const void *PoolAllocator::get(ID p_mem) const {
 void *PoolAllocator::get(ID p_mem) {
 	if (!needs_locking) {
 		Entry *e = get_entry(p_mem);
-		ERR_FAIL_COND_V(!e, nullptr);
+		ERR_FAIL_NULL_V(e, nullptr);
 		return &pool[e->pos];
 	}
 
@@ -472,7 +472,7 @@ void *PoolAllocator::get(ID p_mem) {
 
 	if (!e) {
 		mt_unlock();
-		ERR_FAIL_COND_V(!e, nullptr);
+		ERR_FAIL_NULL_V(e, nullptr);
 	}
 	if (e->lock == 0) {
 		mt_unlock();
@@ -500,7 +500,7 @@ void PoolAllocator::unlock(ID p_mem) {
 	Entry *e = get_entry(p_mem);
 	if (!e) {
 		mt_unlock();
-		ERR_FAIL_COND(!e);
+		ERR_FAIL_NULL(e);
 	}
 	if (e->lock == 0) {
 		mt_unlock();
@@ -540,7 +540,7 @@ void PoolAllocator::create_pool(void *p_mem, int p_size, int p_max_entries) {
 
 PoolAllocator::PoolAllocator(int p_size, bool p_needs_locking, int p_max_entries) {
 	mem_ptr = memalloc(p_size);
-	ERR_FAIL_COND(!mem_ptr);
+	ERR_FAIL_NULL(mem_ptr);
 	align = 1;
 	create_pool(mem_ptr, p_size, p_max_entries);
 	needs_locking = p_needs_locking;

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -73,7 +73,7 @@ int NodePath::get_name_count() const {
 }
 
 StringName NodePath::get_name(int p_idx) const {
-	ERR_FAIL_COND_V(!data, StringName());
+	ERR_FAIL_NULL_V(data, StringName());
 	ERR_FAIL_INDEX_V(p_idx, data->path.size(), StringName());
 	return data->path[p_idx];
 }
@@ -87,7 +87,7 @@ int NodePath::get_subname_count() const {
 }
 
 StringName NodePath::get_subname(int p_idx) const {
-	ERR_FAIL_COND_V(!data, StringName());
+	ERR_FAIL_NULL_V(data, StringName());
 	ERR_FAIL_INDEX_V(p_idx, data->subpath.size(), StringName());
 	return data->subpath[p_idx];
 }
@@ -200,7 +200,7 @@ Vector<StringName> NodePath::get_subnames() const {
 }
 
 StringName NodePath::get_concatenated_names() const {
-	ERR_FAIL_COND_V(!data, StringName());
+	ERR_FAIL_NULL_V(data, StringName());
 
 	if (!data->concatenated_path) {
 		int pc = data->path.size();
@@ -215,7 +215,7 @@ StringName NodePath::get_concatenated_names() const {
 }
 
 StringName NodePath::get_concatenated_subnames() const {
-	ERR_FAIL_COND_V(!data, StringName());
+	ERR_FAIL_NULL_V(data, StringName());
 
 	if (!data->concatenated_subpath) {
 		int spc = data->subpath.size();

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -65,7 +65,7 @@ void remove_print_handler(const PrintHandlerList *p_handler) {
 	//OS::get_singleton()->print("print handler list is %p\n",print_handler_list);
 
 	_global_unlock();
-	ERR_FAIL_COND(l == nullptr);
+	ERR_FAIL_NULL(l);
 }
 
 void __print_line(String p_string) {

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -390,7 +390,7 @@ StringName::StringName(const String &p_name, bool p_static) {
 StringName StringName::search(const char *p_name) {
 	ERR_FAIL_COND_V(!configured, StringName());
 
-	ERR_FAIL_COND_V(!p_name, StringName());
+	ERR_FAIL_NULL_V(p_name, StringName());
 	if (!p_name[0]) {
 		return StringName();
 	}
@@ -426,7 +426,7 @@ StringName StringName::search(const char *p_name) {
 StringName StringName::search(const char32_t *p_name) {
 	ERR_FAIL_COND_V(!configured, StringName());
 
-	ERR_FAIL_COND_V(!p_name, StringName());
+	ERR_FAIL_NULL_V(p_name, StringName());
 	if (!p_name[0]) {
 		return StringName();
 	}

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -409,7 +409,7 @@ public:
 	}
 
 	void wait_and_flush() {
-		ERR_FAIL_COND(!sync);
+		ERR_FAIL_NULL(sync);
 		sync->wait();
 		_flush();
 	}

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -286,7 +286,7 @@ Error CowData<T>::resize(int p_size) {
 			if (current_size == 0) {
 				// alloc from scratch
 				uint32_t *ptr = (uint32_t *)Memory::alloc_static(alloc_size, true);
-				ERR_FAIL_COND_V(!ptr, ERR_OUT_OF_MEMORY);
+				ERR_FAIL_NULL_V(ptr, ERR_OUT_OF_MEMORY);
 				*(ptr - 1) = 0; //size, currently none
 				new (ptr - 2) SafeNumeric<uint32_t>(1); //refcount
 
@@ -294,7 +294,7 @@ Error CowData<T>::resize(int p_size) {
 
 			} else {
 				uint32_t *_ptrnew = (uint32_t *)Memory::realloc_static(_ptr, alloc_size, true);
-				ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
+				ERR_FAIL_NULL_V(_ptrnew, ERR_OUT_OF_MEMORY);
 				new (_ptrnew - 2) SafeNumeric<uint32_t>(rc); //refcount
 
 				_ptr = (T *)(_ptrnew);
@@ -324,7 +324,7 @@ Error CowData<T>::resize(int p_size) {
 
 		if (alloc_size != current_alloc_size) {
 			uint32_t *_ptrnew = (uint32_t *)Memory::realloc_static(_ptr, alloc_size, true);
-			ERR_FAIL_COND_V(!_ptrnew, ERR_OUT_OF_MEMORY);
+			ERR_FAIL_NULL_V(_ptrnew, ERR_OUT_OF_MEMORY);
 			new (_ptrnew - 2) SafeNumeric<uint32_t>(rc); //refcount
 
 			_ptr = (T *)(_ptrnew);

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -219,7 +219,7 @@ private:
 		int size_cache = 0;
 
 		bool erase(const Element *p_I) {
-			ERR_FAIL_COND_V(!p_I, false);
+			ERR_FAIL_NULL_V(p_I, false);
 			ERR_FAIL_COND_V(p_I->data != this, false);
 
 			if (first == p_I) {

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -112,7 +112,7 @@ public:
 	}
 
 	void configure(uint32_t p_page_size) {
-		ERR_FAIL_COND(page_pool != nullptr); //sanity check
+		ERR_FAIL_COND(page_pool != nullptr); // Safety check.
 		ERR_FAIL_COND(p_page_size == 0);
 		page_size = nearest_power_of_2_templated(p_page_size);
 	}
@@ -185,7 +185,7 @@ public:
 			uint32_t new_page_count = page_count + 1;
 
 			if (unlikely(new_page_count > max_pages_used)) {
-				ERR_FAIL_COND(page_pool == nullptr); //sanity check
+				ERR_FAIL_NULL(page_pool); // Safety check.
 
 				_grow_page_array(); //keep out of inline
 			}
@@ -352,7 +352,7 @@ public:
 	}
 
 	void set_page_pool(PagedArrayPool<T> *p_page_pool) {
-		ERR_FAIL_COND(max_pages_used > 0); //sanity check
+		ERR_FAIL_COND(max_pages_used > 0); // Safety check.
 
 		page_pool = p_page_pool;
 		page_size_mask = page_pool->get_page_size_mask();

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -211,12 +211,12 @@ public:
 	}
 	void initialize_rid(RID p_rid) {
 		T *mem = get_or_null(p_rid, true);
-		ERR_FAIL_COND(!mem);
+		ERR_FAIL_NULL(mem);
 		memnew_placement(mem, T);
 	}
 	void initialize_rid(RID p_rid, const T &p_value) {
 		T *mem = get_or_null(p_rid, true);
-		ERR_FAIL_COND(!mem);
+		ERR_FAIL_NULL(mem);
 		memnew_placement(mem, T(p_value));
 	}
 
@@ -391,7 +391,7 @@ public:
 
 	_FORCE_INLINE_ void replace(const RID &p_rid, T *p_new_ptr) {
 		T **ptr = alloc.get_or_null(p_rid);
-		ERR_FAIL_COND(!ptr);
+		ERR_FAIL_NULL(ptr);
 		*ptr = p_new_ptr;
 	}
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -52,7 +52,7 @@ public:
 void Array::_ref(const Array &p_from) const {
 	ArrayPrivate *_fp = p_from._p;
 
-	ERR_FAIL_COND(!_fp); // should NOT happen.
+	ERR_FAIL_NULL(_fp); // Should NOT happen.
 
 	if (_fp == _p) {
 		return; // whatever it is, nothing to do here move along

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -465,20 +465,20 @@ Error Signal::emit(const Variant **p_arguments, int p_argcount) const {
 
 Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 	Object *obj = get_object();
-	ERR_FAIL_COND_V(!obj, ERR_UNCONFIGURED);
+	ERR_FAIL_NULL_V(obj, ERR_UNCONFIGURED);
 
 	return obj->connect(name, p_callable, p_flags);
 }
 
 void Signal::disconnect(const Callable &p_callable) {
 	Object *obj = get_object();
-	ERR_FAIL_COND(!obj);
+	ERR_FAIL_NULL(obj);
 	obj->disconnect(name, p_callable);
 }
 
 bool Signal::is_connected(const Callable &p_callable) const {
 	Object *obj = get_object();
-	ERR_FAIL_COND_V(!obj, false);
+	ERR_FAIL_NULL_V(obj, false);
 
 	return obj->is_connected(name, p_callable);
 }
@@ -500,7 +500,7 @@ Array Signal::get_connections() const {
 }
 
 Signal::Signal(const Object *p_object, const StringName &p_name) {
-	ERR_FAIL_COND_MSG(p_object == nullptr, "Object argument to Signal constructor must be non-null");
+	ERR_FAIL_NULL_MSG(p_object, "Object argument to Signal constructor must be non-null.");
 
 	object = p_object->get_instance_id();
 	name = p_name;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -113,7 +113,7 @@ struct ContainerTypeValidate {
 			return true; // This is fine, it's null.
 		}
 		Object *object = ObjectDB::get_instance(object_id);
-		ERR_FAIL_COND_V_MSG(object == nullptr, false, "Attempted to " + String(p_operation) + " an invalid (previously freed?) object instance into a '" + String(where) + ".");
+		ERR_FAIL_NULL_V_MSG(object, false, "Attempted to " + String(p_operation) + " an invalid (previously freed?) object instance into a '" + String(where) + ".");
 #else
 		Object *object = p_variant;
 		if (object == nullptr) {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -248,7 +248,7 @@ void Dictionary::merge(const Dictionary &p_dictionary, bool p_overwrite) {
 }
 
 void Dictionary::_unref() const {
-	ERR_FAIL_COND(!_p);
+	ERR_FAIL_NULL(_p);
 	if (_p->refcount.unref()) {
 		if (_p->read_only) {
 			memdelete(_p->read_only);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1259,28 +1259,28 @@ bool Variant::has_builtin_method(Variant::Type p_type, const StringName &p_metho
 Variant::ValidatedBuiltInMethod Variant::get_validated_builtin_method(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, nullptr);
+	ERR_FAIL_NULL_V(method, nullptr);
 	return method->validated_call;
 }
 
 Variant::PTRBuiltInMethod Variant::get_ptr_builtin_method(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, nullptr);
+	ERR_FAIL_NULL_V(method, nullptr);
 	return method->ptrcall;
 }
 
 int Variant::get_builtin_method_argument_count(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, 0);
+	ERR_FAIL_NULL_V(method, 0);
 	return method->argument_count;
 }
 
 Variant::Type Variant::get_builtin_method_argument_type(Variant::Type p_type, const StringName &p_method, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::NIL);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Variant::NIL);
+	ERR_FAIL_NULL_V(method, Variant::NIL);
 	ERR_FAIL_INDEX_V(p_argument, method->argument_count, Variant::NIL);
 	return method->get_argument_type(p_argument);
 }
@@ -1288,7 +1288,7 @@ Variant::Type Variant::get_builtin_method_argument_type(Variant::Type p_type, co
 String Variant::get_builtin_method_argument_name(Variant::Type p_type, const StringName &p_method, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, String());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, String());
+	ERR_FAIL_NULL_V(method, String());
 #ifdef DEBUG_METHODS_ENABLED
 	ERR_FAIL_INDEX_V(p_argument, method->argument_count, String());
 	return method->argument_names[p_argument];
@@ -1300,14 +1300,14 @@ String Variant::get_builtin_method_argument_name(Variant::Type p_type, const Str
 Vector<Variant> Variant::get_builtin_method_default_arguments(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Vector<Variant>());
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Vector<Variant>());
+	ERR_FAIL_NULL_V(method, Vector<Variant>());
 	return method->default_arguments;
 }
 
 bool Variant::has_builtin_method_return_value(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_NULL_V(method, false);
 	return method->has_return_type;
 }
 
@@ -1326,35 +1326,35 @@ int Variant::get_builtin_method_count(Variant::Type p_type) {
 Variant::Type Variant::get_builtin_method_return_type(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::NIL);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, Variant::NIL);
+	ERR_FAIL_NULL_V(method, Variant::NIL);
 	return method->return_type;
 }
 
 bool Variant::is_builtin_method_const(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_NULL_V(method, false);
 	return method->is_const;
 }
 
 bool Variant::is_builtin_method_static(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_NULL_V(method, false);
 	return method->is_static;
 }
 
 bool Variant::is_builtin_method_vararg(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, false);
+	ERR_FAIL_NULL_V(method, false);
 	return method->is_vararg;
 }
 
 uint32_t Variant::get_builtin_method_hash(Variant::Type p_type, const StringName &p_method) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 	const VariantBuiltInMethodInfo *method = builtin_method_info[p_type].lookup_ptr(p_method);
-	ERR_FAIL_COND_V(!method, 0);
+	ERR_FAIL_NULL_V(method, 0);
 	uint32_t hash = hash_murmur3_one_32(method->is_const);
 	hash = hash_murmur3_one_32(method->is_static, hash);
 	hash = hash_murmur3_one_32(method->is_vararg, hash);

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -1493,7 +1493,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
-		ERR_FAIL_COND(l == nullptr);
+		ERR_FAIL_NULL(l);
 		const String &a = *VariantGetInternalPtr<String>::get_ptr(left);
 
 		bool valid;
@@ -1527,7 +1527,7 @@ public:
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
 		Object *l = right->get_validated_object();
-		ERR_FAIL_COND(l == nullptr);
+		ERR_FAIL_NULL(l);
 		const StringName &a = *VariantGetInternalPtr<StringName>::get_ptr(left);
 
 		bool valid;

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -318,7 +318,7 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 #ifdef DEBUG_ENABLED
 
 #define NULL_TEST(m_key) \
-	ERR_FAIL_COND(!m_key)
+	ERR_FAIL_NULL(m_key)
 
 #else
 
@@ -1068,7 +1068,7 @@ struct VariantKeyedSetGetObject {
 	}
 	static uint32_t ptr_has(const void *base, const void *key) {
 		const Object *obj = PtrToArg<Object *>::convert(base);
-		ERR_FAIL_COND_V(!obj, false);
+		ERR_FAIL_NULL_V(obj, false);
 		bool valid;
 		obj->getvar(PtrToArg<Variant>::convert(key), &valid);
 		return valid;
@@ -1245,7 +1245,7 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 		}
 	} else if (type == OBJECT) {
 		Object *obj = get_validated_object();
-		ERR_FAIL_COND(!obj);
+		ERR_FAIL_NULL(obj);
 		obj->get_property_list(p_list);
 
 	} else {

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1873,7 +1873,7 @@ bool Variant::is_utility_function_vararg(const StringName &p_name) {
 
 uint32_t Variant::get_utility_function_hash(const StringName &p_name) {
 	const VariantUtilityFunctionInfo *bfi = utility_function_table.lookup_ptr(p_name);
-	ERR_FAIL_COND_V(!bfi, 0);
+	ERR_FAIL_NULL_V(bfi, 0);
 
 	uint32_t hash = hash_murmur3_one_32(bfi->is_vararg);
 	hash = hash_murmur3_one_32(bfi->returns_value, hash);


### PR DESCRIPTION
* Continuation of: https://github.com/godotengine/godot/pull/77945

The primary reason is plain correctness, but several of these cases, especially the wider cases that will be added soon, are hard to tell what they should be with the current code, so having an explicit null check makes reading the code easier

The most straight-forward argument, taken from `display_server_web.cpp`:
```cpp
ERR_FAIL_COND_V_MSG(!tts, false, "Enable the \"audio/general/text_to_speech\" project setting to use text-to-speech.");
```
And the one from `display_server_windows.cpp`:
```cpp
ERR_FAIL_COND_V_MSG(!tts, false, "Enable the \"audio/general/text_to_speech\" project setting to use text-to-speech.");
```
Only one is a null check, despite being entirely identical otherwise.

Edit: Also cleaned up some error messages for style when they were already part of the change.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
