### PR TITLE
Fix Windows file dialog doesn't support multiple file patterns in a single file filter

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -227,7 +227,11 @@ Error DisplayServerWindows::file_dialog_show(const String &p_title, const String
 	for (const String &E : p_filters) {
 		Vector<String> tokens = E.split(";");
 		if (tokens.size() == 2) {
+#if defined(WINDOWS_ENABLED)
+			filter_exts.push_back(tokens[0].replace(",", ";").strip_edges().utf16());
+#else
 			filter_exts.push_back(tokens[0].strip_edges().utf16());
+#endif // WINDOWS_ENABLED
 			filter_names.push_back(tokens[1].strip_edges().utf16());
 		} else if (tokens.size() == 1) {
 			filter_exts.push_back(tokens[0].strip_edges().utf16());


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix Windows file dialog doesn't support multiple file patterns in a single file filter 

* *Bugsquad edit, fixes: #81781*