### PR TITLE
GDExtension: Remove redundant method bind hash check

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1323,10 +1323,6 @@ static GDExtensionMethodBindPtr gdextension_classdb_get_method_bind(GDExtensionC
 		return nullptr;
 	}
 	ERR_FAIL_NULL_V(mb, nullptr);
-	if (mb->get_hash() != p_hash) {
-		ERR_PRINT("Hash mismatch for method '" + classname + "." + methodname + "'.");
-		return nullptr;
-	}
 	return (GDExtensionMethodBindPtr)mb;
 }
 


### PR DESCRIPTION
This fixes a bug in PR https://github.com/godotengine/godot/pull/81521, which is causing GDExtensions built for Godot 4.1 to fail to load.

That PR maps some old method hashes to new method hashes in order to get the correct method bind. Unfortunately, it runs afoul of a check towards the end of the function:

```
	if (mb->get_hash() != p_hash) {
		ERR_PRINT("Hash mismatch for method '" + classname + "." + methodname + "'.");
		return nullptr;
	}
```

This will fail because the hash on the method bind we found doesn't match the hash that was originally requested (because we mapped it to a new hash).

However, this check is completely unnecessary, because `ClassDB::get_method_with_compatibility()` won't return the method bind unless the hash matched the one being searched for. I think this check may be left over from before `ClassDB::get_method_with_compatibility()` was added.

So, this PR completely removes the redundant check.

Sorry for missing this when working on PR #81521! This was a failure to do sufficient testing on my part :-/