### PR TITLE
Remove the equality check for `TabBar.set_tab_metadata`

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -770,11 +770,6 @@ bool TabBar::is_tab_hidden(int p_tab) const {
 
 void TabBar::set_tab_metadata(int p_tab, const Variant &p_metadata) {
 	ERR_FAIL_INDEX(p_tab, tabs.size());
-
-	if (tabs[p_tab].metadata == p_metadata) {
-		return;
-	}
-
 	tabs.write[p_tab].metadata = p_metadata;
 }
 


### PR DESCRIPTION
Makes the code equivalent to the `Tree.set_metadata` code.

Fix: https://github.com/godotengine/godot/issues/81647

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
