### PR TITLE
Expose `get_reaction_force` and `get_reaction_torque` from 2D Joints (and `break_force` and `break_torque`)

### DIFF
--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -9,6 +9,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_reaction_force" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Get the force applied by this joint.
+			</description>
+		</method>
+		<method name="get_reaction_torque" qualifiers="const">
+			<return type="float" />
+			<description>
+				Get the torque applied by this joint.
+			</description>
+		</method>
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
@@ -20,6 +32,15 @@
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0">
 			When [member node_a] and [member node_b] move in different directions the [member bias] controls how fast the joint pulls them back to their original position. The lower the [member bias] the more the two bodies can pull on the joint.
 			When set to [code]0[/code], the default value from [member ProjectSettings.physics/2d/solver/default_constraint_bias] is used.
+		</member>
+		<member name="break_enabled" type="bool" setter="set_break_enabled" getter="is_break_enabled" default="false">
+			Set's this joint to be breakable or not. Breaking the joint will set it's [member Node.process_mode] to [constant Node.PROCESS_MODE_DISABLED]. Also set [member break_force] or [member break_torque] if you are using this flag.
+		</member>
+		<member name="break_force" type="float" setter="set_break_force" getter="get_break_force" default="0.0">
+			The force required to break the joint. Breaking the joint will set it's [member Node.process_mode] to [constant Node.PROCESS_MODE_DISABLED]. Only works if [member break_enabled] is set to [code]true[/code].
+		</member>
+		<member name="break_torque" type="float" setter="set_break_torque" getter="get_break_torque" default="0.0">
+			The torque required to break the joint. Breaking the joint will set it's [member Node.process_mode] to [constant Node.PROCESS_MODE_DISABLED]. Only works if [member break_enabled] is set to [code]true[/code].
 		</member>
 		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], the two bodies bound together do not collide with each other.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -790,12 +790,28 @@
 				Sets whether the bodies attached to the [Joint2D] will collide with each other.
 			</description>
 		</method>
+		<method name="joint_get_flag" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="flag" type="int" enum="PhysicsServer2D.JointFlag" />
+			<description>
+				Gets a joint flag (see [enum JointFlag] constants).
+			</description>
+		</method>
 		<method name="joint_get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<description>
 				Returns the value of the given joint parameter. See [enum JointParam] for the list of available parameters.
+			</description>
+		</method>
+		<method name="joint_get_state" qualifiers="const">
+			<return type="Variant" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer2D.JointState" />
+			<description>
+				Returns the value of the given state of the joint. See [enum JointState] for the list of available states.
 			</description>
 		</method>
 		<method name="joint_get_type" qualifiers="const">
@@ -843,6 +859,15 @@
 			<param index="3" name="body_b" type="RID" default="RID()" />
 			<description>
 				Makes the joint a pin joint. If [param body_b] is an empty [RID], then [param body_a] is pinned to the point [param anchor] (given in global coordinates); otherwise, [param body_a] is pinned to [param body_b] at the point [param anchor] (given in global coordinates). To set the parameters which are specific to the pin joint, see [method pin_joint_set_param].
+			</description>
+		</method>
+		<method name="joint_set_flag">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="flag" type="int" enum="PhysicsServer2D.JointFlag" />
+			<param index="2" name="enabled" type="bool" />
+			<description>
+				Sets a joint flag (see [enum JointFlag] constants).
 			</description>
 		</method>
 		<method name="joint_set_param">
@@ -1188,6 +1213,21 @@
 		<constant name="JOINT_PARAM_MAX_FORCE" value="2" enum="JointParam">
 			Constant to set/get the maximum force that the joint can use to act on the two bodies. The default value of this parameter is [code]3.40282e+38[/code].
 			[b]Note:[/b] In Godot Physics, this parameter is only used for groove joints.
