### PR TITLE
Add support for OpenXR Varjo Quad View rendering

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3873,6 +3873,14 @@
 				[b]Note:[/b] The equivalent node is [Viewport].
 			</description>
 		</method>
+		<method name="viewport_get_for_render_target" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="render_target" type="RID" />
+			<description>
+				Returns the RID of the viewport that uses this render target.
+				[b]Warning:[/b] Calling this from any thread other than the rendering thread will be detrimental to performance.
+			</description>
+		</method>
 		<method name="viewport_get_measured_render_time_cpu" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="viewport" type="RID" />
@@ -3917,6 +3925,14 @@
 			<param index="0" name="viewport" type="RID" />
 			<description>
 				Returns the render target for the viewport.
+			</description>
+		</method>
+		<method name="viewport_get_scenario" qualifiers="const">
+			<return type="RID" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Returns the scenario for the viewport.
+				[b]Warning:[/b] Calling this from any thread other than the rendering thread will be detrimental to performance.
 			</description>
 		</method>
 		<method name="viewport_get_texture" qualifiers="const">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2756,7 +2756,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "xr/openxr/default_action_map", PROPERTY_HINT_FILE, "*.tres"), "res://openxr_action_map.tres");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/form_factor", PROPERTY_HINT_ENUM, "Head Mounted,Handheld"), "0");
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo"), "1"); // "Mono,Stereo,Quad,Observer"
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo,Quad (Varjo)"), "1"); // "Mono,Stereo,Quad,Observer"
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/reference_space", PROPERTY_HINT_ENUM, "Local,Stage,Local Floor"), "1");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/environment_blend_mode", PROPERTY_HINT_ENUM, "Opaque,Additive,Alpha"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/foveation_level", PROPERTY_HINT_ENUM, "Off,Low,Medium,High"), "0");

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -269,8 +269,12 @@ void OpenXRExtensionWrapper::on_session_destroyed() {
 	GDVIRTUAL_CALL(_on_session_destroyed);
 }
 
