### PR TITLE
C# - Add default constructor for ExportAttribute

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -21,6 +21,15 @@ namespace Godot
         /// <summary>
         /// Constructs a new ExportAttribute Instance.
         /// </summary>
+        public ExportAttribute()
+        {
+            Hint = PropertyHint.None;
+            HintString = "";
+        }
+
+        /// <summary>
+        /// Constructs a new ExportAttribute Instance.
+        /// </summary>
         /// <param name="hint">The hint for the exported property.</param>
         /// <param name="hintString">A string that may contain additional metadata for the hint.</param>
         public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")


### PR DESCRIPTION
This makes it so the IDE doesn't automatically add redundant parentheses when using the `Export` attribute, saving a lot of development time in the long run.