### PR TITLE
Fix GLES3 instanced rendering color and custom data defaults

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1420,6 +1420,13 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index) {
 						glEnableVertexAttribArray(5);
 						glVertexAttribIPointer(5, 4, GL_UNSIGNED_INT, instance_stride * sizeof(float), CAST_INT_TO_UCHAR_PTR(instance_color_offset * sizeof(float)));
 						glVertexAttribDivisor(5, 1);
+					} else {
+						// Set all default instance color and custom data values to 1.0 or 0.0 using a compressed format.
+						uint16_t zero = Math::make_half_float(0.0f);
+						uint16_t one = Math::make_half_float(1.0f);
+						GLuint default_color = (uint32_t(one) << 16) | one;
+						GLuint default_custom = (uint32_t(zero) << 16) | zero;
+						glVertexAttribI4ui(5, default_color, default_color, default_custom, default_custom);
 					}
 				}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2962,7 +2962,15 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					glEnableVertexAttribArray(15);
 					glVertexAttribIPointer(15, 4, GL_UNSIGNED_INT, stride * sizeof(float), CAST_INT_TO_UCHAR_PTR(color_custom_offset * sizeof(float)));
 					glVertexAttribDivisor(15, 1);
+				} else {
+					// Set all default instance color and custom data values to 1.0 or 0.0 using a compressed format.
+					uint16_t zero = Math::make_half_float(0.0f);
+					uint16_t one = Math::make_half_float(1.0f);
+					GLuint default_color = (uint32_t(one) << 16) | one;
+					GLuint default_custom = (uint32_t(zero) << 16) | zero;
+					glVertexAttribI4ui(15, default_color, default_color, default_custom, default_custom);
 				}
+
 				if (use_index_buffer) {
 					glDrawElementsInstanced(primitive_gl, count, mesh_storage->mesh_surface_get_index_type(mesh_surface), 0, inst->instance_count);
 				} else {


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/74111
* Fixes https://github.com/godotengine/godot/issues/75085
* Fixes https://github.com/godotengine/godot/issues/80980 (probably, I didn't test a Web build)
* Fixes https://github.com/godotengine/godot/issues/81926 (again probably, but pretty likely)

In the GLES3 Compatibility renderer if a MultiMesh did not have instance colors or custom data enabled, the default instance color and data values ended up being 0.0 (or whatever value happened to be set previously) instead of 1.0 which made most meshes completely black if `vertex_color_use_as_albedo` flag was enabled on the material. This happens often with GridMap which uses internal MultiMesh objects.

This PR sets default compressed values to 1.0 for color and 0.0 for custom data. Looks like this is also needed in canvas rasterizer to satisfy any buggy. strict or paranoid OpenGL implementations (especially web) that check the input attribute declared data type (uvec4) against the bound type even if the shader branch reading the value is disabled by an uniform condition (FLAGS_INSTANCING_HAS_COLORS  and FLAGS_INSTANCING_HAS_CUSTOM_DATA in canvas rasterizer).