+		</constant>
+		<constant name="JOINT_PARAM_BREAK_FORCE" value="3" enum="JointParam">
+			Constant to set/get the maximum torque the joint will handle before it gets disabled.
+		</constant>
+		<constant name="JOINT_PARAM_BREAK_TORQUE" value="4" enum="JointParam">
+			Constant to set/get the maximum torque the joint will handle before it gets disabled.
+		</constant>
+		<constant name="JOINT_FLAG_BREAK_ENABLED" value="0" enum="JointFlag">
+			Constant to set/get if the joint can break. Joints break if the force is higher than [member Joint2D.break_force] or the torque is higher than [member Joint2D.break_torque].
+		</constant>
+		<constant name="JOINT_STATE_REACTION_FORCE" value="0" enum="JointState">
+			Constant to get at what force should the joint break. The default value of this parameter is [code]0.0[/code].
+		</constant>
+		<constant name="JOINT_STATE_REACTION_TORQUE" value="1" enum="JointState">
+			Constant to get at what torque should the joint break. The default value of this parameter is [code]0.0[/code].
 		</constant>
 		<constant name="PIN_JOINT_SOFTNESS" value="0" enum="PinJointParam">
 			Constant to set/get a how much the bond of the pin joint can flex. The default value of this parameter is [code]0.0[/code].

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -840,12 +840,26 @@
 				Overridable version of [method PhysicsServer2D.joint_disable_collisions_between_bodies].
 			</description>
 		</method>
+		<method name="_joint_get_flag" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="flag" type="int" enum="PhysicsServer2D.JointFlag" />
+			<description>
+			</description>
+		</method>
 		<method name="_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_get_param].
+			</description>
+		</method>
+		<method name="_joint_get_state" qualifiers="virtual const">
+			<return type="Variant" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="state" type="int" enum="PhysicsServer2D.JointState" />
+			<description>
 			</description>
 		</method>
 		<method name="_joint_get_type" qualifiers="virtual const">
@@ -893,6 +907,14 @@
 			<param index="3" name="body_b" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_make_pin].
+			</description>
+		</method>
+		<method name="_joint_set_flag" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="joint" type="RID" />
+			<param index="1" name="flag" type="int" enum="PhysicsServer2D.JointFlag" />
+			<param index="2" name="enabled" type="bool" />
+			<description>
 			</description>
 		</method>
 		<method name="_joint_set_param" qualifiers="virtual">

