### PR TITLE
Add a `bus_renamed` AudioServer signal

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -317,7 +317,15 @@
 	<signals>
 		<signal name="bus_layout_changed">
 			<description>
-				Emitted when the [AudioBusLayout] changes.
+				Emitted when an audio bus is added, deleted, or moved.
+			</description>
+		</signal>
+		<signal name="bus_renamed">
+			<param index="0" name="bus_index" type="int" />
+			<param index="1" name="old_name" type="StringName" />
+			<param index="2" name="new_name" type="StringName" />
+			<description>
+				Emitted when the audio bus at [param bus_index] is renamed from [param old_name] to [param new_name].
 			</description>
 		</signal>
 	</signals>

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -298,8 +298,6 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	StringName current = AudioServer::get_singleton()->get_bus_name(get_index());
 
 	ur->create_action(TTR("Rename Audio Bus"));
-	ur->add_do_method(buses, "_set_renaming_buses", true);
-	ur->add_undo_method(buses, "_set_renaming_buses", true);
 
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_name", get_index(), attempt);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_name", get_index(), current);
@@ -317,8 +315,6 @@ void EditorAudioBus::_name_changed(const String &p_new_name) {
 	ur->add_do_method(buses, "_update_sends");
 	ur->add_undo_method(buses, "_update_sends");
 
-	ur->add_do_method(buses, "_set_renaming_buses", false);
-	ur->add_undo_method(buses, "_set_renaming_buses", false);
 	ur->commit_action();
 
 	updating_bus = false;
@@ -1011,18 +1007,7 @@ void EditorAudioBusDrop::_bind_methods() {
 EditorAudioBusDrop::EditorAudioBusDrop() {
 }
 
-void EditorAudioBuses::_set_renaming_buses(bool p_renaming) {
-	renaming_buses = p_renaming;
-}
-
-void EditorAudioBuses::_update_buses() {
-	if (renaming_buses) {
-		// This case will be handled more gracefully, no need to trigger a full rebuild.
-		// This is possibly a mistake in the AudioServer, which fires bus_layout_changed
-		// on a rename. This may not be intended, but no way to tell at the moment.
-		return;
-	}
-
+void EditorAudioBuses::_rebuild_buses() {
 	for (int i = bus_hb->get_child_count() - 1; i >= 0; i--) {
 		EditorAudioBus *audio_bus = Object::cast_to<EditorAudioBus>(bus_hb->get_child(i));
 		if (audio_bus) {
@@ -1063,7 +1048,7 @@ void EditorAudioBuses::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			_update_buses();
+			_rebuild_buses();
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
@@ -1102,8 +1087,6 @@ void EditorAudioBuses::_add_bus() {
 	ur->create_action(TTR("Add Audio Bus"));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count() + 1);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_count", AudioServer::get_singleton()->get_bus_count());
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1144,8 +1127,6 @@ void EditorAudioBuses::_delete_bus(Object *p_which) {
 		ur->add_undo_method(AudioServer::get_singleton(), "add_bus_effect", index, AudioServer::get_singleton()->get_bus_effect(index, i));
 		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_effect_enabled", index, i, AudioServer::get_singleton()->is_bus_effect_enabled(index, i));
 	}
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1165,8 +1146,6 @@ void EditorAudioBuses::_duplicate_bus(int p_which) {
 		ur->add_do_method(AudioServer::get_singleton(), "set_bus_effect_enabled", add_at_pos, i, AudioServer::get_singleton()->is_bus_effect_enabled(p_which, i));
 	}
 	ur->add_undo_method(AudioServer::get_singleton(), "remove_bus", add_at_pos);
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1178,8 +1157,8 @@ void EditorAudioBuses::_reset_bus_volume(Object *p_which) {
 	ur->create_action(TTR("Reset Bus Volume"));
 	ur->add_do_method(AudioServer::get_singleton(), "set_bus_volume_db", index, 0.f);
 	ur->add_undo_method(AudioServer::get_singleton(), "set_bus_volume_db", index, AudioServer::get_singleton()->get_bus_volume_db(index));
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
+	ur->add_do_method(this, "_update_bus", index);
+	ur->add_undo_method(this, "_update_bus", index);
 	ur->commit_action();
 }
 
@@ -1202,8 +1181,6 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 	int real_index = p_index > p_bus ? p_index - 1 : p_index;
 	ur->add_undo_method(AudioServer::get_singleton(), "move_bus", real_index, real_bus);
 
-	ur->add_do_method(this, "_update_buses");
-	ur->add_undo_method(this, "_update_buses");
 	ur->commit_action();
 }
 
@@ -1252,7 +1229,7 @@ void EditorAudioBuses::_load_default_layout() {
 	edited_path = layout_path;
 	file->set_text(String(TTR("Layout:")) + " " + layout_path.get_file());
 	AudioServer::get_singleton()->set_bus_layout(state);
-	_update_buses();
+	_rebuild_buses();
 	EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 	call_deferred(SNAME("_select_layout"));
 }
@@ -1268,7 +1245,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 		edited_path = p_string;
 		file->set_text(String(TTR("Layout:")) + " " + p_string.get_file());
 		AudioServer::get_singleton()->set_bus_layout(state);
-		_update_buses();
+		_rebuild_buses();
 		EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 		call_deferred(SNAME("_select_layout"));
 
@@ -1288,15 +1265,13 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 
 		edited_path = p_string;
 		file->set_text(String(TTR("Layout:")) + " " + p_string.get_file());
-		_update_buses();
+		_rebuild_buses();
 		EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 		call_deferred(SNAME("_select_layout"));
 	}
 }
 
 void EditorAudioBuses::_bind_methods() {
-	ClassDB::bind_method("_set_renaming_buses", &EditorAudioBuses::_set_renaming_buses);
-	ClassDB::bind_method("_update_buses", &EditorAudioBuses::_update_buses);
 	ClassDB::bind_method("_update_bus", &EditorAudioBuses::_update_bus);
 	ClassDB::bind_method("_update_sends", &EditorAudioBuses::_update_sends);
 	ClassDB::bind_method("_select_layout", &EditorAudioBuses::_select_layout);
@@ -1373,7 +1348,7 @@ EditorAudioBuses::EditorAudioBuses() {
 	add_child(file_dialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorAudioBuses::_file_dialog_callback));
 
-	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_update_buses));
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_rebuild_buses));
 
 	set_process(true);
 }
