### PR TITLE
MultiplayerSynchronizer: Improve performance of watched variables

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -709,16 +709,18 @@ void SceneReplicationInterface::_send_delta(int p_peer, const HashSet<ObjectID> 
 	for (const ObjectID &oid : p_synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(oid);
 		ERR_CONTINUE(!sync || !sync->get_replication_config().is_valid() || !sync->is_multiplayer_authority());
-		uint32_t net_id;
-		if (!_verify_synchronizer(p_peer, sync, net_id)) {
-			continue;
-		}
+
 		uint64_t last_usec = p_last_watch_usecs.has(oid) ? p_last_watch_usecs[oid] : 0;
 		uint64_t indexes;
 		List<Variant> delta = sync->get_delta_state(p_usec, last_usec, indexes);
 
 		if (!delta.size()) {
 			continue; // Nothing to update.
+		}
+
+		uint32_t net_id;
+		if (!_verify_synchronizer(p_peer, sync, net_id)) {
+			continue;
 		}
 
 		Vector<const Variant *> varp;


### PR DESCRIPTION
This PR partially resolves a specific issue we encountered while working with the High-Level-Multiplayer-System on our Multiplayer Top-Down Shooter.

I've thoroughly tested these modifications on both version 4.1.1-stable and the master branch. The accompanying screenshots were captured from the master branch for reference.

# Background
We recently encountered performance issues in our game, prompting us to investigate their root causes. During this process, we upgraded our project from version **4.0.3** to  **4.1.1** and transitioned to using variable "watch"ing as opposed to the "sync" option for data synchronization. We applied this approach wherever it made sense, significantly reducing server-client data traffic. This was particularly effective because many variables were not updated every frame. We greatly appreciated the efficiency gains from this feature that was introduced to the MultiplayerSynchronizer.

Unfortunately, this adjustment did not completely resolve our performance problems. After some time, we pinpointed the issue to our server's CPU struggling to handle the workload required. Regrettably, the integrated profiler did not provide sufficient insights in this case. Therefore, we turned to profiling our game using the Hotspot Profiler in conjunction with a debug build of the Godot Engine, as outlined in the Godot-documentation here: [link](https://docs.godotengine.org/en/stable/contributing/development/debugging/using_cpp_profilers.html).

We hope that this pull request, if merged, will contribute to partially alleviating our performance issues as soon as version 4.2 is released. If not, we remain optimistic that it will help to discover alternative ways to enhance the High-Level-Multiplayer-System's performance for all users of the engine. :)

#  Measurements
In our SceneTree, we typically have between **70 to 120** MultiplayerSynchronizers, which varies based on the game state. To optimize network synchronization, we've configured the `replication_interval` and `delta_interval` for most variables to approximately **0.016 seconds**, which aligns with a frame rate of 60 frames per second (i.e., approximately once per frame).

We conducted a gameplay session that lasted precisely 5 minutes, with around 30 seconds of setup time before starting a game round and an additional 20 seconds after finishing the game round. These timings were meticulously controlled by in-game timers. During our profiling analysis, we observed that the processing of calls to `SceneMultiplayer::poll` was consuming a significant amount of time in our specific scenario, accounting for **35.9%** of the processing load. This was even more time-consuming than the processing of calls to `SceneTree::_process`, which constituted **23.7%** of the workload. 

The root cause of this performance issue appears to be the resource-intensive nature of the calls to `_verify_synchronizer`, which are invoked by both `_send_delta` and `_send_sync`.

### Everything
![grafik](https://github.com/godotengine/godot/assets/26871131/0a594530-6676-434a-b5f4-b20601b24385)
### SceneMultiplayer::poll
![grafik](https://github.com/godotengine/godot/assets/26871131/76f12bc3-1940-4634-8230-4a4ed25e6b2e)
### SceneReplicationInterface::_send_delta
![grafik](https://github.com/godotengine/godot/assets/26871131/12021596-a3af-4351-aec2-bf6707e8e78d)
### SceneReplicationInterface::_send_sync
![grafik](https://github.com/godotengine/godot/assets/26871131/fa8a5988-86b9-4444-8b45-bb734c1ea83d)

# How to Improve
The majority of the performance cost associated with the `SceneMultiplayer::poll` method can be attributed to two specific methods: `_send_delta` (responsible for synchronizing variables set to "watch") and `_send_sync` (responsible for synchronizing variables set to "sync"). At least, that's the understanding I've gathered from the code. Both of these methods call `_verify_synchronizer`, which appears to be a potential bottleneck in our performance analysis. It's worth noting that any improvements made to this function could potentially benefit all games utilizing the Highlevel Multiplayer Systems.

Given my current limited familiarity with the codebase, I'm unable to provide a specific enhancement strategy for `_verify_synchronizer`. Instead, I suggest an alternative approach for this pull request. It appears that `_send_delta` invokes the `_verify_synchronizer` method before checking if there is data that requires updating. I propose to modify the code to perform these checks before calling `_verify_synchronizer`. This change would ensure that `_verify_synchronizer` is only invoked when an update is genuinely necessary (similar to what `_send_sync` already does). Currently, it's being called even when no update is needed. To illustrate the impact of this modification, I've provided screenshots of the results after implementing this change.

### Everything
![grafik](https://github.com/godotengine/godot/assets/26871131/dc9b5399-d3a9-450e-8fa5-c7fd7076d3c8)
### SceneMultiplayer::poll
![grafik](https://github.com/godotengine/godot/assets/26871131/aa48517d-4d51-4456-8d03-bbbb06527279)
### SceneReplicationInterface::_send_delta
![grafik](https://github.com/godotengine/godot/assets/26871131/1bc1b8d0-e881-4d72-8db5-eba752cbb747)
### SceneReplicationInterface::_send_sync
![grafik](https://github.com/godotengine/godot/assets/26871131/330cfb62-fa46-4c18-a19d-a636030d1f81)

# Summary
The call to `_send_delta` has undergone a significant reduction in its execution time, which in turn has caused shifts in the **relative execution times** of various methods within the callstack. Here's an overview of these changes:

| Function                                      | before | after |
|-----------------------------------------------|--------|-------|
| Main::iteration                               | 74.8% (1.647E+11 cycles)  | 69.1% (1.294E+11 cycles)  |
| SceneTree::process                            | 60.9% (1.34E+11 cycles)  | 53.5% (1.002E+11 cycles)  |
| SceneMultiplayer::poll                        | 35.9% (0.7912E+11 cycles)  | 24.7%  (0.4632E+11 cycles)  |
| SceneReplicationInterface::on_network_process | 34.8% (0.7659E+11 cycles)  | 23.4% (0.4389E+11 cycles)  |
| SceneReplicationInterface::_send_delta        | 20.2% (0.4447E+11 cycles)  | 6.13% (0.1148E+11 cycles)  |

It's important to note that the data provided is specific to our project, and the extent of improvements or variations in performance could differ significantly for other projects. Regrettably, I am unable to share the specifics of this particular project. However, if necessary, I'd be willing to explore the possibility of creating a sample project to conduct more comprehensive testing and evaluation.

# BUT (Important):
I want to emphasize that there could be potential side-effects that I cannot confidently evaluate due to my limited familiarity with Godot's code. Assistance and insights from those more experienced in the code would be greatly appreciated. In our specific project, we encountered no problems, and everything functioned as expected. However, it's crucial to recognize that this may not necessarily apply to all use cases. Your assistance in assessing and addressing any unforeseen issues would be highly valued. (This is the first time I contribute anything to the Godot-Project)