### PR TITLE
[4.x] Fix zero scale in particle shader

### DIFF
--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -858,7 +858,11 @@ void ParticleProcessMaterial::_update_shader() {
 
 	// scale by scale
 	code += "	float base_scale = mix(scale_min, scale_max, scale_rand);\n";
-	code += "	base_scale = sign(base_scale) * max(abs(base_scale), 0.001);\n";
+	code += "	if (base_scale >= 0.0) {\n";
+	code += "		base_scale = max(base_scale, 0.001);\n";
+	code += "	} else {\n";
+	code += "		base_scale = min(base_scale, -0.001);\n";
+	code += "	}\n";
 	code += "	TRANSFORM[0].xyz *= base_scale * sign(tex_scale.r) * max(abs(tex_scale.r), 0.001);\n";
 	code += "	TRANSFORM[1].xyz *= base_scale * sign(tex_scale.g) * max(abs(tex_scale.g), 0.001);\n";
 	code += "	TRANSFORM[2].xyz *= base_scale * sign(tex_scale.b) * max(abs(tex_scale.b), 0.001);\n";


### PR DESCRIPTION
Fixes the lower bounding of scale when given zero input.
The previous bug was due to `sign` returning 0 with 0.0 input, rather than 1.

## EDIT
Actually I can't seem to get #80863 to occur in master. No idea why.
So I'll set this to draft I guess and watch for issues that may be related in master.

Fixes #80863 for master.
Port of #81902.

## Notes
* This is really as much as anything to get some interest in fixing this class of problems. Am happy if a 4.x contributor wants to take over.
* There may be multiple similar instances where `sign` is used in the shader, causing similar bugs. `tex_scale` may be similarly vulnerable (untested).
* [#6854](https://github.com/godotengine/godot-proposals/issues/6854) suggests adding a new custom `sign` function to return only 1 or -1 (`polar_sign` or something like that maybe). This may be better than writing out longhand in multiple places.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
