### PR TITLE
[macOS, 3.x] Change target version to 11.0+ to fix PCRE SLJIT build.

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -78,10 +78,10 @@ def configure(env):
         env["osxcross"] = True
 
     if env["arch"] == "arm64":
-        print("Building for macOS 10.15+, platform arm64.")
-        env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
-        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
-        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=10.15"])
+        print("Building for macOS 11.0+, platform arm64.")
+        env.Append(ASFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
+        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
     else:
         print("Building for macOS 10.13+, platform x86-64.")
         env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])


### PR DESCRIPTION
10.15 for arm64 only exist as the early 10.16 (released as 11.0) alphas, there's no reason to support it.