### PR TITLE
GLTF: Add root node export options and `GODOT_single_root` extension

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -95,5 +95,20 @@
 		<member name="lossy_quality" type="float" setter="set_lossy_quality" getter="get_lossy_quality" default="0.75">
 			If [member image_format] is a lossy image format, this determines the lossy quality of the image. On a range of [code]0.0[/code] to [code]1.0[/code], where [code]0.0[/code] is the lowest quality and [code]1.0[/code] is the highest quality. A lossy quality of [code]1.0[/code] is not the same as lossless.
 		</member>
+		<member name="root_node_mode" type="int" setter="set_root_node_mode" getter="get_root_node_mode" enum="GLTFDocument.RootNodeMode" default="0">
+			How to process the root node during export. See [enum RootNodeMode] for details. The default and recommended value is [constant ROOT_NODE_MODE_SINGLE_ROOT].
+			[b]Note:[/b] Regardless of how the glTF file is exported, when importing, the root node type and name can be overridden in the scene import settings tab.
+		</member>
 	</members>
+	<constants>
+		<constant name="ROOT_NODE_MODE_SINGLE_ROOT" value="0" enum="RootNodeMode">
+			Treat the Godot scene's root node as the root node of the glTF file, and mark it as the single root node via the [code]GODOT_single_root[/code] glTF extension. This will be parsed the same as [constant ROOT_NODE_MODE_KEEP_ROOT] if the implementation does not support [code]GODOT_single_root[/code].
+		</constant>
+		<constant name="ROOT_NODE_MODE_KEEP_ROOT" value="1" enum="RootNodeMode">
+			Treat the Godot scene's root node as the root node of the glTF file, but do not mark it as anything special. An extra root node will be generated when importing into Godot. This uses only vanilla glTF features. This is equivalent to the behavior in Godot 4.1 and earlier.
+		</constant>
+		<constant name="ROOT_NODE_MODE_MULTI_ROOT" value="2" enum="RootNodeMode">
+			Treat the Godot scene's root node as the name of the glTF scene, and add all of its children as root nodes of the glTF file. This uses only vanilla glTF features. This avoids an extra root node, but only the name of the Godot scene's root node will be preserved, as it will not be saved as a node.
+		</constant>
+	</constants>
 </class>

--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -65,6 +65,7 @@
 			<description>
 				Part of the import process. This method is run after [method _import_post_parse] and before [method _import_node].
 				Runs when generating a Godot scene node from a GLTFNode. The returned node will be added to the scene tree. Multiple nodes can be generated in this step if they are added as a child of the returned node.
+				[b]Note:[/b] The [param scene_parent] parameter may be null if this is the single root node.
 			</description>
 		</method>
 		<method name="_get_image_file_extension" qualifiers="virtual">

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -101,7 +101,6 @@ Error GLTFDocumentExtension::parse_texture_json(Ref<GLTFState> p_state, const Di
 Node3D *GLTFDocumentExtension::generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) {
 	ERR_FAIL_NULL_V(p_state, nullptr);
 	ERR_FAIL_NULL_V(p_gltf_node, nullptr);
-	ERR_FAIL_NULL_V(p_scene_parent, nullptr);
 	Node3D *ret_node = nullptr;
 	GDVIRTUAL_CALL(_generate_scene_node, p_state, p_gltf_node, p_scene_parent, ret_node);
 	return ret_node;

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -40,12 +40,6 @@ class GLTFDocument : public Resource {
 	static Vector<Ref<GLTFDocumentExtension>> all_document_extensions;
 	Vector<Ref<GLTFDocumentExtension>> document_extensions;
 
-private:
-	const float BAKE_FPS = 30.0f;
-	String _image_format = "PNG";
-	float _lossy_quality = 0.75f;
-	Ref<GLTFDocumentExtension> _image_save_extension;
-
 public:
 	const int32_t JOINT_GROUP_SIZE = 4;
 
@@ -71,6 +65,18 @@ public:
 		TEXTURE_TYPE_GENERIC = 0,
 		TEXTURE_TYPE_NORMAL = 1,
 	};
+	enum RootNodeMode {
+		ROOT_NODE_MODE_SINGLE_ROOT,
+		ROOT_NODE_MODE_KEEP_ROOT,
+		ROOT_NODE_MODE_MULTI_ROOT,
+	};
+
+private:
+	const float BAKE_FPS = 30.0f;
+	String _image_format = "PNG";
+	float _lossy_quality = 0.75f;
+	Ref<GLTFDocumentExtension> _image_save_extension;
+	RootNodeMode _root_node_mode = RootNodeMode::ROOT_NODE_MODE_SINGLE_ROOT;
 
 protected:
 	static void _bind_methods();
@@ -84,6 +90,8 @@ public:
 	String get_image_format() const;
 	void set_lossy_quality(float p_lossy_quality);
 	float get_lossy_quality() const;
+	void set_root_node_mode(RootNodeMode p_root_node_mode);
+	RootNodeMode get_root_node_mode() const;
 
 private:
 	void _build_parent_hierachy(Ref<GLTFState> p_state);
@@ -378,5 +386,7 @@ public:
 	Error _serialize(Ref<GLTFState> p_state);
 	Error _parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess> p_file);
 };
+
+VARIANT_ENUM_CAST(GLTFDocument::RootNodeMode);
 
 #endif // GLTF_DOCUMENT_H


### PR DESCRIPTION
Solves https://github.com/godotengine/godot-proposals/discussions/6588

Spec: https://github.com/KhronosGroup/glTF/pull/2329

This PR adds root node export options and a new glTF extension called `GODOT_single_root`.

This was discussed with @lyuma about 2 months ago, but was on hold for most of that time due to me waiting for other PRs to be merged as prerequisites (and me not wanting to open draft PRs with a long dependency chain).

<img width="514" alt="Screenshot 2023-09-18 at 1 41 22 AM" src="https://github.com/godotengine/godot/assets/1646875/56e9c803-33b9-451a-ae15-8b8daa9e6d48">

(with this PR by itself, there is no export settings dialog, but it can be set through GDScript code when exporting from script, and the goal is to make this available in the export settings [once that's added](https://github.com/godotengine/godot/pull/79316))

* Single Root: Treat the Godot scene's root node as the root node of the glTF file, and mark it as the single root node via the `GODOT_single_root` glTF extension. This will be parsed the same as Keep Root if the implementation does not support `GODOT_single_root`.
* Keep Root: Treat the Godot scene's root node as the root node of the glTF file, but do not mark it as anything special. An extra root node will be generated when importing into Godot. This uses only vanilla glTF features. This is equivalent to the behavior in Godot 4.1 and earlier.
* Multi Root: Treat the Godot scene's root node as the name of the glTF scene, and add all of its children as root nodes of the glTF file. This uses only vanilla glTF features. This avoids an extra root node, but only the name of the Godot scene's root node will be preserved, as it will not be saved as a node.

The last 2 options both use only vanilla glTF features. Keep Root is the same as 4.1. Multi Root is a new feature, which allows round-tripping a scene without an extra root node, but the downside is that the root node will only ever be a Node3D because the Godot scene's root node is only being saved as a name instead of a node.

The first option, Single Root, uses the `GODOT_single_root` extension. This extension has no data, it is only a flag with rules and restrictions. Single Root is identical to Keep Root except that it adds this one string to the `"extensionsUsed"` array to mark it as the single root node. Godot will read this flag and set the glTF root as the single root node of the generated Godot scene. This flag will do nothing in implementations that don't support it, so in those cases it behaves identically to exporting with Keep Root, and exporting in 4.1 and earlier.