### PR TITLE
Implemented `{project}` placeholder for external dotnet editor

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -190,6 +190,9 @@ namespace GodotTools
                 case ExternalEditorId.CustomEditor:
                 {
                     string file = ProjectSettings.GlobalizePath(script.ResourcePath);
+                    string project = ProjectSettings.GlobalizePath("res://");
+                    // Since ProjectSettings.GlobalizePath replaces only "res:/", leaving a trailing slash, it is removed here.
+                    project = project[..^1];
                     var execCommand = _editorSettings.GetSetting(Settings.CustomExecPath).As<string>();
                     var execArgs = _editorSettings.GetSetting(Settings.CustomExecPathArgs).As<string>();
                     var args = new List<string>();
@@ -226,6 +229,7 @@ namespace GodotTools
                                 hasFileFlag = true;
                             }
 
+                            arg = arg.ReplaceN("{project}", project);
                             arg = arg.ReplaceN("{file}", file);
                             args.Add(arg);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR fixes #81845 , by mimicking the implementation at https://github.com/godotengine/godot/blob/4df80b0e629e25653a706f6721c13a1f9d1da368/editor/plugins/script_editor_plugin.cpp#L2291-L2316

As the function `ProjectSettings::get_singleton()->get_resource_path()` isn't exposed in the godot API, this solution instead makes use of ProjectSettings.GlobalizePath("res://"), which, on editor builds, returns `ProjectSettings.resource_path + "/"`, according to its implementation at https://github.com/godotengine/godot/blob/4df80b0e629e25653a706f6721c13a1f9d1da368/core/config/project_settings.cpp#L257-L272
