### PR TITLE
Add call validation to CommandPalette

### DIFF
--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_toaster.h"
 #include "scene/gui/control.h"
 #include "scene/gui/tree.h"
 
@@ -184,10 +185,10 @@ void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_ie) {
 
 void EditorCommandPalette::_confirmed() {
 	TreeItem *selected_option = search_options->get_selected();
-	String command_key = selected_option != nullptr ? selected_option->get_metadata(0) : "";
+	const String command_key = selected_option != nullptr ? selected_option->get_metadata(0) : "";
 	if (!command_key.is_empty()) {
 		hide();
-		execute_command(command_key);
+		callable_mp(this, &EditorCommandPalette::execute_command).call_deferred(command_key);
 	}
 }
 
@@ -248,11 +249,19 @@ void EditorCommandPalette::_add_command(String p_command_name, String p_key_name
 	commands[p_key_name] = command;
 }
 
-void EditorCommandPalette::execute_command(String &p_command_key) {
+void EditorCommandPalette::execute_command(const String &p_command_key) {
 	ERR_FAIL_COND_MSG(!commands.has(p_command_key), p_command_key + " not found.");
 	commands[p_command_key].last_used = OS::get_singleton()->get_unix_time();
-	commands[p_command_key].callable.call_deferred();
 	_save_history();
+
+	Variant ret;
+	Callable::CallError ce;
+	const Callable &callable = commands[p_command_key].callable;
+	callable.callp(nullptr, 0, ret, ce);
+
+	if (ce.error != Callable::CallError::CALL_OK) {
+		EditorToaster::get_singleton()->popup_str(vformat(TTR("Failed to execute command \"%s\":\n%s."), p_command_key, Variant::get_callable_error_text(callable, nullptr, 0, ce)), EditorToaster::SEVERITY_ERROR);
+	}
 }
 
 void EditorCommandPalette::register_shortcuts_as_command() {

--- a/editor/editor_command_palette.h
+++ b/editor/editor_command_palette.h
@@ -97,7 +97,7 @@ public:
 	void open_popup();
 	void get_actions_list(List<String> *p_list) const;
 	void add_command(String p_command_name, String p_key_name, Callable p_action, Vector<Variant> arguments, String p_shortcut_text = "None");
-	void execute_command(String &p_command_name);
+	void execute_command(const String &p_command_name);
 	void register_shortcuts_as_command();
 	Ref<Shortcut> add_shortcut_command(const String &p_command, const String &p_key, Ref<Shortcut> p_shortcut);
 	void remove_command(String p_key_name);


### PR DESCRIPTION
Code from confused user™:
```GDScript
@tool
extends EditorScript

func bundle_audio():
	print("Hello World")
	
func _run():
	var command_palette = get_editor_interface().get_command_palette()

	var name = "audio/bundle"
	command_palette.remove_command(name)
	
	command_palette.add_command("Bundle Audio", name, bundle_audio) 

	print("command added")
```
The EditorScript instance is gone before the command is run, so it can't be called. However editor palette doesn't do any call validation and it just fails silently.

This PR adds error messages:
![](https://chat.godotengine.org/file-upload/650ef55dcab4e8d8c5ac04f9/Clipboard%20-%2023%20wrze%C5%9Bnia%202023%2016:25.png)