### PR TITLE
Move `blit_to_screen_list` hash map to a member variable

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -600,6 +600,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 void RendererViewport::draw_viewports() {
 	timestamp_vp_map.clear();
+	blit_to_screen_list.clear();
 
 	// get our xr interface in case we need it
 	Ref<XRInterface> xr_interface;
@@ -621,7 +622,6 @@ void RendererViewport::draw_viewports() {
 		sorted_active_viewports_dirty = false;
 	}
 
-	HashMap<DisplayServer::WindowID, Vector<BlitToScreen>> blit_to_screen_list;
 	//draw viewports
 	RENDER_TIMESTAMP("> Render Viewports");
 

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -185,6 +185,7 @@ public:
 	};
 
 	HashMap<String, RID> timestamp_vp_map;
+	HashMap<DisplayServer::WindowID, Vector<BlitToScreen>> blit_to_screen_list;
 
 	uint64_t draw_viewports_pass = 0;
 


### PR DESCRIPTION
The hash map can be cleared and reused on each `draw_viewports` invocation from the main loop iteration, instead of allocating a new one each time and then freeing it.

Fixes #82097
