### PR TITLE
Document mouse signal propagation for `MOUSE_FILTER_PASS`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1306,6 +1306,7 @@
 		</constant>
 		<constant name="MOUSE_FILTER_PASS" value="1" enum="MouseFilter">
 			The control will receive mouse movement input events and mouse button input events if clicked on through [method _gui_input]. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. If this control does not handle the event, the parent control (if any) will be considered, and so on until there is no more parent control to potentially handle it. This also allows signals to fire in other controls. If no control handled it, the event will be passed to [method Node._shortcut_input] for further processing.
+			[b]Note:[/b] [signal mouse_entered] and [signal mouse_exited] signals are not propagated to the parent control.
 		</constant>
 		<constant name="MOUSE_FILTER_IGNORE" value="2" enum="MouseFilter">
 			The control will not receive mouse movement input events and mouse button input events if clicked on through [method _gui_input]. The control will also not receive the [signal mouse_entered] nor [signal mouse_exited] signals. This will not block other controls from receiving these events or firing the signals. Ignored events will not be handled automatically.


### PR DESCRIPTION
Document that `MOUSE_FILTER_PASS` has no longer an effect on `mouse_entered` and `mouse_exited`.

fix comment https://github.com/godotengine/godot/issues/81909#issuecomment-1727167949 about outdated documentation.

The implementation has changed in #67791.