### PR TITLE
Fix font theming of state machine editor.

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -909,9 +909,9 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	Ref<StyleBoxFlat> style = get_theme_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"));
 	Ref<StyleBoxFlat> style_selected = get_theme_stylebox(SNAME("state_machine_selected_frame"), SNAME("GraphNode"));
 
-	Ref<Font> font = get_theme_font(SNAME("title_font"), SNAME("GraphNode"));
-	int font_size = get_theme_font_size(SNAME("title_font_size"), SNAME("GraphNode"));
-	Color font_color = get_theme_color(SNAME("title_color"), SNAME("GraphNode"));
+	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("GraphNodeTitleLabel"));
+	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("GraphNodeTitleLabel"));
+	Color font_color = get_theme_color(SNAME("font_color"), SNAME("GraphNodeTitleLabel"));
 	Ref<Texture2D> play = get_editor_theme_icon(SNAME("Play"));
 	Ref<Texture2D> edit = get_editor_theme_icon(SNAME("Edit"));
 	Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));


### PR DESCRIPTION
Fixes the font color and style being displayed incorrectly in the state machine editor. Was broken in the commit 5afe78bd9c7e619ebc2dd2fb43d549d16382b51d which changed the internal format of the GraphNode which, while the state machine is not a graph node, does derive theme data from it.
![godot windows editor dev x86_64_BxHzJ7Ct0c](https://github.com/godotengine/godot/assets/12756047/5de100d3-e5a6-4224-9483-21136a397b78)
![godot windows editor dev x86_64_MKFwFmqmPa](https://github.com/godotengine/godot/assets/12756047/d5dae42f-4dc2-47c7-bc86-f3ff05c27eef)
