### PR TITLE
Fix GUI input propagation to ancestors of focused Control

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2223,11 +2223,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		if (gui.key_focus) {
 			gui.key_event_accepted = false;
-			if (gui.key_focus->can_process()) {
-				gui.key_focus->_call_gui_input(p_event);
-			}
+			bool stopped = gui.key_focus->can_process() && _gui_call_input(gui.key_focus, p_event);
 
-			if (gui.key_event_accepted) {
+			if (stopped) {
 				set_input_as_handled();
 				return;
 			}


### PR DESCRIPTION
As suggested in the contributors' chat, I'm submitting two competing fixes to #81186, which reports a conflict between code behavior and documentation. This PR fixes code so its behavior matches the documentation. **_If maintainers prefer to change the documentation instead_**, I've opened a PR for that at godotengine/godot-docs#7899.

`Control::_gui_input()` calls only propagate up the scene tree for mouse events (when appropriate filter flags are set). Keyboard and controller events do not propagate through `_gui_input()`.

Current code calls the focused Control's `_gui_input()` directly for non-mouse action events. I've changed the handling of those events to copy the handling of mouse UI events, by calling `Viewport::_gui_call_input()`. That function contains existing code for event propagation, as well as the key-event-acceptance check performed by current code.

Edit: Fixes #81186.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
