### PR TITLE
Improve the looks of 2D/3D viewport contextual toolbars

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -844,13 +844,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// even though it may not be immediately obvious at first.
 	Ref<StyleBoxFlat> toolbar_stylebox = memnew(StyleBoxFlat);
 	toolbar_stylebox->set_bg_color(accent_color * Color(1, 1, 1, 0.1));
-	toolbar_stylebox->set_corner_radius(CORNER_TOP_LEFT, corner_radius * EDSCALE);
-	toolbar_stylebox->set_corner_radius(CORNER_TOP_RIGHT, corner_radius * EDSCALE);
 	toolbar_stylebox->set_anti_aliased(false);
 	// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
 	toolbar_stylebox->set_border_color(accent_color);
 	toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
 	toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
+	toolbar_stylebox->set_expand_margin_all(2 * EDSCALE);
 	theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
 
 	// Script Editor

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -725,7 +725,6 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
 	selected_point = Vertex();
 	edge_point = PosVertex();
 
-	add_child(memnew(VSeparator));
 	button_create = memnew(Button);
 	button_create->set_flat(true);
 	add_child(button_create);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3888,7 +3888,7 @@ void CanvasItemEditor::_update_editor_settings() {
 	key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
 	animation_menu->set_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
-	context_menu_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
+	context_toolbar_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 
 	panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/2d_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EDITOR_GET("editors/panning/simple_panning")));
 	panner->set_scroll_speed(EDITOR_GET("editors/panning/2d_editor_pan_speed"));
