### PR TITLE
Increase default opacity of Word Highlighted Color in the script editor

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -2443,7 +2443,7 @@ void EditorThemeManager::_generate_text_editor_defaults(ThemeConfiguration &p_co
 	const Color brace_mismatch_color =            p_config.dark_theme ? p_config.error_color : Color(1, 0.08, 0, 1);
 	const Color current_line_color =              alpha1;
 	const Color line_length_guideline_color =     p_config.dark_theme ? p_config.base_color : p_config.dark_color_2;
-	const Color word_highlighted_color =          alpha1;
+	const Color word_highlighted_color =          Color(mono_value, mono_value, mono_value, 0.12);
 	const Color number_color =                    p_config.dark_theme ? Color(0.63, 1, 0.88) : Color(0, 0.55, 0.28, 1);
 	const Color function_color =                  p_config.dark_theme ? Color(0.34, 0.7, 1.0) : Color(0, 0.225, 0.9, 1);
 	const Color member_variable_color =           p_config.dark_theme ? Color(0.34, 0.7, 1.0).lerp(p_config.mono_color, 0.6) : Color(0, 0.4, 0.68, 1);


### PR DESCRIPTION
This makes the highlight more visible.

- This closes https://github.com/godotengine/godot-proposals/issues/7785.

## Preview

### Before

![Screenshot_20230921_160235](https://github.com/godotengine/godot-proposals/assets/180032/298fcc0b-583e-4502-b5fa-441ab30182fc)

### After[^1]

![image](https://github.com/godotengine/godot-proposals/assets/180032/29a5bbaa-f508-495c-a2c8-2effe0f6f216)

[^1]: Screenshot was taken with opacity 32, but the final opacity in this PR is 31. The visual difference is tiny, but it's technically there.