### PR TITLE
Clarify filtering by node type and group in the Scene tree dock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3841,7 +3841,8 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	// The "Filter Nodes" text input above the Scene Tree Editor.
 	filter = memnew(LineEdit);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->set_placeholder(TTR("Filter Nodes"));
+	filter->set_placeholder(TTR("Filter: name, t:type, g:group"));
+	filter->set_tooltip_text(TTR("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\")\nor group (if prefixed with \"group:\" or \"g:\"). Filtering is case-insensitive."));
 	filter_hbc->add_child(filter);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDock::_filter_changed));


### PR DESCRIPTION
This functionality has been available since 4.0, but was difficult to discover since there was no tooltip and the placeholder didn't mention it.

## Preview

To make the most important part of it (`t:type`) squeeze within the default dock width, I had to be a little creative, but it should be self-explanatory enough:

![image](https://github.com/godotengine/godot/assets/180032/f66fcf57-8d36-454a-b998-4ef850dd820f)