### PR TITLE
Fix Godot exitcode

### DIFF
--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -74,6 +74,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (Main::start()) {
+		os.set_exit_code(EXIT_SUCCESS);
 		os.run(); // It is actually the OS that decides how to run.
 	}
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -177,6 +177,7 @@ int widechar_main(int argc, wchar_t **argv) {
 	}
 
 	if (Main::start()) {
+		os.set_exit_code(EXIT_SUCCESS);
 		os.run();
 	}
 	Main::cleanup();


### PR DESCRIPTION
Fix unexpected error exit codes when closing the game.

Fixes #62898 for Windows and macOS as was done in #67421 for Linux already.

Another possibility would be to change how `_exit_code` is initialized in the OS base class,
but I don't know if this would have undesired side-effects for other platforms.