### PR TITLE
Show warning in Scene Dock on node when native type and Script inherited type do not match

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3553,6 +3553,15 @@ PackedStringArray Node::get_configuration_warnings() const {
 	ERR_THREAD_GUARD_V(PackedStringArray());
 	PackedStringArray ret;
 
+	Ref<Script> scr = get_script();
+	if (scr.is_valid()) {
+		const StringName script_base_type = scr->get_instance_base_type();
+		const StringName this_node_type = get_class_name();
+		if (!ClassDB::is_parent_class(this_node_type, script_base_type)) {
+			ret.append(vformat(RTR("Script inherits from native type \"%s\", so it can't be assigned to an object of type: \"%s\""), script_base_type, this_node_type));
+		}
+	}
+
 	Vector<String> warnings;
 	if (GDVIRTUAL_CALL(_get_configuration_warnings, warnings)) {
 		ret.append_array(warnings);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7710.

This PR adds a configuration warning when the **Script**'s inherited type does not itself inherit the native class of the **Node** it has been assigned to. There's no behavior change. A scene set-up this way fails to load the script and display an identical error.

![image](https://github.com/godotengine/godot/assets/66727710/3e274194-d42f-4a65-b64e-d54d38a9fe38)


~~Currently, the warning is not refreshed when the script is adjusted, but changing the whole script, or any other refresh of the Scene Tree Dock updates it accordingly. I'm not sure how to go about this. <sup><sup>help</sup></sup>~~



