### PR TITLE
Clear monitoring in `Area*` when its space changes to invalid

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -384,11 +384,9 @@ void Area2D::_clear_monitoring() {
 	}
 }
 
-void Area2D::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_EXIT_TREE: {
-			_clear_monitoring();
-		} break;
+void Area2D::_space_changed(const RID &p_new_space) {
+	if (p_new_space.is_null()) {
+		_clear_monitoring();
 	}
 }
 

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -133,9 +133,10 @@ private:
 	StringName audio_bus;
 
 protected:
-	void _notification(int p_what);
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
+
+	virtual void _space_changed(const RID &p_new_space) override;
 
 public:
 	void set_gravity_space_override_mode(SpaceOverride p_mode);

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -59,6 +59,7 @@ void CollisionObject2D::_notification(int p_what) {
 				} else {
 					PhysicsServer2D::get_singleton()->body_set_space(rid, space);
 				}
+				_space_changed(space);
 			}
 
 			_update_pickable();
@@ -102,6 +103,7 @@ void CollisionObject2D::_notification(int p_what) {
 					} else {
 						PhysicsServer2D::get_singleton()->body_set_space(rid, RID());
 					}
+					_space_changed(RID());
 				}
 			}
 
@@ -125,6 +127,7 @@ void CollisionObject2D::_notification(int p_what) {
 			} else {
 				PhysicsServer2D::get_singleton()->body_set_space(rid, space);
 			}
+			_space_changed(space);
 		} break;
 
 		case NOTIFICATION_DISABLED: {
@@ -246,6 +249,7 @@ void CollisionObject2D::_apply_disabled() {
 					} else {
 						PhysicsServer2D::get_singleton()->body_set_space(rid, RID());
 					}
+					_space_changed(RID());
 				}
 			}
 		} break;
@@ -272,6 +276,7 @@ void CollisionObject2D::_apply_enabled() {
 				} else {
 					PhysicsServer2D::get_singleton()->body_set_space(rid, space);
 				}
+				_space_changed(space);
 			}
 		} break;
 
@@ -567,6 +572,9 @@ void CollisionObject2D::set_body_mode(PhysicsServer2D::BodyMode p_mode) {
 	}
 
 	PhysicsServer2D::get_singleton()->body_set_mode(rid, p_mode);
+}
+
+void CollisionObject2D::_space_changed(const RID &p_new_space) {
 }
 
 void CollisionObject2D::_update_pickable() {

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -109,6 +109,8 @@ protected:
 
 	void set_body_mode(PhysicsServer2D::BodyMode p_mode);
 
+	virtual void _space_changed(const RID &p_new_space);
+
 	GDVIRTUAL3(_input_event, Viewport *, Ref<InputEvent>, int)
 	GDVIRTUAL0(_mouse_enter)
 	GDVIRTUAL0(_mouse_exit)

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -347,12 +347,14 @@ void Area3D::_clear_monitoring() {
 	}
 }
 
+void Area3D::_space_changed(const RID &p_new_space) {
+	if (p_new_space.is_null()) {
+		_clear_monitoring();
+	}
+}
+
 void Area3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_EXIT_TREE: {
-			_clear_monitoring();
-		} break;
-
 		case NOTIFICATION_ENTER_TREE: {
 			_initialize_wind();
 		} break;

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -149,6 +149,8 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 
+	virtual void _space_changed(const RID &p_new_space) override;
+
 public:
 	void set_gravity_space_override_mode(SpaceOverride p_mode);
 	SpaceOverride get_gravity_space_override_mode() const;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -78,6 +78,7 @@ void CollisionObject3D::_notification(int p_what) {
 				} else {
 					PhysicsServer3D::get_singleton()->body_set_space(rid, space);
 				}
+				_space_changed(space);
 			}
 
 			_update_pickable();
@@ -117,6 +118,7 @@ void CollisionObject3D::_notification(int p_what) {
 					} else {
 						PhysicsServer3D::get_singleton()->body_set_space(rid, RID());
 					}
+					_space_changed(RID());
 				}
 			}
 
@@ -244,6 +246,7 @@ void CollisionObject3D::_apply_disabled() {
 					} else {
 						PhysicsServer3D::get_singleton()->body_set_space(rid, RID());
 					}
+					_space_changed(RID());
 				}
 			}
 		} break;
@@ -270,6 +273,7 @@ void CollisionObject3D::_apply_enabled() {
 				} else {
 					PhysicsServer3D::get_singleton()->body_set_space(rid, space);
 				}
+				_space_changed(space);
 			}
 		} break;
 
@@ -318,6 +322,9 @@ void CollisionObject3D::set_body_mode(PhysicsServer3D::BodyMode p_mode) {
 	}
 
 	PhysicsServer3D::get_singleton()->body_set_mode(rid, p_mode);
