### PR TITLE
Add a new method for EditorInspector "get_object_edited"

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1000,7 +1000,7 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_focusable", "control"), &EditorProperty::add_focusable);
 	ClassDB::bind_method(D_METHOD("set_bottom_editor", "editor"), &EditorProperty::set_bottom_editor);
 
-	ClassDB::bind_method(D_METHOD("get_object_edited"), &EditorProperty::get_object_edited);
+	ClassDB::bind_method(D_METHOD("get_edited_object"), &EditorProperty::get_edited_object);
 
 	ClassDB::bind_method(D_METHOD("emit_changed", "property", "value", "field", "changing"), &EditorProperty::emit_changed, DEFVAL(StringName()), DEFVAL(false));
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1000,6 +1000,8 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_focusable", "control"), &EditorProperty::add_focusable);
 	ClassDB::bind_method(D_METHOD("set_bottom_editor", "editor"), &EditorProperty::set_bottom_editor);
 
+	ClassDB::bind_method(D_METHOD("get_object_edited"), &EditorProperty::get_object_edited);
+
 	ClassDB::bind_method(D_METHOD("emit_changed", "property", "value", "field", "changing"), &EditorProperty::emit_changed, DEFVAL(StringName()), DEFVAL(false));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");


### PR DESCRIPTION
Would allow plugins to know which object is being edited, for a very useful case: live-editing, sending changes back to the server

Valid use:
```gdscript

@tool
extends EditorPlugin

func _print_property_edited(property: String):
	print(get_editor_interface().get_inspector().get_object_edited(),".",property)

func _enter_tree():
	# Initialization of the plugin goes here.
	get_editor_interface().get_inspector().property_edited.connect(_print_property_edited)


func _exit_tree():
	# Clean-up of the plugin goes here.
	get_editor_interface().get_inspector().property_edited.disconnect(_print_property_edited)
