### PR TITLE
Allow contextual plugins to persist temporarily

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3391,11 +3391,16 @@ Object *EditorInspector::get_edited_object() {
 	return object;
 }
 
+Object *EditorInspector::get_next_edited_object() {
+	return next_object;
+}
+
 void EditorInspector::edit(Object *p_object) {
 	if (object == p_object) {
 		return;
 	}
 
+	next_object = p_object; // Some plugins need to know the next edited object when clearing the inspector.
 	if (object) {
 		_clear();
 		object->disconnect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
@@ -3412,6 +3417,10 @@ void EditorInspector::edit(Object *p_object) {
 		object->connect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
 		update_tree();
 	}
+
+	// Keep it available until the end so it works with both main and sub inspectors.
+	next_object = nullptr;
+
 	emit_signal(SNAME("edited_object_changed"));
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -473,6 +473,7 @@ class EditorInspector : public ScrollContainer {
 
 	void _clear(bool p_hide_plugins = true);
 	Object *object = nullptr;
+	Object *next_object = nullptr;
 
 	//
 
@@ -576,6 +577,7 @@ public:
 	void update_property(const String &p_prop);
 	void edit(Object *p_object);
 	Object *get_edited_object();
+	Object *get_next_edited_object();
 
 	void set_keying(bool p_active);
 	void set_read_only(bool p_read_only);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -550,6 +550,7 @@ private:
 
 	void _remove_plugin_from_enabled(const String &p_name);
 	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object);
+	void _plugin_over_self_own(EditorPlugin *p_plugin);
 
 	void _fs_changed();
 	void _resources_reimported(const Vector<String> &p_resources);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -335,6 +335,10 @@ bool EditorPlugin::handles(Object *p_object) const {
 	return success;
 }
 
+bool EditorPlugin::can_auto_hide() const {
+	return true;
+}
+
 Dictionary EditorPlugin::get_state() const {
 	Dictionary state;
 	GDVIRTUAL_CALL(_get_state, state);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -178,6 +178,7 @@ public:
 	virtual void selected_notify() {} //notify that it was raised by the user, not the editor
 	virtual void edit(Object *p_object);
 	virtual bool handles(Object *p_object) const;
+	virtual bool can_auto_hide() const;
 	virtual Dictionary get_state() const; //save editor state so it can't be reloaded when reloading scene
 	virtual void set_state(const Dictionary &p_state); //restore editor state (likely was saved with the scene)
 	virtual void clear(); // clear any temporary data in the editor, reset it (likely new scene or load another scene)

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/inspector_dock.h"
 #include "editor/progress_dialog.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/color_picker.h"
@@ -3528,6 +3529,16 @@ void ThemeEditor::_theme_edit_button_cbk() {
 	theme_edit_dialog->popup_centered(Size2(850, 700) * EDSCALE);
 }
 
+void ThemeEditor::_theme_close_button_cbk() {
+	plugin->make_visible(false); // Enables auto hide.
+	if (theme.is_valid() && InspectorDock::get_inspector_singleton()->get_edited_object() == theme.ptr()) {
+		EditorNode::get_singleton()->push_item(nullptr);
+	} else {
+		theme = Ref<Theme>();
+		EditorNode::get_singleton()->hide_unused_editors(plugin);
+	}
+}
+
 void ThemeEditor::_add_preview_button_cbk() {
 	preview_scene_dialog->popup_file_dialog();
 }
@@ -3645,6 +3656,12 @@ ThemeEditor::ThemeEditor() {
 	theme_save_as_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_save_button_cbk).bind(true));
 	top_menu->add_child(theme_save_as_button);
 
+	Button *theme_close_button = memnew(Button);
+	theme_close_button->set_text(TTR("Close"));
+	theme_close_button->set_flat(true);
+	theme_close_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_close_button_cbk));
+	top_menu->add_child(theme_close_button);
+
 	top_menu->add_child(memnew(VSeparator));
 
 	Button *theme_edit_button = memnew(Button);
