### PR TITLE
Add transition parameters to Tween

### DIFF
--- a/doc/classes/MethodTweener.xml
+++ b/doc/classes/MethodTweener.xml
@@ -32,5 +32,13 @@
 				Sets the type of used transition from [enum Tween.TransitionType]. If not set, the default transition is used from the [Tween] that contains this Tweener.
 			</description>
 		</method>
+		<method name="set_trans_params">
+			<return type="MethodTweener" />
+			<param index="0" name="param1" type="float" />
+			<param index="1" name="param2" type="float" default="inf" />
+			<description>
+				Sets parameters of the transition. They are used only in specific transitions, check [enum Tween.TransitionType] for details.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/PropertyTweener.xml
+++ b/doc/classes/PropertyTweener.xml
@@ -120,5 +120,13 @@
 				Sets the type of used transition from [enum Tween.TransitionType]. If not set, the default transition is used from the [Tween] that contains this Tweener.
 			</description>
 		</method>
+		<method name="set_trans_params">
+			<return type="PropertyTweener" />
+			<param index="0" name="param1" type="float" />
+			<param index="1" name="param2" type="float" default="inf" />
+			<description>
+				Sets parameters of the transition. They are used only in specific transitions, check [enum Tween.TransitionType] for details.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -152,12 +152,15 @@
 			<param index="3" name="duration" type="float" />
 			<param index="4" name="trans_type" type="int" enum="Tween.TransitionType" />
 			<param index="5" name="ease_type" type="int" enum="Tween.EaseType" />
+			<param index="6" name="trans_param1" type="float" default="inf" />
+			<param index="7" name="trans_param2" type="float" default="inf" />
 			<description>
 				This method can be used for manual interpolation of a value, when you don't want [Tween] to do animating for you. It's similar to [method @GlobalScope.lerp], but with support for custom transition and easing.
 				[param initial_value] is the starting value of the interpolation.
 				[param delta_value] is the change of the value in the interpolation, i.e. it's equal to [code]final_value - initial_value[/code].
 				[param elapsed_time] is the time in seconds that passed after the interpolation started and it's used to control the position of the interpolation. E.g. when it's equal to half of the [param duration], the interpolated value will be halfway between initial and final values. This value can also be greater than [param duration] or lower than 0, which will extrapolate the value.
 				[param duration] is the total time of the interpolation.
+				[param trans_param1] and [param trans_param2] are control parameters of the transition. They are used only in specific transitions, check [enum TransitionType] for details.
 				[b]Note:[/b] If [param duration] is equal to [code]0[/code], the method will always return the final value, regardless of [param elapsed_time] provided.
 			</description>
 		</method>
@@ -292,6 +295,14 @@
 				tween.set_trans(Tween.TRANS_SINE)
 				tween.tween_property(self, "rotation_degrees", 45.0, 0.5) # Uses TRANS_SINE.
 				[/codeblock]
+			</description>
+		</method>
+		<method name="set_trans_params">
+			<return type="Tween" />
+			<param index="0" name="param1" type="float" />
+			<param index="1" name="param2" type="float" default="inf" />
+			<description>
+				Sets parameters of the transition. They are used only in specific transitions, check [enum TransitionType] for details.
 			</description>
 		</method>
 		<method name="stop">
@@ -581,6 +592,8 @@
 		</constant>
 		<constant name="TRANS_ELASTIC" value="6" enum="TransitionType">
 			The animation is interpolated with elasticity, wiggling around the edges.
+			[code]param1[/code] is [code]period[/code], it determines the frequency of wiggling. Default is [code]0.3[/code].
+			[code]param2[/code] is [code]damping[/code], it determines how far the value wiggles (lower = more). Default is [code]10[/code].
 		</constant>
 		<constant name="TRANS_CUBIC" value="7" enum="TransitionType">
 			The animation is interpolated with a cubic (to the power of 3) function.
@@ -593,6 +606,7 @@
 		</constant>
 		<constant name="TRANS_BACK" value="10" enum="TransitionType">
 			The animation is interpolated backing out at ends.
