### PR TITLE
LSP: Fix autocomplete quote handling

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -346,6 +346,15 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		}
 	}
 
+	if (item.kind == lsp::CompletionItemKind::Method) {
+		bool is_trigger_character = params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter;
+		bool is_quote_character = params.context.triggerCharacter == "\"" || params.context.triggerCharacter == "'";
+
+		if (is_trigger_character && is_quote_character && item.insertText.is_quoted()) {
+			item.insertText = item.insertText.unquote();
+		}
+	}
+
 	return item.to_json(true);
 }
 

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1429,6 +1429,17 @@ struct CompletionParams : public TextDocumentPositionParams {
 		TextDocumentPositionParams::load(p_params);
 		context.load(p_params["context"]);
 	}
+
+	Dictionary to_json() {
+		Dictionary ctx;
+		ctx["triggerCharacter"] = context.triggerCharacter;
+		ctx["triggerKind"] = context.triggerKind;
+
+		Dictionary dict;
+		dict = TextDocumentPositionParams::to_json();
+		dict["context"] = ctx;
+		return dict;
+	}
 };
 
 /**


### PR DESCRIPTION
Fixes #48436

Updates to language server:
- Add missing context to CompletionParams so context can be used in the resolve function.
- Omit quotes in auto-complete suggestion if triggered with single or double quote.

I'm new to Godot and C++, but after poking around the code base a bit, I was able to get it working by making two changes:

1. CompletionParams has a new `context` member. It provided an implementation for `load()` to include that data, but not one for `to_json()`. So `context` was missing from the JSON and there's already code in `GDScriptTextDocument::resolve()` that depends on that. I added `context` to the JSON so it can be used in `resolve()`.
2. Now that `resolve()` has the context, the current bug can be fixed. If the completion was triggered with a single or double quote,  then there's already a quote (or a pair of quotes) in the external editor. The auto-complete suggestion should be returned without quotes.

Both changes are in language server classes, so this change should not break the built-in editor. I did a quick test to confirm that still returns quotes.

Again, I'm new to Godot and C++, so if I'm overlooking something obvious, please let me know and I'll try to fix it.