### PR TITLE
Fix "visibly" typo in Control.xml

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -933,7 +933,7 @@
 			Also decides if the node's strings should be parsed for POT generation.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
-			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered and won't receive input.
+			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visible outside of this control's rectangle will not be rendered and won't receive input.
 		</member>
 		<member name="custom_minimum_size" type="Vector2" setter="set_custom_minimum_size" getter="get_custom_minimum_size" default="Vector2(0, 0)">
 			The minimum size of the node's bounding rectangle. If you set it to a value greater than (0, 0), the node's bounding rectangle will always have at least this size, even if its content is smaller. If it's set to (0, 0), the node sizes automatically to fit its content, be it a texture or child nodes.


### PR DESCRIPTION
The current text reads: "If true, parts of a child which would be **visibly** outside of this control's..."

This PR corrects the text to: "If true, parts of a child which would be **visible** outside of this control's..."