### PR TITLE
C#: Fix assert and assembly unloading failure when using custom script parameters with a default value 

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -23,6 +23,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> ScriptManagerBridge_ScriptIsOrInherits;
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool> ScriptManagerBridge_AddScriptBridge;
         public delegate* unmanaged<godot_string*, godot_ref*, void> ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
+        public delegate* unmanaged<godot_string*, godot_ref*, godot_bool> ScriptManagerBridge_GetExistingScriptBridgeForPath;
         public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_RemoveScriptBridge;
         public delegate* unmanaged<IntPtr, godot_bool> ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
         public delegate* unmanaged<IntPtr, godot_string*, godot_bool*, godot_bool*, godot_bool*, godot_string*, godot_array*, godot_dictionary*, godot_dictionary*, godot_ref*, void> ScriptManagerBridge_UpdateScriptClassInfo;
@@ -65,6 +66,7 @@ namespace Godot.Bridge
                 ScriptManagerBridge_ScriptIsOrInherits = &ScriptManagerBridge.ScriptIsOrInherits,
                 ScriptManagerBridge_AddScriptBridge = &ScriptManagerBridge.AddScriptBridge,
                 ScriptManagerBridge_GetOrCreateScriptBridgeForPath = &ScriptManagerBridge.GetOrCreateScriptBridgeForPath,
+                ScriptManagerBridge_GetExistingScriptBridgeForPath = &ScriptManagerBridge.GetExistingScriptBridgeForPath,
                 ScriptManagerBridge_RemoveScriptBridge = &ScriptManagerBridge.RemoveScriptBridge,
                 ScriptManagerBridge_TryReloadRegisteredScriptWithClass = &ScriptManagerBridge.TryReloadRegisteredScriptWithClass,
                 ScriptManagerBridge_UpdateScriptClassInfo = &ScriptManagerBridge.UpdateScriptClassInfo,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -451,6 +451,26 @@ namespace Godot.Bridge
             GetOrCreateScriptBridgeForType(scriptType, outScript);
         }
 
+        [UnmanagedCallersOnly]
+        internal static unsafe godot_bool GetExistingScriptBridgeForPath(godot_string* scriptPath, godot_ref* outScript)
+        {
+            string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
+
+            if (_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
+            {
+                lock (_scriptTypeBiMap.ReadWriteLock)
+                {
+                    if (_scriptTypeBiMap.TryGetScriptPtr(scriptType, out IntPtr scriptPtr))
+                    {
+                        NativeFuncs.godotsharp_ref_new_from_ref_counted_ptr(out *outScript, scriptPtr);
+                        return godot_bool.True;
+                    }
+                }
+            }
+
+            return godot_bool.False;
+        }
+
         private static unsafe void GetOrCreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
         {
             lock (_scriptTypeBiMap.ReadWriteLock)

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -64,6 +64,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, ScriptIsOrInherits);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, AddScriptBridge);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetOrCreateScriptBridgeForPath);
+	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, GetExistingScriptBridgeForPath);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, RemoveScriptBridge);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, TryReloadRegisteredScriptWithClass);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, UpdateScriptClassInfo);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -89,6 +89,7 @@ struct ManagedCallbacks {
 	using FuncScriptManagerBridge_ScriptIsOrInherits = bool(GD_CLR_STDCALL *)(const CSharpScript *, const CSharpScript *);
 	using FuncScriptManagerBridge_AddScriptBridge = bool(GD_CLR_STDCALL *)(const CSharpScript *, const String *);
 	using FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath = void(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
+	using FuncScriptManagerBridge_GetExistingScriptBridgeForPath = bool(GD_CLR_STDCALL *)(const String *, Ref<CSharpScript> *);
 	using FuncScriptManagerBridge_RemoveScriptBridge = void(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass = bool(GD_CLR_STDCALL *)(const CSharpScript *);
 	using FuncScriptManagerBridge_UpdateScriptClassInfo = void(GD_CLR_STDCALL *)(const CSharpScript *, String *, bool *, bool *, bool *, String *, Array *, Dictionary *, Dictionary *, Ref<CSharpScript> *);
@@ -125,6 +126,7 @@ struct ManagedCallbacks {
 	FuncScriptManagerBridge_ScriptIsOrInherits ScriptManagerBridge_ScriptIsOrInherits;
 	FuncScriptManagerBridge_AddScriptBridge ScriptManagerBridge_AddScriptBridge;
 	FuncScriptManagerBridge_GetOrCreateScriptBridgeForPath ScriptManagerBridge_GetOrCreateScriptBridgeForPath;
+	FuncScriptManagerBridge_GetExistingScriptBridgeForPath ScriptManagerBridge_GetExistingScriptBridgeForPath;
 	FuncScriptManagerBridge_RemoveScriptBridge ScriptManagerBridge_RemoveScriptBridge;
 	FuncScriptManagerBridge_TryReloadRegisteredScriptWithClass ScriptManagerBridge_TryReloadRegisteredScriptWithClass;
 	FuncScriptManagerBridge_UpdateScriptClassInfo ScriptManagerBridge_UpdateScriptClassInfo;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80175

When an assemby reload gets triggered and a user script is loaded that uses another user script as a parameter with a default value, that script will be loaded on the spot and registered to the `ScriptManagerBridge` `ScriptTypeBiMap`. 
After the assembly reload is done, the script gets reloaded as well and an attempt is made to add it to the map, which will trigger a double insertion assert when trying to add the type to `_typeScriptMap`, but the pointer does gets added to `_scriptTypeMap` which seems to then forever prevent assembly unloading since the pointer lingers in the dictionary.

The fix is fairly naive since I'm not all that familiar with the codebase, so feel free to see this PR as more of an attempt to bring more attention to the issue in case a more comprehensive solution is necessary here (the assembly reloading error is a big workflow hamper for me as it requires a restart after any code change, or to work around the issue by not using default values which is something I'd like to avoid if possible).

MRPs can be found in the original issue - tested that reloading worked correctly without editor errors on both.