### PR TITLE
Remove lgtm.yml since LGTM is now replaced by Github Code Scanning

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,7 +1,0 @@
-extraction:
-  cpp:
-    after_prepare:
-      - pip3 install scons
-      - PATH="/opt/work/.local/bin:$PATH"
-    index:
-      build_command: scons -j2


### PR DESCRIPTION
LGTM has been acquired by Github, and all its features is replaced by Github Code Scanning. 
So seems .lgtm.yml is no longer used.

Detailed Github announcement [here](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)
