### PR TITLE
SceneTreeDock: Remove animation tracks with correct indices

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1757,6 +1757,8 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 						continue;
 					}
 
+					int tracks_removed = 0;
+
 					for (int i = 0; i < anim->get_track_count(); i++) {
 						NodePath track_np = anim->track_get_path(i);
 						Node *n = root->get_node_or_null(track_np);
@@ -1774,14 +1776,8 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 							if (found_path->value.is_empty()) {
 								//will be erased
 
-								int idx = 0;
-								HashSet<int>::Iterator EI = ran.begin();
-								ERR_FAIL_COND(!EI); //bug
-								while (*EI != i) {
-									idx++;
-									++EI;
-									ERR_FAIL_COND(!EI); //another bug
-								}
+								int idx = i - tracks_removed;
+								tracks_removed++;
 
 								undo_redo->add_do_method(anim.ptr(), "remove_track", idx);
 								undo_redo->add_undo_method(anim.ptr(), "add_track", anim->track_get_type(i), idx);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #81602

The index of an animation track to be removed was not determined correctly. `HashSet` was used to find out the updated index but it does not always keep its keys in the same order after erasing a key.