### PR TITLE
Fix sky debanding/dithering strength on dark skies

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -283,6 +283,9 @@ void main() {
 	}
 
 #ifdef USE_DEBANDING
-	frag_color.rgb += interleaved_gradient_noise(gl_FragCoord.xy) * params.luminance_multiplier;
+	// The dithering amount is multiplied by frag_color to approximate adding it in gamma-compressed sRGB.
+	// This is done because the banding quantization happens in sRGB, not in linear light.
+	// Near black, sRGB is linear with a slope of 12.92. Adding 1.0/12.92 ensures that the dithering has the right strength at black.
+	frag_color.rgb += interleaved_gradient_noise(gl_FragCoord.xy) * (frag_color.rgb + vec3(1.0 / 12.92)) * params.luminance_multiplier;
 #endif
 }


### PR DESCRIPTION
Fixes #82036.

I didn't test-build this locally. I made sure the change works by editing the shader text in godot's executable with a hex editor, because doing so was like, 10x faster than rebuilding Godot from scratch. So the CI might not build and someone should still test the CI artifacts if they do build.

Before:

![godot windows editor x86_64_2023-09-21_08-41-11](https://github.com/godotengine/godot/assets/585488/e92f319c-9c00-404c-a9fc-4219c59e56a7)

After:

![godot windows editor x86_64_2023-09-21_08-40-20](https://github.com/godotengine/godot/assets/585488/0f273b28-cfbb-40f7-aeae-8f620578c597)

No debanding for comparison:

![godot windows editor x86_64_2023-09-21_08-40-18](https://github.com/godotengine/godot/assets/585488/29476b80-8265-4b0f-aff3-255bb357e585)

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
