### PR TITLE
Don't paste nodes as sibling of scene root

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2981,7 +2981,10 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("scene_tree/copy_node"), TOOL_COPY);
 		if (selection.size() == 1 && !node_clipboard.is_empty()) {
 			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node"), TOOL_PASTE);
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE);
+			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionPaste")), ED_GET_SHORTCUT("scene_tree/paste_node_as_sibling"), TOOL_PASTE_AS_SIBLING);
+			if (selection.front()->get() == edited_scene) {
+				menu->set_item_disabled(-1, true);
+			}
 		}
 		menu->add_separator();
 	}
@@ -3380,12 +3383,19 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 	}
 
 	Node *paste_parent = edited_scene;
+	Node *paste_sibling = nullptr;
+
 	List<Node *> selection = editor_selection->get_selected_node_list();
 	if (selection.size() > 0) {
 		paste_parent = selection.back()->get();
 	}
 
 	if (p_paste_as_sibling) {
+		if (paste_parent == edited_scene) {
+			return pasted_nodes; // Don't paste as sibling of scene root.
+		}
+
+		paste_sibling = paste_parent;
 		paste_parent = paste_parent->get_parent();
 	}
 
@@ -3399,7 +3409,7 @@ List<Node *> SceneTreeDock::paste_nodes(bool p_paste_as_sibling) {
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 	if (paste_parent) {
-		ur->create_action(vformat(p_paste_as_sibling ? TTR("Paste Node(s) as Sibling of %s") : TTR("Paste Node(s) as Child of %s"), paste_parent->get_name()), UndoRedo::MERGE_DISABLE, edited_scene);
+		ur->create_action(vformat(p_paste_as_sibling ? TTR("Paste Node(s) as Sibling of %s") : TTR("Paste Node(s) as Child of %s"), paste_sibling ? paste_sibling->get_name() : paste_parent->get_name()), UndoRedo::MERGE_DISABLE, edited_scene);
 	} else {
 		ur->create_action(TTR("Paste Node(s) as Root"), UndoRedo::MERGE_DISABLE, edited_scene);
 	}


### PR DESCRIPTION
The new Paste As Sibling option could be used without selection, resulting in node being a sibling of viewport.

https://github.com/godotengine/godot/assets/2223172/3bc63710-398c-42b9-b97b-c8887e689d5a

This PR fixes that. Also fixes wrong node name in the action.

Another thing I noticed is that when pasting as sibling the new node will be always at the end of the list. I think it should be just below the used sibling.

EDIT:
Also fixes the menu option not working correctly.