### PR TITLE
Tilemap selection tool: Erase selected tiles with right click

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -678,12 +678,22 @@ bool TileMapEditorTilesPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p
 					if (tile_map_selection.has(tile_map->local_to_map(drag_start_mouse_pos)) && !mb->is_shift_pressed()) {
 						// Move the selection
 						_update_selection_pattern_from_tilemap_selection(); // Make sure the pattern is up to date before moving.
-						drag_type = DRAG_TYPE_MOVE;
 						drag_modified.clear();
-						for (const Vector2i &E : tile_map_selection) {
-							Vector2i coords = E;
-							drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
-							tile_map->set_cell(tile_map_layer, coords, TileSet::INVALID_SOURCE, TileSetSource::INVALID_ATLAS_COORDS, TileSetSource::INVALID_TILE_ALTERNATIVE);
+						if (drag_erasing) {
+							drag_type = DRAG_TYPE_PAINT;
+							for (const Vector2i &E : tile_map_selection) {
+								Vector2i coords = E;
+								drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
+								tile_map->erase_cell(tile_map_layer, coords);
+							}
+							tile_map_selection.clear();
+						} else {
+							drag_type = DRAG_TYPE_MOVE;
+							for (const Vector2i &E : tile_map_selection) {
+								Vector2i coords = E;
+								drag_modified.insert(coords, tile_map->get_cell(tile_map_layer, coords));
+								tile_map->set_cell(tile_map_layer, coords, TileSet::INVALID_SOURCE, TileSetSource::INVALID_ATLAS_COORDS, TileSetSource::INVALID_TILE_ALTERNATIVE);
+							}
 						}
 					} else {
 						// Select tiles

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -1324,7 +1324,7 @@ void TileMapEditorTilesPlugin::_stop_dragging() {
 			for (int x = rect.position.x; x <= rect.get_end().x; x++) {
 				for (int y = rect.position.y; y <= rect.get_end().y; y++) {
 					Vector2i coords = Vector2i(x, y);
-					if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
+					if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL) || drag_erasing) {
 						if (tile_map_selection.has(coords)) {
 							tile_map_selection.erase(coords);
 						}


### PR DESCRIPTION
As pointed out in the issue https://github.com/godotengine/godot/issues/81933, the documentation for the TileMap states:
> While in Selection mode, you can't place new tiles, but you can still erase tiles by right-clicking after making a selection. The whole selection will be erased, regardless of where you click in the selection.

However, Left and Right click are being treated in the exact same way, so this functionality isn't working as expected.
This PR should fix that.

* *Bugsquad edit, fixes: #81933*