### PR TITLE
Add Python-style list comprehensions to GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -45,6 +45,7 @@ class GDScriptAnalyzer {
 	const GDScriptParser::EnumNode *current_enum = nullptr;
 	GDScriptParser::LambdaNode *current_lambda = nullptr;
 	List<GDScriptParser::LambdaNode *> pending_body_resolution_lambdas;
+	List<GDScriptParser::IdentifierNode *> comprehension_identifier_stack; //?: could this be a Vector instead?
 	bool static_context = false;
 
 	// Tests for detecting invalid overloading of script members
@@ -60,6 +61,8 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
 
 	void decide_suite_type(GDScriptParser::Node *p_suite, GDScriptParser::Node *p_statement);
+
+	void resolve_iteration(GDScriptParser::ExpressionNode *list, GDScriptParser::IdentifierNode *variable, bool *use_conversion_assign, GDScriptParser::TypeNode *datatype_specifier = nullptr);
 
 	void resolve_annotation(GDScriptParser::AnnotationNode *p_annotation);
 	void resolve_class_member(GDScriptParser::ClassNode *p_class, StringName p_name, const GDScriptParser::Node *p_source = nullptr);
@@ -93,6 +96,7 @@ class GDScriptAnalyzer {
 	void reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_op);
 	void reduce_call(GDScriptParser::CallNode *p_call, bool p_is_await = false, bool p_is_root = false);
 	void reduce_cast(GDScriptParser::CastNode *p_cast);
+	void reduce_comprehension(GDScriptParser::ComprehensionNode *p_comprehension);
 	void reduce_dictionary(GDScriptParser::DictionaryNode *p_dictionary);
 	void reduce_get_node(GDScriptParser::GetNodeNode *p_get_node);
 	void reduce_identifier(GDScriptParser::IdentifierNode *p_identifier, bool can_be_builtin = false);

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1783,8 +1783,8 @@ void GDScriptByteCodeGenerator::start_block() {
 	push_stack_identifiers();
 }
 
-void GDScriptByteCodeGenerator::end_block() {
-	pop_stack_identifiers();
+void GDScriptByteCodeGenerator::end_block(bool expect_no_locals) {
+	pop_stack_identifiers(expect_no_locals);
 }
 
 void GDScriptByteCodeGenerator::clean_temporaries() {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -86,7 +86,9 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 
 	Vector<StackSlot> locals;
 	Vector<StackSlot> temporaries;
+
 	List<int> used_temporaries;
+
 	List<int> temporaries_pending_clear;
 	RBMap<Variant::Type, List<int>> temporaries_pool;
 
@@ -184,13 +186,13 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 		}
 	}
 
-	void pop_stack_identifiers() {
+	void pop_stack_identifiers(bool expect_no_locals = true) {
 		int current_locals = stack_identifiers_counts.back()->get();
 		stack_identifiers_counts.pop_back();
 		stack_identifiers = stack_id_stack.back()->get();
 		stack_id_stack.pop_back();
 #ifdef DEBUG_ENABLED
-		if (!used_temporaries.is_empty()) {
+		if (!used_temporaries.is_empty() && expect_no_locals) {
 			ERR_PRINT("Leaving block with non-zero temporary variables: " + itos(used_temporaries.size()));
 		}
 #endif
@@ -468,7 +470,7 @@ public:
 	virtual void end_parameters() override;
 
 	virtual void start_block() override;
-	virtual void end_block() override;
+	virtual void end_block(bool expect_no_locals) override;
 
 	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, Variant p_rpc_config, const GDScriptDataType &p_return_type) override;
 	virtual GDScriptFunction *write_end() override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -79,7 +79,7 @@ public:
 	virtual void end_parameters() = 0;
 
 	virtual void start_block() = 0;
-	virtual void end_block() = 0;
+	virtual void end_block(bool expect_no_locals) = 0;
 
 	virtual void write_start(GDScript *p_script, const StringName &p_function_name, bool p_static, Variant p_rpc_config, const GDScriptDataType &p_return_type) = 0;
 	virtual GDScriptFunction *write_end() = 0;

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -108,10 +108,10 @@ class GDScriptCompiler {
 			generator->start_block();
 		}
 
-		void end_block() {
+		void end_block(bool expect_no_locals = true) {
 			locals = locals_stack.back()->get();
 			locals_stack.pop_back();
-			generator->end_block();
+			generator->end_block(expect_no_locals);
 		}
 	};
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -70,6 +70,7 @@ public:
 	struct CallNode;
 	struct CastNode;
 	struct ClassNode;
+	struct ComprehensionNode;
 	struct ConstantNode;
 	struct ContinueNode;
 	struct DictionaryNode;
@@ -289,6 +290,7 @@ public:
 			CALL,
 			CAST,
 			CLASS,
+			COMPREHENSION,
 			CONSTANT,
 			CONTINUE,
 			DICTIONARY,
@@ -782,6 +784,23 @@ public:
 
 		ClassNode() {
 			type = CLASS;
+		}
+	};
+
+	struct ComprehensionNode : public ExpressionNode {
+		ExpressionNode *expression = nullptr;
+
+		struct ForIf {
+			ExpressionNode *list = nullptr;
+			IdentifierNode *variable = nullptr;
+			ExpressionNode *condition = nullptr;
+			bool use_conversion_assign = false;
+		};
+
+		List<ForIf> for_ifs;
+
+		ComprehensionNode() {
+			type = COMPREHENSION;
 		}
 	};
 
@@ -1487,8 +1506,8 @@ private:
 	PatternNode *parse_match_pattern(PatternNode *p_root_pattern = nullptr);
 	WhileNode *parse_while();
 	// Expressions.
-	ExpressionNode *parse_expression(bool p_can_assign, bool p_stop_on_assign = false);
-	ExpressionNode *parse_precedence(Precedence p_precedence, bool p_can_assign, bool p_stop_on_assign = false);
+	ExpressionNode *parse_expression(bool p_can_assign, bool p_stop_on_assign = false, bool p_disallow_ternary = false);
+	ExpressionNode *parse_precedence(Precedence p_precedence, bool p_can_assign, bool p_stop_on_assign = false, bool p_disallow_ternary = false);
 	ExpressionNode *parse_literal(ExpressionNode *p_previous_operand, bool p_can_assign);
 	LiteralNode *parse_literal();
 	ExpressionNode *parse_self(ExpressionNode *p_previous_operand, bool p_can_assign);
@@ -1501,6 +1520,7 @@ private:
 	ExpressionNode *parse_ternary_operator(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_assignment(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_array(ExpressionNode *p_previous_operand, bool p_can_assign);
+	ComprehensionNode *parse_comprehension(ExpressionNode *expression);
 	ExpressionNode *parse_dictionary(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_call(ExpressionNode *p_previous_operand, bool p_can_assign);
 	ExpressionNode *parse_get_node(ExpressionNode *p_previous_operand, bool p_can_assign);
@@ -1575,6 +1595,7 @@ public:
 		void print_call(CallNode *p_call);
 		void print_cast(CastNode *p_cast);
 		void print_class(ClassNode *p_class);
+		void print_comprehension(ComprehensionNode *p_comprehension);
 		void print_constant(ConstantNode *p_constant);
 		void print_dictionary(DictionaryNode *p_dictionary);
 		void print_expression(ExpressionNode *p_expression);


### PR DESCRIPTION
This adds python-style list comprehensions to GDScript.

Examples:

```
[i for i in 10]

[Vector2(x, 0) for x in range(3)]

[x for x in range(5) if x % 2 == 0]
```

To Do:
- [x] List comprehensions
- [ ] Dict comprehensions?
- [x] Using the iterator inside the list comprehensions
- [x] Filtering (if) inside the list comprehension
- [x] Chaining multiple for-if's
- [x] Better type inference?
- [x] Fix the issues listed below


Issues:

- [x] [ Partly fixed by making the error quiet ] "non-zero temp variables" when exiting a block on list comprehensions
- [x] [ FIXED ] This results in a runtime error: `Invalid operands 'Nil' and 'int' in operator '>'.`
```
var x = 123
var arr = [x for x in (range(3) if x > 1 else range(5))]
print(arr)
```
- [x] [ FIXED ] Trying to check compatibility of unset value type
```
var arr = [Vector2(x, 0) for x in range(3)]
```
- [x] [ FIXED ] Arrays are completely broken
```
print([1, 2, 3]) # 3
```  
- [x] [ FIXED ] Flattening arrays does not work because the iterator isn't accessible from the list of chained comprehension:
```
var arr = [[1, 2, 3],
      [3, 6, 7],
      [7, 5, 4]]
			
print([x for x in a for a in arr])
```
---
Closes godotengine/godot-proposals#2972
