### PR TITLE
Add a warning for when the scene root node is transformed

### DIFF
--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -134,6 +134,7 @@ class SceneTreeEditor : public Control {
 
 	void _compute_hash(Node *p_node, uint64_t &hash);
 	void _reset();
+	PackedStringArray _get_node_configuration_warnings(Node *p_node);
 
 	void _update_node_path(Node *p_node, bool p_recursive = true);
 	void _update_node_subtree(Node *p_node, TreeItem *p_parent, bool p_force = false);


### PR DESCRIPTION
This is a low priority PR, but I think it's a good idea.

This PR adds a configuration warning for when the root node has a transform. This is usually a mistake when saving a branch as a scene, or having the wrong node selected when doing transform operations. Instances of the scene will set their own transform, so it's best practice to not have the root be transformed.

<img width="524" alt="Screenshot 2023-09-18 at 5 31 02 PM" src="https://github.com/godotengine/godot/assets/1646875/46df5809-d961-4a91-ae4f-58e253d9ac3b">
