### PR TITLE
Add beat and bar getters to AudioStreamPlayer[2D/3D]

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -10,6 +10,30 @@
 		<link title="Audio Generator Demo">https://godotengine.org/asset-library/asset/526</link>
 	</tutorials>
 	<methods>
+		<method name="_get_bar_progress" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Should return how far the playback has progressed from the last musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) to the next in range [code][0.0, 1.0][/code].
+			</description>
+		</method>
+		<method name="_get_beat_progress" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+				Should return how far the playback has progressed from the last musical beat to the next in range [code][0.0, 1.0][/code].
+			</description>
+		</method>
+		<method name="_get_current_bar" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Should return the index of the current musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) from the start of the stream, starting at 0.
+			</description>
+		</method>
+		<method name="_get_current_beat" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Should return the index of the current musical beat from the start of the bar in range [code][0, bar_beats - 1][/code].
+			</description>
+		</method>
 		<method name="_get_loop_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>

--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -16,6 +16,34 @@
 		<link title="Audio Spectrum Demo">https://godotengine.org/asset-library/asset/528</link>
 	</tutorials>
 	<methods>
+		<method name="get_bar_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) to the next in range [code][0.0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_beat_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical beat to the next in range [code][0.0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_bar" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) from the start of the stream, starting at 0.
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_beat" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical beat from the start of the bar in range [code][0, bar_beats - 1][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
 		<method name="get_playback_position">
 			<return type="float" />
 			<description>