+}
+
+void CollisionObject3D::_space_changed(const RID &p_new_space) {
 }
 
 void CollisionObject3D::set_only_update_transform_changes(bool p_enable) {

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -116,6 +116,8 @@ protected:
 
 	void set_body_mode(PhysicsServer3D::BodyMode p_mode);
 
+	virtual void _space_changed(const RID &p_new_space);
+
 	void set_only_update_transform_changes(bool p_enable);
 	bool is_only_update_transform_changes_enabled() const;
 

--- a/servers/physics_2d/godot_area_2d.h
+++ b/servers/physics_2d/godot_area_2d.h
@@ -167,7 +167,7 @@ void GodotArea2D::add_body_to_query(GodotBody2D *p_body, uint32_t p_body_shape, 
 void GodotArea2D::remove_body_from_query(GodotBody2D *p_body, uint32_t p_body_shape, uint32_t p_area_shape) {
 	BodyKey bk(p_body, p_body_shape, p_area_shape);
 	monitored_bodies[bk].dec();
-	if (!monitor_query_list.in_list()) {
+	if (get_space() && !monitor_query_list.in_list()) {
 		_queue_monitor_update();
 	}
 }
@@ -183,7 +183,7 @@ void GodotArea2D::add_area_to_query(GodotArea2D *p_area, uint32_t p_area_shape, 
 void GodotArea2D::remove_area_from_query(GodotArea2D *p_area, uint32_t p_area_shape, uint32_t p_self_shape) {
 	BodyKey bk(p_area, p_area_shape, p_self_shape);
 	monitored_areas[bk].dec();
-	if (!monitor_query_list.in_list()) {
+	if (get_space() && !monitor_query_list.in_list()) {
 		_queue_monitor_update();
 	}
 }

--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -407,7 +407,8 @@ void GodotBody2D::set_space(GodotSpace2D *p_space) {
 
 	if (get_space()) {
 		_mass_properties_changed();
-		if (active) {
+
+		if (active && !active_list.in_list()) {
 			get_space()->body_add_to_active_list(&active_list);
 		}
 	}

--- a/servers/physics_2d/godot_collision_object_2d.cpp
+++ b/servers/physics_2d/godot_collision_object_2d.cpp
@@ -212,19 +212,20 @@ void GodotCollisionObject2D::_update_shapes_with_motion(const Vector2 &p_motion)
 }
 
 void GodotCollisionObject2D::_set_space(GodotSpace2D *p_space) {
-	if (space) {
-		space->remove_object(this);
+	GodotSpace2D *old_space = space;
+	space = p_space;
+
+	if (old_space) {
+		old_space->remove_object(this);
 
 		for (int i = 0; i < shapes.size(); i++) {
 			Shape &s = shapes.write[i];
 			if (s.bpid) {
-				space->get_broadphase()->remove(s.bpid);
+				old_space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;
 			}
 		}
 	}
-
-	space = p_space;
 
 	if (space) {
 		space->add_object(this);

--- a/servers/physics_3d/godot_area_3d.h
+++ b/servers/physics_3d/godot_area_3d.h
@@ -204,7 +204,7 @@ void GodotArea3D::add_body_to_query(GodotBody3D *p_body, uint32_t p_body_shape, 
 void GodotArea3D::remove_body_from_query(GodotBody3D *p_body, uint32_t p_body_shape, uint32_t p_area_shape) {
 	BodyKey bk(p_body, p_body_shape, p_area_shape);
 	monitored_bodies[bk].dec();
-	if (!monitor_query_list.in_list()) {
+	if (get_space() && !monitor_query_list.in_list()) {
 		_queue_monitor_update();
 	}
 }
@@ -220,7 +220,7 @@ void GodotArea3D::add_area_to_query(GodotArea3D *p_area, uint32_t p_area_shape, 
 void GodotArea3D::remove_area_from_query(GodotArea3D *p_area, uint32_t p_area_shape, uint32_t p_self_shape) {
 	BodyKey bk(p_area, p_area_shape, p_self_shape);
 	monitored_areas[bk].dec();
-	if (!monitor_query_list.in_list()) {
+	if (get_space() && !monitor_query_list.in_list()) {
 		_queue_monitor_update();
 	}
 }

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -454,7 +454,8 @@ void GodotBody3D::set_space(GodotSpace3D *p_space) {
 
 	if (get_space()) {
 		_mass_properties_changed();
-		if (active) {
+
+		if (active && !active_list.in_list()) {
 			get_space()->body_add_to_active_list(&active_list);
 		}
 	}

--- a/servers/physics_3d/godot_collision_object_3d.cpp
+++ b/servers/physics_3d/godot_collision_object_3d.cpp
@@ -210,19 +210,20 @@ void GodotCollisionObject3D::_update_shapes_with_motion(const Vector3 &p_motion)
 }
 
 void GodotCollisionObject3D::_set_space(GodotSpace3D *p_space) {
-	if (space) {
-		space->remove_object(this);
+	GodotSpace3D *old_space = space;
+	space = p_space;
+
+	if (old_space) {
+		old_space->remove_object(this);
 
 		for (int i = 0; i < shapes.size(); i++) {
 			Shape &s = shapes.write[i];
 			if (s.bpid) {
-				space->get_broadphase()->remove(s.bpid);
+				old_space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;
 			}
 		}
 	}
-
-	space = p_space;
 
 	if (space) {
 		space->add_object(this);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Clear monitoring in `area*` so that ~~they can work properly in the following `NOTIFICATION_ENABLED`.~~ it can work properly when the space changes to valid again.

Change `space` in advance to prevent disabled areas from being queried again. 

That is, if the area as a monitor is disabled, it will no longer be added to the query list. Cached maps information will be cleared later in `NOTIFICATION_DISABLED`. Behavior is similar to **exiting** an area, as opposed to `NOTIFICATION_ENABLED` (which is similar to **entering** an area).

Fixes #61420 ([Wrong behaviors caused by pause](https://github.com/godotengine/godot/issues/61420#issuecomment-1722474137)).
Fixes https://github.com/godotengine/godot/issues/76219.
Fixes https://github.com/godotengine/godot/issues/70848.