### PR TITLE
Make `GraphEdit` toolbar more customizable

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -226,9 +226,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="arrange_nodes_button_hidden" type="bool" setter="set_arrange_nodes_button_hidden" getter="is_arrange_nodes_button_hidden" default="false">
-			If [code]true[/code], the Arrange Nodes button is hidden.
-		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="connection_lines_antialiased" type="bool" setter="set_connection_lines_antialiased" getter="is_connection_lines_antialiased" default="true">
 			If [code]true[/code], the lines between nodes will use antialiasing.
@@ -258,11 +255,26 @@
 		<member name="scroll_offset" type="Vector2" setter="set_scroll_offset" getter="get_scroll_offset" default="Vector2(0, 0)">
 			The scroll offset.
 		</member>
+		<member name="show_arrange_button" type="bool" setter="set_show_arrange_button" getter="is_showing_arrange_button" default="true">
+			If [code]true[/code], the button to automatically arrange graph nodes is visible.
+		</member>
 		<member name="show_grid" type="bool" setter="set_show_grid" getter="is_showing_grid" default="true">
 			If [code]true[/code], the grid is visible.
 		</member>
+		<member name="show_grid_buttons" type="bool" setter="set_show_grid_buttons" getter="is_showing_grid_buttons" default="true">
+			If [code]true[/code], buttons that allow to configure grid and snapping options are visible.
+		</member>
+		<member name="show_menu" type="bool" setter="set_show_menu" getter="is_showing_menu" default="true">
+			If [code]true[/code], the menu toolbar is visible.
+		</member>
+		<member name="show_minimap_button" type="bool" setter="set_show_minimap_button" getter="is_showing_minimap_button" default="true">
+			If [code]true[/code], the button to toggle the minimap is visible.
+		</member>
+		<member name="show_zoom_buttons" type="bool" setter="set_show_zoom_buttons" getter="is_showing_zoom_buttons" default="true">
+			If [code]true[/code], buttons that allow to change and reset the zoom level are visible.
+		</member>
 		<member name="show_zoom_label" type="bool" setter="set_show_zoom_label" getter="is_showing_zoom_label" default="false">
-			If [code]true[/code], makes a label with the current zoom level visible. The zoom value is displayed in percents.
+			If [code]true[/code], the label with the current zoom level is visible. The zoom level is displayed in percents.
 		</member>
 		<member name="snapping_distance" type="int" setter="set_snapping_distance" getter="get_snapping_distance" default="20">
 			The snapping distance in pixels, also determines the grid line distance.
@@ -435,6 +447,8 @@
 		</theme_item>
 		<theme_item name="zoom_reset" data_type="icon" type="Texture2D">
 			The icon for the zoom reset button.
+		</theme_item>
+		<theme_item name="menu_panel" data_type="style" type="StyleBox">
 		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background drawn under the grid.

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1960,6 +1960,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// GraphEdit
 	theme->set_stylebox("panel", "GraphEdit", style_tree_bg);
+	Ref<StyleBoxFlat> graph_toolbar_style = make_flat_stylebox(dark_color_1 * Color(1, 1, 1, 0.6), 4, 2, 4, 2, 3);
+	theme->set_stylebox("menu_panel", "GraphEdit", graph_toolbar_style);
+
 	if (dark_theme) {
 		theme->set_color("grid_major", "GraphEdit", Color(1.0, 1.0, 1.0, 0.1));
 		theme->set_color("grid_minor", "GraphEdit", Color(1.0, 1.0, 1.0, 0.05));

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -38,9 +38,13 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/animation/animation_blend_tree.h"
+#include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/separator.h"
+#include "scene/gui/spin_box.h"
 
 StringName AnimationNodeBlendSpace1DEditor::get_blend_position_path() const {
 	StringName path = AnimationTreeEditor::get_singleton()->get_base_path() + "blend_position";

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -34,15 +34,16 @@
 #include "editor/editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_blend_space_1d.h"
-#include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/popup.h"
-#include "scene/gui/separator.h"
-#include "scene/gui/tree.h"
 
+class Button;
 class CheckBox;
+class LineEdit;
 class OptionButton;
 class PanelContainer;
+class SpinBox;
+class VSeparator;
 
 class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace1DEditor, AnimationTreeNodeEditorPlugin);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -43,12 +43,16 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/panel_container.h"
+#include "scene/gui/separator.h"
+#include "scene/gui/spin_box.h"
 #include "scene/main/window.h"
 
 bool AnimationNodeBlendSpace2DEditor::can_edit(const Ref<AnimationNode> &p_node) {

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -34,15 +34,16 @@
 #include "editor/editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_blend_space_2d.h"
-#include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/popup.h"
-#include "scene/gui/separator.h"
-#include "scene/gui/tree.h"
 
+class Button;
 class CheckBox;
+class LineEdit;
 class OptionButton;
 class PanelContainer;
+class SpinBox;
+class VSeparator;
 
 class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace2DEditor, AnimationTreeNodeEditorPlugin);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1040,7 +1040,7 @@ void AnimationNodeBlendTreeEditor::edit(const Ref<AnimationNode> &p_node) {
 	}
 
 	add_node->set_disabled(read_only);
-	graph->set_arrange_nodes_button_hidden(read_only);
+	graph->set_show_arrange_button(!read_only);
 }
 
 AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -44,8 +44,11 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/button.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
