### PR TITLE
Fix some keys triggering their actions twice in GridMap

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -749,6 +749,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 				for (int i = 0; i < options->get_popup()->get_item_count(); ++i) {
 					const Ref<Shortcut> &shortcut = options->get_popup()->get_item_shortcut(i);
 					if (shortcut.is_valid() && shortcut->matches_event(p_event)) {
+						accept_event();
 						_menu_option(options->get_popup()->get_item_id(i));
 						return EditorPlugin::AFTER_GUI_INPUT_STOP;
 					}


### PR DESCRIPTION
This is a bug introduced by #79529.

Some keys (not all) trigger the associated action twice: one is triggered by the `forward_spatial_input_event` method as intended in the PR and another time from the menu event handler (not intended, we were supposed to prevent further inputs).

The original code contained the `accept_event()` statement but it was removed after the code review.
Apologies for not testing this thoroughly... :disappointed: 

@KoBeWi Can I have your input on this, I'm not sure if it's the right way but it does fix the bug.