@@ -1390,7 +1365,7 @@ void EditorAudioBuses::open_layout(const String &p_path) {
 	edited_path = p_path;
 	file->set_text(p_path.get_file());
 	AudioServer::get_singleton()->set_bus_layout(state);
-	_update_buses();
+	_rebuild_buses();
 	EditorUndoRedoManager::get_singleton()->clear_history(true, EditorUndoRedoManager::GLOBAL_HISTORY);
 	call_deferred(SNAME("_select_layout"));
 }

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -172,14 +172,11 @@ class EditorAudioBuses : public VBoxContainer {
 	Timer *save_timer = nullptr;
 	String edited_path;
 
-	bool renaming_buses = false;
-	void _set_renaming_buses(bool p_renaming);
-
-	void _add_bus();
-	void _update_buses();
+	void _rebuild_buses();
 	void _update_bus(int p_index);
 	void _update_sends();
 
+	void _add_bus();
 	void _delete_bus(Object *p_which);
 	void _duplicate_bus(int p_which);
 	void _reset_bus_volume(Object *p_which);

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -354,10 +354,6 @@ void AudioStreamPlayer2D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void AudioStreamPlayer2D::_bus_layout_changed() {
-	notify_property_list_changed();
-}
-
 void AudioStreamPlayer2D::set_max_distance(float p_pixels) {
 	ERR_FAIL_COND(p_pixels <= 0.0);
 	max_distance = p_pixels;
@@ -426,6 +422,14 @@ float AudioStreamPlayer2D::get_panning_strength() const {
 	return panning_strength;
 }
 
+void AudioStreamPlayer2D::_on_bus_layout_changed() {
+	notify_property_list_changed();
+}
+
+void AudioStreamPlayer2D::_on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name) {
+	notify_property_list_changed();
+}
+
 void AudioStreamPlayer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &AudioStreamPlayer2D::set_stream);
 	ClassDB::bind_method(D_METHOD("get_stream"), &AudioStreamPlayer2D::get_stream);
