### PR TITLE
BoneAttachment3D: Add an enum selection that defines the attachment's bone pose target

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -50,11 +50,11 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
-		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
-			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
-		</member>
 		<member name="bone_pose_mode" type="int" setter="set_bone_pose_mode" getter="get_bone_pose_mode" enum="BoneAttachment3D.BonePoseMode" default="0">
 			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This feature does nothing if [member override_pose] is true.
+		</member>
+		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
+			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -51,7 +51,7 @@
 			The name of the attached bone.
 		</member>
 		<member name="bone_pose_mode" type="int" setter="set_bone_pose_mode" getter="get_bone_pose_mode" enum="BoneAttachment3D.BonePoseMode" default="0">
-			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This property does nothing if [member override_pose] is true.
+			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This property does nothing if [member override_pose] is [code]true[/code].
 		</member>
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
 			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -53,8 +53,22 @@
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
 			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
 		</member>
-		<member name="use_bone_transform_no_override" type="bool" setter="set_use_bone_transform_no_override" getter="get_use_bone_transform_no_override" default="false">
-			Whether the BoneAttachment3D node will use the non overridden bone pose of the bone it is attached to. This feature does nothing if [member override_pose] is true. When set to [code]true[/code], the BoneAttachment3D will be set to the bone's non overridden transform. When set to [code]false[/code], the BoneAttachment3D will be set to the bone's overridden transform.
+		<member name="bone_pose_mode" type="int" setter="set_bone_pose_mode" getter="get_bone_pose_mode" enum="BoneAttachment3D.BonePoseMode" default="0">
+			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This feature does nothing if [member override_pose] is true.
 		</member>
 	</members>
+	<constants>
+		<constant name="BONE_POSE" value="0" enum="BonePoseMode">
+			The BoneAttachment3D will be set to the bone's transform.
+		</constant>
+		<constant name="BONE_POSE_OVERRIDE" value="1" enum="BonePoseMode">
+			The BoneAttachment3D will be set to the bone's overridden transform.
+		</constant>
+		<constant name="BONE_POSE_NO_OVERRIDE" value="2" enum="BonePoseMode">
+			The BoneAttachment3D will be set to the bone's non overridden transform.
+		</constant>
+		<constant name="BONE_REST" value="3" enum="BonePoseMode">
+			The BoneAttachment3D will be set to the bone's rest transform.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -51,7 +51,7 @@
 			The name of the attached bone.
 		</member>
 		<member name="bone_pose_mode" type="int" setter="set_bone_pose_mode" getter="get_bone_pose_mode" enum="BoneAttachment3D.BonePoseMode" default="0">
-			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This feature does nothing if [member override_pose] is true.
+			Which of the bone poses that BoneAttachment3D node will use, uses [enum BonePoseMode] values. This property does nothing if [member override_pose] is true.
 		</member>
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
 			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -54,7 +54,7 @@
 			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
 		</member>
 		<member name="use_bone_transform_no_override" type="bool" setter="set_use_bone_transform_no_override" getter="get_use_bone_transform_no_override" default="false">
-			Whether the BoneAttachment3D node will use the non overriden bone pose of the bone it is attached to. This feature does nothing if [member override_pose] is true. When set to [code]true[/code], the BoneAttachment3D will be set to the bone's non overriden transform. When set to [code]false[/code], the BoneAttachment3D will be set to the bone's overriden transform.
+			Whether the BoneAttachment3D node will use the non overridden bone pose of the bone it is attached to. This feature does nothing if [member override_pose] is true. When set to [code]true[/code], the BoneAttachment3D will be set to the bone's non overridden transform. When set to [code]false[/code], the BoneAttachment3D will be set to the bone's overridden transform.
 		</member>
 	</members>
 </class>

--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -53,5 +53,8 @@
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
 			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
 		</member>
+		<member name="use_bone_transform_no_override" type="bool" setter="set_use_bone_transform_no_override" getter="get_use_bone_transform_no_override" default="false">
+			Whether the BoneAttachment3D node will use the non overriden bone pose of the bone it is attached to. This feature does nothing if [member override_pose] is true. When set to [code]true[/code], the BoneAttachment3D will be set to the bone's non overriden transform. When set to [code]false[/code], the BoneAttachment3D will be set to the bone's overriden transform.
+		</member>
 	</members>
 </class>

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -261,14 +261,14 @@ bool BoneAttachment3D::get_override_pose() const {
 	return override_pose;
 }
 
