### PR TITLE
Expose PropertySelector to scripting

### DIFF
--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -575,7 +575,29 @@ void PropertySelector::set_type_filter(const Vector<Variant::Type> &p_type_filte
 	type_filter = p_type_filter;
 }
 
+//Variant::Type isn't exposed, so need a version that takes int
+void PropertySelector::set_type_filter_exposable(const Vector<int> &p_type_filter) {
+	int n_types = p_type_filter.size();
+	type_filter.clear();
+	type_filter.resize(n_types);
+	for (int i = 0; i < n_types; i++) {
+		type_filter.push_back(static_cast<Variant::Type>(p_type_filter[i]));
+	}
+}
+
 void PropertySelector::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("select_method_from_base_type", "base", "current", "virtuals_only"), &PropertySelector::select_method_from_base_type);
+	ClassDB::bind_method(D_METHOD("select_method_from_script", "script", "current"), &PropertySelector::select_method_from_script);
+	ClassDB::bind_method(D_METHOD("select_method_from_basic_type", "type", "current"), &PropertySelector::select_method_from_basic_type);
+	ClassDB::bind_method(D_METHOD("select_method_from_instance", "instance", "current"), &PropertySelector::select_method_from_instance);
+
+	ClassDB::bind_method(D_METHOD("select_property_from_base_type", "base", "current"), &PropertySelector::select_property_from_base_type);
+	ClassDB::bind_method(D_METHOD("select_property_from_script", "script", "current"), &PropertySelector::select_property_from_instance);
+	ClassDB::bind_method(D_METHOD("select_property_from_basic_type", "type", "current"), &PropertySelector::select_property_from_basic_type);
+	ClassDB::bind_method(D_METHOD("select_property_from_instance", "instance", "current"), &PropertySelector::select_property_from_instance);
+
+	ClassDB::bind_method(D_METHOD("set_type_filter", "type_filter"), &PropertySelector::set_type_filter_exposable);
+
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::STRING, "name")));
 }
 

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -78,6 +78,7 @@ public:
 	void select_property_from_instance(Object *p_instance, const String &p_current = "");
 
 	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
+	void set_type_filter_exposable(const Vector<int> &p_type_filter);
 
 	PropertySelector();
 };

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -126,6 +126,7 @@
 #include "editor/plugins/version_control_editor_plugin.h"
 #include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
+#include "editor/property_selector.h"
 #include "editor/register_exporters.h"
 
 void register_editor_types() {
@@ -174,6 +175,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorResourcePicker);
 	GDREGISTER_CLASS(EditorScriptPicker);
 	GDREGISTER_ABSTRACT_CLASS(EditorUndoRedoManager);
+	GDREGISTER_CLASS(PropertySelector);
 
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);


### PR DESCRIPTION
Exposed `PropertySelector` to scripting so aid addon/plugin development

Closes https://github.com/godotengine/godot-proposals/issues/7635.

Todos:

- [ ] Run doctools to generate documentation
- [ ] Fix error `Parse Error: Native class "PropertySelector" cannot be constructed as it is abstract`
- [ ] Test in minimal project
