### PR TITLE
Fix platform selection, custom tools overrides, and user overrides of `use_mingw`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -114,9 +114,9 @@ if profile:
 
 # Defaults.
 defaults = {
-    "target": { "default": "editor", "converter": lambda v: v },
-    "use_mingw": { "default": False, "converter": BoolVariable("", "", False)[4] },
-    "custom_tools": { "default": ["default"], "converter": lambda v: v.split(",") },
+    "target": {"default": "editor", "converter": lambda v: v},
+    "use_mingw": {"default": False, "converter": BoolVariable("", "", False)[4]},
+    "custom_tools": {"default": ["default"], "converter": lambda v: v.split(",")},
 }
 
 # We'll parse these as strings first, so we can tell if they've been set explicitely.

--- a/SConstruct
+++ b/SConstruct
@@ -58,10 +58,6 @@ import gles3_builders
 import scu_builders
 from platform_methods import architectures, architecture_aliases, generate_export_icons
 
-if ARGUMENTS.get("target", "editor") == "editor":
-    _helper_module("editor.editor_builders", "editor/editor_builders.py")
-    _helper_module("editor.template_builders", "editor/template_builders.py")
-
 # Scan possible build platforms
 
 platform_list = []  # list of platforms
@@ -70,6 +66,8 @@ platform_flags = {}  # flags for each platform
 platform_doc_class_path = {}
 platform_exporters = []
 platform_apis = []
+
+default_tools = ["default"]
 
 time_at_start = time.time()
 
@@ -98,64 +96,14 @@ for x in sorted(glob.glob("platform/*")):
     if os.path.exists(x + "/api/api.cpp"):
         platform_apis.append(platform_name)
     if detect.can_build():
-        x = x.replace("platform/", "")  # rest of world
-        x = x.replace("platform\\", "")  # win32
-        platform_list += [x]
-        platform_opts[x] = detect.get_opts()
-        platform_flags[x] = detect.get_flags()
+        platform_list += [platform_name]
+        platform_opts[platform_name] = detect.get_opts()
+        platform_flags[platform_name] = detect.get_flags()
     sys.path.remove(tmppath)
     sys.modules.pop("detect")
 
-custom_tools = ["default"]
 
-platform_arg = ARGUMENTS.get("platform", ARGUMENTS.get("p", False))
-
-if platform_arg == "android":
-    custom_tools = ["clang", "clang++", "as", "ar", "link"]
-elif platform_arg == "web":
-    # Use generic POSIX build toolchain for Emscripten.
-    custom_tools = ["cc", "c++", "ar", "link", "textfile", "zip"]
-elif os.name == "nt" and methods.get_cmdline_bool("use_mingw", False):
-    custom_tools = ["mingw"]
-
-# We let SCons build its default ENV as it includes OS-specific things which we don't
-# want to have to pull in manually.
-# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
-env_base = Environment(tools=custom_tools)
-env_base.PrependENVPath("PATH", os.getenv("PATH"))
-env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
-if "TERM" in os.environ:  # Used for colored output.
-    env_base["ENV"]["TERM"] = os.environ["TERM"]
-
-env_base.disabled_modules = []
-env_base.module_version_string = ""
-env_base.msvc = False
-
-env_base.__class__.disable_module = methods.disable_module
-
-env_base.__class__.add_module_version_string = methods.add_module_version_string
-
-env_base.__class__.add_source_files = methods.add_source_files
-env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
-
-env_base.__class__.add_shared_library = methods.add_shared_library
-env_base.__class__.add_library = methods.add_library
-env_base.__class__.add_program = methods.add_program
-env_base.__class__.CommandNoCache = methods.CommandNoCache
-env_base.__class__.Run = methods.Run
-env_base.__class__.disable_warnings = methods.disable_warnings
-env_base.__class__.force_optimization_on_debug = methods.force_optimization_on_debug
-env_base.__class__.module_add_dependencies = methods.module_add_dependencies
-env_base.__class__.module_check_dependencies = methods.module_check_dependencies
-
-env_base["x86_libtheora_opt_gcc"] = False
-env_base["x86_libtheora_opt_vc"] = False
-
-# avoid issues when building with different versions of python out of the same directory
-env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
-
-# Build options
-
+# Environment initialization options.
 customs = ["custom.py"]
 
 profile = ARGUMENTS.get("profile", "")
