### PR TITLE
Remove unnecessary line from `Projection::get_z_far`

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -408,7 +408,6 @@ real_t Projection::get_z_far() const {
 			matrix[11] - matrix[10],
 			matrix[15] - matrix[14]);
 
-	new_plane.normal = -new_plane.normal;
 	new_plane.normalize();
 
 	return new_plane.d;


### PR DESCRIPTION
This pull request removes a line from Projection::get_z_far that flips the normal of a plane. While this may be required for similar code elsewhere in the file, this is unnecessary here, as only the length of the normal is used and not the direction. Flipping the normal does not change its magnitude and therefore is unnecessary in this case.
