### PR TITLE
Fix LightmapGI baking with GridMap

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -372,7 +372,7 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 	Node3D *s = Object::cast_to<Node3D>(p_at_node);
 
 	if (!mi && s) {
-		Array bmeshes = p_at_node->call("get_bake_bmeshes");
+		Array bmeshes = p_at_node->call("get_bake_meshes");
 		if (bmeshes.size() && (bmeshes.size() & 1) == 0) {
 			Transform3D xf = get_global_transform().affine_inverse() * s->get_global_transform();
 			for (int i = 0; i < bmeshes.size(); i += 2) {


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/56030
* Closes https://github.com/godotengine/godot-proposals/issues/5701. I think this was already supported, but this bug just stopped it from working.

Looks like a typo was made in https://github.com/godotengine/godot/pull/38386. A variable was renamed from `meshes` to `bmeshes` and looks like the string content was accidentally changed too which stopped GridMap from working when baking lightmaps.

The issue MRP project is old and seems a bit messed up, tweaking the light direction and other settings a bit made things look better, seems there' some odd culling/light issues too with some meshes. Could be caused by some legacy mesh format changes or something else. 

GridMap on the left, baking started working after this fix:

![gridmap2](https://github.com/godotengine/godot/assets/22456603/5b4ef246-73b0-474a-810c-7929cb10fc6c)