-void OpenXRExtensionWrapper::on_pre_draw_viewport(RID p_render_target) {
+bool OpenXRExtensionWrapper::on_pre_draw_viewport(RID p_render_target) {
+	// TODO introduce _on_pre_draw_viewport2 that has a return boolean!
+	
 	GDVIRTUAL_CALL(_on_pre_draw_viewport, p_render_target);
+
+	return false;
 }
 
 void OpenXRExtensionWrapper::on_post_draw_viewport(RID p_render_target) {

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -123,8 +123,18 @@ public:
 	virtual void on_sync_actions(); // `on_sync_actions` is called right after we sync our action sets.
 	virtual void on_pre_render(); // `on_pre_render` is called right before we start rendering our XR viewports.
 	virtual void on_main_swapchains_created(); // `on_main_swapchains_created` is called right after our main swapchains are (re)created.
-	virtual void on_pre_draw_viewport(RID p_render_target); // `on_pre_draw_viewport` is called right before we start rendering this viewport
-	virtual void on_post_draw_viewport(RID p_render_target); // `on_port_draw_viewport` is called right after we start rendering this viewport (note that on Vulkan draw commands may only be queued)
+
+	virtual bool owns_viewport(RID p_render_target) { return false; } // override and return true if our wrapper fully handles this viewport.
+	virtual bool on_pre_draw_viewport(RID p_render_target); // `on_pre_draw_viewport` is called right before we start rendering this viewport, if we own this viewport, only we receive this. If no extension owns the viewport (e.g. main XR viewport), all extensions receive this.
+	virtual uint32_t get_viewport_view_count() { return 0; } // Only called if we own this viewport, return view count.
+	virtual Size2i get_viewport_size() { return Size2i(); } // Only called if we own this viewport, return viewport size.
+	virtual bool get_view_transform(uint32_t p_view, XrTime p_display_time, Transform3D &r_transform) { return false; } // Only called if we own this viewport, return view transform.
+	virtual bool get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, XrTime p_display_time, Projection &r_projection) { return false; } // Only called if we own this viewport, return view projection.
+	virtual XrSwapchain get_color_swapchain() { return XR_NULL_HANDLE; } // Only called if we own this viewport, return color swapchain.
+	virtual RID get_color_texture() { return RID(); } // Only called if we own this viewport, return color texture.
+	virtual RID get_depth_texture() { return RID(); } // Only called if we own this viewport, return depth texture.
+	virtual void on_post_draw_viewport(RID p_render_target); // `on_port_draw_viewport` is called right after we start rendering this viewport (note that on Vulkan draw commands may only be queued).
+	virtual void on_end_frame() {};
 
 	GDVIRTUAL0(_on_register_metadata);
 	GDVIRTUAL0(_on_before_instance_created);

--- a/modules/openxr/extensions/openxr_varjo_quad_view_extension.cpp
+++ b/modules/openxr/extensions/openxr_varjo_quad_view_extension.cpp
@@ -1,0 +1,303 @@
+/**************************************************************************/
+/*  openxr_varjo_quad_view_extension.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_varjo_quad_view_extension.h"
+#include "openxr_composition_layer_depth_extension.h"
+#include "servers/rendering_server.h"
+
+HashMap<String, bool *> OpenXRVarjoQuadViewExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_VARJO_QUAD_VIEWS_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}
+
+void OpenXRVarjoQuadViewExtension::on_session_created(const XrSession p_instance) {
+	if (!available) {
+		// Not available? no need to do anything more...
+		return;
+	}
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	// Note: after instance is created, our view configuration should NOT change
+	XrViewConfigurationType view_configuration = openxr_api->get_view_configuration();
+	if (view_configuration != XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO) {
+		// Didn't select our view configuration? no need to do anything more...
+		return;
+	}
+
+	// Get our rendering server
+	RS *rendering_server = RS::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	// We need to find a way to copy over settings from our primary XR viewport to our secondary viewport (and camera)
+	// but we never get access to that. Or maybe we should make this configurable some other way?
+	//
+	// For now we'll accept this as a limitation.
+
+	// Create a camera for our viewport (most of the state will be ignored)
+	secondary_camera = rendering_server->camera_create();
+	rendering_server->camera_set_perspective(secondary_camera, 60, 0.01f, 4096.0f); // only near and far of this will be used
+
+	// Create the viewport we render too
+	secondary_viewport = rendering_server->viewport_create();
+	rendering_server->viewport_set_disable_2d(secondary_viewport, true);
+	rendering_server->viewport_set_use_xr(secondary_viewport, true);
+	rendering_server->viewport_set_update_mode(secondary_viewport, RS::VIEWPORT_UPDATE_ALWAYS);
+	rendering_server->viewport_attach_camera(secondary_viewport, secondary_camera);
+	rendering_server->viewport_set_active(secondary_viewport, true);
+
+	enabled = true;
+}
+
+void OpenXRVarjoQuadViewExtension::on_session_destroyed() {
+	if (enabled) {
+		// We're disabling...
+		enabled = false;
+
+		// Make sure our swapchains are freed
+		free_swapchains();
+		OpenXRAPI::OpenXRSwapChainInfo::free_queued();
+
+		RS *rendering_server = RS::get_singleton();
+		ERR_FAIL_NULL(rendering_server);
+
+		if (secondary_viewport.is_valid()) {
+			rendering_server->viewport_set_active(secondary_viewport, false);
+			rendering_server->free(secondary_viewport);
+			secondary_viewport = RID();
+		}
+
+		if (secondary_camera.is_valid()) {
+			rendering_server->free(secondary_camera);
+			secondary_camera = RID();
+		}
+	}
+}
+
+bool OpenXRVarjoQuadViewExtension::owns_viewport(RID p_render_target) {
+	if (!enabled) {
+		return false;
+	}
+
+	RS *rendering_server = RS::get_singleton();
+	ERR_FAIL_NULL_V(rendering_server, false);
+
+	return rendering_server->viewport_get_render_target(secondary_viewport) == p_render_target;
+}
+
+bool OpenXRVarjoQuadViewExtension::on_pre_draw_viewport(RID p_render_target) {
+	// This method is called if we own this viewport (it's our secondary viewport) or if it's the main XR viewport.
+	if (!enabled) {
+		// We're not enabled, so no need to check on this, this must be for the main XR viewport.
+		return true;
+	}
+
+	RS *rendering_server = RS::get_singleton();
+	ERR_FAIL_NULL_V(rendering_server, false);
+
+	if (rendering_server->viewport_get_render_target(secondary_viewport) == p_render_target) {
+		// This is our secondary viewport.
+		if (!have_primary_viewport) {
+			// this is ok if it happens once...
+			WARN_PRINT("Attempting to render our secondary XR viewport before rendering our primary XR viewport.");
+			return false;
+		}
+
+		// check our swapchain
+		Size2i new_swapchain_size = get_viewport_size();
+
+		if (swapchain_size != new_swapchain_size) {
+			// out with the old
+			free_swapchains();
+
+			// in with the new
+			create_swapchains(new_swapchain_size);
+		}
+
+		// Acquire our images
+		for (int i = 0; i < OpenXRAPI::OPENXR_SWAPCHAIN_MAX; i++) {
+			if (!swapchains[i].is_image_acquired() && swapchains[i].get_swapchain() != XR_NULL_HANDLE) {
+				bool should_render = true;
+				if (!swapchains[i].acquire(should_render)) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	} else {
+		// We've obtained our primary viewport, make sure we use its scenario
+		have_primary_viewport = true;
+		RID main_xr_viewport = rendering_server->viewport_get_for_render_target(p_render_target);
+		RID scenario = rendering_server->viewport_get_scenario(main_xr_viewport);
+		rendering_server->viewport_set_scenario(secondary_viewport, scenario);
+		return true;
+	}
+}
+
+uint32_t OpenXRVarjoQuadViewExtension::get_viewport_view_count() {
+	// This should only be called if we returned true on owns_viewport
+
+	return 2; // always 2
+}
+
+Size2i OpenXRVarjoQuadViewExtension::get_viewport_size() {
+	// This should only be called if we returned true on owns_viewport
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL_V(openxr_api, Size2i());
+
+	// Views 2 and 3 are for our secondary view but should have the same size.
+	XrViewConfigurationView view_configuration_view = openxr_api->get_view_configuration_view(2);
+
+	// Do we apply render_target_multiplier here?
+
+	// And return result.
+	return Size2i(view_configuration_view.recommendedImageRectWidth, view_configuration_view.recommendedImageRectHeight);
+}
+
+bool OpenXRVarjoQuadViewExtension::get_view_transform(uint32_t p_view, XrTime p_display_time, Transform3D &r_transform) {
+	// This should only be called if we returned true on owns_viewport
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL_V(openxr_api, false);
+
+	// Views 2 and 3 are for our secondary view
+	XrView view = openxr_api->get_view(2 + p_view);
+
+	r_transform = openxr_api->transform_from_pose(view.pose);
+
+	return true;
+}
+
+bool OpenXRVarjoQuadViewExtension::get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, XrTime p_display_time, Projection &r_projection) {
+	// This should only be called if we returned true on owns_viewport
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL_V(openxr_api, false);
+	ERR_FAIL_NULL_V(openxr_api->get_graphics_extension(), false);
+
+	// Views 2 and 3 are for our secondary view
+	XrView view = openxr_api->get_view(2 + p_view);
+
+	// Update near and far
+	openxr_api->set_view_depth(2 + p_view, p_z_near, p_z_far);
+
+	// And set our projection
+	return openxr_api->get_graphics_extension()->create_projection_fov(view.fov, p_z_near, p_z_far, r_projection);
+}
+
+XrSwapchain OpenXRVarjoQuadViewExtension::get_color_swapchain() {
+	// This should only be called if we returned true on owns_viewport
+
+	return swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_COLOR].get_swapchain();
+}
+
+RID OpenXRVarjoQuadViewExtension::get_color_texture() {
+	// This should only be called if we returned true on owns_viewport
+
+	return swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_COLOR].get_image();
+}
+
+RID OpenXRVarjoQuadViewExtension::get_depth_texture() {
+	// This should only be called if we returned true on owns_viewport
+
+	return swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_DEPTH].get_image();
+}
+
+void OpenXRVarjoQuadViewExtension::on_post_draw_viewport(RID p_render_target) {
+	if (!enabled) {
+		return;
+	}
+
+	RS *rendering_server = RS::get_singleton();
+	ERR_FAIL_NULL(rendering_server);
+
+	// For backwards compatibility reasons, double check if this is our viewport
+	if (rendering_server->viewport_get_render_target(secondary_viewport) == p_render_target) {
+		// nothing to do here atm
+	}
+}
+
+void OpenXRVarjoQuadViewExtension::on_end_frame() {
+	for (int i = 0; i < OpenXRAPI::OPENXR_SWAPCHAIN_MAX; i++) {
+		if (swapchains[i].is_image_acquired()) {
+			swapchains[i].release();
+		}
+	}
+}
+
+bool OpenXRVarjoQuadViewExtension::is_available() {
+	return available;
+}
+
+bool OpenXRVarjoQuadViewExtension::is_enabled() {
+	return enabled;
+}
+
+void OpenXRVarjoQuadViewExtension::create_swapchains(Size2i p_size) {
+	swapchain_size = p_size;
+	uint32_t sample_count = 1;
+	uint32_t view_count = get_viewport_view_count();
+
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_NULL(openxr_api);
+
+	// We start with our color swapchain...
+	int64_t color_swapchain_format = openxr_api->get_color_swapchain_format();
+	if (color_swapchain_format != 0) {
+		if (!swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_COLOR].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, color_swapchain_format, swapchain_size.width, swapchain_size.height, sample_count, view_count)) {
+			return;
+		}
+	}
+
+	// Then our depth swapchain
+	int64_t depth_swapchain_format = openxr_api->get_depth_swapchain_format();
+	bool submit_depth_buffer = openxr_api->get_submit_depth_buffer();
+	if (depth_swapchain_format != 0 && submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available()) {
+		if (!swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_DEPTH].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, depth_swapchain_format, swapchain_size.width, swapchain_size.height, sample_count, view_count)) {
+			return;
+		}
+	}
+
+	for (uint32_t i = 0; i < view_count; i++) {
+		openxr_api->set_projection_image(2 + i, i, swapchain_size, swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_COLOR].get_swapchain(), submit_depth_buffer ? swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_DEPTH].get_swapchain() : XR_NULL_HANDLE);
+	};
+}
+
+void OpenXRVarjoQuadViewExtension::free_swapchains() {
+	for (int i = 0; i < OpenXRAPI::OPENXR_SWAPCHAIN_MAX; i++) {
+		swapchains[i].queue_free();
+	}
+}

--- a/modules/openxr/extensions/openxr_varjo_quad_view_extension.h
+++ b/modules/openxr/extensions/openxr_varjo_quad_view_extension.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  openxr_varjo_quad_view_extension.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef OPENXR_VARJO_QUAD_VIEW_EXTENSION_H
+#define OPENXR_VARJO_QUAD_VIEW_EXTENSION_H
+
+#include "../openxr_api.h"
+#include "openxr_extension_wrapper.h"
+
+// This extension enables the XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO
+// view configuration type used for quad buffer rendering on Varjo devices.
+
+class OpenXRVarjoQuadViewExtension : public OpenXRExtensionWrapper {
+public:
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+
+	virtual void on_session_created(const XrSession p_instance) override;
+	virtual void on_session_destroyed() override;
+
+	virtual bool owns_viewport(RID p_render_target) override;
+	virtual bool on_pre_draw_viewport(RID p_render_target) override;
+	virtual uint32_t get_viewport_view_count() override;
+	virtual Size2i get_viewport_size() override;
+	virtual bool get_view_transform(uint32_t p_view, XrTime p_display_time, Transform3D &r_transform) override;
+	virtual bool get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, XrTime p_display_time, Projection &r_projection) override;
+	virtual XrSwapchain get_color_swapchain() override;
+	virtual RID get_color_texture() override;
+	virtual RID get_depth_texture() override;
+	virtual void on_post_draw_viewport(RID p_render_target) override;
+	virtual void on_end_frame() override;
+
+	bool is_available();
+	bool is_enabled();
+
+private:
+	bool available = false;
+	bool enabled = false;
+	bool have_primary_viewport = false;
+
+	RID secondary_viewport;
+	RID secondary_camera;
+	Size2i swapchain_size = Size2i();
+	OpenXRAPI::OpenXRSwapChainInfo swapchains[OpenXRAPI::OPENXR_SWAPCHAIN_MAX];
+
+	void create_swapchains(Size2i p_size);
+	void free_swapchains();
+};
+
+#endif // OPENXR_VARJO_QUAD_VIEW_EXTENSION_H

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -221,6 +221,26 @@ void OpenXROpenGLExtension::get_usable_depth_formats(Vector<int64_t> &p_usable_d
 	p_usable_depth_formats.push_back(GL_DEPTH_COMPONENT24);
 }
 
+/*
+bool OpenXROpenGLExtension::on_pre_draw_viewport(RID p_render_target) {
+	if (srgb_ext_is_available) {
+		hw_linear_to_srgb_is_enabled = glIsEnabled(GL_FRAMEBUFFER_SRGB);
+		if (hw_linear_to_srgb_is_enabled) {
+			// Disable this.
+			glDisable(GL_FRAMEBUFFER_SRGB);
+		}
+	}
+	return true;
+}
+
+void OpenXROpenGLExtension::on_post_draw_viewport(RID p_render_target) {
+	if (srgb_ext_is_available && hw_linear_to_srgb_is_enabled) {
+		// Re-enable this.
+		glEnable(GL_FRAMEBUFFER_SRGB);
+	}
+}
+*/
+
 bool OpenXROpenGLExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int64_t p_swapchain_format, uint32_t p_width, uint32_t p_height, uint32_t p_sample_count, uint32_t p_array_size, void **r_swapchain_graphics_data) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	ERR_FAIL_NULL_V(texture_storage, false);

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -48,6 +48,11 @@ public:
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 
+	/*
+	virtual bool on_pre_draw_viewport(RID p_render_target) override;
+	virtual void on_post_draw_viewport(RID p_render_target) override;
+	*/
+
 	virtual void get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual void get_usable_depth_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual String get_swapchain_format_name(int64_t p_swapchain_format) const override;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1225,6 +1225,96 @@ bool OpenXRAPI::obtain_swapchain_formats() {
 	return true;
 }
 
