### PR TITLE
Fixed VS 2022 Mac compatibility

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -4,8 +4,6 @@
   <PropertyGroup>
     <!-- Determines if we should import Microsoft.NET.Sdk, if it wasn't already imported. -->
     <GodotSdkImportsMicrosoftNetSdk Condition=" '$(UsingMicrosoftNETSdk)' != 'true' ">true</GodotSdkImportsMicrosoftNetSdk>
-
-    <GodotProjectTypeGuid>{8F3E2DF0-C35C-4265-82FC-BEA011F4A7ED}</GodotProjectTypeGuid>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -2,11 +2,6 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition=" '$(GodotSdkImportsMicrosoftNetSdk)' == 'true' " />
 
   <PropertyGroup>
-    <EnableGodotProjectTypeGuid Condition=" '$(EnableGodotProjectTypeGuid)' == '' ">true</EnableGodotProjectTypeGuid>
-    <ProjectTypeGuids Condition=" '$(EnableGodotProjectTypeGuid)' == 'true' ">$(GodotProjectTypeGuid);$(DefaultProjectTypeGuid)</ProjectTypeGuids>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!--
     Define constant to determine whether the real_t type in Godot is double precision or not.
     By default this is false, like the official Godot builds. If someone is using a custom


### PR DESCRIPTION
Visual Studio 2022 on Mac marks the project as invalid if the project Guid is set. The easiest way to fix it is to add an additional check and disable 'EnableGodotProjectTypeGuid' for the SDK when the Visual Studio version is less than 17.0.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/67029.

