### PR TITLE
Return `ERR_FILE_NOT_FOUND` when try to read the file but the result is null

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -723,9 +723,9 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 
-	if (f.is_null()) {
-		// FIXME: Above 'err' error code is ERR_FILE_CANT_OPEN if the file is missing
-		// This needs to be streamlined if we want decent error reporting
+	if (err != OK) {
+		return err;
+	} else if (f.is_null()) {
 		return ERR_FILE_NOT_FOUND;
 	}
 


### PR DESCRIPTION
I wrote within the 'open' function of FileAccess to make it possible to reference the 'is_null()' error. 

However, when changing the rest of the functions from 'f.is_null()' to 'err==ERR_FILE_NOT_FOUND', I realized that several of them were using 'f.is_null()' for 'ERR_CANT_OPEN'. In conclusion:

We need to agree on whether f.is_null() means 'file cannot be opened' or 'file not found'

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