+#include "scene/gui/scroll_container.h"
+#include "scene/gui/separator.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"
 

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -33,10 +33,11 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/animation/animation_tree.h"
-#include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
 
+class Button;
 class EditorFileDialog;
+class ScrollContainer;
 
 class AnimationTreeNodeEditorPlugin : public VBoxContainer {
 	GDCLASS(AnimationTreeNodeEditorPlugin, VBoxContainer);

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -264,3 +264,13 @@ Validate extension JSON: Error: Field 'classes/AnimationTree/methods/set_tree_ro
 These definitions have been moved to those base classes, so the APIs are actually available.
 Some properties were renamed for integration, but the old setter/getters are kept.
 Also changed some methods name/argument/signature. Compatibility methods registered.
+
+
+GH-81582
+--------
+
+Validate extension JSON: API was removed: classes/GraphEdit/methods/is_arrange_nodes_button_hidden
+Validate extension JSON: API was removed: classes/GraphEdit/methods/set_arrange_nodes_button_hidden
+Validate extension JSON: API was removed: classes/GraphEdit/properties/arrange_nodes_button_hidden
+
+Make GraphEdit toolbar more customizable

--- a/scene/gui/graph_edit.compat.inc
+++ b/scene/gui/graph_edit.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  graph_edit.compat.inc                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+bool GraphEdit::_is_arrange_nodes_button_hidden_bind_compat_81582() const {
+	return !is_showing_arrange_button();
+}
+
+void GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582(bool p_enable) {
+	set_show_arrange_button(!p_enable);
+}
+
+void GraphEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("is_arrange_nodes_button_hidden"), &GraphEdit::_is_arrange_nodes_button_hidden_bind_compat_81582);
+	ClassDB::bind_compatibility_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582);
+}
+
+#endif

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "graph_edit.h"
+#include "graph_edit.compat.inc"
 
 #include "core/input/input.h"
 #include "core/math/math_funcs.h"
@@ -36,6 +37,10 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit_arranger.h"
+#include "scene/gui/label.h"
+#include "scene/gui/panel_container.h"
+#include "scene/gui/scroll_bar.h"
+#include "scene/gui/spin_box.h"
 #include "scene/gui/view_panner.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/theme/theme_db.h"