+Vector3i OpenXRAPI::get_viewport_setup(RID p_render_target) const {
+	ERR_FAIL_COND_V(view_configuration_views.is_empty(), Vector3i());
+
+	Vector3i result;
+
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		if (wrapper->owns_viewport(p_render_target)) {
+			Size2i size = wrapper->get_viewport_size();
+			result.x = size.x;
+			result.y = size.y;
+			result.z = wrapper->get_viewport_view_count();
+			return result;
+		}
+	}
+
+	Size2 size = get_recommended_target_size();
+	result.x = size.x;
+	result.y = size.y;
+	result.z = get_main_view_count();
+
+	return result;
+}
+
+uint32_t OpenXRAPI::get_view_count() {
+	if (render_state.render_target_wrapper) {
+		// We're rendering this viewport right now, so we need it's viewcount.
+		return render_state.render_target_wrapper->get_viewport_view_count();
+	} else {
+		// Return our main viewport view count.
+		return get_main_view_count();
+	}
+}
+
+uint32_t OpenXRAPI::get_main_view_count() const {
+	switch (view_configuration) {
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO: {
+			return 1;
+		} break;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO: {
+			return 2;
+		} break;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO: {
+			// We have 4 views, but only the first two are part of our main view.
+			// The other two views are handled by OpenXRVarjoQuadViewExtension.
+			return 2;
+		} break;
+		default: {
+			ERR_FAIL_V_MSG(2, "OpenXR: Unsupported view configuration selected");
+		} break;
+	}
+}
+
+void OpenXRAPI::set_projection_image(uint32_t p_view, uint32_t p_image_index, Size2i p_size, XrSwapchain p_color_swapchain, XrSwapchain p_depth_swapchain) {
+	render_state.projection_views[p_view].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
+	render_state.projection_views[p_view].next = nullptr;
+	render_state.projection_views[p_view].subImage.swapchain = p_color_swapchain;
+	render_state.projection_views[p_view].subImage.imageArrayIndex = p_image_index;
+	render_state.projection_views[p_view].subImage.imageRect.offset.x = 0;
+	render_state.projection_views[p_view].subImage.imageRect.offset.y = 0;
+	render_state.projection_views[p_view].subImage.imageRect.extent.width = p_size.width;
+	render_state.projection_views[p_view].subImage.imageRect.extent.height = p_size.height;
+
+	if (submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available() && p_depth_swapchain != XR_NULL_HANDLE) {
+		render_state.projection_views[p_view].next = &render_state.depth_views[p_view];
+
+		render_state.depth_views[p_view].type = XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR;
+		render_state.depth_views[p_view].next = nullptr;
+		render_state.depth_views[p_view].subImage.swapchain = p_depth_swapchain;
+		render_state.depth_views[p_view].subImage.imageArrayIndex = p_image_index;
+		render_state.depth_views[p_view].subImage.imageRect.offset.x = 0;
+		render_state.depth_views[p_view].subImage.imageRect.offset.y = 0;
+		render_state.depth_views[p_view].subImage.imageRect.extent.width = p_size.width;
+		render_state.depth_views[p_view].subImage.imageRect.extent.height = p_size.height;
+		// OpenXR spec says that: minDepth < maxDepth.
+		render_state.depth_views[p_view].minDepth = 0.0;
+		render_state.depth_views[p_view].maxDepth = 1.0;
+		// But we can reverse near and far for reverse-Z.
+		render_state.depth_views[p_view].nearZ = 4096.0; // Near and far Z will be set to the correct values in fill_projection_matrix
+		render_state.depth_views[p_view].farZ = 0.01;
+	}
+}
+
+void OpenXRAPI::set_view_depth(uint32_t p_view, double p_z_near, double p_z_far) {
+	if (submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available()) {
+		// We reverse near and far for reverse-Z.
+		render_state.depth_views[p_view].nearZ = p_z_far;
+		render_state.depth_views[p_view].farZ = p_z_near;
+	}
+}
+
 bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