--- a/modules/godot_physics_2d/godot_joints_2d.h
+++ b/modules/godot_physics_2d/godot_joints_2d.h
@@ -38,12 +38,22 @@ class GodotJoint2D : public GodotConstraint2D {
 	real_t bias = 0;
 	real_t max_bias = 3.40282e+38;
 	real_t max_force = 3.40282e+38;
+	real_t break_force = 0;
+	real_t break_torque = 0;
+	Vector2 reaction_force;
+	real_t reaction_torque = 0;
+	bool break_enabled = false;
 
 protected:
 	bool dynamic_A = false;
 	bool dynamic_B = false;
 
+	void _set_reaction(Vector2 impulse, real_t torque_impulse, GodotBody2D *A, GodotBody2D *B, real_t p_step);
+
 public:
+	_FORCE_INLINE_ void set_break_enabled(bool p_enabled) { break_enabled = p_enabled; }
+	_FORCE_INLINE_ bool is_break_enabled() const { return break_enabled; }
+
 	_FORCE_INLINE_ void set_max_force(real_t p_force) { max_force = p_force; }
 	_FORCE_INLINE_ real_t get_max_force() const { return max_force; }
 
@@ -52,6 +62,15 @@ public:
 
 	_FORCE_INLINE_ void set_max_bias(real_t p_bias) { max_bias = p_bias; }
 	_FORCE_INLINE_ real_t get_max_bias() const { return max_bias; }
+
+	_FORCE_INLINE_ void set_break_force(real_t p_break_force) { break_force = p_break_force; }
+	_FORCE_INLINE_ real_t get_break_force() const { return break_force; }
+
+	_FORCE_INLINE_ void set_break_torque(real_t p_break_torque) { break_torque = p_break_torque; }
+	_FORCE_INLINE_ real_t get_break_torque() const { return break_torque; }
+
+	_FORCE_INLINE_ Vector2 get_reaction_force() const { return reaction_force; }
+	_FORCE_INLINE_ real_t get_reaction_torque() const { return reaction_torque; }
 
 	virtual bool setup(real_t p_step) override { return false; }
 	virtual bool pre_solve(real_t p_step) override { return false; }

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1047,15 +1047,21 @@ void GodotPhysicsServer2D::joint_set_param(RID p_joint, JointParam p_param, real
 	ERR_FAIL_NULL(joint);
 
 	switch (p_param) {
-		case JOINT_PARAM_BIAS:
+		case JOINT_PARAM_BIAS: {
 			joint->set_bias(p_value);
-			break;
-		case JOINT_PARAM_MAX_BIAS:
+		} break;
+		case JOINT_PARAM_MAX_BIAS: {
 			joint->set_max_bias(p_value);
-			break;
-		case JOINT_PARAM_MAX_FORCE:
+		} break;
+		case JOINT_PARAM_MAX_FORCE: {
 			joint->set_max_force(p_value);
-			break;
+		} break;
+		case JOINT_PARAM_BREAK_FORCE: {
+			joint->set_break_force(p_value);
+		} break;
+		case JOINT_PARAM_BREAK_TORQUE: {
+			joint->set_break_torque(p_value);
+		} break;
 	}
 }
 
@@ -1064,17 +1070,57 @@ real_t GodotPhysicsServer2D::joint_get_param(RID p_joint, JointParam p_param) co
 	ERR_FAIL_NULL_V(joint, -1);
 
 	switch (p_param) {
-		case JOINT_PARAM_BIAS:
+		case JOINT_PARAM_BIAS: {
 			return joint->get_bias();
-			break;
-		case JOINT_PARAM_MAX_BIAS:
+		} break;
+		case JOINT_PARAM_MAX_BIAS: {
 			return joint->get_max_bias();
-			break;
-		case JOINT_PARAM_MAX_FORCE:
+		} break;
+		case JOINT_PARAM_MAX_FORCE: {
 			return joint->get_max_force();
-			break;
+		} break;
+		case JOINT_PARAM_BREAK_FORCE: {
+			return joint->get_break_force();
+		} break;
+		case JOINT_PARAM_BREAK_TORQUE: {
+			return joint->get_break_torque();
+		} break;
 	}
 
+	return 0;
+}
+
+void GodotPhysicsServer2D::joint_set_flag(RID p_joint, JointFlag p_flag, bool p_enabled) {
+	GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL(joint);
+
+	switch (p_flag) {
+		case JOINT_FLAG_BREAK_ENABLED: {
+			joint->set_break_enabled(p_enabled);
+		} break;
+	}
+}
+bool GodotPhysicsServer2D::joint_get_flag(RID p_joint, JointFlag p_flag) const {
+	const GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, false);
+
+	switch (p_flag) {
+		case JOINT_FLAG_BREAK_ENABLED:
+			return joint->is_break_enabled();
+	}
+	return false;
+}
+
+Variant GodotPhysicsServer2D::joint_get_state(RID p_joint, JointState p_param) const {
+	const GodotJoint2D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, -1);
+
+	switch (p_param) {
+		case JOINT_STATE_REACTION_FORCE:
+			return joint->get_reaction_force();
+		case JOINT_STATE_REACTION_TORQUE:
+			return joint->get_reaction_torque();
+	}
 	return 0;
 }
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -268,6 +268,11 @@ public:
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override;
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override;
 
+	virtual void joint_set_flag(RID p_joint, JointFlag p_flag, bool p_enabled) override;
+	virtual bool joint_get_flag(RID p_joint, JointFlag p_flag) const override;
+
+	virtual Variant joint_get_state(RID p_joint, JointState p_param) const override;
+
 	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disabled) override;
 	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
 