@@ -507,11 +512,13 @@ void GraphEdit::_notification(int p_what) {
 			zoom_plus_button->set_icon(theme_cache.zoom_in);
 
 			toggle_snapping_button->set_icon(theme_cache.snapping_toggle);
-			show_grid_button->set_icon(theme_cache.grid_toggle);
+			toggle_grid_button->set_icon(theme_cache.grid_toggle);
 			minimap_button->set_icon(theme_cache.minimap_toggle);
-			layout_button->set_icon(theme_cache.layout);
+			arrange_button->set_icon(theme_cache.layout);
 
 			zoom_label->set_custom_minimum_size(Size2(48, 0) * theme_cache.base_scale);
+
+			menu_panel->add_theme_style_override("panel", theme_cache.menu_panel);
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -1528,18 +1535,6 @@ float GraphEdit::get_zoom_max() const {
 	return zoom_max;
 }
 
-void GraphEdit::set_show_zoom_label(bool p_enable) {
-	if (zoom_label->is_visible() == p_enable) {
-		return;
-	}
-
-	zoom_label->set_visible(p_enable);
-}
-
-bool GraphEdit::is_showing_zoom_label() const {
-	return zoom_label->is_visible();
-}
-
 void GraphEdit::set_right_disconnects(bool p_enable) {
 	right_disconnects = p_enable;
 }
@@ -1644,7 +1639,7 @@ void GraphEdit::set_show_grid(bool p_show) {
 	}
 
 	show_grid = p_show;
-	show_grid_button->set_pressed(p_show);
+	toggle_grid_button->set_pressed(p_show);
 	queue_redraw();
 }
 
@@ -1662,7 +1657,7 @@ void GraphEdit::_snapping_distance_changed(double) {
 }
 
 void GraphEdit::_show_grid_toggled() {
-	show_grid = show_grid_button->is_pressed();
+	show_grid = toggle_grid_button->is_pressed();
 	queue_redraw();
 }
 
@@ -1708,17 +1703,64 @@ bool GraphEdit::is_minimap_enabled() const {
 	return minimap_button->is_pressed();
 }
 
