### PR TITLE
Fix GodotPhysicsDirectBodyState2D get_contact_impulse to return current physics step impulse

### DIFF
--- a/servers/physics_2d/godot_body_pair_2d.h
+++ b/servers/physics_2d/godot_body_pair_2d.h
@@ -70,6 +70,7 @@ class GodotBodyPair2D : public GodotConstraint2D {
 		real_t depth = 0.0;
 		bool active = false;
 		bool used = false;
+		Vector2 initial_rA, initial_rB;
 		Vector2 rA, rB;
 		real_t bounce = 0.0;
 	};
@@ -93,6 +94,7 @@ public:
 	virtual bool setup(real_t p_step) override;
 	virtual bool pre_solve(real_t p_step) override;
 	virtual void solve(real_t p_step) override;
+	virtual void post_solve(real_t p_step) override;
 
 	GodotBodyPair2D(GodotBody2D *p_A, int p_shape_A, GodotBody2D *p_B, int p_shape_B);
 	~GodotBodyPair2D();

--- a/servers/physics_2d/godot_constraint_2d.h
+++ b/servers/physics_2d/godot_constraint_2d.h
@@ -63,6 +63,7 @@ public:
 	virtual bool setup(real_t p_step) = 0;
 	virtual bool pre_solve(real_t p_step) = 0;
 	virtual void solve(real_t p_step) = 0;
+	virtual void post_solve(real_t p_step) {}
 
 	virtual ~GodotConstraint2D() {}
 };

--- a/servers/physics_2d/godot_step_2d.cpp
+++ b/servers/physics_2d/godot_step_2d.cpp
@@ -101,6 +101,13 @@ void GodotStep2D::_solve_island(uint32_t p_island_index, void *p_userdata) const
 	}
 }
 
+void GodotStep2D::_post_solve_island(LocalVector<GodotConstraint2D *> &p_constraint_island) const {
+	uint32_t constraint_count = p_constraint_island.size();
+	for (uint32_t constraint_index = 0; constraint_index < constraint_count; ++constraint_index) {
+		p_constraint_island[constraint_index]->post_solve(delta);
+	}
+}
+
 void GodotStep2D::_check_suspend(LocalVector<GodotBody2D *> &p_body_island) const {
 	bool can_sleep = true;
 
@@ -267,6 +274,11 @@ void GodotStep2D::step(GodotSpace2D *p_space, real_t p_delta) {
 		profile_endtime = OS::get_singleton()->get_ticks_usec();
 		p_space->set_elapsed_time(GodotSpace2D::ELAPSED_TIME_SOLVE_CONSTRAINTS, profile_endtime - profile_begtime);
 		profile_begtime = profile_endtime;
+	}
+
+	// Warning: This doesn't run on threads, because it involves thread-unsafe processing.
+	for (uint32_t island_index = 0; island_index < island_count; ++island_index) {
+		_post_solve_island(constraint_islands[island_index]);
 	}
 
 	/* INTEGRATE VELOCITIES */

--- a/servers/physics_2d/godot_step_2d.h
+++ b/servers/physics_2d/godot_step_2d.h
@@ -49,6 +49,7 @@ class GodotStep2D {
 	void _setup_constraint(uint32_t p_constraint_index, void *p_userdata = nullptr);
 	void _pre_solve_island(LocalVector<GodotConstraint2D *> &p_constraint_island) const;
 	void _solve_island(uint32_t p_island_index, void *p_userdata = nullptr) const;
+	void _post_solve_island(LocalVector<GodotConstraint2D *> &p_constraint_island) const;
 	void _check_suspend(LocalVector<GodotBody2D *> &p_body_island) const;
 
 public:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Issue:
GodotPhysicsDirectBodyState2D get_contact_impulse() function returns wrong value. Initial it returns just a Vector2.ZERO.
The problem is, that not the final impulse sum is used, but the value generated in pre_solve().

Solution:
The only solution I found was to add a function that's called after solve(). It's called post_solve and is optional for stuff that must be done in a GodotConstraint2D after being solved. Here we can add the collision contact info with all required information, instead of adding it in pre_solve(), where some information (the impulse sum) is missing.

Same issue for 3D:
https://github.com/godotengine/godot/pull/73569