@@ -165,6 +113,102 @@ if profile:
     elif os.path.isfile(profile + ".py"):
         customs.append(profile + ".py")
 
+
+opts = Variables(customs, ARGUMENTS)
+opts.Add("platform", "Target platform (%s)" % ("|".join(platform_list),), "")
+opts.Add("p", "Platform (alias for 'platform')", "")
+opts.Add(EnumVariable("target", "Compilation target", "editor", ("editor", "template_release", "template_debug")))
+opts.Add("custom_tools", "Scons Environment toolset override", "")
+
+if os.name == "nt":
+    opts.Add(BoolVariable("use_mingw", "Use the Mingw compiler, even if MSVC is installed.", False)),
+
+# We let SCons build a default environment so we can read environment-specific options
+# from user and platform locations.
+# We will then reinitialize the environment with the correct information.
+env_base = Environment(tools=default_tools)
+opts.Update(env_base)
+
+# Platform selection.
+
+selected_platform = ""
+
+if env_base["platform"] != "":
+    selected_platform = env_base["platform"]
+elif env_base["p"] != "":
+    selected_platform = env_base["p"]
+else:
+    # Missing `platform` argument, try to detect platform automatically
+    if (
+        sys.platform.startswith("linux")
+        or sys.platform.startswith("dragonfly")
+        or sys.platform.startswith("freebsd")
+        or sys.platform.startswith("netbsd")
+        or sys.platform.startswith("openbsd")
+    ):
+        selected_platform = "linuxbsd"
+    elif sys.platform == "darwin":
+        selected_platform = "macos"
+    elif sys.platform == "win32":
+        selected_platform = "windows"
+    else:
+        print("Could not detect platform automatically. Supported platforms:")
+        for x in platform_list:
+            print("\t" + x)
+        print("\nPlease run SCons again and select a valid platform: platform=<string>")
+
+    if selected_platform != "":
+        print("Automatically detected platform: " + selected_platform)
+
+if selected_platform in ["macos", "osx"]:
+    if selected_platform == "osx":
+        # Deprecated alias kept for compatibility.
+        print('Platform "osx" has been renamed to "macos" in Godot 4. Building for platform "macos".')
+    # Alias for convenience.
+    selected_platform = "macos"
+
+if selected_platform in ["ios", "iphone"]:
+    if selected_platform == "iphone":
+        # Deprecated alias kept for compatibility.
+        print('Platform "iphone" has been renamed to "ios" in Godot 4. Building for platform "ios".')
+    # Alias for convenience.
+    selected_platform = "ios"
+
+if selected_platform in ["linux", "bsd", "x11"]:
+    if selected_platform == "x11":
+        # Deprecated alias kept for compatibility.
+        print('Platform "x11" has been renamed to "linuxbsd" in Godot 4. Building for platform "linuxbsd".')
+    # Alias for convenience.
+    selected_platform = "linuxbsd"
+
+# Platform specific flags.
+if selected_platform in platform_flags:
+    platform_dict = dict(platform_flags[selected_platform])
+    for option in opts.options:
+        # Use the platform flag value if it's not set in the environment already (i.e. the user hasn't overridden it).
+        if env_base[option.key] == option.default and option.key in platform_dict:
+            env_base[option.key] = platform_dict[option.key]
+
+selected_target = env_base["target"]
+
+# Determine the Scons toolset.
+custom_tools = default_tools
+
+# Platform or user is overriding the default toolset.
+if env_base["custom_tools"] != "":
+    custom_tools = env_base["custom_tools"].split(",")
+
+# Check for the use_mingw flag, but only replace custom_tools if they haven't been overridden yet.
+if os.name == "nt" and env_base["use_mingw"] and set(default_tools) == set(custom_tools):
+    custom_tools = ["mingw"]
+
+if selected_target == "editor":
+    _helper_module("editor.editor_builders", "editor/editor_builders.py")
+    _helper_module("editor.template_builders", "editor/template_builders.py")
+
+# Prepare the real environment options list, now that we know what platform and toolset we're going to use.
+
+# Build options
 opts = Variables(customs, ARGUMENTS)
 
 # Target build options