@@ -1247,10 +1337,13 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 
 	render_state.main_swapchain_size = p_size;
 	uint32_t sample_count = 1;
+	uint32_t main_view_count = get_main_view_count();
+
+	ERR_FAIL_COND_V(main_view_count > render_state.views.size(), false);
 
 	// We start with our color swapchain...
 	if (color_swapchain_format != 0) {
-		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, color_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, view_configuration_views.size())) {
+		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, color_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, main_view_count)) {
 			return false;
 		}
 
@@ -1262,7 +1355,7 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 	// - we support our depth layer extension
 	// - we have our spacewarp extension (not yet implemented)
 	if (depth_swapchain_format != 0 && submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available()) {
-		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, depth_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, view_configuration_views.size())) {
+		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, depth_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, main_view_count)) {
 			return false;
 		}
 
@@ -1275,37 +1368,8 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 		// TBD
 	}
 
-	for (uint32_t i = 0; i < render_state.views.size(); i++) {
-		render_state.views[i].type = XR_TYPE_VIEW;
-		render_state.views[i].next = nullptr;
-
-		render_state.projection_views[i].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
-		render_state.projection_views[i].next = nullptr;
-		render_state.projection_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
-		render_state.projection_views[i].subImage.imageArrayIndex = i;
-		render_state.projection_views[i].subImage.imageRect.offset.x = 0;
-		render_state.projection_views[i].subImage.imageRect.offset.y = 0;
-		render_state.projection_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size.width;
-		render_state.projection_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size.height;
-
-		if (render_state.submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available() && !render_state.depth_views.is_empty()) {
-			render_state.projection_views[i].next = &render_state.depth_views[i];
-
-			render_state.depth_views[i].type = XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR;
-			render_state.depth_views[i].next = nullptr;
-			render_state.depth_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain();
-			render_state.depth_views[i].subImage.imageArrayIndex = i;
-			render_state.depth_views[i].subImage.imageRect.offset.x = 0;
-			render_state.depth_views[i].subImage.imageRect.offset.y = 0;
-			render_state.depth_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size.width;
-			render_state.depth_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size.height;
-			// OpenXR spec says that: minDepth < maxDepth.
-			render_state.depth_views[i].minDepth = 0.0;
-			render_state.depth_views[i].maxDepth = 1.0;
-			// But we can reverse near and far for reverse-Z.
-			render_state.depth_views[i].nearZ = 100.0; // Near and far Z will be set to the correct values in fill_projection_matrix
-			render_state.depth_views[i].farZ = 0.01;
-		}
+	for (uint32_t i = 0; i < main_view_count; i++) {
+		set_projection_image(i, i, render_state.main_swapchain_size, render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain(), !render_state.depth_views.is_empty() ? render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain() : XR_NULL_HANDLE);
 	};
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
@@ -1516,8 +1580,9 @@ void OpenXRAPI::set_form_factor(XrFormFactor p_form_factor) {
 	form_factor = p_form_factor;
 }
 
-uint32_t OpenXRAPI::get_view_count() {
-	return view_configuration_views.size();
+const XrViewConfigurationType *OpenXRAPI::get_supported_view_configuration_types(uint32_t &count) {
+	count = supported_view_configuration_types.size();
+	return supported_view_configuration_types.ptr();
 }
 
 void OpenXRAPI::set_view_configuration(XrViewConfigurationType p_view_configuration) {
@@ -1830,10 +1895,23 @@ XrHandTrackerEXT OpenXRAPI::get_hand_tracker(int p_hand_index) {
 	return hand_tracking->get_hand_tracker(hand)->hand_tracker;
 }
 
-Size2 OpenXRAPI::get_recommended_target_size() {
+XrViewConfigurationView OpenXRAPI::get_view_configuration_view(uint32_t p_index) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_index, view_configuration_views.size(), XrViewConfigurationView());
+
+	return view_configuration_views[p_index];
+}
+
+XrView OpenXRAPI::get_view(uint32_t p_index) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_index, render_state.views.size(), XrView());
+
+	return render_state.views[p_index];
+}
+
+Size2 OpenXRAPI::get_recommended_target_size() const {
 	RenderingServer *rendering_server = RenderingServer::get_singleton();
 	ERR_FAIL_COND_V(view_configuration_views.is_empty(), Size2());
 
+	// Return our main viewport size
 	Size2 target_size;
 
 	if (rendering_server && rendering_server->is_on_render_thread()) {
@@ -1914,8 +1992,12 @@ bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 		return false;
 	}
 
-	// Note, the timing of this is set right before rendering, which is what we need here.
-	r_transform = transform_from_pose(render_state.views[p_view].pose);
+	if (render_state.render_target_wrapper) {
+		render_state.render_target_wrapper->get_view_transform(p_view, frame_state.predictedDisplayTime, r_transform);
+	} else {
+		// Note, the timing of this is set right before rendering, which is what we need here.
+		r_transform = transform_from_pose(render_state.views[p_view].pose);
+	}
 
 	return true;
 }
