### PR TITLE
Make LineEdit secret character easier to change and enter

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -269,7 +269,7 @@
 			If [code]true[/code], every character is replaced with the secret character (see [member secret_character]).
 		</member>
 		<member name="secret_character" type="String" setter="set_secret_character" getter="get_secret_character" default="&quot;•&quot;">
-			The character to use to mask secret input (defaults to "•"). Only a single character can be used as the secret character.
+			The character to use to mask secret input. Only a single character can be used as the secret character. If it is longer than one character, only the first one will be used. If it is empty, a space will be used instead.
 		</member>
 		<member name="select_all_on_focus" type="bool" setter="set_select_all_on_focus" getter="is_select_all_on_focus" default="false">
 			If [code]true[/code], the [LineEdit] will select the whole text when it gains focus.

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -385,6 +385,8 @@ public:
 
 	virtual bool is_text_field() const override;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 	void show_virtual_keyboard();
 
 	LineEdit(const String &p_placeholder = String());


### PR DESCRIPTION
Fixes #81681.
1. Allow values longer than 1 character in the property, but trim characters after the first one.
2. Allow empty strings, this acts like if a space was used as a secret character, so that an error isn't printed when you erase all characters in the property.

About the implementation, we can add another field for displaying the char and so `secret_character` can only store the result of the above rule or vice versa. But that requires more change, so I decided to change the drawing part, calculate the right `secret_character` based on the rule above.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