@@ -262,74 +306,70 @@ opts.Add("CFLAGS", "Custom flags for the C compiler")
 opts.Add("CXXFLAGS", "Custom flags for the C++ compiler")
 opts.Add("LINKFLAGS", "Custom flags for the linker")
 
-# Update the environment to have all above options defined
-# in following code (especially platform and custom_modules).
-opts.Update(env_base)
+print(
+    'Initializing SCons environment for "'
+    + selected_platform
+    + '" with the following tools: "'
+    + " ".join(custom_tools)
+    + '".'
+)
 
-# Platform selection: validate input, and add options.
-
-selected_platform = ""
-
-if env_base["platform"] != "":
-    selected_platform = env_base["platform"]
-elif env_base["p"] != "":
-    selected_platform = env_base["p"]
-else:
-    # Missing `platform` argument, try to detect platform automatically
-    if (
-        sys.platform.startswith("linux")
-        or sys.platform.startswith("dragonfly")
-        or sys.platform.startswith("freebsd")
-        or sys.platform.startswith("netbsd")
-        or sys.platform.startswith("openbsd")
-    ):
-        selected_platform = "linuxbsd"
-    elif sys.platform == "darwin":
-        selected_platform = "macos"
-    elif sys.platform == "win32":
-        selected_platform = "windows"
-    else:
-        print("Could not detect platform automatically. Supported platforms:")
-        for x in platform_list:
-            print("\t" + x)
-        print("\nPlease run SCons again and select a valid platform: platform=<string>")
-
-    if selected_platform != "":
-        print("Automatically detected platform: " + selected_platform)
-
-if selected_platform in ["macos", "osx"]:
-    if selected_platform == "osx":
-        # Deprecated alias kept for compatibility.
-        print('Platform "osx" has been renamed to "macos" in Godot 4. Building for platform "macos".')
-    # Alias for convenience.
-    selected_platform = "macos"
-
-if selected_platform in ["ios", "iphone"]:
-    if selected_platform == "iphone":
-        # Deprecated alias kept for compatibility.
-        print('Platform "iphone" has been renamed to "ios" in Godot 4. Building for platform "ios".')
-    # Alias for convenience.
-    selected_platform = "ios"
-
-if selected_platform in ["linux", "bsd", "x11"]:
-    if selected_platform == "x11":
-        # Deprecated alias kept for compatibility.
-        print('Platform "x11" has been renamed to "linuxbsd" in Godot 4. Building for platform "linuxbsd".')
-    # Alias for convenience.
-    selected_platform = "linuxbsd"
-
-# Make sure to update this to the found, valid platform as it's used through the buildsystem as the reference.
-# It should always be re-set after calling `opts.Update()` otherwise it uses the original input value.
-env_base["platform"] = selected_platform
+# We let SCons build its default ENV as it includes OS-specific things which we don't
+# want to have to pull in manually.
+# This lets us read the environment, command line, user and platform options and flags.
+# Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
+env_base = Environment(tools=custom_tools)
 
 # Add platform-specific options.
 if selected_platform in platform_opts:
     for opt in platform_opts[selected_platform]:
         opts.Add(opt)
 
-# Update the environment to take platform-specific options into account.
+# Update the environment with all general and platform-specific options.
 opts.Update(env_base)
-env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
+
+# Make sure to update this to the found, valid platform as it's used through the buildsystem as the reference.
+# It should always be re-set after calling `opts.Update()` otherwise it uses the original input value.
+env_base["platform"] = selected_platform
+
+# Make sure the target we've already parsed is set in this environment.
+# The logic for merging platform flags into this environment happens later, and until then, we need
+# to make sure this one is set properly
+env_base["target"] = selected_target
+
+# Now we're ready to set our PATHs
+env_base.PrependENVPath("PATH", os.getenv("PATH"))
+env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
+if "TERM" in os.environ:  # Used for colored output.
+    env_base["ENV"]["TERM"] = os.environ["TERM"]
+
+env_base.disabled_modules = []
+env_base.module_version_string = ""
+env_base.msvc = False
+
+env_base.__class__.disable_module = methods.disable_module
+
+env_base.__class__.add_module_version_string = methods.add_module_version_string
+
+env_base.__class__.add_source_files = methods.add_source_files
+env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
+
+env_base.__class__.add_shared_library = methods.add_shared_library
+env_base.__class__.add_library = methods.add_library
+env_base.__class__.add_program = methods.add_program
+env_base.__class__.CommandNoCache = methods.CommandNoCache
+env_base.__class__.Run = methods.Run
+env_base.__class__.disable_warnings = methods.disable_warnings
+env_base.__class__.force_optimization_on_debug = methods.force_optimization_on_debug
+env_base.__class__.module_add_dependencies = methods.module_add_dependencies
+env_base.__class__.module_check_dependencies = methods.module_check_dependencies
+
+env_base["x86_libtheora_opt_gcc"] = False
+env_base["x86_libtheora_opt_vc"] = False
+
+# avoid issues when building with different versions of python out of the same directory
+env_base.SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))
+
 
 # Detect modules.
 modules_detected = OrderedDict()
