### PR TITLE
Add alternative way to call multi-return-value core methods

### DIFF
--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -987,3 +987,102 @@ PhysicsServer2DManager::PhysicsServer2DManager() {
 PhysicsServer2DManager::~PhysicsServer2DManager() {
 	singleton = nullptr;
 }
+
+///////////////////////////////////////////////////////
+
+bool PhysicsIntersectRay2D::perform() {
+	ERR_FAIL_NULL_V(space_state, false);
+
+	return space_state->intersect_ray(parameters, result);
+}
+
+void PhysicsIntersectRay2D::set_exclude(const TypedArray<RID> &p_exclude) {
+	parameters.exclude.clear();
+	for (int i = 0; i < p_exclude.size(); i++) {
+		parameters.exclude.insert(p_exclude[i]);
+	}
+}
+
+TypedArray<RID> PhysicsIntersectRay2D::get_exclude() const {
+	TypedArray<RID> ret;
+	ret.resize(parameters.exclude.size());
+	int idx = 0;
+	for (const RID &E : parameters.exclude) {
+		ret[idx++] = E;
+	}
+	return ret;
+}
+
+void PhysicsIntersectRay2D::insert_exclude(const RID &p_exclude) {
+	parameters.exclude.insert(p_exclude);
+}
+
+void PhysicsIntersectRay2D::erase_exclude(const RID &p_exclude) {
+	parameters.exclude.erase(p_exclude);
+}
+
+bool PhysicsIntersectRay2D::has_exclude(const RID &p_exclude) {
+	return parameters.exclude.has(p_exclude);
+}
+
+void PhysicsIntersectRay2D::clear_exclude() {
+	parameters.exclude.clear();
+}
+
+PhysicsIntersectRay2D::PhysicsIntersectRay2D() {
+}
+
+void PhysicsIntersectRay2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("perform"), &PhysicsIntersectRay2D::perform);
+
+	ClassDB::bind_method(D_METHOD("set_space_state", "space_state"), &PhysicsIntersectRay2D::set_space_state);
+	ClassDB::bind_method(D_METHOD("get_space_state"), &PhysicsIntersectRay2D::get_space_state);
+
+	ClassDB::bind_method(D_METHOD("set_from", "from"), &PhysicsIntersectRay2D::set_from);
+	ClassDB::bind_method(D_METHOD("get_from"), &PhysicsIntersectRay2D::get_from);
+
+	ClassDB::bind_method(D_METHOD("set_to", "to"), &PhysicsIntersectRay2D::set_to);
+	ClassDB::bind_method(D_METHOD("get_to"), &PhysicsIntersectRay2D::get_to);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "collision_mask"), &PhysicsIntersectRay2D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &PhysicsIntersectRay2D::get_collision_mask);
+
+	ClassDB::bind_method(D_METHOD("set_exclude", "exclude"), &PhysicsIntersectRay2D::set_exclude);
+	ClassDB::bind_method(D_METHOD("get_exclude"), &PhysicsIntersectRay2D::get_exclude);
+	ClassDB::bind_method(D_METHOD("insert_exclude", "exclude"), &PhysicsIntersectRay2D::insert_exclude);
+	ClassDB::bind_method(D_METHOD("erase_exclude", "exclude"), &PhysicsIntersectRay2D::erase_exclude);
+	ClassDB::bind_method(D_METHOD("has_exclude", "exclude"), &PhysicsIntersectRay2D::has_exclude);
+	ClassDB::bind_method(D_METHOD("clear_exclude"), &PhysicsIntersectRay2D::clear_exclude);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_bodies", "enable"), &PhysicsIntersectRay2D::set_collide_with_bodies);
+	ClassDB::bind_method(D_METHOD("is_collide_with_bodies_enabled"), &PhysicsIntersectRay2D::is_collide_with_bodies_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_collide_with_areas", "enable"), &PhysicsIntersectRay2D::set_collide_with_areas);
+	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &PhysicsIntersectRay2D::is_collide_with_areas_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_hit_from_inside", "enable"), &PhysicsIntersectRay2D::set_hit_from_inside);
+	ClassDB::bind_method(D_METHOD("is_hit_from_inside_enabled"), &PhysicsIntersectRay2D::is_hit_from_inside_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsIntersectRay2D::get_position);
+	ClassDB::bind_method(D_METHOD("get_normal"), &PhysicsIntersectRay2D::get_normal);
+	ClassDB::bind_method(D_METHOD("get_rid"), &PhysicsIntersectRay2D::get_rid);
+	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsIntersectRay2D::get_collider_id);
+	ClassDB::bind_method(D_METHOD("get_collider"), &PhysicsIntersectRay2D::get_collider);
+	ClassDB::bind_method(D_METHOD("get_shape"), &PhysicsIntersectRay2D::get_shape);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "space_state"), "set_space_state", "get_space_state");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "from"), "set_from", "get_from");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "to"), "set_to", "get_to");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_bodies"), "set_collide_with_bodies", "is_collide_with_bodies_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "collide_with_areas"), "set_collide_with_areas", "is_collide_with_areas_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hit_from_inside"), "set_hit_from_inside", "is_hit_from_inside_enabled");
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "normal"), "", "get_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "rid"), "", "get_rid");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_id"), "", "get_collider_id");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "collider"), "", "get_collider");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shape"), "", "get_shape");
+}

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -818,6 +818,62 @@ public:
 	~PhysicsServer2DManager();
 };
 
