### PR TITLE
Fix BoneAttachment3D signal connection

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -148,7 +148,7 @@ void BoneAttachment3D::_check_bind() {
 			bone_idx = sk->find_bone(bone_name);
 		}
 		if (bone_idx != -1) {
-			sk->call_deferred(SNAME("connect"), "bone_pose_changed", callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
+			sk->connect(SNAME("bone_pose_changed"), callable_mp(this, &BoneAttachment3D::on_bone_pose_update));
 			bound = true;
 			call_deferred(SNAME("on_bone_pose_update"), bone_idx);
 		}


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/69614

Previous attempt PR (https://github.com/godotengine/godot/pull/75907) was never merged as the issue became a bit harder to repro, but it can still happen in normal editor use, including in repro project https://github.com/godotengine/godot/issues/69614#issuecomment-1584179363 by switching tabs and reloading the project. The code snippet in https://github.com/godotengine/godot/issues/81552 can repro this 100% of the time.

The problem is that `bound` variable which is used to track if the BoneAttachment3D is attached to a Skeleton3D and connected to its `bone_pose_changed` signal is set immediately, but the connection is made using a deferred call. This leaves one frame of time where the state can get messed up in various ways.

Looks like the deferred connection trick is a pretty rarely used pattern in Godot code base, after a quick search I could only find 4 similar uses, all in editor specific UI code. It was added in https://github.com/godotengine/godot/pull/51368 and replaced a more direct call `bind_child_node_to_bone()`. There might be a real reason why it creates the connection using a deferred call, but currently it's wrong because if BoneAttachment3D or any of its parent node is reparented or moved in a tree during the same frame the connection tracking (`bound` variable) will end out of sync with the real connection state.

I tested this with some models+MRP and couldn't notice any regressions, but skeleton related interactions can be pretty complex and subtle. Testing this more for example by importing and re-importing complex models which create BoneAttachment3Ds during import is recommended.