--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -13,6 +13,34 @@
 		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_bar_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) to the next in range [code][0.0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_beat_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical beat to the next in range [code][0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_bar" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) from the start of the stream, starting at 0.
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_beat" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical beat from the start of the bar in range [code][0, bar_beats - 1][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
 		<method name="get_playback_position">
 			<return type="float" />
 			<description>

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -13,6 +13,34 @@
 		<link title="Audio streams">$DOCS_URL/tutorials/audio/audio_streams.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_bar_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) to the next in range [code][0.0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_beat_progress" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns how far the playback has progressed from the last musical beat to the next in range [code][0.0, 1.0][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_bar" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical bar (usually 4 beats, depends on `bar_beats` in the stream import settings) from the start of the stream, starting at 0.
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
+		<method name="get_current_beat" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the current musical beat from the start of the bar in range [code][0, bar_beats - 1][/code].
+				You need to set the BPM in the audio import settings for this to work.
+			</description>
+		</method>
 		<method name="get_playback_position">
 			<return type="float" />
 			<description>

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -143,6 +143,31 @@ void AudioStreamPlaybackMP3::tag_used_streams() {
 	mp3_stream->tag_used(get_playback_position());
 }
 
+int AudioStreamPlaybackMP3::get_frames_per_beat() const {
+	ERR_FAIL_COND_V_MSG(mp3_stream->get_bpm() <= 0, -1, "bpm needs to be assigned in import settings.");
+	return mp3_stream->sample_rate * 60 / mp3_stream->get_bpm();
+}
+
+int AudioStreamPlaybackMP3::get_current_beat() const {
+	ERR_FAIL_COND_V_MSG(mp3_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return (frames_mixed / get_frames_per_beat()) % mp3_stream->bar_beats;
+}
+
+int AudioStreamPlaybackMP3::get_current_bar() const {
+	ERR_FAIL_COND_V_MSG(mp3_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return (frames_mixed / get_frames_per_beat()) / mp3_stream->bar_beats;
+}
+
+float AudioStreamPlaybackMP3::get_beat_progress() const {
+	ERR_FAIL_COND_V_MSG(mp3_stream->get_bpm() <= 0, -1, "bpm needs to be assigned in import settings.");
+	return Math::fmod(frames_mixed / (float)get_frames_per_beat(), 1.0f);
+}
+
+float AudioStreamPlaybackMP3::get_bar_progress() const {
+	ERR_FAIL_COND_V_MSG(mp3_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return Math::fmod(frames_mixed / (float)(mp3_stream->bar_beats * get_frames_per_beat()), 1.0f);
+}
+
 AudioStreamPlaybackMP3::~AudioStreamPlaybackMP3() {
 	if (mp3d) {
 		mp3dec_ex_close(mp3d);

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -59,6 +59,7 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 protected:
 	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
+	int get_frames_per_beat() const;
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;
@@ -71,6 +72,11 @@ public:
 	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
+
+	virtual int get_current_beat() const override;
+	virtual int get_current_bar() const override;
+	virtual float get_beat_progress() const override;
+	virtual float get_bar_progress() const override;
 
 	AudioStreamPlaybackMP3() {}
 	~AudioStreamPlaybackMP3();

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -257,6 +257,31 @@ void AudioStreamPlaybackOggVorbis::tag_used_streams() {
 	vorbis_stream->tag_used(get_playback_position());
 }
 
+int AudioStreamPlaybackOggVorbis::get_frames_per_beat() const {
+	ERR_FAIL_COND_V_MSG(vorbis_stream->get_bpm() <= 0, -1, "bpm needs to be assigned in import settings.");
+	return vorbis_data->get_sampling_rate() * 60 / vorbis_stream->get_bpm();
+}
+
+int AudioStreamPlaybackOggVorbis::get_current_beat() const {
+	ERR_FAIL_COND_V_MSG(vorbis_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return (frames_mixed / get_frames_per_beat()) % vorbis_stream->bar_beats;
+}
+
+int AudioStreamPlaybackOggVorbis::get_current_bar() const {
+	ERR_FAIL_COND_V_MSG(vorbis_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return (frames_mixed / get_frames_per_beat()) / vorbis_stream->bar_beats;
+}
+
+float AudioStreamPlaybackOggVorbis::get_beat_progress() const {
+	ERR_FAIL_COND_V_MSG(vorbis_stream->get_bpm() <= 0, -1, "bpm needs to be assigned in import settings.");
+	return Math::fmod(frames_mixed / (float)get_frames_per_beat(), 1.0f);
+}
+
+float AudioStreamPlaybackOggVorbis::get_bar_progress() const {
+	ERR_FAIL_COND_V_MSG(vorbis_stream->bar_beats <= 0, -1, "bar_beats needs to be assigned in import settings.");
+	return Math::fmod(frames_mixed / (float)(vorbis_stream->bar_beats * get_frames_per_beat()), 1.0f);
+}
+
 void AudioStreamPlaybackOggVorbis::seek(double p_time) {
 	ERR_FAIL_COND(!ready);
 	ERR_FAIL_COND(vorbis_stream.is_null());

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -82,6 +82,7 @@ class AudioStreamPlaybackOggVorbis : public AudioStreamPlaybackResampled {
 protected:
 	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
+	int get_frames_per_beat() const;
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;
@@ -94,6 +95,11 @@ public:
 	virtual void seek(double p_time) override;
 
 	virtual void tag_used_streams() override;
+
+	virtual int get_current_beat() const override;
+	virtual int get_current_bar() const override;
+	virtual float get_beat_progress() const override;
+	virtual float get_bar_progress() const override;
 
 	AudioStreamPlaybackOggVorbis() {}
 	~AudioStreamPlaybackOggVorbis();

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -403,6 +403,34 @@ Ref<AudioStreamPlayback> AudioStreamPlayer2D::get_stream_playback() {
 	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
+int AudioStreamPlayer2D::get_current_beat() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_beat();
+}
+
+int AudioStreamPlayer2D::get_current_bar() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_bar();
+}
+
+float AudioStreamPlayer2D::get_beat_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_beat_progress();
+}
+
+float AudioStreamPlayer2D::get_bar_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_bar_progress();
+}
+
 void AudioStreamPlayer2D::set_max_polyphony(int p_max_polyphony) {
 	if (p_max_polyphony > 0) {
 		max_polyphony = p_max_polyphony;
@@ -476,6 +504,11 @@ void AudioStreamPlayer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_stream_playback"), &AudioStreamPlayer2D::has_stream_playback);
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer2D::get_stream_playback);
+
+	ClassDB::bind_method(D_METHOD("get_current_beat"), &AudioStreamPlayer2D::get_current_beat);
+	ClassDB::bind_method(D_METHOD("get_current_bar"), &AudioStreamPlayer2D::get_current_bar);
+	ClassDB::bind_method(D_METHOD("get_beat_progress"), &AudioStreamPlayer2D::get_beat_progress);
+	ClassDB::bind_method(D_METHOD("get_bar_progress"), &AudioStreamPlayer2D::get_bar_progress);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,suffix:dB"), "set_volume_db", "get_volume_db");

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -137,6 +137,11 @@ public:
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();
 
+	int get_current_beat() const;
+	int get_current_bar() const;
+	float get_beat_progress() const;
+	float get_bar_progress() const;
+
 	AudioStreamPlayer2D();
 	~AudioStreamPlayer2D();
 };

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -791,6 +791,34 @@ Ref<AudioStreamPlayback> AudioStreamPlayer3D::get_stream_playback() {
 	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
+int AudioStreamPlayer3D::get_current_beat() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_beat();
+}
+
+int AudioStreamPlayer3D::get_current_bar() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_bar();
+}
+
+float AudioStreamPlayer3D::get_beat_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_beat_progress();
+}
+
+float AudioStreamPlayer3D::get_bar_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_bar_progress();
+}
+
 void AudioStreamPlayer3D::set_max_polyphony(int p_max_polyphony) {
 	if (p_max_polyphony > 0) {
 		max_polyphony = p_max_polyphony;
@@ -888,6 +916,11 @@ void AudioStreamPlayer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_stream_playback"), &AudioStreamPlayer3D::has_stream_playback);
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer3D::get_stream_playback);
+
+	ClassDB::bind_method(D_METHOD("get_current_beat"), &AudioStreamPlayer3D::get_current_beat);
+	ClassDB::bind_method(D_METHOD("get_current_bar"), &AudioStreamPlayer3D::get_current_bar);
+	ClassDB::bind_method(D_METHOD("get_beat_progress"), &AudioStreamPlayer3D::get_beat_progress);
+	ClassDB::bind_method(D_METHOD("get_bar_progress"), &AudioStreamPlayer3D::get_bar_progress);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,Inverse Square,Logarithmic,Disabled"), "set_attenuation_model", "get_attenuation_model");

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -193,6 +193,11 @@ public:
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();
 
+	int get_current_beat() const;
+	int get_current_bar() const;
+	float get_beat_progress() const;
+	float get_bar_progress() const;
+
 	AudioStreamPlayer3D();
 	~AudioStreamPlayer3D();
 };

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -320,6 +320,34 @@ Ref<AudioStreamPlayback> AudioStreamPlayer::get_stream_playback() {
 	return stream_playbacks[stream_playbacks.size() - 1];
 }
 
+int AudioStreamPlayer::get_current_beat() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_beat();
+}
+
+int AudioStreamPlayer::get_current_bar() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_current_bar();
+}
+
+float AudioStreamPlayer::get_beat_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_beat_progress();
+}
+
+float AudioStreamPlayer::get_bar_progress() const {
+	if (stream_playbacks.is_empty()) {
+		return 0;
+	}
+	return stream_playbacks[stream_playbacks.size() - 1]->get_bar_progress();
+}
+
 void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &AudioStreamPlayer::set_stream);
 	ClassDB::bind_method(D_METHOD("get_stream"), &AudioStreamPlayer::get_stream);
@@ -357,6 +385,11 @@ void AudioStreamPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_stream_playback"), &AudioStreamPlayer::has_stream_playback);
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer::get_stream_playback);
+
+	ClassDB::bind_method(D_METHOD("get_current_beat"), &AudioStreamPlayer::get_current_beat);
+	ClassDB::bind_method(D_METHOD("get_current_bar"), &AudioStreamPlayer::get_current_bar);
+	ClassDB::bind_method(D_METHOD("get_beat_progress"), &AudioStreamPlayer::get_beat_progress);
+	ClassDB::bind_method(D_METHOD("get_bar_progress"), &AudioStreamPlayer::get_bar_progress);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,suffix:dB"), "set_volume_db", "get_volume_db");

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -107,6 +107,11 @@ public:
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();
 
