### PR TITLE
Remake non-functional playback in WASAPI driver

### DIFF
--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -309,7 +309,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		// This is the event that WASAPI will signal when it wants more data from us (push method).
 		// The initial state for this event must be unsignaled!
 		p_device->feed_event = CreateEventW(nullptr, FALSE, FALSE, nullptr);
-		ERR_FAIL_COND_V_MSG(p_device->feed_event == nullptr, ERR_CANT_OPEN, "WASAPI: Could not create event handle with error: " + String::num(GetLastError()) + ".");
+		ERR_FAIL_NULL_V_MSG(p_device->feed_event, ERR_CANT_OPEN, "WASAPI: Could not create event handle with error: " + String::num(GetLastError()) + ".");
 
 		hr = p_device->audio_client->SetEventHandle(p_device->feed_event);
 		ERR_FAIL_COND_V_MSG(hr != S_OK, ERR_CANT_OPEN, "WASAPI: Could not set event handle with error: 0x" + String::num_uint64(hr, 16) + ".");
@@ -442,7 +442,7 @@ Error AudioDriverWASAPI::init() {
 	// Literally impossible for this call to fail. You be the judge if you need to check the return value of this.
 	// It is however fundamental to the logic for this to exist.
 	render_wake = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-	ERR_FAIL_COND_V_MSG(render_wake == nullptr, ERR_CANT_OPEN, "WASAPI: Could not create render wake handle with error: " + String::num(GetLastError()) + ".");
+	ERR_FAIL_NULL_V_MSG(render_wake, ERR_CANT_OPEN, "WASAPI: Could not create render wake handle with error: " + String::num(GetLastError()) + ".");
 
 	exit_thread.clear();
 

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -658,7 +658,7 @@ void AudioDriverWASAPI::render_thread_func(void *p_udata) {
 		// Play out the engine samples to the speakers.
 
 		HRESULT hr = E_FAIL; // Annoyingly, the device may be removed at any point so we have to constantly check the return values.
-		UINT32 padding; // How many samples are in the WASAPI buffer already. Don't have to initialize because it is only used in the success path.
+		UINT32 padding = 0; // How many samples are in the WASAPI buffer already.
 		bool need_to_remake_device = false; // Will be set in case device disappears, or if the user changes device.
 
 		while (true) {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -57,7 +57,6 @@ class AudioDriverWASAPI : public AudioDriver {
 		WORD bits_per_sample = 0;
 		unsigned int channels = 0;
 
-		SafeFlag has_new_device;
 		String device_name = "Default"; // Output OR Input
 		String new_device = "Default"; // Output OR Input
 
@@ -80,7 +79,7 @@ class AudioDriverWASAPI : public AudioDriver {
 	Vector<int32_t> samples_in;
 
 	int mix_rate = 0;
-	int buffer_frames = 0;
+	unsigned int buffer_frames = 0; // This is how many frames at most we can write to the speakers.
 	float real_latency = 0.0f;
 
 	SafeFlag exit_thread;
@@ -109,7 +108,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 public:
 	// Calls from notif_client.
-	void default_device_changed(EDataFlow flow);
+	void default_device_changed(EDataFlow p_flow);
 
 public:
 	virtual const char *get_name() const override {

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -54,7 +54,6 @@ class AudioDriverWASAPI : public AudioDriver {
 		WORD format_tag = 0;
 		WORD bits_per_sample = 0;
 		unsigned int channels = 0;
-		unsigned int frame_size = 0;
 
 		String device_name = "Default"; // Output OR Input
 		String new_device = "Default"; // Output OR Input
@@ -73,13 +72,12 @@ class AudioDriverWASAPI : public AudioDriver {
 	unsigned int channels = 0;
 	int mix_rate = 0;
 	int buffer_frames = 0;
-	int target_latency_ms = 0;
-	float real_latency = 0.0;
-	bool using_audio_client_3 = false;
+	float real_latency = 0.0f;
 
+	HANDLE feed_event = nullptr; // Set by the system when the device needs more samples.
 	SafeFlag exit_thread;
 
-	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i, int32_t sample);
+	static _FORCE_INLINE_ void write_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, unsigned int i, int32_t sample);
 	static _FORCE_INLINE_ int32_t read_sample(WORD format_tag, int bits_per_sample, BYTE *buffer, int i);
 	static void thread_func(void *p_udata);
 
@@ -89,7 +87,7 @@ class AudioDriverWASAPI : public AudioDriver {
 	Error finish_output_device();
 	Error finish_input_device();
 
-	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_input, bool p_reinit, bool p_no_audio_client_3 = false);
+	Error audio_device_init(AudioDeviceWASAPI *p_device, bool p_input, bool p_reinit);
 	Error audio_device_finish(AudioDeviceWASAPI *p_device);
 	PackedStringArray audio_device_get_list(bool p_input);
 


### PR DESCRIPTION
This addresses and fixes mainly https://github.com/godotengine/godot/issues/75109. This probably fixes more issues but that is the lead that I used.

So this became fairly large but it appears the previous WASAPI code has not been functional. WASAPI in shared mode has a minimal buffer size that you cannot go under, and I don't know why the previous code was trying to be clever about this. Functioning audio playback is kinda a very important feature to have.

It also appeared that the logic for switching output devices at runtime was not working, neither was the logic for trying to recover from a broken device. I think the code has become significantly simpler while also addressing all of these issues in one package. There was lots of questioanble code that I removed which appeared to have no purpose.

I have not touched the microphone capturing logic here, but I have separated stream rendering and stream capturing into separate threads so the capturing logic doesn't affect the stream rendering. Let me know if that is a problem, because now the WASAPI driver doesn't really follow the AudioDriver "contract" of having a singular lock and unlock. I could not find that these were used for anything though?

For rendering I decided to use the push method which means that the system will notify the rendering thread the exact moment it wants more data. This then calls into the engine and paints the samples and then blasts to the speakers. There are some questions regarding the logic of that:

1) Do you always need to call ``audio_server_process``? The previous code seems to have complicated logic to always do so, but in my testing it didn't matter since the engine is still advancing.
2) What format are we even getting out of ``audio_server_process``?

With this change I also want to enforce that the WASAPI interfaces are only used in the rendering thread, except for the main thread during init.

The "audio output latency" setting in the project configuration is no longer relevant, as WASAPI in shared mode internally has a limit to how small your buffer can be. Though larger values are allowed, what WASAPI says is minimal should be safe for any kind of application.

The ``real_latency`` variable also has no bearing anymore since we are always topping off the render buffer immediately when the system wants.

The code is commented so you should be able to follow it easily.

This properly handles switching output devices at runtime and falling back in case there are no more devices in the system but one is added later. This did not and still does not handle the case if you try to start the engine with no audio device in the system, and then add one later. That would require more work as the previous code has tangled this up a fair bit.

Edit:
Also I have no idea how ``audio_server_process`` is even functioning, but the previous code and the dummy driver calls them from non-main threads so it should be ok? It is very unclear to me since it is not obviously marked what functions are being run in what thread.

Edit 2:
~I also have no idea if ``IAudioClient`` should be used from separate threads like this (capture and render thread uses the same ``IAudioClient`` but different services). I could not find any documentation regarding this from Microsoft, but to solve that you would have to use separate ``IAudioClient``s I guess. I have not tested the microphone capturing, but logically it is the same as it was before. So if something goes wrong with the capturing then I guess you need separate ``IAudioClient``s.~

Edit 3:
This also fixes the mix rate option in the audio project settings not working at all.

- *Production edit: This closes https://github.com/godotengine/godot/issues/75109.*