### PR TITLE
Tweaks to ViewportTexture's Documentation

### DIFF
--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -4,9 +4,10 @@
 		Provides the content of a [Viewport] as a dynamic texture.
 	</brief_description>
 	<description>
-		Provides the content of a [Viewport] as a dynamic [Texture2D]. This can be used to mix controls, 2D game objects, and 3D game objects in the same scene.
-		To create a [ViewportTexture] in code, use the [method Viewport.get_texture] method on the target viewport.
+		A [ViewportTexture] provides the content of a [Viewport] as a dynamic [Texture2D]. This can be used to combine the rendering of [Control], [Node2D] and [Node3D] nodes. For example, you can use this texture to display a 3D scene inside a [TextureRect], or a 2D overlay in a [Sprite3D].
+		To get a [ViewportTexture] in code, use the [method Viewport.get_texture] method on the target viewport.
 		[b]Note:[/b] A [ViewportTexture] is always local to its scene (see [member Resource.resource_local_to_scene]). If the scene root is not ready, it may return incorrect data (see [signal Node.ready]).
+		[b]Note:[/b] Instantiating scenes containing a high-resolution [ViewportTexture] may cause noticeable stutter.
 	</description>
 	<tutorials>
 		<link title="GUI in 3D Demo">https://godotengine.org/asset-library/asset/127</link>
@@ -16,8 +17,8 @@
 	</tutorials>
 	<members>
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
-			The path to the [Viewport] node to display. This is relative to the scene root, not to the node that uses the texture.
-			[b]Note:[/b] In the editor, this path is automatically updated when the target viewport or one of its ancestors is renamed or moved. At runtime, the path may not be able to automatically update due to the inability to determine the scene root.
+			The path to the [Viewport] node to display. This is relative to the local scene root (see [method Resource.get_local_scene]), [b]not[/b] to the nodes that use this texture.
+			[b]Note:[/b] In the editor, this path is automatically updated when the target viewport or one of its ancestors is renamed or moved. At runtime, this path may not automatically update if the scene root cannot be found.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Yeah, sure, why not.

- Add an actual concrete example in the leading description.
- There's a minor yet notable difference between saying "_create_ a ViewportTexture" and "_get_ a ViewportTexture". The latter is correct, the former makes it sound like it's a new one, every time.
    - Closes https://github.com/godotengine/godot-docs/issues/7576.
- Added a note about the lag spike with huge ViewportTextures.
    - Closes (?) https://github.com/godotengine/godot-docs/issues/4084.
- `viewport_path`'s description has changed to mention what it refers to (`get_local_scene`) and to simplify the additional note.