+	int get_current_beat() const;
+	int get_current_bar() const;
+	float get_beat_progress() const;
+	float get_bar_progress() const;
+
 	AudioStreamPlayer();
 	~AudioStreamPlayer();
 };

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -80,15 +80,43 @@ void AudioStreamPlayback::tag_used_streams() {
 	GDVIRTUAL_CALL(_tag_used_streams);
 }
 
+int AudioStreamPlayback::get_current_beat() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_current_beat, ret);
+	return ret;
+}
+
+int AudioStreamPlayback::get_current_bar() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_current_bar, ret);
+	return ret;
+}
+
+float AudioStreamPlayback::get_beat_progress() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_beat_progress, ret);
+	return ret;
+}
+
+float AudioStreamPlayback::get_bar_progress() const {
+	float ret = 0;
+	GDVIRTUAL_CALL(_get_bar_progress, ret);
+	return ret;
+}
+
 void AudioStreamPlayback::_bind_methods() {
-	GDVIRTUAL_BIND(_start, "from_pos")
-	GDVIRTUAL_BIND(_stop)
-	GDVIRTUAL_BIND(_is_playing)
-	GDVIRTUAL_BIND(_get_loop_count)
-	GDVIRTUAL_BIND(_get_playback_position)
-	GDVIRTUAL_BIND(_seek, "position")
+	GDVIRTUAL_BIND(_start, "from_pos");
+	GDVIRTUAL_BIND(_stop);
+	GDVIRTUAL_BIND(_is_playing);
+	GDVIRTUAL_BIND(_get_loop_count);
+	GDVIRTUAL_BIND(_get_playback_position);
+	GDVIRTUAL_BIND(_seek, "position");
 	GDVIRTUAL_BIND(_mix, "buffer", "rate_scale", "frames");
 	GDVIRTUAL_BIND(_tag_used_streams);
+	GDVIRTUAL_BIND(_get_current_beat);
+	GDVIRTUAL_BIND(_get_current_bar);
+	GDVIRTUAL_BIND(_get_beat_progress);
+	GDVIRTUAL_BIND(_get_bar_progress);
 }
 //////////////////////////////
 