@@ -490,7 +494,8 @@ void AudioStreamPlayer2D::_bind_methods() {
 }
 
 AudioStreamPlayer2D::AudioStreamPlayer2D() {
-	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer2D::_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer2D::_on_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &AudioStreamPlayer2D::_on_bus_renamed));
 	cached_global_panning_strength = GLOBAL_GET("audio/general/2d_panning_strength");
 	set_hide_clip_children(true);
 }

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -75,7 +75,9 @@ private:
 
 	StringName _get_actual_bus();
 	void _update_panning();
-	void _bus_layout_changed();
+
+	void _on_bus_layout_changed();
+	void _on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name);
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -674,10 +674,6 @@ void AudioStreamPlayer3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void AudioStreamPlayer3D::_bus_layout_changed() {
-	notify_property_list_changed();
-}
-
 void AudioStreamPlayer3D::set_max_distance(float p_metres) {
 	ERR_FAIL_COND(p_metres < 0.0);
 	max_distance = p_metres;
@@ -814,6 +810,14 @@ float AudioStreamPlayer3D::get_panning_strength() const {
 	return panning_strength;
 }
 
+void AudioStreamPlayer3D::_on_bus_layout_changed() {
+	notify_property_list_changed();
+}
+
+void AudioStreamPlayer3D::_on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name) {
+	notify_property_list_changed();
+}
+
 void AudioStreamPlayer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stream", "stream"), &AudioStreamPlayer3D::set_stream);
 	ClassDB::bind_method(D_METHOD("get_stream"), &AudioStreamPlayer3D::get_stream);
@@ -923,7 +927,8 @@ void AudioStreamPlayer3D::_bind_methods() {
 
 AudioStreamPlayer3D::AudioStreamPlayer3D() {
 	velocity_tracker.instantiate();
-	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer3D::_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer3D::_on_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &AudioStreamPlayer3D::_on_bus_renamed));
 	set_disable_scale(true);
 	cached_global_panning_strength = GLOBAL_GET("audio/general/3d_panning_strength");
 }

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -97,7 +97,8 @@ private:
 	Area3D *_get_overriding_area();
 	Vector<AudioFrame> _update_panning();
 
-	void _bus_layout_changed();
+	void _on_bus_layout_changed();
+	void _on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name);
 
 	uint32_t area_mask = 1;
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -236,6 +236,14 @@ bool AudioStreamPlayer::_is_active() const {
 	return false;
 }
 
+void AudioStreamPlayer::_on_bus_layout_changed() {
+	notify_property_list_changed();
+}
+
+void AudioStreamPlayer::_on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name) {
+	notify_property_list_changed();
+}
+
 void AudioStreamPlayer::set_stream_paused(bool p_pause) {
 	// TODO this does not have perfect recall, fix that maybe? If there are zero playbacks registered with the AudioServer, this bool isn't persisted.
 	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
@@ -303,10 +311,6 @@ void AudioStreamPlayer::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void AudioStreamPlayer::_bus_layout_changed() {
-	notify_property_list_changed();
-}
-
 bool AudioStreamPlayer::has_stream_playback() {
 	return !stream_playbacks.is_empty();
 }
@@ -372,7 +376,8 @@ void AudioStreamPlayer::_bind_methods() {
 }
 
 AudioStreamPlayer::AudioStreamPlayer() {
-	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer::_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer::_on_bus_layout_changed));
+	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &AudioStreamPlayer::_on_bus_renamed));
 }
 
 AudioStreamPlayer::~AudioStreamPlayer() {

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -63,7 +63,8 @@ private:
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
-	void _bus_layout_changed();
+	void _on_bus_layout_changed();
+	void _on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name);
 
 	Vector<AudioFrame> _get_volume_vector();
 


### PR DESCRIPTION
Adds a new signal and uses it to avoid unnecessary rebuilds of the audio bus editor, softening some lag spikes.

A slightly compat-breaking alternative to #81611 that also adds a new feature. The compat-breaking could be called a bugfix, depending on how you want to look at it. See the first few comments of the linked PR.