### PR TITLE
Improve "Add" button consistency in Project Settings

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -36,6 +36,7 @@
 #include "editor/event_listener_line_edit.h"
 #include "editor/input_event_configuration_dialog.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 #include "scene/scene_string_names.h"
 
@@ -357,6 +358,7 @@ void ActionMapEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			action_list_search->set_right_icon(get_editor_theme_icon(SNAME("Search")));
+			add_button->set_icon(get_editor_theme_icon(SNAME("Add")));
 			if (!actions_cache.is_empty()) {
 				update_action_list();
 			}
@@ -569,6 +571,8 @@ ActionMapEditor::ActionMapEditor() {
 	add_hbox->add_child(add_button);
 	// Disable the button and set its tooltip.
 	_add_edit_text_changed(add_edit->get_text());
+
+	add_hbox->add_child(memnew(VSeparator));
 
 	show_builtin_actions_checkbutton = memnew(CheckButton);
 	show_builtin_actions_checkbutton->set_text(TTR("Show Built-in Actions"));

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -65,6 +65,7 @@ void EditorAutoloadSettings::_notification(int p_what) {
 
 		case NOTIFICATION_THEME_CHANGED: {
 			browse_button->set_icon(get_editor_theme_icon(SNAME("Folder")));
+			add_autoload->set_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {

--- a/editor/group_settings_editor.cpp
+++ b/editor/group_settings_editor.cpp
@@ -45,6 +45,9 @@ void GroupSettingsEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			update_groups();
 		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+			add_button->set_icon(get_editor_theme_icon(SNAME("Add")));
+		} break;
 	}
 }
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -556,6 +556,8 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 }
 
 void ProjectSettingsEditor::_update_theme() {
+	add_button->set_icon(get_editor_theme_icon(SNAME("Add")));
+	del_button->set_icon(get_editor_theme_icon(SNAME("Remove")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 	restart_close_button->set_icon(get_editor_theme_icon(SNAME("Close")));
 	restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Tree")));

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -344,15 +344,29 @@ static Variant create_var(RS::GlobalShaderParameterType p_type) {
 	}
 }
 
-void ShaderGlobalsEditor::_variable_added() {
-	String var = variable_name->get_text().strip_edges();
-	if (var.is_empty() || !var.is_valid_identifier()) {
-		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid shader uniform identifier name."));
-		return;
+String ShaderGlobalsEditor::_check_new_variable_name(const String &p_variable_name) {
+	if (p_variable_name.is_empty()) {
+		return TTR("Name cannot be empty.");
 	}
 
+	if (!p_variable_name.is_valid_identifier()) {
+		return TTR("Name must be a valid identifier.");
+	}
+
+	return "";
+}
+
+void ShaderGlobalsEditor::_variable_name_text_changed(const String &p_variable_name) {
+	const String &warning = _check_new_variable_name(p_variable_name.strip_edges());
+	variable_add->set_tooltip_text(warning);
+	variable_add->set_disabled(!warning.is_empty());
+}
+
+void ShaderGlobalsEditor::_variable_added() {
+	String var = variable_name->get_text().strip_edges();
+
 	if (RenderingServer::get_singleton()->global_shader_parameter_get(var).get_type() != Variant::NIL) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Global shader parameter '%s' already exists'"), var));
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Global shader parameter '%s' already exists."), var));
 		return;
 	}
 
@@ -416,6 +430,10 @@ void ShaderGlobalsEditor::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_THEME_CHANGED: {
+			variable_add->set_icon(get_editor_theme_icon(SNAME("Add")));
+		} break;
+
 		case NOTIFICATION_PREDELETE: {
 			inspector->edit(nullptr);
 		} break;
@@ -431,6 +449,9 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	add_menu_hb->add_child(memnew(Label(TTR("Name:"))));
 	variable_name = memnew(LineEdit);
 	variable_name->set_h_size_flags(SIZE_EXPAND_FILL);
+	variable_name->set_clear_button_enabled(true);
+	variable_name->connect("text_changed", callable_mp(this, &ShaderGlobalsEditor::_variable_name_text_changed));
+
 	add_menu_hb->add_child(variable_name);
 
 	add_menu_hb->add_child(memnew(Label(TTR("Type:"))));
@@ -443,6 +464,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	}
 
 	variable_add = memnew(Button(TTR("Add")));
+	variable_add->set_disabled(true);
 	add_menu_hb->add_child(variable_add);
 	variable_add->connect("pressed", callable_mp(this, &ShaderGlobalsEditor::_variable_added));
 

--- a/editor/shader_globals_editor.h
+++ b/editor/shader_globals_editor.h
@@ -49,6 +49,9 @@ class ShaderGlobalsEditor : public VBoxContainer {
 	OptionButton *variable_type = nullptr;
 	Button *variable_add = nullptr;
 
+	String _check_new_variable_name(const String &p_variable_name);
+
+	void _variable_name_text_changed(const String &p_variable_name);
 	void _variable_added();
 	void _variable_deleted(const String &p_variable);
 	void _changed();


### PR DESCRIPTION
There's a few inconsistencies I've noticed while using the project settings window, mainly in places where we have a textbox with a button next to them that we're using to "Add" things.

This PR attempts to make all of these tabs behave more consistently and tidy up some minor UX things:

 * Adds a plus icon icon to all the "Add" buttons next to text inputs, with the hopes of making them more distinguishable
 * Adds a separator next to the action map "add" button for clarity
 * Modifies the Shader Globals editor to be consistent with the others (moving the name based error to the button popup, I kept the other errors in the message boxes since I'm unsure if those are more expensive checks that might not be wise to make every time there's a change in the input and they're a bit less obvious than an empty input or a bad character)
 * Adds the "Clear" button to the shader globals input since we may not want to clear it entirely when adding a new variable in case we're doing something sequential "var1, var2, var3", but if we're adding multiple variables at time, just clicking on the clear button and typing a new name to add a second variable is convenient.
 
Before and after screenshot:
![before_and_after](https://github.com/godotengine/godot/assets/138269/1673360e-6ffc-4b2e-af91-fb0bcf43bb35)

I took the liberty of going directly to my first PR without creating a proposal for this because I figured it was a small thing, but I'm not super familiar with how the process goes for things like this usually, since this isn't really a "fix" or a "feature" per-se, and I have some more ideas for things I'd like to implement on the UX side of the editor, mostly minor like this, would making a proposal for several changes for a single window/panel/widget make sense or should I just keep making direct PRs as long as the changes are minor and in line with how things in the editor usually work?