+class PhysicsIntersectRay2D : public Object {
+	GDCLASS(PhysicsIntersectRay2D, Object);
+
+	PhysicsDirectSpaceState2D *space_state;
+	PhysicsDirectSpaceState2D::RayParameters parameters;
+	PhysicsDirectSpaceState2D::RayResult result;
+
+protected:
+	static void _bind_methods();
+
+public:
+	bool perform();
+
+	void set_space_state(PhysicsDirectSpaceState2D *p_space_state) { space_state = p_space_state; }
+	PhysicsDirectSpaceState2D *get_space_state() const { return space_state; }
+
+	void set_from(const Vector2 &p_from) { parameters.from = p_from; }
+	const Vector2 &get_from() const { return parameters.from; }
+
+	void set_to(const Vector2 &p_to) { parameters.to = p_to; }
+	const Vector2 &get_to() const { return parameters.to; }
+
+	void set_collision_mask(uint32_t p_mask) { parameters.collision_mask = p_mask; }
+	uint32_t get_collision_mask() const { return parameters.collision_mask; }
+
+	void set_collide_with_bodies(bool p_enable) { parameters.collide_with_bodies = p_enable; }
+	bool is_collide_with_bodies_enabled() const { return parameters.collide_with_bodies; }
+
+	void set_collide_with_areas(bool p_enable) { parameters.collide_with_areas = p_enable; }
+	bool is_collide_with_areas_enabled() const { return parameters.collide_with_areas; }
+
+	void set_hit_from_inside(bool p_enable) { parameters.hit_from_inside = p_enable; }
+	bool is_hit_from_inside_enabled() const { return parameters.hit_from_inside; }
+
+	void set_exclude(const TypedArray<RID> &p_exclude);
+	TypedArray<RID> get_exclude() const;
+	void insert_exclude(const RID &p_exclude);
+	void erase_exclude(const RID &p_exclude);
+	bool has_exclude(const RID &p_exclude);
+	void clear_exclude();
+
+	const Vector2 &get_position() const { return result.position; }
+
+	const Vector2 &get_normal() const { return result.normal; }
+
+	const RID &get_rid() const { return result.rid; }
+
+	ObjectID get_collider_id() const { return result.collider_id; }
+
+	Object *get_collider() const { return result.collider; }
+
+	int get_shape() const { return result.shape; }
+
+	PhysicsIntersectRay2D();
+};
+
 VARIANT_ENUM_CAST(PhysicsServer2D::ShapeType);
 VARIANT_ENUM_CAST(PhysicsServer2D::SpaceParameter);
 VARIANT_ENUM_CAST(PhysicsServer2D::AreaParameter);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -263,6 +263,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters2D);
 	GDREGISTER_CLASS(PhysicsTestMotionParameters2D);
 	GDREGISTER_CLASS(PhysicsTestMotionResult2D);
+	GDREGISTER_CLASS(PhysicsIntersectRay2D);
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
 	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);


### PR DESCRIPTION
Following discussion in RocketChat, this PR deals with the various methods in core that return `Dictionary` or `Array`. Since each such returns incurs a heap allocation, this PR allows using a pre-allocated object to hold the return value instead.

It involves using a pattern in which a class is defined that carries both inputs and outputs as member variables, and a single method for performing the original action. For instance, code like this:
```gdscript
var ret : Dictionary = my_object.do_action({param1='foo', param2='bar'})
print(ret['out1'])
print(ret['out2'])
```
can be rewritten as:
```gdscript
var mycall := ObjectDoAction.new()
mycall.object = my_object
mycall.param1 = 'foo'
mycall.param2 = 'bar'
mycall.perform()
print(mycall.out1)
print(mycall.out2)
```

This has the advantage that `mycall` can be reused multiple times, while being allocated only once. Meanwhile, `my_object.do_action` would create a new `Dictionary` every call.

Draft status:
Currently only `PhysicsDirectSpaceState2D.intersect_ray` is implemented (as `PhysicsIntersectRay2D`)

This PR is opened for discussion on whether this is the correct pattern, and which additional methods should receive similar treatment.