--- a/scene/2d/physics/joints/joint_2d.cpp
+++ b/scene/2d/physics/joints/joint_2d.cpp
@@ -199,6 +199,62 @@ real_t Joint2D::get_bias() const {
 	return bias;
 }
 
+void Joint2D::set_break_force(real_t p_break_force) {
+	if (break_force == p_break_force) {
+		return;
+	}
+	break_force = p_break_force;
+	if (joint.is_valid()) {
+		PhysicsServer2D::get_singleton()->joint_set_param(joint, PhysicsServer2D::JOINT_PARAM_BREAK_FORCE, break_force);
+	}
+}
+
+real_t Joint2D::get_break_force() const {
+	return break_force;
+}
+
+void Joint2D::set_break_torque(real_t p_break_torque) {
+	if (break_torque == p_break_torque) {
+		return;
+	}
+	break_torque = p_break_torque;
+	if (joint.is_valid()) {
+		PhysicsServer2D::get_singleton()->joint_set_param(joint, PhysicsServer2D::JOINT_PARAM_BREAK_TORQUE, break_torque);
+	}
+}
+
+real_t Joint2D::get_break_torque() const {
+	return break_torque;
+}
+
+Vector2 Joint2D::get_reaction_force() const {
+	if (joint.is_valid()) {
+		return PhysicsServer2D::get_singleton()->joint_get_state(joint, PhysicsServer2D::JOINT_STATE_REACTION_FORCE);
+	}
+	return Vector2();
+}
+
+void Joint2D::set_break_enabled(bool p_break_enabled) {
+	if (break_enabled == p_break_enabled) {
+		return;
+	}
+	break_enabled = p_break_enabled;
+	if (joint.is_valid()) {
+		PhysicsServer2D::get_singleton()->joint_set_flag(joint, PhysicsServer2D::JOINT_FLAG_BREAK_ENABLED, break_enabled);
+	}
+}
+
+bool Joint2D::is_break_enabled() const {
+	return break_enabled;
+}
+
+real_t Joint2D::get_reaction_torque() const {
+	if (joint.is_valid()) {
+		return PhysicsServer2D::get_singleton()->joint_get_state(joint, PhysicsServer2D::JOINT_STATE_REACTION_TORQUE);
+	}
+	return 0.0;
+}
+
 void Joint2D::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
@@ -235,6 +291,18 @@ void Joint2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_bias", "bias"), &Joint2D::set_bias);
 	ClassDB::bind_method(D_METHOD("get_bias"), &Joint2D::get_bias);
 
+	ClassDB::bind_method(D_METHOD("set_break_force", "break_force"), &Joint2D::set_break_force);
+	ClassDB::bind_method(D_METHOD("get_break_force"), &Joint2D::get_break_force);
+
+	ClassDB::bind_method(D_METHOD("set_break_enabled", "break_enabled"), &Joint2D::set_break_enabled);
+	ClassDB::bind_method(D_METHOD("is_break_enabled"), &Joint2D::is_break_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_break_torque", "break_torque"), &Joint2D::set_break_torque);
+	ClassDB::bind_method(D_METHOD("get_break_torque"), &Joint2D::get_break_torque);
+
+	ClassDB::bind_method(D_METHOD("get_reaction_force"), &Joint2D::get_reaction_force);
+	ClassDB::bind_method(D_METHOD("get_reaction_torque"), &Joint2D::get_reaction_torque);
+
 	ClassDB::bind_method(D_METHOD("set_exclude_nodes_from_collision", "enable"), &Joint2D::set_exclude_nodes_from_collision);
 	ClassDB::bind_method(D_METHOD("get_exclude_nodes_from_collision"), &Joint2D::get_exclude_nodes_from_collision);
 
@@ -243,6 +311,9 @@ void Joint2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_a", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_a", "get_node_a");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "node_b", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PhysicsBody2D"), "set_node_b", "get_node_b");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bias", PROPERTY_HINT_RANGE, "0,0.9,0.001"), "set_bias", "get_bias");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "break_enabled"), "set_break_enabled", "is_break_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "break_force", PROPERTY_HINT_RANGE, "0,200,0.1"), "set_break_force", "get_break_force");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "break_torque", PROPERTY_HINT_RANGE, "0,200,0.1"), "set_break_torque", "get_break_torque");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disable_collision"), "set_exclude_nodes_from_collision", "get_exclude_nodes_from_collision");
 }
 

