### PR TITLE
Set `open_dominant_script_on_scene_change` to off by default

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4354,7 +4354,7 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 
 	EDITOR_GET("text_editor/behavior/files/auto_reload_scripts_on_external_change");
 	ScriptServer::set_reload_scripts_on_save(EDITOR_DEF("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true));
-	EDITOR_DEF("text_editor/behavior/files/open_dominant_script_on_scene_change", true);
+	EDITOR_DEF("text_editor/behavior/files/open_dominant_script_on_scene_change", false);
 	EDITOR_DEF("text_editor/external/use_external_editor", false);
 	EDITOR_DEF("text_editor/external/exec_path", "");
 	EDITOR_DEF("text_editor/script_list/script_temperature_enabled", true);


### PR DESCRIPTION
Super tiny change - just changes the default for the `text_editor/behavior/files/open_dominant_script_on_scene_change` editor settings option to `false`.

This behavior is super unintuitive imo. When a user tabs into a scene, they may not necessarily want to edit the dominant script in that scene, but this functionality seems to assume they always do. This has the side effect (in my experience) of making the list of open scripts super messy as scripts I never intended to edit are opened in the background, requiring me to "Close All" on the list often if I want to maintain any clarity on what I am actually working on.

From https://github.com/godotengine/godot-proposals/issues/7434 it seems like others have the same feeling that this behavior is odd, however I think it makes sense to leave the option there for those who do find it useful.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8372*