### PR TITLE
Core: Some code style improvements to `AStarGrid2D`

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -32,8 +32,6 @@
 
 #include "core/variant/typed_array.h"
 
-#define GET_POINT_UNCHECKED(m_id) points[m_id.y - region.position.y][m_id.x - region.position.x]
-
 static real_t heuristic_euclidian(const Vector2i &p_from, const Vector2i &p_to) {
 	real_t dx = (real_t)ABS(p_to.x - p_from.x);
 	real_t dy = (real_t)ABS(p_to.y - p_from.y);
@@ -110,19 +108,22 @@ Size2 AStarGrid2D::get_cell_size() const {
 
 void AStarGrid2D::update() {
 	points.clear();
-	const int64_t end_x = region.position.x + region.size.width;
-	const int64_t end_y = region.position.y + region.size.height;
-	for (int64_t y = region.position.y; y < end_y; y++) {
+
+	const int32_t end_x = region.get_end().x;
+	const int32_t end_y = region.get_end().y;
+
+	for (int32_t y = region.position.y; y < end_y; y++) {
 		LocalVector<Point> line;
-		for (int64_t x = region.position.x; x < end_x; x++) {
+		for (int32_t x = region.position.x; x < end_x; x++) {
 			line.push_back(Point(Vector2i(x, y), offset + Vector2(x, y) * cell_size));
 		}
 		points.push_back(line);
 	}
+
 	dirty = false;
 }
 
-bool AStarGrid2D::is_in_bounds(int p_x, int p_y) const {
+bool AStarGrid2D::is_in_bounds(int32_t p_x, int32_t p_y) const {
 	return region.has_point(Vector2i(p_x, p_y));
 }
 
@@ -172,40 +173,38 @@ AStarGrid2D::Heuristic AStarGrid2D::get_default_estimate_heuristic() const {
 void AStarGrid2D::set_point_solid(const Vector2i &p_id, bool p_solid) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_MSG(!is_in_boundsv(p_id), vformat("Can't set if point is disabled. Point %s out of bounds %s.", p_id, region));
-	GET_POINT_UNCHECKED(p_id).solid = p_solid;
+	_get_point_unchecked(p_id)->solid = p_solid;
 }
 
 bool AStarGrid2D::is_point_solid(const Vector2i &p_id) const {
 	ERR_FAIL_COND_V_MSG(dirty, false, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_id), false, vformat("Can't get if point is disabled. Point %s out of bounds %s.", p_id, region));
-	return GET_POINT_UNCHECKED(p_id).solid;
+	return _get_point_unchecked(p_id)->solid;
 }
 
 void AStarGrid2D::set_point_weight_scale(const Vector2i &p_id, real_t p_weight_scale) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_MSG(!is_in_boundsv(p_id), vformat("Can't set point's weight scale. Point %s out of bounds %s.", p_id, region));
 	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
-	GET_POINT_UNCHECKED(p_id).weight_scale = p_weight_scale;
+	_get_point_unchecked(p_id)->weight_scale = p_weight_scale;
 }
 
 real_t AStarGrid2D::get_point_weight_scale(const Vector2i &p_id) const {
 	ERR_FAIL_COND_V_MSG(dirty, 0, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_id), 0, vformat("Can't get point's weight scale. Point %s out of bounds %s.", p_id, region));
-	return GET_POINT_UNCHECKED(p_id).weight_scale;
+	return _get_point_unchecked(p_id)->weight_scale;
 }
 
 void AStarGrid2D::fill_solid_region(const Rect2i &p_region, bool p_solid) {
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 
-	Rect2i safe_region = p_region.intersection(region);
-	int from_x = safe_region.get_position().x;
-	int from_y = safe_region.get_position().y;
-	int end_x = safe_region.get_end().x;
-	int end_y = safe_region.get_end().y;
+	const Rect2i safe_region = p_region.intersection(region);
+	const int32_t end_x = safe_region.get_end().x;
+	const int32_t end_y = safe_region.get_end().y;
 
-	for (int x = from_x; x < end_x; x++) {
-		for (int y = from_y; y < end_y; y++) {
-			GET_POINT_UNCHECKED(Vector2i(x, y)).solid = p_solid;
+	for (int32_t y = safe_region.position.y; y < end_y; y++) {
+		for (int32_t x = safe_region.position.x; x < end_x; x++) {
+			_get_point_unchecked(x, y)->solid = p_solid;
 		}
 	}
 }
@@ -214,14 +213,13 @@ void AStarGrid2D::fill_weight_scale_region(const Rect2i &p_region, real_t p_weig
 	ERR_FAIL_COND_MSG(dirty, "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
 
-	Rect2i safe_region = p_region.intersection(region);
-	int from_x = safe_region.get_position().x;
-	int from_y = safe_region.get_position().y;
-	int end_x = safe_region.get_end().x;
-	int end_y = safe_region.get_end().y;
-	for (int x = from_x; x < end_x; x++) {
-		for (int y = from_y; y < end_y; y++) {
-			GET_POINT_UNCHECKED(Vector2i(x, y)).weight_scale = p_weight_scale;
+	const Rect2i safe_region = p_region.intersection(region);
+	const int32_t end_x = safe_region.get_end().x;
+	const int32_t end_y = safe_region.get_end().y;
+
+	for (int32_t y = safe_region.position.y; y < end_y; y++) {
+		for (int32_t x = safe_region.position.x; x < end_x; x++) {
+			_get_point_unchecked(x, y)->weight_scale = p_weight_scale;
 		}
 	}
 }
@@ -234,14 +232,14 @@ AStarGrid2D::Point *AStarGrid2D::_jump(Point *p_from, Point *p_to) {
 		return p_to;
 	}
 
-	int64_t from_x = p_from->id.x;
-	int64_t from_y = p_from->id.y;
+	int32_t from_x = p_from->id.x;
+	int32_t from_y = p_from->id.y;
 
-	int64_t to_x = p_to->id.x;
-	int64_t to_y = p_to->id.y;
+	int32_t to_x = p_to->id.x;
+	int32_t to_y = p_to->id.y;
 
-	int64_t dx = to_x - from_x;
-	int64_t dy = to_y - from_y;
+	int32_t dx = to_x - from_x;
+	int32_t dy = to_y - from_y;
 
 	if (diagonal_mode == DIAGONAL_MODE_ALWAYS || diagonal_mode == DIAGONAL_MODE_AT_LEAST_ONE_WALKABLE) {
 		if (dx != 0 && dy != 0) {
@@ -516,7 +514,7 @@ void AStarGrid2D::clear() {
 Vector2 AStarGrid2D::get_point_position(const Vector2i &p_id) const {
 	ERR_FAIL_COND_V_MSG(dirty, Vector2(), "Grid is not initialized. Call the update method.");
 	ERR_FAIL_COND_V_MSG(!is_in_boundsv(p_id), Vector2(), vformat("Can't get point's position. Point %s out of bounds %s.", p_id, region));
-	return GET_POINT_UNCHECKED(p_id).pos;
+	return _get_point_unchecked(p_id)->pos;
 }
 
 Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vector2i &p_to_id) {
@@ -542,7 +540,7 @@ Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vec
 	}
 
 	Point *p = end_point;
-	int64_t pc = 1;
+	int32_t pc = 1;
 	while (p != begin_point) {
 		pc++;
 		p = p->prev_point;
@@ -555,7 +553,7 @@ Vector<Vector2> AStarGrid2D::get_point_path(const Vector2i &p_from_id, const Vec
 		Vector2 *w = path.ptrw();
 
 		p = end_point;
-		int64_t idx = pc - 1;
+		int32_t idx = pc - 1;
 		while (p != begin_point) {
 			w[idx--] = p->pos;
 			p = p->prev_point;
@@ -590,7 +588,7 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 	}
 
 	Point *p = end_point;
-	int64_t pc = 1;
+	int32_t pc = 1;
 	while (p != begin_point) {
 		pc++;
 		p = p->prev_point;
@@ -601,7 +599,7 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 
 	{
 		p = end_point;
-		int64_t idx = pc - 1;
+		int32_t idx = pc - 1;
 		while (p != begin_point) {
 			path[idx--] = p->id;
 			p = p->prev_point;
@@ -671,5 +669,3 @@ void AStarGrid2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(DIAGONAL_MODE_ONLY_IF_NO_OBSTACLES);
 	BIND_ENUM_CONSTANT(DIAGONAL_MODE_MAX);
 }
-
-#undef GET_POINT_UNCHECKED

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -105,22 +105,30 @@ private:
 	uint64_t pass = 1;
 
 private: // Internal routines.
-	_FORCE_INLINE_ bool _is_walkable(int64_t p_x, int64_t p_y) const {
+	_FORCE_INLINE_ bool _is_walkable(int32_t p_x, int32_t p_y) const {
 		if (region.has_point(Vector2i(p_x, p_y))) {
 			return !points[p_y - region.position.y][p_x - region.position.x].solid;
 		}
 		return false;
 	}
 
-	_FORCE_INLINE_ Point *_get_point(int64_t p_x, int64_t p_y) {
+	_FORCE_INLINE_ Point *_get_point(int32_t p_x, int32_t p_y) {
 		if (region.has_point(Vector2i(p_x, p_y))) {
 			return &points[p_y - region.position.y][p_x - region.position.x];
 		}
 		return nullptr;
 	}
 
-	_FORCE_INLINE_ Point *_get_point_unchecked(int64_t p_x, int64_t p_y) {
+	_FORCE_INLINE_ Point *_get_point_unchecked(int32_t p_x, int32_t p_y) {
 		return &points[p_y - region.position.y][p_x - region.position.x];
+	}
+
+	_FORCE_INLINE_ Point *_get_point_unchecked(const Vector2i &p_id) {
+		return &points[p_id.y - region.position.y][p_id.x - region.position.x];
+	}
+
+	_FORCE_INLINE_ const Point *_get_point_unchecked(const Vector2i &p_id) const {
+		return &points[p_id.y - region.position.y][p_id.x - region.position.x];
 	}
 
 	void _get_nbors(Point *p_point, LocalVector<Point *> &r_nbors);
@@ -151,10 +159,7 @@ public:
 
 	void update();
 
-	int get_width() const;
-	int get_height() const;
-
-	bool is_in_bounds(int p_x, int p_y) const;
+	bool is_in_bounds(int32_t p_x, int32_t p_y) const;
 	bool is_in_boundsv(const Vector2i &p_id) const;
 	bool is_dirty() const;
 


### PR DESCRIPTION
1. Remove unused, undefined and unexposed `get_width()` and `get_height()` declarations.
2. Replace `GET_POINT_UNCHECKED()` macro with `_get_point_unchecked()` method, for consistency and better style.
3. Replace `int64_t` with `int32_t` since components of `Vector2i` and `Rect2i` are `int32_t`.
4. Make loops consistent.