### PR TITLE
Rename BaseMaterial3D "Particles Anim" section to "Particles Animation"

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2862,7 +2862,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "billboard_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Y-Billboard,Particle Billboard"), "set_billboard_mode", "get_billboard_mode");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "billboard_keep_scale"), "set_flag", "get_flag", FLAG_BILLBOARD_KEEP_SCALE);
 
-	ADD_GROUP("Particles Anim", "particles_anim_");
+	ADD_GROUP("Particles Animation", "particles_anim_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_h_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_h_frames", "get_particles_anim_h_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "particles_anim_v_frames", PROPERTY_HINT_RANGE, "1,128,1"), "set_particles_anim_v_frames", "get_particles_anim_v_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "particles_anim_loop"), "set_particles_anim_loop", "get_particles_anim_loop");


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/81996.

In my experience, this is easier to visually parse, and we don't have a strict guideline on having section names match the actual property prefix anyway.