-void GraphEdit::set_arrange_nodes_button_hidden(bool p_enable) {
-	arrange_nodes_button_hidden = p_enable;
-	if (arrange_nodes_button_hidden) {
-		layout_button->hide();
-	} else {
-		layout_button->show();
-	}
+void GraphEdit::set_show_menu(bool p_hidden) {
+	show_menu = p_hidden;
+	menu_panel->set_visible(show_menu);
 }
 
-bool GraphEdit::is_arrange_nodes_button_hidden() const {
-	return arrange_nodes_button_hidden;
+bool GraphEdit::is_showing_menu() const {
+	return show_menu;
+}
+
+void GraphEdit::set_show_zoom_label(bool p_hidden) {
+	show_zoom_label = p_hidden;
+	zoom_label->set_visible(show_zoom_label);
+}
+
+bool GraphEdit::is_showing_zoom_label() const {
+	return show_zoom_label;
+}
+
+void GraphEdit::set_show_zoom_buttons(bool p_hidden) {
+	show_zoom_buttons = p_hidden;
+
+	zoom_minus_button->set_visible(show_zoom_buttons);
+	zoom_reset_button->set_visible(show_zoom_buttons);
+	zoom_plus_button->set_visible(show_zoom_buttons);
+}
+
+bool GraphEdit::is_showing_zoom_buttons() const {
+	return show_zoom_buttons;
+}
+
+void GraphEdit::set_show_grid_buttons(bool p_hidden) {
+	show_grid_buttons = p_hidden;
+
+	toggle_grid_button->set_visible(show_grid_buttons);
+	toggle_snapping_button->set_visible(show_grid_buttons);
+	snapping_distance_spinbox->set_visible(show_grid_buttons);
+}
+
+bool GraphEdit::is_showing_grid_buttons() const {
+	return show_grid_buttons;
+}
+
+void GraphEdit::set_show_minimap_button(bool p_hidden) {
+	show_minimap_button = p_hidden;
+	minimap_button->set_visible(show_minimap_button);
+}
+
+bool GraphEdit::is_showing_minimap_button() const {
+	return show_minimap_button;
+}
+
+void GraphEdit::set_show_arrange_button(bool p_hidden) {
+	show_arrange_button = p_hidden;
+	arrange_button->set_visible(show_arrange_button);
+}
+
+bool GraphEdit::is_showing_arrange_button() const {
+	return show_arrange_button;
 }
 
 void GraphEdit::_minimap_toggled() {
@@ -1814,9 +1856,6 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_zoom_step", "zoom_step"), &GraphEdit::set_zoom_step);
 	ClassDB::bind_method(D_METHOD("get_zoom_step"), &GraphEdit::get_zoom_step);
 
-	ClassDB::bind_method(D_METHOD("set_show_zoom_label", "enable"), &GraphEdit::set_show_zoom_label);
-	ClassDB::bind_method(D_METHOD("is_showing_zoom_label"), &GraphEdit::is_showing_zoom_label);
-
 	ClassDB::bind_method(D_METHOD("set_show_grid", "enable"), &GraphEdit::set_show_grid);
 	ClassDB::bind_method(D_METHOD("is_showing_grid"), &GraphEdit::is_showing_grid);
 
@@ -1843,8 +1882,23 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_minimap_enabled", "enable"), &GraphEdit::set_minimap_enabled);
 	ClassDB::bind_method(D_METHOD("is_minimap_enabled"), &GraphEdit::is_minimap_enabled);
 
-	ClassDB::bind_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::set_arrange_nodes_button_hidden);
-	ClassDB::bind_method(D_METHOD("is_arrange_nodes_button_hidden"), &GraphEdit::is_arrange_nodes_button_hidden);
+	ClassDB::bind_method(D_METHOD("set_show_menu", "hidden"), &GraphEdit::set_show_menu);
+	ClassDB::bind_method(D_METHOD("is_showing_menu"), &GraphEdit::is_showing_menu);
+
+	ClassDB::bind_method(D_METHOD("set_show_zoom_label", "enable"), &GraphEdit::set_show_zoom_label);
+	ClassDB::bind_method(D_METHOD("is_showing_zoom_label"), &GraphEdit::is_showing_zoom_label);
+
+	ClassDB::bind_method(D_METHOD("set_show_grid_buttons", "hidden"), &GraphEdit::set_show_grid_buttons);
+	ClassDB::bind_method(D_METHOD("is_showing_grid_buttons"), &GraphEdit::is_showing_grid_buttons);
+
+	ClassDB::bind_method(D_METHOD("set_show_zoom_buttons", "hidden"), &GraphEdit::set_show_zoom_buttons);
+	ClassDB::bind_method(D_METHOD("is_showing_zoom_buttons"), &GraphEdit::is_showing_zoom_buttons);
+
+	ClassDB::bind_method(D_METHOD("set_show_minimap_button", "hidden"), &GraphEdit::set_show_minimap_button);
+	ClassDB::bind_method(D_METHOD("is_showing_minimap_button"), &GraphEdit::is_showing_minimap_button);
+
+	ClassDB::bind_method(D_METHOD("set_show_arrange_button", "hidden"), &GraphEdit::set_show_arrange_button);
+	ClassDB::bind_method(D_METHOD("is_showing_arrange_button"), &GraphEdit::is_showing_arrange_button);
 
 	ClassDB::bind_method(D_METHOD("set_right_disconnects", "enable"), &GraphEdit::set_right_disconnects);
 	ClassDB::bind_method(D_METHOD("is_right_disconnects_enabled"), &GraphEdit::is_right_disconnects_enabled);
@@ -1861,12 +1915,12 @@ void GraphEdit::_bind_methods() {
 	GDVIRTUAL_BIND(_get_connection_line, "from_position", "to_position")
 	GDVIRTUAL_BIND(_is_node_hover_valid, "from_node", "from_port", "to_node", "to_port");
 
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "right_disconnects"), "set_right_disconnects", "is_right_disconnects_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "scroll_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_scroll_offset", "get_scroll_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grid"), "set_show_grid", "is_showing_grid");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snapping_enabled"), "set_snapping_enabled", "is_snapping_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "snapping_distance", PROPERTY_HINT_NONE, "suffix:px"), "set_snapping_distance", "get_snapping_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans"), "set_panning_scheme", "get_panning_scheme");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "right_disconnects"), "set_right_disconnects", "is_right_disconnects_enabled");
 
 	ADD_GROUP("Connection Lines", "connection_lines");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "connection_lines_curvature"), "set_connection_lines_curvature", "get_connection_lines_curvature");
@@ -1878,15 +1932,19 @@ void GraphEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom_min"), "set_zoom_min", "get_zoom_min");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom_max"), "set_zoom_max", "get_zoom_max");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom_step"), "set_zoom_step", "get_zoom_step");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_zoom_label"), "set_show_zoom_label", "is_showing_zoom_label");
 
 	ADD_GROUP("Minimap", "minimap_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "minimap_enabled"), "set_minimap_enabled", "is_minimap_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "minimap_size", PROPERTY_HINT_NONE, "suffix:px"), "set_minimap_size", "get_minimap_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "minimap_opacity"), "set_minimap_opacity", "get_minimap_opacity");
 
