### PR TITLE
Change to InputEventMIDI event to include connection_index property

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1717,14 +1717,6 @@ int InputEventMIDI::get_controller_value() const {
 	return controller_value;
 }
 
-void InputEventMIDI::set_connection_index(const int p_connection_index) {
-	connection_index = p_connection_index;
-}
-
-int InputEventMIDI::get_connection_index() const {
-	return connection_index;
-}
-
 String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }
@@ -1770,8 +1762,6 @@ void InputEventMIDI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_number"), &InputEventMIDI::get_controller_number);
 	ClassDB::bind_method(D_METHOD("set_controller_value", "controller_value"), &InputEventMIDI::set_controller_value);
 	ClassDB::bind_method(D_METHOD("get_controller_value"), &InputEventMIDI::get_controller_value);
-	ClassDB::bind_method(D_METHOD("set_connection_index", "connection_index"), &InputEventMIDI::set_connection_index);
-	ClassDB::bind_method(D_METHOD("get_connection_index"), &InputEventMIDI::get_connection_index);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "channel"), "set_channel", "get_channel");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "message"), "set_message", "get_message");
@@ -1781,7 +1771,6 @@ void InputEventMIDI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pressure"), "set_pressure", "get_pressure");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_number"), "set_controller_number", "get_controller_number");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_value"), "set_controller_value", "get_controller_value");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "connection_index"), "set_connection_index", "get_connection_index");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1717,6 +1717,14 @@ int InputEventMIDI::get_controller_value() const {
 	return controller_value;
 }
 
+void InputEventMIDI::set_connection_index(const int p_connection_index) {
+	connection_index = p_connection_index;
+}
+
+int InputEventMIDI::get_connection_index() const {
+	return connection_index;
+}
+
 String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }
@@ -1725,22 +1733,22 @@ String InputEventMIDI::to_string() {
 	String ret;
 	switch (message) {
 		case MIDIMessage::NOTE_ON:
-			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
+			ret = vformat("Note On: channel=%d, pitch=%d, velocity=%d, connection_index=%d", channel, pitch, velocity, connection_index);
 			break;
 		case MIDIMessage::NOTE_OFF:
-			ret = vformat("Note Off: channel=%d, pitch=%d, velocity=%d", channel, pitch, velocity);
+			ret = vformat("Note Off: channel=%d, pitch=%d, velocity=%d, connection_index=%d", channel, pitch, velocity, connection_index);
 			break;
 		case MIDIMessage::PITCH_BEND:
-			ret = vformat("Pitch Bend: channel=%d, pitch=%d", channel, pitch);
+			ret = vformat("Pitch Bend: channel=%d, pitch=%d, connection_index=%d", channel, pitch, connection_index);
 			break;
 		case MIDIMessage::CHANNEL_PRESSURE:
-			ret = vformat("Channel Pressure: channel=%d, pressure=%d", channel, pressure);
+			ret = vformat("Channel Pressure: channel=%d, pressure=%d, connection_index=%d", channel, pressure, connection_index);
 			break;
 		case MIDIMessage::CONTROL_CHANGE:
-			ret = vformat("Control Change: channel=%d, controller_number=%d, controller_value=%d", channel, controller_number, controller_value);
+			ret = vformat("Control Change: channel=%d, controller_number=%d, controller_value=%d, connection_index=%d", channel, controller_number, controller_value, connection_index);
 			break;
 		default:
-			ret = vformat("channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d, controller_number=%d, controller_value=%d, instrument=%d", channel, message, pitch, velocity, pressure, controller_number, controller_value, instrument);
+			ret = vformat("channel=%d, message=%d, pitch=%d, velocity=%d, pressure=%d, controller_number=%d, controller_value=%d, instrument=%d, connection_index=%d", channel, message, pitch, velocity, pressure, controller_number, controller_value, instrument, connection_index);
 	}
 	return "InputEventMIDI: " + ret;
 }
