### PR TITLE
Fix massive validation errors when enabling TAA + MSAA

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -600,7 +600,7 @@ void RenderSceneBuffersRD::ensure_velocity() {
 		uint32_t usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_STORAGE_BIT;
 
 		if (msaa_3d != RS::VIEWPORT_MSAA_DISABLED) {
-			uint32_t msaa_usage_bits = usage_bits | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
+			uint32_t msaa_usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 			usage_bits |= RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 
 			create_texture(RB_SCOPE_BUFFERS, RB_TEX_VELOCITY_MSAA, RD::DATA_FORMAT_R16G16_SFLOAT, msaa_usage_bits, texture_samples);


### PR DESCRIPTION
TAA + MSAA would make Godot request unnecessary flags for an MSAA velocity texture, flags that were not even actually needed.

This was causing:
 1. Unsupported GPUs to fail completely (e.g. Intel Arc 770)
 2. Wrong codepaths to be followed (causing validation errors, possibly crashes or glitches)
 3. Unnecessary performance impact in all GPUs.

See
https://github.com/godotengine/godot/issues/71929#issuecomment-1722274359