-	ADD_GROUP("UI", "");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "arrange_nodes_button_hidden"), "set_arrange_nodes_button_hidden", "is_arrange_nodes_button_hidden");
+	ADD_GROUP("Toolbar Menu", "");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_menu"), "set_show_menu", "is_showing_menu");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_zoom_label"), "set_show_zoom_label", "is_showing_zoom_label");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_zoom_buttons"), "set_show_zoom_buttons", "is_showing_zoom_buttons");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_grid_buttons"), "set_show_grid_buttons", "is_showing_grid_buttons");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_minimap_button"), "set_show_minimap_button", "is_showing_minimap_button");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_arrange_button"), "set_show_arrange_button", "is_showing_arrange_button");
 
 	ADD_SIGNAL(MethodInfo("connection_request", PropertyInfo(Variant::STRING_NAME, "from_node"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::STRING_NAME, "to_node"), PropertyInfo(Variant::INT, "to_port")));
 	ADD_SIGNAL(MethodInfo("disconnection_request", PropertyInfo(Variant::STRING_NAME, "from_node"), PropertyInfo(Variant::INT, "from_port"), PropertyInfo(Variant::STRING_NAME, "to_node"), PropertyInfo(Variant::INT, "to_port")));
@@ -1919,6 +1977,8 @@ void GraphEdit::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_COLOR, GraphEdit, activity_color, "activity");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, selection_fill);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, selection_stroke);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, GraphEdit, menu_panel);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, GraphEdit, zoom_in);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, GraphEdit, zoom_out);
@@ -1979,84 +2039,106 @@ GraphEdit::GraphEdit() {
 	h_scrollbar->connect("value_changed", callable_mp(this, &GraphEdit::_scroll_moved));
 	v_scrollbar->connect("value_changed", callable_mp(this, &GraphEdit::_scroll_moved));
 
+	// Toolbar menu.
+
+	menu_panel = memnew(PanelContainer);
+	menu_panel->set_visible(show_menu);
+	top_layer->add_child(menu_panel);
+	menu_panel->set_position(Vector2(10, 10));
+
 	menu_hbox = memnew(HBoxContainer);
-	top_layer->add_child(menu_hbox);
-	menu_hbox->set_position(Vector2(10, 10));
+	menu_panel->add_child(menu_hbox);
+
+	// Zoom label and controls.
 
 	zoom_label = memnew(Label);
-	menu_hbox->add_child(zoom_label);
-	zoom_label->set_visible(false);
+	zoom_label->set_visible(show_zoom_label);
 	zoom_label->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	zoom_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	zoom_label->set_custom_minimum_size(Size2(48, 0));
+	menu_hbox->add_child(zoom_label);
 	_update_zoom_label();
 
 	zoom_minus_button = memnew(Button);
 	zoom_minus_button->set_theme_type_variation("FlatButton");
-	menu_hbox->add_child(zoom_minus_button);
+	zoom_minus_button->set_visible(show_zoom_buttons);
 	zoom_minus_button->set_tooltip_text(RTR("Zoom Out"));
-	zoom_minus_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_minus));
 	zoom_minus_button->set_focus_mode(FOCUS_NONE);
+	menu_hbox->add_child(zoom_minus_button);
+	zoom_minus_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_minus));
 
 	zoom_reset_button = memnew(Button);
 	zoom_reset_button->set_theme_type_variation("FlatButton");
-	menu_hbox->add_child(zoom_reset_button);
+	zoom_reset_button->set_visible(show_zoom_buttons);
 	zoom_reset_button->set_tooltip_text(RTR("Zoom Reset"));
-	zoom_reset_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_reset));
 	zoom_reset_button->set_focus_mode(FOCUS_NONE);
+	menu_hbox->add_child(zoom_reset_button);
+	zoom_reset_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_reset));
 
 	zoom_plus_button = memnew(Button);
 	zoom_plus_button->set_theme_type_variation("FlatButton");
