### PR TITLE
Defer updating the animations Tree in SpriteFramesEditor to avoid crashes

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -189,6 +189,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _down_pressed();
 	void _frame_duration_changed(double p_value);
 	void _update_library(bool p_skip_selector = false);
+	void _update_library_impl();
 
 	void _update_stop_icon();
 	void _play_pressed();
@@ -213,6 +214,9 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _zoom_in();
 	void _zoom_out();
 	void _zoom_reset();
+
+	bool animations_dirty = false;
+	bool pending_update = false;
 
 	bool updating;
 	bool updating_split_settings = false; // Skip SpinBox/Range callback when setting value by code.


### PR DESCRIPTION
Previously, clicking the LMB while renaming an animation could cause `SpriteFramesEditor::_update_library(false)` to be called during `Tree::propagate_mouse_event()`. This may cause a crash.

https://github.com/godotengine/godot/blob/3ed4497113fa10611b90290ce22a751fb9d26e2e/scene/gui/tree.cpp#L3783-L3784

https://github.com/godotengine/godot/blob/3ed4497113fa10611b90290ce22a751fb9d26e2e/scene/gui/tree.cpp#L4290-L4291

https://github.com/godotengine/godot/blob/3ed4497113fa10611b90290ce22a751fb9d26e2e/editor/plugins/sprite_frames_editor_plugin.cpp#L1222-L1223

We can defer updates to the editor interface to avoid calling `Tree::create_item()` at the wrong time.

Fix #79149.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
