### PR TITLE
Make AudioStreamPlayer's `get_playback_position` more accurate

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -20,6 +20,7 @@
 			<return type="float" />
 			<description>
 				Returns the position in the [AudioStream] in seconds.
+				[b]Note:[/b] This method does not account for the small delay between mixing and hearing audio (see [method AudioServer.get_output_latency]).
 			</description>
 		</method>
 		<method name="get_stream_playback">

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -301,7 +301,8 @@ bool AudioStreamPlayer2D::is_playing() const {
 float AudioStreamPlayer2D::get_playback_position() {
 	// Return the playback position of the most recently started playback stream.
 	if (!stream_playbacks.is_empty()) {
-		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]);
+		float time_to_next_mix = get_stream_paused() ? 0.0 : MAX(AudioServer::get_singleton()->get_time_to_next_mix() * pitch_scale, 0.0);
+		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]) - time_to_next_mix;
 	}
 	return 0;
 }

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -618,7 +618,8 @@ bool AudioStreamPlayer3D::is_playing() const {
 float AudioStreamPlayer3D::get_playback_position() {
 	// Return the playback position of the most recently started playback stream.
 	if (!stream_playbacks.is_empty()) {
-		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]);
+		float time_to_next_mix = get_stream_paused() ? 0.0 : MAX(AudioServer::get_singleton()->get_time_to_next_mix() * pitch_scale, 0.0);
+		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]) - time_to_next_mix;
 	}
 	return 0;
 }

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -182,7 +182,8 @@ bool AudioStreamPlayer::is_playing() const {
 float AudioStreamPlayer::get_playback_position() {
 	// Return the playback position of the most recently started playback stream.
 	if (!stream_playbacks.is_empty()) {
-		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]);
+		float time_to_next_mix = get_stream_paused() ? 0.0 : MAX(AudioServer::get_singleton()->get_time_to_next_mix() * pitch_scale, 0.0);
+		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]) - time_to_next_mix;
 	}
 	return 0;
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/71122

This PR introduces a bit of a "workaround" to the inaccuracy of **AudioStreamPlayer**'s `get_playback_position`. As inspired [by a comment](https://github.com/godotengine/godot/issues/71122#issuecomment-1436675028), we can subtract the time to the next mix from the **AudioServer** to get more precise results.
The results are fairly noticeable. When testing, the same result rarely appears twice across multiple processed frames (unless the stream is paused of course).
However, this may come at the cost of performance (_if you actually used this previously unreliable method_).
I am also a tad concerned about thread conflicts of some kind? Please take a look.


##### Also affects **AudioStreamPlayer2D** and **AudioStreamPlayer3D**.