-	menu_hbox->add_child(zoom_plus_button);
+	zoom_plus_button->set_visible(show_zoom_buttons);
 	zoom_plus_button->set_tooltip_text(RTR("Zoom In"));
-	zoom_plus_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_plus));
 	zoom_plus_button->set_focus_mode(FOCUS_NONE);
+	menu_hbox->add_child(zoom_plus_button);
+	zoom_plus_button->connect("pressed", callable_mp(this, &GraphEdit::_zoom_plus));
 
-	show_grid_button = memnew(Button);
-	show_grid_button->set_theme_type_variation("FlatButton");
-	show_grid_button->set_toggle_mode(true);
-	show_grid_button->set_tooltip_text(RTR("Toggle the visual grid."));
-	show_grid_button->connect("pressed", callable_mp(this, &GraphEdit::_show_grid_toggled));
-	show_grid_button->set_pressed(true);
-	show_grid_button->set_focus_mode(FOCUS_NONE);
-	menu_hbox->add_child(show_grid_button);
+	// Grid controls.
+
+	toggle_grid_button = memnew(Button);
+	toggle_grid_button->set_theme_type_variation("FlatButton");
+	toggle_grid_button->set_visible(show_grid_buttons);
+	toggle_grid_button->set_toggle_mode(true);
+	toggle_grid_button->set_pressed(true);
+	toggle_grid_button->set_tooltip_text(RTR("Toggle the visual grid."));
+	toggle_grid_button->set_focus_mode(FOCUS_NONE);
+	menu_hbox->add_child(toggle_grid_button);
+	toggle_grid_button->connect("pressed", callable_mp(this, &GraphEdit::_show_grid_toggled));
 
 	toggle_snapping_button = memnew(Button);
 	toggle_snapping_button->set_theme_type_variation("FlatButton");
+	toggle_snapping_button->set_visible(show_grid_buttons);
 	toggle_snapping_button->set_toggle_mode(true);
 	toggle_snapping_button->set_tooltip_text(RTR("Toggle snapping to the grid."));
-	toggle_snapping_button->connect("pressed", callable_mp(this, &GraphEdit::_snapping_toggled));
 	toggle_snapping_button->set_pressed(snapping_enabled);
 	toggle_snapping_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(toggle_snapping_button);
+	toggle_snapping_button->connect("pressed", callable_mp(this, &GraphEdit::_snapping_toggled));
 
 	snapping_distance_spinbox = memnew(SpinBox);
+	snapping_distance_spinbox->set_visible(show_grid_buttons);
 	snapping_distance_spinbox->set_min(GRID_MIN_SNAPPING_DISTANCE);
 	snapping_distance_spinbox->set_max(GRID_MAX_SNAPPING_DISTANCE);
 	snapping_distance_spinbox->set_step(1);
 	snapping_distance_spinbox->set_value(snapping_distance);
 	snapping_distance_spinbox->set_tooltip_text(RTR("Change the snapping distance."));
-	snapping_distance_spinbox->connect("value_changed", callable_mp(this, &GraphEdit::_snapping_distance_changed));
 	menu_hbox->add_child(snapping_distance_spinbox);
+	snapping_distance_spinbox->connect("value_changed", callable_mp(this, &GraphEdit::_snapping_distance_changed));
+
+	// Extra controls.
 
 	minimap_button = memnew(Button);
 	minimap_button->set_theme_type_variation("FlatButton");
+	minimap_button->set_visible(show_minimap_button);
 	minimap_button->set_toggle_mode(true);
 	minimap_button->set_tooltip_text(RTR("Toggle the graph minimap."));
-	minimap_button->connect("pressed", callable_mp(this, &GraphEdit::_minimap_toggled));
 	minimap_button->set_pressed(show_grid);
 	minimap_button->set_focus_mode(FOCUS_NONE);
 	menu_hbox->add_child(minimap_button);
+	minimap_button->connect("pressed", callable_mp(this, &GraphEdit::_minimap_toggled));
 