@@ -1945,8 +2027,15 @@ bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z
 	render_state.z_near = p_z_near;
 	render_state.z_far = p_z_far;
 
-	// now update our projection
-	return graphics_extension->create_projection_fov(render_state.views[p_view].fov, p_z_near, p_z_far, p_camera_matrix);
+	if (render_state.render_target_wrapper) {
+		return render_state.render_target_wrapper->get_view_projection(p_view, p_z_near, p_z_far, frame_state.predictedDisplayTime, p_camera_matrix);
+	} else {
+		// if we're using depth views, make sure we update our near and far there...
+		set_view_depth(p_view, p_z_near, p_z_far);
+
+		// now update our projection
+		return graphics_extension->create_projection_fov(render_state.views[p_view].fov, p_z_near, p_z_far, p_camera_matrix);
+	}
 }
 
 Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
@@ -2113,6 +2202,12 @@ void OpenXRAPI::_allocate_view_buffers(uint32_t p_view_count, bool p_submit_dept
 
 	if (p_submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available()) {
 		openxr_api->render_state.depth_views.resize(p_view_count);
+	}
+
+	// Init view type
+	for (uint32_t i = 0; i < p_view_count; i++) {
+		openxr_api->render_state.views[i].type = XR_TYPE_VIEW;
+		openxr_api->render_state.views[i].next = nullptr;
 	}
 }
 