@@ -3711,20 +3728,12 @@ ThemeEditor::ThemeEditor() {
 
 ///////////////////////
 
-void ThemeEditorPlugin::edit(Object *p_node) {
-	if (Object::cast_to<Theme>(p_node)) {
-		theme_editor->edit(Object::cast_to<Theme>(p_node));
-	} else {
-		// We intentionally keep a reference to the last used theme to work around
-		// the the editor being hidden while base resources are edited. Uncomment
-		// the following line again and remove this comment once that bug has been
-		// fixed (scheduled for Godot 4.1 in PR 73098):
-		// theme_editor->edit(Ref<Theme>());
-	}
+void ThemeEditorPlugin::edit(Object *p_object) {
+	theme_editor->edit(Ref<Theme>(p_object));
 }
 
-bool ThemeEditorPlugin::handles(Object *p_node) const {
-	return Object::cast_to<Theme>(p_node) != nullptr;
+bool ThemeEditorPlugin::handles(Object *p_object) const {
+	return Object::cast_to<Theme>(p_object) != nullptr;
 }
 
 void ThemeEditorPlugin::make_visible(bool p_visible) {
@@ -3740,8 +3749,77 @@ void ThemeEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
+bool ThemeEditorPlugin::can_auto_hide() const {
+	Ref<Theme> edited_theme = theme_editor->theme;
+	if (edited_theme.is_null()) {
+		return true;
+	}
+
+	Ref<Resource> edited_resource = Ref<Resource>(InspectorDock::get_inspector_singleton()->get_next_edited_object());
+	if (edited_resource.is_null()) {
+		return true;
+	}
+
+	// Don't hide if edited resource used by this theme.
+	Ref<StyleBox> sbox = edited_resource;
+	if (sbox.is_valid()) {
+		List<StringName> type_list;
+		edited_theme->get_stylebox_type_list(&type_list);
+
+		for (const StringName &E : type_list) {
+			List<StringName> list;
+			edited_theme->get_stylebox_list(E, &list);
+
+			for (const StringName &F : list) {
+				if (edited_theme->get_stylebox(F, E) == sbox) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	Ref<Texture2D> tex = edited_resource;
+	if (tex.is_valid()) {
+		List<StringName> type_list;
+		edited_theme->get_icon_type_list(&type_list);
+
+		for (const StringName &E : type_list) {
+			List<StringName> list;
+			edited_theme->get_icon_list(E, &list);
+
+			for (const StringName &F : list) {
+				if (edited_theme->get_icon(F, E) == tex) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	Ref<Font> fnt = edited_resource;
+	if (fnt.is_valid()) {
+		List<StringName> type_list;
+		edited_theme->get_font_type_list(&type_list);
+
+		for (const StringName &E : type_list) {
+			List<StringName> list;
+			edited_theme->get_font_list(E, &list);
+
+			for (const StringName &F : list) {
+				if (edited_theme->get_font(F, E) == fnt) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+	return true;
+}
+
 ThemeEditorPlugin::ThemeEditorPlugin() {
 	theme_editor = memnew(ThemeEditor);
+	theme_editor->plugin = this;
 	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
 	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Theme"), theme_editor);

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -47,6 +47,7 @@ class OptionButton;
 class PanelContainer;
 class TabBar;
 class TabContainer;
+class ThemeEditorPlugin;
 class TextureRect;
 
 class ThemeItemImportTree : public VBoxContainer {
@@ -419,6 +420,9 @@ public:
 class ThemeEditor : public VBoxContainer {
 	GDCLASS(ThemeEditor, VBoxContainer);
 
+	friend class ThemeEditorPlugin;
+	ThemeEditorPlugin *plugin = nullptr;
+
 	Ref<Theme> theme;
 
 	TabBar *preview_tabs = nullptr;
@@ -433,6 +437,7 @@ class ThemeEditor : public VBoxContainer {
 
 	void _theme_save_button_cbk(bool p_save_as);
 	void _theme_edit_button_cbk();
+	void _theme_close_button_cbk();
 
 	void _add_preview_button_cbk();
 	void _preview_scene_dialog_cbk(const String &p_path);
@@ -462,9 +467,10 @@ class ThemeEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Theme"; }
 	bool has_main_screen() const override { return false; }
-	virtual void edit(Object *p_node) override;
-	virtual bool handles(Object *p_node) const override;
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+	virtual bool can_auto_hide() const override;
 
 	ThemeEditorPlugin();
 };


### PR DESCRIPTION
Fixes #72271

This makes the theme editor semi-persistent. If you edit a theme from the FileSystem Dock or directly in the inspector (via Edit), the editor will not be closed when something else takes over its editing context. A close button was added to close the editor manually.
The editor can still close automatically if its editing context vanishes (EditorProperty).

https://github.com/godotengine/godot/assets/2223172/7c23c1c8-be56-4085-83f3-b60316eab9d4

