### PR TITLE
[3.x] Add "position" as an alias for "translation" in Spatial

### DIFF
--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -253,6 +253,9 @@
 		<member name="gizmo" type="SpatialGizmo" setter="set_gizmo" getter="get_gizmo">
 			The [SpatialGizmo] for this node. Used for example in [EditorSpatialGizmo] as custom visualization and editing handles in Editor.
 		</member>
+		<member name="global_position" type="Vector3" setter="set_global_translation" getter="get_global_translation">
+			Global position of this node. This is a forward-compatible alias for [member global_translation].
+		</member>
 		<member name="global_rotation" type="Vector3" setter="set_global_rotation" getter="get_global_rotation">
 			Rotation part of the global transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).
 			[b]Note:[/b] In the mathematical sense, rotation is a matrix and not a vector. The three Euler angles, which are the three independent parameters of the Euler-angle parametrization of the rotation matrix, are stored in a [Vector3] data structure not because the rotation is a vector, but only because [Vector3] exists as a convenient data-structure to store 3 floating-point numbers. Therefore, applying affine operations on the rotation "vector" is not meaningful.
@@ -262,6 +265,9 @@
 		</member>
 		<member name="global_translation" type="Vector3" setter="set_global_translation" getter="get_global_translation">
 			Global position of this node. This is equivalent to [code]global_transform.origin[/code].
+		</member>
+		<member name="position" type="Vector3" setter="set_translation" getter="get_translation">
+			Local position of this node. This is a forward-compatible alias for [member translation].
 		</member>
 		<member name="rotation" type="Vector3" setter="set_rotation" getter="get_rotation">
 			Rotation part of the local transformation in radians, specified in terms of YXZ-Euler angles in the format (X angle, Y angle, Z angle).

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -936,11 +936,13 @@ void Spatial::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_EXIT_GAMEPLAY);
 
 	ADD_GROUP("Transform", "");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position", PROPERTY_HINT_NONE, "", 0), "set_translation", "get_translation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "translation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_translation", "get_translation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation_degrees", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_rotation_degrees", "get_rotation_degrees");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "rotation", PROPERTY_HINT_NONE, "", 0), "set_rotation", "get_rotation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_LINK, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM, "global_transform", PROPERTY_HINT_NONE, "", 0), "set_global_transform", "get_global_transform");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_NONE, "", 0), "set_global_translation", "get_global_translation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_translation", PROPERTY_HINT_NONE, "", 0), "set_global_translation", "get_global_translation");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_NONE, "", 0), "set_global_rotation", "get_global_rotation");
 


### PR DESCRIPTION
On Discord I have observed new Godot users who choose 3.x due to stability and not needing the new features in 4.x being confused by the position property being called "translation". I think it makes sense to add "position" as an alias, so that users can use this terminology in Godot 3.x and have it match Godot 4.x.

Note: This new property just wraps around the existing get/set translation methods. If it's desired to add get/set position methods, I can do that.