--- a/scene/2d/physics/joints/joint_2d.h
+++ b/scene/2d/physics/joints/joint_2d.h
@@ -44,6 +44,9 @@ class Joint2D : public Node2D {
 	NodePath a;
 	NodePath b;
 	real_t bias = 0.0;
+	real_t break_force = 0.0;
+	real_t break_torque = 0.0;
+	bool break_enabled = false;
 
 	bool exclude_from_collision = true;
 	bool configured = false;
@@ -72,6 +75,18 @@ public:
 
 	void set_bias(real_t p_bias);
 	real_t get_bias() const;
+
+	void set_break_force(real_t p_break_force);
+	real_t get_break_force() const;
+
+	void set_break_torque(real_t p_break_torque);
+	real_t get_break_torque() const;
+
+	void set_break_enabled(bool p_break_enabled);
+	bool is_break_enabled() const;
+
+	Vector2 get_reaction_force() const;
+	real_t get_reaction_torque() const;
 
 	void set_exclude_nodes_from_collision(bool p_enable);
 	bool get_exclude_nodes_from_collision() const;

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -309,6 +309,11 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_joint_get_param, "joint", "param");
 
+	GDVIRTUAL_BIND(_joint_set_flag, "joint", "flag", "enabled");
+	GDVIRTUAL_BIND(_joint_get_flag, "joint", "flag");
+
+	GDVIRTUAL_BIND(_joint_get_state, "joint", "state");
+
 	GDVIRTUAL_BIND(_joint_disable_collisions_between_bodies, "joint", "disable");
 	GDVIRTUAL_BIND(_joint_is_disabled_collisions_between_bodies, "joint");
 

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -412,6 +412,11 @@ public:
 	EXBIND3(joint_set_param, RID, JointParam, real_t)
 	EXBIND2RC(real_t, joint_get_param, RID, JointParam)
 
+	EXBIND3(joint_set_flag, RID, JointFlag, bool)
+	EXBIND2RC(bool, joint_get_flag, RID, JointFlag)
+
+	EXBIND2RC(Variant, joint_get_state, RID, JointState)
+
 	EXBIND2(joint_disable_collisions_between_bodies, RID, bool)
 	EXBIND1RC(bool, joint_is_disabled_collisions_between_bodies, RID)
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -771,6 +771,11 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("joint_set_param", "joint", "param", "value"), &PhysicsServer2D::joint_set_param);
 	ClassDB::bind_method(D_METHOD("joint_get_param", "joint", "param"), &PhysicsServer2D::joint_get_param);
 
+	ClassDB::bind_method(D_METHOD("joint_set_flag", "joint", "flag", "enabled"), &PhysicsServer2D::joint_set_flag);
+	ClassDB::bind_method(D_METHOD("joint_get_flag", "joint", "flag"), &PhysicsServer2D::joint_get_flag);
+
+	ClassDB::bind_method(D_METHOD("joint_get_state", "joint", "state"), &PhysicsServer2D::joint_get_state);
+
 	ClassDB::bind_method(D_METHOD("joint_disable_collisions_between_bodies", "joint", "disable"), &PhysicsServer2D::joint_disable_collisions_between_bodies);
 	ClassDB::bind_method(D_METHOD("joint_is_disabled_collisions_between_bodies", "joint"), &PhysicsServer2D::joint_is_disabled_collisions_between_bodies);
 
@@ -866,6 +871,13 @@ void PhysicsServer2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(JOINT_PARAM_BIAS);
 	BIND_ENUM_CONSTANT(JOINT_PARAM_MAX_BIAS);
 	BIND_ENUM_CONSTANT(JOINT_PARAM_MAX_FORCE);
