### PR TITLE
Fix a lag spike in the audio bus editor

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -298,8 +298,6 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	StringName current = AudioServer::get_singleton()->get_bus_name(get_index());
 
 	ur->create_action(TTR("Rename Audio Bus"));
-	ur->add_do_method(buses, "_set_renaming_buses", true);
-	ur->add_undo_method(buses, "_set_renaming_buses", true);
 
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
@@ -317,8 +315,6 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	ur->add_do_method(buses, "_update_sends");
 	ur->add_undo_method(buses, "_update_sends");
 
-	ur->add_do_method(buses, "_set_renaming_buses", false);
-	ur->add_undo_method(buses, "_set_renaming_buses", false);
 	ur->commit_action();
 
 	updating_bus = false;
@@ -1011,17 +1007,9 @@ void EditorAudioBusDrop::_bind_methods() {
 EditorAudioBusDrop::EditorAudioBusDrop() {
 }
 
-void EditorAudioBuses::_set_renaming_buses(bool p_renaming) {
-	renaming_buses = p_renaming;
-}
-
-void EditorAudioBuses::_update_buses() {
-	if (renaming_buses) {
-		// This case will be handled more gracefully, no need to trigger a full rebuild.
-		// This is possibly a mistake in the AudioServer, which fires bus_layout_changed
-		// on a rename. This may not be intended, but no way to tell at the moment.
-		return;
-	}
+void EditorAudioBuses::_rebuild_buses() {
+	// This is not called when AudioServer emits the bus_layout_changed signal.
+	// Being called manually helps to avoid unnecessary rebuilding when renaming buses.
 
 	for (int i = bus_hb->get_child_count() - 1; i >= 0; i--) {
 		EditorAudioBus *audio_bus = Object::cast_to<EditorAudioBus>(bus_hb->get_child(i));
@@ -1063,7 +1051,7 @@ void EditorAudioBuses::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			_update_buses();
+			_rebuild_buses();
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
@@ -1102,8 +1090,8 @@ void EditorAudioBuses::_add_bus() {
 	ur->create_action(TTR("Add Audio Bus"));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count() + 1);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count());
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_rebuild_buses");
+	ur->add_undo_method(this, "_rebuild_buses");
 	ur->commit_action();
 }
 
@@ -1144,8 +1132,8 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 		ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", index, AudioServer::get_singleton()->get_bus_effect(index, i));
 		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", index, i, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
 	}
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_rebuild_buses");
+	ur->add_undo_method(this, "_rebuild_buses");
 	ur->commit_action();
 }
 
@@ -1165,8 +1153,8 @@ void EditorAudioBuses::_duplicate_bus(int p_which) {
 		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", add_at_pos, i, AudioServer::get_singleton()->is_bus_effect_enabled(p_which, i));
 	}
 	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus", add_at_pos);
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_rebuild_buses");
+	ur->add_undo_method(this, "_rebuild_buses");
 	ur->commit_action();
 }
 
@@ -1178,8 +1166,8 @@ void EditorAudioBuses::_reset_bus_volume(Object *p_which) {
 	ur->create_action(TTR("Reset Bus Volume"));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_update_bus", index);
+	ur->add_undo_method(this, "_update_bus", index);
 	ur->commit_action();
 }
 
@@ -1202,8 +1190,8 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 	int real_index = p_index > p_bus ? p_index - 1 : p_index;
 	ur->add_undo_method(AudioServer::get_singleton(), "move_bus", real_index, real_bus);
 
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_rebuild_buses");
+	ur->add_undo_method(this, "_rebuild_buses");
 	ur->commit_action();
 }
 
@@ -1252,7 +1240,7 @@ void EditorAudioBuses::_load_default_layout() {
 	edited_path = layout_path;
 	file->set_text(String(TTR("Layout:")) + " " + layout_path.get_file());
 	AudioServer::get_singleton()->set_bus_layout(state);
-	_update_buses();
+	_rebuild_buses();
 	EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 	call_deferred(SNAME("_select_layout"));
 }
