### PR TITLE
Add support for ImageTexture3D serialization

### DIFF
--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -137,6 +137,9 @@ class ImageTexture3D : public Texture3D {
 	int depth = 1;
 	bool mipmaps = false;
 
+	TypedArray<Image> _get_images() const;
+	void _set_images(const TypedArray<Image> &p_images);
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
Fixes #80866

In the issue comment, @clayjohn posted a partially working diff to support ImageTexture3D serilization. I took it and modifed the code to make it work correctly (at least in the MRP provided).

If anyone needs this function, feel free to take it and help test this code. I would appreciate any feedback or alternative suggestions.


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
