### PR TITLE
[3.x] Fix zero scale in particle shader

### DIFF
--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -659,8 +659,14 @@ void ParticlesMaterial::_update_shader() {
 	}
 	//scale by scale
 	code += "	float base_scale = tex_scale * mix(scale, 1.0, scale_random * scale_rand);\n";
+
 	// Prevent zero scale (which can cause rendering issues).
-	code += "	base_scale = sign(base_scale) * max(abs(base_scale), 0.000001);\n";
+	code += "	if (base_scale >= 0.0) {\n";
+	code += "		base_scale = max(base_scale, 0.000001);\n";
+	code += "	} else {\n";
+	code += "		base_scale = min(base_scale, -0.000001);\n";
+	code += "	}\n";
+
 	if (trail_size_modifier.is_valid()) {
 		code += "	if (trail_divisor > 1) {\n";
 		code += "		base_scale *= textureLod(trail_size_modifier, vec2(float(int(NUMBER) % trail_divisor) / float(trail_divisor - 1), 0.0), 0.0).r;\n";


### PR DESCRIPTION
Fixes the lower bounding of scale when given zero input.

The previous bug was due to `sign` returning 0 with 0.0 input, rather than 1.

Fixes #80863

## Notes
* Regression introduced in #53852
* There are also proposals to introduce special `abs_sign` function to deal with this (https://github.com/godotengine/godot-proposals/issues/6854) but I've just fixed in place for now
* There might be some slightly more efficient way of doing this to avoid the branch

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
