### PR TITLE
GDScript: Add `INFERRED_DECLARATION` warning

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -472,6 +472,10 @@
 		<member name="debug/gdscript/warnings/inference_on_variant" type="int" setter="" getter="" default="2">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a static inferred type uses a [Variant] as initial value, which makes the static type to also be Variant.
 		</member>
+		<member name="debug/gdscript/warnings/inferred_declaration" type="int" setter="" getter="" default="0">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a variable, constant, or parameter has an implicitly inferred static type.
+			[b]Note:[/b] This warning is recommended [i]in addition[/i] to [member debug/gdscript/warnings/untyped_declaration] if you want to always specify the type explicitly. Having [code]INFERRED_DECLARATION[/code] warning level higher than [code]UNTYPED_DECLARATION[/code] warning level makes little sense and is not recommended.
+		</member>
 		<member name="debug/gdscript/warnings/int_as_enum_without_cast" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when trying to use an integer as an enum without an explicit cast.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1932,9 +1932,14 @@ void GDScriptAnalyzer::resolve_assignable(GDScriptParser::AssignableNode *p_assi
 	}
 
 #ifdef DEBUG_ENABLED
-	if (!has_specified_type && !p_assignable->infer_datatype && !is_constant) {
+	if (!has_specified_type) {
 		const bool is_parameter = p_assignable->type == GDScriptParser::Node::PARAMETER;
-		parser->push_warning(p_assignable, GDScriptWarning::UNTYPED_DECLARATION, is_parameter ? "Parameter" : "Variable", p_assignable->identifier->name);
+		const String declaration_type = is_constant ? "Constant" : (is_parameter ? "Parameter" : "Variable");
+		if (p_assignable->infer_datatype || is_constant) {
+			parser->push_warning(p_assignable, GDScriptWarning::INFERRED_DECLARATION, declaration_type, p_assignable->identifier->name);
+		} else {
+			parser->push_warning(p_assignable, GDScriptWarning::UNTYPED_DECLARATION, declaration_type, p_assignable->identifier->name);
+		}
 	}
 #endif
 
@@ -2148,7 +2153,9 @@ void GDScriptAnalyzer::resolve_for(GDScriptParser::ForNode *p_for) {
 		} else {
 			p_for->variable->set_datatype(variable_type);
 #ifdef DEBUG_ENABLED
-			if (!variable_type.is_hard_type()) {
+			if (variable_type.is_hard_type()) {
+				parser->push_warning(p_for->variable, GDScriptWarning::INFERRED_DECLARATION, R"("for" iterator variable)", p_for->variable->name);
+			} else {
 				parser->push_warning(p_for->variable, GDScriptWarning::UNTYPED_DECLARATION, R"("for" iterator variable)", p_for->variable->name);
 			}
 #endif

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -94,6 +94,9 @@ String GDScriptWarning::get_message() const {
 				return vformat(R"*(%s "%s()" has no static return type.)*", symbols[0], symbols[1]);
 			}
 			return vformat(R"(%s "%s" has no static type.)", symbols[0], symbols[1]);
+		case INFERRED_DECLARATION:
+			CHECK_SYMBOLS(2);
+			return vformat(R"(%s "%s" has an implicitly inferred static type.)", symbols[0], symbols[1]);
 		case UNSAFE_PROPERTY_ACCESS:
 			CHECK_SYMBOLS(2);
 			return vformat(R"(The property "%s" is not present on the inferred type "%s" (but may be present on a subtype).)", symbols[0], symbols[1]);
@@ -207,6 +210,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"CONSTANT_USED_AS_FUNCTION",
 		"FUNCTION_USED_AS_PROPERTY",
 		"UNTYPED_DECLARATION",
+		"INFERRED_DECLARATION",
 		"UNSAFE_PROPERTY_ACCESS",
 		"UNSAFE_METHOD_ACCESS",
 		"UNSAFE_CAST",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -64,7 +64,8 @@ public:
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
 		FUNCTION_USED_AS_PROPERTY, // Property not found, but there's a function with the same name.
-		UNTYPED_DECLARATION, // Variable/parameter/function has no static type, explicitly specified or inferred (`:=`).
+		UNTYPED_DECLARATION, // Variable/parameter/function has no static type, explicitly specified or implicitly inferred.
+		INFERRED_DECLARATION, // Variable/constant/parameter has an implicitly inferred static type.
 		UNSAFE_PROPERTY_ACCESS, // Property not found in the detected type (but can be in subtypes).
 		UNSAFE_METHOD_ACCESS, // Function not found in the detected type (but can be in subtypes).
 		UNSAFE_CAST, // Cast used in an unknown type.
@@ -113,6 +114,7 @@ public:
 		WARN, // CONSTANT_USED_AS_FUNCTION
 		WARN, // FUNCTION_USED_AS_PROPERTY
 		IGNORE, // UNTYPED_DECLARATION // Static typing is optional, we don't want to spam warnings.
+		IGNORE, // INFERRED_DECLARATION // Static typing is optional, we don't want to spam warnings.
 		IGNORE, // UNSAFE_PROPERTY_ACCESS // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_METHOD_ACCESS // Too common in untyped scenarios.
 		IGNORE, // UNSAFE_CAST // Too common in untyped scenarios.

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -149,7 +149,7 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 	// Set all warning levels to "Warn" in order to test them properly, even the ones that default to error.
 	ProjectSettings::get_singleton()->set_setting("debug/gdscript/warnings/enable", true);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
-		if (i == GDScriptWarning::UNTYPED_DECLARATION) {
+		if (i == GDScriptWarning::UNTYPED_DECLARATION || i == GDScriptWarning::INFERRED_DECLARATION) {
 			// TODO: Add ability for test scripts to specify which warnings to enable/disable for testing.
 			continue;
 		}


### PR DESCRIPTION
* Continuation of #81355.
* Closes godotengine/godot-proposals#3284.

**Note A.** This warning is _in addition_ to `UNTYPED_DECLARATION`, rather than _including_ to. In my opinion, this makes the most sense because if the user enables all warnings, then they won't end up with a situation where one declaration generates both warnings.

```gdscript
var a = 1 # Warning: UNTYPED_DECLARATION.
var b := 2 # Warning: INFERRED_DECLARATION.
var c: int = 3 # No warning.
```

So the user has a choice:

1. Don't enable warnings.
2. Enable only `UNTYPED_DECLARATION`, use static types (explicitly or implicitly), gaining the benefits of static checks.
3. Enable both warnings. More readable, but more verbose. Like C++ without the `auto` keyword.

It's technically possible to only enable `INFERRED_DECLARATION`, but I don't see much point in doing so.

**Note B.** This is a bit against the style we recommend, since a warning is generated on _any_ type inference. It doesn't matter whether the initializer contains a type name or not. The warning requires that you specify the type explicitly:

```gdscript
var vector := Vector2() # Warning.
var node := Node.new() # Warning.
var control: Control = Control.new() # No warning.
```

While this is more verbose and we can implement this check, I don't think we should do it. This verbosity gives additional reliability.

For example, if you have `var x := Type.new()`, you could forget about the **type** and accidentally change it when you change the **value** to `SubType.new()`. Or copy-paste `Vector2i(128, 96)` in place of `Vector2(64, 48)` and change the type from `Vector2` to `Vector2i` without noticing it due to implicit conversions.

**Note С.** I'm not sure about the name, maybe `INFERRED_TYPE_DECLARATION` is better (instead of `INFERRED_DECLARATION`)?

CC @ryanabx