+			[code]param1[/code] is [code]overshoot[/code], it determines how far the value goes out of range. Default is [code]1.70158[/code].
 		</constant>
 		<constant name="TRANS_SPRING" value="11" enum="TransitionType">
 			The animation is interpolated like a spring towards the end.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-82155.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-82155.txt
@@ -1,0 +1,5 @@
+GH-82155
+--------
+Validate extension JSON: Error: Field 'classes/Tween/methods/interpolate_value/arguments': size changed value in new API, from 6 to 8.
+
+Added optional arguments. Compatibility method registered.

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4528,7 +4528,13 @@ bool BindingsGenerator::_arg_default_value_from_variant(const Variant &p_val, Ar
 			r_iarg.default_argument = p_val.operator String();
 
 			if (r_iarg.type.cname == name_cache.type_float) {
-				r_iarg.default_argument += "f";
+				if (r_iarg.default_argument == "inf") {
+					r_iarg.default_argument = "float.PositiveInfinity";
+				} else if (r_iarg.default_argument == "inf_neg") {
+					r_iarg.default_argument = "float.NegativeInfinity";
+				} else {
+					r_iarg.default_argument += "f";
+				}
 			}
 			break;
 		case Variant::STRING:

--- a/scene/animation/easing_equations.h
+++ b/scene/animation/easing_equations.h
@@ -56,44 +56,46 @@
  * SOFTWARE.
  */
 
+#define EASING_FUNC(m_type) inline real_t m_type(real_t t, real_t b, real_t c, real_t d, real_t p1, real_t p2)
+
 namespace Linear {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	return c * t / d + b;
 }
 }; // namespace Linear
 
 namespace Sine {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	return -c * std::cos(t / d * (Math::PI / 2)) + c + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	return c * std::sin(t / d * (Math::PI / 2)) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	return -c / 2 * (std::cos(Math::PI * t / d) - 1) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Sine
 
 namespace Quint {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	return c * std::pow(t / d, 5) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	return c * (std::pow(t / d - 1, 5) + 1) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	t = t / d * 2;
 
 	if (t < 1) {
@@ -102,25 +104,25 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return c / 2 * (std::pow(t - 2, 5) + 2) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Quint
 
 namespace Quart {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	return c * std::pow(t / d, 4) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	return -c * (std::pow(t / d - 1, 4) - 1) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	t = t / d * 2;
 
 	if (t < 1) {
@@ -129,26 +131,26 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return -c / 2 * (std::pow(t - 2, 4) - 2) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Quart
 
 namespace Quad {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	return c * std::pow(t / d, 2) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	t /= d;
 	return -c * t * (t - 2) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	t = t / d * 2;
 
 	if (t < 1) {
@@ -157,31 +159,31 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return -c / 2 * ((t - 1) * (t - 3) - 1) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Quad
 
 namespace Expo {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	if (t == 0) {
 		return b;
 	}
 	return c * std::pow(2, 10 * (t / d - 1)) + b - c * 0.001;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	if (t == d) {
 		return b + c;
 	}
 	return c * 1.001 * (-std::pow(2, -10 * t / d) + 1) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	if (t == 0) {
 		return b;
 	}
@@ -198,17 +200,17 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return c / 2 * 1.0005 * (-std::pow(2, -10 * (t - 1)) + 2) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Expo
 
 namespace Elastic {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	if (t == 0) {
 		return b;
 	}
@@ -219,14 +221,14 @@ inline real_t in(real_t t, real_t b, real_t c, real_t d) {
 	}
 
 	t -= 1;
-	float p = d * 0.3f;
-	float a = c * std::pow(2, 10 * t);
+	float p = d * p1;
+	float a = c * std::pow(2, p2 * t);
 	float s = p / 4;
 
 	return -(a * std::sin((t * d - s) * (2 * Math::PI) / p)) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	if (t == 0) {
 		return b;
 	}
@@ -236,13 +238,13 @@ inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 		return b + c;
 	}
 
-	float p = d * 0.3f;
+	float p = d * p1;
 	float s = p / 4;
 
 	return (c * std::pow(2, -10 * t) * std::sin((t * d - s) * (2 * Math::PI) / p) + c + b);
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	if (t == 0) {
 		return b;
 	}
@@ -251,42 +253,42 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 		return b + c;
 	}
 
-	float p = d * (0.3f * 1.5f);
+	float p = d * (p1 * 1.5f);
 	float a = c;
 	float s = p / 4;
 
 	if (t < 1) {
 		t -= 1;
-		a *= std::pow(2, 10 * t);
+		a *= std::pow(2, p2 * t);
 		return -0.5f * (a * std::sin((t * d - s) * (2 * Math::PI) / p)) + b;
 	}
 
 	t -= 1;
-	a *= std::pow(2, -10 * t);
+	a *= std::pow(2, -p2 * t);
 	return a * std::sin((t * d - s) * (2 * Math::PI) / p) * 0.5f + c + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Elastic
 
 namespace Cubic {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	t /= d;
 	return c * t * t * t + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	t = t / d - 1;
 	return c * (t * t * t + 1) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	t /= d / 2;
 	if (t < 1) {
 		return c / 2 * t * t * t + b;
@@ -296,27 +298,27 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return c / 2 * (t * t * t + 2) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Cubic
 
 namespace Circ {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in) {
 	t /= d;
 	return -c * (std::sqrt(1 - t * t) - 1) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	t = t / d - 1;
 	return c * std::sqrt(1 - t * t) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	t /= d / 2;
 	if (t < 1) {
 		return -c / 2 * (std::sqrt(1 - t * t) - 1) + b;
@@ -326,17 +328,17 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return c / 2 * (std::sqrt(1 - t * t) + 1) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Circ
 
 namespace Bounce {
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	t /= d;
 
 	if (t < (1 / 2.75f)) {
@@ -357,44 +359,44 @@ inline real_t out(real_t t, real_t b, real_t c, real_t d) {
 	return c * (7.5625f * t * t + 0.984375f) + b;
 }
 
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return c - out(d - t, 0, c, d) + b;
+EASING_FUNC(in) {
+	return c - out(d - t, 0, c, d, p1, p2) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	if (t < d / 2) {
-		return in(t * 2, b, c / 2, d);
+		return in(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return out(t * 2 - d, b + h, h, d);
+	return out(t * 2 - d, b + h, h, d, p1, p2);
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Bounce
 
 namespace Back {
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	float s = 1.70158f;
+EASING_FUNC(in) {
+	float s = p1;
 	t /= d;
 
 	return c * t * t * ((s + 1) * t - s) + b;
 }
 
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
-	float s = 1.70158f;
+EASING_FUNC(out) {
+	float s = p1;
 	t = t / d - 1;
 
 	return c * (t * t * ((s + 1) * t + s) + 1) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
-	float s = 1.70158f * 1.525f;
+EASING_FUNC(in_out) {
+	float s = p1 * 1.525f;
 	t /= d / 2;
 
 	if (t < 1) {
@@ -405,40 +407,40 @@ inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
 	return c / 2 * (t * t * ((s + 1) * t + s) + 2) + b;
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Back
 
 namespace Spring {
-inline real_t out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out) {
 	t /= d;
 	real_t s = 1.0 - t;
 	t = (std::sin(t * Math::PI * (0.2 + 2.5 * t * t * t)) * std::pow(s, 2.2) + t) * (1.0 + (1.2 * s));
 	return c * t + b;
 }
 
-inline real_t in(real_t t, real_t b, real_t c, real_t d) {
-	return c - out(d - t, 0, c, d) + b;
+EASING_FUNC(in) {
+	return c - out(d - t, 0, c, d, p1, p2) + b;
 }
 
-inline real_t in_out(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(in_out) {
 	if (t < d / 2) {
-		return in(t * 2, b, c / 2, d);
+		return in(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return out(t * 2 - d, b + h, h, d);
+	return out(t * 2 - d, b + h, h, d, p1, p2);
 }
 
-inline real_t out_in(real_t t, real_t b, real_t c, real_t d) {
+EASING_FUNC(out_in) {
 	if (t < d / 2) {
-		return out(t * 2, b, c / 2, d);
+		return out(t * 2, b, c / 2, d, p1, p2);
 	}
 	real_t h = c / 2;
-	return in(t * 2 - d, b + h, h, d);
+	return in(t * 2 - d, b + h, h, d, p1, p2);
 }
 }; // namespace Spring

--- a/scene/animation/tween.compat.inc
+++ b/scene/animation/tween.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  tween.compat.inc                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Variant Tween::_interpolate_variant_bind_compat_82155(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, TransitionType p_trans, EaseType p_ease) {
+	return interpolate_variant(p_initial_val, p_delta_val, p_time, p_duration, p_trans, p_ease, INFINITY, INFINITY);
+}
+
+void Tween::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_static_method("Tween", D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type"), &Tween::_interpolate_variant_bind_compat_82155);
+}
+
+#endif

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "tween.h"
+#include "tween.compat.inc"
 
 #include "scene/animation/easing_equations.h"
 #include "scene/main/node.h"
@@ -293,6 +294,12 @@ RequiredResult<Tween> Tween::set_trans(TransitionType p_trans) {
 	return this;
 }
 
+RequiredResult<Tween> Tween::set_trans_params(double p_param1, double p_param2) {
+	default_trans_params[0] = p_param1;
+	default_trans_params[1] = p_param2;
+	return this;
+}
+
 Tween::TransitionType Tween::get_trans() const {
 	return default_transition;
 }
@@ -304,6 +311,39 @@ RequiredResult<Tween> Tween::set_ease(EaseType p_ease) {
 
 Tween::EaseType Tween::get_ease() const {
 	return default_ease;
+}
+
+void Tween::get_transition_parameters(TransitionType p_trans, double *r_params) const {
+	for (int i = 0; i < Tween::PARAM_COUNT; i++) {
+		if (r_params[i] == Math::INF) {
+			r_params[i] = default_trans_params[i];
+		}
+	}
+
+	if (p_trans == TRANS_MAX) {
+		p_trans = default_transition;
+	}
+
+	switch (p_trans) {
+		case TransitionType::TRANS_ELASTIC: {
+			if (r_params[0] == Math::INF) { // period
+				r_params[0] = 0.3f;
+			}
+
+			if (r_params[1] == Math::INF) { // damping
+				r_params[1] = 10.f;
+			}
+		} break;
+
+		case TransitionType::TRANS_BACK: {
+			if (r_params[0] == Math::INF) { // overshoot
+				r_params[0] = 1.70158f;
+			}
+		} break;
+
+		default:
+			break;
+	}
 }
 
 RequiredResult<Tween> Tween::parallel() {
@@ -448,22 +488,22 @@ double Tween::get_total_time() const {
 	return total_time;
 }
 
-real_t Tween::run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t p_time, real_t p_initial, real_t p_delta, real_t p_duration) {
+real_t Tween::run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t p_time, real_t p_initial, real_t p_delta, real_t p_duration, double p_param1, double p_param2) {
 	if (p_duration == 0) {
 		// Special case to avoid dividing by 0 in equations.
 		return p_initial + p_delta;
 	}
 
 	interpolater func = interpolaters[p_trans_type][p_ease_type];
-	return func(p_time, p_initial, p_delta, p_duration);
+	return func(p_time, p_initial, p_delta, p_duration, (real_t)p_param1, (real_t)p_param2);
 }
 
-Variant Tween::interpolate_variant(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, TransitionType p_trans, EaseType p_ease) {
+Variant Tween::interpolate_variant(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, TransitionType p_trans, EaseType p_ease, double p_param1, double p_param2) {
 	ERR_FAIL_INDEX_V(p_trans, TransitionType::TRANS_MAX, Variant());
 	ERR_FAIL_INDEX_V(p_ease, EaseType::EASE_MAX, Variant());
 
 	Variant ret = Animation::add_variant(p_initial_val, p_delta_val);
-	ret = Animation::interpolate_variant(p_initial_val, ret, run_equation(p_trans, p_ease, p_time, 0.0, 1.0, p_duration), p_initial_val.is_string());
+	ret = Animation::interpolate_variant(p_initial_val, ret, run_equation(p_trans, p_ease, p_time, 0.0, 1.0, p_duration, p_param1, p_param2), p_initial_val.is_string());
 	return ret;
 }
 
@@ -503,12 +543,13 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_loops_left"), &Tween::get_loops_left);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed"), &Tween::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("set_trans", "trans"), &Tween::set_trans);
+	ClassDB::bind_method(D_METHOD("set_trans_params", "param1", "param2"), &Tween::set_trans_params, DEFVAL(Math::INF));
 	ClassDB::bind_method(D_METHOD("set_ease", "ease"), &Tween::set_ease);
 
 	ClassDB::bind_method(D_METHOD("parallel"), &Tween::parallel);
 	ClassDB::bind_method(D_METHOD("chain"), &Tween::chain);
 
-	ClassDB::bind_static_method("Tween", D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type"), &Tween::interpolate_variant);
+	ClassDB::bind_static_method("Tween", D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type", "trans_param1", "trans_param2"), &Tween::interpolate_variant, DEFVAL(INFINITY), DEFVAL(INFINITY));
 
 	ADD_SIGNAL(MethodInfo("step_finished", PropertyInfo(Variant::INT, "idx")));
 	ADD_SIGNAL(MethodInfo("loop_finished", PropertyInfo(Variant::INT, "loop_count")));
@@ -592,6 +633,12 @@ RequiredResult<PropertyTweener> PropertyTweener::set_trans(Tween::TransitionType
 	return this;
 }
 
+RequiredResult<PropertyTweener> PropertyTweener::set_trans_params(double p_param1, double p_param2) {
+	trans_params[0] = p_param1;
+	trans_params[1] = p_param2;
+	return this;
+}
+
 RequiredResult<PropertyTweener> PropertyTweener::set_ease(Tween::EaseType p_ease) {
 	ease_type = p_ease;
 	return this;
@@ -628,6 +675,7 @@ void PropertyTweener::start() {
 	}
 
 	delta_val = Animation::subtract_variant(final_val, initial_val);
+	_get_tween()->get_transition_parameters(trans_type, trans_params);
 }
 
 bool PropertyTweener::step(double &r_delta) {
@@ -657,11 +705,11 @@ bool PropertyTweener::step(double &r_delta) {
 	double time = MIN(elapsed_time - delay, duration);
 	if (time < duration) {
 		if (custom_method.is_valid()) {
-			const Variant t = tween->interpolate_variant(0.0, 1.0, time, duration, trans_type, ease_type);
+			const Variant t = tween->interpolate_variant(0.0, 1.0, time, duration, trans_type, ease_type, trans_params[0], trans_params[1]);
 			double result = _get_custom_interpolated_value(t);
 			target_instance->set_indexed(property, Animation::interpolate_variant(initial_val, final_val, result));
 		} else {
-			target_instance->set_indexed(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type));
+			target_instance->set_indexed(property, tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type, trans_params[0], trans_params[1]));
 		}
 		r_delta = 0;
 		return true;
@@ -693,6 +741,7 @@ void PropertyTweener::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("from_current"), &PropertyTweener::from_current);
 	ClassDB::bind_method(D_METHOD("as_relative"), &PropertyTweener::as_relative);
 	ClassDB::bind_method(D_METHOD("set_trans", "trans"), &PropertyTweener::set_trans);
+	ClassDB::bind_method(D_METHOD("set_trans_params", "param1", "param2"), &PropertyTweener::set_trans_params, DEFVAL(Math::INF));
 	ClassDB::bind_method(D_METHOD("set_ease", "ease"), &PropertyTweener::set_ease);
 	ClassDB::bind_method(D_METHOD("set_custom_interpolator", "interpolator_method"), &PropertyTweener::set_custom_interpolator);
 	ClassDB::bind_method(D_METHOD("set_delay", "delay"), &PropertyTweener::set_delay);
@@ -800,9 +849,20 @@ RequiredResult<MethodTweener> MethodTweener::set_trans(Tween::TransitionType p_t
 	return this;
 }
 
+RequiredResult<MethodTweener> MethodTweener::set_trans_params(double p_param1, double p_param2) {
+	trans_params[0] = p_param1;
+	trans_params[1] = p_param2;
+	return this;
+}
+
 RequiredResult<MethodTweener> MethodTweener::set_ease(Tween::EaseType p_ease) {
 	ease_type = p_ease;
 	return this;
+}
+
+void MethodTweener::start() {
+	Tweener::start();
+	_get_tween()->get_transition_parameters(trans_type, trans_params);
 }
 
 bool MethodTweener::step(double &r_delta) {
@@ -827,7 +887,7 @@ bool MethodTweener::step(double &r_delta) {
 	Variant current_val;
 	double time = MIN(elapsed_time - delay, duration);
 	if (time < duration) {
-		current_val = tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type);
+		current_val = tween->interpolate_variant(initial_val, delta_val, time, duration, trans_type, ease_type, trans_params[0], trans_params[1]);
 	} else {
 		current_val = final_val;
 	}
@@ -864,6 +924,7 @@ void MethodTweener::set_tween(const Ref<Tween> &p_tween) {
 void MethodTweener::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_delay", "delay"), &MethodTweener::set_delay);
 	ClassDB::bind_method(D_METHOD("set_trans", "trans"), &MethodTweener::set_trans);
+	ClassDB::bind_method(D_METHOD("set_trans_params", "param1", "param2"), &MethodTweener::set_trans_params, DEFVAL(Math::INF));
 	ClassDB::bind_method(D_METHOD("set_ease", "ease"), &MethodTweener::set_ease);
 }
 
@@ -997,3 +1058,5 @@ void AwaitTweener::_bind_methods() {
 void AwaitTweener::_signal_received(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	received = true;
 }
+
+#undef CHECK_VALID

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -69,6 +69,8 @@ class Tween : public RefCounted {
 	friend class PropertyTweener;
 
 public:
+	static inline constexpr int PARAM_COUNT = 2;
+
 	enum TweenProcessMode {
 		TWEEN_PROCESS_PHYSICS,
 		TWEEN_PROCESS_IDLE,
@@ -108,6 +110,7 @@ private:
 	TweenProcessMode process_mode = TweenProcessMode::TWEEN_PROCESS_IDLE;
 	TweenPauseMode pause_mode = TweenPauseMode::TWEEN_PAUSE_BOUND;
 	TransitionType default_transition = TransitionType::TRANS_LINEAR;
+	double default_trans_params[PARAM_COUNT] = { Math::INF, Math::INF };
 	EaseType default_ease = EaseType::EASE_IN_OUT;
 	ObjectID bound_node;
 
@@ -133,7 +136,7 @@ private:
 	bool is_infinite = false;
 #endif
 
-	typedef real_t (*interpolater)(real_t t, real_t b, real_t c, real_t d);
+	typedef real_t (*interpolater)(real_t t, real_t b, real_t c, real_t d, real_t p1, real_t p2);
 	static interpolater interpolaters[TRANS_MAX][EASE_MAX];
 
 	void _start_tweeners();
@@ -142,6 +145,12 @@ private:
 protected:
 	static void _bind_methods();
 	virtual String _to_string() override;
+
+#ifndef DISABLE_DEPRECATED
+	static Variant _interpolate_variant_bind_compat_82155(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, TransitionType p_trans, EaseType p_ease);
+
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	RequiredResult<PropertyTweener> tween_property(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_to, double p_duration);
@@ -175,15 +184,17 @@ public:
 	int get_loops_left() const;
 	RequiredResult<Tween> set_speed_scale(float p_speed);
 	RequiredResult<Tween> set_trans(TransitionType p_trans);
+	RequiredResult<Tween> set_trans_params(double p_param1, double p_param2 = Math::INF);
 	TransitionType get_trans() const;
 	RequiredResult<Tween> set_ease(EaseType p_ease);
 	EaseType get_ease() const;
+	void get_transition_parameters(TransitionType p_trans, double *r_params) const;
 
 	RequiredResult<Tween> parallel();
 	RequiredResult<Tween> chain();
 
-	static real_t run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d);
-	static Variant interpolate_variant(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease);
+	static real_t run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d, double p_param1 = Math::INF, double p_param2 = Math::INF);
+	static Variant interpolate_variant(const Variant &p_initial_val, const Variant &p_delta_val, double p_time, double p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease, double p_param1 = Math::INF, double p_param2 = Math::INF);
 
 	bool step(double p_delta);
 	bool can_process(bool p_tree_paused) const;
@@ -209,6 +220,7 @@ public:
 	RequiredResult<PropertyTweener> from_current();
 	RequiredResult<PropertyTweener> as_relative();
 	RequiredResult<PropertyTweener> set_trans(Tween::TransitionType p_trans);
+	RequiredResult<PropertyTweener> set_trans_params(double p_param1, double p_param2 = Math::INF);
 	RequiredResult<PropertyTweener> set_ease(Tween::EaseType p_ease);
 	RequiredResult<PropertyTweener> set_custom_interpolator(const Callable &p_method);
 	RequiredResult<PropertyTweener> set_delay(double p_delay);
@@ -236,6 +248,7 @@ private:
 	double duration = 0;
 	Tween::TransitionType trans_type = Tween::TRANS_MAX; // This is set inside set_tween();
 	Tween::EaseType ease_type = Tween::EASE_MAX;
+	double trans_params[Tween::PARAM_COUNT] = { Math::INF, Math::INF };
 	Callable custom_method;
 
 	double delay = 0;
@@ -283,10 +296,12 @@ class MethodTweener : public Tweener {
 
 public:
 	RequiredResult<MethodTweener> set_trans(Tween::TransitionType p_trans);
+	RequiredResult<MethodTweener> set_trans_params(double p_param1, double p_param2 = Math::INF);
 	RequiredResult<MethodTweener> set_ease(Tween::EaseType p_ease);
 	RequiredResult<MethodTweener> set_delay(double p_delay);
 
 	void set_tween(const Ref<Tween> &p_tween) override;
+	void start() override;
 	bool step(double &r_delta) override;
 
 	MethodTweener(const Callable &p_callback, const Variant &p_from, const Variant &p_to, double p_duration);
@@ -300,6 +315,7 @@ private:
 	double delay = 0;
 	Tween::TransitionType trans_type = Tween::TRANS_MAX;
 	Tween::EaseType ease_type = Tween::EASE_MAX;
+	double trans_params[Tween::PARAM_COUNT] = { Math::INF, Math::INF };
 
 	Variant initial_val;
 	Variant delta_val;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7802
tbh this change makes the code more complex than it's probably worth it. I don't think there is better way though; I didn't want it to affect performance.

TODO:
- ~~figure out `amplitude`, `period` for BACK equations~~ It doesn't use them?
- ~~figure out `overshoot`, `amplitude`, `period` for ELASTIC equations~~ It's `period` and `damping` now.
- TRANS_SPRING might also get parameters, as it's similar to elastic
- maybe other transitions might get parameters too?
- ~~add compat methods~~

I'll need help with the equations. I did `overshoot` for TRANS_BACK, because it was obvious. I'd appreciate if someone could just drop me implementations for other equations >_> (I have no idea about these numbers)

Here's BACK with default overshoot and 5

https://github.com/godotengine/godot/assets/2223172/43f1c52d-80df-4399-a59b-8152df5c9e24

