### PR TITLE
Enable vertex colors by default on Blender importer settings

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -253,7 +253,7 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	ADD_OPTION_BOOL("blender/nodes/cameras", true);
 	ADD_OPTION_BOOL("blender/nodes/custom_properties", true);
 	ADD_OPTION_ENUM("blender/nodes/modifiers", "No Modifiers,All Modifiers", BLEND_MODIFIERS_ALL);
-	ADD_OPTION_BOOL("blender/meshes/colors", false);
+	ADD_OPTION_BOOL("blender/meshes/colors", true);
 	ADD_OPTION_BOOL("blender/meshes/uvs", true);
 	ADD_OPTION_BOOL("blender/meshes/normals", true);
 	ADD_OPTION_BOOL("blender/meshes/tangents", true);


### PR DESCRIPTION
When a mesh has vertex colors, materials are configured to use them as albedo. However, vertex colors are disabled by default only when importing blend files. Because the materials are properly configured and other file types, including glb, automatically import vertex colors, this behavior causes confusion looking like a bug.