### PR TITLE
Allow values greater than 1.0 in ReflectionProbe Intensity

### DIFF
--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -35,7 +35,7 @@
 			If [code]true[/code], computes shadows in the reflection probe. This makes the reflection probe slower to render; you may want to disable this if using the [constant UPDATE_ALWAYS] [member update_mode].
 		</member>
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="1.0">
-			Defines the reflection intensity. Intensity modulates the strength of the reflection.
+			Defines the reflection intensity. Intensity modulates the strength of the reflection. Only [code]1.0[/code] is physically accurate, but lower or greater values can be used for artistic control. If set to [code]0.0[/code], the [ReflectionProbe] will not display reflections on any materials. Instead, it will only affect ambient light through its ambient color properties.
 		</member>
 		<member name="interior" type="bool" setter="set_as_interior" getter="is_set_as_interior" default="false">
 			If [code]true[/code], reflections will ignore sky contribution.

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -242,7 +242,7 @@ void ReflectionProbe::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_update_mode"), &ReflectionProbe::get_update_mode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Once (Fast),Always (Slow)"), "set_update_mode", "get_update_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_intensity", "get_intensity");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity", PROPERTY_HINT_RANGE, "0,16,0.001,or_greater"), "set_intensity", "get_intensity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,16384,0.1,or_greater,exp,suffix:m"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "origin_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_origin_offset", "get_origin_offset");


### PR DESCRIPTION
Like for Light3D Specular, this is not physically accurate but can be used for artistic control.

Like with Intensity < 1.0, [blending with the background sky isn't functional](https://github.com/godotengine/godot/pull/67465), but blending with other ReflectionProbes is. This can be addressed in a separate PR.

This also improves documentation related to the Intensity property.

**Testing project:** [test_reflectionprobe_intensity_greater_1.zip](https://github.com/godotengine/godot/files/12600835/test_reflectionprobe_intensity_greater_1.zip)

- This closes https://github.com/godotengine/godot-proposals/issues/7654.