### PR TITLE
Fix VoxelGI MultiMesh and CSG mesh baking

### DIFF
--- a/scene/3d/multimesh_instance_3d.cpp
+++ b/scene/3d/multimesh_instance_3d.cpp
@@ -49,6 +49,26 @@ Ref<MultiMesh> MultiMeshInstance3D::get_multimesh() const {
 	return multimesh;
 }
 
+Array MultiMeshInstance3D::get_meshes() const {
+	if (multimesh.is_null() || multimesh->get_mesh().is_null() || multimesh->get_transform_format() != MultiMesh::TransformFormat::TRANSFORM_3D) {
+		return Array();
+	}
+
+	int count = multimesh->get_visible_instance_count();
+	if (count == -1) {
+		count = multimesh->get_instance_count();
+	}
+
+	Ref<Mesh> mesh = multimesh->get_mesh();
+
+	Array results;
+	for (int i = 0; i < count; i++) {
+		results.push_back(multimesh->get_instance_transform(i));
+		results.push_back(mesh);
+	}
+	return results;
+}
+
 AABB MultiMeshInstance3D::get_aabb() const {
 	if (multimesh.is_null()) {
 		return AABB();

--- a/scene/3d/multimesh_instance_3d.h
+++ b/scene/3d/multimesh_instance_3d.h
@@ -47,6 +47,8 @@ public:
 	void set_multimesh(const Ref<MultiMesh> &p_multimesh);
 	Ref<MultiMesh> get_multimesh() const;
 
+	Array get_meshes() const;
+
 	virtual AABB get_aabb() const override;
 
 	MultiMeshInstance3D();

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -383,6 +383,8 @@ Voxelizer::MaterialCache Voxelizer::_get_material_cache(Ref<Material> p_material
 }
 
 void Voxelizer::plot_mesh(const Transform3D &p_xform, Ref<Mesh> &p_mesh, const Vector<Ref<Material>> &p_materials, const Ref<Material> &p_override_material) {
+	ERR_FAIL_COND_MSG(!p_xform.is_finite(), "Invalid mesh bake transform.");
+
 	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
 		if (p_mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
 			continue; //only triangles


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/56024
* Fixes https://github.com/godotengine/godot/issues/79987 as a side effect.

Adds `MultiMeshInstance3D::get_meshes()` so that VoxelGI will collect the non-node geometry from MultiMeshInstance3D. That method is the semi-secret handshake that VoxelGI uses for this, currently GridMap, CSGShape3D and after this PR MultiMeshInstance3D support it. I'm not a big fan of that way of exposing this functionality, it's kind of limited, hard to extend and has to be made public only for this one usecase, but it's currently the supported way.

Also fixes a node GI mode check so that disabled, static and dynamic options work correctly. Bug https://github.com/godotengine/godot/issues/79987 was caused because this check was missing from one branch when collecting nodes during VoxelGI baking. This meant that CSGShape3D VoxelGI baking was wrong in following ways depending on its GI mode:

* Disabled was actually Static
* Static was Static (correct)
* Dynamic was both Static AND Dynamic, which is not normally possible.

The last issue caused https://github.com/godotengine/godot/issues/79987 as the CSGShape3D was both baked as static while also considered dynamic, which caused some visual issues.

I also added the `ERR_FAIL_COND_MSG()` transform check to `Voxelizer::plot_mesh()` because of https://github.com/godotengine/godot/issues/75485. It's pretty easy to accidentally create NAN's and INF's when currently playing around with MultiMesh, this adds a simple validation check and skips the mesh with an error message if the transform is obviously wrong.