### PR TITLE
Fix validation error when using pipeline cache control

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -9158,7 +9158,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 	VkPipelineCacheCreateInfo cache_info = {};
 	cache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
 	cache_info.pNext = nullptr;
-	if (context->is_device_extension_enabled(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME)) {
+	if (context->get_pipeline_cache_control_support()) {
 		cache_info.flags = VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT;
 	}
 	cache_info.initialDataSize = pipelines_cache.buffer.size();

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -116,6 +116,7 @@ private:
 	VRSCapabilities vrs_capabilities;
 	ShaderCapabilities shader_capabilities;
 	StorageBufferCapabilities storage_buffer_capabilities;
+	bool pipeline_cache_control_support = false;
 
 	String device_vendor;
 	String device_name;
@@ -281,6 +282,7 @@ public:
 	const ShaderCapabilities &get_shader_capabilities() const { return shader_capabilities; };
 	const StorageBufferCapabilities &get_storage_buffer_capabilities() const { return storage_buffer_capabilities; };
 	const VkPhysicalDeviceFeatures &get_physical_device_features() const { return physical_device_features; };
+	bool get_pipeline_cache_control_support() const { return pipeline_cache_control_support; };
 
 	VkDevice get_device();
 	VkPhysicalDevice get_physical_device();


### PR DESCRIPTION
PR #80296 introduced a regression because it checks if the VK_EXT_pipeline_creation_cache_control extension has been enabled before using it, but turns out the process is a bit more convoluted than that (a Vulkan driver may support the extension but then say the feature is not supported)