### PR TITLE
GDScript: Prevent constructing and inheriting engine singletons

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/engine_singleton_instantiate.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/engine_singleton_instantiate.gd
@@ -1,0 +1,2 @@
+func test():
+	Time.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/engine_singleton_instantiate.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/engine_singleton_instantiate.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot construct native class "Time" because it is an engine singleton.

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_engine_singleton.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_engine_singleton.gd
@@ -1,0 +1,6 @@
+# GH-82081
+
+extends Time
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/extend_engine_singleton.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/extend_engine_singleton.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Cannot inherit native class "Time" because it is an engine singleton.


### PR DESCRIPTION
* Fixes #80728.
* Fixes #82081.

You cannot create a new instance of an engine singleton.

https://github.com/godotengine/godot/blob/fe5b1c8d49313d63fbe91cb7cdf463e10fb86afa/core/os/time.cpp#L446-L449