### PR TITLE
Change get_current_edited_scene_history_id() to handle negative indices

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -431,7 +431,7 @@ int EditorData::get_scene_history_id_from_path(const String &p_path) const {
 }
 
 int EditorData::get_current_edited_scene_history_id() const {
-	if (current_edited_scene != -1) {
+	if (current_edited_scene != -1 && !(current_edited_scene < 0 && current_edited_scene < edited_scene.size())) {
 		return edited_scene[current_edited_scene].history_id;
 	}
 	return 0;


### PR DESCRIPTION
> 2023-09-09 19:22:48.438831-0700 godot.macos.editor.double.arm64[67638:487576] ERROR: FATAL: Index p_index = 0 is out of bounds (size() = 0).
at: get (./core/templates/cowdata.h:155)
ERROR: FATAL: Index p_index = 0 is out of bounds (size() = 0).
   at: get (./core/templates/cowdata.h:155)

The code change modifies the condition in get_current_edited_scene_history_id() to handle negative indices properly. This ensures that the function returns the correct history ID when the current edited scene is a valid index or within the range of edited scenes.

I am not sure if I'm able to find a minimal reproduction project for this. Will try to narrow it down.