### PR TITLE
Rename Geometry2D "point_is_inside_triangle" to "is_point_in_triangle" for consistency

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -724,7 +724,7 @@ Vector2 Geometry2D::get_closest_point_to_segment_uncapped(const Vector2 &p_point
 	return ::Geometry2D::get_closest_point_to_segment_uncapped(p_point, s);
 }
 
-bool Geometry2D::point_is_inside_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const {
+bool Geometry2D::is_point_in_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const {
 	return ::Geometry2D::is_point_in_triangle(s, a, b, c);
 }
 
@@ -883,7 +883,7 @@ void Geometry2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_closest_point_to_segment_uncapped", "point", "s1", "s2"), &Geometry2D::get_closest_point_to_segment_uncapped);
 
-	ClassDB::bind_method(D_METHOD("point_is_inside_triangle", "point", "a", "b", "c"), &Geometry2D::point_is_inside_triangle);
+	ClassDB::bind_method(D_METHOD("is_point_in_triangle", "point", "a", "b", "c"), &Geometry2D::is_point_in_triangle);
 
 	ClassDB::bind_method(D_METHOD("is_polygon_clockwise", "polygon"), &Geometry2D::is_polygon_clockwise);
 	ClassDB::bind_method(D_METHOD("is_point_in_polygon", "point", "polygon"), &Geometry2D::is_point_in_polygon);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -261,7 +261,7 @@ public:
 	Vector<Vector2> get_closest_points_between_segments(const Vector2 &p1, const Vector2 &q1, const Vector2 &p2, const Vector2 &q2);
 	Vector2 get_closest_point_to_segment(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b);
 	Vector2 get_closest_point_to_segment_uncapped(const Vector2 &p_point, const Vector2 &p_a, const Vector2 &p_b);
-	bool point_is_inside_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const;
+	bool is_point_in_triangle(const Vector2 &s, const Vector2 &a, const Vector2 &b, const Vector2 &c) const;
 
 	bool is_point_in_circle(const Vector2 &p_point, const Vector2 &p_circle_pos, real_t p_circle_radius);
 	real_t segment_intersects_circle(const Vector2 &p_from, const Vector2 &p_to, const Vector2 &p_circle_pos, real_t p_circle_radius);

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -184,7 +184,7 @@
 				The operation may result in an outer polygon (boundary) and inner polygon (hole) produced which could be distinguished by calling [method is_polygon_clockwise].
 			</description>
 		</method>
-		<method name="point_is_inside_triangle" qualifiers="const">
+		<method name="is_point_in_triangle" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />
 			<param index="1" name="a" type="Vector2" />


### PR DESCRIPTION
I renamed the Geometry2D function "point_is_inside_triangle" to "is_point_in_triangle" for consistency with "is_point_in_polygon" and "is_point_in_circle".