@@ -1268,9 +1256,6 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 		edited_path = p_string;
 		file->set_text(String(TTR("Layout:")) + " " + p_string.get_file());
 		AudioServer::get_singleton()->set_bus_layout(state);
-		_update_buses();
-		EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
-		call_deferred(SNAME("_select_layout"));
 
 	} else if (file_dialog->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
 		if (new_layout) {
@@ -1288,15 +1273,15 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 
 		edited_path = p_string;
 		file->set_text(String(TTR("Layout:")) + " " + p_string.get_file());
-		_update_buses();
-		EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
-		call_deferred(SNAME("_select_layout"));
 	}
+
+	_rebuild_buses();
+	EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
+	call_deferred(SNAME("_select_layout"));
 }
 
 void EditorAudioBuses::_bind_methods() {
-	ClassDB::bind_method("_set_renaming_buses", &EditorAudioBuses::_set_renaming_buses);
-	ClassDB::bind_method("_update_buses", &EditorAudioBuses::_update_buses);
+	ClassDB::bind_method("_rebuild_buses", &EditorAudioBuses::_rebuild_buses);
 	ClassDB::bind_method("_update_bus", &EditorAudioBuses::_update_bus);
 	ClassDB::bind_method("_update_sends", &EditorAudioBuses::_update_sends);
 	ClassDB::bind_method("_select_layout", &EditorAudioBuses::_select_layout);
@@ -1373,8 +1358,6 @@ EditorAudioBuses::EditorAudioBuses() {
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));
 
-	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_update_buses));
-
 	set_process(true);
 }
 
@@ -1390,7 +1373,7 @@ void EditorAudioBuses::open_layout(const String &p_path) {
 	edited_path = p_path;
 	file->set_text(p_path.get_file());
 	AudioServer::get_singleton()->set_bus_layout(state);
-	_update_buses();
+	_rebuild_buses();
 	EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 	call_deferred(SNAME("_select_layout"));
 }

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -172,14 +172,11 @@ class EditorAudioBuses : public VBoxContainer {
 	Timer *save_timer = nullptr;
 	String edited_path;
 
-	bool renaming_buses = false;
-	void _set_renaming_buses(bool p_renaming);
-
-	void _add_bus();
-	void _update_buses();
+	void _rebuild_buses();
 	void _update_bus(int p_index);
 	void _update_sends();
 
+	void _add_bus();
 	void _delete_bus(Object *p_which);
 	void _duplicate_bus(int p_which);
 	void _reset_bus_volume(Object *p_which);


### PR DESCRIPTION
I disconnected `bus_layout_changed` from the function that rebuilds audio buses, as renaming audio buses causes the whole audio bus editor to rebuild which is undesired. This required a hefty workaround to avoid a lag spike when renaming, and it also caused duplicating to rebuild the audio bus editor twice just to add a new bus, and to then rename it. Now I removed the hefty workaround.

On top of unnecessary rebuilds from renaming, UndoRedo often asked for YET another rebuild. Rebuilding is an expensive operation that can cause a visible lag spike, especially if you have a lot of audio buses, which made this blunder quite noticeable. The rebuilds UndoRedo asks for are now the only ones I've kept (actually I removed one when resetting a bus volume, as you can ask for a single bus to be updated there)

- Duplicating buses: 3 rebuilds -> 1 rebuild
- Adding, moving, and deleting buses: 2 rebuilds -> 1 rebuild
- Resetting bus volume: 1 rebuild -> no rebuild

Regarding the comment I wiped - I'm positive that renaming audio buses should emit `bus_layout_changed` - as it changes how you interact with the audio bus system, not just how it affects audio. For example, AudioStreamPlayer relies on this signal to have an up-to-date list of buses you can pick in the inspector.