### PR TITLE
GDExtension: Delete left-over DLL copy before making a new copy

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -711,6 +711,11 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 		// This is so relative path to dependencies are satisfied.
 		String copy_path = abs_path.get_base_dir().path_join("~" + abs_path.get_file());
 
+		// If there's a left-over copy (possibly from a crash) then delete it first.
+		if (FileAccess::exists(copy_path)) {
+			DirAccess::remove_absolute(copy_path);
+		}
+
 		Error copy_err = DirAccess::copy_absolute(abs_path, copy_path);
 		if (copy_err) {
 			if (r_error) {


### PR DESCRIPTION
As reported in [this comment](https://github.com/godotengine/godot/pull/80284#issuecomment-1714696204), if Godot crashes before it can clean up the DLL copy, then it will fail to copy it again (and hence fail to load the GDExtension).

This PR will check if the DLL already exists and attempt to delete it, before attempting the copy.

It appears to work in some quick testing on Windows! Like shown in the linked comment, I'm hitting Ctrl-C shortly after starting the editor to force a crash (which leaves the copy behind), and then running the editor again until it fully loads.