### PR TITLE
Check if property exists before tweening

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -104,7 +104,15 @@ Ref<PropertyTweener> Tween::tween_property(const Object *p_target, const NodePat
 	CHECK_VALID();
 
 	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();
-	if (!_validate_type_match(p_target->get_indexed(property_subnames), p_to)) {
+#ifdef DEBUG_ENABLED
+	bool prop_valid;
+	const Variant &prop_value = p_target->get_indexed(property_subnames, &prop_valid);
+	ERR_FAIL_COND_V_MSG(!prop_valid, nullptr, vformat("The tweened property \"%s\" does not exist in object \"%s\".", p_property, p_target));
+#else
+	const Variant &prop_value = p_target->get_indexed(property_subnames);
+#endif
+
+	if (!_validate_type_match(prop_value, p_to)) {
 		return nullptr;
 	}
 


### PR DESCRIPTION
When you try to tween a non-existent property, you get a confusing message about type mismatch between "nil" and target value type.
This PR adds a debug check whether a property exists, to print a clearer error.