@@ -2335,16 +2430,35 @@ void OpenXRAPI::pre_render() {
 	}
 }
 
+bool OpenXRAPI::is_main_viewport(RID p_render_target) {
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		if (wrapper->owns_viewport(p_render_target)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 	// Must be called from rendering thread!
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 
-	// We found an XR viewport!
-	render_state.has_xr_viewport = true;
-
-	if (instance == XR_NULL_HANDLE || session == XR_NULL_HANDLE || !render_state.running || !render_state.view_pose_valid || !render_state.should_render) {
+	// Are we skipping this frame?
+	if (!can_render()) {
 		return false;
 	}
+
+	// If one of our wrappers "owns" this viewport, let it handle this.
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		if (wrapper->owns_viewport(p_render_target)) {
+			render_state.render_target_wrapper = wrapper;
+			return render_state.render_target_wrapper->on_pre_draw_viewport(p_render_target);
+		}
+	}
+
+	// We found our main XR viewport!
+	render_state.has_xr_viewport = true;
 
 	// Acquire our images
 	for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
@@ -2355,34 +2469,41 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 		}
 	}
 
-	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
-		wrapper->on_pre_draw_viewport(p_render_target);
-	}
-
 	return true;
 }
 
 XrSwapchain OpenXRAPI::get_color_swapchain() {
 	ERR_NOT_ON_RENDER_THREAD_V(XR_NULL_HANDLE);
-
-	return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
+	if (render_state.render_target_wrapper) {
+		return render_state.render_target_wrapper->get_color_swapchain();
+	} else {
+		return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
+	}
 }
 
 RID OpenXRAPI::get_color_texture() {
 	ERR_NOT_ON_RENDER_THREAD_V(RID());
 
-	return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_image();
+	if (render_state.render_target_wrapper) {
+		return render_state.render_target_wrapper->get_color_texture();
+	} else {
+		return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_image();
+	}
 }
 
 RID OpenXRAPI::get_depth_texture() {
 	ERR_NOT_ON_RENDER_THREAD_V(RID());
 
 	// Note, image will not be acquired if we didn't have a suitable swap chain format.
-	if (render_state.submit_depth_buffer && render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].is_image_acquired()) {
-		return render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_image();
-	} else {
-		return RID();
+	if (render_state.submit_depth_buffer) {
+		if (render_state.render_target_wrapper) {
+			return render_state.render_target_wrapper->get_depth_texture();
+		} else if (render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].is_image_acquired()) {
+			return render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_image();
+		}
 	}
+
+	return RID();
 }
 
 RID OpenXRAPI::get_density_map_texture() {
@@ -2434,8 +2555,15 @@ void OpenXRAPI::post_draw_viewport(RID p_render_target) {
 		return;
 	}
 
-	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
-		wrapper->on_post_draw_viewport(p_render_target);
+	if (render_state.render_target_wrapper != nullptr) {
+		// Only let ouor owning extension know we've finished with this viewport.
+		render_state.render_target_wrapper->on_post_draw_viewport(p_render_target);
+		render_state.render_target_wrapper = nullptr;
+	} else {
+		// Always let all extension know we've finished with our primary viewport.
+		for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+			wrapper->on_post_draw_viewport(p_render_target);
+		}
 	}
 }
 
