### PR TITLE
Made signal handling more uniform during crashes.

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -49,6 +49,10 @@
 #include <stdlib.h>
 
 static void handle_crash(int sig) {
+	signal(SIGSEGV, SIG_DFL);
+	signal(SIGFPE, SIG_DFL);
+	signal(SIGILL, SIG_DFL);
+
 	if (OS::get_singleton() == nullptr) {
 		abort();
 	}
@@ -156,9 +160,9 @@ void CrashHandler::disable() {
 	}
 
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, nullptr);
-	signal(SIGFPE, nullptr);
-	signal(SIGILL, nullptr);
+	signal(SIGSEGV, SIG_DFL);
+	signal(SIGFPE, SIG_DFL);
+	signal(SIGILL, SIG_DFL);
 #endif
 
 	disabled = true;

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -72,6 +72,10 @@ static uint64_t load_address() {
 }
 
 static void handle_crash(int sig) {
+	signal(SIGSEGV, SIG_DFL);
+	signal(SIGFPE, SIG_DFL);
+	signal(SIGILL, SIG_DFL);
+
 	if (OS::get_singleton() == nullptr) {
 		abort();
 	}
@@ -186,9 +190,9 @@ void CrashHandler::disable() {
 	}
 
 #ifdef CRASH_HANDLER_ENABLED
-	signal(SIGSEGV, nullptr);
-	signal(SIGFPE, nullptr);
-	signal(SIGILL, nullptr);
+	signal(SIGSEGV, SIG_DFL);
+	signal(SIGFPE, SIG_DFL);
+	signal(SIGILL, SIG_DFL);
 #endif
 
 	disabled = true;


### PR DESCRIPTION
Fixes #82102

I've learned that signal is heavily implementation specific. According to the [cppreference docs](https://en.cppreference.com/w/c/program/signal):

> When signal handler is set to a function and a signal occurs, it is implementation defined whether signal(sig, [SIG_DFL](http://en.cppreference.com/w/c/program/SIG_strategies)) will be executed immediately before the start of signal handler. Also, the implementation can prevent some implementation-defined set of signals from occurring while the signal handler runs.

This means that we won't know if further exceptions during crash handling will  be ignored, cause loops, lockups, or crashes since it's completely implementation specific.

It also states

> POSIX recommends [sigaction](http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html) instead of signal, due to its underspecified behavior and significant implementation variations, regarding signal delivery while a signal handler is executed.

I'm not sure if sigaction is a good fit for godot, since godot is multi-platform and sigaction is not. And it's nice keeping the crash handlers somewhat similar in design when possible.

So now for my proposed solution: a very simple fix is to enforce the behavior of signal by starting the crash handler with 
```c
static void handle_crash(int sig) {
    signal(SIGSEGV, SIG_DFL);
    signal(SIGFPE,  SIG_DFL);
    signal(SIGILL,  SIG_DFL);
...
```
This prevents further fatal errors from initiating patty-cake with the kernel for _most_ implementations. The trade-off being that we still won't know if the implementation is currently _ignoring_ any of the signals.

I think making it work for _all_ implementations would require a reassessment for using sigaction.

Regardless, this change should make the crash handlers more sane without being complicated. Tested it and it works okay:
![image](https://github.com/godotengine/godot/assets/1131571/330db0d1-907e-408d-bb40-16dee3522f95)