### PR TITLE
Fix for SpinBox decimal input when update_on_text_changed is true

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -78,6 +78,10 @@ void SpinBox::_text_submitted(const String &p_string) {
 }
 
 void SpinBox::_text_changed(const String &p_string) {
+	if (p_string.ends_with(".")) {
+		return;
+	}
+
 	int cursor_pos = line_edit->get_caret_column();
 
 	_text_submitted(p_string);


### PR DESCRIPTION
Fixes [Issue #81989](https://github.com/godotengine/godot/issues/81989)

Fixes decimal input in SpinBox when update_on_text_changed is true.

![SpinBoxDecimal](https://github.com/godotengine/godot/assets/13213713/b704cb40-c88f-4a0b-8a14-94b75056fc73)