@@ -1762,6 +1770,8 @@ void InputEventMIDI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_number"), &InputEventMIDI::get_controller_number);
 	ClassDB::bind_method(D_METHOD("set_controller_value", "controller_value"), &InputEventMIDI::set_controller_value);
 	ClassDB::bind_method(D_METHOD("get_controller_value"), &InputEventMIDI::get_controller_value);
+	ClassDB::bind_method(D_METHOD("set_connection_index", "connection_index"), &InputEventMIDI::set_connection_index);
+	ClassDB::bind_method(D_METHOD("get_connection_index"), &InputEventMIDI::get_connection_index);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "channel"), "set_channel", "get_channel");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "message"), "set_message", "get_message");
@@ -1771,6 +1781,7 @@ void InputEventMIDI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pressure"), "set_pressure", "get_pressure");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_number"), "set_controller_number", "get_controller_number");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "controller_value"), "set_controller_value", "get_controller_value");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "connection_index"), "set_connection_index", "get_connection_index");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -518,6 +518,7 @@ class InputEventMIDI : public InputEvent {
 	int pressure = 0;
 	int controller_number = 0;
 	int controller_value = 0;
+	int connection_index = 0;
 
 protected:
 	static void _bind_methods();
@@ -546,6 +547,9 @@ public:
 
 	void set_controller_value(const int p_controller_value);
 	int get_controller_value() const;
+
+	void set_connection_index(const int p_connection_index);
+	int get_connection_index() const;
 
 	virtual String as_text() const override;
 	virtual String to_string() override;

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -548,9 +548,6 @@ public:
 	void set_controller_value(const int p_controller_value);
 	int get_controller_value() const;
 
-	void set_connection_index(const int p_connection_index);
-	int get_connection_index() const;
-
 	virtual String as_text() const override;
 	virtual String to_string() override;
 

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -46,7 +46,7 @@ void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_
 	Ref<InputEventMIDI> event;
 	event.instantiate();
 	uint32_t param_position = 1;
-	
+
 	event->set_connection_index(connectionIndex);
 
 	if (length >= 1) {

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -42,12 +42,12 @@ void MIDIDriver::set_singleton() {
 	singleton = this;
 }
 
-void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connectionIndex) {
+void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connection_index) {
 	Ref<InputEventMIDI> event;
 	event.instantiate();
 	uint32_t param_position = 1;
 
-	event->set_connection_index(connectionIndex);
+	event->set_device(connection_index);
 
 	if (length >= 1) {
 		if (data[0] >= 0xF0) {

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -42,10 +42,12 @@ void MIDIDriver::set_singleton() {
 	singleton = this;
 }
 
-void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length) {
+void MIDIDriver::receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connectionIndex) {
 	Ref<InputEventMIDI> event;
 	event.instantiate();
 	uint32_t param_position = 1;
+	
+	event->set_connection_index(connectionIndex);
 
 	if (length >= 1) {
 		if (data[0] >= 0xF0) {

--- a/core/os/midi_driver.h
+++ b/core/os/midi_driver.h
@@ -51,7 +51,7 @@ public:
 
 	virtual PackedStringArray get_connected_inputs();
 
-	static void receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length);
+	static void receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connectionIndex);
 
 	MIDIDriver();
 	virtual ~MIDIDriver() {}

--- a/core/os/midi_driver.h
+++ b/core/os/midi_driver.h
@@ -51,7 +51,7 @@ public:
 
 	virtual PackedStringArray get_connected_inputs();
 
-	static void receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connectionIndex);
+	static void receive_input_packet(uint64_t timestamp, uint8_t *data, uint32_t length, int connection_index);
 
 	MIDIDriver();
 	virtual ~MIDIDriver() {}

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -27,6 +27,7 @@
 		    print("Pressure " + str(midi_event.pressure))
 		    print("Controller number: " + str(midi_event.controller_number))
 		    print("Controller value: " + str(midi_event.controller_value))
+		    print("Connection index: " + str{midi_event.connection_index));
 		[/gdscript]
 		[csharp]
 		public override void _Ready()
@@ -54,6 +55,7 @@
 		    GD.Print($"Pressure {midiEvent.Pressure}");
 		    GD.Print($"Controller number: {midiEvent.ControllerNumber}");
 		    GD.Print($"Controller value: {midiEvent.ControllerValue}");
+		    GD.Print($"Connection index: {midiEvent.ConnectionIndex}");
 		}
 		[/csharp]
 		[/codeblocks]
@@ -67,6 +69,9 @@
 	<members>
 		<member name="channel" type="int" setter="set_channel" getter="get_channel" default="0">
 			The MIDI channel of this input event. There are 16 channels, so this value ranges from 0 to 15. MIDI channel 9 is reserved for the use with percussion instruments, the rest of the channels are for non-percussion instruments.
+		</member>
+		<member name="connection_index" type="int" setter="set_connection_index" getter="get_connection_index" default="0">
+			The connection index of the MIDI device that relates to this message. Each MIDI device will have a unique connection index.
 		</member>
 		<member name="controller_number" type="int" setter="set_controller_number" getter="get_controller_number" default="0">
 			If the message is [constant MIDI_MESSAGE_CONTROL_CHANGE], this indicates the controller number, otherwise this is zero. Controllers include devices such as pedals and levers.

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -27,7 +27,7 @@
 		    print("Pressure " + str(midi_event.pressure))
 		    print("Controller number: " + str(midi_event.controller_number))
 		    print("Controller value: " + str(midi_event.controller_value))
-		    print("Connection index: " + str{midi_event.connection_index));
+		    print("Connection index: " + str(midi_event.connection_index))
 		[/gdscript]
 		[csharp]
 		public override void _Ready()

--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -70,9 +70,6 @@
 		<member name="channel" type="int" setter="set_channel" getter="get_channel" default="0">
 			The MIDI channel of this input event. There are 16 channels, so this value ranges from 0 to 15. MIDI channel 9 is reserved for the use with percussion instruments, the rest of the channels are for non-percussion instruments.
 		</member>
-		<member name="connection_index" type="int" setter="set_connection_index" getter="get_connection_index" default="0">
-			The connection index of the MIDI device that relates to this message. Each MIDI device will have a unique connection index.
-		</member>
 		<member name="controller_number" type="int" setter="set_controller_number" getter="get_controller_number" default="0">
 			If the message is [constant MIDI_MESSAGE_CONTROL_CHANGE], this indicates the controller number, otherwise this is zero. Controllers include devices such as pedals and levers.
 		</member>

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -82,13 +82,13 @@ size_t MIDIDriverALSAMidi::msg_expected_data(uint8_t status_byte) {
 }
 
 void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver,
-		uint64_t timestamp) {
+		uint64_t timestamp, int connectionIndex) {
 	switch (msg_category(byte)) {
 		case MessageCategory::RealTime:
 			// Real-Time messages are single byte messages that can
 			// occur at any point.
 			// We pass them straight through.
-			driver.receive_input_packet(timestamp, &byte, 1);
+			driver.receive_input_packet(timestamp, &byte, 1, connectionIndex);
 			break;
 
 		case MessageCategory::Data:
@@ -100,7 +100,7 @@ void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALS
 
 				// Forward a complete message and reset relevant state.
 				if (received_data == expected_data) {
-					driver.receive_input_packet(timestamp, buffer, received_data + 1);
+					driver.receive_input_packet(timestamp, buffer, received_data + 1, connectionIndex);
 					received_data = 0;
 
 					if (msg_category(buffer[0]) != MessageCategory::Voice) {
@@ -130,13 +130,13 @@ void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALS
 			expected_data = msg_expected_data(byte);
 			skipping_sys_ex = false;
 			if (expected_data == 0) {
-				driver.receive_input_packet(timestamp, &byte, 1);
+				driver.receive_input_packet(timestamp, &byte, 1, connectionIndex);
 			}
 			break;
 	}
 }
 
-int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp) {
+int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex) {
 	int ret;
 	do {
 		uint8_t byte = 0;
@@ -147,7 +147,7 @@ int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uin
 				ERR_PRINT("snd_rawmidi_read error: " + String(snd_strerror(ret)));
 			}
 		} else {
-			parse_byte(byte, driver, timestamp);
+			parse_byte(byte, driver, timestamp, connectionIndex);
 		}
 	} while (ret > 0);
 
@@ -165,7 +165,7 @@ void MIDIDriverALSAMidi::thread_func(void *p_udata) {
 		size_t connection_count = md->connected_inputs.size();
 
 		for (size_t i = 0; i < connection_count; i++) {
-			connections[i].read_in(*md, timestamp);
+			connections[i].read_in(*md, timestamp, (int)i);
 		}
 
 		md->unlock();

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -82,13 +82,13 @@ size_t MIDIDriverALSAMidi::msg_expected_data(uint8_t status_byte) {
 }
 
 void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver,
-		uint64_t timestamp, int connectionIndex) {
+		uint64_t timestamp, int connection_index) {
 	switch (msg_category(byte)) {
 		case MessageCategory::RealTime:
 			// Real-Time messages are single byte messages that can
 			// occur at any point.
 			// We pass them straight through.
-			driver.receive_input_packet(timestamp, &byte, 1, connectionIndex);
+			driver.receive_input_packet(timestamp, &byte, 1, connection_index);
 			break;
 
 		case MessageCategory::Data:
@@ -100,7 +100,7 @@ void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALS
 
 				// Forward a complete message and reset relevant state.
 				if (received_data == expected_data) {
-					driver.receive_input_packet(timestamp, buffer, received_data + 1, connectionIndex);
+					driver.receive_input_packet(timestamp, buffer, received_data + 1, connection_index);
 					received_data = 0;
 
 					if (msg_category(buffer[0]) != MessageCategory::Voice) {
@@ -130,13 +130,13 @@ void MIDIDriverALSAMidi::InputConnection::parse_byte(uint8_t byte, MIDIDriverALS
 			expected_data = msg_expected_data(byte);
 			skipping_sys_ex = false;
 			if (expected_data == 0) {
-				driver.receive_input_packet(timestamp, &byte, 1, connectionIndex);
+				driver.receive_input_packet(timestamp, &byte, 1, connection_index);
 			}
 			break;
 	}
 }
 
-int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex) {
+int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connection_index) {
 	int ret;
 	do {
 		uint8_t byte = 0;
@@ -147,7 +147,7 @@ int MIDIDriverALSAMidi::InputConnection::read_in(MIDIDriverALSAMidi &driver, uin
 				ERR_PRINT("snd_rawmidi_read error: " + String(snd_strerror(ret)));
 			}
 		} else {
-			parse_byte(byte, driver, timestamp, connectionIndex);
+			parse_byte(byte, driver, timestamp, connection_index);
 		}
 	} while (ret > 0);
 

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -58,7 +58,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 				rawmidi_ptr{ midi_in } {}
 
 		// Read in and parse available data, forwarding any complete messages through the driver.
-		int read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex);
+		int read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connection_index);
 
 		snd_rawmidi_t *rawmidi_ptr = nullptr;
 
@@ -68,7 +68,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 		size_t expected_data = 0;
 		size_t received_data = 0;
 		bool skipping_sys_ex = false;
-		void parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex);
+		void parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver, uint64_t timestamp, int connection_index);
 	};
 
 	Vector<InputConnection> connected_inputs;

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -58,7 +58,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 				rawmidi_ptr{ midi_in } {}
 
 		// Read in and parse available data, forwarding any complete messages through the driver.
