### PR TITLE
Fix SpinBox will reset unsubmitted text when redrawing

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -40,7 +40,7 @@ Size2 SpinBox::get_minimum_size() const {
 	return ms;
 }
 
-void SpinBox::_update_text() {
+void SpinBox::_update_text(bool p_keep_line_edit) {
 	String value = String::num(get_value(), Math::range_step_decimals(get_step()));
 	if (is_localizing_numeral_system()) {
 		value = TS->format_number(value);
@@ -55,7 +55,12 @@ void SpinBox::_update_text() {
 		}
 	}
 
+	if (p_keep_line_edit && value == last_updated_text && value != line_edit->get_text()) {
+		return;
+	}
+
 	line_edit->set_text_with_selection(value);
+	last_updated_text = value;
 }
 
 void SpinBox::_text_submitted(const String &p_string) {
@@ -245,7 +250,7 @@ inline void SpinBox::_adjust_width_for_icon(const Ref<Texture2D> &icon) {
 void SpinBox::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			_update_text();
+			_update_text(true);
 			_adjust_width_for_icon(theme_cache.updown_icon);
 
 			RID ci = get_canvas_item();

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -46,12 +46,13 @@ class SpinBox : public Range {
 	void _range_click_timeout();
 	void _release_mouse();
 
-	void _update_text();
+	void _update_text(bool p_keep_line_edit = false);
 	void _text_submitted(const String &p_string);
 	void _text_changed(const String &p_string);
 
 	String prefix;
 	String suffix;
+	String last_updated_text;
 	double custom_arrow_step = 0.0;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
This should fix #79507

As I mentioned in the issue, this [commit](https://github.com/godotengine/godot/commit/9500f8e69ae798c070c4daca9c46beaf8db18bd4) added `_update_text()` to `NOTIFICATION_DRAW`. And insided `_update_text()`, it uses the shared range value to update the `line_edit`'s text, but the value will override the unsubmited user's input. 

Originally this commit makes sense because user may call `set_value_no_signal` which will directly change shared range's value, but when a user input some text and then triggered `NOTIFICATION_DRAW`, this could be wrong and cause this bug.

So we will encounter a situation where we have two sources of value that need to consider in `_update_text`, one from script like `set_value_no_signal` which directly change range's value , one from user's uncommited input reflected in `line_edit` compoment. 

Basically what my fix do is that it trys to remember the last_updated_text, and when the value get from shared range equals this last_updated_text but not euqal to line_edit's current value, just return to keep line_edit's current value. That being saied, when a user is inputing something and some script called `set_value_no_signal` at the same time, this code will keep the shared range's value instead of user's input.

It should work in most cases, I know this is not the best fix, but I think it is less invasive in this way. I would appreciate any feedback or alternative suggestions.



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
