### PR TITLE
Expose SceneTreeDialog to scripting

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1619,6 +1619,13 @@ void SceneTreeDialog::_filter_changed(const String &p_filter) {
 }
 
 void SceneTreeDialog::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("popup_scenetree_dialog"), &SceneTreeDialog::popup_scenetree_dialog);
+	// TODO: fix bind_method error with set_valid_types
+	//ClassDB::bind_method(D_METHOD("set_valid_types", "valid"), &SceneTreeDialog::set_valid_types);
+
+	ClassDB::bind_method(D_METHOD("get_scene_tree"), &SceneTreeDialog::get_scene_tree);
+	ClassDB::bind_method(D_METHOD("get_filter_line_edit"), &SceneTreeDialog::get_filter_line_edit);
+
 	ClassDB::bind_method("_cancel", &SceneTreeDialog::_cancel);
 
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::NODE_PATH, "path")));

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -50,6 +50,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/gui/scene_tree_editor.h"
 #include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
@@ -174,6 +175,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorResourcePicker);
 	GDREGISTER_CLASS(EditorScriptPicker);
 	GDREGISTER_ABSTRACT_CLASS(EditorUndoRedoManager);
+	GDREGISTER_CLASS(SceneTreeDialog);
 
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);


### PR DESCRIPTION
Exposes `SceneTreeDialog` https://github.com/godotengine/godot/blob/fc99492d3066098e938449b10e02f8e01d07e2d1/editor/gui/scene_tree_editor.cpp#L1515C4-L1515C4 to scripting.

Closes https://github.com/godotengine/godot-proposals/issues/7636.

- [ ] Run doctools to generate documentation.
- [ ] Fix error with exposing `SceneTreeDialog::set_valid_types`.
- [ ] Test in minimal project.
