### PR TITLE
Hide the `dialog_text` property from `FileDialog`

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -91,6 +91,13 @@ VBoxContainer *FileDialog::get_vbox() {
 	return vbox;
 }
 
+void FileDialog::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "dialog_text") {
+		// File dialogs have a custom layout, and dialog nodes can't have both a text and a layout.
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
 void FileDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -166,6 +166,7 @@ private:
 	virtual void _post_popup() override;
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
It's useless in `FileDialog`, because dialogs can have either a text label or a custom layout, and `FileDialog` already has a custom layout. If you use the property, this is what it ends up looking like:


<img width="321" alt="godot windows editor dev x86_64_2023-09-11_14-47-52" src="https://github.com/godotengine/godot/assets/11782833/ef0ffc12-9563-4924-a505-6f264ac4bd83">

So to avoid confusion I propose we just hide it, like we do in other nodes in similar cases.

~PS. I'll have to rebase after https://github.com/godotengine/godot/pull/81312 due to neighboring changes in the header file.~ Done.