### PR TITLE
Fix ImporterMesh bone weight handling during lightmap unwrap

### DIFF
--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -1225,6 +1225,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 	for (int i = 0; i < lightmap_surfaces.size(); i++) {
 		Ref<SurfaceTool> st;
 		st.instantiate();
+		st->set_skin_weight_count((lightmap_surfaces[i].format & Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? SurfaceTool::SKIN_8_WEIGHTS : SurfaceTool::SKIN_4_WEIGHTS);
 		st->begin(Mesh::PRIMITIVE_TRIANGLES);
 		st->set_material(lightmap_surfaces[i].material);
 		st->set_meta("name", lightmap_surfaces[i].name);
@@ -1292,7 +1293,15 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 		Ref<SurfaceTool> &tool = surfaces_tools[i];
 		tool->index();
 		Array arrays = tool->commit_to_arrays();
-		add_surface(tool->get_primitive_type(), arrays, Array(), Dictionary(), tool->get_material(), tool->get_meta("name"), lightmap_surfaces[i].format);
+
+		uint64_t format = lightmap_surfaces[i].format;
+		if (tool->get_skin_weight_count() == SurfaceTool::SKIN_8_WEIGHTS) {
+			format |= RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
+		} else {
+			format &= ~RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
+		}
+
+		add_surface(tool->get_primitive_type(), arrays, Array(), Dictionary(), tool->get_material(), tool->get_meta("name"), format);
 	}
 
 	set_lightmap_size_hint(Size2(size_x, size_y));


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/81636

When unwrapping surfaces for lightmaps we need to update the format flag depending on if we use 0, 4 or 8 influences. Previously this was not done and afterwards the code read invalid memory in some cases (for example seeing invalid bone indices like 545021568 in the bug report).

After this patch, the cube import works. The cube does look pretty busted, but as it is just a test model it might be intentional and bones still seem to affect it correctly when moved. And removing the skeleton influence makes it look like a normal cube. I don't have access to the original model, so @QbieShay might be able to test this more.

Also, I spotted another weird thing with the test project. Simply repeatedly selecting between the Cube mesh node and then another node causes errors and the top UI toolbar keeps growing and adds what looks like a vertical separator every time you do this:

```
Attempt to disconnect a nonexistent connection from 'test2:<Node3D#1869871115769>'. Signal: 'replacing_by', callable: 'EditorNode::set_edited_scene'.
editor\plugins\node_3d_editor_plugin.cpp:7693 - Condition "p_control->get_parent() != context_toolbar_hbox" is true.
editor\plugins\node_3d_editor_plugin.cpp:7693 - Condition "p_control->get_parent() != context_toolbar_hbox" is true.
editor\plugins\node_3d_editor_plugin.cpp:7693 - Condition "p_control->get_parent() != context_toolbar_hbox" is true.
```

![bug](https://github.com/godotengine/godot/assets/22456603/849235fb-1f82-4557-a24c-c4b5e1bb144c)