@@ -211,7 +239,7 @@ double AudioStream::get_bpm() const {
 }
 
 bool AudioStream::has_loop() const {
-	bool ret = 0;
+	bool ret = false;
 	GDVIRTUAL_CALL(_has_loop, ret);
 	return ret;
 }
@@ -257,8 +285,8 @@ void AudioStream::_bind_methods() {
 	GDVIRTUAL_BIND(_get_stream_name);
 	GDVIRTUAL_BIND(_get_length);
 	GDVIRTUAL_BIND(_is_monophonic);
-	GDVIRTUAL_BIND(_get_bpm)
-	GDVIRTUAL_BIND(_get_beat_count)
+	GDVIRTUAL_BIND(_get_bpm);
+	GDVIRTUAL_BIND(_get_beat_count);
 }
 
 ////////////////////////////////

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -54,6 +54,10 @@ protected:
 	GDVIRTUAL1(_seek, double)
 	GDVIRTUAL3R(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
+	GDVIRTUAL0RC(int, _get_current_beat)
+	GDVIRTUAL0RC(int, _get_current_bar)
+	GDVIRTUAL0RC(float, _get_beat_progress)
+	GDVIRTUAL0RC(float, _get_bar_progress)
 public:
 	virtual void start(double p_from_pos = 0.0);
 	virtual void stop();
@@ -65,6 +69,11 @@ public:
 	virtual void seek(double p_time);
 
 	virtual void tag_used_streams();
+
+	virtual int get_current_beat() const;
+	virtual int get_current_bar() const;
+	virtual float get_beat_progress() const;
+	virtual float get_bar_progress() const;
 
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames);
 };


