### PR TITLE
Add shader load API

### DIFF
--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -35,6 +35,13 @@
 				If argument [param get_groups] is true, parameter grouping hints will be provided.
 			</description>
 		</method>
+		<method name="load">
+			<return type="void" />
+			<description>
+				Loads the shader object immediately.
+				[b]Note:[/b] This only affects the `Compatability` renderer, as other renderers use async compilation.
+			</description>
+		</method>
 		<method name="set_default_texture_parameter">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -486,6 +486,15 @@ RS::ShaderNativeSourceCode ShaderGLES3::version_get_native_source_code(RID p_ver
 	return source_code;
 }
 
+void ShaderGLES3::version_load(RID p_version) {
+	Version *version = version_owner.get_or_null(p_version);
+	ERR_FAIL_NULL(version);
+	if (!version->variants.is_empty()) {
+		return; // already loaded.
+	}
+	_initialize_version(version);
+}
+
 String ShaderGLES3::_version_get_sha1(Version *p_version) const {
 	StringBuilder hash_build;
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -261,6 +261,8 @@ public:
 
 	RS::ShaderNativeSourceCode version_get_native_source_code(RID p_version);
 
+	void version_load(RID p_version);
+
 	void initialize(const String &p_general_defines = "", int p_base_texture_index = 0);
 	virtual ~ShaderGLES3();
 };

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2151,6 +2151,12 @@ void MaterialStorage::shader_free(RID p_rid) {
 	shader_owner.free(p_rid);
 }
 
+void MaterialStorage::shader_load(RID p_shader) {
+	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_COND(!shader || !shader->data);
+	shader->data->load();
+}
+
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);
@@ -2614,6 +2620,10 @@ RS::ShaderNativeSourceCode CanvasShaderData::get_native_source_code() const {
 	return MaterialStorage::get_singleton()->shaders.canvas_shader.version_get_native_source_code(version);
 }
 
