### PR TITLE
Add missing `is_deprecated` flag on the `SurfaceTool.generate_lod` function.

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -119,7 +119,7 @@
 				Removes the index array by expanding the vertex array.
 			</description>
 		</method>
-		<method name="generate_lod">
+		<method name="generate_lod" is_deprecated="true">
 			<return type="PackedInt32Array" />
 			<param index="0" name="nd_threshold" type="float" />
 			<param index="1" name="target_index_count" type="int" default="3" />


### PR DESCRIPTION
@fire noticed that this function was missing the deprecated flag.

The method description already mentions that it is deprecated. it's just missing the flag.