### PR TITLE
Harmonize prolog to include vk_mem_alloc.h

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -39,7 +39,7 @@
 #include "servers/rendering/rendering_device.h"
 
 #ifdef DEBUG_ENABLED
-#ifndef _DEBUG
+#ifndef _MSC_VER
 #define _DEBUG
 #endif
 #endif


### PR DESCRIPTION
We are including `vk_mem_alloc.h` in two places, with slightly different rules to define `_DEBUG` before the inclusion happens. I've chosen to favor the most recent one as the most correct (added in db81928e08cb58d5f67908c6dfcf9433e572ffe8).

This may help avoiding violations of the ODR. Maybe changes nothing in practice, but it's more correct this way.