-		int read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp);
+		int read_in(MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex);
 
 		snd_rawmidi_t *rawmidi_ptr = nullptr;
 
@@ -68,7 +68,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 		size_t expected_data = 0;
 		size_t received_data = 0;
 		bool skipping_sys_ex = false;
-		void parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver, uint64_t timestamp);
+		void parse_byte(uint8_t byte, MIDIDriverALSAMidi &driver, uint64_t timestamp, int connectionIndex);
 	};
 
 	Vector<InputConnection> connected_inputs;

--- a/drivers/coremidi/midi_driver_coremidi.cpp
+++ b/drivers/coremidi/midi_driver_coremidi.cpp
@@ -39,8 +39,9 @@
 
 void MIDIDriverCoreMidi::read(const MIDIPacketList *packet_list, void *read_proc_ref_con, void *src_conn_ref_con) {
 	MIDIPacket *packet = const_cast<MIDIPacket *>(packet_list->packet);
+	int *connection_index = static_cast<int *>(src_conn_ref_con);
 	for (UInt32 i = 0; i < packet_list->numPackets; i++) {
-		receive_input_packet(packet->timeStamp, packet->data, packet->length, (int)src_conn_ref_con);
+		receive_input_packet(packet->timeStamp, packet->data, packet->length, *connection_index);
 		packet = MIDIPacketNext(packet);
 	}
 }
