### PR TITLE
Converted get_available_bytes return type from int to uint32_t

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -438,8 +438,8 @@ Error HTTPClientTCP::poll() {
 			return OK;
 		} break;
 		case STATUS_REQUESTING: {
-			if (request_buffer->get_available_bytes()) {
-				int avail = request_buffer->get_available_bytes();
+			uint32_t avail = request_buffer->get_available_bytes();
+			if (avail) {
 				int pos = request_buffer->get_position();
 				const Vector<uint8_t> data = request_buffer->get_data_array();
 				int wrote = 0;

--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -66,7 +66,7 @@ public:
 	virtual Ref<NetSocket> accept(IPAddress &r_ip, uint16_t &r_port) = 0;
 
 	virtual bool is_open() const = 0;
-	virtual int get_available_bytes() const = 0;
+	virtual uint32_t get_available_bytes() const = 0;
 	virtual Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) const = 0;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled) = 0; // Returns OK if the socket option has been set successfully.

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -522,7 +522,7 @@ Error StreamPeerBuffer::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_
 	return OK;
 }
 
-int StreamPeerBuffer::get_available_bytes() const {
+uint32_t StreamPeerBuffer::get_available_bytes() const {
 	return data.size() - pointer;
 }
 

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -59,7 +59,7 @@ public:
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) = 0; ///< read as much data as p_bytes into buffer, if less was read, return in r_received
 
-	virtual int get_available_bytes() const = 0;
+	virtual uint32_t get_available_bytes() const = 0;
 
 	/* helpers */
 	void set_big_endian(bool p_big_endian);
@@ -115,7 +115,7 @@ public:
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 	GDVIRTUAL3R(Error, _get_partial_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>);
 
-	EXBIND0RC(int, get_available_bytes);
+	EXBIND0RC(uint32_t, get_available_bytes);
 };
 
 class StreamPeerBuffer : public StreamPeer {
@@ -134,7 +134,7 @@ public:
 	Error get_data(uint8_t *p_buffer, int p_bytes) override;
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 
-	virtual int get_available_bytes() const override;
+	virtual uint32_t get_available_bytes() const override;
 
 	void seek(int p_pos);
 	int get_size() const;

--- a/core/io/stream_peer_gzip.cpp
+++ b/core/io/stream_peer_gzip.cpp
@@ -187,7 +187,7 @@ Error StreamPeerGZIP::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_re
 	return OK;
 }
 
-int StreamPeerGZIP::get_available_bytes() const {
+uint32_t StreamPeerGZIP::get_available_bytes() const {
 	return rb.data_left();
 }
 

--- a/core/io/stream_peer_gzip.h
+++ b/core/io/stream_peer_gzip.h
@@ -67,7 +67,7 @@ public:
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 
-	virtual int get_available_bytes() const override;
+	virtual uint32_t get_available_bytes() const override;
 
 	StreamPeerGZIP();
 	~StreamPeerGZIP();

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -279,8 +279,8 @@ Error StreamPeerTCP::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_rec
 	return read(p_buffer, p_bytes, r_received, false);
 }
 
-int StreamPeerTCP::get_available_bytes() const {
-	ERR_FAIL_COND_V(!_sock.is_valid(), -1);
+uint32_t StreamPeerTCP::get_available_bytes() const {
+	ERR_FAIL_COND_V(!_sock.is_valid(), 0);
 	return _sock->get_available_bytes();
 }
 

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -70,7 +70,7 @@ public:
 	int get_local_port() const;
 	void disconnect_from_host();
 
-	int get_available_bytes() const override;
+	uint32_t get_available_bytes() const override;
 	Status get_status() const;
 
 	void set_no_delay(bool p_enabled);

--- a/drivers/unix/net_socket_posix.cpp
+++ b/drivers/unix/net_socket_posix.cpp
@@ -739,15 +739,15 @@ bool NetSocketPosix::is_open() const {
 	return _sock != SOCK_EMPTY;
 }
 
-int NetSocketPosix::get_available_bytes() const {
-	ERR_FAIL_COND_V(!is_open(), -1);
+uint32_t NetSocketPosix::get_available_bytes() const {
+	ERR_FAIL_COND_V(!is_open(), 0);
 
 	unsigned long len;
 	int ret = SOCK_IOCTL(_sock, FIONREAD, &len);
 	if (ret == -1) {
 		_get_socket_error();
 		print_verbose("Error when checking available bytes on socket.");
-		return -1;
+		return 0;
 	}
 	return len;
 }

--- a/drivers/unix/net_socket_posix.h
+++ b/drivers/unix/net_socket_posix.h
@@ -89,7 +89,7 @@ public:
 	virtual Ref<NetSocket> accept(IPAddress &r_ip, uint16_t &r_port);
 
 	virtual bool is_open() const;
-	virtual int get_available_bytes() const;
+	virtual uint32_t get_available_bytes() const;
 	virtual Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) const;
 
 	virtual Error set_broadcasting_enabled(bool p_enabled);

--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -184,3 +184,11 @@ Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHan
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_normal/arguments/1': type changed value in new API, from "const void*" to "Vector3".
 
 Intentional compatibility breakage to be consistent with the new non-virtual set_vertex/set_normal.
+
+
+GH-82087
+--------
+Validate extension JSON: Error: Field 'classes/StreamPeer/methods/get_available_bytes/return_value': meta changed value in new API, from "int32" to "uint32".
+Validate extension JSON: Error: Field 'classes/StreamPeerExtension/methods/_get_available_bytes/return_value': meta changed value in new API, from "int32" to "uint32".
+
+get_available_bytes return type changed to uin32_t to fix undefined behavior

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -259,7 +259,7 @@ void StreamPeerMbedTLS::poll() {
 	}
 }
 
-int StreamPeerMbedTLS::get_available_bytes() const {
+uint32_t StreamPeerMbedTLS::get_available_bytes() const {
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, 0);
 
 	return mbedtls_ssl_get_bytes_avail(&(tls_ctx->tls));

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -68,7 +68,7 @@ public:
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes);
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
-	virtual int get_available_bytes() const;
+	virtual uint32_t get_available_bytes() const;
 
 	static void initialize_tls();
 	static void finalize_tls();

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -276,7 +276,7 @@ Error WSLPeer::_do_server_handshake() {
 		return OK;
 	}
 
-	int left = handshake_buffer->get_available_bytes();
+	uint32_t left = handshake_buffer->get_available_bytes();
 	if (left) {
 		Vector<uint8_t> data = handshake_buffer->get_data_array();
 		int pos = handshake_buffer->get_position();
@@ -351,7 +351,7 @@ void WSLPeer::_do_client_handshake() {
 
 	// Do websocket handshake.
 	if (pending_request) {
-		int left = handshake_buffer->get_available_bytes();
+		uint32_t left = handshake_buffer->get_available_bytes();
 		int pos = handshake_buffer->get_position();
 		const Vector<uint8_t> data = handshake_buffer->get_data_array();
 		int sent = 0;
@@ -371,7 +371,7 @@ void WSLPeer::_do_client_handshake() {
 	} else {
 		int read = 0;
 		while (true) {
-			int left = handshake_buffer->get_available_bytes();
+			uint32_t left = handshake_buffer->get_available_bytes();
 			int pos = handshake_buffer->get_position();
 			if (left == 0) {
 				// Header is too big


### PR DESCRIPTION
Fixes #41287

Problem: undefined behavior because of conversion from unsigned long to signed int. Possible bug because return value is used as implicit bool (error was -1)

Solution : Use size_t for return type as the method returns a number of bytes in a buffer