### PR TITLE
Improve GLES3 scene renderer compatibility with older devices

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2666,7 +2666,7 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now
 		global_defines += "\n#define MAX_LIGHT_DATA_STRUCTS " + itos(config->max_renderable_lights) + "\n";
 		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(MAX_DIRECTIONAL_LIGHTS) + "\n";
-		global_defines += "\n#define MAX_FORWARD_LIGHTS uint(" + itos(config->max_lights_per_object) + ")\n";
+		global_defines += "\n#define MAX_FORWARD_LIGHTS " + itos(config->max_lights_per_object) + "u\n";
 		material_storage->shaders.scene_shader.initialize(global_defines);
 		scene_globals.shader_default_version = material_storage->shaders.scene_shader.version_create();
 		material_storage->shaders.scene_shader.version_bind_shader(scene_globals.shader_default_version, SceneShaderGLES3::MODE_COLOR);


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/godotengine/godot/issues/78888#issuecomment-1615884898 and also on RocketChat where Shoozza mentioned that replacing the `uint(8)` with simply `8` helped with their NVIDIA GFX card (the actualy value of `8` will be generated dynamically, I just chose that as example). This probably doesn't fix the actual issue causing https://github.com/godotengine/godot/issues/78888 (although it might, I have seen stranger things), but it should help some older devices to work with our OpenGL Compatibility renderer.

It looks like some older ATI and NVDIA drivers and shader compilers don't consider `uint(8)` a constant expression, so let's go with `8u` instead as the shader code using this constant also uses uints. NVIDIA shader compiler is notoriously lax with type conversion and using `8` (signed int) does also work here on most NVIDIA devices (including mine), but it would fail on many other devices.