-	layout_button = memnew(Button);
-	layout_button->set_theme_type_variation("FlatButton");
-	menu_hbox->add_child(layout_button);
-	layout_button->set_tooltip_text(RTR("Automatically arrange selected nodes."));
-	layout_button->connect("pressed", callable_mp(this, &GraphEdit::arrange_nodes));
-	layout_button->set_focus_mode(FOCUS_NONE);
+	arrange_button = memnew(Button);
+	arrange_button->set_theme_type_variation("FlatButton");
+	arrange_button->set_visible(show_arrange_button);
+	arrange_button->connect("pressed", callable_mp(this, &GraphEdit::arrange_nodes));
+	arrange_button->set_focus_mode(FOCUS_NONE);
+	menu_hbox->add_child(arrange_button);
+	arrange_button->set_tooltip_text(RTR("Automatically arrange selected nodes."));
 
-	Vector2 minimap_size = Vector2(240, 160);
-	float minimap_opacity = 0.65;
+	// Minimap.
+
+	const Vector2 minimap_size = Vector2(240, 160);
+	const float minimap_opacity = 0.65;
 
 	minimap = memnew(GraphEditMinimap(this));
 	top_layer->add_child(minimap);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -32,15 +32,17 @@
 #define GRAPH_EDIT_H
 
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
 #include "scene/gui/graph_node.h"
-#include "scene/gui/label.h"
-#include "scene/gui/scroll_bar.h"
-#include "scene/gui/spin_box.h"
 
+class Button;
 class GraphEdit;
 class GraphEditArranger;
+class HScrollBar;
+class Label;
+class PanelContainer;
+class SpinBox;
 class ViewPanner;