+	BIND_ENUM_CONSTANT(JOINT_PARAM_BREAK_FORCE);
+	BIND_ENUM_CONSTANT(JOINT_PARAM_BREAK_TORQUE);
+
+	BIND_ENUM_CONSTANT(JOINT_FLAG_BREAK_ENABLED);
+
+	BIND_ENUM_CONSTANT(JOINT_STATE_REACTION_FORCE);
+	BIND_ENUM_CONSTANT(JOINT_STATE_REACTION_TORQUE);
 
 	BIND_ENUM_CONSTANT(PIN_JOINT_SOFTNESS);
 	BIND_ENUM_CONSTANT(PIN_JOINT_LIMIT_UPPER);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -540,10 +540,26 @@ public:
 		JOINT_PARAM_BIAS,
 		JOINT_PARAM_MAX_BIAS,
 		JOINT_PARAM_MAX_FORCE,
+		JOINT_PARAM_BREAK_FORCE,
+		JOINT_PARAM_BREAK_TORQUE,
+	};
+
+	enum JointFlag {
+		JOINT_FLAG_BREAK_ENABLED,
+	};
+
+	enum JointState {
+		JOINT_STATE_REACTION_FORCE,
+		JOINT_STATE_REACTION_TORQUE,
 	};
 
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) = 0;
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const = 0;
+
+	virtual void joint_set_flag(RID p_joint, JointFlag p_flag, bool p_enabled) = 0;
+	virtual bool joint_get_flag(RID p_joint, JointFlag p_flag) const = 0;
+
+	virtual Variant joint_get_state(RID p_joint, JointState p_param) const = 0;
 
 	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) = 0;
 	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const = 0;
@@ -838,7 +854,9 @@ VARIANT_ENUM_CAST(PhysicsServer2D::BodyParameter);
 VARIANT_ENUM_CAST(PhysicsServer2D::BodyDampMode);
 VARIANT_ENUM_CAST(PhysicsServer2D::BodyState);
 VARIANT_ENUM_CAST(PhysicsServer2D::CCDMode);
+VARIANT_ENUM_CAST(PhysicsServer2D::JointFlag);
 VARIANT_ENUM_CAST(PhysicsServer2D::JointParam);
+VARIANT_ENUM_CAST(PhysicsServer2D::JointState);
 VARIANT_ENUM_CAST(PhysicsServer2D::JointType);
 VARIANT_ENUM_CAST(PhysicsServer2D::PinJointParam);
 VARIANT_ENUM_CAST(PhysicsServer2D::PinJointFlag);

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -303,6 +303,11 @@ public:
 
 	virtual void joint_clear(RID p_joint) override {}
 
+	virtual void joint_set_flag(RID p_joint, JointFlag p_flag, bool p_enabled) override {}
+	virtual bool joint_get_flag(RID p_joint, JointFlag p_flag) const override { return false; }
+
+	virtual Variant joint_get_state(RID p_joint, JointState p_param) const override { return Variant(); }
+
 	virtual void joint_set_param(RID p_joint, JointParam p_param, real_t p_value) override {}
 	virtual real_t joint_get_param(RID p_joint, JointParam p_param) const override { return 0; }
 

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -279,6 +279,11 @@ public:
 	FUNC3(joint_set_param, RID, JointParam, real_t);
 	FUNC2RC(real_t, joint_get_param, RID, JointParam);
 
+	FUNC3(joint_set_flag, RID, JointFlag, bool);
+	FUNC2RC(bool, joint_get_flag, RID, JointFlag);
+
+	FUNC2RC(Variant, joint_get_state, RID, JointState);
+
 	FUNC2(joint_disable_collisions_between_bodies, RID, const bool);
 	FUNC1RC(bool, joint_is_disabled_collisions_between_bodies, RID);
 


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot-proposals/issues/7672