### PR TITLE
Fix audio stream generators getting freed accidentally

### DIFF
--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -143,6 +143,10 @@ void AudioStreamGeneratorPlayback::clear_buffer() {
 }
 
 int AudioStreamGeneratorPlayback::_mix_internal(AudioFrame *p_buffer, int p_frames) {
+	if (!active) {
+		return 0;
+	}
+
 	int read_amount = buffer.data_left();
 	if (p_frames < read_amount) {
 		read_amount = p_frames;
@@ -151,16 +155,15 @@ int AudioStreamGeneratorPlayback::_mix_internal(AudioFrame *p_buffer, int p_fram
 	buffer.read(p_buffer, read_amount);
 
 	if (read_amount < p_frames) {
-		//skipped, not ideal
+		// Fill with zeros as fallback in case of buffer underrun.
 		for (int i = read_amount; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0, 0);
 		}
-
 		skips++;
 	}
 
 	mixed += p_frames / generator->get_mix_rate();
-	return read_amount < p_frames ? read_amount : p_frames;
+	return p_frames;
 }
 
 float AudioStreamGeneratorPlayback::get_stream_sampling_rate() {
@@ -181,7 +184,7 @@ void AudioStreamGeneratorPlayback::stop() {
 }
 
 bool AudioStreamGeneratorPlayback::is_playing() const {
-	return active; //always playing, can't be stopped
+	return active;
 }
 
 int AudioStreamGeneratorPlayback::get_loop_count() const {


### PR DESCRIPTION
Closes #65155

This is an alternative to #73162 following @reduz suggestion there https://github.com/godotengine/godot/pull/73162#issuecomment-1427134553

**To recap**: In Godot 4.x audio stream generators have a fundamental bug that they get killed by the audio server in case of a buffer underrun. This leads to a very ugly race condition already when trying to set them up: If the very first "buffer fill" comes too late, the audio server will kill the playback generator even before it got its first chance to fill the buffer! Taking my [minimal debug project](https://github.com/godotengine/godot/issues/65155#issuecomment-1421337379) as an example, I just had to launch this small app 53 times (!) to get one working instance of an audio stream generator. This means that in Godot 4.x, generators are almost completely unusable right now. (I have a music project that I'd love to migrate to Godot 4.x, but this bug is a complete showstopper.)

**Possible minimal bugfixes**: There are a few ways to fix this issue without the need for a big refactoring. #73162 had proposed to fix it on the level of the audio server, by changing the logic when to kill a playback to incorporate the `.is_playing()` information. This PR here basically solves it on the other end -- in `AudioStreamGeneratorPlayback` itself. In my opinion both fixes are a big improvement over the more or less completely broken state in 4.x / master. There are a few minor aspects why the approach taken in this PR may be preferable:

1. It is a more local change, not having to touch audio server logic itself, thus affecting only the anyway broken `AudioStreamGeneratorPlayback`.

2. The change makes the behavior consistent with the other playback's `_mix_internal` implementations ([`AudioStreamPlaybackMP3::_mix_internal`](https://github.com/godotengine/godot/blob/fc99492d3066098e938449b10e02f8e01d07e2d1/modules/minimp3/audio_stream_mp3.cpp#L40-L43), [`AudioStreamPlaybackOggVorbis::_mix_internal`](https://github.com/godotengine/godot/blob/fc99492d3066098e938449b10e02f8e01d07e2d1/modules/vorbis/audio_stream_ogg_vorbis.cpp#L39-L44)), which all have the semantics: Return 0 if inactive/stopped, otherwise return either the number of requested frames, or the number of available frames due to their _finite_ nature. A generator conceptually falls into the _infinite_ category though. Therefore, it should always simply return the number of requested frames. In particular, a buffer underrun should not become a signal to the audio server to kill the playback -- a buffer underrun is always an accident!

3. There is currently an inconsistency between how `mixed` gets updated vs the return value:

    https://github.com/godotengine/godot/blob/fc99492d3066098e938449b10e02f8e01d07e2d1/servers/audio/effects/audio_stream_generator.cpp#L162-L163

    `mixed` already gets incremented by an amount corresponding to `p_frames` (the number of requested frames), but the return value can indicate something else. This PR would make the update to `mixed` and the return value consistent.


-----------------------

In the long term I fully agree with @reduz that it is probably best to partially revert #51296 and do things like ramp up/down rather on the playback/stream level, because they have better capabilities of doing lookaheads e.g. in case of file based playback. I've collected a few relevant parts of the discussion:

- https://github.com/godotengine/godot/pull/73162#discussion_r1103875581
- https://github.com/godotengine/godot/pull/73162#issuecomment-1427146963
- https://github.com/godotengine/godot/pull/71780#issuecomment-1427131768

However, this would obviously require a bigger refactoring.

For the time being, I'd really appreciate if we could either merge (and release) the bugfix in #73162 or this PR here. Over the course over the last half year I've tried numerous hacks on user side trying to work around this bug, but I don't think there is anything that's really practical. Either of the two PRs would change the situation from "more or less unusable" to "basically fully working", so I hope we can go for a temporary fix now, and look into this bigger refactoring as a second step.

