### PR TITLE
Fix `push_error` hiding prints in editor output

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -644,6 +644,11 @@
 				Triggers when the mouse enters a meta tag.
 			</description>
 		</signal>
+		<signal name="thread_finish">
+			<description>
+				Triggers when the background thread has finished text processing. See [member threaded].
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="LIST_NUMBERS" value="0" enum="ListType">

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -284,6 +284,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 
 	if (unlikely(log->is_updating())) {
 		// The new message arrived during log RTL text processing/redraw (invalid BiDi control characters / font error), ignore it to avoid RTL data corruption.
+		need_rebuld = true;
 		return;
 	}
 
@@ -379,6 +380,13 @@ void EditorLog::_reset_message_counts() {
 	}
 }
 
+void EditorLog::_check_need_rebuild() {
+	if (need_rebuld && !log->is_updating()) {
+		need_rebuld = false;
+		_rebuild_log();
+	}
+}
+
 EditorLog::EditorLog() {
 	save_state_timer = memnew(Timer);
 	save_state_timer->set_wait_time(2);
@@ -405,6 +413,7 @@ EditorLog::EditorLog() {
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
 	log->set_deselect_on_focus_loss_enabled(false);
+	log->connect("thread_finish", callable_mp(this, &EditorLog::_check_need_rebuild));
 	vb_left->add_child(log);
 
 	// Search box

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -149,6 +149,7 @@ private:
 
 	bool is_loading_state = false; // Used to disable saving requests while loading (some signals from buttons will try trigger a save, which happens during loading).
 	Timer *save_state_timer = nullptr;
+	bool need_rebuld = false;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type);
 
@@ -178,6 +179,8 @@ private:
 	void _load_state();
 
 	void _update_theme();
+
+	void _check_need_rebuild();
 
 protected:
 	void _notification(int p_what);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2708,6 +2708,7 @@ void RichTextLabel::_thread_function(void *p_userdata) {
 	_process_line_caches();
 	updating.store(false);
 	call_deferred(SNAME("thread_end"));
+	call_deferred("emit_signal", SNAME("thread_finish"));
 }
 
 void RichTextLabel::_thread_end() {
@@ -5778,6 +5779,8 @@ void RichTextLabel::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("meta_hover_ended", PropertyInfo(Variant::NIL, "meta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 
 	ADD_SIGNAL(MethodInfo("finished"));
+
+	ADD_SIGNAL(MethodInfo("thread_finish"));
 
 	BIND_ENUM_CONSTANT(LIST_NUMBERS);
 	BIND_ENUM_CONSTANT(LIST_LETTERS);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix push_error hiding prints in editor output

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/81930*