-void BoneAttachment3D::set_use_bone_transform_no_override(bool p_use_bone_transform_no_override) {
-	use_bone_transform_no_override = p_use_bone_transform_no_override;
+void BoneAttachment3D::set_bone_pose_mode(BonePoseMode p_pose_mode) {
+	bone_pose_mode = p_pose_mode;
 
 	notify_property_list_changed();
 }
 
-bool BoneAttachment3D::get_use_bone_transform_no_override() const {
-	return use_bone_transform_no_override;
+BoneAttachment3D::BonePoseMode BoneAttachment3D::get_bone_pose_mode() const {
+	return bone_pose_mode;
 }
 
 void BoneAttachment3D::set_use_external_skeleton(bool p_use_external) {
@@ -329,16 +329,40 @@ void BoneAttachment3D::on_bone_pose_update(int p_bone_index) {
 		if (sk) {
 			if (!override_pose) {
 				if (use_external_skeleton) {
-					if (!use_bone_transform_no_override) {
-						set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
-					} else {
-						set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_no_override(bone_idx));
+					switch (bone_pose_mode) {
+							case BONE_POSE: {
+								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+							} break;
+
+							case BONE_POSE_OVERRIDE: {
+								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_override(bone_idx));
+							} break;
+
+							case BONE_POSE_NO_OVERRIDE: {
+								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_no_override(bone_idx));
+							} break;
+
+							case BONE_REST: {
+								set_global_transform(sk->get_global_transform() * sk->get_bone_global_rest(bone_idx));
+							} break;
 					}
 				} else {
-					if (!use_bone_transform_no_override) {
-						set_transform(sk->get_bone_global_pose(bone_idx));
-					} else {
-						set_transform(sk->get_bone_global_pose_no_override(bone_idx));
+					switch (bone_pose_mode) {
+							case BONE_POSE: {
+								set_transform(sk->get_bone_global_pose(bone_idx));
+							} break;
+
+							case BONE_POSE_OVERRIDE: {
+								set_transform(sk->get_bone_global_pose_override(bone_idx));
+							} break;
+
+							case BONE_POSE_NO_OVERRIDE: {
+								set_transform(sk->get_bone_global_pose_no_override(bone_idx));
+							} break;
+
+							case BONE_REST: {
+								set_transform(sk->get_bone_global_rest(bone_idx));
+							} break;
 					}
 				}
 			} else {
@@ -384,8 +408,8 @@ void BoneAttachment3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_override_pose", "override_pose"), &BoneAttachment3D::set_override_pose);
 	ClassDB::bind_method(D_METHOD("get_override_pose"), &BoneAttachment3D::get_override_pose);
 
-	ClassDB::bind_method(D_METHOD("set_use_bone_transform_no_override", "use_bone_transform_no_override"), &BoneAttachment3D::set_use_bone_transform_no_override);
-	ClassDB::bind_method(D_METHOD("get_use_bone_transform_no_override"), &BoneAttachment3D::get_use_bone_transform_no_override);
+	ClassDB::bind_method(D_METHOD("set_bone_pose_mode", "mode"), &BoneAttachment3D::set_bone_pose_mode);
+	ClassDB::bind_method(D_METHOD("get_bone_pose_mode"), &BoneAttachment3D::get_bone_pose_mode);
 
 	ClassDB::bind_method(D_METHOD("set_use_external_skeleton", "use_external_skeleton"), &BoneAttachment3D::set_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_use_external_skeleton"), &BoneAttachment3D::get_use_external_skeleton);
@@ -398,5 +422,13 @@ void BoneAttachment3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_bone_transform_no_override"), "set_use_bone_transform_no_override", "get_use_bone_transform_no_override");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_pose_mode", PROPERTY_HINT_ENUM, "Bone Pose,Bone Pose Override,Bone Pose No Override, Bone Rest"), "set_bone_pose_mode", "get_bone_pose_mode");
+
+
+	BIND_ENUM_CONSTANT(BONE_POSE);
+	BIND_ENUM_CONSTANT(BONE_POSE_OVERRIDE);
+	BIND_ENUM_CONSTANT(BONE_POSE_NO_OVERRIDE);
+	BIND_ENUM_CONSTANT(BONE_REST);
 }
+
+VARIANT_ENUM_CAST(BoneAttachment3D::BonePoseMode);

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -424,7 +424,6 @@ void BoneAttachment3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_pose_mode", PROPERTY_HINT_ENUM, "Bone Pose,Bone Pose Override,Bone Pose No Override, Bone Rest"), "set_bone_pose_mode", "get_bone_pose_mode");
 
-
 	BIND_ENUM_CONSTANT(BONE_POSE);
 	BIND_ENUM_CONSTANT(BONE_POSE_OVERRIDE);
 	BIND_ENUM_CONSTANT(BONE_POSE_NO_OVERRIDE);

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -330,39 +330,39 @@ void BoneAttachment3D::on_bone_pose_update(int p_bone_index) {
 			if (!override_pose) {
 				if (use_external_skeleton) {
 					switch (bone_pose_mode) {
-							case BONE_POSE: {
-								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
-							} break;
+						case BONE_POSE: {
+							set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+						} break;
 
-							case BONE_POSE_OVERRIDE: {
-								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_override(bone_idx));
-							} break;
+						case BONE_POSE_OVERRIDE: {
+							set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_override(bone_idx));
+						} break;
 
-							case BONE_POSE_NO_OVERRIDE: {
-								set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_no_override(bone_idx));
-							} break;
+						case BONE_POSE_NO_OVERRIDE: {
+							set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_no_override(bone_idx));
+						} break;
 
-							case BONE_REST: {
-								set_global_transform(sk->get_global_transform() * sk->get_bone_global_rest(bone_idx));
-							} break;
+						case BONE_REST: {
+							set_global_transform(sk->get_global_transform() * sk->get_bone_global_rest(bone_idx));
+						} break;
 					}
 				} else {
 					switch (bone_pose_mode) {
-							case BONE_POSE: {
-								set_transform(sk->get_bone_global_pose(bone_idx));
-							} break;
+						case BONE_POSE: {
+							set_transform(sk->get_bone_global_pose(bone_idx));
+						} break;
 
-							case BONE_POSE_OVERRIDE: {
-								set_transform(sk->get_bone_global_pose_override(bone_idx));
-							} break;
+						case BONE_POSE_OVERRIDE: {
+							set_transform(sk->get_bone_global_pose_override(bone_idx));
+						} break;
 
-							case BONE_POSE_NO_OVERRIDE: {
-								set_transform(sk->get_bone_global_pose_no_override(bone_idx));
-							} break;
+						case BONE_POSE_NO_OVERRIDE: {
+							set_transform(sk->get_bone_global_pose_no_override(bone_idx));
+						} break;
 
-							case BONE_REST: {
-								set_transform(sk->get_bone_global_rest(bone_idx));
-							} break;
+						case BONE_REST: {
+							set_transform(sk->get_bone_global_rest(bone_idx));
+						} break;
 					}
 				}
 			} else {

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -263,7 +263,6 @@ bool BoneAttachment3D::get_override_pose() const {
 
 void BoneAttachment3D::set_bone_pose_mode(BonePoseMode p_pose_mode) {
 	bone_pose_mode = p_pose_mode;
-
 	notify_property_list_changed();
 }
 
@@ -422,7 +421,7 @@ void BoneAttachment3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_pose_mode", PROPERTY_HINT_ENUM, "Bone Pose,Bone Pose Override,Bone Pose No Override, Bone Rest"), "set_bone_pose_mode", "get_bone_pose_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_pose_mode", PROPERTY_HINT_ENUM, "Bone Pose,Bone Pose Override,Bone Pose No Override,Bone Rest"), "set_bone_pose_mode", "get_bone_pose_mode");
 
 	BIND_ENUM_CONSTANT(BONE_POSE);
 	BIND_ENUM_CONSTANT(BONE_POSE_OVERRIDE);

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -261,6 +261,16 @@ bool BoneAttachment3D::get_override_pose() const {
 	return override_pose;
 }
 
+void BoneAttachment3D::set_use_bone_transform_no_override(bool p_use_bone_transform_no_override) {
+	use_bone_transform_no_override = p_use_bone_transform_no_override;
+
+	notify_property_list_changed();
+}
+
+bool BoneAttachment3D::get_use_bone_transform_no_override() const {
+	return use_bone_transform_no_override;
+}
+
 void BoneAttachment3D::set_use_external_skeleton(bool p_use_external) {
 	use_external_skeleton = p_use_external;
 
@@ -319,9 +329,17 @@ void BoneAttachment3D::on_bone_pose_update(int p_bone_index) {
 		if (sk) {
 			if (!override_pose) {
 				if (use_external_skeleton) {
-					set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+					if (!use_bone_transform_no_override) {
+						set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+					} else {
+						set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose_no_override(bone_idx));
+					}
 				} else {
-					set_transform(sk->get_bone_global_pose(bone_idx));
+					if (!use_bone_transform_no_override) {
+						set_transform(sk->get_bone_global_pose(bone_idx));
+					} else {
+						set_transform(sk->get_bone_global_pose_no_override(bone_idx));
+					}
 				}
 			} else {
 				if (!_override_dirty) {
@@ -366,6 +384,9 @@ void BoneAttachment3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_override_pose", "override_pose"), &BoneAttachment3D::set_override_pose);
 	ClassDB::bind_method(D_METHOD("get_override_pose"), &BoneAttachment3D::get_override_pose);
 
+	ClassDB::bind_method(D_METHOD("set_use_bone_transform_no_override", "use_bone_transform_no_override"), &BoneAttachment3D::set_use_bone_transform_no_override);
+	ClassDB::bind_method(D_METHOD("get_use_bone_transform_no_override"), &BoneAttachment3D::get_use_bone_transform_no_override);
+
 	ClassDB::bind_method(D_METHOD("set_use_external_skeleton", "use_external_skeleton"), &BoneAttachment3D::set_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_use_external_skeleton"), &BoneAttachment3D::get_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("set_external_skeleton", "external_skeleton"), &BoneAttachment3D::set_external_skeleton);
@@ -377,4 +398,5 @@ void BoneAttachment3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_bone_transform_no_override"), "set_use_bone_transform_no_override", "get_use_bone_transform_no_override");
 }

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -46,6 +46,7 @@ public:
 		BONE_POSE_NO_OVERRIDE,
 		BONE_REST
 	};
+
 private:
 	bool bound = false;
 	String bone_name;

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -46,6 +46,8 @@ class BoneAttachment3D : public Node3D {
 	bool override_pose = false;
 	bool _override_dirty = false;
 
+	bool use_bone_transform_no_override = false;
+
 	bool use_external_skeleton = false;
 	NodePath external_skeleton_node;
 	ObjectID external_skeleton_node_cache;
@@ -80,6 +82,9 @@ public:
 
 	void set_override_pose(bool p_override);
 	bool get_override_pose() const;
+
+	void set_use_bone_transform_no_override(bool p_use_bone_transform_no_override);
+	bool get_use_bone_transform_no_override() const;
 
 	void set_use_external_skeleton(bool p_external_skeleton);
 	bool get_use_external_skeleton() const;

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -39,6 +39,14 @@
 class BoneAttachment3D : public Node3D {
 	GDCLASS(BoneAttachment3D, Node3D);
 
+public:
+	enum BonePoseMode {
+		BONE_POSE,
+		BONE_POSE_OVERRIDE,
+		BONE_POSE_NO_OVERRIDE,
+		BONE_REST
+	};
+private:
 	bool bound = false;
 	String bone_name;
 	int bone_idx = -1;
@@ -46,7 +54,7 @@ class BoneAttachment3D : public Node3D {
 	bool override_pose = false;
 	bool _override_dirty = false;
 
-	bool use_bone_transform_no_override = false;
+	BonePoseMode bone_pose_mode = BONE_POSE;
 
 	bool use_external_skeleton = false;
 	NodePath external_skeleton_node;
@@ -83,8 +91,8 @@ public:
 	void set_override_pose(bool p_override);
 	bool get_override_pose() const;
 
-	void set_use_bone_transform_no_override(bool p_use_bone_transform_no_override);
-	bool get_use_bone_transform_no_override() const;
+	void set_bone_pose_mode(BonePoseMode p_pose_mode);
+	BonePoseMode get_bone_pose_mode() const;
 
 	void set_use_external_skeleton(bool p_external_skeleton);
 	bool get_use_external_skeleton() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes: https://github.com/godotengine/godot-proposals/issues/7820

