### PR TITLE
Fix Connection dock's popups always allowing disconnect

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1213,6 +1213,11 @@ void ConnectionsDock::_rmb_pressed(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	if (item->is_selectable(0)) {
+		// Update selection now, before `about_to_popup` signal. Needed for SIGNAL and CONNECTION context menus.
+		tree->set_selected(item);
+	}
+
 	Vector2 screen_position = tree->get_screen_position() + mb_event->get_position();
 
 	switch (_get_item_type(*item)) {


### PR DESCRIPTION
Fixes [the issue described in this comment](https://github.com/godotengine/godot/pull/81737#issuecomment-1722243949) as a regression from https://github.com/godotengine/godot/pull/81221.

A Connection Dock's TreeItem needs to be selected for the connection's **PopupMenu**, called `slot_menu` to update accordingly **on the spot**. However, this doesn't happen. It means that it is either possible to disconnect inherited signals, or the opposite, at seemingly completely random. This PR fixes that.