### PR TITLE
Expose `PopupMenu` `activate_item_by_event` method

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -13,6 +13,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="activate_item_by_event">
+			<return type="bool" />
+			<param index="0" name="event" type="InputEvent" />
+			<param index="1" name="for_global_only" type="bool" default="false" />
+			<description>
+				Checks the provided [param event] against the [PopupMenu]'s shortcuts and accelerators, and activates the first item with matching events. If [param for_global_only] is [code]true[/code], only shortcuts and accelerators with [code]global[/code] set to [code]true[/code] will be called.
+				Returns [code]true[/code] if an item was successfully activated.
+				[b]Note:[/b] Certain [Control]s, such as [MenuButton], will call this method automatically.
+			</description>
+		</method>
 		<method name="add_check_item">
 			<return type="void" />
 			<param index="0" name="label" type="String" />

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2161,6 +2161,8 @@ void PopupMenu::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 void PopupMenu::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("activate_item_by_event", "event", "for_global_only"), &PopupMenu::activate_item_by_event, DEFVAL(false));
+
 	ClassDB::bind_method(D_METHOD("add_item", "label", "id", "accel"), &PopupMenu::add_item, DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_icon_item", "texture", "label", "id", "accel"), &PopupMenu::add_icon_item, DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_check_item", "label", "id", "accel"), &PopupMenu::add_check_item, DEFVAL(-1), DEFVAL(0));


### PR DESCRIPTION
Fixes #40836

Exposes the method that `Control`s like `MenuButton` use to propagate input information to the `PopupMenu`, so that accelerator and shortcut functionality isn't limited to those `Control`s.