### PR TITLE
Fix `button_up` and `button_down` signals with focus changes or multiple inputs

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -115,6 +115,11 @@ void BaseButton::_notification(int p_what) {
 			} else if (status.hovering) {
 				queue_redraw();
 			}
+
+			if (status.pressed_down_with_focus) {
+				status.pressed_down_with_focus = false;
+				emit_signal(SNAME("button_up"));
+			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED:
@@ -147,9 +152,10 @@ void BaseButton::_toggled(bool p_pressed) {
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseButton> mouse_button = p_event;
 
-	if (p_event->is_pressed() && (mouse_button.is_null() || status.hovering)) {
+	if (!status.pressed_down_with_focus && p_event->is_pressed() && (mouse_button.is_null() || status.hovering)) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
+		status.pressed_down_with_focus = true;
 		emit_signal(SNAME("button_down"));
 	}
 
@@ -176,9 +182,10 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 	}
 
-	if (!p_event->is_pressed()) {
+	if (status.pressed_down_with_focus && !p_event->is_pressed()) {
 		status.press_attempt = false;
 		status.pressing_inside = false;
+		status.pressed_down_with_focus = false;
 		emit_signal(SNAME("button_up"));
 	}
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -61,7 +61,7 @@ private:
 		bool hovering = false;
 		bool press_attempt = false;
 		bool pressing_inside = false;
-
+		bool pressed_down_with_focus = false;
 		bool disabled = false;
 
 	} status;


### PR DESCRIPTION
Proposed fix for #52578. Adds a flag to guard `button_up` and `button_down` events based on whether `button_down` has been previously emitted while focused, and emits `button_up` if focus is lost after `button_down` is emitted. 

Behavior changes are that buttons:
* emit `button_up` signals if they have emitted `button_down`, have not yet emitted `button_up`, and lose focus
* do not emit `button_up` if they gain focus while a `ui_accept` key is still pressed and it is subsequently released
* do not emit multiple up/down signals if multiple press actions overlap (e.g., space and enter keys)

This is based on work in #52621, but seems to avoid the mouse-event regressions identified for that PR. In particular:
* pressed buttons with `keep_pressed_outside` correctly become unpressed when the mouse click is released outside the button area
* pressed buttons without `keep_pressed_outside` do not become re-pressed if the mouse click is released outside the button area and the cursor subsequently re-enters the button area

![button-focus-event-bug-cropped](https://github.com/godotengine/godot/assets/23439518/6d7dd84a-f547-4a99-8ac4-afe44ca26282)

I know there are pitfalls and subtleties around this behavior, so I'm happy to hear if this needs to be changed in some way - or it's fine if this approach doesn't work for some reason I didn't anticipate.

I'm attaching a test project I used to check for introduced bugs, in case it's helpful - it's not exhaustive, but it has many different kinds of buttons with different options set to see if their behavior remains correct. 
[ButtonDownUpFocusBug.zip](https://github.com/godotengine/godot/files/12571799/ButtonDownUpFocusBug.zip)

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/52578