+void CanvasShaderData::load() {
+	MaterialStorage::get_singleton()->shaders.canvas_shader.version_load(version);
+}
+
 CanvasShaderData::CanvasShaderData() {
 	valid = false;
 	uses_screen_texture = false;
@@ -2779,6 +2789,10 @@ bool SkyShaderData::casts_shadows() const {
 
 RS::ShaderNativeSourceCode SkyShaderData::get_native_source_code() const {
 	return MaterialStorage::get_singleton()->shaders.sky_shader.version_get_native_source_code(version);
+}
+
+void SkyShaderData::load() {
+	MaterialStorage::get_singleton()->shaders.sky_shader.version_load(version);
 }
 
 SkyShaderData::SkyShaderData() {
@@ -3038,6 +3052,10 @@ RS::ShaderNativeSourceCode SceneShaderData::get_native_source_code() const {
 	return MaterialStorage::get_singleton()->shaders.scene_shader.version_get_native_source_code(version);
 }
 
+void SceneShaderData::load() {
+	MaterialStorage::get_singleton()->shaders.scene_shader.version_load(version);
+}
+
 SceneShaderData::SceneShaderData() {
 	valid = false;
 	uses_screen_texture = false;
@@ -3148,6 +3166,10 @@ bool ParticlesShaderData::casts_shadows() const {
 
 RS::ShaderNativeSourceCode ParticlesShaderData::get_native_source_code() const {
 	return MaterialStorage::get_singleton()->shaders.particles_process_shader.version_get_native_source_code(version);
+}
+
+void ParticlesShaderData::load() {
+	MaterialStorage::get_singleton()->shaders.particles_process_shader.version_load(version);
 }
 
 ParticlesShaderData::~ParticlesShaderData() {

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -69,6 +69,8 @@ struct ShaderData {
 	virtual bool casts_shadows() const = 0;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const { return RS::ShaderNativeSourceCode(); }
 
+	virtual void load() = 0;
+
 	virtual ~ShaderData() {}
 };
 
@@ -170,6 +172,8 @@ struct CanvasShaderData : public ShaderData {
 	virtual bool casts_shadows() const;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
 
+	virtual void load();
+
 	CanvasShaderData();
 	virtual ~CanvasShaderData();
 };
@@ -211,6 +215,9 @@ struct SkyShaderData : public ShaderData {
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+
+	virtual void load();
+
 	SkyShaderData();
 	virtual ~SkyShaderData();
 };
@@ -326,6 +333,8 @@ struct SceneShaderData : public ShaderData {
 	virtual bool casts_shadows() const;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
 
+	virtual void load();
+
 	SceneShaderData();
 	virtual ~SceneShaderData();
 };
@@ -374,6 +383,8 @@ struct ParticlesShaderData : public ShaderData {
 	virtual bool is_animated() const;
 	virtual bool casts_shadows() const;
 	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+
+	virtual void load();
 
 	ParticlesShaderData() {}
 	virtual ~ParticlesShaderData();
@@ -571,6 +582,8 @@ public:
 	virtual RID shader_allocate() override;
 	virtual void shader_initialize(RID p_rid) override;
 	virtual void shader_free(RID p_rid) override;
+
+	virtual void shader_load(RID p_shader) override;
 
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -209,6 +209,8 @@ void Shader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_shader_uniform_list", "get_groups"), &Shader::_get_shader_uniform_list, DEFVAL(false));
 
+	ClassDB::bind_method(D_METHOD("load"), &Shader::load);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
 
 	BIND_ENUM_CONSTANT(MODE_SPATIAL);
@@ -216,6 +218,10 @@ void Shader::_bind_methods() {
 	BIND_ENUM_CONSTANT(MODE_PARTICLES);
 	BIND_ENUM_CONSTANT(MODE_SKY);
 	BIND_ENUM_CONSTANT(MODE_FOG);
+}
+
+void Shader::load() {
+	RenderingServer::get_singleton()->shader_load(shader);
 }
 
 Shader::Shader() {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -88,6 +88,8 @@ public:
 
 	virtual RID get_rid() const override;
 
+	void load();
+
 	Shader();
 	~Shader();
 };

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -62,6 +62,8 @@ public:
 	virtual void shader_initialize(RID p_rid) override {}
 	virtual void shader_free(RID p_rid) override{};
 
+	virtual void shader_load(RID p_shader) override{};
+
 	virtual void shader_set_code(RID p_shader, const String &p_code) override {}
 	virtual void shader_set_path_hint(RID p_shader, const String &p_code) override {}
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2088,6 +2088,10 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	}
 }
 
+void MaterialStorage::shader_load(RID p_shader) {
+	// Nothing to do, shaders are async loaded in set_code in vulkan.
+}
+
 void MaterialStorage::shader_set_path_hint(RID p_shader, const String &p_path) {
 	Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -383,6 +383,8 @@ public:
 	virtual void shader_initialize(RID p_shader) override;
 	virtual void shader_free(RID p_rid) override;
 
+	virtual void shader_load(RID p_shader) override;
+
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;
 	virtual String shader_get_code(RID p_shader) const override;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -232,6 +232,8 @@ public:
 
 	FUNCRIDSPLIT(shader)
 
+	FUNC1(shader_load, RID)
+
 	FUNC2(shader_set_code, RID, const String &)
 	FUNC2(shader_set_path_hint, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -60,6 +60,8 @@ public:
 	virtual void shader_initialize(RID p_rid) = 0;
 	virtual void shader_free(RID p_rid) = 0;
 
+	virtual void shader_load(RID p_shader) = 0;
+
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -177,6 +177,8 @@ public:
 
 	virtual RID shader_create() = 0;
 
+	virtual void shader_load(RID p_shader) = 0;
+
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;


### PR DESCRIPTION
Add a shader.load API to allow loading shaders before using them This is only relevant for OGL as shaders are being preloaded in vulkan in ASYNC.

This helps solve loading stutters in Computability mode (OpenGL) as all shaders
are being compiled on first use.

I tried to apply the same code to the Vulkan based renderers, but it appears that they do not suffer from shader load stutters
as it happens async.
Vulkan does suffer from about 600ms first frame due to lots of pipeline creation tasks (as far as I can understand)
but due to the complex requirements for pipeline creation (needs to know verted input data, and surface format data) I could not apply similar preload logic to them.


I used the following test script to check the impact:

```gdscript
extends Node3D

var shader_template = """shader_type spatial;

void vertex() {
}

void fragment() {
	ALBEDO = vec3(XXX, YYY, 0.0);
}

void light() {
}
"""

var rect_length = 32

var materials = []

var with_load = false

# Called when the node enters the scene tree for the first time.
func _ready():
	var camera = Camera3D.new()
	add_child(camera)
	camera.position = Vector3(rect_length / 2, rect_length / 2, rect_length / 2)
	camera.look_at(Vector3(rect_length / 2, rect_length / 2, 0), Vector3.UP)
	camera.current = true
	
	var environment = WorldEnvironment.new()
	environment.environment = Environment.new()
	add_child(environment)
	
	create()

func float_str(f):
	var fstr = str(f)
	if fstr.find(".") == -1:
		return fstr + ".0"
	return fstr

var loader

func show_loader():
	var label = Label.new()
	var center_container = CenterContainer.new()
	center_container.set_anchors_preset(Control.PRESET_CENTER)
	center_container.use_top_left = true
	center_container.add_child(label)
	add_child(center_container)
	label.text = "Loading"
	var tween = center_container.create_tween()
	tween.tween_property(center_container, "rotation", PI*2, 2.0)
	tween.set_loops()
	loader = center_container

func hide_loader():
	loader.queue_free()

func create():
	show_loader()
	var ticks = Time.get_ticks_msec()
	var ticks_start = Time.get_ticks_msec()
	materials.resize(rect_length*rect_length)
	for i in range(rect_length):
		for j in range(rect_length):
			var shader_code = shader_template.replace("XXX", float_str(float(i) / float(rect_length))).replace("YYY", float_str(float(j) / float(rect_length)))
			var shader := Shader.new()
			shader.code = shader_code
			if with_load:
				shader.load()
			var material = ShaderMaterial.new()
			material.shader = shader
			materials[i*rect_length + j] = material
			
			var new_ticks = Time.get_ticks_msec()
			if new_ticks - ticks > 10:
				print("await")
				await get_tree().process_frame
				ticks = Time.get_ticks_msec()
	print("adding boxes")
	var boxes = Node3D.new()
	for i in range(rect_length):
		for j in range(rect_length):
			var box = CSGBox3D.new()
			box.material = materials[i*rect_length + j]
			box.position = Vector3(i, j, 0)
			box.scale = Vector3.ONE * 0.55
			boxes.add_child(box)

	add_child(boxes)
	var draw_start = Time.get_ticks_msec()

	hide_loader()
		# make sure 1 extra frame is drawn
	await get_tree().process_frame
	print("ready, total time = " + str(Time.get_ticks_msec() - ticks_start) + "ms" + " first draw time = " + str(Time.get_ticks_msec() - draw_start) + "ms")
```
the script creates a scene with a loader, and loads 32*32 shaders to display on 32*32 boxes (1024 total each)

Without the load API, the entire app is frozen for 4 seconds compiling all the shaders.
With the load API, it is possible to spread the loading between several frames and have a smoother loader showing.

The "with_load" variable controls the 2 cases.

without load:
ready, total time = 4123ms first draw time = 4034ms

with load:
ready, total time = 5442ms first draw time = 193ms

the total time can be explained since I only allow for 10ms load time between each frame (leaving 6 potential ms in 60FPS)



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
