### PR TITLE
Fix allocation size overflow check in `CowData`

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -90,6 +90,10 @@ private:
 	}
 
 	_FORCE_INLINE_ bool _get_alloc_size_checked(size_t p_elements, size_t *out) const {
+		if (unlikely(p_elements == 0)) {
+			*out = 0;
+			return true;
+		}
 #if defined(__GNUC__)
 		size_t o;
 		size_t p;
@@ -101,13 +105,12 @@ private:
 		if (__builtin_add_overflow(o, static_cast<size_t>(32), &p)) {
 			return false; // No longer allocated here.
 		}
-		return true;
 #else
 		// Speed is more important than correctness here, do the operations unchecked
 		// and hope for the best.
 		*out = _get_alloc_size(p_elements);
-		return true;
 #endif
+		return *out;
 	}
 
 	void _unref(void *p_data);


### PR DESCRIPTION
For large input data, the next power of two check can return 0, causing the allocation size to not be valid, this ensures that it fails if that is the case.

Will look into adding error checks to code that uses `resize` on things and then depends on it being successful, but taking that in a separate PR

* Fixes: https://github.com/godotengine/godot/issues/81911 (This partially fixes it, the specific case will still crash as the internal string operations do not check for errors after resize, can add that too but felt this was a specific fix to core)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
