### PR TITLE
C#: Add documentation for Interfaces and Attributes

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotClassNameAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace Godot
 {
@@ -8,7 +9,7 @@ namespace Godot
     /// the name associated with the class. If the attribute is not present,
     /// the C# class name can be used instead.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class), EditorBrowsable(EditorBrowsableState.Never)]
     public class GodotClassNameAttribute : Attribute
     {
         /// <summary>
@@ -16,6 +17,10 @@ namespace Godot
         /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Specify the name that represents the original engine class.
+        /// </summary>
+        /// <param name="name">Name of the original engine class.</param>
         public GodotClassNameAttribute(string name)
         {
             Name = name;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/SignalAttribute.cs
@@ -2,6 +2,11 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// Declares a <see langword="delegate"/> as a signal. This allows any connected
+    /// <see cref="Callable"/> (and, by extension, their respective objects) to listen and react
+    /// to events, without directly referencing one another.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Delegate)]
     public sealed class SignalAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ToolAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// Allows the annotated class to execute in the editor.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ToolAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -5,6 +5,10 @@ namespace Godot
     /// </summary>
     public interface IAwaitable
     {
+        /// <summary>
+        /// Gets an Awaiter for this <see cref="IAwaitable"/>.
+        /// </summary>
+        /// <returns>An Awaiter.</returns>
         IAwaiter GetAwaiter();
     }
 
@@ -14,6 +18,10 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaitable<out TResult>
     {
+        /// <summary>
+        /// Gets an Awaiter for this <see cref="IAwaitable{TResult}"/>.
+        /// </summary>
+        /// <returns>An Awaiter.</returns>
         IAwaiter<TResult> GetAwaiter();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -7,8 +7,14 @@ namespace Godot
     /// </summary>
     public interface IAwaiter : INotifyCompletion
     {
+        /// <summary>
+        /// The completion status of this <see cref="IAwaiter"/>.
+        /// </summary>
         bool IsCompleted { get; }
 
+        /// <summary>
+        /// Gets the result of completion for this <see cref="IAwaiter"/>.
+        /// </summary>
         void GetResult();
     }
 
@@ -18,8 +24,14 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaiter<out TResult> : INotifyCompletion
     {
+        /// <summary>
+        /// The completion status of this <see cref="IAwaiter{TResult}"/>.
+        /// </summary>
         bool IsCompleted { get; }
 
+        /// <summary>
+        /// Gets the result of completion for this <see cref="IAwaiter{TResult}"/>.
+        /// </summary>
         TResult GetResult();
     }
 }


### PR DESCRIPTION
Adds documentation for the remaining publicly visible types/members in the GodotSharp "Attributes" & "Interfaces" folders