### PR TITLE
Fix ShaderGlobalsOverride property handling

### DIFF
--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -41,7 +41,7 @@ StringName *ShaderGlobalsOverride::_remap(const StringName &p_name) const {
 		if (p.begins_with("params/")) {
 			String q = p.replace_first("params/", "");
 			param_remaps[p] = q;
-			r = param_remaps.getptr(q);
+			r = param_remaps.getptr(p);
 		}
 	}
 


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/82090

A simple typo in property name remapping stopped the overrides from working properly. The properties were actually serialized correctly, but because the remapped names came out wrong they didn't show correct values in the inspector or have any visual effect in rendering after a reload.