### PR TITLE
Animation: Fix reset value when adding new Bezier track

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4429,7 +4429,7 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 				for (int i = 0; i < subindices.size(); i++) {
 					InsertData id = p_id;
 					id.type = Animation::TYPE_BEZIER;
-					id.value = p_id.value.get(subindices[i].substr(1, subindices[i].length()));
+					id.value = subindices[i].is_empty() ? p_id.value : p_id.value.get(subindices[i].substr(1, subindices[i].length()));
 					id.path = String(p_id.path) + subindices[i];
 					p_next_tracks = _confirm_insert(id, p_next_tracks, p_reset_wanted, p_reset_anim, false);
 				}


### PR DESCRIPTION
* *fixes: #81929*

In Float and Integer types, there is no subindex – only the primary value. Currently, trying to retrieve a subindex from these types in the Variant leads to a return value of null. To address this, the proposed change ensures that the default value is returned for these types instead of attempting an invalid subindex retrieval.