### PR TITLE
Option for Texture Importer to ignore image alpha

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -218,7 +218,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "compress/lossy_quality", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.7));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/hdr_compression", PROPERTY_HINT_ENUM, "Disabled,Opaque Only,Always"), 1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/normal_map", PROPERTY_HINT_ENUM, "Detect,Enable,Disabled"), 0));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized,Opaque RGB,BGRA,Only R Channel,Only RG channels"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/generate"), (p_preset == PRESET_3D ? true : false)));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "mipmaps/limit", PROPERTY_HINT_RANGE, "-1,256"), -1));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "roughness/mode", PROPERTY_HINT_ENUM, "Detect,Disabled,Red,Green,Blue,Alpha,Gray"), 0));
@@ -586,6 +586,18 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 				}
 			}
 		}
+
+		if (pack_channels == 3) { // BGRA mode, swapping B and R channels.
+			const int height = target_image->get_height();
+			const int width = target_image->get_width();
+
+			for (int i = 0; i < width; i++) {
+				for (int j = 0; j < height; j++) {
+					const Color color = target_image->get_pixel(i, j);
+					target_image->set_pixel(i, j, Color(color.b, color.g, color.r, color.a));
+				}
+			}
+		}
 	}
 
 	if (compress_mode == COMPRESS_BASIS_UNIVERSAL && image->get_format() >= Image::FORMAT_RF) {
@@ -643,6 +655,18 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 					use_uncompressed = true;
 				}
 			}
+		} else if (pack_channels == 2) { // Discard alpha.
+			if (image->get_format() == Image::FORMAT_RGBAF) {
+				image->convert(Image::FORMAT_RGBF);
+			} else if (image->get_format() == Image::FORMAT_RGBAH) {
+				image->convert(Image::FORMAT_RGBH);
+			} else if (image->get_format() == Image::FORMAT_RGBA8) {
+				image->convert(Image::FORMAT_RGB8);
+			}
+		} else if (pack_channels == 4) { // Discard all channels except R.
+			image->convert(Image::FORMAT_R8);
+		} else if (pack_channels == 5) { // Discard all channels except RG.
+			image->convert(Image::FORMAT_RG8);
 		}
 
 		if (use_uncompressed) {


### PR DESCRIPTION
In some workflows, opaque images are stored in with alpha channel that results in DXT5 and other compression formats with abundant data. This patch adds an option to the Channel Pack dropdown to ignore the alpha channel. It works only for non-HDR RGBAF, RGBAH, and RGBA8 images.

Correctly cherry-picked and fixed.