### PR TITLE
Fixes inconsistencies in names

### DIFF
--- a/editor/translations/editor/pt_BR.po
+++ b/editor/translations/editor/pt_BR.po
@@ -16952,7 +16952,7 @@ msgid "Invalid else."
 msgstr "else Inválido."
 
 msgid "Unmatched endif."
-msgstr "Endif incomparável."
+msgstr "endif incomparável."
 
 msgid "Invalid endif."
 msgstr "endif Inválido."


### PR DESCRIPTION
This commit addresses an issue where one of the strings starting with "endif" was inconsistent, with only one of them starting with an uppercase letter. To maintain code consistency, it was changed to lowercase.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
