### PR TITLE
C#: CS1591 from `NoWarn` to `suggestion`

### DIFF
--- a/modules/mono/glue/GodotSharp/.editorconfig
+++ b/modules/mono/glue/GodotSharp/.editorconfig
@@ -1,5 +1,5 @@
 [**/Generated/**.cs]
-# Validate parameter is non-null before using it
+# CA1062: Validate parameter is non-null before using it
 # Useful for generated code, as it disables nullable
 dotnet_diagnostic.CA1062.severity = error
 # CA1069: Enums should not have duplicate values
@@ -10,3 +10,8 @@ dotnet_diagnostic.CA1708.severity = none
 dotnet_diagnostic.CS1591.severity = none
 # CS1573: Parameter has no matching param tag in the XML comment
 dotnet_diagnostic.CS1573.severity = none
+
+[GodotSharp/Core/**.cs]
+# CS1591: Missing XML comment for publicly visible type or member
+# TODO: Temporary change to not pollute the warnings, but we need to document public APIs
+dotnet_diagnostic.CS1591.severity = suggestion

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -11,9 +11,6 @@
     <LangVersion>10</LangVersion>
 
     <AnalysisMode>Recommended</AnalysisMode>
-
-    <!-- Disabled temporarily as it pollutes the warnings, but we need to document public APIs. -->
-    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Godot C# Core API.</Description>


### PR DESCRIPTION
Migrates `CS1591` (Missing XML comment for publicly visible type or member) from `GodotSharp.csproj` to a custom rule in `.editorconfig`. Instead of being outright removed as a warning, it's now handled as a suggestion; this retains the benefit of cleaning up the flood editor warnings, but doesn't tuck away it completely (for the editor, it's functionally disabled for build-related tasks). The actual method it will choose to show a suggestion depends on the IDE, but it's never in a way that frustratingly pollutes the editor (or, at least, not anywhere close to the extent seen with warnings)

I prefer this style over outright disabling it because, as the comment on the original implementation mentions, this is meant to be a temporary measure. Keeping it hidden away entirely doesn't give much incentive to eventually populate the documentation, and risks future contributions not realizing it was an expectation in the first place. I believe keeping it as a suggestion will lend itself to the gradual implementation of the remaining documentation