@@ -390,6 +430,8 @@ methods.write_modules(modules_detected)
 # Update the environment again after all the module options are added.
 opts.Update(env_base)
 env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
+env_base["target"] = selected_target  # Make sure this is set until the Platform specific flags section below.
+
 Help(opts.GenerateHelpText(env_base))
 
 # add default include paths

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,6 +68,7 @@ def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
+        ("custom_tools", "clang,clang++,as,ar,link"),
     ]
 
 

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -68,7 +68,7 @@ def get_flags():
     return [
         ("arch", "arm64"),  # Default for convenience.
         ("target", "template_debug"),
-        ("custom_tools", "clang,clang++,as,ar,link"),
+        ("custom_tools", ["clang", "clang++", "as", "ar", "link"]),
     ]
 
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -67,6 +67,8 @@ def get_flags():
         # 100 KiB over -Os, which does not justify the negative impact on
         # run-time performance.
         ("optimize", "size"),
+        # Use generic POSIX build toolchain for Emscripten.
+        ("custom_tools", "cc,c++,ar,link,textfile,zip"),
     ]
 
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -68,7 +68,7 @@ def get_flags():
         # run-time performance.
         ("optimize", "size"),
         # Use generic POSIX build toolchain for Emscripten.
-        ("custom_tools", "cc,c++,ar,link,textfile,zip"),
+        ("custom_tools", ["cc", "c++", "ar", "link", "textfile", "zip"]),
     ]
 
 


### PR DESCRIPTION
## TL;DR

This PR lets the platforms optionally override the default scons environment tools via a `custom_tools` flag, so the default SConstruct only needs to set the defaults and not worry about each individual platform requirements. The android and web toolsets that were previously hardcoded in SConstruct are moved to the respective `get_flags()` method in detect.py. Users can also override the tools via `custom_tools`.

In order to properly initialize the SCons environment with the right toolset, this adds an initial temporary SCons environment that only processes `use_mingw`, `platform`, `target` and `custom_tools` options from all the different places where they can be set. These values are parsed and then used to initialize the actual environment that we use to build, as well as determine which builder scripts to load based on the target.

This also fixes multiple related issues where, if a platform sets a default target in `get_flags` different from editor, and the user doesn't pass in the target in the command line, the build will be partially configured to be an editor build, setting wrong defines and source files (see "target flag" section below)

Fixes #60719

## How to test this

The important bits to test are builds with a combination of use_mingw, custom tools, and default target set in the platform flags. Here is expected output for some of these configurations:

#### Windows host
```
scons
scons: Reading SConscript files ...
Automatically detected platform: windows
Initializing SCons environment for "windows" with the following tools: "default".
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Found MSVC version 14.3, arch x86_64
Building for platform "windows", architecture "x86_64", target "editor".
```

#### Windows host, non-mingw bash shell, use_mingw=yes
```
🚀  scons use_mingw=yes
scons: Reading SConscript files ...
Automatically detected platform: windows
Initializing SCons environment for "windows" with the following tools: "mingw".
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.

            Running from base MSYS2 console/environment, use target specific environment instead (e.g., mingw32, mingw64, clang32, clang64).
```

#### Windows host, mingw64 bash shell, use_mingw=yes
```
$ scons use_mingw=yes
scons: Reading SConscript files ...
Automatically detected platform: windows
Initializing SCons environment for "windows" with the following tools: "mingw".
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Using MinGW, arch x86_64
Building for platform "windows", architecture "x86_64", target "editor". 
```

