### PR TITLE
[3.x] Backport "Add `finished` signal to GPUParticles"

### DIFF
--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -105,6 +105,14 @@
 			[b]Note:[/b] If the [ParticlesMaterial] in use is configured to cast shadows, you may want to enlarge this AABB to ensure the shadow is updated when particles are off-screen.
 		</member>
 	</members>
+	<signals>
+		<signal name="finished">
+			<description>
+				Emitted when all active particles have finished processing. When [member one_shot] is disabled, particles will process continuously, so this is never emitted.
+				[b]Note:[/b] Due to the particles being computed on the GPU there might be a delay before the signal gets emitted.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="DRAW_ORDER_INDEX" value="0" enum="DrawOrder">
 			Particles are drawn in the order emitted.

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -21,6 +21,7 @@
 			<return type="Rect2" />
 			<description>
 				Returns a rectangle containing the positions of all existing particles.
+				[b]Note:[/b] When using threaded rendering this method synchronizes the rendering thread. Calling it often may have a negative impact on performance.
 			</description>
 		</method>
 		<method name="restart">
@@ -83,6 +84,14 @@
 			Grow the rect if particles suddenly appear/disappear when the node enters/exits the screen. The [Rect2] can be grown via code or with the [b]Particles → Generate Visibility Rect[/b] editor tool.
 		</member>
 	</members>
+	<signals>
+		<signal name="finished">
+			<description>
+				Emitted when all active particles have finished processing. When [member one_shot] is disabled, particles will process continuously, so this is never emitted.
+				[b]Note:[/b] Due to the particles being computed on the GPU there might be a delay before the signal gets emitted.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="DRAW_ORDER_INDEX" value="0" enum="DrawOrder">
 			Particles are drawn in the order emitted.

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -39,13 +39,30 @@
 #endif
 
 void Particles2D::set_emitting(bool p_emitting) {
-	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
+	// Do not return even if `p_emitting == emitting` because `emitting` is just an approximation.
 
 	if (p_emitting && one_shot) {
+		if (!active && !emitting) {
+			// Last cycle ended.
+			active = true;
+			time = 0;
+			signal_canceled = false;
+			emission_time = lifetime;
+			active_time = lifetime * (2 - explosiveness_ratio);
+		} else {
+			signal_canceled = true;
+		}
 		set_process_internal(true);
 	} else if (!p_emitting) {
-		set_process_internal(false);
+		if (one_shot) {
+			set_process_internal(true);
+		} else {
+			set_process_internal(false);
+		}
 	}
+
+	emitting = p_emitting;
+	VS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
 void Particles2D::set_amount(int p_amount) {
@@ -148,7 +165,7 @@ void Particles2D::set_show_visibility_rect(bool p_show_visibility_rect) {
 #endif
 
 bool Particles2D::is_emitting() const {
-	return VS::get_singleton()->particles_get_emitting(particles);
+	return emitting;
 }
 int Particles2D::get_amount() const {
 	return amount;
@@ -287,6 +304,16 @@ void Particles2D::_validate_property(PropertyInfo &property) const {
 void Particles2D::restart() {
 	VS::get_singleton()->particles_restart(particles);
 	VS::get_singleton()->particles_set_emitting(particles, true);
+
+	emitting = true;
+	active = true;
+	signal_canceled = false;
+	time = 0;
+	emission_time = lifetime;
+	active_time = lifetime * (2 - explosiveness_ratio);
+	if (one_shot) {
+		set_process_internal(true);
+	}
 }
 
 void Particles2D::_notification(int p_what) {
@@ -322,9 +349,23 @@ void Particles2D::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		if (one_shot && !is_emitting()) {
-			_change_notify();
-			set_process_internal(false);
+		if (one_shot) {
+			time += get_process_delta_time();
+			if (time > emission_time) {
+				emitting = false;
+				if (!active) {
+					set_process_internal(false);
+				}
+			}
+			if (time > active_time) {
+				if (active && !signal_canceled) {
+					emit_signal(SceneStringNames::get_singleton()->finished);
+				}
+				active = false;
+				if (!emitting) {
+					set_process_internal(false);
+				}
+			}
 		}
 	}
 }
@@ -370,6 +411,8 @@ void Particles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("capture_rect"), &Particles2D::capture_rect);
 
 	ClassDB::bind_method(D_METHOD("restart"), &Particles2D::restart);
+
+	ADD_SIGNAL(MethodInfo("finished"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_EXP_RANGE, "1,1000000,1"), "set_amount", "get_amount");

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -48,7 +48,10 @@ public:
 private:
 	RID particles;
 
-	bool one_shot;
+	bool emitting = false;
+	bool active = false;
+	bool signal_canceled = false;
+	bool one_shot = false;
 	int amount;
 	float lifetime;
 	float pre_process_time;
@@ -72,6 +75,10 @@ private:
 	Ref<Texture> normal_map;
 
 	void _update_particle_emission_transform();
+
+	double time = 0.0;
+	double emission_time = 0.0;
+	double active_time = 0.0;
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/particles.h
+++ b/scene/3d/particles.h
@@ -53,7 +53,10 @@ public:
 private:
 	RID particles;
 
-	bool one_shot;
+	bool emitting = false;
+	bool active = false;
+	bool signal_canceled = false;
+	bool one_shot = false;
 	int amount;
 	float lifetime;
 	float pre_process_time;
@@ -70,6 +73,10 @@ private:
 	DrawOrder draw_order;
 
 	Vector<Ref<Mesh>> draw_passes;
+
+	double time = 0.0;
+	double emission_time = 0.0;
+	double active_time = 0.0;
 
 protected:
 	static void _bind_methods();

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -61,7 +61,6 @@ SceneStringNames::SceneStringNames() {
 	finished = StaticCString::create("finished");
 	loop_finished = StaticCString::create("loop_finished");
 	step_finished = StaticCString::create("step_finished");
-	emission_finished = StaticCString::create("emission_finished");
 	animation_finished = StaticCString::create("animation_finished");
 	animation_changed = StaticCString::create("animation_changed");
 	animation_started = StaticCString::create("animation_started");

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -93,7 +93,6 @@ public:
 	StringName finished;
 	StringName loop_finished;
 	StringName step_finished;
-	StringName emission_finished;
 	StringName animation_finished;
 	StringName animation_changed;
 	StringName animation_started;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Backporting #76859 to 3.x

I moved the changes over by hand instead of cherry picking in git becuase there was significant enough changes in file names and code names that it was easier to do by hand. There was some structural differences; namely using `VS` instead of `RS` in 3.x and `_notification` being if statements instead of a switch in 3.x. I am fairly confident the changes in `_notification` should be semantically the same as the original change but I am not familiar with the difference between `RS` and `VS`.

Related to issue #64094 

