### PR TITLE
C#: Hide hostfxr not found error

### DIFF
--- a/modules/mono/editor/hostfxr_resolver.cpp
+++ b/modules/mono/editor/hostfxr_resolver.cpp
@@ -320,7 +320,12 @@ bool get_dotnet_root_from_env(String &r_dotnet_root) {
 
 bool godotsharp::hostfxr_resolver::try_get_path_from_dotnet_root(const String &p_dotnet_root, String &r_fxr_path) {
 	String fxr_dir = path::join(p_dotnet_root, "host", "fxr");
-	ERR_FAIL_COND_V_MSG(!DirAccess::exists(fxr_dir), false, "The host fxr folder does not exist: " + fxr_dir);
+	if (!DirAccess::exists(fxr_dir)) {
+		if (OS::get_singleton()->is_stdout_verbose()) {
+			ERR_PRINT("The host fxr folder does not exist: " + fxr_dir + ".");
+		}
+		return false;
+	}
 	return get_latest_fxr(fxr_dir, r_fxr_path);
 }
 


### PR DESCRIPTION
Godot tries to find hostfxr in two locations, the method that tries to retrieve the location printed an error when it was not found. So when the first location fails it was printing an error, even if the second location succeeded, and users were left confused thinking there was something wrong with their installation.

Now the error will only be printed when stdout verbose is enabled. Users will still get an error later if hostfxr is not found in any of the two locations.

- Closes https://github.com/godotengine/godot/issues/70510.

I originally wanted to wait for _Editor unification_ but we've been receiving multiple error reports about this, so I think we should address it sooner.