### PR TITLE
GDScript: Fix and improve doc comment parsing

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1517,10 +1517,11 @@ private:
 	TypeNode *parse_type(bool p_allow_void = false);
 
 #ifdef TOOLS_ENABLED
-	int class_doc_line = 0x7FFFFFFF;
+	int max_script_doc_line = INT_MAX;
+	int min_member_doc_line = 1;
 	bool has_comment(int p_line, bool p_must_be_doc = false);
 	MemberDocData parse_doc_comment(int p_line, bool p_single_line = false);
-	ClassDocData parse_class_doc_comment(int p_line, bool p_inner_class, bool p_single_line = false);
+	ClassDocData parse_class_doc_comment(int p_line, bool p_single_line = false);
 #endif // TOOLS_ENABLED
 
 public:

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -187,6 +187,8 @@ public:
 #ifdef TOOLS_ENABLED
 	struct CommentData {
 		String comment;
+		// true: Comment starts at beginning of line or after indentation.
+		// false: Inline comment (starts after some code).
 		bool new_line = false;
 		CommentData() {}
 		CommentData(const String &p_comment, bool p_new_line) {


### PR DESCRIPTION
* Closes #78934.
* Closes #81578.

1\. Handle annotations correctly.

2\. Handle inline doc comments on multiline declarations. Now this works:

```gdscript
func my_func(): ## Doc.
    pass

class MyClass: ## Doc.
    pass
```

3\. Handle the case of multiple declarations on the same line.

4\. Add `@tag` support for inline doc comments.

<details>
<summary>Test script</summary>

```gdscript
## desc 1
var a1; var a2; var a3 ## desc 2

var b1; var b2; var b3 ## desc 3

## desc 4
var c1; var c2; var c3

enum E1 { A, B, C } ## desc 5

## desc 6
enum E2 { A, B, C }

enum E3 { ## desc 7
    A, B, C
}

enum E4 {
    ## desc 8
    A, B, C
}

enum E5 {
    A, B, C ## desc 9
}

enum E6 {
    A,
    B, ## desc 10
    C,
}

enum E7 { ## desc 11
    A, ## desc 12
    B, ## desc 13
    C, ## desc 14
}
```

</details>