### PR TITLE
Fix Skeleton modifications' default index from -1 to 0

### DIFF
--- a/scene/resources/skeleton_modification_2d_ccdik.h
+++ b/scene/resources/skeleton_modification_2d_ccdik.h
@@ -43,7 +43,7 @@ class SkeletonModification2DCCDIK : public SkeletonModification2D {
 
 private:
 	struct CCDIK_Joint_Data2D {
-		int bone_idx = -1;
+		int bone_idx = 0;
 		NodePath bone2d_node;
 		ObjectID bone2d_node_cache;
 		bool rotate_from_joint = false;

--- a/scene/resources/skeleton_modification_2d_fabrik.h
+++ b/scene/resources/skeleton_modification_2d_fabrik.h
@@ -43,7 +43,7 @@ class SkeletonModification2DFABRIK : public SkeletonModification2D {
 
 private:
 	struct FABRIK_Joint_Data2D {
-		int bone_idx = -1;
+		int bone_idx = 0;
 		NodePath bone2d_node;
 		ObjectID bone2d_node_cache;
 

--- a/scene/resources/skeleton_modification_2d_jiggle.h
+++ b/scene/resources/skeleton_modification_2d_jiggle.h
@@ -43,7 +43,7 @@ class SkeletonModification2DJiggle : public SkeletonModification2D {
 
 private:
 	struct Jiggle_Joint_Data2D {
-		int bone_idx = -1;
+		int bone_idx = 0;
 		NodePath bone2d_node;
 		ObjectID bone2d_node_cache;
 

--- a/scene/resources/skeleton_modification_2d_lookat.h
+++ b/scene/resources/skeleton_modification_2d_lookat.h
@@ -42,7 +42,7 @@ class SkeletonModification2DLookAt : public SkeletonModification2D {
 	GDCLASS(SkeletonModification2DLookAt, SkeletonModification2D);
 
 private:
-	int bone_idx = -1;
+	int bone_idx = 0;
 	NodePath bone2d_node;
 	ObjectID bone2d_node_cache;
 

--- a/scene/resources/skeleton_modification_2d_twoboneik.h
+++ b/scene/resources/skeleton_modification_2d_twoboneik.h
@@ -50,11 +50,11 @@ private:
 
 	NodePath joint_one_bone2d_node;
 	ObjectID joint_one_bone2d_node_cache;
-	int joint_one_bone_idx = -1;
+	int joint_one_bone_idx = 0;
 
 	NodePath joint_two_bone2d_node;
 	ObjectID joint_two_bone2d_node_cache;
-	int joint_two_bone_idx = -1;
+	int joint_two_bone_idx = 0;
 
 #ifdef TOOLS_ENABLED
 	bool editor_draw_min_max = false;


### PR DESCRIPTION
A possible fix for https://github.com/godotengine/godot/issues/81433

Changes the default index value of 5 SkeletonModification types, as arrays never have a position -1. This will make a freshly added modification immediately point to the first bone of a Skeleton2D. While not ideal, it's better than having the output box spam errors nonstop.