### PR TITLE
Fix GraphEdit port valid connections incorrectly checking sides

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -774,7 +774,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 
 						int type = graph_node->get_output_port_type(j);
 						if ((type == connecting_type ||
-									valid_connection_types.has(ConnectionType(connecting_type, type))) &&
+									valid_connection_types.has(ConnectionType(type, connecting_type))) &&
 								is_in_output_hotzone(graph_node, j, mpos, port_size)) {
 							if (!is_node_hover_valid(graph_node->get_name(), j, connecting_from, connecting_index)) {
 								continue;


### PR DESCRIPTION
Minimal reproduction project: [GraphEditPortConnectionTest.zip](https://github.com/godotengine/godot/files/12592274/GraphEditPortConnectionTest.zip)

<img width="577" alt="Screenshot 2023-09-12 at 8 41 35 PM" src="https://github.com/godotengine/godot/assets/1646875/e35a6ff9-bbdf-4789-9a18-ac9d20dbd83e">

The project has this code in it to create an asymmetric valid connection type:

```gdscript
func _ready():
	add_valid_connection_type(0, 1)
```

In the above screenshot, red is type 0 and green is type 1. This code makes it so that a connection from red to green is valid. The expectation is that this will allow to connect the top two GraphNodes, either by dragging from the red output to the green input or the green input to the red output, because we have an output of red and an input of green, and we stated that from red to green is allowed.

However, in the current master, this does not work correctly. In master, the test project will allow you to drag from red to green left to right on top, and from right to left on bottom, and doesn't let you start with green. This behavior is wrong, the only thing that matters is which inputs and outputs may be used together, not where the user started clicking. The fix is to flip the order of the arguments in this `ConnectionType` constructor (note: this must be the opposite of a similar line of code 20 lines down, in master they are the same which is wrong).