### PR TITLE
Enable scrolling of output with UI scale changes

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1760,7 +1760,7 @@ void RichTextLabel::_scroll_changed(double) {
 		return;
 	}
 
-	if (scroll_follow && vscroll->get_value() >= (vscroll->get_max() - vscroll->get_page())) {
+	if (scroll_follow && vscroll->get_value() >= (vscroll->get_max() - Math::round(vscroll->get_page()))) {
 		scroll_following = true;
 	} else {
 		scroll_following = false;


### PR DESCRIPTION
Fixes #82041

Changing the UI custom scale could prevent editor output window from scrolling.

Cause: The logic for determining to scroll the editor output window could be adversely affected by the UI custom scaling.

Solution: Added rounding to vscroll->getpage() within the logic for determining if the output window should scroll.
