### PR TITLE
Add a new method for EditorInspector "get_object_edited"

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4242,6 +4242,7 @@ void EditorInspector::_show_add_meta_dialog() {
 void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
+	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));


### PR DESCRIPTION
Would allow plugins to know which object is being edited, for a very useful case: live-editing, sending changes back to the server

Valid use:

```gdscript
@tool
extends EditorPlugin

func _print_property_edited(property: String):
	print(get_editor_interface().get_inspector().get_object_edited(),".",property)

func _enter_tree():
	# Initialization of the plugin goes here.
	get_editor_interface().get_inspector().property_edited.connect(_print_property_edited)


func _exit_tree():
	# Clean-up of the plugin goes here.
	get_editor_interface().get_inspector().property_edited.disconnect(_print_property_edited)
```