@@ -64,7 +65,7 @@ Error MIDIDriverCoreMidi::open() {
 	for (int i = 0; i < sources; i++) {
 		MIDIEndpointRef source = MIDIGetSource(i);
 		if (source) {
-			MIDIPortConnectSource(port_in, source, (void *)i);
+			MIDIPortConnectSource(port_in, source, static_cast<void *>(&i));
 			connected_sources.insert(i, source);
 		}
 	}

--- a/drivers/coremidi/midi_driver_coremidi.cpp
+++ b/drivers/coremidi/midi_driver_coremidi.cpp
@@ -40,7 +40,7 @@
 void MIDIDriverCoreMidi::read(const MIDIPacketList *packet_list, void *read_proc_ref_con, void *src_conn_ref_con) {
 	MIDIPacket *packet = const_cast<MIDIPacket *>(packet_list->packet);
 	for (UInt32 i = 0; i < packet_list->numPackets; i++) {
-		receive_input_packet(packet->timeStamp, packet->data, packet->length);
+		receive_input_packet(packet->timeStamp, packet->data, packet->length, (int)src_conn_ref_con);
 		packet = MIDIPacketNext(packet);
 	}
 }
@@ -64,7 +64,7 @@ Error MIDIDriverCoreMidi::open() {
 	for (int i = 0; i < sources; i++) {
 		MIDIEndpointRef source = MIDIGetSource(i);
 		if (source) {
-			MIDIPortConnectSource(port_in, source, (void *)this);
+			MIDIPortConnectSource(port_in, source, (void *)i);
 			connected_sources.insert(i, source);
 		}
 	}

--- a/drivers/winmidi/midi_driver_winmidi.cpp
+++ b/drivers/winmidi/midi_driver_winmidi.cpp
@@ -36,7 +36,7 @@
 
 void MIDIDriverWinMidi::read(HMIDIIN hMidiIn, UINT wMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2) {
 	if (wMsg == MIM_DATA) {
-		receive_input_packet((uint64_t)dwParam2, (uint8_t *)&dwParam1, 3);
+		receive_input_packet((uint64_t)dwParam2, (uint8_t *)&dwParam1, 3, (int)dwInstance);
 	}
 }
 
@@ -44,7 +44,7 @@ Error MIDIDriverWinMidi::open() {
 	for (UINT i = 0; i < midiInGetNumDevs(); i++) {
 		HMIDIIN midi_in;
 
-		MMRESULT res = midiInOpen(&midi_in, i, (DWORD_PTR)read, (DWORD_PTR)this, CALLBACK_FUNCTION);
+		MMRESULT res = midiInOpen(&midi_in, i, (DWORD_PTR)read, (DWORD_PTR)i, CALLBACK_FUNCTION);
 		if (res == MMSYSERR_NOERROR) {
 			midiInStart(midi_in);
 			connected_sources.insert(i, midi_in);


### PR DESCRIPTION
Added connection_index to the InputEventMIDI so that each MIDI message can be associated with a specific opened MIDI device.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/7733.*
