### PR TITLE
Add note about format to splash image description

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -247,6 +247,7 @@
 		<member name="application/boot_splash/image" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to an image used as the boot splash. If left empty, the default Godot Engine splash will be displayed instead.
 			[b]Note:[/b] Only effective if [member application/boot_splash/show_image] is [code]true[/code].
+			[b]Note:[/b] The only supported format is PNG. Using another image format will result in an error.
 		</member>
 		<member name="application/boot_splash/minimum_display_time" type="int" setter="" getter="" default="0">
 			Minimum boot splash display time (in milliseconds). It is not recommended to set too high values for this setting.


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/7327#issuecomment-1719759787
While the file dialog by default allows picking only PNG, you can select another format using other means.