### PR TITLE
Expose `SceneTreeDialog` and `PropertySelector` via `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -285,6 +285,47 @@
 				See also [method Window.set_unparent_when_invisible].
 			</description>
 		</method>
+		<method name="popup_node_selector">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<param index="1" name="valid_types" type="StringName[]" default="[]" />
+			<description>
+				Pops up an editor dialog for selecting a [Node] from the edited scene. The [param callback] must take a single argument of type [NodePath]. It is called on the selected [NodePath] or the empty path [code]^""[/code] if the dialog is canceled. If [param valid_types] is provided, the dialog will only show Nodes that match one of the listed Node types.
+				[b]Example:[/b]
+				[codeblock]
+				func _ready():
+				    if Engine.is_editor_hint():
+				        EditorInterface.popup_node_selector(_on_node_selected, ["Button"])
+
+				func _on_node_selected(node_path):
+				    if node_path.is_empty():
+				        print("node selection canceled")
+				    else:
+				        print("selected ", node_path)
+				[/codeblock]
+			</description>
+		</method>
+		<method name="popup_property_selector">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="callback" type="Callable" />
+			<param index="2" name="type_filter" type="PackedInt32Array" default="PackedInt32Array()" />
+			<description>
+				Pops up an editor dialog for selecting properties from [param object]. The [param callback] must take a single argument of type [NodePath]. It is called on the selected property path (see [method NodePath.get_as_property_path]) or the empty path [code]^""[/code] if the dialog is canceled. If [param type_filter] is provided, the dialog will only show properties that match one of the listed [enum Variant.Type] values.
+				[b]Example:[/b]
+				[codeblock]
+				func _ready():
+				    if Engine.is_editor_hint():
+				        EditorInterface.popup_property_selector(this, _on_property_selected, [TYPE_INT])
+
+				func _on_property_selected(property_path):
+				    if property_path.is_empty():
+				        print("property selection canceled")
+				    else:
+				        print("selected ", property_path)
+				[/codeblock]
+			</description>
+		</method>
 		<method name="reload_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -39,8 +39,10 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_run_bar.h"
+#include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
+#include "editor/property_selector.h"
 #include "editor/themes/editor_scale.h"
 #include "main/main.h"
 #include "scene/gui/box_container.h"
@@ -263,6 +265,93 @@ void EditorInterface::set_current_feature_profile(const String &p_profile_name) 
 	EditorFeatureProfileManager::get_singleton()->set_current_profile(p_profile_name, true);
 }
 
+// Editor dialogs.
+
+void EditorInterface::popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types) {
+	// TODO: Should reuse dialog instance instead of creating a fresh one, but need to rework set_valid_types first.
+	if (node_selector) {
+		node_selector->disconnect(SNAME("selected"), callable_mp(this, &EditorInterface::_node_selected).bind(p_callback));
+		node_selector->disconnect(SNAME("canceled"), callable_mp(this, &EditorInterface::_node_selection_canceled).bind(p_callback));
+		get_base_control()->remove_child(node_selector);
+		node_selector->queue_free();
+	}
+	node_selector = memnew(SceneTreeDialog);
+
+	Vector<StringName> valid_types;
+	int length = p_valid_types.size();
+	valid_types.resize(length);
+	for (int i = 0; i < length; i++) {
+		valid_types.write[i] = p_valid_types[i];
+	}
+	node_selector->set_valid_types(valid_types);
+
+	get_base_control()->add_child(node_selector);
+
+	node_selector->popup_scenetree_dialog();
+
+	const Callable selected_callback = callable_mp(this, &EditorInterface::_node_selected).bind(p_callback);
+	node_selector->connect(SNAME("selected"), selected_callback, CONNECT_DEFERRED);
+
+	const Callable canceled_callback = callable_mp(this, &EditorInterface::_node_selection_canceled).bind(p_callback);
+	node_selector->connect(SNAME("canceled"), canceled_callback, CONNECT_DEFERRED);
+}
+
+void EditorInterface::popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter) {
+	// TODO: Should reuse dialog instance instead of creating a fresh one, but need to rework set_type_filter first.
+	if (property_selector) {
+		property_selector->disconnect(SNAME("selected"), callable_mp(this, &EditorInterface::_property_selected).bind(p_callback));
+		property_selector->disconnect(SNAME("canceled"), callable_mp(this, &EditorInterface::_property_selection_canceled).bind(p_callback));
+		get_base_control()->remove_child(property_selector);
+		property_selector->queue_free();
+	}
+	property_selector = memnew(PropertySelector);
+
+	Vector<Variant::Type> type_filter;
+	int length = p_type_filter.size();
+	type_filter.resize(length);
+	for (int i = 0; i < length; i++) {
+		type_filter.write[i] = (Variant::Type)p_type_filter[i];
+	}
+	property_selector->set_type_filter(type_filter);
+
+	get_base_control()->add_child(property_selector);
+
+	property_selector->select_property_from_instance(p_object);
+
+	const Callable selected_callback = callable_mp(this, &EditorInterface::_property_selected).bind(p_callback);
+	property_selector->connect(SNAME("selected"), selected_callback, CONNECT_DEFERRED);
+
+	const Callable canceled_callback = callable_mp(this, &EditorInterface::_property_selection_canceled).bind(p_callback);
+	property_selector->connect(SNAME("canceled"), canceled_callback, CONNECT_DEFERRED);
+}
+
+void EditorInterface::_node_selected(const NodePath &p_node_path, const Callable &p_callback) {
+	const NodePath path = get_edited_scene_root()->get_path().rel_path_to(p_node_path);
+	_call_dialog_callback(p_callback, path, "node selected");
+}
+
+void EditorInterface::_node_selection_canceled(const Callable &p_callback) {
+	_call_dialog_callback(p_callback, NodePath(), "node selection canceled");
+}
+
+void EditorInterface::_property_selected(const String &p_property_name, const Callable &p_callback) {
+	_call_dialog_callback(p_callback, NodePath(p_property_name).get_as_property_path(), "property selected");
+}
+
+void EditorInterface::_property_selection_canceled(const Callable &p_callback) {
+	_call_dialog_callback(p_callback, NodePath(), "property selection canceled");
+}
+
+void EditorInterface::_call_dialog_callback(const Callable &p_callback, const Variant &p_selected, const String &p_context) {
+	Callable::CallError ce;
+	Variant ret;
+	const Variant *args[1] = { &p_selected };
+	p_callback.callp(args, 1, ret, ce);
+	if (ce.error != Callable::CallError::CALL_OK) {
+		ERR_PRINT(vformat("Error calling %s callback: %s", p_context, Variant::get_callable_error_text(p_callback, args, 1, ce)));
+	}
+}
+
 // Editor docks.
 
 FileSystemDock *EditorInterface::get_file_system_dock() const {
@@ -457,6 +546,11 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_current_feature_profile", "profile_name"), &EditorInterface::set_current_feature_profile);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "distraction_free_mode"), "set_distraction_free_mode", "is_distraction_free_mode_enabled");
+
+	// Editor dialogs.
+
+	ClassDB::bind_method(D_METHOD("popup_node_selector", "callback", "valid_types"), &EditorInterface::popup_node_selector, DEFVAL(TypedArray<StringName>()));
+	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()));
 
 	// Editor docks.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -48,6 +48,8 @@ class EditorSettings;
 class FileSystemDock;
 class Mesh;
 class Node;
+class PropertySelector;
+class SceneTreeDialog;
 class ScriptEditor;
 class SubViewport;
 class Texture2D;
@@ -59,6 +61,17 @@ class EditorInterface : public Object {
 	GDCLASS(EditorInterface, Object);
 
 	static EditorInterface *singleton;
+
+	// Editor dialogs.
+
+	PropertySelector *property_selector = nullptr;
+	SceneTreeDialog *node_selector = nullptr;
+
+	void _node_selected(const NodePath &p_node_paths, const Callable &p_callback);
+	void _node_selection_canceled(const Callable &p_callback);
+	void _property_selected(const String &p_property_name, const Callable &p_callback);
+	void _property_selection_canceled(const Callable &p_callback);
+	void _call_dialog_callback(const Callable &p_callback, const Variant &p_selected, const String &p_context);
 
 	// Editor tools.
 
@@ -109,6 +122,12 @@ public:
 
 	String get_current_feature_profile() const;
 	void set_current_feature_profile(const String &p_profile_name);
+
+	// Editor dialogs.
+
+	void popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>());
+	// Must use Vector<int> because exposing Vector<Variant::Type> is not supported.
+	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array());
 
 	// Editor docks.
 


### PR DESCRIPTION
Allows users to create `SceneTreeDialog` and `PropertySelector` dialogs via the `EditorInterface`. Lays the groundwork for adding similar dialogs in the future as needed.

The API is

```gdscript
EditorInterface.popup_dialog_scene_tree(callback: Callable, valid_types: Array[StringName] = [])
EditorInterface.popup_dialog_property_selector(object: Object, callback: Callable, type_filter: PackedIntArray = [])
```

Example usage

```gdscript
@tool
extends Node
class_name Main


func _ready() -> void:
	if Engine.is_editor_hint():
		EditorInterface.popup_dialog_scene_tree(_on_node_selected, [&"Button"])

func _on_node_selected(node_path : NodePath) -> void:
	if node_path == ^"":
		print("scene tree dialog canceled")
	else:
		EditorInterface.popup_dialog_property_selector(get_node(node_path), func(x) : print(x), [TYPE_BOOL])
```

Closes https://github.com/godotengine/godot-proposals/issues/7635.
Closes https://github.com/godotengine/godot-proposals/issues/7636.

Supersedes https://github.com/godotengine/godot/pull/81488.
Supersedes https://github.com/godotengine/godot/pull/81489.

Related: https://github.com/godotengine/godot-proposals/issues/300.

Edit 2023-Oct-05 12:45: 
I have only implemented `PropertySelector::select_property_from_instance`, but there are several related methods: `select_property_from_base_type`, `select_property_from_script`, and `select_property_from_basic_type`. Should I implement these now or wait until the need arises?

Edit 2023-Dec-09 19:06:
Edited example usage to reflect new API that uses a single NodePath instead of an array of NodePaths.