### PR TITLE
Use pass by reference in ZIPPacker & ZIPReader signatures

### DIFF
--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -33,7 +33,7 @@
 #include "core/io/zip_io.h"
 #include "core/os/os.h"
 
-Error ZIPPacker::open(String p_path, ZipAppend p_append) {
+Error ZIPPacker::open(const String &p_path, ZipAppend p_append) {
 	if (fa.is_valid()) {
 		close();
 	}
@@ -55,7 +55,7 @@ Error ZIPPacker::close() {
 	return err;
 }
 
-Error ZIPPacker::start_file(String p_path) {
+Error ZIPPacker::start_file(const String &p_path) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
 	zip_fileinfo zipfi;
@@ -76,7 +76,7 @@ Error ZIPPacker::start_file(String p_path) {
 	return err == ZIP_OK ? OK : FAILED;
 }
 
-Error ZIPPacker::write_file(Vector<uint8_t> p_data) {
+Error ZIPPacker::write_file(const Vector<uint8_t> &p_data) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
 
 	return zipWriteInFileInZip(zf, p_data.ptr(), p_data.size()) == ZIP_OK ? OK : FAILED;

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -52,11 +52,11 @@ public:
 		APPEND_ADDINZIP = 2,
 	};
 
-	Error open(String p_path, ZipAppend p_append);
+	Error open(const String &p_path, ZipAppend p_append);
 	Error close();
 
-	Error start_file(String p_path);
-	Error write_file(Vector<uint8_t> p_data);
+	Error start_file(const String &p_path);
+	Error write_file(const Vector<uint8_t> &p_data);
 	Error close_file();
 
 	ZIPPacker();

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -33,7 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/io/zip_io.h"
 
-Error ZIPReader::open(String p_path) {
+Error ZIPReader::open(const String &p_path) {
 	if (fa.is_valid()) {
 		close();
 	}
@@ -81,7 +81,7 @@ PackedStringArray ZIPReader::get_files() {
 	return arr;
 }
 
-PackedByteArray ZIPReader::read_file(String p_path, bool p_case_sensitive) {
+PackedByteArray ZIPReader::read_file(const String &p_path, bool p_case_sensitive) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedByteArray(), "ZIPReader must be opened before use.");
 
 	int err = UNZ_OK;
@@ -118,7 +118,7 @@ PackedByteArray ZIPReader::read_file(String p_path, bool p_case_sensitive) {
 	return data;
 }
 
-bool ZIPReader::file_exists(String p_path, bool p_case_sensitive) {
+bool ZIPReader::file_exists(const String &p_path, bool p_case_sensitive) {
 	ERR_FAIL_COND_V_MSG(fa.is_null(), false, "ZIPReader must be opened before use.");
 
 	int cs = p_case_sensitive ? 1 : 2;

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -46,12 +46,12 @@ protected:
 	static void _bind_methods();
 
 public:
-	Error open(String p_path);
+	Error open(const String &p_path);
 	Error close();
 
 	PackedStringArray get_files();
-	PackedByteArray read_file(String p_path, bool p_case_sensitive);
-	bool file_exists(String p_path, bool p_case_sensitive);
+	PackedByteArray read_file(const String &p_path, bool p_case_sensitive);
+	bool file_exists(const String &p_path, bool p_case_sensitive);
 
 	ZIPReader();
 	~ZIPReader();


### PR DESCRIPTION
Minor changes to the ZIPPacker and ZIPReader function signatures to use `const` pass by reference. This should improve performance a tiny bit and is more in line with the rest of the code base