### PR TITLE
Revamp how documentation tooltips work

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -835,35 +835,9 @@ ConnectDialog::~ConnectDialog() {
 
 //////////////////////////////////////////
 
-// Originally copied and adapted from EditorProperty, try to keep style in sync.
 Control *ConnectionsDockTree::make_custom_tooltip(const String &p_text) const {
-	// `p_text` is expected to be something like this:
-	// - `class|Control||Control brief description.`;
-	// - `signal|gui_input|(event: InputEvent)|gui_input description.`;
-	// - `../../.. :: _on_gui_input()`.
-	// Note that the description can be empty or contain `|`.
-	PackedStringArray slices = p_text.split("|", true, 3);
-	if (slices.size() < 4) {
-		return nullptr; // Use default tooltip instead.
-	}
-
-	String item_type = (slices[0] == "class") ? TTR("Class:") : TTR("Signal:");
-	String item_name = slices[1].strip_edges();
-	String item_params = slices[2].strip_edges();
-	String item_descr = slices[3].strip_edges();
-
-	String text = item_type + " [u][b]" + item_name + "[/b][/u]" + item_params + "\n";
-	if (item_descr.is_empty()) {
-		text += "[i]" + TTR("No description.") + "[/i]";
-	} else {
-		text += item_descr;
-	}
-
-	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->get_rich_text()->set_custom_minimum_size(Size2(360 * EDSCALE, 1));
-	help_bit->set_text(text);
-
-	return help_bit;
+	// If it's not a doc tooltip, fallback to the default one.
+	return p_text.contains("::") ? nullptr : memnew(EditorHelpTooltip(p_text));
 }
 
 struct _ConnectionsDockMethodInfoSort {
@@ -1341,7 +1315,6 @@ void ConnectionsDock::update_tree() {
 	while (native_base != StringName()) {
 		String class_name;
 		String doc_class_name;
-		String class_brief;
 		Ref<Texture2D> class_icon;
 		List<MethodInfo> class_signals;
 
@@ -1355,21 +1328,8 @@ void ConnectionsDock::update_tree() {
 			if (doc_class_name.is_empty()) {
 				doc_class_name = script_base->get_path().trim_prefix("res://").quote();
 			}
-
-			// For a script class, the cache is filled each time.
-			if (!doc_class_name.is_empty()) {
-				if (descr_cache.has(doc_class_name)) {
-					descr_cache[doc_class_name].clear();
-				}
-				HashMap<String, DocData::ClassDoc>::ConstIterator F = doc_data->class_list.find(doc_class_name);
-				if (F) {
-					class_brief = F->value.brief_description;
-					for (int i = 0; i < F->value.signals.size(); i++) {
-						descr_cache[doc_class_name][F->value.signals[i].name] = F->value.signals[i].description;
-					}
-				} else {
-					doc_class_name = String();
-				}
+			if (!doc_class_name.is_empty() && !doc_data->class_list.find(doc_class_name)) {
+				doc_class_name = String();
 			}
 
 			class_icon = editor_data.get_script_icon(script_base);
@@ -1398,18 +1358,9 @@ void ConnectionsDock::update_tree() {
 			script_base = base;
 		} else {
 			class_name = native_base;
-			doc_class_name = class_name;
+			doc_class_name = native_base;
 
-			HashMap<String, DocData::ClassDoc>::ConstIterator F = doc_data->class_list.find(doc_class_name);
-			if (F) {
-				class_brief = DTR(F->value.brief_description);
-				// For a native class, the cache is filled once.
-				if (!descr_cache.has(doc_class_name)) {
-					for (int i = 0; i < F->value.signals.size(); i++) {
-						descr_cache[doc_class_name][F->value.signals[i].name] = DTR(F->value.signals[i].description);
-					}
-				}
-			} else {
+			if (!doc_data->class_list.find(doc_class_name)) {
 				doc_class_name = String();
 			}
 
@@ -1434,8 +1385,8 @@ void ConnectionsDock::update_tree() {
 
 			section_item = tree->create_item(root);
 			section_item->set_text(0, class_name);
-			// `|` separators used in `make_custom_tooltip()` for formatting.
-			section_item->set_tooltip_text(0, "class|" + class_name + "||" + class_brief);
+			// `|` separators used in `EditorHelpTooltip` for formatting.
+			section_item->set_tooltip_text(0, "class|" + doc_class_name + "||");
 			section_item->set_icon(0, class_icon);
 			section_item->set_selectable(0, false);
 			section_item->set_editable(0, false);
@@ -1466,22 +1417,8 @@ void ConnectionsDock::update_tree() {
 			sinfo["args"] = argnames;
 			signal_item->set_metadata(0, sinfo);
 			signal_item->set_icon(0, get_editor_theme_icon(SNAME("Signal")));
-
-			// Set tooltip with the signal's documentation.
-			{
-				String descr;
-
-				HashMap<StringName, HashMap<StringName, String>>::ConstIterator G = descr_cache.find(doc_class_name);
-				if (G) {
-					HashMap<StringName, String>::ConstIterator F = G->value.find(signal_name);
-					if (F) {
-						descr = F->value;
-					}
-				}
-
-				// `|` separators used in `make_custom_tooltip()` for formatting.
-				signal_item->set_tooltip_text(0, "signal|" + String(signal_name) + "|" + signame.trim_prefix(mi.name) + "|" + descr);
-			}
+			// `|` separators used in `EditorHelpTooltip` for formatting.
+			signal_item->set_tooltip_text(0, "signal|" + doc_class_name + "|" + String(signal_name) + "|" + signame.trim_prefix(mi.name));
 
 			// List existing connections.
 			List<Object::Connection> existing_connections;

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -231,8 +231,6 @@ class ConnectionsDock : public VBoxContainer {
 	PopupMenu *slot_menu = nullptr;
 	LineEdit *search_box = nullptr;
 
-	HashMap<StringName, HashMap<StringName, String>> descr_cache;
-
 	void _filter_changed(const String &p_text);
 
 	void _make_or_edit_connection();

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -500,10 +500,11 @@ void CreateDialog::select_type(const String &p_type, bool p_center_on_item) {
 	to_select->select(0);
 	search_options->scroll_to_item(to_select, p_center_on_item);
 
-	if (EditorHelp::get_doc_data()->class_list.has(p_type) && !DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description).is_empty()) {
+	String text = help_bit->get_class_description(p_type);
+	if (!text.is_empty()) {
 		// Display both class name and description, since the help bit may be displayed
 		// far away from the location (especially if the dialog was resized to be taller).
-		help_bit->set_text(vformat("[b]%s[/b]: %s", p_type, DTR(EditorHelp::get_doc_data()->class_list[p_type].brief_description)));
+		help_bit->set_text(vformat("[b]%s[/b]: %s", p_type, text));
 		help_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
 	} else {
 		// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -646,24 +646,21 @@ void EditorBuildProfileManager::_class_list_item_selected() {
 
 	Variant md = item->get_metadata(0);
 	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
-		String class_name = md;
-		String class_description;
-
-		DocTools *dd = EditorHelp::get_doc_data();
-		HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_name);
-		if (E) {
-			class_description = DTR(E->value.brief_description);
+		String text = description_bit->get_class_description(md);
+		if (!text.is_empty()) {
+			// Display both class name and description, since the help bit may be displayed
+			// far away from the location (especially if the dialog was resized to be taller).
+			description_bit->set_text(vformat("[b]%s[/b]: %s", md, text));
+			description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
+		} else {
+			// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.
+			description_bit->set_text(vformat(TTR("No description available for %s."), vformat("[b]%s[/b]", md)));
+			description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
 		}
-
-		description_bit->set_text(class_description);
 	} else if (md.get_type() == Variant::INT) {
-		int build_option_id = md;
-		String build_option_description = EditorBuildProfile::get_build_option_description(EditorBuildProfile::BuildOption(build_option_id));
-
-		description_bit->set_text(TTRGET(build_option_description));
-		return;
-	} else {
-		return;
+		String build_option_description = EditorBuildProfile::get_build_option_description(EditorBuildProfile::BuildOption((int)md));
+		description_bit->set_text(vformat("[b]%s[/b]: %s", TTR(item->get_text(0)), TTRGET(build_option_description)));
+		description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
 	}
 }
 

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -555,21 +555,22 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 
 	Variant md = item->get_metadata(0);
 	if (md.get_type() == Variant::STRING || md.get_type() == Variant::STRING_NAME) {
-		String class_name = md;
-		String class_description;
-
-		DocTools *dd = EditorHelp::get_doc_data();
-		HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_name);
-		if (E) {
-			class_description = DTR(E->value.brief_description);
+		String text = description_bit->get_class_description(md);
+		if (!text.is_empty()) {
+			// Display both class name and description, since the help bit may be displayed
+			// far away from the location (especially if the dialog was resized to be taller).
+			description_bit->set_text(vformat("[b]%s[/b]: %s", md, text));
+			description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
+		} else {
+			// Use nested `vformat()` as translators shouldn't interfere with BBCode tags.
+			description_bit->set_text(vformat(TTR("No description available for %s."), vformat("[b]%s[/b]", md)));
+			description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 0.5));
 		}
-
-		description_bit->set_text(class_description);
 	} else if (md.get_type() == Variant::INT) {
-		int feature_id = md;
-		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature(feature_id));
+		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature((int)md));
+		description_bit->set_text(vformat("[b]%s[/b]: %s", TTR(item->get_text(0)), TTRGET(feature_description)));
+		description_bit->get_rich_text()->set_self_modulate(Color(1, 1, 1, 1));
 
-		description_bit->set_text(TTRGET(feature_description));
 		return;
 	} else {
 		return;

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -232,6 +232,12 @@ public:
 class EditorHelpBit : public MarginContainer {
 	GDCLASS(EditorHelpBit, MarginContainer);
 
+	inline static HashMap<StringName, String> doc_class_cache;
+	inline static HashMap<StringName, HashMap<StringName, String>> doc_property_cache;
+	inline static HashMap<StringName, HashMap<StringName, String>> doc_method_cache;
+	inline static HashMap<StringName, HashMap<StringName, String>> doc_signal_cache;
+	inline static HashMap<StringName, HashMap<StringName, String>> doc_theme_item_cache;
+
 	RichTextLabel *rich_text = nullptr;
 	void _go_to_help(String p_what);
 	void _meta_clicked(String p_select);
@@ -243,9 +249,30 @@ protected:
 	void _notification(int p_what);
 
 public:
+	String get_class_description(const StringName &p_class_name) const;
+	String get_property_description(const StringName &p_class_name, const StringName &p_property_name) const;
+	String get_method_description(const StringName &p_class_name, const StringName &p_method_name) const;
+	String get_signal_description(const StringName &p_class_name, const StringName &p_signal_name) const;
+	String get_theme_item_description(const StringName &p_class_name, const StringName &p_theme_item_name) const;
+
 	RichTextLabel *get_rich_text() { return rich_text; }
 	void set_text(const String &p_text);
+
 	EditorHelpBit();
+};
+
+class EditorHelpTooltip : public EditorHelpBit {
+	GDCLASS(EditorHelpTooltip, EditorHelpBit);
+
+	String tooltip_text;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void parse_tooltip(const String &p_text);
+
+	EditorHelpTooltip(const String &p_text = String());
 };
 
 #endif // EDITOR_HELP_H

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -501,13 +501,7 @@ class EditorInspector : public ScrollContainer {
 	int property_focusable;
 	int update_scroll_request;
 
-	struct PropertyDocInfo {
-		String description;
-		String path;
-	};
-
-	HashMap<StringName, HashMap<StringName, PropertyDocInfo>> doc_info_cache;
-	HashMap<StringName, String> class_descr_cache;
+	HashMap<StringName, HashMap<StringName, String>> doc_path_cache;
 	HashSet<StringName> restart_request_props;
 
 	HashMap<ObjectID, int> scroll_cache;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -370,46 +370,15 @@ void PropertySelector::_item_selected() {
 		class_type = instance->get_class();
 	}
 
-	DocTools *dd = EditorHelp::get_doc_data();
 	String text;
-	if (properties) {
-		while (!class_type.is_empty()) {
-			HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_type);
-			if (E) {
-				for (int i = 0; i < E->value.properties.size(); i++) {
-					if (E->value.properties[i].name == name) {
-						text = DTR(E->value.properties[i].description);
-						break;
-					}
-				}
-			}
-
-			if (!text.is_empty()) {
-				break;
-			}
-
-			// The property may be from a parent class, keep looking.
-			class_type = ClassDB::get_parent_class(class_type);
+	while (!class_type.is_empty()) {
+		text = properties ? help_bit->get_property_description(class_type, name) : help_bit->get_method_description(class_type, name);
+		if (!text.is_empty()) {
+			break;
 		}
-	} else {
-		while (!class_type.is_empty()) {
-			HashMap<String, DocData::ClassDoc>::Iterator E = dd->class_list.find(class_type);
-			if (E) {
-				for (int i = 0; i < E->value.methods.size(); i++) {
-					if (E->value.methods[i].name == name) {
-						text = DTR(E->value.methods[i].description);
-						break;
-					}
-				}
-			}
 
-			if (!text.is_empty()) {
-				break;
-			}
-
-			// The method may be from a parent class, keep looking.
-			class_type = ClassDB::get_parent_class(class_type);
-		}
+		// It may be from a parent class, keep looking.
+		class_type = ClassDB::get_parent_class(class_type);
 	}
 
 	if (!text.is_empty()) {


### PR DESCRIPTION
This PR does the following this:

- Add a set of `get_*_description()` functions to `EditorHelpBit`, that fetches the doc description of various components, and then caches them.
- Create `EditorHelpTooltip`, that handles the doc tooltips that before were scattered across multiple places. It internally uses the functions above.
- As a bonus, prettify a little some simple uses of `EditorHelpBit` I found while making this PR.

This PR is necessary for #81284 (see https://github.com/godotengine/godot/pull/81284#discussion_r1314821331).