### PR TITLE
Allow creating project directory from path input more easily

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -69,6 +69,7 @@ private:
 
 	Mode mode = MODE_NEW;
 	bool is_folder_empty = true;
+	bool need_mkdir = false;
 
 	Button *browse = nullptr;
 	Button *install_browse = nullptr;


### PR DESCRIPTION
So that you can just enter project name and where you want to save it, without the need to create the folder manually outside the engine or needing to hit the "Create Folder" button.

e.g. project names may often contain spaces, but you might not want them in your (auto generated) folder name.

Just an ergonomic thing since it annoyed me needing to create a folder every time when creating a project.

Will only create folders if the parent folder path exists and shows a warning message in case it will create a folder.

I don't think there are any security considerations for this, since it doesn't introduce any new functionality, since there was already a "Create Folder" button that does basically the same thing, but being less transparent to the user what is happening.

The root motivation that appeared in my youtube recommendations why I added this:  https://youtu.be/KTWHdLZZdGw?t=57 (loud audio warning)

It's just a meme, but the struggle creating a new project seems genuine.

I would also like to add that just entering a path should update the project name while typing, instead of just taking the first letter like it does now. However I would do that in a separate PR.

https://github.com/godotengine/godot/assets/2035977/69debb1f-e22f-4830-bff0-2ee938b2f8b7

Before there would be a real overhaul of the project manager & creator, I think this is a simple improvement to the existing one.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