### PR DESCRIPTION
Implements godotengine/godot-proposals#6166.

## Video demo

https://github.com/godotengine/godot/assets/93539/161a47aa-1010-4875-a4e0-eb1a6130e628

## API
It adds the following functions and signals:

- `AudioStreamPlayer.get_current_beat() -> int`
- `AudioStreamPlayer.get_current_bar() -> int`
- `AudioStreamPlayer.get_beat_progress() -> float` in range [0,1]
- `AudioStreamPlayer.get_bar_progress() -> float` in range [0,1]
~- Signal `AudioStreamPlayback.beat_changed(beat: int)`~
~- Signal `AudioStreamPlayback.bar_changed(bar: int)`~

Edit: Signals were removed, see below.

This allows syncing gameplay or visual effects to the BPM (beats per minute) of music.
It is implemented for MP3 and OGG Vorbis streams (since those are the only ones that have BPM information attached, although it could be implemented for WAV if desired and the bpm/ bar_beats fields are added to that).
This works for `AudioStreamPlayer`, `AudioStreamPlayer2D` and `AudioStreamPlayer3D`.

## Test project
~[BeatToolsTestProject_v2.zip](https://github.com/godotengine/godot/files/12575207/BeatToolsTestProject_v2.zip)~

**Update**: New version that uses the signals on `AudioStreamPlayer` and adds tweens for label colors when the signals are triggered to demonstrate their usage.

[BeatToolsTestProject_v3.zip](https://github.com/godotengine/godot/files/12578734/BeatToolsTestProject_v3.zip)

This project contains two music files in ogg and mp3 formats with different BPM (to test both implementations and show that it syncs correctly to different speeds).

The contained music files are CC0 licensed and can be [found here](https://opengameart.org/content/t-t-free-cyberpunk-pack-2).

If desired, I can polish this project a bit and add it to the [godot-demo-projects](https://github.com/godotengine/godot-demo-projects) repository/ Godot Asset Library, so that we can show a working reference implementation for the BPM features.

## Outstanding work
<del>Ideally the events from `AudioStreamPlayback` would be exposed on `AudioStreamPlayer` as well (I have defined them there too, but haven't found a good way to re-emit a signal emitted by `AudioStreamPlayback` from `AudioStreamPlayer`, since `AudioStreamPlayback` doesn't have a reference to the player and the player can have multiple playback instances. If someone has an idea how this signal could be exposed, please let me know and I'll adjust the implementation. Otherwise I will remove the signal definitions from AudioStreamPlayer[2D/3D].</del>

<del>Another option would be to emit the signals from the AudioStream instead, which the AudioStreamPlayback has a reference to and could call a method on. This is slightly less elegant to work with in GDScript than signals emitted on the AudioStreamPlayer, since the stream might be changed and then the signals need to be reconnected from code. It also means that you can't connect the signal from the editor UI on the node as usual. It's much nicer than having to connect to signals on the AudioStreamPlayback object though, since that changes often (e.g. when seeking it seems) and isn't available until you play the stream (see the test project for this being tricky to work around).</del>

<del>Another issue is that the signals are emitted from the audio thread, so you have to use `call_deferred` or `set_deferred` to interact with UI or other nodes from a function connected to one of the signals (as seen in the example code). Is there a way to emit the signal on the main thread instead?</del>

**Update**: The signals are now emitted from `AudioStreamPlayer[2D/3D]` directly, so the GDScript interface is much nicer to use now. Thanks for the feedback and help in getting this to work! :sparkles: 