### PR TITLE
[3.x] Add `--lsp-port` as a command line argument

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -86,6 +86,12 @@
 #endif
 #endif
 
+#ifdef MODULE_GDSCRIPT_ENABLED
+#if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+#include "modules/gdscript/language_server/gdscript_language_server.h"
+#endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
+#endif // MODULE_GDSCRIPT_ENABLED
+
 /* Static members */
 
 // Singletons
@@ -268,6 +274,9 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -e, --editor                     Start the editor instead of running the scene.\n");
 	OS::get_singleton()->print("  -p, --project-manager            Start the project manager, even if a project is auto-detected.\n");
 	OS::get_singleton()->print("  --debug-server <address>         Start the editor debug server (<IP>:<port>, e.g. 127.0.0.1:6007)\n");
+#if defined(MODULE_GDSCRIPT_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+	OS::get_singleton()->print("  --lsp-port <port>                 Use the specified port for the language server protocol. The port must be between 0 to 65535.\n");
+#endif // MODULE_GDSCRIPT_ENABLED && !GDSCRIPT_NO_LSP
 #endif
 	OS::get_singleton()->print("  -q, --quit                       Quit after the first iteration.\n");
 	OS::get_singleton()->print("  -l, --language <locale>          Use a specific locale (<locale> being a two-letter code).\n");
@@ -941,7 +950,21 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing <path> argument for --benchmark-file <path>.\n");
 				goto error;
 			}
-
+#if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
+		} else if (I->get() == "--lsp-port") {
+			if (I->next()) {
+				int port_override = I->next()->get().to_int();
+				if (port_override < 0 || port_override > 65535) {
+					OS::get_singleton()->print("<port> argument for --lsp-port <port> must be between 0 and 65535.\n");
+					goto error;
+				}
+				GDScriptLanguageServer::port_override = port_override;
+				N = I->next()->next();
+			} else {
+				OS::get_singleton()->print("Missing <port> argument for --lsp-port <port>.\n");
+				goto error;
+			}
+#endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
 		} else {
 			main_args.push_back(I->get());
 		}

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -35,6 +35,8 @@
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 
+int GDScriptLanguageServer::port_override = -1;
+
 GDScriptLanguageServer::GDScriptLanguageServer() {
 	thread_running = false;
 	started = false;
@@ -64,7 +66,7 @@ void GDScriptLanguageServer::_notification(int p_what) {
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			String host = String(_EDITOR_GET("network/language_server/remote_host"));
-			int port = (int)_EDITOR_GET("network/language_server/remote_port");
+			int port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 			bool use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 			if (host != this->host || port != this->port || use_thread != this->use_thread) {
 				this->stop();
@@ -85,10 +87,10 @@ void GDScriptLanguageServer::thread_main(void *p_userdata) {
 
 void GDScriptLanguageServer::start() {
 	host = String(_EDITOR_GET("network/language_server/remote_host"));
-	port = (int)_EDITOR_GET("network/language_server/remote_port");
+	port = (GDScriptLanguageServer::port_override > -1) ? GDScriptLanguageServer::port_override : (int)_EDITOR_GET("network/language_server/remote_port");
 	use_thread = (bool)_EDITOR_GET("network/language_server/use_thread");
 	if (protocol.start(port, IP_Address(host)) == OK) {
-		EditorNode::get_log()->add_message("--- GDScript language server started ---", EditorLog::MSG_TYPE_EDITOR);
+		EditorNode::get_log()->add_message("--- GDScript language server started on port " + itos(port) + " ---", EditorLog::MSG_TYPE_EDITOR);
 		if (use_thread) {
 			thread_running = true;
 			thread.start(GDScriptLanguageServer::thread_main, this);

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -52,6 +52,7 @@ private:
 	void _notification(int p_what);
 
 public:
+	static int port_override;
 	GDScriptLanguageServer();
 	void start();
 	void stop();


### PR DESCRIPTION
This PR is a cherry-pick of #81844 , which was accepted this week.

Implements an `--lsp-port` command line argument for Godot. This argument overrides the user's editor setting for `network/language_server/remote_port`.

The use case for this argument would be for the godot-vscode-plugin to be able to specify the port used for the language server instance spun up by the plugin.

This would potentially solve a few long standing issues with the godot-vscode-plugin, including:

Godot's 3.x LSP port and 4.x LSP port don't match, causing the plugin to have to tell users to explicitly specify the port they have selected in their editor settings. (See https://github.com/godotengine/godot-vscode-plugin/issues/473)
Spinning up multiple workspaces in vscode would cause both to use the same language server.
If the change is accepted, it should be cherry picked to 3.x. I can help with that if need be.

Let me know what things I have to change. Since this is my first time working with main.cpp and further with #ifdef and #ifndef, please pay attention to my use of those and let me know if they are up to standard.

I also added the port to the language server editor print that says --- GDScript language server started ---, changing it to --- GDScript language server started on port "port"---.

Bringing this change to 3.x will allow the godot-vscode-plugin's upcoming support for the argument to work in 3.x as well. Otherwise, the command line argument will just pass through.