### PR TITLE
Fix dependency handling on move or rename in the filesystem dock

### DIFF
--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -262,12 +262,12 @@ private:
 	void _update_import_dock();
 
 	void _get_all_items_in_dir(EditorFileSystemDirectory *p_efsd, Vector<String> &r_files, Vector<String> &r_folders) const;
-	void _find_remaps(EditorFileSystemDirectory *p_efsd, const HashMap<String, String> &r_renames, Vector<String> &r_to_remaps) const;
+	void _find_remaps(EditorFileSystemDirectory *p_efsd, const Vector<String> &r_renames, Vector<String> &r_to_remaps) const;
 	void _try_move_item(const FileOrFolder &p_item, const String &p_new_path, HashMap<String, String> &p_file_renames, HashMap<String, String> &p_folder_renames);
 	void _try_duplicate_item(const FileOrFolder &p_item, const String &p_new_path) const;
-	void _update_dependencies_after_move(const HashMap<String, String> &p_renames) const;
-	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames) const;
-	void _save_scenes_after_move(const HashMap<String, String> &p_renames) const;
+	void _before_move(Vector<String> &r_old_paths, HashMap<String, ResourceUID::ID> &r_uids, Vector<String> &r_remaps) const;
+	void _update_dependencies_after_move(const HashMap<String, String> &p_renames, const Vector<String> &p_remaps) const;
+	void _update_resource_paths_after_move(const HashMap<String, String> &p_renames, const HashMap<String, ResourceUID::ID> &p_uids) const;
 	void _update_favorites_list_after_move(const HashMap<String, String> &p_files_renames, const HashMap<String, String> &p_folders_renames) const;
 	void _update_project_settings_after_move(const HashMap<String, String> &p_renames, const HashMap<String, String> &p_folders_renames);
 	String _get_unique_name(const FileOrFolder &p_entry, const String &p_at_path);


### PR DESCRIPTION
Fixes #79850.
...and probably more.

Moving a scene's dependency in the filesystem while the scene is open should no longer corrupt the scene.
Moving a scene together with it's dependency while it's open should no longer crash the engine.
Also fixes most of the error spam that was happening when moving things around.

Open scenes which depend on moved files are now saved before the move, which prevents losing unsaved changes like before, but in a less error-prone way.
The `ResourceUID` system is properly informed of resources changing paths now, this was the source of most of the problems.
A lot of expensive function calls were removed, moving things around in the filesystem should be faster.
There are some errors remaining related to scripts being looked for in the old location, but nothing seems to actually break now.

Please test this by moving stuff around in the filesystem with a copy of your non-trivial project.

*Bugsquad edit:* Fixes #77289 Fixes #59116