### PR TITLE
Apply global scale when redrawing Bone2D

### DIFF
--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -320,6 +320,8 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 	}
 
 	Vector2 rel;
+	Vector2 global_scale_abs = get_global_scale().abs();
+
 	if (p_other_bone) {
 		rel = (p_other_bone->get_global_position() - get_global_position());
 		rel = rel.rotated(-get_global_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
@@ -329,7 +331,7 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 		rel = rel.rotated(-get_rotation()); // Undo Bone2D node's rotation so its drawn correctly regardless of the node's rotation
 	}
 
-	Vector2 relt = rel.rotated(Math_PI * 0.5).normalized() * bone_width;
+	Vector2 relt = rel.rotated(Math_PI * 0.5).normalized() * bone_width * global_scale_abs;
 	Vector2 reln = rel.normalized();
 	Vector2 reltn = relt.normalized();
 
@@ -343,12 +345,12 @@ bool Bone2D::_editor_get_bone_shape(Vector<Vector2> *p_shape, Vector<Vector2> *p
 
 	if (p_outline_shape) {
 		p_outline_shape->clear();
-		p_outline_shape->push_back((-reln - reltn) * bone_outline_width);
-		p_outline_shape->push_back((-reln + reltn) * bone_outline_width);
-		p_outline_shape->push_back(rel * 0.2 + relt + reltn * bone_outline_width);
-		p_outline_shape->push_back(rel + (reln + reltn) * bone_outline_width);
-		p_outline_shape->push_back(rel + (reln - reltn) * bone_outline_width);
-		p_outline_shape->push_back(rel * 0.2 - relt - reltn * bone_outline_width);
+		p_outline_shape->push_back((-reln - reltn) * bone_outline_width * global_scale_abs);
+		p_outline_shape->push_back((-reln + reltn) * bone_outline_width * global_scale_abs);
+		p_outline_shape->push_back(rel * 0.2 + relt + reltn * bone_outline_width * global_scale_abs);
+		p_outline_shape->push_back(rel + (reln + reltn) * bone_outline_width * global_scale_abs);
+		p_outline_shape->push_back(rel + (reln - reltn) * bone_outline_width * global_scale_abs);
+		p_outline_shape->push_back(rel * 0.2 - relt - reltn * bone_outline_width * global_scale_abs);
 	}
 	return true;
 }


### PR DESCRIPTION
Issue: #76087  

Creating a Bone2D and scaling works as expected, the problem happens when the user save the scene.  
Godot will redraw the bone using the same function that created it and this function doesn't seem to take scale in account.  

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