@@ -2449,6 +2577,10 @@ void OpenXRAPI::end_frame() {
 
 	if (!render_state.running) {
 		return;
+	}
+
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		wrapper->on_end_frame();
 	}
 
 	if (render_state.should_render && render_state.view_pose_valid) {
@@ -2737,10 +2869,10 @@ OpenXRAPI::OpenXRAPI() {
 			case 1: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 			} break;
-			/* we don't support quad and observer configurations (yet)
 			case 2: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO;
 			} break;
+			/* we don't support observer configurations (yet)
 			case 3: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT;
 			} break;

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1024,8 +1024,12 @@ Size2 OpenXRInterface::get_render_target_size() {
 }
 
 uint32_t OpenXRInterface::get_view_count() {
-	// TODO set this based on our configuration
-	return 2;
+	if (openxr_api == nullptr) {
+		// Assume stereo
+		return 2;
+	} else {
+		return openxr_api->get_view_count();
+	}
 }
 
 void OpenXRInterface::_set_default_pos(Transform3D &p_transform, double p_world_scale, uint64_t p_eye) {
@@ -1237,6 +1241,14 @@ void OpenXRInterface::pre_render() {
 	}
 }
 
+Vector3i OpenXRInterface::get_viewport_setup(RID p_render_target) const {
+	if (openxr_api) {
+		return openxr_api->get_viewport_setup(p_render_target);
+	} else {
+		return Vector3i();
+	}
+}
+
 bool OpenXRInterface::pre_draw_viewport(RID p_render_target) {
 	if (openxr_api) {
 		return openxr_api->pre_draw_viewport(p_render_target);
@@ -1251,7 +1263,7 @@ Vector<BlitToScreen> OpenXRInterface::post_draw_viewport(RID p_render_target, co
 
 #ifndef ANDROID_ENABLED
 	// If separate HMD we should output one eye to screen
-	if (p_screen_rect != Rect2()) {
+	if (openxr_api && openxr_api->is_main_viewport(p_render_target) && p_screen_rect != Rect2()) {
 		BlitToScreen blit;
 
 		blit.render_target = p_render_target;

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -57,6 +57,7 @@
 #include "extensions/openxr_hand_tracking_extension.h"
 #include "openxr_api.h"
 
+#include "servers/rendering/renderer_scene_render.h"
 #include "servers/xr/xr_controller_tracker.h"
 #include "servers/xr/xr_interface.h"
 
@@ -78,7 +79,7 @@ private:
 	Vector3 head_linear_velocity;
 	Vector3 head_angular_velocity;
 	XRPose::TrackingConfidence head_confidence;
-	Transform3D transform_for_view[2]; // We currently assume 2, but could be 4 for VARJO which we do not support yet
+	Transform3D transform_for_view[RendererSceneRender::MAX_RENDER_VIEWS];
 
 	XRVRS xr_vrs;
 
@@ -192,6 +193,7 @@ public:
 
 	virtual void process() override;
 	virtual void pre_render() override;
+	virtual Vector3i get_viewport_setup(RID p_render_target) const override;
 	bool pre_draw_viewport(RID p_render_target) override;
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 	virtual void end_frame() override;

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -74,6 +74,7 @@
 #include "extensions/openxr_render_model_extension.h"
 #include "extensions/openxr_valve_analog_threshold_extension.h"
 #include "extensions/openxr_visibility_mask_extension.h"
+#include "extensions/openxr_varjo_quad_view_extension.h"
 #include "extensions/openxr_wmr_controller_extension.h"
 
 #ifdef TOOLS_ENABLED
@@ -157,6 +158,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMxInkExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVisibilityMaskExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPerformanceSettingsExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVarjoQuadViewExtension));
 
 			// Futures extension has to be registered as a singleton so extensions can access it.
 			OpenXRFutureExtension *future_extension = memnew(OpenXRFutureExtension);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -775,8 +775,8 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 				visible = true;
 
 				// Override our size, make sure it matches our required size and is created as a stereo target
-				Size2 xr_size = xr_interface->get_render_target_size();
-				_viewport_set_size(vp, xr_size.width, xr_size.height, xr_interface->get_view_count());
+				Vector3i vp_setup = xr_interface->get_viewport_setup(vp->render_target);
+				_viewport_set_size(vp, vp_setup.x, vp_setup.y, vp_setup.z);
 			} else {
 				// don't render anything
 				visible = false;
@@ -1158,6 +1158,22 @@ RID RendererViewport::viewport_get_render_target(RID p_viewport) const {
 	return viewport->render_target;
 }
 
+RID RendererViewport::viewport_get_for_render_target(RID p_render_target) const {
+	if (p_render_target.is_null()) {
+		return RID();
+	}
+
+	const LocalVector<RID> viewports = viewport_owner.get_owned_list();
+	for (const RID &viewport_rid : viewports) {
+		const Viewport *viewport = viewport_owner.get_or_null(viewport_rid);
+		if (viewport && viewport->render_target == p_render_target) {
+			return viewport_rid;
+		}
+	}
+
+	return RID();
+}
+
 RID RendererViewport::viewport_get_texture(RID p_viewport) const {
 	const Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_NULL_V(viewport, RID());
@@ -1241,6 +1257,13 @@ void RendererViewport::viewport_set_scenario(RID p_viewport, RID p_scenario) {
 	if (viewport->use_occlusion_culling) {
 		RendererSceneOcclusionCull::get_singleton()->buffer_set_scenario(p_viewport, p_scenario);
 	}
+}
+
+RID RendererViewport::viewport_get_scenario(RID p_viewport) const {
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
+	ERR_FAIL_NULL_V(viewport, RID());
+
+	return viewport->scenario;
 }
 
 void RendererViewport::viewport_attach_canvas(RID p_viewport, RID p_canvas) {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -239,6 +239,7 @@ public:
 	void viewport_set_clear_mode(RID p_viewport, RS::ViewportClearMode p_clear_mode);
 
 	RID viewport_get_render_target(RID p_viewport) const;
+	RID viewport_get_for_render_target(RID p_render_target) const;
 	RID viewport_get_texture(RID p_viewport) const;
 	RID viewport_get_occluder_debug_texture(RID p_viewport) const;
 
@@ -253,6 +254,7 @@ public:
 
 	void viewport_attach_camera(RID p_viewport, RID p_camera);
 	void viewport_set_scenario(RID p_viewport, RID p_scenario);
+	RID viewport_get_scenario(RID p_viewport) const;
 	void viewport_attach_canvas(RID p_viewport, RID p_canvas);
 	void viewport_remove_canvas(RID p_viewport, RID p_canvas);
 	void viewport_set_canvas_transform(RID p_viewport, RID p_canvas, const Transform2D &p_offset);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -711,6 +711,7 @@ public:
 	FUNC1RC(ViewportUpdateMode, viewport_get_update_mode, RID)
 
 	FUNC1RC(RID, viewport_get_render_target, RID)
+	FUNC1RC(RID, viewport_get_for_render_target, RID)
 	FUNC1RC(RID, viewport_get_texture, RID)
 
 	FUNC2(viewport_set_disable_2d, RID, bool)
@@ -721,6 +722,7 @@ public:
 
 	FUNC2(viewport_attach_camera, RID, RID)
 	FUNC2(viewport_set_scenario, RID, RID)
+	FUNC1RC(RID, viewport_get_scenario, RID)
 	FUNC2(viewport_attach_canvas, RID, RID)
 
 	FUNC2(viewport_remove_canvas, RID, RID)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2838,12 +2838,14 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_get_update_mode", "viewport"), &RenderingServer::viewport_get_update_mode);
 	ClassDB::bind_method(D_METHOD("viewport_set_clear_mode", "viewport", "clear_mode"), &RenderingServer::viewport_set_clear_mode);
 	ClassDB::bind_method(D_METHOD("viewport_get_render_target", "viewport"), &RenderingServer::viewport_get_render_target);
+	ClassDB::bind_method(D_METHOD("viewport_get_for_render_target", "render_target"), &RenderingServer::viewport_get_for_render_target);
 	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport"), &RenderingServer::viewport_get_texture);
 	ClassDB::bind_method(D_METHOD("viewport_set_disable_3d", "viewport", "disable"), &RenderingServer::viewport_set_disable_3d);
 	ClassDB::bind_method(D_METHOD("viewport_set_disable_2d", "viewport", "disable"), &RenderingServer::viewport_set_disable_2d);
 	ClassDB::bind_method(D_METHOD("viewport_set_environment_mode", "viewport", "mode"), &RenderingServer::viewport_set_environment_mode);
 	ClassDB::bind_method(D_METHOD("viewport_attach_camera", "viewport", "camera"), &RenderingServer::viewport_attach_camera);
 	ClassDB::bind_method(D_METHOD("viewport_set_scenario", "viewport", "scenario"), &RenderingServer::viewport_set_scenario);
+	ClassDB::bind_method(D_METHOD("viewport_get_scenario", "viewport"), &RenderingServer::viewport_get_scenario);
 	ClassDB::bind_method(D_METHOD("viewport_attach_canvas", "viewport", "canvas"), &RenderingServer::viewport_attach_canvas);
 	ClassDB::bind_method(D_METHOD("viewport_remove_canvas", "viewport", "canvas"), &RenderingServer::viewport_remove_canvas);
 	ClassDB::bind_method(D_METHOD("viewport_set_snap_2d_transforms_to_pixel", "viewport", "enabled"), &RenderingServer::viewport_set_snap_2d_transforms_to_pixel);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1013,6 +1013,7 @@ public:
 	virtual void viewport_set_clear_mode(RID p_viewport, ViewportClearMode p_clear_mode) = 0;
 
 	virtual RID viewport_get_render_target(RID p_viewport) const = 0;
+	virtual RID viewport_get_for_render_target(RID p_render_target) const = 0;
 	virtual RID viewport_get_texture(RID p_viewport) const = 0;
 
 	enum ViewportEnvironmentMode {
@@ -1028,6 +1029,7 @@ public:
 
 	virtual void viewport_attach_camera(RID p_viewport, RID p_camera) = 0;
 	virtual void viewport_set_scenario(RID p_viewport, RID p_scenario) = 0;
+	virtual RID viewport_get_scenario(RID p_viewport) const = 0;
 	virtual void viewport_attach_canvas(RID p_viewport, RID p_canvas) = 0;
 	virtual void viewport_remove_canvas(RID p_viewport, RID p_canvas) = 0;
 	virtual void viewport_set_canvas_transform(RID p_viewport, RID p_canvas, const Transform2D &p_offset) = 0;

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -226,3 +226,15 @@ Array XRInterface::get_supported_environment_blend_modes() {
 	Array default_blend_modes = { XR_ENV_BLEND_MODE_OPAQUE };
 	return default_blend_modes;
 }
+
+Vector3i XRInterface::get_viewport_setup(RID p_render_target) const {
+	// For backwards compatibility
+	Vector3i result;
+
+	Size2 target_size = const_cast<XRInterface *>(this)->get_render_target_size();
+	result.x = target_size.x;
+	result.y = target_size.y;
+	result.z = const_cast<XRInterface *>(this)->get_view_count();
+
+	return result;
+}

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -146,8 +146,10 @@ public:
 	virtual RID get_velocity_depth_texture();
 	virtual Size2i get_velocity_target_size();
 	virtual Rect2i get_render_region();
-	virtual void pre_render() {}
-	virtual bool pre_draw_viewport(RID p_render_target) { return true; } /* inform XR interface we are about to start our viewport draw process */
+
+	virtual void pre_render(){};
+	virtual Vector3i get_viewport_setup(RID p_render_target) const; /* get our viewport setup. */
+	virtual bool pre_draw_viewport(RID p_render_target) { return true; }; /* inform XR interface we are about to start our viewport draw process */
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
 	virtual void end_frame() {}
 


### PR DESCRIPTION
**Note:** Did a major rewrite, this no longer uses extra views in multiview, but has the extension register and extra viewport that we render to.

This PR adds support for Varjos Quad view rendering that is available in OpenXR. Varjo takes a novel approach to the issue of high resolution rendering in VR. Instead of relying just on VRS for foveated rendering, Varjo renders each eye twice:
- once to a lower resolution buffer with full FOV
- once to a higher resolution buffer with a smaller FOV, and a projection matrix centred on the eye view direction
The higher resolution buffer is also eye tracked meaning our focal point will get rendered at high resolution.
The two are then superimposed within the VR compositor.

The end result is 4 buffers rendered and a very crips high resolution VR result.

**THIS IS UNTESTED**
Currently hoping on some feedback from Varjo,

To test, grab any existing XR application, go to project settings, and change the View Configuration to Quad (Varjo):
![image](https://github.com/godotengine/godot/assets/1945449/83b15aad-df88-4abb-83da-637f70fe515a)

When targeting other PCVR headsets its recommended to create a feature tag for this and setup a separate export for Varjo, see the [feature tags documentation](https://docs.godotengine.org/en/stable/tutorials/export/feature_tags.html) for more info.

Still need to do a lot of testing.