### PR TITLE
Added Shortcuts to TileSetEditor Actions

### DIFF
--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -874,12 +874,14 @@ TileSetEditor::TileSetEditor() {
 	sources_delete_button->set_flat(true);
 	sources_delete_button->set_disabled(true);
 	sources_delete_button->connect("pressed", callable_mp(this, &TileSetEditor::_source_delete_pressed));
+	sources_delete_button->set_shortcut(ED_SHORTCUT("tile_set_editor/delete_tile_source", TTR("Delete Tile Source"), Key::KEY_DELETE)); 
 	sources_bottom_actions->add_child(sources_delete_button);
 
 	sources_add_button = memnew(MenuButton);
 	sources_add_button->set_flat(true);
 	sources_add_button->get_popup()->add_item(TTR("Atlas"));
 	sources_add_button->get_popup()->add_item(TTR("Scenes Collection"));
+	sources_add_button->set_shortcut(ED_SHORTCUT("tile_set_editor/add_tile_source", TTR("Add Tile Source"), KeyModifierMask::CMD_OR_CTRL | Key::A));
 	sources_add_button->get_popup()->connect("id_pressed", callable_mp(this, &TileSetEditor::_source_add_id_pressed));
 	sources_bottom_actions->add_child(sources_add_button);
 


### PR DESCRIPTION
# What has been done
* Shortcut for when TileSet Source is Added
* Shortcut for when TileSetSource is Deleted

# Showcase

https://github.com/godotengine/godot/assets/12395493/e8fe5a8e-3768-43ab-bca4-8dbdb82a747a

