### PR TITLE
Allow multiple file patterns per filter in Windows file dialog

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -224,14 +224,17 @@ Error DisplayServerWindows::file_dialog_show(const String &p_title, const String
 	Vector<Char16String> filter_names;
 	Vector<Char16String> filter_exts;
 	for (const String &E : p_filters) {
+		String filter_ext_text;
 		Vector<String> tokens = E.split(";");
 		if (tokens.size() == 2) {
-			filter_exts.push_back(tokens[0].strip_edges().utf16());
+			filter_ext_text = tokens[0].strip_edges();
 			filter_names.push_back(tokens[1].strip_edges().utf16());
 		} else if (tokens.size() == 1) {
-			filter_exts.push_back(tokens[0].strip_edges().utf16());
+			filter_ext_text = tokens[0].strip_edges();
 			filter_names.push_back(tokens[0].strip_edges().utf16());
 		}
+		Vector<String> ext_tokens = filter_ext_text.split(",");
+		filter_exts.push_back(String(";").join(ext_tokens).utf16());
 	}
 
 	Vector<COMDLG_FILTERSPEC> filters;


### PR DESCRIPTION
**EDIT:** Is this made obsolete by #80842, #81218?

Fixes #81781

Allows for multiple file types to be used in the same filter in Windows file dialogues. This allows for a consistent syntax with the built-in `FileAccess` and now allows filters like `*.png,*.jpg,*.jpeg;Supported Images` to work as intended.

[windows_file_dialogue_test.zip](https://github.com/godotengine/godot/files/12641984/windows_file_dialogue_test.zip)
