### PR TITLE
Add OS_Windows "missing system directory" error message

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -290,6 +290,29 @@ String OS::get_system_dir(SystemDir p_dir, bool p_shared_storage) const {
 	return ".";
 }
 
+String OS::system_dir_to_string(SystemDir p_dir) {
+	switch (p_dir) {
+		case SYSTEM_DIR_DESKTOP:
+			return "SYSTEM_DIR_DESKTOP";
+		case SYSTEM_DIR_DCIM:
+			return "SYSTEM_DIR_DCIM";
+		case SYSTEM_DIR_DOCUMENTS:
+			return "SYSTEM_DIR_DOCUMENTS";
+		case SYSTEM_DIR_DOWNLOADS:
+			return "SYSTEM_DIR_DOWNLOADS";
+		case SYSTEM_DIR_MOVIES:
+			return "SYSTEM_DIR_MOVIES";
+		case SYSTEM_DIR_MUSIC:
+			return "SYSTEM_DIR_MUSIC";
+		case SYSTEM_DIR_PICTURES:
+			return "SYSTEM_DIR_PICTURES";
+		case SYSTEM_DIR_RINGTONES:
+			return "SYSTEM_DIR_RINGTONES";
+		default:
+			return String();
+	}
+}
+
 Error OS::shell_open(String p_uri) {
 	return ERR_UNAVAILABLE;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -334,6 +334,9 @@ public:
 
 	OS();
 	virtual ~OS();
+
+protected:
+	static String system_dir_to_string(SystemDir p_dir);
 };
 
 #endif // OS_H

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1599,7 +1599,7 @@ String OS_Windows::get_system_dir(SystemDir p_dir, bool p_shared_storage) const 
 
 	PWSTR szPath;
 	HRESULT res = SHGetKnownFolderPath(id, 0, nullptr, &szPath);
-	ERR_FAIL_COND_V(res != S_OK, String());
+	ERR_FAIL_COND_V_MSG(res != S_OK, String(), vformat("Missing system directory: %s.", OS::system_dir_to_string(p_dir)));
 	String path = String::utf16((const char16_t *)szPath).replace("\\", "/");
 	CoTaskMemFree(szPath);
 	return path;


### PR DESCRIPTION
Add more descriptive error message to OS_Windows::get_system_dir if unable to get directory

Addresses Issue #76420

I know `OS::system_dir_to_string` isn't the most elegant thing, but I predict it could help on other OSs as well. Please let me know if you have a more elegant solution.

* *Bugsquad edit, fixes: #76420*