### PR TITLE
Implement `load_resource_pack` destination support 

### DIFF
--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  project_settings.compat.inc                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset){
+        return _load_resource_pack(p_pack, p_replace_files, p_offset, "");
+}
+
+
+void ProjectSettings::_bind_compatibility_methods() {
+        ClassDB::bind_compatibility_method(D_METHOD("_load_resource_pack"), &ProjectSettings::_load_resource_pack_compat_82035);
+}
+
+#endif

--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -30,10 +30,9 @@
 
 #ifndef DISABLE_DEPRECATED
 
-bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset){
+bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset) {
         return _load_resource_pack(p_pack, p_replace_files, p_offset, "");
 }
-
 
 void ProjectSettings::_bind_compatibility_methods() {
         ClassDB::bind_compatibility_method(D_METHOD("_load_resource_pack"), &ProjectSettings::_load_resource_pack_compat_82035);

--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -30,12 +30,12 @@
 
 #ifndef DISABLE_DEPRECATED
 
-bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset) {
-        return _load_resource_pack(p_pack, p_replace_files, p_offset, "");
+bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset){
+	return _load_resource_pack(p_pack, p_replace_files, p_offset, "");
 }
 
 void ProjectSettings::_bind_compatibility_methods() {
-        ClassDB::bind_compatibility_method(D_METHOD("_load_resource_pack"), &ProjectSettings::_load_resource_pack_compat_82035);
+	ClassDB::bind_compatibility_method(D_METHOD("_load_resource_pack"), &ProjectSettings::_load_resource_pack_compat_82035);
 }
 
 #endif

--- a/core/config/project_settings.compat.inc
+++ b/core/config/project_settings.compat.inc
@@ -30,7 +30,7 @@
 
 #ifndef DISABLE_DEPRECATED
 
-bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset){
+bool ProjectSettings::_load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files, int p_offset) {
 	return _load_resource_pack(p_pack, p_replace_files, p_offset, "");
 }
 

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "project_settings.h"
+#include "project_settings.compat.inc"
 
 #include "core/core_bind.h" // For Compression enum.
 #include "core/core_string_names.h"

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -458,12 +458,12 @@ void ProjectSettings::_emit_changed() {
 	emit_signal("settings_changed");
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, const String &p_path) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset, p_path) == OK;
 
 	if (!ok) {
 		return false;
@@ -1256,7 +1256,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset", "path"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0), DEFVAL(""));
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -147,6 +147,11 @@ protected:
 
 	void _add_builtin_input_map();
 
+#ifndef DISABLE_DEPRECATED
+	bool _load_resource_pack_compat_82035(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
+	static void _bind_compatibility_methods();
+#endif
+
 protected:
 	static void _bind_methods();
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -139,7 +139,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, const String &p_path = "");
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -249,7 +249,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f->get_buffer(md5, 16);
 		uint32_t flags = f->get_32();
 
-		PackedData::get_singleton()->add_path(p_path, path , ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
+		PackedData::get_singleton()->add_path(p_path, path, ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
 	}
 
 	return true;

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -241,7 +241,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 
 		String path;
 		path.parse_utf8(cs.ptr());
-		path = String("res://") + p_prefix + path.replace_first("res://", "");
+		path = String("res://") + p_prefix.path_join(path.replace_first("res://", ""));
 
 		uint64_t ofs = file_base + f->get_64();
 		uint64_t size = f->get_64();

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -37,9 +37,9 @@
 
 #include <stdio.h>
 
-Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
+Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) {
 	for (int i = 0; i < sources.size(); i++) {
-		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset)) {
+		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset, p_prefix)) {
 			return OK;
 		}
 	}
@@ -127,7 +127,7 @@ PackedData::~PackedData() {
 
 //////////////////////////////////////////////////////////////////
 
-bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
+bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
 		return false;
@@ -241,6 +241,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 
 		String path;
 		path.parse_utf8(cs.ptr());
+		path = String("res://") + p_prefix + path.replace_first("res://", "");
 
 		uint64_t ofs = file_base + f->get_64();
 		uint64_t size = f->get_64();
@@ -248,7 +249,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f->get_buffer(md5, 16);
 		uint32_t flags = f->get_32();
 
-		PackedData::get_singleton()->add_path(p_path, path, ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
+		PackedData::get_singleton()->add_path(p_path, path , ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
 	}
 
 	return true;

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -115,7 +115,7 @@ public:
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
-	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset);
+	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix);
 
 	_FORCE_INLINE_ Ref<FileAccess> try_open_path(const String &p_path);
 	_FORCE_INLINE_ bool has_path(const String &p_path);
@@ -129,14 +129,14 @@ public:
 
 class PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) = 0;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) = 0;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
 public:
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 };
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -191,7 +191,7 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 		f.package = pkg_num;
 		unzGetFilePos(zfile, &f.file_pos);
 