@@ -4941,13 +4941,51 @@ void CanvasItemEditor::clear() {
 }
 
 void CanvasItemEditor::add_control_to_menu_panel(Control *p_control) {
-	ERR_FAIL_COND(!p_control);
+	ERR_FAIL_NULL(p_control);
+	ERR_FAIL_COND(p_control->get_parent());
 
-	context_menu_hbox->add_child(p_control);
+	VSeparator *sep = memnew(VSeparator);
+	context_toolbar_hbox->add_child(sep);
+	context_toolbar_hbox->add_child(p_control);
+	context_toolbar_separators[p_control] = sep;
+
+	p_control->connect("visibility_changed", callable_mp(this, &CanvasItemEditor::_update_context_toolbar));
+
+	_update_context_toolbar();
 }
 
 void CanvasItemEditor::remove_control_from_menu_panel(Control *p_control) {
-	context_menu_hbox->remove_child(p_control);
+	ERR_FAIL_NULL(p_control);
+	ERR_FAIL_COND(p_control->get_parent() != context_toolbar_hbox);
+
+	p_control->disconnect("visibility_changed", callable_mp(this, &CanvasItemEditor::_update_context_toolbar));
+
+	context_toolbar_hbox->remove_child(context_toolbar_separators[p_control]);
+	context_toolbar_hbox->remove_child(p_control);
+	context_toolbar_separators.erase(p_control);
+
+	_update_context_toolbar();
+}
+
+void CanvasItemEditor::_update_context_toolbar() {
+	bool has_visible = false;
+	bool first_visible = false;
+
+	for (int i = 0; i < context_toolbar_hbox->get_child_count(); i++) {
+		Control *child = Object::cast_to<Control>(context_toolbar_hbox->get_child(i));
+		if (!child || !context_toolbar_separators.has(child)) {
+			continue;
+		}
+		if (child->is_visible()) {
+			first_visible = !has_visible;
+			has_visible = true;
+		}
+
+		VSeparator *sep = context_toolbar_separators[child];
+		sep->set_visible(!first_visible && child->is_visible());
+	}
+
+	context_toolbar_panel->set_visible(has_visible);
 }
 
 void CanvasItemEditor::add_control_to_left_panel(Control *p_control) {
@@ -4997,9 +5035,17 @@ CanvasItemEditor::CanvasItemEditor() {
 	EditorRunBar::get_singleton()->call_deferred(SNAME("connect"), "play_pressed", callable_mp(this, &CanvasItemEditor::_update_override_camera_button).bind(true));
 	EditorRunBar::get_singleton()->call_deferred(SNAME("connect"), "stop_pressed", callable_mp(this, &CanvasItemEditor::_update_override_camera_button).bind(false));
 
+	// Add some margin to the sides for better aesthetics.
+	// This prevents the first button's hover/pressed effect from "touching" the panel's border,
+	// which looks ugly.
+	MarginContainer *toolbar_margin = memnew(MarginContainer);
+	toolbar_margin->add_theme_constant_override("margin_left", 4 * EDSCALE);
+	toolbar_margin->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	add_child(toolbar_margin);
+
 	// A fluid container for all toolbars.
 	HFlowContainer *main_flow = memnew(HFlowContainer);
-	add_child(main_flow);
+	toolbar_margin->add_child(main_flow);
 
 	// Main toolbars.
 	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
@@ -5106,13 +5152,6 @@ CanvasItemEditor::CanvasItemEditor() {
 	v_scroll->hide();
 
 	viewport->add_child(controls_vb);
-
-	// Add some margin to the left for better esthetics.
-	// This prevents the first button's hover/pressed effect from "touching" the panel's border,
-	// which looks ugly.
-	Control *margin_left = memnew(Control);
-	main_menu_hbox->add_child(margin_left);
-	margin_left->set_custom_minimum_size(Size2(2, 0) * EDSCALE);
 
 	select_button = memnew(Button);
 	select_button->set_flat(true);
@@ -5355,15 +5394,14 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_menu_hbox->add_child(memnew(VSeparator));
 
 	// Contextual toolbars.
-	context_menu_panel = memnew(PanelContainer);
-	context_menu_hbox = memnew(HBoxContainer);
-	context_menu_panel->add_child(context_menu_hbox);
-	main_flow->add_child(context_menu_panel);
+	context_toolbar_panel = memnew(PanelContainer);
+	context_toolbar_hbox = memnew(HBoxContainer);
+	context_toolbar_panel->add_child(context_toolbar_hbox);
+	main_flow->add_child(context_toolbar_panel);
 
 	// Animation controls.
 	animation_hb = memnew(HBoxContainer);
-	context_menu_hbox->add_child(animation_hb);
-	animation_hb->add_child(memnew(VSeparator));
+	add_control_to_menu_panel(animation_hb);
 	animation_hb->hide();
 
 	key_loc_button = memnew(Button);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -48,6 +48,7 @@ class PanelContainer;
 class StyleBoxTexture;
 class ViewPanner;
 class VScrollBar;
+class VSeparator;
 class VSplitContainer;
 
 class CanvasItemEditorSelectedItem : public Object {
@@ -192,10 +193,14 @@ private:
 
 	HScrollBar *h_scroll = nullptr;
 	VScrollBar *v_scroll = nullptr;
+
 	// Used for secondary menu items which are displayed depending on the currently selected node
 	// (such as MeshInstance's "Mesh" menu).
-	PanelContainer *context_menu_panel = nullptr;
-	HBoxContainer *context_menu_hbox = nullptr;
+	PanelContainer *context_toolbar_panel = nullptr;
+	HBoxContainer *context_toolbar_hbox = nullptr;
+	HashMap<Control *, VSeparator *> context_toolbar_separators;
+
+	void _update_context_toolbar();
 
 	Transform2D transform;
 	GridVisibility grid_visibility = GRID_VISIBILITY_SHOW_WHEN_SNAPPING;

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -976,8 +976,6 @@ void ControlEditorToolbar::_notification(int p_what) {
 }
 
 ControlEditorToolbar::ControlEditorToolbar() {
-	add_child(memnew(VSeparator));
-
 	// Anchor and offset tools.
 	anchors_button = memnew(ControlEditorPopupButton);
 	anchors_button->set_tooltip_text(TTR("Presets for the anchor and offset values of a Control node."));

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -267,8 +267,6 @@ CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
 	toolbar->hide();
 
-	toolbar->add_child(memnew(VSeparator));
-
 	menu = memnew(MenuButton);
 	menu->get_popup()->add_item(TTR("Restart"), MENU_RESTART);
 	menu->get_popup()->add_item(TTR("Load Emission Mask"), MENU_LOAD_EMISSION_MASK);

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -369,8 +369,6 @@ GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
 	toolbar->hide();
 
-	toolbar->add_child(memnew(VSeparator));
-
 	menu = memnew(MenuButton);
 	menu->get_popup()->add_item(TTR("Restart"), MENU_RESTART);
 	menu->get_popup()->add_item(TTR("Generate Visibility Rect"), MENU_GENERATE_VISIBILITY_RECT);

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.cpp
@@ -521,7 +521,6 @@ void NavigationObstacle3DEditor::_bind_methods() {
 NavigationObstacle3DEditor::NavigationObstacle3DEditor() {
 	obstacle_node = nullptr;
 
-	add_child(memnew(VSeparator));
 	button_create = memnew(Button);
 	button_create->set_flat(true);
 	add_child(button_create);

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -56,9 +56,10 @@ class PanelContainer;
 class ProceduralSkyMaterial;
 class SubViewport;
 class SubViewportContainer;
+class VSeparator;
 class VSplitContainer;
-class WorldEnvironment;
 class ViewportNavigationControl;
+class WorldEnvironment;
 
 class ViewportRotationControl : public Control {
 	GDCLASS(ViewportRotationControl, Control);
@@ -715,8 +716,11 @@ private:
 	void _update_camera_override_viewport(Object *p_viewport);
 	// Used for secondary menu items which are displayed depending on the currently selected node
 	// (such as MeshInstance's "Mesh" menu).
-	PanelContainer *context_menu_panel = nullptr;
-	HBoxContainer *context_menu_hbox = nullptr;
+	PanelContainer *context_toolbar_panel = nullptr;
+	HBoxContainer *context_toolbar_hbox = nullptr;
+	HashMap<Control *, VSeparator *> context_toolbar_separators;
+
+	void _update_context_toolbar();
 
 	void _generate_selection_boxes();
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -532,19 +532,14 @@ Path2DEditor::Path2DEditor() {
 	mode = MODE_EDIT;
 	action = ACTION_NONE;
 
-	base_hb = memnew(HBoxContainer);
-	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(base_hb);
-
-	sep = memnew(VSeparator);
-	base_hb->add_child(sep);
-
 	curve_edit = memnew(Button);
 	curve_edit->set_flat(true);
 	curve_edit->set_toggle_mode(true);
+	curve_edit->set_pressed(true);
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip_text(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Click: Add Point") + "\n" + TTR("Left Click: Split Segment (in curve)") + "\n" + TTR("Right Click: Delete Point"));
 	curve_edit->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT));
-	base_hb->add_child(curve_edit);
+	add_child(curve_edit);
 
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_flat(true);
@@ -552,7 +547,7 @@ Path2DEditor::Path2DEditor() {
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip_text(TTR("Select Control Points (Shift+Drag)"));
 	curve_edit_curve->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_EDIT_CURVE));
-	base_hb->add_child(curve_edit_curve);
+	add_child(curve_edit_curve);
 
 	curve_create = memnew(Button);
 	curve_create->set_flat(true);
@@ -560,7 +555,7 @@ Path2DEditor::Path2DEditor() {
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip_text(TTR("Add Point (in empty space)"));
 	curve_create->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_CREATE));
-	base_hb->add_child(curve_create);
+	add_child(curve_create);
 
 	curve_del = memnew(Button);
 	curve_del->set_flat(true);
@@ -568,20 +563,20 @@ Path2DEditor::Path2DEditor() {
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip_text(TTR("Delete Point"));
 	curve_del->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected).bind(MODE_DELETE));
-	base_hb->add_child(curve_del);
+	add_child(curve_del);
 
 	curve_close = memnew(Button);
 	curve_close->set_flat(true);
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip_text(TTR("Close Curve"));
 	curve_close->connect("pressed", callable_mp(this, &Path2DEditor::_mode_selected).bind(ACTION_CLOSE));
-	base_hb->add_child(curve_close);
+	add_child(curve_close);
 
 	PopupMenu *menu;
 
 	handle_menu = memnew(MenuButton);
 	handle_menu->set_text(TTR("Options"));
-	base_hb->add_child(handle_menu);
+	add_child(handle_menu);
 
 	menu = handle_menu->get_popup();
 	menu->add_check_item(TTR("Mirror Handle Angles"));
@@ -589,10 +584,6 @@ Path2DEditor::Path2DEditor() {
 	menu->add_check_item(TTR("Mirror Handle Lengths"));
 	menu->set_item_checked(HANDLE_OPTION_LENGTH, mirror_handle_length);
 	menu->connect("id_pressed", callable_mp(this, &Path2DEditor::_handle_option_pressed));
-
-	base_hb->hide();
-
-	curve_edit->set_pressed(true);
 }
 
 void Path2DEditorPlugin::edit(Object *p_object) {
@@ -606,11 +597,9 @@ bool Path2DEditorPlugin::handles(Object *p_object) const {
 void Path2DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		path2d_editor->show();
-		path2d_editor->base_hb->show();
 
 	} else {
 		path2d_editor->hide();
-		path2d_editor->base_hb->hide();
 		path2d_editor->edit(nullptr);
 	}
 }

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -34,7 +34,6 @@
 #include "editor/editor_plugin.h"
 #include "scene/2d/path_2d.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/separator.h"
 
 class CanvasItemEditor;
 class MenuButton;
@@ -47,7 +46,6 @@ class Path2DEditor : public HBoxContainer {
 	Path2D *node = nullptr;
 
 	HBoxContainer *base_hb = nullptr;
-	Separator *sep = nullptr;
 
 	enum Mode {
 		MODE_CREATE,

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -623,21 +623,9 @@ bool Path3DEditorPlugin::handles(Object *p_object) const {
 
 void Path3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		curve_create->show();
-		curve_edit->show();
-		curve_edit_curve->show();
-		curve_del->show();
-		curve_close->show();
-		handle_menu->show();
-		sep->show();
+		topmenu_bar->show();
 	} else {
-		curve_create->hide();
-		curve_edit->hide();
-		curve_edit_curve->hide();
-		curve_del->hide();
-		curve_close->hide();
-		handle_menu->hide();
-		sep->hide();
+		topmenu_bar->hide();
 
 		{
 			Path3D *pre = path;
@@ -736,55 +724,49 @@ Path3DEditorPlugin::Path3DEditorPlugin() {
 	gizmo_plugin.instantiate();
 	Node3DEditor::get_singleton()->add_gizmo_plugin(gizmo_plugin);
 
-	sep = memnew(VSeparator);
-	sep->hide();
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(sep);
+	topmenu_bar = memnew(HBoxContainer);
+	topmenu_bar->hide();
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(topmenu_bar);
 
 	curve_edit = memnew(Button);
 	curve_edit->set_flat(true);
 	curve_edit->set_toggle_mode(true);
-	curve_edit->hide();
 	curve_edit->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit->set_tooltip_text(TTR("Select Points") + "\n" + TTR("Shift+Drag: Select Control Points") + "\n" + keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL) + TTR("Click: Add Point") + "\n" + TTR("Right Click: Delete Point"));
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_edit);
+	topmenu_bar->add_child(curve_edit);
 
 	curve_edit_curve = memnew(Button);
 	curve_edit_curve->set_flat(true);
 	curve_edit_curve->set_toggle_mode(true);
-	curve_edit_curve->hide();
 	curve_edit_curve->set_focus_mode(Control::FOCUS_NONE);
 	curve_edit_curve->set_tooltip_text(TTR("Select Control Points (Shift+Drag)"));
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_edit_curve);
+	topmenu_bar->add_child(curve_edit_curve);
 
 	curve_create = memnew(Button);
 	curve_create->set_flat(true);
 	curve_create->set_toggle_mode(true);
-	curve_create->hide();
 	curve_create->set_focus_mode(Control::FOCUS_NONE);
 	curve_create->set_tooltip_text(TTR("Add Point (in empty space)") + "\n" + TTR("Split Segment (in curve)"));
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_create);
+	topmenu_bar->add_child(curve_create);
 
 	curve_del = memnew(Button);
 	curve_del->set_flat(true);
 	curve_del->set_toggle_mode(true);
-	curve_del->hide();
 	curve_del->set_focus_mode(Control::FOCUS_NONE);
 	curve_del->set_tooltip_text(TTR("Delete Point"));
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_del);
+	topmenu_bar->add_child(curve_del);
 
 	curve_close = memnew(Button);
 	curve_close->set_flat(true);
-	curve_close->hide();
 	curve_close->set_focus_mode(Control::FOCUS_NONE);
 	curve_close->set_tooltip_text(TTR("Close Curve"));
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(curve_close);
+	topmenu_bar->add_child(curve_close);
 
 	PopupMenu *menu;
 
 	handle_menu = memnew(MenuButton);
 	handle_menu->set_text(TTR("Options"));
-	handle_menu->hide();
-	Node3DEditor::get_singleton()->add_control_to_menu_panel(handle_menu);
+	topmenu_bar->add_child(handle_menu);
 
 	menu = handle_menu->get_popup();
 	menu->add_check_item(TTR("Mirror Handle Angles"));

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -35,8 +35,8 @@
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/path_3d.h"
-#include "scene/gui/separator.h"
 
+class HBoxContainer;
 class MenuButton;
 
 class Path3DGizmo : public EditorNode3DGizmo {
@@ -87,7 +87,7 @@ public:
 class Path3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Path3DEditorPlugin, EditorPlugin);
 
-	Separator *sep = nullptr;
+	HBoxContainer *topmenu_bar = nullptr;
 	Button *curve_create = nullptr;
 	Button *curve_edit = nullptr;
 	Button *curve_edit_curve = nullptr;

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -53,8 +53,6 @@ PhysicalBone3DEditor::PhysicalBone3DEditor() {
 	spatial_editor_hb->set_alignment(BoxContainer::ALIGNMENT_BEGIN);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(spatial_editor_hb);
 
-	spatial_editor_hb->add_child(memnew(VSeparator));
-
 	button_transform_joint = memnew(Button);
 	button_transform_joint->set_flat(true);
 	spatial_editor_hb->add_child(button_transform_joint);

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -536,7 +536,6 @@ void Polygon3DEditor::_bind_methods() {
 Polygon3DEditor::Polygon3DEditor() {
 	node = nullptr;
 
-	add_child(memnew(VSeparator));
 	button_create = memnew(Button);
 	button_create->set_flat(true);
 	add_child(button_create);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -712,12 +712,12 @@ void Skeleton3DEditor::create_editors() {
 	add_child(file_dialog);
 
 	// Create Top Menu Bar.
-	separator = memnew(VSeparator);
-	ne->add_control_to_menu_panel(separator);
+	HBoxContainer *topmenu_bar = memnew(HBoxContainer);
+	ne->add_control_to_menu_panel(topmenu_bar);
 
 	// Create Skeleton Option in Top Menu Bar.
 	skeleton_options = memnew(MenuButton);
-	ne->add_control_to_menu_panel(skeleton_options);
+	topmenu_bar->add_child(skeleton_options);
 
 	skeleton_options->set_text(TTR("Skeleton3D"));
 
@@ -737,7 +737,7 @@ void Skeleton3DEditor::create_editors() {
 	button_binds.resize(1);
 
 	edit_mode_button = memnew(Button);
-	ne->add_control_to_menu_panel(edit_mode_button);
+	topmenu_bar->add_child(edit_mode_button);
 	edit_mode_button->set_flat(true);
 	edit_mode_button->set_toggle_mode(true);
 	edit_mode_button->set_focus_mode(FOCUS_NONE);
@@ -753,7 +753,7 @@ void Skeleton3DEditor::create_editors() {
 
 	// Keying buttons.
 	animation_hb = memnew(HBoxContainer);
-	ne->add_control_to_menu_panel(animation_hb);
+	topmenu_bar->add_child(animation_hb);
 	animation_hb->add_child(memnew(VSeparator));
 	animation_hb->hide();
 


### PR DESCRIPTION
Fixing two annoyances about contextual toolbars:

1. The panel style is visually compressing, making extra toolbars look weird compared to static toolbars.
2. There is always an extra vertical separator at the start of it.

To address the first one I've added expand margins to all sides. I also replaced a control that was used to add extra left padding to the whole toolbar row with a margin container, so this extra padding is added to rows wrapped by the `FlowContainer`.

To address the second I've added some extra logic to dynamically add separators when we add controls to the toolbar. These automatic separators correctly react to their owner node being hidden and shown too. To make this work, I had to remove hardcoded separators from all custom toolbars, and in some cases rework the layout a bit (for the better).

This does mean that if any user plugins have hardcoded `VSeparator`, it will look meh, because one would be added by us anyway. But to fix this they would simply need to remove their extra node, et voila, a consistent and neat look!

### Some before-and-afters

<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-52-43" src="https://github.com/godotengine/godot/assets/11782833/52a7dc78-81d1-48c8-8543-aa1fc8b89623">
<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-48-20" src="https://github.com/godotengine/godot/assets/11782833/878d417c-0851-4328-9183-b96e87df0364">

----

<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-52-52" src="https://github.com/godotengine/godot/assets/11782833/7337c362-093d-455c-9512-04758925f7b6">
<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-48-06" src="https://github.com/godotengine/godot/assets/11782833/11596234-34ab-4538-906d-66d450ad1249">

----

<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-53-00" src="https://github.com/godotengine/godot/assets/11782833/8d624e6b-16ad-433c-bc31-ee077de91aed">
<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-47-55" src="https://github.com/godotengine/godot/assets/11782833/d5dcedea-c8bf-416d-8eaf-4a6f00764754">

----

<img width="380" alt="godot windows editor dev x86_64_2023-09-12_00-02-21" src="https://github.com/godotengine/godot/assets/11782833/852971de-1f97-4776-a6e2-fbb41ce3c17e">
<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-47-18" src="https://github.com/godotengine/godot/assets/11782833/e5b31eae-56b0-4be2-a81f-41d80aeba5fb">

----

<img width="380" alt="godot windows editor dev x86_64_2023-09-12_00-02-28" src="https://github.com/godotengine/godot/assets/11782833/8018828a-1c4f-48c0-81ed-85281fa477d0">
<img width="380" alt="godot windows editor dev x86_64_2023-09-11_23-47-05" src="https://github.com/godotengine/godot/assets/11782833/6aa9c120-214d-4d20-9505-1cd2832e79e3">
