### PR TITLE
Fix missing clear for some `set_exclude*` query parameter methods

### DIFF
--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -476,6 +476,7 @@ TypedArray<RID> PhysicsTestMotionParameters2D::get_exclude_bodies() const {
 }
 
 void PhysicsTestMotionParameters2D::set_exclude_bodies(const TypedArray<RID> &p_exclude) {
+	parameters.exclude_bodies.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
 		parameters.exclude_bodies.insert(p_exclude[i]);
 	}
@@ -494,6 +495,7 @@ TypedArray<uint64_t> PhysicsTestMotionParameters2D::get_exclude_objects() const 
 }
 
 void PhysicsTestMotionParameters2D::set_exclude_objects(const TypedArray<uint64_t> &p_exclude) {
+	parameters.exclude_objects.clear();
 	for (int i = 0; i < p_exclude.size(); ++i) {
 		ObjectID object_id = p_exclude[i];
 		ERR_CONTINUE(object_id.is_null());

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -501,6 +501,7 @@ TypedArray<RID> PhysicsTestMotionParameters3D::get_exclude_bodies() const {
 }
 
 void PhysicsTestMotionParameters3D::set_exclude_bodies(const TypedArray<RID> &p_exclude) {
+	parameters.exclude_bodies.clear();
 	for (int i = 0; i < p_exclude.size(); i++) {
 		parameters.exclude_bodies.insert(p_exclude[i]);
 	}
@@ -519,6 +520,7 @@ TypedArray<uint64_t> PhysicsTestMotionParameters3D::get_exclude_objects() const 
 }
 
 void PhysicsTestMotionParameters3D::set_exclude_objects(const TypedArray<uint64_t> &p_exclude) {
+	parameters.exclude_objects.clear();
 	for (int i = 0; i < p_exclude.size(); ++i) {
 		ObjectID object_id = p_exclude[i];
 		ERR_CONTINUE(object_id.is_null());


### PR DESCRIPTION
* Fixes: #82042

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