-		String fname = String("res://") + p_prefix + String::utf8(filename_inzip);
+		String fname = String("res://") + p_prefix.path_join(String::utf8(filename_inzip));
 		files[fname] = f;
 
 		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -146,7 +146,7 @@ unzFile ZipArchive::get_file_handle(String p_file) const {
 	return pkg;
 }
 
-bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset = 0) {
+bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) {
 	// load with offset feature only supported for PCK files
 	ERR_FAIL_COND_V_MSG(p_offset != 0, false, "Invalid PCK data. Note that loading files with a non-zero offset isn't supported with ZIP archives.");
 
@@ -191,7 +191,7 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 		f.package = pkg_num;
 		unzGetFilePos(zfile, &f.file_pos);
 
-		String fname = String("res://") + String::utf8(filename_inzip);
+		String fname = String("res://") + p_prefix + String::utf8(filename_inzip);
 		files[fname] = f;
 
 		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -67,7 +67,7 @@ public:
 
 	bool file_exists(String p_name) const;
 
-	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
+	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const String &p_prefix) override;
 	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 
 	static ZipArchive *get_singleton();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -150,8 +150,9 @@
 			<param index="0" name="pack" type="String" />
 			<param index="1" name="replace_files" type="bool" default="true" />
 			<param index="2" name="offset" type="int" default="0" />
+			<param index="3" name="path" type="String" default="&quot;&quot;" />
 			<description>
-				Loads the contents of the .pck or .zip file specified by [param pack] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
+				Loads the contents of the .pck or .zip file specified by [param pack] into the resource filesystem ([code]res://[/code], optionally prefixed by [param path]). Returns [code]true[/code] on success.
 				[b]Note:[/b] If a file from [param pack] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [param pack] unless [param replace_files] is set to [code]false[/code].
 				[b]Note:[/b] The optional [param offset] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
 			</description>

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -188,7 +188,6 @@ Intentional compatibility breakage to be consistent with the new non-virtual set
 
 GH-82035
 --------
-
 Validate extension JSON: Error: Field 'classes/ProjectSettings/methods/load_resource_pack/arguments': size changed value in new API, from 3 to 4.
 
 Added an optional argument to prefix the paths with (a "mount point", if you will) in the virtual filesystem.

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -184,3 +184,11 @@ Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHan
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_normal/arguments/1': type changed value in new API, from "const void*" to "Vector3".
 
 Intentional compatibility breakage to be consistent with the new non-virtual set_vertex/set_normal.
+
+
+GH-82035
+--------
+
+Validate extension JSON: Error: Field 'classes/ProjectSettings/methods/load_resource_pack/arguments': size changed value in new API, from 3 to 4.
+
+Added an optional argument to prefix the paths with (a "mount point", if you will) in the virtual filesystem.


### PR DESCRIPTION
Example usage:
```gdscript
func dir_contents(path, ind =""):
	var dir = DirAccess.open(path)
	if dir:
		dir.list_dir_begin()
		var file_name = dir.get_next()
		while file_name != "":
			if dir.current_is_dir():
				print(ind+"Found directory: " + file_name)
				dir_contents(path+"/"+file_name, ind+"  ")
			else:
				print(ind+"Found file: " + file_name)
			file_name = dir.get_next()
	else:
		print("An error occurred when trying to access the path.")

func _ready():
	print("ZIP:")
	ProjectSettings.load_resource_pack("res://test.zip",false,0,"blah/")
	dir_contents("res://blah")

	print("PCK:")
	ProjectSettings.load_resource_pack("res://test.pck",false,0,"blub/")
	dir_contents("res://blub")

	# test actual loading
	print("LOAD:")
	print(load("res://blub/icon.svg"))
```

Output:
```
ZIP:
Found directory: .godot
  Found directory: imported
	Found file: icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex
  Found directory: exported
	Found directory: 133200997
	  Found file: export-3070c538c03ee49b7677ff960a3f5195-main.scn
  Found file: global_script_class_cache.cfg
  Found file: uid_cache.bin
Found file: icon.svg.import
Found file: main.gd
Found file: main.tscn.remap
Found file: icon.svg
Found file: project.binary
PCK:
Found directory: .godot
  Found directory: exported
	Found directory: 133200997
	  Found file: export-3070c538c03ee49b7677ff960a3f5195-main.scn
  Found directory: imported
	Found file: icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex
  Found file: global_script_class_cache.cfg
  Found file: uid_cache.bin
Found file: icon.svg
Found file: icon.svg.import
Found file: main.gd
Found file: main.tscn.remap
Found file: project.binary
LOAD:
<CompressedTexture2D#-9223372013014350661>
```

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/7769*