### PR TITLE
Fix `SubViewport` with `UPDATE_WHEN_VISIBLE` not working properly in exported project

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -931,11 +931,11 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 						roughness_detect_texture = tex;
 						roughness_channel = RS::TextureDetectRoughnessChannel(p_texture_uniforms[i].hint - ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_R);
 					}
+#endif // TOOLS_ENABLED
 					if (tex->render_target) {
 						tex->render_target->was_used = true;
 						render_target_cache.push_back(tex->render_target);
 					}
-#endif
 				}
 				if (rd_texture.is_null()) {
 					rd_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_WHITE);


### PR DESCRIPTION
The issue is primarily due to `RSG::texture_storage->render_target_was_used()` returning inconsistent results in the editor and exported projects.

Fix #81173, fix #80636.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
