### PR TITLE
i18n: Expose editor's translation via `EditorInterface`.

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -116,6 +116,12 @@
 				[b]Note:[/b] When creating custom editor UI, prefer accessing theme items directly from your GUI nodes using the [code]get_theme_*[/code] methods.
 			</description>
 		</method>
+		<method name="get_editor_translation" qualifiers="const">
+			<return type="Translation" />
+			<description>
+				Returns the editor's [Translation]. Returns null if there is no [Translation] for current locale.
+			</description>
+		</method>
 		<method name="get_file_system_dock" qualifiers="const">
 			<return type="FileSystemDock" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -82,6 +82,10 @@ Ref<EditorSettings> EditorInterface::get_editor_settings() const {
 	return EditorSettings::get_singleton();
 }
 
+Ref<Translation> EditorInterface::get_editor_translation() const {
+	return TranslationServer::get_singleton()->get_tool_translation();
+}
+
 TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size) {
 	Vector<Ref<Mesh>> meshes;
 
@@ -402,6 +406,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
+	ClassDB::bind_method(D_METHOD("get_editor_translation"), &EditorInterface::get_editor_translation);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/object/script_language.h"
+#include "core/string/translation.h"
 
 class Control;
 class EditorCommandPalette;
@@ -79,6 +80,7 @@ public:
 	EditorResourcePreview *get_resource_previewer() const;
 	EditorSelection *get_selection() const;
 	Ref<EditorSettings> get_editor_settings() const;
+	Ref<Translation> get_editor_translation() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6885
Closes https://github.com/godotengine/godot-proposals/issues/1262

Expose editor's translation via `EditorInterface.get_editor_translation()`. This will allow developers to add translations for their plugin.

Example (Updated):
```gdscript
var translation : Translation
var tool_translation := EditorInterface.get_editor_translation()

func load_translation():
    if not tool_translation:
        return
    var tr_path = "res://addons/tr_test/locales/" + tool_translation.locale + ".po"
    if ResourceLoader.exists(tr_path):
        translation = load(tr_path) 
        for msg in translation.get_message_list():
            if tool_translation.get_message(msg) != "":
                push_warning("Translation conflict for '%s'! Please report to the author!" % msg)
                translation.erase_message(msg) # avoid removal on unloading
            else:
                tool_translation.add_message(msg, translation.get_message(msg))

func unload_translation():
    if translation:
        for msg in translation.get_message_list():
            tool_translation.erase_message(msg)
        translation = null
```
[tr_test.zip](https://github.com/godotengine/godot/files/12705075/tr_test.zip)
