### PR TITLE
Improve undo action names

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -136,22 +136,22 @@ bool AnimationTrackKeyEdit::_set(const StringName &p_name, const Variant &p_valu
 			if (name == "position" || name == "rotation" || name == "scale") {
 				Variant old = animation->track_get_key_value(track, key);
 				setting = true;
-				String chan;
+				String action_name;
 				switch (animation->track_get_type(track)) {
 					case Animation::TYPE_POSITION_3D:
-						chan = "Position3D";
+						action_name = TTR("Animation Change Position3D");
 						break;
 					case Animation::TYPE_ROTATION_3D:
-						chan = "Rotation3D";
+						action_name = TTR("Animation Change Rotation3D");
 						break;
 					case Animation::TYPE_SCALE_3D:
-						chan = "Scale3D";
+						action_name = TTR("Animation Change Scale3D");
 						break;
 					default: {
 					}
 				}
 
-				undo_redo->create_action(vformat(TTR("Animation Change %s"), chan));
+				undo_redo->create_action(action_name);
 				undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, p_value);
 				undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, old);
 				undo_redo->add_do_method(this, "_update_obj", animation);
@@ -730,23 +730,23 @@ bool AnimationMultiTrackKeyEdit::_set(const StringName &p_name, const Variant &p
 				case Animation::TYPE_SCALE_3D: {
 					Variant old = animation->track_get_key_value(track, key);
 					if (!setting) {
-						String chan;
+						String action_name;
 						switch (animation->track_get_type(track)) {
 							case Animation::TYPE_POSITION_3D:
-								chan = "Position3D";
+								action_name = TTR("Animation Multi Change Position3D");
 								break;
 							case Animation::TYPE_ROTATION_3D:
-								chan = "Rotation3D";
+								action_name = TTR("Animation Multi Change Rotation3D");
 								break;
 							case Animation::TYPE_SCALE_3D:
-								chan = "Scale3D";
+								action_name = TTR("Animation Multi Change Scale3D");
 								break;
 							default: {
 							}
 						}
 
 						setting = true;
-						undo_redo->create_action(vformat(TTR("Animation Multi Change %s"), chan));
+						undo_redo->create_action(action_name);
 					}
 					undo_redo->add_do_method(animation.ptr(), "track_set_key_value", track, key, p_value);
 					undo_redo->add_undo_method(animation.ptr(), "track_set_key_value", track, key, old);
@@ -6052,7 +6052,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 		case EDIT_BAKE_ANIMATION_CONFIRM: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-			undo_redo->create_action(TTR("Bake Animation as Linear keys."));
+			undo_redo->create_action(TTR("Bake Animation as Linear Keys"));
 
 			int track_len = animation->get_track_count();
 			bool b_trs = bake_trs->is_pressed();

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1897,7 +1897,7 @@ void EditorInspectorArray::_move_element(int p_element_index, int p_to_pos) {
 
 void EditorInspectorArray::_clear_array() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(vformat(TTR("Clear property array with prefix %s."), array_element_prefix));
+	undo_redo->create_action(vformat(TTR("Clear Property Array with Prefix %s"), array_element_prefix));
 	if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 		for (int i = count - 1; i >= 0; i--) {
 			// Call the function.
@@ -1950,7 +1950,7 @@ void EditorInspectorArray::_resize_array(int p_size) {
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(vformat(TTR("Resize property array with prefix %s."), array_element_prefix));
+	undo_redo->create_action(vformat(TTR("Resize Property Array with Prefix %s"), array_element_prefix));
 	if (p_size > count) {
 		if (mode == MODE_USE_MOVE_ARRAY_ELEMENT_FUNCTION) {
 			for (int i = count; i < p_size; i++) {
@@ -3856,7 +3856,8 @@ void EditorInspector::_multiple_properties_changed(Vector<String> p_paths, Array
 		names += p_paths[i];
 	}
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Set Multiple:") + " " + names, UndoRedo::MERGE_ENDS);
+	// TRANSLATORS: This is describing a change to multiple properties at once. The parameter is a list of property names.
+	undo_redo->create_action(vformat(TTR("Set Multiple: %s"), names), UndoRedo::MERGE_ENDS);
 	for (int i = 0; i < p_paths.size(); i++) {
 		_edit_set(p_paths[i], p_values[i], false, "");
 		if (restart_request_props.has(p_paths[i])) {

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -234,7 +234,7 @@ void EditorSettingsDialog::_update_builtin_action(const String &p_name, const Ar
 	Array old_input_array = EditorSettings::get_singleton()->get_builtin_action_overrides(p_name);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Edit Built-in Action") + " '" + p_name + "'");
+	undo_redo->create_action(vformat(TTR("Edit Built-in Action: %s"), p_name));
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
 	undo_redo->add_undo_method(EditorSettings::get_singleton(), "mark_setting_changed", "builtin_action_overrides");
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "set_builtin_action_override", p_name, p_events);
@@ -250,7 +250,7 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 	Ref<Shortcut> current_sc = EditorSettings::get_singleton()->get_shortcut(p_path);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Edit Shortcut") + " '" + p_path + "'");
+	undo_redo->create_action(vformat(TTR("Edit Shortcut: %s"), p_path));
 	undo_redo->add_do_method(current_sc.ptr(), "set_events", p_events);
 	undo_redo->add_undo_method(current_sc.ptr(), "set_events", current_sc->get_events());
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -106,7 +106,7 @@ void AnimationNodeBlendTreeEditor::_property_changed(const StringName &p_propert
 	}
 	updating = true;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Parameter Changed:") + " " + String(p_property), UndoRedo::MERGE_ENDS);
+	undo_redo->create_action(vformat(TTR("Parameter Changed: %s"), p_property), UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_property(tree, p_property, p_value);
 	undo_redo->add_undo_property(tree, p_property, tree->get(p_property));
 	undo_redo->add_do_method(this, "update_graph");

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6370,7 +6370,7 @@ public:
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 		updating = true;
-		undo_redo->create_action(TTR("Edit Visual Property:") + " " + p_property, UndoRedo::MERGE_ENDS);
+		undo_redo->create_action(vformat(TTR("Edit Visual Property: %s"), p_property), UndoRedo::MERGE_ENDS);
 		undo_redo->add_do_property(node.ptr(), p_property, p_value);
 		undo_redo->add_undo_property(node.ptr(), p_property, node->get(p_property));
 


### PR DESCRIPTION
* Avoid concating strings manually for better i18n and easy l10n
   * Use `vformat` when possible
   * Use separate strings if the changing part is only a few hardcoded strings
* Don't put a period at the end of the name

---

The format of these two is also changed from `Do Something 'object'` to `Do Something: object` since most other names use this format and the names won't be empty.

https://github.com/godotengine/godot/blob/b8b03395498d403c82a9b0e386711251d9207a84/editor/editor_settings_dialog.cpp#L237

https://github.com/godotengine/godot/blob/b8b03395498d403c82a9b0e386711251d9207a84/editor/editor_settings_dialog.cpp#L253