### PR TITLE
LSP: Add `--lsp-port` as a command line argument

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -114,7 +114,10 @@
 
 #ifdef MODULE_GDSCRIPT_ENABLED
 #include "modules/gdscript/gdscript.h"
-#endif
+#if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+#include "modules/gdscript/language_server/gdscript_language_server.h"
+#endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
+#endif // MODULE_GDSCRIPT_ENABLED
 
 /* Static members */
 
@@ -389,7 +392,10 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -e, --editor                      Start the editor instead of running the scene.\n");
 	OS::get_singleton()->print("  -p, --project-manager             Start the project manager, even if a project is auto-detected.\n");
 	OS::get_singleton()->print("  --debug-server <uri>              Start the editor debug server (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007)\n");
-#endif
+#if defined(MODULE_GDSCRIPT_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+	OS::get_singleton()->print("  --lsp-port <port>                 Use the specified port for the language server protocol. The port must be between 0 to 65535.\n");
+#endif // MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
+#endif // TOOLS_ENABLED
 	OS::get_singleton()->print("  --quit                            Quit after the first iteration.\n");
 	OS::get_singleton()->print("  --quit-after <int>                Quit after the given number of iterations. Set to 0 to disable.\n");
 	OS::get_singleton()->print("  -l, --language <locale>           Use a specific locale (<locale> being a two-letter code).\n");
@@ -1504,7 +1510,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing <path> argument for --benchmark-file <path>.\n");
 				goto error;
 			}
-
+#if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+		} else if (I->get() == "--lsp-port") {
+			if (I->next()) {
+				int port_override = I->next()->get().to_int();
+				if (port_override < 0 || port_override > 65535) {
+					OS::get_singleton()->print("<port> argument for --lsp-port <port> must be between 0 and 65535.\n");
+					goto error;
+				}
+				GDScriptLanguageServer::port_override = port_override;
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing <port> argument for --lsp-port <port>.\n");
+				goto error;
+			}
+#endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
 		} else if (I->get() == "--" || I->get() == "++") {
 			adding_user_args = true;
 		} else {

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -36,6 +36,8 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 
+int GDScriptLanguageServer::port_override = -1;
+
 GDScriptLanguageServer::GDScriptLanguageServer() {
 	_EDITOR_DEF("network/language_server/remote_host", host);
 	_EDITOR_DEF("network/language_server/remote_port", port);
@@ -62,7 +64,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			String remote_host = String(_EDITOR_GET("network/language_server/remote_host"));
-			int remote_port = (int)_EDITOR_GET("network/language_server/remote_port");
+			int remote_port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 			bool remote_use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 			if (remote_host != host || remote_port != port || remote_use_thread != use_thread) {
 				stop();
@@ -84,10 +86,10 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 
 void GDScriptLanguageServer::start() {
 	host = String(_EDITOR_GET("network/language_server/remote_host"));
-	port = (int)_EDITOR_GET("network/language_server/remote_port");
+	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 	if (protocol.start(port, IPAddress(host)) == OK) {
-		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
+		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {
 			thread_running = true;
 			thread.start(GDScriptLanguageServer::thread_main, this);

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -53,6 +53,7 @@ private:
 	void _notification(int p_what);
 
 public:
+	static int port_override;
 	GDScriptLanguageServer();
 	void start();
 	void stop();


### PR DESCRIPTION
Per discussion in https://github.com/godotengine/godot-vscode-plugin/pull/488, and the suggestion by @Calinou in https://github.com/godotengine/godot-vscode-plugin/pull/488#issuecomment-1722339162.

Implements an `--lsp-port` command line argument for Godot. This argument overrides the user's editor setting for `network/language_server/remote_port`.

The use case for this argument would be for the godot-vscode-plugin to be able to specify the port used for the language server instance spun up by the plugin.

This would potentially solve a few long standing issues with the godot-vscode-plugin, including:
1. Godot's 3.x LSP port and 4.x LSP port don't match, causing the plugin to have to tell users to explicitly specify the port they have selected in their editor settings. (See https://github.com/godotengine/godot-vscode-plugin/issues/473)
2. Spinning up multiple workspaces in vscode would cause both to use the same language server.

If the change is accepted, it should be cherry picked to 3.x. I can help with that if need be.

Let me know what things I have to change. Since this is my first time working with main.cpp and further with #ifdef and #ifndef, please pay attention to my use of those and let me know if they are up to standard.

I also added the port to the language server editor print that says --- GDScript language server started ---, changing it to --- GDScript language server started on port "port"---.

If there are places I need to document this change at, let me know as well. :)