### PR TITLE
Fix leak when calling `remove_control_from_menu_panel`

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4979,9 +4979,11 @@ void CanvasItemEditor::remove_control_from_menu_panel(Control *p_control) {
 
 	p_control->disconnect("visibility_changed", callable_mp(this, &CanvasItemEditor::_update_context_toolbar));
 
-	context_toolbar_hbox->remove_child(context_toolbar_separators[p_control]);
+	VSeparator *sep = context_toolbar_separators[p_control];
+	context_toolbar_hbox->remove_child(sep);
 	context_toolbar_hbox->remove_child(p_control);
 	context_toolbar_separators.erase(p_control);
+	memdelete(sep);
 
 	_update_context_toolbar();
 }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7695,9 +7695,11 @@ void Node3DEditor::remove_control_from_menu_panel(Control *p_control) {
 
 	p_control->disconnect("visibility_changed", callable_mp(this, &Node3DEditor::_update_context_toolbar));
 
-	context_toolbar_hbox->remove_child(context_toolbar_separators[p_control]);
+	VSeparator *sep = context_toolbar_separators[p_control];
+	context_toolbar_hbox->remove_child(sep);
 	context_toolbar_hbox->remove_child(p_control);
 	context_toolbar_separators.erase(p_control);
+	memdelete(sep);
 
 	_update_context_toolbar();
 }


### PR DESCRIPTION
The separator allocated in `add_control_to_menu_panel()` was never freed.

The separator will be leaked if `remove_control_from_menu_panel()` is called.