#### Windows host, Android platform, use_mingw=yes

Android sets its own custom toolset for SCons, so use_mingw flag can be set, but the SCons toolset is controlled by the platform.
Android also sets a different default target, so the build output should not include any `editor/` files.

```
scons use_mingw=yes p=android
scons: Reading SConscript files ...
Initializing SCons environment for "android" with the following tools: "clang clang++ as ar link".
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Checking for Android NDK...
Building for platform "android", architecture "arm64", target "template_debug".
```

#### Advanced scenario: Windows host, Windows platform, mingw64 bash shell, use_mingw=yes, custom toolset

Enabling the "msvs" SCons tool for a mingw build requires passing the full toolset list to `custom_tools`, so the SCons environment is correctly initialized. `use_mingw` needs to be passed in as well, so scripts that check it directly will do the right thing.
```
scons platform=windows target=template_debug use_mingw=yes custom_tools=mingw,msvs
scons: Reading SConscript files ...
Initializing SCons environment for "windows" with the following tools: "mingw msvs".
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Using MinGW, arch x86_64
Building for platform "windows", architecture "x86_64", target "template_debug".
```

#### Mac host
```
scons: Reading SConscript files ...
Automatically detected platform: macos
Initializing SCons environment for "macos" with the following tools: "default".
Auto-detected 10 CPU cores available for build parallelism. Using 9 cores by default. You can override it with the -j argument.
Building for macOS 11.0+.
MoltenVK found at: /Users/shana/VulkanSDK/1.3.261.1/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/
Building for platform "macos", architecture "arm64", target "editor".
```

#### Mac host, iOS platform, default target set by platform

Running this build into a log file and then grepping the log file to make sure there are no editor sources included.
```
scons p=ios
scons: Reading SConscript files ...
Initializing SCons environment for "ios" with the following tools: "default".
Auto-detected 10 CPU cores available for build parallelism. Using 9 cores by default. You can override it with the -j argument.
Building for platform "ios", architecture "arm64", target "template_debug".
```

## Early build environment initialization issues

#### use_mingw

The `use_mingw` flag is a very special case, in that it both forces replacing the `default` toolset with the `mingw` toolset for Scons environment initialization, and is also used to determine the format of compiler flags (msvc style or gcc/clang style). This is usually not a big issue, because `use_mingw` is used to switch between windows+msvc and windows+mingw, so having both the toolset and the compiler check done from one option is ok.

Certain platforms (namely consoles) use a mix of windows+non-msvc compilers, so they require `use_mingw` to be set at all times. The problem is that `use_mingw` is initially only read from the command line, at the point where it's used to determine the SCons toolset to pass to the environment initialization. This means that platforms cannot set `use_mingw` by default in their platform flags, as these flags are ignored at this point and only read later, once the environment is already initialized with the wrong toolset.

Issue #60719 is a symptom of the way that we're currently reading `use_mingw` directly from the command line and ignoring any user overrides until it's too late - the flag gets set in env eventually, but by then the environment has already been created with the wrong toolset.


Another problem is that `use_mingw` forcebly replaces the custom tools used to initialize the environment, and not all tools enabled by the `default` scons toolset are enabled in the `mingw` toolset. Scons only initializes build tools like compilers and linkers in the mingw toolset, while the default toolset initializes a lot more tools, depending on the detected host platform. For example, the `msvs` tool, which enables Scons to generate visual studio projects for the current build configuration, is not enabled when using the `mingw` toolset. In order to allow a vs project to be generated when the `mingw` toolset is selected, the environment has to be initialized with `["mingw","msvs"]`. This is, again, probably not a big issue for most mingw users, but since console platforms are often a mix of windows+clang+visual studio support, the way that the `use_mingw` flag clobbers the Scons environment toolset becomes a bit of a problem.

#### target flag

The `target` flag is being used to load editor builders (needed when building for the editor), but this particular check only looks at the flag in the command line, not the flag in the platform flags or in the environment. This means that platforms like ios, that sets a default target of `template_debug`, will have the editor builders loaded for non-editor builds that don't specify a target in the command line.

The `env.editor_build` flag is being set before reading platform flags. This means that platforms that set a different default target via `get_flags()` will get editor sources and defines set for non-editor builds that don't specify a target in the command line.

_Contributed by W4Games_