### PR TITLE
GDScript: Fix lambda hot reloading

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -86,6 +86,8 @@ class GDScript : public Script {
 	friend class GDScriptAnalyzer;
 	friend class GDScriptCompiler;
 	friend class GDScriptDocGen;
+	friend class GDScriptLambdaCallable;
+	friend class GDScriptLambdaSelfCallable;
 	friend class GDScriptLanguage;
 	friend struct GDScriptUtilityFunctionsDefinitions;
 
@@ -107,6 +109,30 @@ class GDScript : public Script {
 	HashMap<StringName, Ref<GDScript>> subclasses;
 	HashMap<StringName, MethodInfo> _signals;
 	Dictionary rpc_config;
+
+	struct LambdaInfo {
+		int capture_count;
+		bool use_self;
+	};
+
+	HashMap<GDScriptFunction *, LambdaInfo> lambda_info;
+
+	// List is used here because a ptr to elements are stored, so the memory locations need to be stable
+	struct UpdatableFuncPtr {
+		List<GDScriptFunction **> ptrs;
+		Mutex mutex;
+		bool initialized = false;
+	};
+	struct UpdatableFuncPtrElement {
+		List<GDScriptFunction **>::Element *element = nullptr;
+		Mutex *mutex = nullptr;
+	};
+	static thread_local UpdatableFuncPtr func_ptrs_to_update_thread_local;
+	List<UpdatableFuncPtr *> func_ptrs_to_update;
+	Mutex func_ptrs_to_update_mutex;
+
+	UpdatableFuncPtrElement _add_func_ptr_to_update(GDScriptFunction **p_func_ptr_ptr);
+	static void _remove_func_ptr_to_update(const UpdatableFuncPtrElement p_func_ptr_element);
 
 #ifdef TOOLS_ENABLED
 	// For static data storage during hot-reloading.

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1371,6 +1371,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				return GDScriptCodeGenerator::Address();
 			}
 
+			main_script->lambda_info.insert(function, { lambda->captures.size(), lambda->use_self });
 			gen->write_lambda(result, function, captures, lambda->use_self);
 
 			for (int i = 0; i < captures.size(); i++) {
@@ -2631,6 +2632,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 	p_script->implicit_ready = nullptr;
 	p_script->static_initializer = nullptr;
 	p_script->rpc_config.clear();
+	p_script->lambda_info.clear();
 
 	p_script->clearing = false;
 
@@ -3040,6 +3042,128 @@ void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::Cl
 	}
 }
 
+GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement_info(GDScriptFunction *p_func, int p_index, int p_depth, GDScriptFunction *p_parent_func) {
+	FunctionLambdaInfo info;
+	info.function = p_func;
+	info.parent = p_parent_func;
+	info.script = p_parent_func;
+	info.name = p_func->get_name();
+	info.line = p_func->_initial_line;
+	info.index = p_index;
+	info.depth = p_depth;
+	info.capture_count = 0;
+	info.use_self = false;
+	info.arg_count = p_func->_argument_count;
+	info.default_arg_count = p_func->_default_arg_count;
+	info.sublambdas = _get_function_lambda_replacement_info(p_func, p_depth, p_parent_func);
+
+	GDScript::LambdaInfo *extra_info = main_script->lambda_info.getptr(p_func);
+	if (extra_info != nullptr) {
+		info.capture_count = extra_info->capture_count;
+		info.use_self = extra_info->use_self;
+	}
+
+	return info;
+}
+
+Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
+	Vector<FunctionLambdaInfo> result;
+	// Only scrape the lambdas inside p_func.
+	for (int i = 0; i < p_func->lambdas.size(); ++i) {
+		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
+	}
+	return result;
+}
+
+GDScriptCompiler::ScriptLambdaInfo GDScriptCompiler::_get_script_lambda_replacement_info(GDScript *p_script) {
+	ScriptLambdaInfo info;
+
+	if (p_script->implicit_initializer) {
+		info.implicit_initializer_info = _get_function_lambda_replacement_info(p_script->implicit_initializer);
+	}
+	if (p_script->implicit_ready) {
+		info.implicit_ready_info = _get_function_lambda_replacement_info(p_script->implicit_ready);
+	}
+	if (p_script->static_initializer) {
+		info.static_initializer_info = _get_function_lambda_replacement_info(p_script->static_initializer);
+	}
+
+	for (const KeyValue<StringName, GDScriptFunction *> &E : p_script->member_functions) {
+		info.member_function_infos.insert(E.key, _get_function_lambda_replacement_info(E.value));
+	}
+
+	for (const KeyValue<StringName, Ref<GDScript>> &KV : p_script->get_subclasses()) {
+		info.subclass_info.insert(KV.key, _get_script_lambda_replacement_info(KV.value.ptr()));
+	}
+
+	return info;
+}
+
+bool GDScriptCompiler::_do_function_infos_match(const FunctionLambdaInfo &p_old_info, const FunctionLambdaInfo *p_new_info) {
+	if (p_new_info == nullptr) {
+		return false;
+	}
+
+	if (p_new_info->capture_count != p_old_info.capture_count || p_new_info->use_self != p_old_info.use_self) {
+		return false;
+	}
+
+	int old_required_arg_count = p_old_info.arg_count - p_old_info.default_arg_count;
+	int new_required_arg_count = p_new_info->arg_count - p_new_info->default_arg_count;
+	if (new_required_arg_count > old_required_arg_count || p_new_info->arg_count < old_required_arg_count) {
+		return false;
+	}
+
+	return true;
+}
+
+void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const FunctionLambdaInfo &p_old_info, const FunctionLambdaInfo *p_new_info) {
+	ERR_FAIL_COND(r_replacements.has(p_old_info.function));
+	if (!_do_function_infos_match(p_old_info, p_new_info)) {
+		p_new_info = nullptr;
+	}
+
+	r_replacements.insert(p_old_info.function, p_new_info != nullptr ? p_new_info->function : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.sublambdas, p_new_info != nullptr ? &p_new_info->sublambdas : nullptr);
+}
+
+void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const Vector<FunctionLambdaInfo> &p_old_infos, const Vector<FunctionLambdaInfo> *p_new_infos) {
+	for (int i = 0; i < p_old_infos.size(); ++i) {
+		const FunctionLambdaInfo &old_info = p_old_infos[i];
+		const FunctionLambdaInfo *new_info = nullptr;
+		if (p_new_infos != nullptr && p_new_infos->size() == p_old_infos.size()) {
+			// For now only attempt if the size is the same.
+			new_info = &p_new_infos->get(i);
+		}
+		_get_function_ptr_replacements(r_replacements, old_info, new_info);
+	}
+}
+
+void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const ScriptLambdaInfo &p_old_info, const ScriptLambdaInfo *p_new_info) {
+	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_initializer_info, p_new_info != nullptr ? &p_new_info->implicit_initializer_info : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_ready_info, p_new_info != nullptr ? &p_new_info->implicit_ready_info : nullptr);
+	_get_function_ptr_replacements(r_replacements, p_old_info.static_initializer_info, p_new_info != nullptr ? &p_new_info->static_initializer_info : nullptr);
+
+	for (const KeyValue<StringName, Vector<FunctionLambdaInfo>> &old_kv : p_old_info.member_function_infos) {
+		_get_function_ptr_replacements(r_replacements, old_kv.value, p_new_info != nullptr ? p_new_info->member_function_infos.getptr(old_kv.key) : nullptr);
+	}
+	for (int i = 0; i < p_old_info.other_function_infos.size(); ++i) {
+		const FunctionLambdaInfo &old_other_info = p_old_info.other_function_infos[i];
+		const FunctionLambdaInfo *new_other_info = nullptr;
+		if (p_new_info != nullptr && p_new_info->other_function_infos.size() == p_old_info.other_function_infos.size()) {
+			// For now only attempt if the size is the same.
+			new_other_info = &p_new_info->other_function_infos[i];
+		}
+		// Needs to be called on all old lambdas, even if there's no replacement.
+		_get_function_ptr_replacements(r_replacements, old_other_info, new_other_info);
+	}
+	for (const KeyValue<StringName, ScriptLambdaInfo> &old_kv : p_old_info.subclass_info) {
+		const ScriptLambdaInfo &old_subinfo = old_kv.value;
+		const ScriptLambdaInfo *new_subinfo = p_new_info != nullptr ? p_new_info->subclass_info.getptr(old_kv.key) : nullptr;
+		_get_function_ptr_replacements(r_replacements, old_subinfo, new_subinfo);
+	}
+}
+
 Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_script, bool p_keep_state) {
 	err_line = -1;
 	err_column = -1;
@@ -3049,6 +3173,8 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	const GDScriptParser::ClassNode *root = parser->get_tree();
 
 	source = p_script->get_path();
+
+	ScriptLambdaInfo old_lambda_info = _get_script_lambda_replacement_info(p_script);
 
 	// Create scripts for subclasses beforehand so they can be referenced
 	make_scripts(p_script, root, p_keep_state);
@@ -3063,6 +3189,27 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 	err = _compile_class(main_script, root, p_keep_state);
 	if (err) {
 		return err;
+	}
+
+	ScriptLambdaInfo new_lambda_info = _get_script_lambda_replacement_info(p_script);
+
+	HashMap<GDScriptFunction *, GDScriptFunction *> func_ptr_replacements;
+	_get_function_ptr_replacements(func_ptr_replacements, old_lambda_info, &new_lambda_info);
+
+	{
+		MutexLock outer_lock(main_script->func_ptrs_to_update_mutex);
+		for (GDScript::UpdatableFuncPtr *updatable : main_script->func_ptrs_to_update) {
+			MutexLock inner_lock(updatable->mutex);
+			for (GDScriptFunction **func_ptr_ptr : updatable->ptrs) {
+				GDScriptFunction **replacement = func_ptr_replacements.getptr(*func_ptr_ptr);
+				if (replacement != nullptr) {
+					*func_ptr_ptr = *replacement;
+				} else {
+					// Probably a lambda from another reload, ignore.
+					*func_ptr_ptr = nullptr;
+				}
+			}
+		}
 	}
 
 	if (has_static_data && !root->annotated_static_unload) {

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -31,12 +31,13 @@
 #ifndef GDSCRIPT_LAMBDA_CALLABLE_H
 #define GDSCRIPT_LAMBDA_CALLABLE_H
 
+#include "gdscript.h"
+
 #include "core/object/ref_counted.h"
 #include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"
 
-class GDScript;
 class GDScriptFunction;
 class GDScriptInstance;
 
@@ -44,6 +45,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	GDScriptFunction *function = nullptr;
 	Ref<GDScript> script;
 	uint32_t h;
+	GDScript::UpdatableFuncPtrElement updatable_func_ptr_element;
 
 	Vector<Variant> captures;
 
@@ -51,6 +53,7 @@ class GDScriptLambdaCallable : public CallableCustom {
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
 
 public:
+	bool is_valid() const override;
 	uint32_t hash() const override;
 	String get_as_text() const override;
 	CompareEqualFunc get_compare_equal_func() const override;
@@ -60,7 +63,7 @@ public:
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(Ref<GDScript> p_script, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	virtual ~GDScriptLambdaCallable() = default;
+	virtual ~GDScriptLambdaCallable();
 };
 
 // Lambda callable that references a particular object, so it can use `self` in the body.
@@ -69,6 +72,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	Ref<RefCounted> reference; // For objects that are RefCounted, keep a reference.
 	Object *object = nullptr; // For non RefCounted objects, use a direct pointer.
 	uint32_t h;
+	GDScript::UpdatableFuncPtrElement updatable_func_ptr_element;
 
 	Vector<Variant> captures;
 
@@ -76,6 +80,7 @@ class GDScriptLambdaSelfCallable : public CallableCustom {
 	static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
 
 public:
+	bool is_valid() const override;
 	uint32_t hash() const override;
 	String get_as_text() const override;
 	CompareEqualFunc get_compare_equal_func() const override;
@@ -85,7 +90,7 @@ public:
 
 	GDScriptLambdaSelfCallable(Ref<RefCounted> p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
 	GDScriptLambdaSelfCallable(Object *p_self, GDScriptFunction *p_function, const Vector<Variant> &p_captures);
-	virtual ~GDScriptLambdaSelfCallable() = default;
+	virtual ~GDScriptLambdaSelfCallable();
 };
 
 #endif // GDSCRIPT_LAMBDA_CALLABLE_H

--- a/modules/gdscript/gdscript_rpc_callable.cpp
+++ b/modules/gdscript/gdscript_rpc_callable.cpp
@@ -73,6 +73,7 @@ void GDScriptRPCCallable::call(const Variant **p_arguments, int p_argcount, Vari
 }
 
 GDScriptRPCCallable::GDScriptRPCCallable(Object *p_object, const StringName &p_method) {
+	ERR_FAIL_NULL(p_object);
 	object = p_object;
 	method = p_method;
 	h = method.hash();


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/62769

swaps out the function pointers used in LambdaCallables when a script is reloaded
if it cant find a good replacement it invalidates the callable, so no more 'Bad Address Index' and crashes, it tells you its called an invalid lambda
the logic it uses to swap lambdas is very simple right now, swapping only if the argument count vaguely matches, and no lambdas were added or removed, evaluated for each function the lambda was in
also should be safe across threads, because lambdas can be created on any thread. i took care to make sure it wouldnt slow lambda creation down

it may be a good idea to add some more logic to how old lamdas are matched to new ones, the data is there but i dont know what would be intuitive, what would break logic, im all ears for heuristics

**MRP:**
[81628.zip](https://github.com/godotengine/godot/files/12830903/81628.zip)

_Production edit: added the MRP_