+class VScrollBar;
 
 class GraphEditFilter : public Control {
 	GDCLASS(GraphEditFilter, Control);
@@ -154,10 +156,9 @@ private:
 
 	Button *toggle_snapping_button = nullptr;
 	SpinBox *snapping_distance_spinbox = nullptr;
-	Button *show_grid_button = nullptr;
+	Button *toggle_grid_button = nullptr;
 	Button *minimap_button = nullptr;
-
-	Button *layout_button = nullptr;
+	Button *arrange_button = nullptr;
 
 	HScrollBar *h_scrollbar = nullptr;
 	VScrollBar *v_scrollbar = nullptr;
@@ -165,7 +166,12 @@ private:
 	Ref<ViewPanner> panner;
 	bool warped_panning = true;
 
-	bool arrange_nodes_button_hidden = false;
+	bool show_menu = true;
+	bool show_zoom_label = false;
+	bool show_grid_buttons = true;
+	bool show_zoom_buttons = true;
+	bool show_minimap_button = true;
+	bool show_arrange_button = true;
 
 	bool snapping_enabled = true;
 	int snapping_distance = 20;
@@ -216,6 +222,7 @@ private:
 	float lines_curvature = 0.5f;
 	bool lines_antialiased = true;
 
+	PanelContainer *menu_panel = nullptr;
 	HBoxContainer *menu_hbox = nullptr;
 	Control *connections_layer = nullptr;
 	GraphEditFilter *top_layer = nullptr;
@@ -237,6 +244,8 @@ private:
 		Color activity_color;
 		Color selection_fill;
 		Color selection_stroke;
+
+		Ref<StyleBox> menu_panel;
 
 		Ref<Texture2D> zoom_in;
 		Ref<Texture2D> zoom_out;
@@ -293,6 +302,11 @@ private:
 
 	bool _check_clickable_control(Control *p_control, const Vector2 &r_mouse_pos, const Vector2 &p_offset);
 
+#ifndef DISABLE_DEPRECATED
+	bool _is_arrange_nodes_button_hidden_bind_compat_81582() const;
+	void _set_arrange_nodes_button_hidden_bind_compat_81582(bool p_enable);
+#endif
+
 protected:
 	virtual void _update_theme_item_cache() override;
 
@@ -301,6 +315,9 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+#endif
 
 	virtual bool is_in_input_hotzone(GraphNode *p_graph_node, int p_port_idx, const Vector2 &p_mouse_pos, const Vector2i &p_port_size);
 	virtual bool is_in_output_hotzone(GraphNode *p_graph_node, int p_port_idx, const Vector2 &p_mouse_pos, const Vector2i &p_port_size);
@@ -346,9 +363,6 @@ public:
 	void set_zoom_step(float p_zoom_step);
 	float get_zoom_step() const;
 
-	void set_show_zoom_label(bool p_enable);
-	bool is_showing_zoom_label() const;
-
 	void set_minimap_size(Vector2 p_size);
 	Vector2 get_minimap_size() const;
 	void set_minimap_opacity(float p_opacity);
@@ -357,8 +371,18 @@ public:
 	void set_minimap_enabled(bool p_enable);
 	bool is_minimap_enabled() const;
 
-	void set_arrange_nodes_button_hidden(bool p_enable);
-	bool is_arrange_nodes_button_hidden() const;
+	void set_show_menu(bool p_hidden);
+	bool is_showing_menu() const;
+	void set_show_zoom_label(bool p_hidden);
+	bool is_showing_zoom_label() const;
+	void set_show_grid_buttons(bool p_hidden);
+	bool is_showing_grid_buttons() const;
+	void set_show_zoom_buttons(bool p_hidden);
+	bool is_showing_zoom_buttons() const;
+	void set_show_minimap_button(bool p_hidden);
+	bool is_showing_minimap_button() const;
+	void set_show_arrange_button(bool p_hidden);
+	bool is_showing_arrange_button() const;
 
 	GraphEditFilter *get_top_layer() const { return top_layer; }
 	GraphEditMinimap *get_minimap() const { return minimap; }

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1148,6 +1148,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_stylebox("panel", "GraphEdit", make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
 
+	Ref<StyleBoxFlat> graph_toolbar_style = make_flat_stylebox(Color(0.24, 0.24, 0.24, 0.6), 4, 2, 4, 2);
+	theme->set_stylebox("menu_panel", "GraphEdit", graph_toolbar_style);
+
 	theme->set_color("grid_minor", "GraphEdit", Color(1, 1, 1, 0.05));
 	theme->set_color("grid_major", "GraphEdit", Color(1, 1, 1, 0.2));
 	theme->set_color("selection_fill", "GraphEdit", Color(1, 1, 1, 0.3));


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/81551 ~(drafting for now)~.
This should address the issues mentioned in https://github.com/godotengine/godot-proposals/issues/7061, possibly enough to close the proposal.

I'm introducing a set of exposed properties to hide parts of the menu bar, and the menu bar itself. Previously existing properties to hide the arrange button and to show the zoom label are grouped together with the new properties in the inspector. The property to hide the arrange button has been renamed, because its appearance in the inspector can be very misleading:

<img width="377" alt="godot windows editor dev x86_64_2023-09-12_19-36-03" src="https://github.com/godotengine/godot/assets/11782833/a47d8aa6-a953-4f70-adac-e55792dbc75d">

Now the property is called `hide_arrange_button`, and its methods are `set_hide_arrange_button` and `is_hiding_arrange_button`. Similar naming scheme was used for the new properties. The property to show the zoom label remains unchanged.

This can be discussed further because the problem of negative and positive names is a pretty annoying one. But for now this is my proposal.


https://github.com/godotengine/godot/assets/11782833/2d00b84f-2d2e-4443-80d4-db9756909eaf

----

Additionally I addressed a usability issue with the toolbar that I had noticed long ago. Since the toolbar didn't have a background and could easily appear on top of various text and icons, it could be hard to read and use under certain circumstances:

<img width="773" alt="godot windows editor dev x86_64_2023-09-12_19-07-41" src="https://github.com/godotengine/godot/assets/11782833/cf4a7f96-cfd5-40eb-b662-35860f6688d8">

So I added a semi-transparent background (both in the default theme and in the editor):

<img width="765" alt="godot windows editor dev x86_64_2023-09-12_19-28-03" src="https://github.com/godotengine/godot/assets/11782833/f0bc0e9a-37e9-49a9-a721-f24edbb9bfec">

<img width="576" alt="godot windows editor dev x86_64_2023-09-12_19-30-52" src="https://github.com/godotengine/godot/assets/11782833/ae86f2c3-0b0b-4a79-b954-cfcd8fd3f1b3">

PS. There are some changes in unrelated files because I've cleaned up includes in `graph_edit.h`.