### PR TITLE
Remove unused `close_request` signal from `GraphElement`

### DIFF
--- a/doc/classes/GraphElement.xml
+++ b/doc/classes/GraphElement.xml
@@ -27,11 +27,6 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="close_request">
-			<description>
-				Emitted when closing the GraphElement is requested.
-			</description>
-		</signal>
 		<signal name="dragged">
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -238,7 +238,6 @@ void GraphElement::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("node_deselected"));
 	ADD_SIGNAL(MethodInfo("dragged", PropertyInfo(Variant::VECTOR2, "from"), PropertyInfo(Variant::VECTOR2, "to")));
 	ADD_SIGNAL(MethodInfo("raise_request"));
-	ADD_SIGNAL(MethodInfo("close_request"));
 	ADD_SIGNAL(MethodInfo("resize_request", PropertyInfo(Variant::VECTOR2, "new_minsize")));
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, GraphElement, resizer);


### PR DESCRIPTION
It's never emitted.

The latest documentation also instructs users to use [`get_titlebar_hbox()`](https://docs.godotengine.org/en/latest/classes/class_graphnode.html#class-graphnode-method-get-titlebar-hbox) in order to add their own close button.