### PR TITLE
Implement a struct-like type that can be exposed to scripting.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -858,6 +858,8 @@ if env.msvc and not methods.using_clang(env):  # MSVC
             ]
         )
 
+        env.Append(CCFLAGS=["/permissive-"])
+
     if env["werror"]:
         env.Append(CCFLAGS=["/WX"])
         env.Append(LINKFLAGS=["/WX"])

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1666,16 +1666,7 @@ TypedArray<Dictionary> ClassDB::class_get_struct_list(const StringName &p_class,
 	TypedArray<Dictionary> ret;
 	::ClassDB::get_struct_list(p_class, &structs, p_no_inheritance);
 	for (const StructInfo &struct_info : structs) {
-		Dictionary struct_dict;
-		for (int i = 0; i < struct_info.count; i++) {
-			Dictionary member_dict;
-			member_dict[SNAME("name")] = struct_info.names[i];
-			member_dict[SNAME("type")] = struct_info.types[i];
-			member_dict[SNAME("class_name")] = struct_info.class_names[i];
-			member_dict[SNAME("default_value")] = struct_info.default_values[i];
-			struct_dict[struct_info.name] = member_dict;
-		}
-		ret.push_back(struct_dict);
+		ret.push_back(StructInfo::Layout::to_dict(struct_info));
 	}
 	return ret;
 }
@@ -1691,7 +1682,7 @@ TypedArray<Dictionary> ClassDB::class_get_struct_members(const StringName &p_cla
 		Dictionary dict;
 		dict[SNAME("name")] = struct_info->names[i];
 		dict[SNAME("type")] = struct_info->types[i];
-		dict[SNAME("class_name")] = struct_info->class_names[i];
+		dict[SNAME("type_name")] = struct_info->type_names[i];
 		dict[SNAME("default_value")] = struct_info->default_values[i];
 		ret.push_back(dict);
 	}

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -42,6 +42,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/os/keyboard.h"
 #include "core/os/thread_safe.h"
+#include "core/variant/struct.h"
 #include "core/variant/typed_array.h"
 
 namespace core_bind {
@@ -1462,6 +1463,15 @@ Dictionary ClassDB::class_get_signal(const StringName &p_class, const StringName
 	}
 }
 
+//Struct<MethodInfo> ClassDB::class_get_signal_as_struct(const StringName &p_class, const StringName &p_signal) const {
+//	MethodInfo signal;
+//	if (::ClassDB::get_signal(p_class, p_signal, &signal)) {
+//		return Struct<MethodInfo>(signal);
+//	} else {
+//		return Struct<MethodInfo>();
+//	}
+//}
+
 TypedArray<Dictionary> ClassDB::class_get_signal_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<MethodInfo> signals;
 	::ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
@@ -1474,6 +1484,12 @@ TypedArray<Dictionary> ClassDB::class_get_signal_list(const StringName &p_class,
 	return ret;
 }
 
+//TypedArray<Struct<MethodInfo>> ClassDB::class_get_signal_list_as_structs(const StringName &p_class, bool p_no_inheritance) const {
+//	List<MethodInfo> signals;
+//	::ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
+//	return TypedArray<Struct<MethodInfo>>(&signals);
+//}
+
 TypedArray<Dictionary> ClassDB::class_get_property_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<PropertyInfo> plist;
 	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
@@ -1484,6 +1500,12 @@ TypedArray<Dictionary> ClassDB::class_get_property_list(const StringName &p_clas
 
 	return ret;
 }
+
+//TypedArray<Struct<PropertyInfo>> ClassDB::class_get_property_list_as_structs(const StringName &p_class, bool p_no_inheritance) const {
+//	List<PropertyInfo> plist;
+//	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
+//	return TypedArray<Struct<PropertyInfo>>(&plist);
+//}
 
 StringName ClassDB::class_get_property_getter(const StringName &p_class, const StringName &p_property) {
 	return ::ClassDB::get_property_getter(p_class, p_property);
@@ -1544,6 +1566,12 @@ TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class,
 
 	return ret;
 }
+
+//TypedArray<Struct<MethodInfo>> ClassDB::class_get_method_list_as_structs(const StringName &p_class, bool p_no_inheritance) const {
+//	List<MethodInfo> methods;
+//	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
+//	return TypedArray<Struct<MethodInfo>>(&methods);
+//}
 
 Variant ClassDB::class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) {
 	if (p_argcount < 2) {
@@ -1629,6 +1657,47 @@ bool ClassDB::is_class_enum_bitfield(const StringName &p_class, const StringName
 	return ::ClassDB::is_enum_bitfield(p_class, p_enum, p_no_inheritance);
 }
 
+bool ClassDB::class_has_struct(const StringName &p_class, const StringName &p_struct, bool p_no_inheritance) const {
+	return ::ClassDB::get_struct_info(p_class, p_struct, p_no_inheritance) != nullptr;
+}
+
+TypedArray<Dictionary> ClassDB::class_get_struct_list(const StringName &p_class, bool p_no_inheritance) const {
+	List<StructInfo> structs;
+	TypedArray<Dictionary> ret;
+	::ClassDB::get_struct_list(p_class, &structs, p_no_inheritance);
+	for (const StructInfo &struct_info : structs) {
+		Dictionary struct_dict;
+		for (int i = 0; i < struct_info.count; i++) {
+			Dictionary member_dict;
+			member_dict[SNAME("name")] = struct_info.names[i];
+			member_dict[SNAME("type")] = struct_info.types[i];
+			member_dict[SNAME("class_name")] = struct_info.class_names[i];
+			member_dict[SNAME("default_value")] = struct_info.default_values[i];
+			struct_dict[struct_info.name] = member_dict;
+		}
+		ret.push_back(struct_dict);
+	}
+	return ret;
+}
+
+TypedArray<Dictionary> ClassDB::class_get_struct_members(const StringName &p_class, const StringName &p_struct) const {
+	// TODO: this should return an array of structs if possible without circular reference
+	TypedArray<Dictionary> ret;
+	const StructInfo *struct_info = ::ClassDB::get_struct_info(p_class, p_struct);
+	if (!struct_info) {
+		return ret; // TODO: should this be an error?
+	}
+	for (int i = 0; i < struct_info->count; i++) {
+		Dictionary dict;
+		dict[SNAME("name")] = struct_info->names[i];
+		dict[SNAME("type")] = struct_info->types[i];
+		dict[SNAME("class_name")] = struct_info->class_names[i];
+		dict[SNAME("default_value")] = struct_info->default_values[i];
+		ret.push_back(dict);
+	}
+	return ret;
+}
+
 bool ClassDB::is_class_enabled(const StringName &p_class) const {
 	return ::ClassDB::is_class_enabled(p_class);
 }
@@ -1670,9 +1739,12 @@ void ClassDB::_bind_methods() {
 
 	::ClassDB::bind_method(D_METHOD("class_has_signal", "class", "signal"), &ClassDB::class_has_signal);
 	::ClassDB::bind_method(D_METHOD("class_get_signal", "class", "signal"), &ClassDB::class_get_signal);
+	//::ClassDB::bind_method(D_METHOD("class_get_signal_as_struct", "class", "signal"), &ClassDB::class_get_signal_as_struct);
 	::ClassDB::bind_method(D_METHOD("class_get_signal_list", "class", "no_inheritance"), &ClassDB::class_get_signal_list, DEFVAL(false));
+	//::ClassDB::bind_method(D_METHOD("class_get_signal_list_as_structs", "class", "no_inheritance"), &ClassDB::class_get_signal_list_as_structs, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_property_list", "class", "no_inheritance"), &ClassDB::class_get_property_list, DEFVAL(false));
+	//::ClassDB::bind_method(D_METHOD("class_get_property_list_as_structs", "class", "no_inheritance"), &ClassDB::class_get_property_list_as_structs, DEFVAL(false));
 	::ClassDB::bind_method(D_METHOD("class_get_property_getter", "class", "property"), &ClassDB::class_get_property_getter);
 	::ClassDB::bind_method(D_METHOD("class_get_property_setter", "class", "property"), &ClassDB::class_get_property_setter);
 	::ClassDB::bind_method(D_METHOD("class_get_property", "object", "property"), &ClassDB::class_get_property);
@@ -1685,6 +1757,7 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_get_method_argument_count", "class", "method", "no_inheritance"), &ClassDB::class_get_method_argument_count, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &ClassDB::class_get_method_list, DEFVAL(false));
+	//::ClassDB::bind_method(D_METHOD("class_get_method_list_as_structs", "class", "no_inheritance"), &ClassDB::class_get_method_list_as_structs, DEFVAL(false));
 
 	::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "class_call_static", &ClassDB::class_call_static, MethodInfo("class_call_static", PropertyInfo(Variant::STRING_NAME, "class"), PropertyInfo(Variant::STRING_NAME, "method")));
 
@@ -1699,6 +1772,10 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_get_integer_constant_enum", "class", "name", "no_inheritance"), &ClassDB::class_get_integer_constant_enum, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("is_class_enum_bitfield", "class", "enum", "no_inheritance"), &ClassDB::is_class_enum_bitfield, DEFVAL(false));
+
+	//	::ClassDB::bind_method(D_METHOD("class_has_struct", "class", "struct", "no_inheritance"), &ClassDB::class_has_struct, DEFVAL(false));
+	//	::ClassDB::bind_method(D_METHOD("class_get_struct_list", "class", "no_inheritance"), &ClassDB::class_get_struct_list, DEFVAL(false));
+	//	::ClassDB::bind_method(D_METHOD("class_get_struct_members", "class", "struct"), &ClassDB::class_get_struct_members);
 
 	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -471,9 +471,12 @@ public:
 	APIType class_get_api_type(const StringName &p_class) const;
 	bool class_has_signal(const StringName &p_class, const StringName &p_signal) const;
 	Dictionary class_get_signal(const StringName &p_class, const StringName &p_signal) const;
+	//Struct<MethodInfo> class_get_signal_as_struct(const StringName &p_class, const StringName &p_signal) const;
 	TypedArray<Dictionary> class_get_signal_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	//TypedArray<Struct<MethodInfo>> class_get_signal_list_as_structs(const StringName &p_class, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_property_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	//TypedArray<Struct<PropertyInfo>> class_get_property_list_as_structs(const StringName &p_class, bool p_no_inheritance = false) const;
 	StringName class_get_property_getter(const StringName &p_class, const StringName &p_property);
 	StringName class_get_property_setter(const StringName &p_class, const StringName &p_property);
 	Variant class_get_property(Object *p_object, const StringName &p_property) const;
@@ -486,6 +489,7 @@ public:
 	int class_get_method_argument_count(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_method_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	//TypedArray<Struct<MethodInfo>> class_get_method_list_as_structs(const StringName &p_class, bool p_no_inheritance = false) const;
 	Variant class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error);
 
 	PackedStringArray class_get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
@@ -500,6 +504,10 @@ public:
 	bool is_class_enum_bitfield(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance = false) const;
 
 	bool is_class_enabled(const StringName &p_class) const;
+
+	bool class_has_struct(const StringName &p_class, const StringName &p_struct, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> class_get_struct_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> class_get_struct_members(const StringName &p_class, const StringName &p_struct) const;
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -507,6 +507,7 @@ public:
 
 	bool class_has_struct(const StringName &p_class, const StringName &p_struct, bool p_no_inheritance = false) const;
 	TypedArray<Dictionary> class_get_struct_list(const StringName &p_class, bool p_no_inheritance = false) const;
+	// TODO: class_get_struct_members seems kind of pointless. It should maybe just be class_get_struct or something.
 	TypedArray<Dictionary> class_get_struct_members(const StringName &p_class, const StringName &p_struct) const;
 
 #ifdef TOOLS_ENABLED

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -114,6 +114,7 @@ public:
 		};
 
 		HashMap<StringName, EnumInfo> enum_map;
+		HashMap<StringName, StructInfo> struct_map;
 		HashMap<StringName, MethodInfo> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
@@ -426,6 +427,7 @@ public:
 	static void add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix = "", int p_indent_depth = 0);
 	static void add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage = PROPERTY_USAGE_DEFAULT);
 	static void add_property_array(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix);
+	static void add_property_struct(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix);
 	static void add_property(const StringName &p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index = -1);
 	static void set_property_default_value(const StringName &p_class, const StringName &p_name, const Variant &p_default);
 	static void add_linked_property(const StringName &p_class, const String &p_property, const String &p_linked_property);
@@ -467,6 +469,11 @@ public:
 	static bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 	static bool is_enum_bitfield(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 
+	static void bind_struct(const StringName &p_class, const StructInfo &p_struct_info);
+	static void get_struct_list(const StringName &p_class, List<StructInfo> *r_structs, bool p_no_inheritance = false);
+	static const StructInfo *get_struct_info(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
+	static const StructInfo *get_struct_info(const String &p_qualified_name, bool p_no_inheritance = false);
+
 	static void set_method_error_return_values(const StringName &p_class, const StringName &p_method, const Vector<Error> &p_values);
 	static Vector<Error> get_method_error_return_values(const StringName &p_class, const StringName &p_method);
 	static Variant class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid = nullptr);
@@ -505,6 +512,9 @@ public:
 
 #define BIND_CONSTANT(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);
+
+#define BIND_STRUCT(m_struct) \
+	::ClassDB::bind_struct(get_class_static(), m_struct::Layout::get_struct_info());
 
 #ifdef DEBUG_METHODS_ENABLED
 

--- a/core/object/method_info.cpp
+++ b/core/object/method_info.cpp
@@ -1,0 +1,99 @@
+/**************************************************************************/
+/*  method_info.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "method_info.h"
+#include "core/variant/struct.h"
+#include "core/variant/typed_array.h"
+
+PropertyInfo MethodInfo::return_val::from_variant(const Variant &p_variant) {
+	return PropertyInfo(Struct<PropertyInfo>(p_variant));
+}
+
+Variant MethodInfo::return_val::to_variant(const PropertyInfo &p_value) {
+	return Struct<PropertyInfo>(p_value);
+}
+
+List<PropertyInfo> MethodInfo::arguments::from_variant(const Variant &p_variant) {
+	return (List<PropertyInfo>)TypedArray<Struct<PropertyInfo>>(p_variant);
+}
+
+Variant MethodInfo::arguments::to_variant(const List<PropertyInfo> &p_value) {
+	return TypedArray<Struct<PropertyInfo>>(&p_value);
+}
+
+MethodInfo::operator Dictionary() const {
+	Dictionary d;
+	d["name"] = name;
+	d["args"] = convert_property_list(&arguments);
+	Array da;
+	for (int i = 0; i < default_arguments.size(); i++) {
+		da.push_back(default_arguments[i]);
+	}
+	d["default_args"] = da;
+	d["flags"] = flags;
+	d["id"] = id;
+	Dictionary r = return_val;
+	d["return"] = r;
+	return d;
+}
+
+MethodInfo MethodInfo::from_dict(const Dictionary &p_dict) {
+	MethodInfo mi;
+
+	if (p_dict.has("name")) {
+		mi.name = p_dict["name"];
+	}
+	Array args;
+	if (p_dict.has("args")) {
+		args = p_dict["args"];
+	}
+
+	for (const Variant &arg : args) {
+		Dictionary d = arg;
+		mi.arguments.push_back(PropertyInfo::from_dict(d));
+	}
+	Array defargs;
+	if (p_dict.has("default_args")) {
+		defargs = p_dict["default_args"];
+	}
+	for (const Variant &defarg : defargs) {
+		mi.default_arguments.push_back(defarg);
+	}
+
+	if (p_dict.has("return")) {
+		mi.return_val = PropertyInfo::from_dict(p_dict["return"]);
+	}
+
+	if (p_dict.has("flags")) {
+		mi.flags = p_dict["flags"];
+	}
+
+	return mi;
+}

--- a/core/object/method_info.h
+++ b/core/object/method_info.h
@@ -1,0 +1,137 @@
+/**************************************************************************/
+/*  method_info.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef METHOD_INFO_H
+#define METHOD_INFO_H
+
+#include "core/object/property_info.h"
+#include "core/variant/variant.h"
+
+enum MethodFlags {
+	METHOD_FLAG_NORMAL = 1,
+	METHOD_FLAG_EDITOR = 2,
+	METHOD_FLAG_CONST = 4,
+	METHOD_FLAG_VIRTUAL = 8,
+	METHOD_FLAG_VARARG = 16,
+	METHOD_FLAG_STATIC = 32,
+	METHOD_FLAG_OBJECT_CORE = 64,
+	METHOD_FLAG_VIRTUAL_REQUIRED = 128,
+	METHOD_FLAGS_DEFAULT = METHOD_FLAG_NORMAL,
+};
+
+struct MethodInfo {
+	STRUCT_DECLARE(MethodInfo);
+	STRUCT_MEMBER_PRIMITIVE(String, name, String());
+	STRUCT_MEMBER_PRIMITIVE_FROM_TO_ALIAS(List<PropertyInfo>, arguments, "args", List<PropertyInfo>());
+	STRUCT_MEMBER_PRIMITIVE_ALIAS(Vector<Variant>, default_arguments, "default_args", Vector<Variant>());
+	STRUCT_MEMBER_PRIMITIVE(uint32_t, flags, METHOD_FLAGS_DEFAULT);
+	STRUCT_MEMBER_PRIMITIVE(int, id, 0);
+	STRUCT_MEMBER_STRUCT_FROM_TO_ALIAS(PropertyInfo, return_val, "return", PropertyInfo());
+
+	STRUCT_MEMBER_PRIMITIVE(int, return_val_metadata, 0);
+	STRUCT_MEMBER_PRIMITIVE(Vector<int>, arguments_metadata, Vector<int>());
+	STRUCT_LAYOUT_OWNER(Object, MethodInfo, struct name, struct arguments, struct default_arguments, struct flags, struct id, struct return_val, struct return_val_metadata, struct arguments_metadata);
+
+	int get_argument_meta(int p_arg) const {
+		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);
+		if (p_arg == -1) {
+			return return_val_metadata;
+		}
+		return arguments_metadata.size() > p_arg ? arguments_metadata[p_arg] : 0;
+	}
+
+	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
+	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }
+
+	operator Dictionary() const;
+
+	static MethodInfo from_dict(const Dictionary &p_dict);
+
+	MethodInfo() {}
+
+	explicit MethodInfo(const GDExtensionMethodInfo &pinfo) :
+			name(*reinterpret_cast<StringName *>(pinfo.name)) {
+		for (uint32_t j = 0; j < pinfo.argument_count; j++) {
+			arguments.push_back(PropertyInfo(pinfo.arguments[j]));
+		}
+		const Variant *def_values = (const Variant *)pinfo.default_arguments;
+		for (uint32_t j = 0; j < pinfo.default_argument_count; j++) {
+			default_arguments.push_back(def_values[j]);
+		}
+		flags = pinfo.flags;
+		id = pinfo.id;
+		return_val = PropertyInfo(pinfo.return_value);
+	}
+
+	void _push_params(const PropertyInfo &p_param) {
+		arguments.push_back(p_param);
+	}
+
+	template <typename... VarArgs>
+	void _push_params(const PropertyInfo &p_param, VarArgs... p_params) {
+		arguments.push_back(p_param);
+		_push_params(p_params...);
+	}
+
+	MethodInfo(const String &p_name) { name = p_name; }
+
+	template <typename... VarArgs>
+	MethodInfo(const String &p_name, VarArgs... p_params) {
+		name = p_name;
+		_push_params(p_params...);
+	}
+
+	MethodInfo(Variant::Type ret) { return_val.type = ret; }
+	MethodInfo(Variant::Type ret, const String &p_name) {
+		return_val.type = ret;
+		name = p_name;
+	}
+
+	template <typename... VarArgs>
+	MethodInfo(Variant::Type ret, const String &p_name, VarArgs... p_params) {
+		name = p_name;
+		return_val.type = ret;
+		_push_params(p_params...);
+	}
+
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name) {
+		return_val = p_ret;
+		name = p_name;
+	}
+
+	template <typename... VarArgs>
+	MethodInfo(const PropertyInfo &p_ret, const String &p_name, VarArgs... p_params) {
+		return_val = p_ret;
+		name = p_name;
+		_push_params(p_params...);
+	}
+};
+
+#endif // METHOD_INFO_H

--- a/core/object/method_info.h
+++ b/core/object/method_info.h
@@ -48,16 +48,15 @@ enum MethodFlags {
 
 struct MethodInfo {
 	STRUCT_DECLARE(MethodInfo);
-	STRUCT_MEMBER_PRIMITIVE(String, name, String());
-	STRUCT_MEMBER_PRIMITIVE_FROM_TO_ALIAS(List<PropertyInfo>, arguments, "args", List<PropertyInfo>());
-	STRUCT_MEMBER_PRIMITIVE_ALIAS(Vector<Variant>, default_arguments, "default_args", Vector<Variant>());
-	STRUCT_MEMBER_PRIMITIVE(uint32_t, flags, METHOD_FLAGS_DEFAULT);
-	STRUCT_MEMBER_PRIMITIVE(int, id, 0);
+	STRUCT_MEMBER(String, name, String());
+	STRUCT_MEMBER_FROM_TO_ALIAS(List<PropertyInfo>, arguments, "args", List<PropertyInfo>());
+	STRUCT_MEMBER_ALIAS(Vector<Variant>, default_arguments, "default_args", Vector<Variant>());
+	STRUCT_MEMBER(uint32_t, flags, METHOD_FLAGS_DEFAULT);
+	STRUCT_MEMBER(int, id, 0);
 	STRUCT_MEMBER_STRUCT_FROM_TO_ALIAS(PropertyInfo, return_val, "return", PropertyInfo());
-
-	STRUCT_MEMBER_PRIMITIVE(int, return_val_metadata, 0);
-	STRUCT_MEMBER_PRIMITIVE(Vector<int>, arguments_metadata, Vector<int>());
-	STRUCT_LAYOUT_OWNER(Object, MethodInfo, struct name, struct arguments, struct default_arguments, struct flags, struct id, struct return_val, struct return_val_metadata, struct arguments_metadata);
+	STRUCT_MEMBER(int, return_val_metadata, 0);
+	STRUCT_MEMBER(Vector<int>, arguments_metadata, Vector<int>());
+	STRUCT_LAYOUT(Object, MethodInfo, struct name, struct arguments, struct default_arguments, struct flags, struct id, struct return_val, struct return_val_metadata, struct arguments_metadata);
 
 	int get_argument_meta(int p_arg) const {
 		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -39,6 +39,7 @@
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
 #include "core/templates/local_vector.h"
+#include "core/variant/struct.h"
 #include "core/variant/typed_array.h"
 
 #ifdef DEBUG_ENABLED
@@ -65,106 +66,6 @@ struct _ObjectDebugLock {
 #define OBJ_DEBUG_LOCK
 
 #endif
-
-PropertyInfo::operator Dictionary() const {
-	Dictionary d;
-	d["name"] = name;
-	d["class_name"] = class_name;
-	d["type"] = type;
-	d["hint"] = hint;
-	d["hint_string"] = hint_string;
-	d["usage"] = usage;
-	return d;
-}
-
-PropertyInfo PropertyInfo::from_dict(const Dictionary &p_dict) {
-	PropertyInfo pi;
-
-	if (p_dict.has("type")) {
-		pi.type = Variant::Type(int(p_dict["type"]));
-	}
-
-	if (p_dict.has("name")) {
-		pi.name = p_dict["name"];
-	}
-
-	if (p_dict.has("class_name")) {
-		pi.class_name = p_dict["class_name"];
-	}
-
-	if (p_dict.has("hint")) {
-		pi.hint = PropertyHint(int(p_dict["hint"]));
-	}
-
-	if (p_dict.has("hint_string")) {
-		pi.hint_string = p_dict["hint_string"];
-	}
-
-	if (p_dict.has("usage")) {
-		pi.usage = p_dict["usage"];
-	}
-
-	return pi;
-}
-
-TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list) {
-	TypedArray<Dictionary> va;
-	for (const List<PropertyInfo>::Element *E = p_list->front(); E; E = E->next()) {
-		va.push_back(Dictionary(E->get()));
-	}
-
-	return va;
-}
-
-MethodInfo::operator Dictionary() const {
-	Dictionary d;
-	d["name"] = name;
-	d["args"] = convert_property_list(&arguments);
-	Array da;
-	for (int i = 0; i < default_arguments.size(); i++) {
-		da.push_back(default_arguments[i]);
-	}
-	d["default_args"] = da;
-	d["flags"] = flags;
-	d["id"] = id;
-	Dictionary r = return_val;
-	d["return"] = r;
-	return d;
-}
-
-MethodInfo MethodInfo::from_dict(const Dictionary &p_dict) {
-	MethodInfo mi;
-
-	if (p_dict.has("name")) {
-		mi.name = p_dict["name"];
-	}
-	Array args;
-	if (p_dict.has("args")) {
-		args = p_dict["args"];
-	}
-
-	for (const Variant &arg : args) {
-		Dictionary d = arg;
-		mi.arguments.push_back(PropertyInfo::from_dict(d));
-	}
-	Array defargs;
-	if (p_dict.has("default_args")) {
-		defargs = p_dict["default_args"];
-	}
-	for (const Variant &defarg : defargs) {
-		mi.default_arguments.push_back(defarg);
-	}
-
-	if (p_dict.has("return")) {
-		mi.return_val = PropertyInfo::from_dict(p_dict["return"]);
-	}
-
-	if (p_dict.has("flags")) {
-		mi.flags = p_dict["flags"];
-	}
-
-	return mi;
-}
 
 Object::Connection::operator Variant() const {
 	Dictionary d;
@@ -1039,6 +940,12 @@ TypedArray<Dictionary> Object::_get_property_list_bind() const {
 	return convert_property_list(&lpi);
 }
 
+//TypedArray<Struct<PropertyInfo>> Object::_get_property_list_as_structs_bind() const {
+//	List<PropertyInfo> lpi;
+//	get_property_list(&lpi);
+//	return TypedArray<Struct<PropertyInfo>>(&lpi);
+//}
+
 TypedArray<Dictionary> Object::_get_method_list_bind() const {
 	List<MethodInfo> ml;
 	get_method_list(&ml);
@@ -1052,6 +959,12 @@ TypedArray<Dictionary> Object::_get_method_list_bind() const {
 
 	return ret;
 }
+
+//TypedArray<Struct<MethodInfo>> Object::_get_method_list_as_structs_bind() const {
+//	List<MethodInfo> ml;
+//	get_method_list(&ml);
+//	return TypedArray<Struct<MethodInfo>>(&ml);
+//}
 
 TypedArray<StringName> Object::_get_meta_list_bind() const {
 	TypedArray<StringName> _metaret;
@@ -1253,6 +1166,10 @@ void Object::_add_user_signal(const String &p_name, const Array &p_args) {
 	}
 }
 
+//void Object::_add_user_signal_as_struct(const Struct<MethodInfo> &p_signal) {
+//	add_user_signal(MethodInfo(p_signal));
+//}
+
 TypedArray<Dictionary> Object::_get_signal_list() const {
 	List<MethodInfo> signal_list;
 	get_signal_list(&signal_list);
@@ -1264,6 +1181,12 @@ TypedArray<Dictionary> Object::_get_signal_list() const {
 
 	return ret;
 }
+
+//TypedArray<Struct<MethodInfo>> Object::_get_signal_list_as_structs() const {
+//	List<MethodInfo> signal_list;
+//	get_signal_list(&signal_list);
+//	return TypedArray<Struct<MethodInfo>>(&signal_list);
+//}
 
 TypedArray<Dictionary> Object::_get_signal_connection_list(const StringName &p_signal) const {
 	List<Connection> conns;
@@ -1280,6 +1203,12 @@ TypedArray<Dictionary> Object::_get_signal_connection_list(const StringName &p_s
 	return ret;
 }
 
+//TypedArray<Struct<Object::Connection>> Object::_get_signal_connection_list_as_structs(const StringName &p_signal) const {
+//	List<Connection> conns;
+//	get_all_signal_connections(&conns);
+//	return TypedArray<Struct<Connection>>(&conns);
+//}
+
 TypedArray<Dictionary> Object::_get_incoming_connections() const {
 	TypedArray<Dictionary> ret;
 	for (const Object::Connection &connection : connections) {
@@ -1288,6 +1217,10 @@ TypedArray<Dictionary> Object::_get_incoming_connections() const {
 
 	return ret;
 }
+
+//TypedArray<Struct<Object::Connection>> Object::_get_incoming_connections_as_structs() const {
+//	return TypedArray<Struct<Connection>>(&connections);
+//}
 
 bool Object::has_signal(const StringName &p_name) const {
 	if (!script.is_null()) {
@@ -1655,7 +1588,9 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_indexed", "property_path", "value"), &Object::_set_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_indexed", "property_path"), &Object::_get_indexed_bind);
 	ClassDB::bind_method(D_METHOD("get_property_list"), &Object::_get_property_list_bind);
+	//ClassDB::bind_method(D_METHOD("get_property_list_as_structs"), &Object::_get_property_list_as_structs_bind);
 	ClassDB::bind_method(D_METHOD("get_method_list"), &Object::_get_method_list_bind);
+	//ClassDB::bind_method(D_METHOD("get_method_list_as_structs"), &Object::_get_method_list_as_structs_bind);
 	ClassDB::bind_method(D_METHOD("property_can_revert", "property"), &Object::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "property"), &Object::property_get_revert);
 	ClassDB::bind_method(D_METHOD("notification", "what", "reversed"), &Object::notification, DEFVAL(false));
@@ -1672,6 +1607,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_meta_list"), &Object::_get_meta_list_bind);
 
 	ClassDB::bind_method(D_METHOD("add_user_signal", "signal", "arguments"), &Object::_add_user_signal, DEFVAL(Array()));
+	//ClassDB::bind_method(D_METHOD("add_user_signal_as_struct", "signal"), &Object::_add_user_signal_as_struct);
 	ClassDB::bind_method(D_METHOD("has_user_signal", "signal"), &Object::_has_user_signal);
 	ClassDB::bind_method(D_METHOD("remove_user_signal", "signal"), &Object::_remove_user_signal);
 
@@ -1709,8 +1645,11 @@ void Object::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_signal", "signal"), &Object::has_signal);
 	ClassDB::bind_method(D_METHOD("get_signal_list"), &Object::_get_signal_list);
+	//ClassDB::bind_method(D_METHOD("get_signal_list_as_structs"), &Object::_get_signal_list_as_structs);
 	ClassDB::bind_method(D_METHOD("get_signal_connection_list", "signal"), &Object::_get_signal_connection_list);
+	//ClassDB::bind_method(D_METHOD("get_signal_connection_list_as_structs", "signal"), &Object::_get_signal_connection_list_as_structs);
 	ClassDB::bind_method(D_METHOD("get_incoming_connections"), &Object::_get_incoming_connections);
+	//ClassDB::bind_method(D_METHOD("get_incoming_connections_as_structs"), &Object::_get_incoming_connections_as_structs);
 
 	ClassDB::bind_method(D_METHOD("connect", "signal", "callable", "flags"), &Object::connect, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("disconnect", "signal", "callable"), &Object::disconnect);
@@ -1807,6 +1746,10 @@ void Object::_bind_methods() {
 	BIND_ENUM_CONSTANT(CONNECT_PERSIST);
 	BIND_ENUM_CONSTANT(CONNECT_ONE_SHOT);
 	BIND_ENUM_CONSTANT(CONNECT_REFERENCE_COUNTED);
+
+	BIND_STRUCT(PropertyInfo);
+	BIND_STRUCT(MethodInfo);
+	BIND_STRUCT(Connection);
 }
 
 void Object::set_deferred(const StringName &p_property, const Variant &p_value) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -33,7 +33,9 @@
 
 #include "core/extension/gdextension_interface.h"
 #include "core/object/message_queue.h"
+#include "core/object/method_info.h"
 #include "core/object/object_id.h"
+#include "core/object/property_info.h"
 #include "core/os/rw_lock.h"
 #include "core/os/spin_lock.h"
 #include "core/templates/hash_map.h"
@@ -42,90 +44,14 @@
 #include "core/templates/rb_map.h"
 #include "core/templates/safe_refcount.h"
 #include "core/variant/callable_bind.h"
+#include "core/variant/struct_generator.h"
 #include "core/variant/variant.h"
 
 template <typename T>
 class TypedArray;
 
-enum PropertyHint {
-	PROPERTY_HINT_NONE, ///< no hint provided.
-	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians_as_degrees][,degrees][,exp][,suffix:<keyword>] range.
-	PROPERTY_HINT_ENUM, ///< hint_text= "val1,val2,val3,etc"
-	PROPERTY_HINT_ENUM_SUGGESTION, ///< hint_text= "val1,val2,val3,etc"
-	PROPERTY_HINT_EXP_EASING, /// exponential easing function (Math::ease) use "attenuation" hint string to revert (flip h), "positive_only" to exclude in-out and out-in. (ie: "attenuation,positive_only")
-	PROPERTY_HINT_LINK,
-	PROPERTY_HINT_FLAGS, ///< hint_text= "flag1,flag2,etc" (as bit flags)
-	PROPERTY_HINT_LAYERS_2D_RENDER,
-	PROPERTY_HINT_LAYERS_2D_PHYSICS,
-	PROPERTY_HINT_LAYERS_2D_NAVIGATION,
-	PROPERTY_HINT_LAYERS_3D_RENDER,
-	PROPERTY_HINT_LAYERS_3D_PHYSICS,
-	PROPERTY_HINT_LAYERS_3D_NAVIGATION,
-	PROPERTY_HINT_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
-	PROPERTY_HINT_DIR, ///< a directory path must be passed
-	PROPERTY_HINT_GLOBAL_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
-	PROPERTY_HINT_GLOBAL_DIR, ///< a directory path must be passed
-	PROPERTY_HINT_RESOURCE_TYPE, ///< a resource object type
-	PROPERTY_HINT_MULTILINE_TEXT, ///< used for string properties that can contain multiple lines
-	PROPERTY_HINT_EXPRESSION, ///< used for string properties that can contain multiple lines
-	PROPERTY_HINT_PLACEHOLDER_TEXT, ///< used to set a placeholder text for string properties
-	PROPERTY_HINT_COLOR_NO_ALPHA, ///< used for ignoring alpha component when editing a color
-	PROPERTY_HINT_OBJECT_ID,
-	PROPERTY_HINT_TYPE_STRING, ///< a type string, the hint is the base type to choose
-	PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE, // Deprecated.
-	PROPERTY_HINT_OBJECT_TOO_BIG, ///< object is too big to send
-	PROPERTY_HINT_NODE_PATH_VALID_TYPES,
-	PROPERTY_HINT_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
-	PROPERTY_HINT_GLOBAL_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
-	PROPERTY_HINT_INT_IS_OBJECTID, // Deprecated.
-	PROPERTY_HINT_INT_IS_POINTER,
-	PROPERTY_HINT_ARRAY_TYPE,
-	PROPERTY_HINT_LOCALE_ID,
-	PROPERTY_HINT_LOCALIZABLE_STRING,
-	PROPERTY_HINT_NODE_TYPE, ///< a node object type
-	PROPERTY_HINT_HIDE_QUATERNION_EDIT, /// Only Node3D::transform should hide the quaternion editor.
-	PROPERTY_HINT_PASSWORD,
-	PROPERTY_HINT_LAYERS_AVOIDANCE,
-	PROPERTY_HINT_DICTIONARY_TYPE,
-	PROPERTY_HINT_TOOL_BUTTON,
-	PROPERTY_HINT_MAX,
-};
-
-enum PropertyUsageFlags {
-	PROPERTY_USAGE_NONE = 0,
-	PROPERTY_USAGE_STORAGE = 1 << 1,
-	PROPERTY_USAGE_EDITOR = 1 << 2,
-	PROPERTY_USAGE_INTERNAL = 1 << 3,
-	PROPERTY_USAGE_CHECKABLE = 1 << 4, // Used for editing global variables.
-	PROPERTY_USAGE_CHECKED = 1 << 5, // Used for editing global variables.
-	PROPERTY_USAGE_GROUP = 1 << 6, // Used for grouping props in the editor.
-	PROPERTY_USAGE_CATEGORY = 1 << 7,
-	PROPERTY_USAGE_SUBGROUP = 1 << 8,
-	PROPERTY_USAGE_CLASS_IS_BITFIELD = 1 << 9,
-	PROPERTY_USAGE_NO_INSTANCE_STATE = 1 << 10,
-	PROPERTY_USAGE_RESTART_IF_CHANGED = 1 << 11,
-	PROPERTY_USAGE_SCRIPT_VARIABLE = 1 << 12,
-	PROPERTY_USAGE_STORE_IF_NULL = 1 << 13,
-	PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED = 1 << 14,
-	PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE = 1 << 15, // Deprecated.
-	PROPERTY_USAGE_CLASS_IS_ENUM = 1 << 16,
-	PROPERTY_USAGE_NIL_IS_VARIANT = 1 << 17,
-	PROPERTY_USAGE_ARRAY = 1 << 18, // Used in the inspector to group properties as elements of an array.
-	PROPERTY_USAGE_ALWAYS_DUPLICATE = 1 << 19, // When duplicating a resource, always duplicate, even with subresource duplication disabled.
-	PROPERTY_USAGE_NEVER_DUPLICATE = 1 << 20, // When duplicating a resource, never duplicate, even with subresource duplication enabled.
-	PROPERTY_USAGE_HIGH_END_GFX = 1 << 21,
-	PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT = 1 << 22,
-	PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT = 1 << 23,
-	PROPERTY_USAGE_KEYING_INCREMENTS = 1 << 24, // Used in inspector to increment property when keyed in animation player.
-	PROPERTY_USAGE_DEFERRED_SET_RESOURCE = 1 << 25, // Deprecated.
-	PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT = 1 << 26, // For Object properties, instantiate them when creating in editor.
-	PROPERTY_USAGE_EDITOR_BASIC_SETTING = 1 << 27, //for project or editor settings, show when basic settings are selected.
-	PROPERTY_USAGE_READ_ONLY = 1 << 28, // Mark a property as read-only in the inspector.
-	PROPERTY_USAGE_SECRET = 1 << 29, // Export preset credentials that should be stored separately from the rest of the export config.
-
-	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
-	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE,
-};
+template <typename T>
+class Struct;
 
 #define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, _scs_create(m_setter), _scs_create(m_getter))
@@ -140,170 +66,12 @@ enum PropertyUsageFlags {
 #define ADD_ARRAY_COUNT(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, _scs_create(m_count_property_setter), _scs_create(m_count_property_getter), m_prefix)
 #define ADD_ARRAY_COUNT_WITH_USAGE_FLAGS(m_label, m_count_property, m_count_property_setter, m_count_property_getter, m_prefix, m_property_usage_flags) ClassDB::add_property_array_count(get_class_static(), m_label, m_count_property, _scs_create(m_count_property_setter), _scs_create(m_count_property_getter), m_prefix, m_property_usage_flags)
 #define ADD_ARRAY(m_array_path, m_prefix) ClassDB::add_property_array(get_class_static(), m_array_path, m_prefix)
+// TODO: This probably doesn't work yet as is.
+#define ADD_STRUCT(m_array_path, m_prefix) ClassDB::add_property_struct(get_class_static(), m_array_path, m_prefix)
 
 // Helper macro to use with PROPERTY_HINT_ARRAY_TYPE for arrays of specific resources:
 // PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")
 #define MAKE_RESOURCE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, m_type)
-
-struct PropertyInfo {
-	Variant::Type type = Variant::NIL;
-	String name;
-	StringName class_name; // For classes
-	PropertyHint hint = PROPERTY_HINT_NONE;
-	String hint_string;
-	uint32_t usage = PROPERTY_USAGE_DEFAULT;
-
-	// If you are thinking about adding another member to this class, ask the maintainer (Juan) first.
-
-	_FORCE_INLINE_ PropertyInfo added_usage(uint32_t p_fl) const {
-		PropertyInfo pi = *this;
-		pi.usage |= p_fl;
-		return pi;
-	}
-
-	operator Dictionary() const;
-
-	static PropertyInfo from_dict(const Dictionary &p_dict);
-
-	PropertyInfo() {}
-
-	PropertyInfo(const Variant::Type p_type, const String &p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
-			type(p_type),
-			name(p_name),
-			hint(p_hint),
-			hint_string(p_hint_string),
-			usage(p_usage) {
-		if (hint == PROPERTY_HINT_RESOURCE_TYPE) {
-			class_name = hint_string;
-		} else {
-			class_name = p_class_name;
-		}
-	}
-
-	PropertyInfo(const StringName &p_class_name) :
-			type(Variant::OBJECT),
-			class_name(p_class_name) {}
-
-	explicit PropertyInfo(const GDExtensionPropertyInfo &pinfo) :
-			type((Variant::Type)pinfo.type),
-			name(*reinterpret_cast<StringName *>(pinfo.name)),
-			class_name(*reinterpret_cast<StringName *>(pinfo.class_name)),
-			hint((PropertyHint)pinfo.hint),
-			hint_string(*reinterpret_cast<String *>(pinfo.hint_string)),
-			usage(pinfo.usage) {}
-
-	bool operator==(const PropertyInfo &p_info) const {
-		return ((type == p_info.type) &&
-				(name == p_info.name) &&
-				(class_name == p_info.class_name) &&
-				(hint == p_info.hint) &&
-				(hint_string == p_info.hint_string) &&
-				(usage == p_info.usage));
-	}
-
-	bool operator<(const PropertyInfo &p_info) const {
-		return name < p_info.name;
-	}
-};
-
-TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list);
-
-enum MethodFlags {
-	METHOD_FLAG_NORMAL = 1,
-	METHOD_FLAG_EDITOR = 2,
-	METHOD_FLAG_CONST = 4,
-	METHOD_FLAG_VIRTUAL = 8,
-	METHOD_FLAG_VARARG = 16,
-	METHOD_FLAG_STATIC = 32,
-	METHOD_FLAG_OBJECT_CORE = 64,
-	METHOD_FLAG_VIRTUAL_REQUIRED = 128,
-	METHOD_FLAGS_DEFAULT = METHOD_FLAG_NORMAL,
-};
-
-struct MethodInfo {
-	String name;
-	PropertyInfo return_val;
-	uint32_t flags = METHOD_FLAGS_DEFAULT;
-	int id = 0;
-	List<PropertyInfo> arguments;
-	Vector<Variant> default_arguments;
-	int return_val_metadata = 0;
-	Vector<int> arguments_metadata;
-
-	int get_argument_meta(int p_arg) const {
-		ERR_FAIL_COND_V(p_arg < -1 || p_arg > arguments.size(), 0);
-		if (p_arg == -1) {
-			return return_val_metadata;
-		}
-		return arguments_metadata.size() > p_arg ? arguments_metadata[p_arg] : 0;
-	}
-
-	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id && name == p_method.name; }
-	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }
-
-	operator Dictionary() const;
-
-	static MethodInfo from_dict(const Dictionary &p_dict);
-
-	MethodInfo() {}
-
-	explicit MethodInfo(const GDExtensionMethodInfo &pinfo) :
-			name(*reinterpret_cast<StringName *>(pinfo.name)),
-			return_val(PropertyInfo(pinfo.return_value)),
-			flags(pinfo.flags),
-			id(pinfo.id) {
-		for (uint32_t j = 0; j < pinfo.argument_count; j++) {
-			arguments.push_back(PropertyInfo(pinfo.arguments[j]));
-		}
-		const Variant *def_values = (const Variant *)pinfo.default_arguments;
-		for (uint32_t j = 0; j < pinfo.default_argument_count; j++) {
-			default_arguments.push_back(def_values[j]);
-		}
-	}
-
-	void _push_params(const PropertyInfo &p_param) {
-		arguments.push_back(p_param);
-	}
-
-	template <typename... VarArgs>
-	void _push_params(const PropertyInfo &p_param, VarArgs... p_params) {
-		arguments.push_back(p_param);
-		_push_params(p_params...);
-	}
-
-	MethodInfo(const String &p_name) { name = p_name; }
-
-	template <typename... VarArgs>
-	MethodInfo(const String &p_name, VarArgs... p_params) {
-		name = p_name;
-		_push_params(p_params...);
-	}
-
-	MethodInfo(Variant::Type ret) { return_val.type = ret; }
-	MethodInfo(Variant::Type ret, const String &p_name) {
-		return_val.type = ret;
-		name = p_name;
-	}
-
-	template <typename... VarArgs>
-	MethodInfo(Variant::Type ret, const String &p_name, VarArgs... p_params) {
-		name = p_name;
-		return_val.type = ret;
-		_push_params(p_params...);
-	}
-
-	MethodInfo(const PropertyInfo &p_ret, const String &p_name) {
-		return_val = p_ret;
-		name = p_name;
-	}
-
-	template <typename... VarArgs>
-	MethodInfo(const PropertyInfo &p_ret, const String &p_name, VarArgs... p_params) {
-		return_val = p_ret;
-		name = p_name;
-		_push_params(p_params...);
-	}
-};
 
 // API used to extend in GDExtension and other C compatible compiled languages.
 class MethodBind;
@@ -575,10 +343,12 @@ public:
 	};
 
 	struct Connection {
-		::Signal signal;
-		Callable callable;
+		STRUCT_DECLARE(Connection);
+		STRUCT_MEMBER_PRIMITIVE(::Signal, signal, ::Signal());
+		STRUCT_MEMBER_PRIMITIVE(Callable, callable, Callable());
+		STRUCT_MEMBER_PRIMITIVE(uint32_t, flags, 0);
+		STRUCT_LAYOUT_OWNER(Object, Connection, struct signal, struct callable, struct flags);
 
-		uint32_t flags = 0;
 		bool operator<(const Connection &p_conn) const;
 
 		operator Variant() const;
@@ -634,12 +404,16 @@ private:
 	mutable const StringName *_class_name_ptr = nullptr;
 
 	void _add_user_signal(const String &p_name, const Array &p_args = Array());
+	//void _add_user_signal_as_struct(const Struct<MethodInfo> &p_signal);
 	bool _has_user_signal(const StringName &p_name) const;
 	void _remove_user_signal(const StringName &p_name);
 	Error _emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	TypedArray<Dictionary> _get_signal_list() const;
 	TypedArray<Dictionary> _get_signal_connection_list(const StringName &p_signal) const;
 	TypedArray<Dictionary> _get_incoming_connections() const;
+	//TypedArray<Struct<MethodInfo>> _get_signal_list_as_structs() const;
+	//TypedArray<Struct<Connection>> _get_signal_connection_list_as_structs(const StringName &p_signal) const;
+	//TypedArray<Struct<Connection>> _get_incoming_connections_as_structs() const;
 	void _set_bind(const StringName &p_set, const Variant &p_value);
 	Variant _get_bind(const StringName &p_name) const;
 	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
@@ -746,7 +520,9 @@ protected:
 
 	TypedArray<StringName> _get_meta_list_bind() const;
 	TypedArray<Dictionary> _get_property_list_bind() const;
+	//TypedArray<Struct<PropertyInfo>> _get_property_list_as_structs_bind() const;
 	TypedArray<Dictionary> _get_method_list_bind() const;
+	//TypedArray<Struct<MethodInfo>> _get_method_list_as_structs_bind() const;
 
 	void _clear_internal_resource_paths(const Variant &p_var);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -344,10 +344,10 @@ public:
 
 	struct Connection {
 		STRUCT_DECLARE(Connection);
-		STRUCT_MEMBER_PRIMITIVE(::Signal, signal, ::Signal());
-		STRUCT_MEMBER_PRIMITIVE(Callable, callable, Callable());
-		STRUCT_MEMBER_PRIMITIVE(uint32_t, flags, 0);
-		STRUCT_LAYOUT_OWNER(Object, Connection, struct signal, struct callable, struct flags);
+		STRUCT_MEMBER(::Signal, signal, ::Signal());
+		STRUCT_MEMBER(Callable, callable, Callable());
+		STRUCT_MEMBER(uint32_t, flags, 0);
+		STRUCT_LAYOUT(Object, Connection, struct signal, struct callable, struct flags);
 
 		bool operator<(const Connection &p_conn) const;
 

--- a/core/object/property_info.cpp
+++ b/core/object/property_info.cpp
@@ -1,0 +1,90 @@
+/**************************************************************************/
+/*  property_info.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "property_info.h"
+#include "core/variant/typed_array.h"
+
+Variant::Type PropertyInfo::type::from_variant(const Variant &p_variant) {
+	return (Variant::Type)(int)p_variant;
+}
+
+PropertyHint PropertyInfo::hint::from_variant(const Variant &p_variant) {
+	return (PropertyHint)(int)p_variant;
+}
+
+PropertyInfo::operator Dictionary() const {
+	Dictionary d;
+	d["name"] = name;
+	d["class_name"] = class_name;
+	d["type"] = type;
+	d["hint"] = hint;
+	d["hint_string"] = hint_string;
+	d["usage"] = usage;
+	return d;
+}
+
+PropertyInfo PropertyInfo::from_dict(const Dictionary &p_dict) {
+	PropertyInfo pi;
+
+	if (p_dict.has("type")) {
+		pi.type = Variant::Type(int(p_dict["type"]));
+	}
+
+	if (p_dict.has("name")) {
+		pi.name = p_dict["name"];
+	}
+
+	if (p_dict.has("class_name")) {
+		pi.class_name = p_dict["class_name"];
+	}
+
+	if (p_dict.has("hint")) {
+		pi.hint = PropertyHint(int(p_dict["hint"]));
+	}
+
+	if (p_dict.has("hint_string")) {
+		pi.hint_string = p_dict["hint_string"];
+	}
+
+	if (p_dict.has("usage")) {
+		pi.usage = p_dict["usage"];
+	}
+
+	return pi;
+}
+
+TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list) {
+	TypedArray<Dictionary> va;
+	for (const List<PropertyInfo>::Element *E = p_list->front(); E; E = E->next()) {
+		va.push_back(Dictionary(E->get()));
+	}
+
+	return va;
+}

--- a/core/object/property_info.h
+++ b/core/object/property_info.h
@@ -1,0 +1,176 @@
+/**************************************************************************/
+/*  property_info.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PROPERTY_INFO_H
+#define PROPERTY_INFO_H
+
+#include "core/extension/gdextension_interface.h"
+#include "core/variant/struct_generator.h"
+#include "core/variant/variant.h"
+
+enum PropertyHint {
+	PROPERTY_HINT_NONE, ///< no hint provided.
+	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians_as_degrees][,degrees][,exp][,suffix:<keyword>] range.
+	PROPERTY_HINT_ENUM, ///< hint_text= "val1,val2,val3,etc"
+	PROPERTY_HINT_ENUM_SUGGESTION, ///< hint_text= "val1,val2,val3,etc"
+	PROPERTY_HINT_EXP_EASING, /// exponential easing function (Math::ease) use "attenuation" hint string to revert (flip h), "positive_only" to exclude in-out and out-in. (ie: "attenuation,positive_only")
+	PROPERTY_HINT_LINK,
+	PROPERTY_HINT_FLAGS, ///< hint_text= "flag1,flag2,etc" (as bit flags)
+	PROPERTY_HINT_LAYERS_2D_RENDER,
+	PROPERTY_HINT_LAYERS_2D_PHYSICS,
+	PROPERTY_HINT_LAYERS_2D_NAVIGATION,
+	PROPERTY_HINT_LAYERS_3D_RENDER,
+	PROPERTY_HINT_LAYERS_3D_PHYSICS,
+	PROPERTY_HINT_LAYERS_3D_NAVIGATION,
+	PROPERTY_HINT_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
+	PROPERTY_HINT_DIR, ///< a directory path must be passed
+	PROPERTY_HINT_GLOBAL_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
+	PROPERTY_HINT_GLOBAL_DIR, ///< a directory path must be passed
+	PROPERTY_HINT_RESOURCE_TYPE, ///< a resource object type
+	PROPERTY_HINT_MULTILINE_TEXT, ///< used for string properties that can contain multiple lines
+	PROPERTY_HINT_EXPRESSION, ///< used for string properties that can contain multiple lines
+	PROPERTY_HINT_PLACEHOLDER_TEXT, ///< used to set a placeholder text for string properties
+	PROPERTY_HINT_COLOR_NO_ALPHA, ///< used for ignoring alpha component when editing a color
+	PROPERTY_HINT_OBJECT_ID,
+	PROPERTY_HINT_TYPE_STRING, ///< a type string, the hint is the base type to choose
+	PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE, // Deprecated.
+	PROPERTY_HINT_OBJECT_TOO_BIG, ///< object is too big to send
+	PROPERTY_HINT_NODE_PATH_VALID_TYPES,
+	PROPERTY_HINT_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
+	PROPERTY_HINT_GLOBAL_SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
+	PROPERTY_HINT_INT_IS_OBJECTID, // Deprecated.
+	PROPERTY_HINT_INT_IS_POINTER,
+	PROPERTY_HINT_ARRAY_TYPE,
+	PROPERTY_HINT_LOCALE_ID,
+	PROPERTY_HINT_LOCALIZABLE_STRING,
+	PROPERTY_HINT_NODE_TYPE, ///< a node object type
+	PROPERTY_HINT_HIDE_QUATERNION_EDIT, /// Only Node3D::transform should hide the quaternion editor.
+	PROPERTY_HINT_PASSWORD,
+	PROPERTY_HINT_LAYERS_AVOIDANCE,
+	PROPERTY_HINT_DICTIONARY_TYPE,
+	PROPERTY_HINT_TOOL_BUTTON,
+	PROPERTY_HINT_MAX,
+};
+
+enum PropertyUsageFlags {
+	PROPERTY_USAGE_NONE = 0,
+	PROPERTY_USAGE_STORAGE = 1 << 1,
+	PROPERTY_USAGE_EDITOR = 1 << 2,
+	PROPERTY_USAGE_INTERNAL = 1 << 3,
+	PROPERTY_USAGE_CHECKABLE = 1 << 4, // Used for editing global variables.
+	PROPERTY_USAGE_CHECKED = 1 << 5, // Used for editing global variables.
+	PROPERTY_USAGE_GROUP = 1 << 6, // Used for grouping props in the editor.
+	PROPERTY_USAGE_CATEGORY = 1 << 7,
+	PROPERTY_USAGE_SUBGROUP = 1 << 8,
+	PROPERTY_USAGE_CLASS_IS_BITFIELD = 1 << 9,
+	PROPERTY_USAGE_NO_INSTANCE_STATE = 1 << 10,
+	PROPERTY_USAGE_RESTART_IF_CHANGED = 1 << 11,
+	PROPERTY_USAGE_SCRIPT_VARIABLE = 1 << 12,
+	PROPERTY_USAGE_STORE_IF_NULL = 1 << 13,
+	PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED = 1 << 14,
+	PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE = 1 << 15, // Deprecated.
+	PROPERTY_USAGE_CLASS_IS_ENUM = 1 << 16,
+	PROPERTY_USAGE_NIL_IS_VARIANT = 1 << 17,
+	PROPERTY_USAGE_ARRAY = 1 << 18, // Used in the inspector to group properties as elements of an array.
+	PROPERTY_USAGE_ALWAYS_DUPLICATE = 1 << 19, // When duplicating a resource, always duplicate, even with subresource duplication disabled.
+	PROPERTY_USAGE_NEVER_DUPLICATE = 1 << 20, // When duplicating a resource, never duplicate, even with subresource duplication enabled.
+	PROPERTY_USAGE_HIGH_END_GFX = 1 << 21,
+	PROPERTY_USAGE_NODE_PATH_FROM_SCENE_ROOT = 1 << 22,
+	PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT = 1 << 23,
+	PROPERTY_USAGE_KEYING_INCREMENTS = 1 << 24, // Used in inspector to increment property when keyed in animation player.
+	PROPERTY_USAGE_DEFERRED_SET_RESOURCE = 1 << 25, // Deprecated.
+	PROPERTY_USAGE_EDITOR_INSTANTIATE_OBJECT = 1 << 26, // For Object properties, instantiate them when creating in editor.
+	PROPERTY_USAGE_EDITOR_BASIC_SETTING = 1 << 27, //for project or editor settings, show when basic settings are selected.
+	PROPERTY_USAGE_READ_ONLY = 1 << 28, // Mark a property as read-only in the inspector.
+	PROPERTY_USAGE_SECRET = 1 << 29, // Export preset credentials that should be stored separately from the rest of the export config.
+
+	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
+	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE,
+};
+
+struct PropertyInfo {
+	STRUCT_DECLARE(PropertyInfo);
+	STRUCT_MEMBER_PRIMITIVE(String, name, String());
+	STRUCT_MEMBER_PRIMITIVE(StringName, class_name, StringName());
+	STRUCT_MEMBER_PRIMITIVE_FROM(Variant::Type, type, Variant::NIL);
+	STRUCT_MEMBER_PRIMITIVE_FROM(PropertyHint, hint, PROPERTY_HINT_NONE);
+	STRUCT_MEMBER_PRIMITIVE(String, hint_string, String());
+	STRUCT_MEMBER_PRIMITIVE(uint32_t, usage, PROPERTY_USAGE_DEFAULT);
+	STRUCT_LAYOUT_OWNER(Object, PropertyInfo, struct name, struct class_name, struct type, struct hint, struct hint_string, struct usage);
+
+	_FORCE_INLINE_ PropertyInfo added_usage(uint32_t p_fl) const {
+		PropertyInfo pi = *this;
+		pi.usage |= p_fl;
+		return pi;
+	}
+
+	operator Dictionary() const;
+
+	static PropertyInfo from_dict(const Dictionary &p_dict);
+
+	PropertyInfo() {}
+
+	PropertyInfo(const Variant::Type p_type, const String p_name, const PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", const uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const StringName &p_class_name = StringName()) :
+			name(p_name),
+			class_name(p_hint == PROPERTY_HINT_RESOURCE_TYPE ? StringName(p_hint_string) : p_class_name),
+			type(p_type),
+			hint(p_hint),
+			hint_string(p_hint_string),
+			usage(p_usage) {}
+
+	PropertyInfo(const StringName &p_class_name) :
+			class_name(p_class_name),
+			type(Variant::OBJECT) {}
+
+	explicit PropertyInfo(const GDExtensionPropertyInfo &pinfo) :
+			name(*reinterpret_cast<StringName *>(pinfo.name)),
+			class_name(*reinterpret_cast<StringName *>(pinfo.class_name)),
+			type((Variant::Type)pinfo.type),
+			hint((PropertyHint)pinfo.hint),
+			hint_string(*reinterpret_cast<String *>(pinfo.hint_string)),
+			usage(pinfo.usage) {}
+
+	bool operator==(const PropertyInfo &p_info) const {
+		return ((type == p_info.type) &&
+				(name == p_info.name) &&
+				(class_name == p_info.class_name) &&
+				(hint == p_info.hint) &&
+				(hint_string == p_info.hint_string) &&
+				(usage == p_info.usage));
+	}
+
+	bool operator<(const PropertyInfo &p_info) const {
+		return name < p_info.name;
+	}
+};
+
+TypedArray<Dictionary> convert_property_list(const List<PropertyInfo> *p_list);
+
+#endif // PROPERTY_INFO_H

--- a/core/object/property_info.h
+++ b/core/object/property_info.h
@@ -117,13 +117,13 @@ enum PropertyUsageFlags {
 
 struct PropertyInfo {
 	STRUCT_DECLARE(PropertyInfo);
-	STRUCT_MEMBER_PRIMITIVE(String, name, String());
-	STRUCT_MEMBER_PRIMITIVE(StringName, class_name, StringName());
-	STRUCT_MEMBER_PRIMITIVE_FROM(Variant::Type, type, Variant::NIL);
-	STRUCT_MEMBER_PRIMITIVE_FROM(PropertyHint, hint, PROPERTY_HINT_NONE);
-	STRUCT_MEMBER_PRIMITIVE(String, hint_string, String());
-	STRUCT_MEMBER_PRIMITIVE(uint32_t, usage, PROPERTY_USAGE_DEFAULT);
-	STRUCT_LAYOUT_OWNER(Object, PropertyInfo, struct name, struct class_name, struct type, struct hint, struct hint_string, struct usage);
+	STRUCT_MEMBER(String, name, String());
+	STRUCT_MEMBER(StringName, class_name, StringName());
+	STRUCT_MEMBER_FROM(Variant::Type, type, Variant::NIL);
+	STRUCT_MEMBER_FROM(PropertyHint, hint, PROPERTY_HINT_NONE);
+	STRUCT_MEMBER(String, hint_string, String());
+	STRUCT_MEMBER(uint32_t, usage, PROPERTY_USAGE_DEFAULT);
+	STRUCT_LAYOUT(Object, PropertyInfo, struct name, struct class_name, struct type, struct hint, struct hint_string, struct usage);
 
 	_FORCE_INLINE_ PropertyInfo added_usage(uint32_t p_fl) const {
 		PropertyInfo pi = *this;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4055,7 +4055,11 @@ String String::format(const Variant &values, const String &placeholder) const {
 
 	if (values.get_type() == Variant::ARRAY) {
 		Array values_arr = values;
-
+		if (const StructInfo *struct_info = values_arr.get_struct_info()) {
+			for (int32_t i = 0; i < struct_info->count; i++) {
+				new_string = new_string.replace(placeholder.replace("_", struct_info->names[i]), values_arr[(int)i]);
+			}
+		}
 		for (int i = 0; i < values_arr.size(); i++) {
 			String i_as_str = String::num_int64(i);
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -39,7 +39,9 @@
 #include "core/templates/vector.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
+#include "core/variant/struct.h"
 #include "core/variant/variant.h"
+#include "struct_generator.h"
 
 class ArrayPrivate {
 public:
@@ -47,6 +49,40 @@ public:
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	ContainerTypeValidate typed;
+
+	_FORCE_INLINE_ bool is_struct() const {
+		return !typed.is_array_of_structs && typed.struct_info != nullptr;
+	}
+
+	_FORCE_INLINE_ bool is_array_of_structs() const {
+		return typed.is_array_of_structs;
+	}
+
+	_FORCE_INLINE_ bool is_struct_array() const {
+		return false; // TODO: not supported yet
+	}
+
+	_FORCE_INLINE_ int32_t find_member_index(const StringName &p_member) const {
+		// TODO: is there a better way to do this than linear search?
+		ERR_FAIL_NULL_V_MSG(typed.struct_info, -1, "Can only find member on a Struct");
+		for (int32_t i = 0; i < typed.struct_info->count; i++) {
+			if (p_member == typed.struct_info->names[i]) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	_FORCE_INLINE_ int32_t rfind_member_index(const StringName &p_member) const {
+		// TODO: is there a better way to do this than linear search?
+		ERR_FAIL_NULL_V_MSG(typed.struct_info, -1, "Can only find member on a Struct");
+		for (int32_t i = typed.struct_info->count - 1; i >= 0; i--) {
+			if (p_member == typed.struct_info->names[i]) {
+				return i;
+			}
+		}
+		return -1;
+	}
 };
 
 void Array::_ref(const Array &p_from) const {
@@ -218,7 +254,7 @@ void Array::assign(const Array &p_array) {
 	const ContainerTypeValidate &typed = _p->typed;
 	const ContainerTypeValidate &source_typed = p_array._p->typed;
 
-	if (typed == source_typed || typed.type == Variant::NIL || (source_typed.type == Variant::OBJECT && typed.can_reference(source_typed))) {
+	if (typed.can_reference(source_typed)) {
 		// from same to same or
 		// from anything to variants or
 		// from subclasses to base classes
@@ -234,8 +270,9 @@ void Array::assign(const Array &p_array) {
 		// from base classes to subclasses
 		for (int i = 0; i < size; i++) {
 			const Variant &element = source[i];
-			if (element.get_type() != Variant::NIL && (element.get_type() != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
+			const Variant::Type type = source[i].get_type();
+			if (type != Variant::NIL && (type != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
+				ERR_FAIL_MSG(vformat(R"(Unable to convert array index %d from "%s" to "%s".)", i, Variant::get_type_name(type), Variant::get_type_name(typed.type)));
 			}
 		}
 		_p->array = p_array._p->array;
@@ -248,6 +285,21 @@ void Array::assign(const Array &p_array) {
 	Vector<Variant> array;
 	array.resize(size);
 	Variant *data = array.ptrw();
+
+	if (is_struct()) {
+		if (source_typed.type != Variant::NIL) {
+			ERR_FAIL_COND_MSG(typed != source_typed, "Attempted to assign a typed array to a struct.");
+			_p->array = p_array._p->array;
+			return;
+		}
+		for (int i = 0; i < size; i++) {
+			ValidatedVariant validated = typed.validate_struct_member(source[i], i, "assign");
+			ERR_FAIL_COND_MSG(!validated.valid, vformat(R"(Unable to convert array index %i from "%s" to "%s".)", i, Variant::get_type_name(source[i].get_type()), Variant::get_type_name(typed.type)));
+			array.write[i] = validated.value;
+		}
+		_p->array = array;
+		return;
+	}
 
 	if (source_typed.type == Variant::NIL && typed.type != Variant::OBJECT) {
 		// from variants to primitives
@@ -281,17 +333,21 @@ void Array::assign(const Array &p_array) {
 
 void Array::push_back(const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND(!_p->typed.validate(value, "push_back"));
-	_p->array.push_back(value);
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->typed.validate(p_value, "push_back");
+	ERR_FAIL_COND(!validated.valid);
+	_p->array.push_back(validated.value);
 }
 
 void Array::append_array(const Array &p_array) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 
 	Vector<Variant> validated_array = p_array._p->array;
 	for (int i = 0; i < validated_array.size(); ++i) {
-		ERR_FAIL_COND(!_p->typed.validate(validated_array.write[i], "append_array"));
+		ValidatedVariant validated = _p->typed.validate(validated_array[i], "append_array");
+		validated_array.write[i] = validated.value;
+		ERR_FAIL_COND(!validated.valid);
 	}
 
 	_p->array.append_array(validated_array);
@@ -299,36 +355,48 @@ void Array::append_array(const Array &p_array) {
 
 Error Array::resize(int p_new_size) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
-	Variant::Type &variant_type = _p->typed.type;
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), ERR_LOCKED, "Array is a struct."); // TODO: better error message
+
 	int old_size = _p->array.size();
+	Variant::Type &variant_type = _p->typed.type;
 	Error err = _p->array.resize_zeroed(p_new_size);
-	if (!err && variant_type != Variant::NIL && variant_type != Variant::OBJECT) {
+	if (err || variant_type == Variant::NIL || variant_type == Variant::OBJECT) {
+		return err;
+	}
+	if (const StructInfo *info = _p->typed.struct_info) { // Typed array of structs
 		for (int i = old_size; i < p_new_size; i++) {
-			VariantInternal::initialize(&_p->array.write[i], variant_type);
+			_p->array.write[i] = Array(*info);
 		}
+		return err;
+	}
+	for (int i = old_size; i < p_new_size; i++) {
+		VariantInternal::initialize(&_p->array.write[i], variant_type);
 	}
 	return err;
 }
 
 Error Array::insert(int p_pos, const Variant &p_value) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "insert"), ERR_INVALID_PARAMETER);
-	return _p->array.insert(p_pos, value);
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), ERR_LOCKED, "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->typed.validate(p_value, "insert");
+	ERR_FAIL_COND_V(!validated.valid, ERR_INVALID_PARAMETER);
+	return _p->array.insert(p_pos, validated.value);
 }
 
 void Array::fill(const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND(!_p->typed.validate(value, "fill"));
-	_p->array.fill(value);
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->typed.validate(p_value, "fill");
+	ERR_FAIL_COND(!validated.valid);
+	_p->array.fill(validated.value);
 }
 
 void Array::erase(const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND(!_p->typed.validate(value, "erase"));
-	_p->array.erase(value);
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->typed.validate(p_value, "erase");
+	ERR_FAIL_COND(!validated.valid);
+	_p->array.erase(validated.value);
 }
 
 Variant Array::front() const {
@@ -350,8 +418,15 @@ int Array::find(const Variant &p_value, int p_from) const {
 	if (_p->array.size() == 0) {
 		return -1;
 	}
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "find"), -1);
+	if (is_struct()) {
+		ERR_FAIL_COND_V_MSG(!p_value.is_string(), -1, "Can only find a String or StringName in a Struct.");
+		StringName member = p_value;
+		return find_member(member);
+	}
+
+	ValidatedVariant validated = _p->typed.validate(p_value, "find");
+
+	ERR_FAIL_COND_V(!validated.valid, -1);
 
 	int ret = -1;
 
@@ -360,7 +435,7 @@ int Array::find(const Variant &p_value, int p_from) const {
 	}
 
 	for (int i = p_from; i < size(); i++) {
-		if (StringLikeVariantComparator::compare(_p->array[i], value)) {
+		if (StringLikeVariantComparator::compare(_p->array[i], validated.value)) {
 			ret = i;
 			break;
 		}
@@ -401,8 +476,14 @@ int Array::rfind(const Variant &p_value, int p_from) const {
 	if (_p->array.size() == 0) {
 		return -1;
 	}
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "rfind"), -1);
+	if (is_struct()) {
+		ERR_FAIL_COND_V_MSG(!p_value.is_string(), -1, "Can only find a String or StringName in a Struct.");
+		StringName member = p_value;
+		return rfind_member(member);
+	}
+
+	ValidatedVariant validated = _p->typed.validate(p_value, "rfind");
+	ERR_FAIL_COND_V(!validated.valid, -1);
 
 	if (p_from < 0) {
 		// Relative offset from the end
@@ -414,7 +495,7 @@ int Array::rfind(const Variant &p_value, int p_from) const {
 	}
 
 	for (int i = p_from; i >= 0; i--) {
-		if (StringLikeVariantComparator::compare(_p->array[i], value)) {
+		if (StringLikeVariantComparator::compare(_p->array[i], validated.value)) {
 			return i;
 		}
 	}
@@ -458,15 +539,15 @@ int Array::rfind_custom(const Callable &p_callable, int p_from) const {
 }
 
 int Array::count(const Variant &p_value) const {
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "count"), 0);
+	ValidatedVariant validated = _p->typed.validate(p_value, "count");
+	ERR_FAIL_COND_V(!validated.valid, 0);
 	if (_p->array.size() == 0) {
 		return 0;
 	}
 
 	int amount = 0;
 	for (int i = 0; i < _p->array.size(); i++) {
-		if (StringLikeVariantComparator::compare(_p->array[i], value)) {
+		if (StringLikeVariantComparator::compare(_p->array[i], validated.value)) {
 			amount++;
 		}
 	}
@@ -475,27 +556,70 @@ int Array::count(const Variant &p_value) const {
 }
 
 bool Array::has(const Variant &p_value) const {
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "use 'has'"), false);
+	ValidatedVariant validated = _p->typed.validate(p_value, "use 'has'");
+	ERR_FAIL_COND_V(!validated.valid, false);
 
-	return find(value) != -1;
+	return find(validated.value) != -1;
 }
 
 void Array::remove_at(int p_pos) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 	_p->array.remove_at(p_pos);
 }
 
 void Array::set(int p_idx, const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND(!_p->typed.validate(value, "set"));
-
-	operator[](p_idx) = value;
+	ERR_FAIL_COND_MSG(_p->is_struct() && (p_idx >= size()), "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->is_struct() ? _p->typed.validate_struct_member(p_value, p_idx, "set") : _p->typed.validate(p_value, "set");
+	ERR_FAIL_COND(!validated.valid); // TODO: wrong error message
+	operator[](p_idx) = validated.value;
 }
 
 const Variant &Array::get(int p_idx) const {
 	return operator[](p_idx);
+}
+
+void Array::set_named(const StringName &p_member, const Variant &p_value) {
+	CRASH_COND_MSG(!_p->is_struct(), "Array is not a struct"); // TODO: should this crash?
+	int32_t index = _p->find_member_index(p_member);
+	CRASH_COND_MSG(index < 0, vformat("member '%s' not found", p_member));
+	set(index, p_value);
+}
+
+Variant &Array::get_named(const StringName &p_member) {
+	CRASH_COND_MSG(!_p->is_struct(), "Array is not a struct"); // TODO: should this crash?
+	int32_t index = _p->find_member_index(p_member);
+	CRASH_COND_MSG(index < 0, vformat("member '%s' not found", p_member));
+	return operator[](index);
+}
+
+const Variant &Array::get_named(const StringName &p_member) const {
+	CRASH_COND_MSG(!_p->is_struct(), "Array is not a struct"); // TODO: should this crash?
+	int32_t index = _p->find_member_index(p_member);
+	CRASH_COND_MSG(index < 0, vformat("member '%s' not found", p_member));
+	return get(index);
+}
+
+const StringName Array::get_member_name(int p_idx) const {
+	// TODO: probably need some error handling here.
+	return _p->typed.struct_info->names[p_idx];
+}
+
+int Array::find_member(const StringName &p_member) const {
+	return _p->find_member_index(p_member);
+}
+
+int Array::rfind_member(const StringName &p_member) const {
+	return _p->rfind_member_index(p_member);
+}
+
+const Variant *Array::getptr(const StringName &p_member) const {
+	int index = _p->find_member_index(p_member);
+	if (index < 0) {
+		return nullptr;
+	}
+	return &get(index);
 }
 
 Array Array::duplicate(bool p_deep) const {
@@ -504,7 +628,14 @@ Array Array::duplicate(bool p_deep) const {
 
 Array Array::recursive_duplicate(bool p_deep, int recursion_count) const {
 	Array new_arr;
-	new_arr._p->typed = _p->typed;
+	if (const StructInfo *struct_info = get_struct_info()) {
+		new_arr.set_struct(*struct_info, is_array_of_structs());
+	} else {
+		new_arr._p->typed = _p->typed;
+		if (p_deep) {
+			new_arr.resize(size());
+		}
+	}
 
 	if (recursion_count > MAX_RECURSION) {
 		ERR_PRINT("Max recursion reached");
@@ -514,7 +645,6 @@ Array Array::recursive_duplicate(bool p_deep, int recursion_count) const {
 	if (p_deep) {
 		recursion_count++;
 		int element_count = size();
-		new_arr.resize(element_count);
 		for (int i = 0; i < element_count; i++) {
 			new_arr[i] = get(i).recursive_duplicate(true, recursion_count);
 		}
@@ -692,16 +822,19 @@ struct _ArrayVariantSort {
 
 void Array::sort() {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 	_p->array.sort_custom<_ArrayVariantSort>();
 }
 
 void Array::sort_custom(const Callable &p_callable) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 	_p->array.sort_custom<CallableComparator, true>(p_callable);
 }
 
 void Array::shuffle() {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 	const int n = _p->array.size();
 	if (n < 2) {
 		return;
@@ -716,33 +849,36 @@ void Array::shuffle() {
 }
 
 int Array::bsearch(const Variant &p_value, bool p_before) const {
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "binary search"), -1);
+	ValidatedVariant validated = _p->typed.validate(p_value, "binary search");
+	ERR_FAIL_COND_V(!validated.valid, -1);
 	SearchArray<Variant, _ArrayVariantSort> avs;
-	return avs.bisect(_p->array.ptrw(), _p->array.size(), value, p_before);
+	return avs.bisect(_p->array.ptrw(), _p->array.size(), validated.value, p_before);
 }
 
 int Array::bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before) const {
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed.validate(value, "custom binary search"), -1);
+	ValidatedVariant validated = _p->typed.validate(p_value, "custom binary search");
+	ERR_FAIL_COND_V(!validated.valid, -1);
 
-	return _p->array.bsearch_custom<CallableComparator>(value, p_before, p_callable);
+	return _p->array.bsearch_custom<CallableComparator>(validated.value, p_before, p_callable);
 }
 
 void Array::reverse() {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
 	_p->array.reverse();
 }
 
 void Array::push_front(const Variant &p_value) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	Variant value = p_value;
-	ERR_FAIL_COND(!_p->typed.validate(value, "push_front"));
-	_p->array.insert(0, value);
+	ERR_FAIL_COND_MSG(_p->is_struct(), "Array is a struct."); // TODO: better error message
+	ValidatedVariant validated = _p->typed.validate(p_value, "push_front");
+	ERR_FAIL_COND(!validated.valid);
+	_p->array.insert(0, validated.value);
 }
 
 Variant Array::pop_back() {
 	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), Variant(), "Array is a struct."); // TODO: better error message
 	if (!_p->array.is_empty()) {
 		const int n = _p->array.size() - 1;
 		const Variant ret = _p->array.get(n);
@@ -754,6 +890,7 @@ Variant Array::pop_back() {
 
 Variant Array::pop_front() {
 	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), Variant(), "Array is a struct."); // TODO: better error message
 	if (!_p->array.is_empty()) {
 		const Variant ret = _p->array.get(0);
 		_p->array.remove_at(0);
@@ -764,6 +901,7 @@ Variant Array::pop_front() {
 
 Variant Array::pop_at(int p_pos) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, Variant(), "Array is in read-only state.");
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), Variant(), "Array is a struct."); // TODO: better error message
 	if (_p->array.is_empty()) {
 		// Return `null` without printing an error to mimic `pop_back()` and `pop_front()` behavior.
 		return Variant();
@@ -839,27 +977,65 @@ const void *Array::id() const {
 Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	_p = memnew(ArrayPrivate);
 	_p->refcount.init();
-	set_typed(p_type, p_class_name, p_script);
+	initialize_typed(p_type, p_class_name, p_script);
 	assign(p_from);
 }
 
+Error Array::validate_set_type() {
+	// TODO: better return values?
+	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
+	ERR_FAIL_COND_V_MSG(_p->is_struct(), ERR_LOCKED, "Array is a struct."); // TODO: better error message
+	ERR_FAIL_COND_V_MSG(_p->array.size() > 0, ERR_LOCKED, "Type can only be set when array is empty.");
+	ERR_FAIL_COND_V_MSG(_p->refcount.get() > 1, ERR_LOCKED, "Type can only be set when array has no more than one user.");
+	ERR_FAIL_COND_V_MSG(_p->typed.type != Variant::NIL, ERR_LOCKED, "Type can only be set once.");
+	return OK;
+}
+
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
-	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
-	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed.type != Variant::NIL, "Type can only be set once.");
-	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");
+	if (validate_set_type() != OK) {
+		return;
+	}
+	ERR_FAIL_COND_MSG(p_class_name != StringName() && !(p_type == Variant::OBJECT || p_type == Variant::ARRAY), "Class names can only be set for type OBJECT or ARRAY");
 	Ref<Script> script = p_script;
 	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
 
-	_p->typed.type = Variant::Type(p_type);
-	_p->typed.class_name = p_class_name;
-	_p->typed.script = script;
-	_p->typed.where = "TypedArray";
+	_p->typed = ContainerTypeValidate(Variant::Type(p_type), p_class_name, script, "TypedArray");
+}
+
+void Array::set_struct(const StructInfo &p_struct_info, bool p_is_array_of_structs) {
+	if (validate_set_type() != OK) {
+		return;
+	}
+	const int32_t size = p_struct_info.count;
+	_p->array.resize(size);
+	_p->typed = ContainerTypeValidate(p_struct_info, p_is_array_of_structs);
+}
+
+void Array::initialize_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
+	ERR_FAIL_COND_MSG(p_class_name != StringName() && !(p_type == Variant::OBJECT || p_type == Variant::ARRAY), "Class names can only be set for type OBJECT or ARRAY");
+	Ref<Script> script = p_script;
+	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
+
+	_p->typed = ContainerTypeValidate(Variant::Type(p_type), p_class_name, script, "TypedArray");
+}
+
+void Array::initialize_struct_type(const StructInfo &p_struct_info, bool is_array_of_structs) {
+	if (!is_array_of_structs) {
+		_p->array.resize(p_struct_info.count);
+	}
+	_p->typed = ContainerTypeValidate(p_struct_info, is_array_of_structs);
 }
 
 bool Array::is_typed() const {
 	return _p->typed.type != Variant::NIL;
+}
+
+bool Array::is_struct() const {
+	return _p->is_struct();
+}
+
+bool Array::is_array_of_structs() const {
+	return _p->is_array_of_structs();
 }
 
 bool Array::is_same_typed(const Array &p_other) const {
@@ -882,6 +1058,10 @@ Variant Array::get_typed_script() const {
 	return _p->typed.script;
 }
 
+const StructInfo *Array::get_struct_info() const {
+	return _p->typed.struct_info;
+}
+
 Array Array::create_read_only() {
 	Array array;
 	array.make_read_only();
@@ -901,6 +1081,38 @@ bool Array::is_read_only() const {
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);
+}
+
+Array::Array(const Array &p_from, const StructInfo &p_struct_info) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init(); // TODO: should this be _ref(p_from)?
+
+	initialize_struct_type(p_struct_info, p_from.is_array_of_structs());
+	assign(p_from);
+}
+
+Array::Array(const Dictionary &p_from, const StructInfo &p_struct_info) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init(); // TODO: should this be _ref(p_from)?
+
+	initialize_struct_type(p_struct_info, false);
+	Variant *pw = _p->array.ptrw();
+	for (int32_t i = 0; i < p_struct_info.count; i++) {
+		pw[i] = p_from.has(p_struct_info.names[i]) ? p_from[p_struct_info.names[i]] : p_struct_info.default_values[i];
+	}
+}
+
+Array::Array(const StructInfo &p_struct_info, bool is_array_of_structs) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+
+	initialize_struct_type(p_struct_info, is_array_of_structs);
+	if (!is_array_of_structs) {
+		Variant *pw = _p->array.ptrw();
+		for (int32_t i = 0; i < p_struct_info.count; i++) {
+			pw[i] = p_struct_info.default_values[i].duplicate(true);
+		}
+	}
 }
 
 Array::Array() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -40,6 +40,12 @@ class ArrayPrivate;
 class Object;
 class StringName;
 class Callable;
+template <typename T>
+class Vector;
+struct StructMember;
+struct ContainerTypeValidate;
+struct StructInfo;
+class Dictionary;
 
 class Array {
 	mutable ArrayPrivate *_p;
@@ -118,6 +124,14 @@ public:
 	void set(int p_idx, const Variant &p_value);
 	const Variant &get(int p_idx) const;
 
+	void set_named(const StringName &p_member, const Variant &p_value);
+	Variant &get_named(const StringName &p_member);
+	const Variant &get_named(const StringName &p_member) const; // TODO: should be & return?
+	const StringName get_member_name(int p_idx) const;
+	int find_member(const StringName &p_member) const;
+	int rfind_member(const StringName &p_member) const;
+	const Variant *getptr(const StringName &p_member) const;
+
 	int size() const;
 	bool is_empty() const;
 	void clear();
@@ -185,13 +199,24 @@ public:
 
 	const void *id() const;
 
+	Error validate_set_type();
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
+	void set_struct(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
+
+protected:
+	void initialize_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
+	void initialize_struct_type(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
+
+public:
 	bool is_typed() const;
+	bool is_struct() const;
+	bool is_array_of_structs() const;
 	bool is_same_typed(const Array &p_other) const;
 	bool is_same_instance(const Array &p_other) const;
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;
+	const StructInfo *get_struct_info() const;
 
 	void make_read_only();
 	bool is_read_only() const;
@@ -199,6 +224,9 @@ public:
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
+	Array(const Array &p_from, const StructInfo &p_struct_info);
+	Array(const Dictionary &p_from, const StructInfo &p_struct_info);
+	Array(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
 	Array();
 	~Array();
 };

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -42,7 +42,6 @@ class StringName;
 class Callable;
 template <typename T>
 class Vector;
-struct StructMember;
 struct ContainerTypeValidate;
 struct StructInfo;
 class Dictionary;
@@ -144,6 +143,7 @@ public:
 	uint32_t recursive_hash(int recursion_count) const;
 	void operator=(const Array &p_array);
 
+	bool can_reference(const Array &p_array) const;
 	void assign(const Array &p_array);
 	void push_back(const Variant &p_value);
 	_FORCE_INLINE_ void append(const Variant &p_value) { push_back(p_value); } //for python compatibility
@@ -201,11 +201,11 @@ public:
 
 	Error validate_set_type();
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
-	void set_struct(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
+	void set_struct(const StructInfo &p_struct_info, bool p_is_struct = true);
 
 protected:
 	void initialize_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
-	void initialize_struct_type(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
+	void initialize_struct_type(const StructInfo &p_struct_info, bool p_is_struct = true);
 
 public:
 	bool is_typed() const;
@@ -226,7 +226,7 @@ public:
 	Array(const Array &p_from);
 	Array(const Array &p_from, const StructInfo &p_struct_info);
 	Array(const Dictionary &p_from, const StructInfo &p_struct_info);
-	Array(const StructInfo &p_struct_info, bool p_is_array_of_structs = false);
+	Array(const StructInfo &p_struct_info, bool p_is_struct = true);
 	Array();
 	~Array();
 };

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -32,18 +32,59 @@
 #define CONTAINER_TYPE_VALIDATE_H
 
 #include "core/object/script_language.h"
+#include "core/variant/struct_generator.h"
 #include "core/variant/variant.h"
+
+struct ValidatedVariant {
+	Variant value;
+	bool valid;
+
+	ValidatedVariant(const Variant &p_value, const bool p_valid) {
+		value = p_value;
+		valid = p_valid;
+	}
+};
 
 struct ContainerTypeValidate {
 	Variant::Type type = Variant::NIL;
 	StringName class_name;
 	Ref<Script> script;
+
+	bool is_array_of_structs = false;
+	const StructInfo *struct_info = nullptr; // TODO: if is_array_of_structs == true, then require struct_info != nullptr, but not sure the best way to enforce this.
 	const char *where = "container";
 
+	ContainerTypeValidate() {};
+	ContainerTypeValidate(const Variant::Type p_type, const StringName &p_class_name, const Ref<Script> &p_script, const char *p_where = "container") {
+		type = p_type;
+		class_name = p_class_name;
+		script = p_script;
+		struct_info = nullptr;
+		where = p_where;
+	}
+	ContainerTypeValidate(const StructInfo &p_struct_info, bool p_is_array_of_structs = false) {
+		type = Variant::ARRAY;
+		class_name = p_struct_info.name;
+		script = Ref<Script>();
+		is_array_of_structs = p_is_array_of_structs;
+		struct_info = &p_struct_info;
+		where = p_is_array_of_structs ? "TypedArray" : "Struct";
+	}
+
 	_FORCE_INLINE_ bool can_reference(const ContainerTypeValidate &p_type) const {
+		if (type == Variant::NIL) {
+			return true;
+		}
 		if (type != p_type.type) {
 			return false;
-		} else if (type != Variant::OBJECT) {
+		}
+		if (is_array_of_structs != p_type.is_array_of_structs) {
+			return false;
+		}
+		if (!StructInfo::is_compatible(struct_info, p_type.struct_info)) {
+			return false;
+		}
+		if (type != Variant::OBJECT) {
 			return true;
 		}
 
@@ -67,44 +108,39 @@ struct ContainerTypeValidate {
 	}
 
 	_FORCE_INLINE_ bool operator==(const ContainerTypeValidate &p_type) const {
-		return type == p_type.type && class_name == p_type.class_name && script == p_type.script;
+		return type == p_type.type && class_name == p_type.class_name && script == p_type.script && is_array_of_structs == p_type.is_array_of_structs && StructInfo::is_compatible(struct_info, p_type.struct_info);
 	}
 	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
-		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
+		return type != p_type.type || class_name != p_type.class_name || script != p_type.script || is_array_of_structs != p_type.is_array_of_structs || !StructInfo::is_compatible(struct_info, p_type.struct_info);
 	}
 
-	// Coerces String and StringName into each other and int into float when needed.
-	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {
-		if (type == Variant::NIL) {
-			return true;
+	_FORCE_INLINE_ static ValidatedVariant validate_variant_type(const Variant::Type p_type, const Variant &p_variant, const char *p_where, const char *p_operation = "use") {
+		if (p_type == Variant::NIL) {
+			return ValidatedVariant(p_variant, true);
 		}
-
-		if (type != inout_variant.get_type()) {
-			if (inout_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
-				return true;
-			}
-			if (type == Variant::STRING && inout_variant.get_type() == Variant::STRING_NAME) {
-				inout_variant = String(inout_variant);
-				return true;
-			} else if (type == Variant::STRING_NAME && inout_variant.get_type() == Variant::STRING) {
-				inout_variant = StringName(inout_variant);
-				return true;
-			} else if (type == Variant::FLOAT && inout_variant.get_type() == Variant::INT) {
-				inout_variant = (float)inout_variant;
-				return true;
-			}
-
-			ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of type '%s'.", String(p_operation), Variant::get_type_name(inout_variant.get_type()), where, Variant::get_type_name(type)));
+		if (p_type == p_variant.get_type()) {
+			return ValidatedVariant(p_variant, true);
 		}
-
-		if (type != Variant::OBJECT) {
-			return true;
+		if (p_type == Variant::OBJECT && p_variant.get_type() == Variant::NIL) {
+			return ValidatedVariant(p_variant, true);
 		}
-
-		return validate_object(inout_variant, p_operation);
+		if (p_type == Variant::STRING && p_variant.get_type() == Variant::STRING_NAME) {
+			return ValidatedVariant(String(p_variant), true);
+		}
+		if (p_type == Variant::STRING_NAME && p_variant.get_type() == Variant::STRING) {
+			return ValidatedVariant(StringName(p_variant), true);
+		}
+		if (p_type == Variant::FLOAT && p_variant.get_type() == Variant::INT) {
+			return ValidatedVariant((float)p_variant, true);
+		}
+		ERR_FAIL_V_MSG(ValidatedVariant(p_variant, false), vformat("Attempted to %s a variable of type '%s' into a %s of type '%s'.", String(p_operation), Variant::get_type_name(p_variant.get_type()), p_where, Variant::get_type_name(p_type)));
 	}
 
 	_FORCE_INLINE_ bool validate_object(const Variant &p_variant, const char *p_operation = "use") const {
+		return validate_object(class_name, script, p_variant, where, p_operation);
+	}
+
+	_FORCE_INLINE_ static bool validate_object(const StringName &p_class_name, const Ref<Script> &p_script, const Variant &p_variant, const char *p_where, const char *p_operation = "use") {
 		ERR_FAIL_COND_V(p_variant.get_type() != Variant::OBJECT, false);
 
 #ifdef DEBUG_ENABLED
@@ -113,33 +149,76 @@ struct ContainerTypeValidate {
 			return true; // This is fine, it's null.
 		}
 		Object *object = ObjectDB::get_instance(object_id);
-		ERR_FAIL_NULL_V_MSG(object, false, vformat("Attempted to %s an invalid (previously freed?) object instance into a '%s'.", String(p_operation), String(where)));
+		ERR_FAIL_NULL_V_MSG(object, false, vformat("Attempted to %s an invalid (previously freed?) object instance into a '%s'.", String(p_operation), String(p_where)));
 #else
 		Object *object = p_variant;
 		if (object == nullptr) {
 			return true; //fine
 		}
 #endif
-		if (class_name == StringName()) {
+		if (p_class_name == StringName()) {
 			return true; // All good, no class type requested.
 		}
 
 		StringName obj_class = object->get_class_name();
-		if (obj_class != class_name) {
-			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(object->get_class_name(), class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
+		if (obj_class != p_class_name) {
+			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(object->get_class_name(), p_class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), p_where, String(p_class_name)));
 		}
 
-		if (script.is_null()) {
+		if (p_script.is_null()) {
 			return true; // All good, no script requested.
 		}
 
 		Ref<Script> other_script = object->get_script();
 
 		// Check base script..
-		ERR_FAIL_COND_V_MSG(other_script.is_null(), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
-		ERR_FAIL_COND_V_MSG(!other_script->inherits_script(script), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
+		ERR_FAIL_COND_V_MSG(other_script.is_null(), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(p_where), String(p_script->get_class_name())));
+		ERR_FAIL_COND_V_MSG(!other_script->inherits_script(p_script), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(p_where), String(p_script->get_class_name())));
 
 		return true;
+	}
+
+	_FORCE_INLINE_ ValidatedVariant validate(const Variant &p_variant, const char *p_operation = "use") const {
+		// TODO: Ensure !is_struct ?
+		// Coerces String and StringName into each other and int into float when needed.
+		ValidatedVariant ret = ContainerTypeValidate::validate_variant_type(type, p_variant, where, p_operation);
+		if (!ret.valid) {
+			return ret;
+		}
+
+		// Variant types match
+		if (type == Variant::ARRAY) {
+			const Array array = p_variant;
+			if (array.is_struct()) { // validating a struct into a typed array of structs
+				ret.valid = StructInfo::is_compatible(struct_info, array.get_struct_info());
+			} else { // validating a typed array into a typed array of typed arrays (which is currently not supported)
+				ret.valid = class_name == array.get_typed_class_name();
+			}
+		} else if (type == Variant::OBJECT) {
+			ret.valid = validate_object(p_variant, p_operation);
+		}
+		return ret;
+	}
+
+	_FORCE_INLINE_ ValidatedVariant validate_struct_member(const Variant &p_variant, const int p_struct_index, const char *p_operation = "use") const {
+		// TODO: Ensure is_struct and struct_info != nullptr ?
+		CRASH_BAD_INDEX_MSG(p_struct_index, struct_info->count, "Struct tried validation for a non-existent member");
+		const Variant::Type variant_type = struct_info->types[p_struct_index];
+		// Coerces String and StringName into each other and int into float when needed.
+		ValidatedVariant ret = ContainerTypeValidate::validate_variant_type(variant_type, p_variant, where, p_operation);
+		if (!ret.valid) {
+			return ret;
+		}
+
+		// Variant types match
+		if (variant_type == Variant::ARRAY) {
+			const Array array = p_variant;
+			// Valid if (the struct member is itself a struct and the other array is a compatible struct) or (neither the struct member nor the other array are a struct).
+			ret.valid = StructInfo::is_compatible(struct_info->struct_member_infos[p_struct_index], array.get_struct_info());
+		} else if (variant_type == Variant::OBJECT) {
+			ret.valid = validate_object(struct_info->class_names[p_struct_index], Ref<Script>(), p_variant, where, p_operation);
+		}
+		return ret;
 	}
 };
 

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -86,31 +86,31 @@ Variant Dictionary::get_value_at_index(int p_index) const {
 // WARNING: This operator does not validate the value type. For scripting/extensions this is
 // done in `variant_setget.cpp`. Consider using `set()` if the data might be invalid.
 Variant &Dictionary::operator[](const Variant &p_key) {
-	Variant key = p_key;
-	if (unlikely(!_p->typed_key.validate(key, "use `operator[]`"))) {
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "use `operator[]`");
+	if (unlikely(!validated_key.valid)) {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
 		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.type);
 		return *_p->typed_fallback;
 	} else if (unlikely(_p->read_only)) {
-		if (likely(_p->variant_map.has(key))) {
-			*_p->read_only = _p->variant_map[key];
+		if (likely(_p->variant_map.has(validated_key.value))) {
+			*_p->read_only = _p->variant_map[validated_key.value];
 		} else {
 			VariantInternal::initialize(_p->read_only, _p->typed_value.type);
 		}
 		return *_p->read_only;
 	} else {
-		if (unlikely(!_p->variant_map.has(key))) {
-			VariantInternal::initialize(&_p->variant_map[key], _p->typed_value.type);
+		if (unlikely(!_p->variant_map.has(validated_key.value))) {
+			VariantInternal::initialize(&_p->variant_map[validated_key.value], _p->typed_value.type);
 		}
-		return _p->variant_map[key];
+		return _p->variant_map[validated_key.value];
 	}
 }
 
 const Variant &Dictionary::operator[](const Variant &p_key) const {
-	Variant key = p_key;
-	if (unlikely(!_p->typed_key.validate(key, "use `operator[]`"))) {
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "use `operator[]`");
+	if (unlikely(!validated_key.valid)) {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
@@ -118,16 +118,16 @@ const Variant &Dictionary::operator[](const Variant &p_key) const {
 		return *_p->typed_fallback;
 	} else {
 		// Will not insert key, so no initialization is necessary.
-		return _p->variant_map[key];
+		return _p->variant_map[validated_key.value];
 	}
 }
 
 const Variant *Dictionary::getptr(const Variant &p_key) const {
-	Variant key = p_key;
-	if (unlikely(!_p->typed_key.validate(key, "getptr"))) {
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "getptr");
+	if (unlikely(!validated_key.valid)) {
 		return nullptr;
 	}
-	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(key));
+	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(validated_key.value));
 	if (!E) {
 		return nullptr;
 	}
@@ -136,11 +136,11 @@ const Variant *Dictionary::getptr(const Variant &p_key) const {
 
 // WARNING: This method does not validate the value type.
 Variant *Dictionary::getptr(const Variant &p_key) {
-	Variant key = p_key;
-	if (unlikely(!_p->typed_key.validate(key, "getptr"))) {
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "getptr");
+	if (unlikely(!validated_key.valid)) {
 		return nullptr;
 	}
-	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::Iterator E(_p->variant_map.find(key));
+	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::Iterator E(_p->variant_map.find(validated_key.value));
 	if (!E) {
 		return nullptr;
 	}
@@ -153,9 +153,9 @@ Variant *Dictionary::getptr(const Variant &p_key) {
 }
 
 Variant Dictionary::get_valid(const Variant &p_key) const {
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "get_valid"), Variant());
-	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(key));
+	ValidatedVariant validated = _p->typed_key.validate(p_key, "get_valid");
+	ERR_FAIL_COND_V(!validated.valid, Variant());
+	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::ConstIterator E(_p->variant_map.find(validated.value));
 
 	if (!E) {
 		return Variant();
@@ -164,9 +164,9 @@ Variant Dictionary::get_valid(const Variant &p_key) const {
 }
 
 Variant Dictionary::get(const Variant &p_key, const Variant &p_default) const {
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "get"), p_default);
-	const Variant *result = getptr(key);
+	ValidatedVariant validated = _p->typed_key.validate(p_key, "get");
+	ERR_FAIL_COND_V(!validated.valid, p_default);
+	const Variant *result = getptr(validated.value);
 	if (!result) {
 		return p_default;
 	}
@@ -175,25 +175,27 @@ Variant Dictionary::get(const Variant &p_key, const Variant &p_default) const {
 }
 
 Variant Dictionary::get_or_add(const Variant &p_key, const Variant &p_default) {
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "get"), p_default);
-	const Variant *result = getptr(key);
-	if (!result) {
-		Variant value = p_default;
-		ERR_FAIL_COND_V(!_p->typed_value.validate(value, "add"), value);
-		operator[](key) = value;
-		return value;
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "get");
+	ERR_FAIL_COND_V(!validated_key.valid, p_default);
+	const Variant *result = getptr(validated_key.value);
+
+	if (result) {
+		return *result;
 	}
-	return *result;
+
+	ValidatedVariant validated_default = _p->typed_key.validate(p_default, "add");
+	ERR_FAIL_COND_V(!validated_default.valid, validated_default.value);
+	operator[](validated_key.value) = validated_default.value;
+	return validated_default.value;
 }
 
 bool Dictionary::set(const Variant &p_key, const Variant &p_value) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, false, "Dictionary is in read-only state.");
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "set"), false);
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed_value.validate(value, "set"), false);
-	_p->variant_map[key] = value;
+	ValidatedVariant validated_key = _p->typed_key.validate(p_key, "set");
+	ERR_FAIL_COND_V(!validated_key.valid, false);
+	ValidatedVariant validated_value = _p->typed_value.validate(p_value, "set");
+	ERR_FAIL_COND_V(!validated_value.valid, false);
+	_p->variant_map[validated_key.value] = validated_value.value;
 	return true;
 }
 
@@ -206,16 +208,16 @@ bool Dictionary::is_empty() const {
 }
 
 bool Dictionary::has(const Variant &p_key) const {
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "use 'has'"), false);
+	ValidatedVariant validated = _p->typed_key.validate(p_key, "use 'has'");
+	ERR_FAIL_COND_V(!validated.valid, false);
 	return _p->variant_map.has(p_key);
 }
 
 bool Dictionary::has_all(const Array &p_keys) const {
 	for (int i = 0; i < p_keys.size(); i++) {
-		Variant key = p_keys[i];
-		ERR_FAIL_COND_V(!_p->typed_key.validate(key, "use 'has_all'"), false);
-		if (!has(key)) {
+		ValidatedVariant validated = _p->typed_key.validate(p_keys[i], "use 'has_all'");
+		ERR_FAIL_COND_V(!validated.valid, false);
+		if (!has(validated.value)) {
 			return false;
 		}
 	}
@@ -223,10 +225,10 @@ bool Dictionary::has_all(const Array &p_keys) const {
 }
 
 Variant Dictionary::find_key(const Variant &p_value) const {
-	Variant value = p_value;
-	ERR_FAIL_COND_V(!_p->typed_value.validate(value, "find_key"), Variant());
+	ValidatedVariant validated = _p->typed_key.validate(p_value, "find_key");
+	ERR_FAIL_COND_V(!validated.valid, Variant());
 	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
-		if (E.value == value) {
+		if (E.value == validated.value) {
 			return E.key;
 		}
 	}
@@ -234,10 +236,10 @@ Variant Dictionary::find_key(const Variant &p_value) const {
 }
 
 bool Dictionary::erase(const Variant &p_key) {
-	Variant key = p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "erase"), false);
+	ValidatedVariant validated = _p->typed_key.validate(p_key, "erase");
+	ERR_FAIL_COND_V(!validated.valid, false);
 	ERR_FAIL_COND_V_MSG(_p->read_only, false, "Dictionary is in read-only state.");
-	return _p->variant_map.erase(key);
+	return _p->variant_map.erase(validated.value);
 }
 
 bool Dictionary::operator==(const Dictionary &p_dictionary) const {
@@ -302,12 +304,12 @@ void Dictionary::sort() {
 void Dictionary::merge(const Dictionary &p_dictionary, bool p_overwrite) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
-		Variant key = E.key;
-		Variant value = E.value;
-		ERR_FAIL_COND(!_p->typed_key.validate(key, "merge"));
-		ERR_FAIL_COND(!_p->typed_value.validate(value, "merge"));
-		if (p_overwrite || !has(key)) {
-			operator[](key) = value;
+		ValidatedVariant validated_key = _p->typed_key.validate(E.key, "merge");
+		ERR_FAIL_COND(!validated_key.valid);
+		ValidatedVariant validated_value = _p->typed_key.validate(E.value, "merge");
+		ERR_FAIL_COND(!validated_value.valid);
+		if (p_overwrite || !has(validated_key.value)) {
+			operator[](validated_key.value) = validated_value.value;
 		}
 	}
 }
@@ -541,9 +543,9 @@ const Variant *Dictionary::next(const Variant *p_key) const {
 		}
 		return nullptr;
 	}
-	Variant key = *p_key;
-	ERR_FAIL_COND_V(!_p->typed_key.validate(key, "next"), nullptr);
-	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::Iterator E = _p->variant_map.find(key);
+	ValidatedVariant validated = _p->typed_key.validate(*p_key, "next");
+	ERR_FAIL_COND_V(!validated.valid, nullptr);
+	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::Iterator E = _p->variant_map.find(validated.value);
 
 	if (!E) {
 		return nullptr;
@@ -686,6 +688,15 @@ Dictionary::Dictionary(const Dictionary &p_base, uint32_t p_key_type, const Stri
 Dictionary::Dictionary(const Dictionary &p_from) {
 	_p = nullptr;
 	_ref(p_from);
+}
+
+Dictionary::Dictionary(const Array &p_from, const StructInfo &p_struct_info) {
+	_p = memnew(DictionaryPrivate);
+	_p->refcount.init();
+	for (int i = 0; i < p_struct_info.count; i++) { // TODO: is there a more efficient way to do this?
+		Variant value = (0 <= i && i < p_from.size()) ? p_from[i] : p_struct_info.default_values[i];
+		_p->variant_map.insert(p_struct_info.names[i], value);
+	}
 }
 
 Dictionary::Dictionary() {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -395,6 +395,10 @@ Array Dictionary::values() const {
 	return varr;
 }
 
+bool Dictionary::can_reference(const Dictionary &p_dictionary) const {
+	return _p->typed_key.can_reference(p_dictionary._p->typed_key) && _p->typed_value.can_reference(p_dictionary._p->typed_value);
+}
+
 void Dictionary::assign(const Dictionary &p_dictionary) {
 	const ContainerTypeValidate &typed_key = _p->typed_key;
 	const ContainerTypeValidate &typed_key_source = p_dictionary._p->typed_key;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -112,6 +112,7 @@ public:
 
 	Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script);
 	Dictionary(const Dictionary &p_from);
+	Dictionary(const Array &p_from, const StructInfo &p_struct_info);
 	Dictionary();
 	~Dictionary();
 };

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -82,6 +82,7 @@ public:
 	uint32_t recursive_hash(int recursion_count) const;
 	void operator=(const Dictionary &p_dictionary);
 
+	bool can_reference(const Dictionary &p_dictionary) const;
 	void assign(const Dictionary &p_dictionary);
 	const Variant *next(const Variant *p_key = nullptr) const;
 

--- a/core/variant/struct.h
+++ b/core/variant/struct.h
@@ -1,0 +1,146 @@
+/**************************************************************************/
+/*  struct.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef STRUCT_H
+#define STRUCT_H
+
+#include "core/object/object.h"
+#include "core/variant/array.h"
+#include "core/variant/binder_common.h"
+#include "core/variant/method_ptrcall.h"
+#include "core/variant/type_info.h"
+#include "core/variant/variant.h"
+
+class Array;
+
+template <class T>
+class Struct : public Array {
+public:
+	_FORCE_INLINE_ void operator=(const Array &p_array) {
+		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign a Struct from array with a different format.");
+		_ref(p_array);
+	}
+	_FORCE_INLINE_ Variant &operator[](const StringName &p_struct_member) {
+		return get_named(p_struct_member);
+	}
+	_FORCE_INLINE_ const Variant &operator[](const StringName &p_struct_member) const {
+		return get_named(p_struct_member);
+	}
+	template <typename StructMember>
+	_FORCE_INLINE_ int get_member_index() const {
+		return T::Layout::template get_member_index<StructMember>();
+	}
+	template <typename StructMember>
+	_FORCE_INLINE_ Variant get_member_value() const {
+		return get(get_member_index<StructMember>());
+	}
+	template <typename StructMember>
+	_FORCE_INLINE_ void set_member_value(const typename StructMember::Type &p_value) {
+		set(get_member_index<StructMember>(), p_value);
+	}
+	template <typename StructMember>
+	_FORCE_INLINE_ typename StructMember::Type get_member() const {
+		return StructMember::from_variant(get(get_member_index<StructMember>()));
+	}
+	template <typename StructMember>
+	_FORCE_INLINE_ void set_member(const typename StructMember::Type &p_struct_member) {
+		set(get_member_index<StructMember>(), StructMember::to_variant(p_struct_member));
+	}
+	_FORCE_INLINE_ Struct(const T &p_struct) :
+			Array(T::Layout::to_array(p_struct), T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ Struct(const Variant &p_variant) :
+			Array(Array(p_variant), T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ Struct(const Array &p_array) :
+			Array(p_array, T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ Struct() :
+			Array(T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ operator Dictionary() {
+		Dictionary dict;
+		for (int i = 0; i < size(); i++) {
+			dict[get_member_name(i)] = get(i);
+		}
+		return dict;
+	}
+};
+
+template <class T>
+struct VariantInternalAccessor<Struct<T>> {
+	_FORCE_INLINE_ static Struct<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
+	_FORCE_INLINE_ static void set(Variant *v, const Struct<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
+};
+
+template <class T>
+struct VariantInternalAccessor<const Struct<T> &> {
+	_FORCE_INLINE_ static Struct<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
+	_FORCE_INLINE_ static void set(Variant *v, const Struct<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
+};
+
+template <class T>
+struct PtrToArg<Struct<T>> {
+	_FORCE_INLINE_ static Struct<T> convert(const void *p_ptr) {
+		return Struct<T>(*reinterpret_cast<const Array *>(p_ptr));
+	}
+	typedef Array EncodeT;
+	_FORCE_INLINE_ static void encode(Struct<T> p_val, void *p_ptr) {
+		*(Array *)p_ptr = p_val;
+	}
+};
+
+template <class T>
+struct PtrToArg<const Struct<T> &> {
+	typedef Array EncodeT;
+	_FORCE_INLINE_ static Struct<T> convert(const void *p_ptr) {
+		return Struct<T>(*reinterpret_cast<const Array *>(p_ptr));
+	}
+};
+
+template <class T>
+struct GetTypeInfo<Struct<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::Layout::get_struct_name());
+	}
+};
+
+template <class T>
+struct GetTypeInfo<const Struct<T> &> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::Layout::get_struct_name());
+	}
+};
+
+#endif // STRUCT_H

--- a/core/variant/struct.h
+++ b/core/variant/struct.h
@@ -130,7 +130,7 @@ struct GetTypeInfo<Struct<T>> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::Layout::get_struct_name());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_struct_name());
 	}
 };
 
@@ -139,7 +139,7 @@ struct GetTypeInfo<const Struct<T> &> {
 	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
 	static PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::Layout::get_struct_name());
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_struct_name());
 	}
 };
 

--- a/core/variant/struct_generator.cpp
+++ b/core/variant/struct_generator.cpp
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*  struct_generator.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "struct_generator.h"
+
+#include "core/variant/struct.h"
+#include "core/variant/typed_array.h"
+
+Variant StructInfo::types::to_variant(const Vector<Variant::Type> &p_value) {
+	PackedInt32Array packed_types;
+	packed_types.resize(p_value.size());
+	for (int i = 0; i < p_value.size(); i++) {
+		packed_types.write[i] = p_value[i];
+	}
+	return packed_types;
+}
+
+Vector<Variant::Type> StructInfo::types::from_variant(const Variant &p_variant) {
+	const PackedInt32Array &packed_types = p_variant;
+	Vector<Variant::Type> types;
+	types.resize(packed_types.size());
+	for (int i = 0; i < packed_types.size(); i++) {
+		types.write[i] = static_cast<Variant::Type>(packed_types[i]);
+	}
+	return types;
+}
+
+Dictionary StructInfo::to_dict() const {
+	Dictionary dict;
+	dict["name"] = name;
+	dict["count"] = count;
+	dict["names"] = names;
+	PackedInt32Array packed_types;
+	packed_types.resize(count);
+	for (int i = 0; i < count; i++) {
+		packed_types.write[i] = types[i];
+	}
+	dict["types"] = packed_types;
+	dict["class_names"] = class_names;
+	TypedArray<Dictionary> member_info_dictionaries;
+	member_info_dictionaries.resize(count);
+	for (int i = 0; i < count; i++) {
+		const StructInfo *member_info = struct_member_infos[i];
+		// TODO: Recursion limit?
+		member_info_dictionaries[i] = member_info ? member_info->to_dict() : Dictionary();
+	}
+	dict["struct_member_infos"] = member_info_dictionaries;
+	dict["default_values"] = default_values;
+	return dict;
+}
+
+// Needs to be in .cpp so struct.h can be included
+template <typename StructType, typename... StructMembers>
+void StructLayout<StructType, StructMembers...>::fill_struct_array(Struct<StructType> &p_array, const StructType &p_struct) {
+	int dummy[] = { 0, (p_array.template set_member_value<StructMembers>(StructMembers::get_variant(p_struct)), 0)... };
+	(void)dummy; // Suppress unused variable warning
+}

--- a/core/variant/struct_generator.h
+++ b/core/variant/struct_generator.h
@@ -1,0 +1,305 @@
+/**************************************************************************/
+/*  struct_generator.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef STRUCT_GENERATOR_H
+#define STRUCT_GENERATOR_H
+
+#include "core/variant/variant.h"
+
+template <typename T>
+class TypedArray;
+
+template <typename T>
+class Struct;
+
+#define STRUCT_DECLARE(m_struct_name) using StructType = m_struct_name
+
+#define STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default)                                                       \
+	using Type = m_type;                                                                                                                         \
+	_FORCE_INLINE_ static const StringName get_name() { return SNAME(m_member_name_alias); }                                                     \
+	_FORCE_INLINE_ static Variant get_variant(const StructType &p_struct) { return to_variant(p_struct.m_member_name); }                         \
+	_FORCE_INLINE_ static const Variant get_default_value_variant() { return to_variant(m_default); }                                            \
+	_FORCE_INLINE_ static Type get(const StructType &p_struct) { return p_struct.m_member_name; }                                                \
+	_FORCE_INLINE_ static Type get_default_value() { return m_default; }                                                                         \
+	_FORCE_INLINE_ static void set_variant(StructType &p_struct, const Variant &p_variant) { p_struct.m_member_name = from_variant(p_variant); } \
+	_FORCE_INLINE_ static void set(StructType &p_struct, const m_type &p_value) { p_struct.m_member_name = p_value; }
+
+#define STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default) \
+	STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, #m_member_name, m_default)
+
+#define STRUCT_MEMBER_TYPEDEF_POINTER(m_type, m_member_name, m_default)                                                                          \
+	using Type = m_type *;                                                                                                                       \
+	_FORCE_INLINE_ static const StringName get_name() { return SNAME(#m_member_name); }                                                          \
+	_FORCE_INLINE_ static Variant get_variant(const StructType &p_struct) { return to_variant(p_struct.m_member_name); }                         \
+	_FORCE_INLINE_ static const Variant get_default_value_variant() { return to_variant(m_default); }                                            \
+	_FORCE_INLINE_ static Type get(const StructType &p_struct) { return p_struct.m_member_name; }                                                \
+	_FORCE_INLINE_ static const m_type *get_default_value() { return m_default; }                                                                \
+	_FORCE_INLINE_ static void set_variant(StructType &p_struct, const Variant &p_variant) { p_struct.m_member_name = from_variant(p_variant); } \
+	_FORCE_INLINE_ static void set(StructType &p_struct, Type p_value) { p_struct.m_member_name = p_value; }
+
+#define STRUCT_MEMBER_PRIMITIVE_ALIAS(m_type, m_member_name, m_member_name_alias, m_default)                \
+	m_type m_member_name = m_default;                                                                       \
+	struct m_member_name {                                                                                  \
+		_FORCE_INLINE_ static m_type from_variant(const Variant &p_variant) { return p_variant; }           \
+		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }                 \
+		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);                 \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
+		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
+		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+	}
+
+#define STRUCT_MEMBER_PRIMITIVE_FROM(m_type, m_member_name, m_default)                                      \
+	m_type m_member_name = m_default;                                                                       \
+	struct m_member_name {                                                                                  \
+		static m_type from_variant(const Variant &p_variant);                                               \
+		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }                 \
+		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                            \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
+		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
+		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+	}
+
+#define STRUCT_MEMBER_PRIMITIVE(m_type, m_member_name, m_default) \
+	STRUCT_MEMBER_PRIMITIVE_ALIAS(m_type, m_member_name, #m_member_name, m_default)
+
+#define STRUCT_MEMBER_PRIMITIVE_FROM_TO_ALIAS(m_type, m_member_name, m_member_name_alias, m_default)        \
+	m_type m_member_name = m_default;                                                                       \
+	struct m_member_name {                                                                                  \
+		static m_type from_variant(const Variant &p_variant);                                               \
+		static Variant to_variant(const m_type &p_value);                                                   \
+		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);                 \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
+		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
+		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+	}
+
+#define STRUCT_MEMBER_PRIMITIVE_FROM_TO(m_type, m_member_name, m_default) \
+	STRUCT_MEMBER_PRIMITIVE_FROM_TO_ALIAS(m_type, m_member_name, #m_member_name, m_default)
+
+#define STRUCT_MEMBER_CLASS_POINTER(m_type, m_member_name, m_default)                                                       \
+	m_type *m_member_name = m_default;                                                                                      \
+	struct m_member_name {                                                                                                  \
+		_FORCE_INLINE_ static m_type *from_variant(const Variant &p_variant) { return Object::cast_to<m_type>(p_variant); } \
+		_FORCE_INLINE_ static Variant to_variant(m_type *p_value) { return p_value; }                                       \
+		STRUCT_MEMBER_TYPEDEF_POINTER(m_type, m_member_name, m_default);                                                    \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::OBJECT; }                                  \
+		_FORCE_INLINE_ static const StringName get_class_name() { return SNAME(#m_type); }                                  \
+		static const StructInfo *get_struct_member_info() { return nullptr; }                                               \
+	}
+
+#define STRUCT_MEMBER_CLASS_VALUE(m_type, m_member_name, m_default)                               \
+	m_type m_member_name = m_default;                                                             \
+	struct m_member_name {                                                                        \
+		_FORCE_INLINE_ static m_type from_variant(const Variant &p_variant) { return p_variant; } \
+		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }       \
+		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                  \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::OBJECT; }        \
+		_FORCE_INLINE_ static const StringName get_class_name() { return SNAME(#m_type); }        \
+		static const StructInfo *get_struct_member_info() { return nullptr; }                     \
+	}
+
+#define STRUCT_MEMBER_STRUCT(m_type, m_member_name, m_default)                                                          \
+	m_type m_member_name = m_default;                                                                                   \
+	struct m_member_name {                                                                                              \
+		_FORCE_INLINE_ static m_type from_variant(const Variant &p_variant) { return Struct<m_type>(p_variant); }       \
+		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return Struct<m_type>(p_value); }             \
+		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                                        \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::ARRAY; }                               \
+		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                                \
+		_FORCE_INLINE_ static const StructInfo *get_struct_member_info() { return &m_type::Layout::get_struct_info(); } \
+	}
+
+#define STRUCT_MEMBER_STRUCT_FROM_TO_ALIAS(m_type, m_member_name, m_member_name_alias, m_default) \
+	m_type m_member_name = m_default;                                                             \
+	struct m_member_name {                                                                        \
+		static m_type from_variant(const Variant &p_variant);                                     \
+		static Variant to_variant(const m_type &p_value);                                         \
+		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);       \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::ARRAY; }         \
+		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }          \
+		_FORCE_INLINE_ static const StructInfo *get_struct_member_info() {                        \
+			return &m_type::Layout::get_struct_info();                                            \
+		}                                                                                         \
+	}
+
+#define STRUCT_MEMBER_STRUCT_FROM_TO(m_type, m_member_name, m_default) \
+	STRUCT_MEMBER_STRUCT_FROM_TO_ALIAS(m_type, m_member_name, #m_member_name, m_default)
+
+#define STRUCT_LAYOUT_WITH_NAME(m_struct_name, m_struct, ...) \
+	static const StringName get_struct_name() {               \
+		return SNAME(m_struct_name);                          \
+	}                                                         \
+	static const StructInfo &get_struct_info() {              \
+		return Layout::get_struct_info();                     \
+	}                                                         \
+	using Layout = StructLayout<m_struct, __VA_ARGS__>;       \
+	m_struct(const Dictionary &p_dict) {                      \
+		Layout::fill_struct(p_dict, *this);                   \
+	}                                                         \
+	m_struct(const Array &p_array) {                          \
+		Layout::fill_struct(p_array, *this);                  \
+	}
+
+#define STRUCT_LAYOUT_OWNER(m_owner, m_struct, ...) STRUCT_LAYOUT_WITH_NAME(#m_owner "." #m_struct, m_struct, __VA_ARGS__)
+
+#define STRUCT_LAYOUT(m_struct, ...) STRUCT_LAYOUT_WITH_NAME(#m_struct, m_struct, __VA_ARGS__)
+
+template <typename StructType, typename... StructMembers>
+struct StructLayout {
+	static constexpr int32_t struct_member_count = sizeof...(StructMembers);
+	_FORCE_INLINE_ static const StringName get_struct_name() {
+		return StructType::get_struct_name();
+	}
+	_FORCE_INLINE_ static const StructInfo &get_struct_info() {
+		static const Vector<StringName> names = { StructMembers::get_name()... };
+		static const Vector<Variant::Type> types = { StructMembers::get_variant_type()... };
+		static const Vector<StringName> class_names = { StructMembers::get_class_name()... };
+		static const Vector<const StructInfo *> struct_member_infos = { StructMembers::get_struct_member_info()... };
+		static const Vector<Variant> default_values = { StructMembers::get_default_value_variant()... };
+		static const StructInfo info = StructInfo(get_struct_name(), struct_member_count, names, types, class_names, struct_member_infos, default_values);
+		return info;
+	}
+
+	static Array to_array(const StructType &p_struct) {
+		Array array;
+		fill_array(array, p_struct);
+		return array;
+	}
+	static void fill_array(Array &p_array, const StructType &p_struct) {
+		p_array.resize(struct_member_count);
+		Variant vals[struct_member_count] = { StructMembers::get_variant(p_struct)... };
+		for (int32_t i = 0; i < struct_member_count; i++) {
+			p_array.set(i, vals[i]);
+		}
+	}
+	static void fill_struct(const Array &p_array, StructType &p_struct) {
+		int32_t i = 0;
+		int temp[] = { 0, (StructMembers::set_variant(p_struct, p_array.get(i)), i++, 0)... };
+		(void)temp; // Suppress unused variable warning
+	}
+	static void fill_struct_array(Struct<StructType> &p_array, const StructType &p_struct);
+
+	static Dictionary to_dict(const StructType &p_struct) {
+		Dictionary dict;
+		fill_dict(dict, p_struct);
+		return dict;
+	}
+	static void fill_dict(Dictionary &p_dict, const StructType &p_struct) {
+		int temp[] = { 0, (p_dict[StructMembers::get_name()] = StructMembers::get_variant(p_struct), 0)... };
+		(void)temp; // Suppress unused variable warning
+	}
+	static void fill_struct(const Dictionary &p_dict, StructType &p_struct) {
+		int temp[] = { 0, (StructMembers::set_variant(p_struct, p_dict[StructMembers::get_name()]), 0)... };
+		(void)temp; // Suppress unused variable warning
+	}
+
+	template <typename T>
+	_FORCE_INLINE_ static constexpr int get_member_index() {
+		return sizeof...(StructMembers) - TypeFinder<T, StructMembers...>::remaining_count - 1;
+	}
+
+private:
+	template <typename TypeToFind, typename... TypesToSearch>
+	struct TypeFinder;
+
+	template <typename TypeFound, typename... TypesRemaining>
+	struct TypeFinder<TypeFound, TypeFound, TypesRemaining...> {
+		static constexpr int remaining_count = sizeof...(TypesRemaining);
+	};
+
+	template <typename TypeNotFound>
+	struct TypeFinder<TypeNotFound> {
+		static constexpr int remaining_count = 0;
+	};
+
+	template <typename TypeToFind, typename TypeToCheck, typename... TypesRemaining>
+	struct TypeFinder<TypeToFind, TypeToCheck, TypesRemaining...> {
+		static constexpr int remaining_count = TypeFinder<TypeToFind, TypesRemaining...>::remaining_count;
+	};
+};
+
+struct StructInfo {
+	STRUCT_DECLARE(StructInfo);
+	STRUCT_MEMBER_PRIMITIVE(StringName, name, StringName());
+	STRUCT_MEMBER_PRIMITIVE(int32_t, count, 0);
+	STRUCT_MEMBER_PRIMITIVE(Vector<StringName>, names, Vector<StringName>());
+	STRUCT_MEMBER_PRIMITIVE_FROM_TO(Vector<Variant::Type>, types, Vector<Variant::Type>());
+	STRUCT_MEMBER_PRIMITIVE(Vector<StringName>, class_names, Vector<StringName>());
+	STRUCT_MEMBER_PRIMITIVE(Vector<Variant>, default_values, Vector<Variant>());
+	STRUCT_LAYOUT(StructInfo, struct name, struct count, struct names, struct types, struct class_names, struct default_values);
+
+	Vector<const StructInfo *> struct_member_infos;
+
+	StructInfo() {};
+	StructInfo(const StringName &p_name, const int32_t p_count) :
+			name(p_name), count(p_count) {
+		names.resize(p_count);
+		types.resize(p_count);
+		class_names.resize(p_count);
+		struct_member_infos.resize(p_count);
+		default_values.resize(p_count);
+	}
+	StructInfo(const StringName &p_name, const int32_t p_count, const Vector<StringName> &p_names, const Vector<Variant::Type> &p_types, const Vector<StringName> &p_class_names, const Vector<const StructInfo *> &p_struct_member_infos, const Vector<Variant> &p_default_values) :
+			name(p_name),
+			count(p_count),
+			names(p_names),
+			types(p_types),
+			class_names(p_class_names),
+			struct_member_infos(p_struct_member_infos),
+			default_values(p_default_values) {};
+
+	Dictionary to_dict() const;
+
+	_FORCE_INLINE_ void set(int32_t p_index, const StringName &p_name, const Variant::Type &p_type, const StringName &p_class_name, const StructInfo *p_struct_member_info, const Variant &p_default_value) {
+		names.write[p_index] = p_name;
+		types.write[p_index] = p_type;
+		class_names.write[p_index] = p_class_name;
+		struct_member_infos.write[p_index] = p_struct_member_info;
+		default_values.write[p_index] = p_default_value;
+	}
+
+	_FORCE_INLINE_ bool operator==(const StructInfo &p_struct_info) const {
+		return name == p_struct_info.name;
+	}
+	_FORCE_INLINE_ bool operator!=(const StructInfo &p_struct_info) const {
+		return name != p_struct_info.name;
+	}
+	_FORCE_INLINE_ static bool is_compatible(const StructInfo *p_struct_info_1, const StructInfo *p_struct_info_2) {
+		if (p_struct_info_1) {
+			if (p_struct_info_2) {
+				return *p_struct_info_1 == *p_struct_info_2;
+			}
+			return false;
+		}
+		return p_struct_info_2 == nullptr;
+	}
+};
+
+#endif // STRUCT_GENERATOR_H

--- a/core/variant/struct_generator.h
+++ b/core/variant/struct_generator.h
@@ -39,6 +39,8 @@ class TypedArray;
 template <typename T>
 class Struct;
 
+class Script;
+
 /* The following set of macros let you seamlessly add reflection data to
  * a C++ struct or class so that it can be exposed as a Godot Struct.
  * The StructInfo struct below uses these macros and serves as a good
@@ -70,7 +72,7 @@ class Struct;
 	_FORCE_INLINE_ static Variant get_variant(const StructType &p_struct) { return to_variant(p_struct.m_member_name); }                         \
 	_FORCE_INLINE_ static const Variant get_default_value_variant() { return to_variant(m_default); }                                            \
 	_FORCE_INLINE_ static Type get(const StructType &p_struct) { return p_struct.m_member_name; }                                                \
-	_FORCE_INLINE_ static const Type get_default_value() { return m_default; }                                                                   \
+	_FORCE_INLINE_ static const m_type *get_default_value() { return m_default; }                                                                \
 	_FORCE_INLINE_ static void set_variant(StructType &p_struct, const Variant &p_variant) { p_struct.m_member_name = from_variant(p_variant); } \
 	_FORCE_INLINE_ static void set(StructType &p_struct, Type p_value) { p_struct.m_member_name = p_value; }
 
@@ -88,8 +90,8 @@ class Struct;
 		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }                 \
 		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);                 \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
-		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
-		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+		_FORCE_INLINE_ static StringName get_type_name() { return StringName(); }                           \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                                \
 	}
 
 #define STRUCT_MEMBER(m_type, m_member_name, m_default) \
@@ -104,8 +106,8 @@ class Struct;
 		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }                 \
 		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                            \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
-		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
-		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+		_FORCE_INLINE_ static StringName get_type_name() { return StringName(); }                           \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                                \
 	}
 
 // Macros that include _TO allow you to customize the way the struct is converted to a Variant. You must
@@ -117,8 +119,8 @@ class Struct;
 		static Variant to_variant(const m_type &p_value);                                                   \
 		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);                 \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return to_variant(m_default).get_type(); } \
-		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                    \
-		static const StructInfo *get_struct_member_info() { return nullptr; }                               \
+		_FORCE_INLINE_ static StringName get_type_name() { return StringName(); }                           \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                                \
 	}
 
 #define STRUCT_MEMBER_FROM_TO(m_type, m_member_name, m_default) \
@@ -131,8 +133,8 @@ class Struct;
 		_FORCE_INLINE_ static Variant to_variant(m_type *p_value) { return p_value; }                                       \
 		STRUCT_MEMBER_TYPEDEF_POINTER(m_type, m_member_name, m_default);                                                    \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::OBJECT; }                                  \
-		_FORCE_INLINE_ static const StringName get_class_name() { return SNAME(#m_type); }                                  \
-		static const StructInfo *get_struct_member_info() { return nullptr; }                                               \
+		_FORCE_INLINE_ static StringName get_type_name() { return SNAME(#m_type); }                                         \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                                                \
 	}
 
 #define STRUCT_MEMBER_CLASS_VALUE(m_type, m_member_name, m_default)                               \
@@ -142,19 +144,19 @@ class Struct;
 		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return p_value; }       \
 		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                  \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::OBJECT; }        \
-		_FORCE_INLINE_ static const StringName get_class_name() { return SNAME(#m_type); }        \
-		static const StructInfo *get_struct_member_info() { return nullptr; }                     \
+		_FORCE_INLINE_ static StringName get_type_name() { return SNAME(#m_type); }               \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                      \
 	}
 
-#define STRUCT_MEMBER_STRUCT(m_type, m_member_name, m_default)                                                          \
-	m_type m_member_name = m_default;                                                                                   \
-	struct m_member_name {                                                                                              \
-		_FORCE_INLINE_ static m_type from_variant(const Variant &p_variant) { return Struct<m_type>(p_variant); }       \
-		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return Struct<m_type>(p_value); }             \
-		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                                        \
-		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::ARRAY; }                               \
-		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }                                \
-		_FORCE_INLINE_ static const StructInfo *get_struct_member_info() { return &m_type::Layout::get_struct_info(); } \
+#define STRUCT_MEMBER_STRUCT(m_type, m_member_name, m_default)                                                    \
+	m_type m_member_name = m_default;                                                                             \
+	struct m_member_name {                                                                                        \
+		_FORCE_INLINE_ static m_type from_variant(const Variant &p_variant) { return Struct<m_type>(p_variant); } \
+		_FORCE_INLINE_ static Variant to_variant(const m_type &p_value) { return Struct<m_type>(p_value); }       \
+		STRUCT_MEMBER_TYPEDEF(m_type, m_member_name, m_default);                                                  \
+		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::ARRAY; }                         \
+		_FORCE_INLINE_ static StringName get_type_name() { return m_type::get_struct_name(); }                    \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                                      \
 	}
 
 #define STRUCT_MEMBER_STRUCT_FROM_TO_ALIAS(m_type, m_member_name, m_member_name_alias, m_default) \
@@ -164,10 +166,8 @@ class Struct;
 		static Variant to_variant(const m_type &p_value);                                         \
 		STRUCT_MEMBER_TYPEDEF_ALIAS(m_type, m_member_name, m_member_name_alias, m_default);       \
 		_FORCE_INLINE_ static Variant::Type get_variant_type() { return Variant::ARRAY; }         \
-		_FORCE_INLINE_ static const StringName get_class_name() { return StringName(); }          \
-		_FORCE_INLINE_ static const StructInfo *get_struct_member_info() {                        \
-			return &m_type::Layout::get_struct_info();                                            \
-		}                                                                                         \
+		_FORCE_INLINE_ static StringName get_type_name() { return m_type::get_struct_name(); }    \
+		_FORCE_INLINE_ static const Script *get_script() { return nullptr; }                      \
 	}
 
 #define STRUCT_MEMBER_STRUCT_FROM_TO(m_type, m_member_name, m_default) \
@@ -193,6 +193,76 @@ class Struct;
 // Most of the time, the exposed name of a struct follows the pattern "OwningClass.StructName".
 #define STRUCT_LAYOUT(m_owner, m_struct, ...) STRUCT_LAYOUT_ALIAS(#m_owner "." #m_struct, m_struct, __VA_ARGS__)
 
+template <typename StructType, typename... StructMembers>
+struct StructLayout;
+
+/* Represents the type data of both native and user Godot Structs.
+ * StructInfo is itself exposed as a Godot Struct, so it serves as
+ * a good example for how to expose other structs. */
+struct StructInfo {
+	STRUCT_DECLARE(StructInfo);
+	STRUCT_MEMBER(StringName, name, StringName());
+	STRUCT_MEMBER(int32_t, count, 0);
+	STRUCT_MEMBER(Vector<StringName>, names, Vector<StringName>());
+	STRUCT_MEMBER_FROM_TO(Vector<Variant::Type>, types, Vector<Variant::Type>());
+	STRUCT_MEMBER(Vector<StringName>, type_names, Vector<StringName>());
+	STRUCT_MEMBER_FROM_TO(Vector<const Script *>, scripts, Vector<const Script *>()); // wants to be Vector<Ref<Script>> but can't include Ref here.
+	STRUCT_MEMBER(Vector<Variant>, default_values, Vector<Variant>());
+
+	/* Normally, you would write
+	 * STRUCT_LAYOUT(StructInfo, struct name, struct count, struct names, struct types, struct type_names, struct scripts, struct default_values);
+	 * but we can't do that for StructInfo or it will create a circular dependency. */
+	static const StringName get_struct_name() {
+		return SNAME("StructInfo");
+	}
+	static const StructInfo &get_struct_info();
+	using Layout = StructLayout<StructInfo, struct StructInfo::name, struct StructInfo::count, struct StructInfo::names, struct StructInfo::types, struct StructInfo::type_names, struct StructInfo::scripts, struct StructInfo::default_values>;
+	StructInfo(const Dictionary &p_dict);
+	StructInfo(const Array &p_array);
+
+	StructInfo() {}
+	StructInfo(const StringName &p_name, const int32_t p_count) :
+			name(p_name), count(p_count) {
+		names.resize(p_count);
+		types.resize(p_count);
+		type_names.resize(p_count);
+		scripts.resize(p_count);
+		default_values.resize(p_count);
+	}
+	StructInfo(const StringName &p_name, const int32_t p_count, const Vector<StringName> &p_names, const Vector<Variant::Type> &p_types, const Vector<StringName> &p_type_names, const Vector<const Script *> &p_scripts, const Vector<Variant> &p_default_values) :
+			name(p_name),
+			count(p_count),
+			names(p_names),
+			types(p_types),
+			type_names(p_type_names),
+			scripts(p_scripts),
+			default_values(p_default_values) {}
+
+	_FORCE_INLINE_ void set(int32_t p_index, const StringName &p_name, const Variant::Type &p_type, const StringName &p_type_name, const Script *p_script, const Variant &p_default_value) {
+		names.write[p_index] = p_name;
+		types.write[p_index] = p_type;
+		type_names.write[p_index] = p_type_name;
+		scripts.write[p_index] = p_script;
+		default_values.write[p_index] = p_default_value;
+	}
+
+	_FORCE_INLINE_ bool operator==(const StructInfo &p_struct_info) const {
+		return name == p_struct_info.name;
+	}
+	_FORCE_INLINE_ bool operator!=(const StructInfo &p_struct_info) const {
+		return name != p_struct_info.name;
+	}
+	_FORCE_INLINE_ static bool is_compatible(const StructInfo *p_struct_info_1, const StructInfo *p_struct_info_2) {
+		if (p_struct_info_1) {
+			if (p_struct_info_2) {
+				return *p_struct_info_1 == *p_struct_info_2;
+			}
+			return false;
+		}
+		return p_struct_info_2 == nullptr;
+	}
+};
+
 /* The StructLayout template manages all the reflection data for a native struct. It automatically generates
  * functions for converting the C++ struct to and from a Godot Struct, Array, or Dictionary.
  * The StructType argument is expected to be a struct declared with STRUCT_DECLARE and the StructMember
@@ -206,10 +276,10 @@ struct StructLayout {
 	_FORCE_INLINE_ static const StructInfo &get_struct_info() {
 		static const Vector<StringName> names = { StructMembers::get_name()... };
 		static const Vector<Variant::Type> types = { StructMembers::get_variant_type()... };
-		static const Vector<StringName> class_names = { StructMembers::get_class_name()... };
-		static const Vector<const StructInfo *> struct_member_infos = { StructMembers::get_struct_member_info()... };
+		static const Vector<StringName> type_names = { StructMembers::get_type_name()... };
+		static const Vector<const Script *> scripts = { StructMembers::get_script()... };
 		static const Vector<Variant> default_values = { StructMembers::get_default_value_variant()... };
-		static const StructInfo info = StructInfo(get_struct_name(), struct_member_count, names, types, class_names, struct_member_infos, default_values);
+		static const StructInfo info = StructInfo(get_struct_name(), struct_member_count, names, types, type_names, scripts, default_values);
 		return info;
 	}
 
@@ -272,66 +342,6 @@ private:
 	struct TypeFinder<TypeToFind, TypeToCheck, TypesRemaining...> {
 		static constexpr int remaining_count = TypeFinder<TypeToFind, TypesRemaining...>::remaining_count;
 	};
-};
-
-/* Represents the type data of both native and user Godot Structs.
- * StructInfo is itself exposed as a Godot Struct, so it serves as
- * a good example for how to expose other structs. */
-struct StructInfo {
-	STRUCT_DECLARE(StructInfo);
-	STRUCT_MEMBER(StringName, name, StringName());
-	STRUCT_MEMBER(int32_t, count, 0);
-	STRUCT_MEMBER(Vector<StringName>, names, Vector<StringName>());
-	STRUCT_MEMBER_FROM_TO(Vector<Variant::Type>, types, Vector<Variant::Type>());
-	STRUCT_MEMBER(Vector<StringName>, class_names, Vector<StringName>());
-	STRUCT_MEMBER(Vector<Variant>, default_values, Vector<Variant>());
-	STRUCT_LAYOUT_ALIAS("StructInfo", StructInfo, struct name, struct count, struct names, struct types, struct class_names, struct default_values);
-
-	Vector<const StructInfo *> struct_member_infos;
-
-	StructInfo() {};
-	StructInfo(const StringName &p_name, const int32_t p_count) :
-			name(p_name), count(p_count) {
-		names.resize(p_count);
-		types.resize(p_count);
-		class_names.resize(p_count);
-		struct_member_infos.resize(p_count);
-		default_values.resize(p_count);
-	}
-	StructInfo(const StringName &p_name, const int32_t p_count, const Vector<StringName> &p_names, const Vector<Variant::Type> &p_types, const Vector<StringName> &p_class_names, const Vector<const StructInfo *> &p_struct_member_infos, const Vector<Variant> &p_default_values) :
-			name(p_name),
-			count(p_count),
-			names(p_names),
-			types(p_types),
-			class_names(p_class_names),
-			struct_member_infos(p_struct_member_infos),
-			default_values(p_default_values) {};
-
-	Dictionary to_dict() const;
-
-	_FORCE_INLINE_ void set(int32_t p_index, const StringName &p_name, const Variant::Type &p_type, const StringName &p_class_name, const StructInfo *p_struct_member_info, const Variant &p_default_value) {
-		names.write[p_index] = p_name;
-		types.write[p_index] = p_type;
-		class_names.write[p_index] = p_class_name;
-		struct_member_infos.write[p_index] = p_struct_member_info;
-		default_values.write[p_index] = p_default_value;
-	}
-
-	_FORCE_INLINE_ bool operator==(const StructInfo &p_struct_info) const {
-		return name == p_struct_info.name;
-	}
-	_FORCE_INLINE_ bool operator!=(const StructInfo &p_struct_info) const {
-		return name != p_struct_info.name;
-	}
-	_FORCE_INLINE_ static bool is_compatible(const StructInfo *p_struct_info_1, const StructInfo *p_struct_info_2) {
-		if (p_struct_info_1) {
-			if (p_struct_info_2) {
-				return *p_struct_info_1 == *p_struct_info_2;
-			}
-			return false;
-		}
-		return p_struct_info_2 == nullptr;
-	}
 };
 
 #endif // STRUCT_GENERATOR_H

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -57,7 +57,7 @@ public:
 		}
 	}
 	_FORCE_INLINE_ TypedArray() {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+		initialize_typed(Variant::OBJECT, T::get_class_static(), Variant());
 	}
 };
 
@@ -70,6 +70,53 @@ template <typename T>
 struct VariantInternalAccessor<const TypedArray<T> &> {
 	static _FORCE_INLINE_ TypedArray<T> get(const Variant *v) { return *VariantInternal::get_array(v); }
 	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
+};
+
+template <typename T>
+class TypedArray<Struct<T>> : public Array {
+public:
+	_FORCE_INLINE_ void operator=(const Array &p_array) {
+		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
+		_ref(p_array);
+	}
+	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
+			Array(Array(p_variant), T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ TypedArray(const Array &p_array) : // TypedArray(struct) creates [ struct ]
+			Array(p_array.is_array_of_structs() ? p_array : Array({ p_array }, T::get_struct_info()), T::get_struct_info()) {
+	}
+	_FORCE_INLINE_ TypedArray() {
+		initialize_struct_type(T::get_struct_info(), true);
+	}
+	_FORCE_INLINE_ TypedArray(const List<T> *p_list) {
+		initialize_struct_type(T::get_struct_info(), true);
+		for (const typename List<T>::Element *E = p_list->front(); E; E = E->next()) {
+			push_back(Struct<T>(E->get()));
+		}
+	}
+	_FORCE_INLINE_ operator List<T>() const {
+		List<T> list;
+		for (int i = 0; i < size(); i++) {
+			list.push_back(T(Struct<T>(get(i))));
+		}
+		return list;
+	}
+};
+template <typename T>
+struct GetTypeInfo<TypedArray<Struct<T>>> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_struct_name());
+	}
+};
+template <typename T>
+struct GetTypeInfo<const TypedArray<Struct<T>> &> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_struct_name());
+	}
 };
 
 //specialization for the rest of variant types
@@ -94,7 +141,7 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 			}                                                                                                    \
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
+			initialize_typed(m_variant_type, StringName(), Variant());                                           \
 		}                                                                                                        \
 	};
 

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -86,10 +86,10 @@ public:
 			Array(p_array.is_array_of_structs() ? p_array : Array({ p_array }, T::get_struct_info()), T::get_struct_info()) {
 	}
 	_FORCE_INLINE_ TypedArray() {
-		initialize_struct_type(T::get_struct_info(), true);
+		initialize_struct_type(T::get_struct_info(), false);
 	}
 	_FORCE_INLINE_ TypedArray(const List<T> *p_list) {
-		initialize_struct_type(T::get_struct_info(), true);
+		initialize_struct_type(T::get_struct_info(), false);
 		for (const typename List<T>::Element *E = p_list->front(); E; E = E->next()) {
 			push_back(Struct<T>(E->get()));
 		}

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1727,6 +1727,21 @@ String stringify_vector(const T &vec, int recursion_count) {
 	return str;
 }
 
+String stringify_array(const Array &p_array, int recursion_count) { // TODO: should this be called r_recursion_count?
+	String str("[");
+	for (int i = 0; i < p_array.size(); i++) {
+		if (i > 0) {
+			str += ", ";
+		}
+		if (p_array.is_struct()) {
+			str += String(p_array.get_member_name(i)) + ": ";
+		}
+		str += stringify_variant_clean(p_array[i], recursion_count);
+	}
+	str += "]";
+	return str;
+}
+
 String Variant::stringify(int recursion_count) const {
 	switch (type) {
 		case NIL:
@@ -1842,7 +1857,7 @@ String Variant::stringify(int recursion_count) const {
 			ERR_FAIL_COND_V_MSG(recursion_count > MAX_RECURSION, "[...]", "Maximum array recursion reached!");
 			recursion_count++;
 
-			return stringify_vector(operator Array(), recursion_count);
+			return stringify_array(operator Array(), recursion_count);
 		}
 		case OBJECT: {
 			if (_get_obj().obj) {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -368,6 +368,9 @@ public:
 	_FORCE_INLINE_ bool is_array() const {
 		return type >= ARRAY;
 	}
+	_FORCE_INLINE_ bool is_struct() const {
+		return Array(*this).is_struct(); // TODO: not sure if this is the best way to do this.
+	}
 	bool is_shared() const;
 	bool is_zero() const;
 	bool is_one() const;

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -203,6 +203,7 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructNoArgs<Array>>(sarray());
 	add_constructor<VariantConstructor<Array, Array>>(sarray("from"));
 	add_constructor<VariantConstructorTypedArray>(sarray("base", "type", "class_name", "script"));
+	//	add_constructor<VariantConstructorStruct>(sarray("base", "size", "struct_name", "member_names"));
 	add_constructor<VariantConstructorToArray<PackedByteArray>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedInt32Array>>(sarray("from"));
 	add_constructor<VariantConstructorToArray<PackedInt64Array>>(sarray("from"));

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -580,6 +580,93 @@ public:
 	}
 };
 
+//class VariantConstructorStruct {
+//public:
+//	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
+//		// want to call Array::Array(const Array &p_from, uint32_t p_size, const StringName &p_name, const StructMember &(*p_get_member)(uint32_t))
+//		for (int i = 0; i < get_argument_count(); i++) {
+//			Variant::Type arg_type = get_argument_type(i);
+//			if (p_args[i]->get_type() != arg_type) {
+//				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+//				r_error.argument = i;
+//				r_error.expected = arg_type;
+//				return;
+//			}
+//		}
+//
+//		const Array &base_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+//		const uint32_t size = p_args[1]->operator uint32_t();
+//		const StringName &struct_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
+//		// TODO: I don't like have to use PackedStringArray here, but there is no PackedStringNameArray
+//		const PackedStringArray &member_names = *VariantGetInternalPtr<PackedStringArray>::get_ptr(p_args[3]);
+//		Vector<StringName> names;
+//		const int count = member_names.size();
+//		names.resize(count);
+//		for (int i = 0; i < count; i++) {
+//			names.write[i] = StringName(member_names[i]);
+//		}
+//		r_ret = Array(base_arr, size, struct_name, names);
+//	}
+//
+//	_FORCE_INLINE_ static void validated_construct(Variant *r_ret, const Variant **p_args) {
+//		const Array &base_arr = *VariantGetInternalPtr<Array>::get_ptr(p_args[0]);
+//		const uint32_t size = p_args[1]->operator uint32_t();
+//		const StringName &struct_name = *VariantGetInternalPtr<StringName>::get_ptr(p_args[2]);
+//		const PackedStringArray &member_names = *VariantGetInternalPtr<PackedStringArray>::get_ptr(p_args[3]);
+//		Vector<StringName> names;
+//		const int count = member_names.size();
+//		names.resize(count);
+//		for (int i = 0; i < count; i++) {
+//			names.write[i] = StringName(member_names[i]);
+//		}
+//		*r_ret = Array(base_arr, size, struct_name, names);
+//	}
+//
+//	static void ptr_construct(void *base, const void **p_args) {
+//		const Array &base_arr = PtrToArg<Array>::convert(p_args[0]);
+//		const uint32_t size = PtrToArg<uint32_t>::convert(p_args[1]);
+//		const StringName &struct_name = PtrToArg<StringName>::convert(p_args[2]);
+//		const PackedStringArray &member_names = PtrToArg<PackedStringArray>::convert(p_args[3]);
+//		Vector<StringName> names;
+//		const int count = member_names.size();
+//		names.resize(count);
+//		for (int i = 0; i < count; i++) {
+//			names.write[i] = StringName(member_names[i]);
+//		}
+//		Array dst_arr = Array(base_arr, size, struct_name, names);
+//
+//		PtrConstruct<Array>::construct(dst_arr, base);
+//	}
+//
+//	_FORCE_INLINE_ static int get_argument_count() { // TODO: should this be const?
+//		return 4;
+//	}
+//
+//	_FORCE_INLINE_ static Variant::Type get_argument_type(int p_arg) { // TODO: should this be const?
+//		switch (p_arg) {
+//			case 0: {
+//				return Variant::ARRAY;
+//			} break;
+//			case 1: {
+//				return Variant::INT;
+//			} break;
+//			case 2: {
+//				return Variant::STRING_NAME;
+//			} break;
+//			case 3: {
+//				return Variant::PACKED_STRING_ARRAY;
+//			} break;
+//			default: {
+//				return Variant::NIL;
+//			} break;
+//		}
+//	}
+//
+//	_FORCE_INLINE_ static Variant::Type get_base_type() { // TODO: should this be const?
+//		return Variant::ARRAY;
+//	}
+//};
+
 template <typename T>
 class VariantConstructorToArray {
 public:

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -257,6 +257,13 @@ void Variant::set_named(const StringName &p_member, const Variant &p_value, bool
 	} else if (type == Variant::DICTIONARY) {
 		Dictionary &dict = *VariantGetInternalPtr<Dictionary>::get_ptr(this);
 		r_valid = dict.set(p_member, p_value);
+	} else if (type == Variant::ARRAY && is_struct()) {
+		Array &array = *VariantGetInternalPtr<Array>::get_ptr(this);
+		int index = array.find_member(p_member);
+		if (index >= 0) {
+			array.set(index, p_value);
+			r_valid = true;
+		}
 	} else {
 		r_valid = false;
 	}
@@ -287,6 +294,20 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 		} break;
 		case Variant::DICTIONARY: {
 			const Variant *v = VariantGetInternalPtr<Dictionary>::get_ptr(this)->getptr(p_member);
+			if (v) {
+				r_valid = true;
+				return *v;
+			}
+		} break;
+		case Variant::ARRAY: {
+			const Array *array = VariantGetInternalPtr<Array>::get_ptr(this);
+			if (!array->get_struct_info()) {
+				if (Variant::has_builtin_method(type, p_member)) {
+					r_valid = true;
+					return Callable(memnew(VariantCallable(*this, p_member)));
+				}
+			}
+			const Variant *v = array->getptr(p_member);
 			if (v) {
 				r_valid = true;
 				return *v;
@@ -1256,28 +1277,45 @@ Variant Variant::get(const Variant &p_index, bool *r_valid, VariantGetError *err
 }
 
 void Variant::get_property_list(List<PropertyInfo> *p_list) const {
-	if (type == DICTIONARY) {
-		const Dictionary *dic = reinterpret_cast<const Dictionary *>(_data._mem);
-		List<Variant> keys;
-		dic->get_key_list(&keys);
-		for (const Variant &E : keys) {
-			if (E.is_string()) {
-				p_list->push_back(PropertyInfo(dic->get_valid(E).get_type(), E));
+	switch (type) {
+		case DICTIONARY: {
+			const Dictionary *dic = reinterpret_cast<const Dictionary *>(_data._mem);
+			List<Variant> keys;
+			dic->get_key_list(&keys);
+			for (const Variant &E : keys) {
+				if (E.is_string()) {
+					p_list->push_back(PropertyInfo(dic->get_valid(E).get_type(), E));
+				}
 			}
+			break;
 		}
-	} else if (type == OBJECT) {
-		Object *obj = get_validated_object();
-		ERR_FAIL_NULL(obj);
-		obj->get_property_list(p_list);
-
-	} else {
-		List<StringName> members;
-		get_member_list(type, &members);
-		for (const StringName &E : members) {
-			PropertyInfo pi;
-			pi.name = E;
-			pi.type = get_member_type(type, E);
-			p_list->push_back(pi);
+		case OBJECT: {
+			Object *obj = get_validated_object();
+			ERR_FAIL_NULL(obj);
+			obj->get_property_list(p_list);
+			break;
+		}
+		case ARRAY: {
+			const Array *array = reinterpret_cast<const Array *>(_data._mem);
+			// if not struct, continue on to default case, otherwise...
+			if (array->is_struct()) {
+				const StructInfo *struct_info = array->get_struct_info();
+				for (int32_t i = 0; i < struct_info->count; i++) {
+					p_list->push_back(PropertyInfo(struct_info->types[i], struct_info->names[i], PropertyHint::PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, struct_info->class_names[i]));
+				}
+				break;
+			}
+			[[fallthrough]];
+		}
+		default: {
+			List<StringName> members;
+			get_member_list(type, &members);
+			for (const StringName &E : members) {
+				PropertyInfo pi;
+				pi.name = E;
+				pi.type = get_member_type(type, E);
+				p_list->push_back(pi);
+			}
 		}
 	}
 }

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1301,7 +1301,7 @@ void Variant::get_property_list(List<PropertyInfo> *p_list) const {
 			if (array->is_struct()) {
 				const StructInfo *struct_info = array->get_struct_info();
 				for (int32_t i = 0; i < struct_info->count; i++) {
-					p_list->push_back(PropertyInfo(struct_info->types[i], struct_info->names[i], PropertyHint::PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, struct_info->class_names[i]));
+					p_list->push_back(PropertyInfo(struct_info->types[i], struct_info->names[i], PropertyHint::PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, struct_info->type_names[i]));
 				}
 				break;
 			}

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -152,8 +152,8 @@ class TileSet : public Resource {
 private:
 	struct CompatibilityShapeData {
 		Vector2i autotile_coords;
-		bool one_way;
-		float one_way_margin;
+		bool one_way = false; // TODO: I added these defaults to make the CI happy but I'm not sure if it will break anything
+		float one_way_margin = 1.0f;
 		Ref<Shape2D> shape;
 		Transform2D transform;
 	};

--- a/tests/core/variant/test_struct.h
+++ b/tests/core/variant/test_struct.h
@@ -238,7 +238,7 @@ TEST_CASE("[Struct] StructInfo") {
 		CHECK_EQ(info_as_c_struct.count, info_as_godot_struct.get_member<struct StructInfo::count>());
 		CHECK_EQ(info_as_c_struct.names, info_as_godot_struct.get_member<struct StructInfo::names>());
 		CHECK_EQ(info_as_c_struct.types, info_as_godot_struct.get_member<struct StructInfo::types>());
-		CHECK_EQ(info_as_c_struct.class_names, info_as_godot_struct.get_member<struct StructInfo::class_names>());
+		CHECK_EQ(info_as_c_struct.type_names, info_as_godot_struct.get_member<struct StructInfo::type_names>());
 		CHECK_EQ(info_as_c_struct.default_values, info_as_godot_struct.get_member<struct StructInfo::default_values>());
 	}
 
@@ -332,7 +332,7 @@ TEST_CASE("[Struct] Nesting") {
 		STRUCT_MEMBER(int, int_val, 4);
 		STRUCT_MEMBER(float, float_val, 5.5f);
 		STRUCT_LAYOUT(TestStruct, BasicStruct, struct int_val, struct float_val);
-		BasicStruct() {};
+		BasicStruct() {}
 	};
 	struct BasicStructLookalike {
 		STRUCT_DECLARE(BasicStructLookalike);
@@ -348,8 +348,6 @@ TEST_CASE("[Struct] Nesting") {
 	};
 
 	REQUIRE_EQ(NestedStruct::Layout::struct_member_count, 2);
-	CHECK_EQ(NestedStruct::Layout::get_struct_info().struct_member_infos[0], nullptr);
-	CHECK_EQ(NestedStruct::Layout::get_struct_info().struct_member_infos[1]->count, 2);
 
 	Struct<BasicStruct> basic_struct;
 	Struct<BasicStructLookalike> basic_struct_lookalike;
@@ -425,7 +423,7 @@ TEST_CASE("[Struct] ClassDB") {
 	CHECK_EQ(struct_info->name, "Object.PropertyInfo");
 	CHECK_EQ(struct_info->names[3], "hint");
 	CHECK_EQ(struct_info->types[3], Variant::INT);
-	CHECK_EQ(struct_info->class_names[3], "");
+	CHECK_EQ(struct_info->type_names[3], "");
 	CHECK_EQ((int)struct_info->default_values[3], PROPERTY_HINT_NONE);
 }
 

--- a/tests/core/variant/test_struct.h
+++ b/tests/core/variant/test_struct.h
@@ -1,0 +1,434 @@
+/**************************************************************************/
+/*  test_struct.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_STRUCT_H
+#define TEST_STRUCT_H
+
+#include "core/variant/array.h"
+#include "core/variant/struct.h"
+#include "core/variant/struct_generator.h"
+#include "core/variant/variant.h"
+#include "scene/main/node.h"
+#include "tests/test_macros.h"
+#include "tests/test_tools.h"
+
+// TODO: methods to structify:
+/*
+ * ClassDB::class_get_signal_list()
+ * ClassDB::class_get_property_list()
+ * ClassDB::class_get_method_list()
+ * CodeEdit::_filter_code_completion_candidates()
+ * CodeEdit::get_code_completion_options()
+ * DisplayServer::tts_get_voices()
+ * EditorExportPlugin::_get_export_options()
+ * EditorImportPlugin::_get_import_options()
+ * ScriptLanguage::CodeCompletionOption
+ * ResourceImporter::ImportOption
+ * EditorVCSInterface::DiffLine
+ * EditorVCSInterface::DiffHunk
+ * EditorVCSInterface::DiffFile
+ * EditorVCSInterface::Commit
+ * EditorVCSInterface::StatusFile
+ * EditorVCSInterface::_get_modified_files_data()
+ * EditorVCSInterface::_get_diff()
+ * EditorVCSInterface::_get_previous_commits()
+ * EditorVCSInterface::_get_line_diff()
+ * EditorVCSInterface::add_diff_hunks_into_diff_file()
+ * EditorVCSInterface::add_line_diffs_into_diff_hunk()
+ * Engine::get_author_info()
+ * Engine::get_copyright_info()
+ * Engine::get_donor_info()
+ * Engine::get_version_info()
+ * Font::get_opentype_features()
+ * Font::get_ot_name_strings()
+ * Font::get_supported_variation_list()
+ * Font::find_variation()
+ * Font::get_opentype_feature_overrides()
+ * GLTFCamera::to_dictionary()
+ * GLTFCamera::from_dictionary()
+ * GLTFLight::to_dictionary()
+ * GLTFLight::from_dictionary()
+ * GLTFPhysicsBody::to_dictionary()
+ * GLTFPhysicsBody::from_dictionary()
+ * GLTFPhysicsShape::to_dictionary()
+ * GLTFPhysicsShape::from_dictionary()
+ * Geometry2D::make_atlas()
+ * GraphEdit::get_connection_list()
+ * Image::compute_image_metrics()
+ * Image::data
+ * IP::get_local_interfaces()
+ * LightmapGIData::probe_data
+ * NavigationAgent2D::waypoint_reached()
+ * NavigationAgent2D::link_reached()
+ * NavigationAgent3D::waypoint_reached()
+ * NavigationAgent3D::link_reached()
+ * Object::get_property_list()
+ * Object::get_method_list()
+ * Object::get_signal_list()
+ * Object::get_signal_connection_list()
+ * Object::get_incoming_connections()
+ * OS::get_memory_info()
+ * PhysicsDirectSpaceState2D::get_rest_info()
+ * PhysicsDirectSpaceState2D::intersect_point()
+ * PhysicsDirectSpaceState2D::intersect_ray()
+ * PhysicsDirectSpaceState2D::intersect_shape()
+ * PhysicsDirectSpaceState3D::get_rest_info()
+ * PhysicsDirectSpaceState3D::intersect_point()
+ * PhysicsDirectSpaceState3D::intersect_ray()
+ * PhysicsDirectSpaceState3D::intersect_shape()
+ * PolygonPathFinder::data
+ * ProjectSettings::add_property_info()
+ * ProjectSettings::get_global_class_list()
+ * RenderingServer::mesh_add_surface()
+ * RenderingServer::mesh_get_surface()
+ * RenderingServer::get_shader_parameter_list()
+ * RenderingServer::mesh_create_from_surfaces()
+ * RenderingServer::instance_geometry_get_shader_parameter_list()
+ * Script::get_script_property_list()
+ * Script::get_script_method_list()
+ * Script::get_script_signal_list()
+ * ScriptLanguage::_get_method_info()
+ * ScriptLanguageExtension::_validate()
+ * ScriptLanguageExtension::_complete_code()
+ * ScriptLanguageExtension::_lookup_code()
+ * ScriptLanguageExtension::_debug_get_current_stack_info()
+ * ScriptLanguageExtension::_get_public_functions()
+ * ScriptLanguageExtension::_get_public_annotations()
+ * ScriptLanguageExtension::_debug_get_stack_level_locals()
+ * ScriptLanguageExtension::_debug_get_stack_level_members()
+ * ScriptLanguageExtension::_debug_get_globals()
+ * ScriptLanguageExtension::_get_built_in_templates()
+ * ScriptLanguageExtension::_get_public_constants()
+ * ScriptLanguageExtension::_get_public_annotations()
+ * ScriptLanguageExtension::_get_global_class_name()
+ * ScriptExtension::_get_documentation()
+ * ScriptExtension::_get_script_signal_list()
+ * ScriptExtension::_get_script_method_list()
+ * ScriptExtension::_get_script_property_list()
+ * TextServer::font_set_variation_coordinates()
+ * TextServer::font_get_variation_coordinates()
+ * TextServer::font_get_glyph_contours()
+ * TextServer::font_set_opentype_feature_overrides()
+ * TextServer::font_get_opentype_feature_overrides()
+ * TextServer::font_supported_feature_list()
+ * TextServer::font_supported_variation_list()
+ * TextServer::shaped_text_add_string()
+ * TextServer::shaped_set_span_update_font()
+ * TextServer::shaped_text_get_carets()
+ * TextServer::shaped_text_get_glyphs()
+ * TextServer::shaped_text_sort_logical()
+ * TextServer::shaped_text_get_ellipsis_glyphs()
+ * TextServerExtension::_font_set_variation_coordinates()
+ * TextServerExtension::_font_get_variation_coordinates()
+ * TextServerExtension::_font_get_glyph_contours()
+ * TextServerExtension::_font_set_opentype_feature_overrides()
+ * TextServerExtension::_font_get_opentype_feature_overrides()
+ * TextServerExtension::_font_supported_feature_list()
+ * TextServerExtension::_font_supported_variation_list()
+ * TextServerExtension::_shaped_text_add_string()
+ * TextServerExtension::_shaped_set_span_update_font()
+ * TextServerManager::get_interfaces()
+ * Time::get_datetime_dict_from_unix_time()
+ * Time::get_date_dict_from_unix_time()
+ * Time::get_time_dict_from_unix_time()
+ * Time::get_datetime_dict_from_datetime_string()
+ * Time::get_datetime_string_from_datetime_dict()
+ * Time::get_unix_time_from_datetime_dict()
+ * Time::get_datetime_dict_from_system()
+ * Time::get_date_dict_from_system()
+ * Time::get_time_dict_from_system()
+ * Time::get_time_zone_from_system()
+ * Tree::get_range_config()
+ * VisualShader::get_node_connections()
+ * WebRTCMultiplayerPeer::get_peer()
+ * WebRTCMultiplayerPeer::get_peers()
+ * WebRTCPeerConnection::initialize()
+ * WebRTCPeerConnection::create_data_channel()
+ * WebRTCPeerConnectionExtension::_initialize()
+ * WebRTCPeerConnectionExtension::_create_data_channel()
+ * XRInterface::get_system_info()
+ * XRInterfaceExtension::_get_system_info()
+ * XRServer::get_interfaces()
+ * XRServer::get_trackers()
+ *
+ *
+ * */
+
+namespace TestStruct {
+
+//TEST_CASE("[Struct] PropertyInfo") {
+//	Node *my_node = memnew(Node);
+//
+//	List<PropertyInfo> list;
+//	my_node->get_property_list(&list);
+//	PropertyInfo info = list.get(0);
+//
+//	TypedArray<Struct<PropertyInfo>> property_list = my_node->call(SNAME("get_property_list_as_structs"));
+//	Struct<PropertyInfo> prop = property_list[0];
+//
+//	SUBCASE("Equality") {
+//		CHECK_EQ(info.name, prop.get_member<struct PropertyInfo::name>());
+//		CHECK_EQ(info.class_name, prop.get_member<struct PropertyInfo::class_name>());
+//		CHECK_EQ(info.type, prop.get_member<struct PropertyInfo::type>());
+//		CHECK_EQ(info.hint, prop.get_member<struct PropertyInfo::hint>());
+//		CHECK_EQ(info.hint_string, prop.get_member<struct PropertyInfo::hint_string>());
+//		CHECK_EQ(info.usage, prop.get_member<struct PropertyInfo::usage>());
+//	}
+//
+//	SUBCASE("Duplication") {
+//		Variant var = prop;
+//		CHECK_EQ(var.get_type(), Variant::ARRAY);
+//		Variant var_dup = prop.duplicate();
+//		CHECK_EQ(var_dup.get_type(), Variant::ARRAY);
+//		CHECK_EQ(var, var_dup);
+//	}
+//
+//	SUBCASE("Setget Named") {
+//		Variant variant_prop = prop;
+//		bool valid = false;
+//		variant_prop.set_named(SNAME("name"), SNAME("Changed"), valid);
+//		CHECK_EQ(valid, true);
+//		Variant val = variant_prop.get_named(SNAME("name"), valid);
+//		CHECK_EQ(valid, true);
+//		CHECK_EQ((StringName)val, SNAME("Changed"));
+//
+//		val = variant_prop.get_named(SNAME("oops"), valid);
+//		CHECK_EQ(valid, false);
+//		CHECK_EQ(val, Variant());
+//
+//		variant_prop.set_named(SNAME("oops"), SNAME("oh no"), valid);
+//		CHECK_EQ(valid, false);
+//	}
+//	memdelete(my_node);
+//}
+
+TEST_CASE("[Struct] StructInfo") {
+	StructInfo info_as_c_struct = StructInfo::get_struct_info();
+	Struct<StructInfo> info_as_godot_struct = info_as_c_struct;
+
+	SUBCASE("Equality") {
+		CHECK_EQ(info_as_c_struct.name, info_as_godot_struct.get_member<struct StructInfo::name>());
+		CHECK_EQ(info_as_c_struct.count, info_as_godot_struct.get_member<struct StructInfo::count>());
+		CHECK_EQ(info_as_c_struct.names, info_as_godot_struct.get_member<struct StructInfo::names>());
+		CHECK_EQ(info_as_c_struct.types, info_as_godot_struct.get_member<struct StructInfo::types>());
+		CHECK_EQ(info_as_c_struct.class_names, info_as_godot_struct.get_member<struct StructInfo::class_names>());
+		CHECK_EQ(info_as_c_struct.default_values, info_as_godot_struct.get_member<struct StructInfo::default_values>());
+	}
+
+	SUBCASE("Duplication") {
+		Variant var = info_as_godot_struct;
+		CHECK_EQ(var.get_type(), Variant::ARRAY);
+		Variant var_dup = info_as_godot_struct.duplicate();
+		CHECK_EQ(var_dup.get_type(), Variant::ARRAY);
+		CHECK_EQ(var, var_dup);
+	}
+
+	SUBCASE("Setget Named") {
+		Variant var = info_as_godot_struct;
+		bool valid = false;
+		var.set_named(SNAME("name"), SNAME("Changed"), valid);
+		CHECK_EQ(valid, true);
+		Variant val = var.get_named(SNAME("name"), valid);
+		CHECK_EQ(valid, true);
+		CHECK_EQ((StringName)val, SNAME("Changed"));
+
+		val = var.get_named(SNAME("oops"), valid);
+		CHECK_EQ(valid, false);
+		CHECK_EQ(val, Variant());
+
+		var.set_named(SNAME("oops"), SNAME("oh no"), valid);
+		CHECK_EQ(valid, false);
+	}
+}
+
+TEST_CASE("[Struct] Validation") {
+	struct NamedInt {
+		STRUCT_DECLARE(NamedInt);
+		STRUCT_MEMBER_PRIMITIVE(String, name, String());
+		STRUCT_MEMBER_PRIMITIVE(int, value, 0);
+		STRUCT_LAYOUT(NamedInt, struct name, struct value);
+	};
+
+	Struct<NamedInt> named_int;
+	named_int["name"] = "Godot";
+	named_int["value"] = 4;
+	CHECK_EQ(((Variant)named_int).stringify(), "[name: \"Godot\", value: 4]");
+
+	SUBCASE("Self Equal") {
+		CHECK(named_int.is_same_typed(named_int));
+		Variant variant_named_int = named_int;
+		CHECK(named_int.is_same_typed(variant_named_int));
+		Struct<NamedInt> same_named_int = variant_named_int;
+		CHECK_EQ(named_int, same_named_int);
+	}
+
+	SUBCASE("Assignment") {
+		Struct<NamedInt> a_match = named_int;
+		CHECK_EQ(named_int, a_match);
+		Array not_a_match;
+
+		ERR_PRINT_OFF;
+		named_int.set_named("name", 4);
+		CHECK_MESSAGE(named_int["name"] == "Godot", "assigned an int to a string member");
+
+		named_int.set_named("value", "Godot");
+		CHECK_MESSAGE((int)named_int["value"] == 4, "assigned a string to an int member");
+
+		named_int = not_a_match;
+		CHECK_MESSAGE(named_int != not_a_match, "assigned an empty array to a struct");
+
+		not_a_match.resize(2);
+		named_int.assign(not_a_match);
+		CHECK_MESSAGE(named_int != not_a_match, "assigned an array with the wrong size");
+
+		not_a_match[0] = 4;
+		not_a_match[1] = "Godot";
+		named_int.assign(not_a_match);
+		CHECK_MESSAGE(named_int != not_a_match, "assigned an array with mismatched types");
+
+		Array also_a_match;
+		also_a_match.resize(2);
+		also_a_match[0] = "Godooot";
+		also_a_match[1] = 5;
+		named_int = not_a_match;
+		CHECK_MESSAGE(named_int != not_a_match, "assigned a non-struct to a struct using '=' operator");
+		ERR_PRINT_ON;
+
+		named_int.assign(also_a_match);
+		CHECK_MESSAGE(named_int == also_a_match, "failed to assign an array with correct types using 'assign' function");
+	}
+}
+
+TEST_CASE("[Struct] Nesting") {
+	struct BasicStruct {
+		STRUCT_DECLARE(BasicStruct);
+		STRUCT_MEMBER_PRIMITIVE(int, int_val, 4);
+		STRUCT_MEMBER_PRIMITIVE(float, float_val, 5.5f);
+		STRUCT_LAYOUT(BasicStruct, struct int_val, struct float_val);
+		BasicStruct() {};
+	};
+	struct BasicStructLookalike {
+		STRUCT_DECLARE(BasicStructLookalike);
+		STRUCT_MEMBER_PRIMITIVE(int, int_val, 4);
+		STRUCT_MEMBER_PRIMITIVE(float, float_val, 5.5f);
+		STRUCT_LAYOUT(BasicStructLookalike, struct int_val, struct float_val);
+	};
+	struct NestedStruct {
+		STRUCT_DECLARE(NestedStruct);
+		STRUCT_MEMBER_CLASS_POINTER(Node, node, nullptr);
+		STRUCT_MEMBER_STRUCT(BasicStruct, value, BasicStruct());
+		STRUCT_LAYOUT(NestedStruct, struct node, struct value);
+	};
+
+	REQUIRE_EQ(NestedStruct::Layout::struct_member_count, 2);
+	CHECK_EQ(NestedStruct::Layout::get_struct_info().struct_member_infos[0], nullptr);
+	CHECK_EQ(NestedStruct::Layout::get_struct_info().struct_member_infos[1]->count, 2);
+
+	Struct<BasicStruct> basic_struct;
+	Struct<BasicStructLookalike> basic_struct_lookalike;
+	Struct<NestedStruct> nested_struct;
+
+	SUBCASE("Defaults") {
+		CHECK_EQ(basic_struct.get_member<struct BasicStruct::int_val>(), 4);
+		CHECK_EQ(basic_struct.get_member<struct BasicStruct::float_val>(), 5.5);
+
+		CHECK_EQ(nested_struct.get_member<struct NestedStruct::node>(), nullptr);
+		CHECK_EQ(Struct<BasicStruct>(nested_struct.get_member<struct NestedStruct::value>()), basic_struct);
+	}
+
+	SUBCASE("Assignment") {
+		basic_struct.set_member<struct BasicStruct::int_val>(1);
+		basic_struct.set_member<struct BasicStruct::float_val>(3.14);
+
+		basic_struct_lookalike.set_member<struct BasicStructLookalike::int_val>(2);
+		basic_struct_lookalike.set_member<struct BasicStructLookalike::float_val>(2.7);
+
+		Node *node = memnew(Node);
+		nested_struct.set_member<struct NestedStruct::node>(node);
+		nested_struct.set_member<struct NestedStruct::value>(basic_struct);
+
+		CHECK_EQ(nested_struct.get_member<struct NestedStruct::node>(), node);
+		Struct<BasicStruct> basic_struct_match = nested_struct.get_member<struct NestedStruct::value>();
+		CHECK_EQ(basic_struct_match, basic_struct);
+		CHECK_EQ(basic_struct_match.get_member<struct BasicStruct::int_val>(), basic_struct.get_member<struct BasicStruct::int_val>());
+		CHECK_EQ(basic_struct_match.get_member<struct BasicStruct::float_val>(), basic_struct.get_member<struct BasicStruct::float_val>());
+
+		ERR_PRINT_OFF;
+		nested_struct.set_named("value", basic_struct_lookalike);
+		CHECK_EQ(nested_struct["value"], basic_struct);
+		ERR_PRINT_ON;
+
+		memdelete(node);
+	}
+
+	SUBCASE("Typed Array of Struct") {
+		TypedArray<Struct<BasicStruct>> array;
+		Struct<BasicStruct> basic_struct_0;
+		basic_struct_0["int_val"] = 1;
+		basic_struct_0["float_val"] = 3.14;
+		Struct<BasicStruct> basic_struct_1;
+		basic_struct_1["int_val"] = 2;
+		basic_struct_1["float_val"] = 2.7;
+		array.push_back(basic_struct_0);
+		array.push_back(basic_struct_1);
+		CHECK_EQ(array[0], basic_struct_0);
+		CHECK_EQ(array[1], basic_struct_1);
+
+		ERR_PRINT_OFF;
+		array.push_back(0);
+		CHECK_EQ(array.size(), 2);
+
+		basic_struct_lookalike["int_val"] = 3;
+		basic_struct_lookalike["float_val"] = 5.4;
+		array.push_back(basic_struct_lookalike);
+		CHECK_EQ(array.size(), 2);
+		ERR_PRINT_ON;
+
+		TypedArray<Struct<BasicStruct>> array_of_defaults;
+		array_of_defaults.resize(2);
+		CHECK_EQ(array_of_defaults[0], Variant(Struct<BasicStruct>()));
+		CHECK_EQ(array_of_defaults[1], Variant(Struct<BasicStruct>()));
+	}
+}
+
+TEST_CASE("[Struct] ClassDB") {
+	const StructInfo *struct_info = ::ClassDB::get_struct_info(SNAME("Object"), SNAME("PropertyInfo"));
+	REQUIRE(struct_info);
+	CHECK_EQ(struct_info->count, 6);
+	CHECK_EQ(struct_info->name, "Object.PropertyInfo");
+	CHECK_EQ(struct_info->names[3], "hint");
+	CHECK_EQ(struct_info->types[3], Variant::INT);
+	CHECK_EQ(struct_info->class_names[3], "");
+	CHECK_EQ((int)struct_info->default_values[3], PROPERTY_HINT_NONE);
+}
+
+} // namespace TestStruct
+
+#endif // TEST_STRUCT_H

--- a/tests/core/variant/test_struct.h
+++ b/tests/core/variant/test_struct.h
@@ -271,9 +271,9 @@ TEST_CASE("[Struct] StructInfo") {
 TEST_CASE("[Struct] Validation") {
 	struct NamedInt {
 		STRUCT_DECLARE(NamedInt);
-		STRUCT_MEMBER_PRIMITIVE(String, name, String());
-		STRUCT_MEMBER_PRIMITIVE(int, value, 0);
-		STRUCT_LAYOUT(NamedInt, struct name, struct value);
+		STRUCT_MEMBER(String, name, String());
+		STRUCT_MEMBER(int, value, 0);
+		STRUCT_LAYOUT(TestStruct, NamedInt, struct name, struct value);
 	};
 
 	Struct<NamedInt> named_int;
@@ -329,22 +329,22 @@ TEST_CASE("[Struct] Validation") {
 TEST_CASE("[Struct] Nesting") {
 	struct BasicStruct {
 		STRUCT_DECLARE(BasicStruct);
-		STRUCT_MEMBER_PRIMITIVE(int, int_val, 4);
-		STRUCT_MEMBER_PRIMITIVE(float, float_val, 5.5f);
-		STRUCT_LAYOUT(BasicStruct, struct int_val, struct float_val);
+		STRUCT_MEMBER(int, int_val, 4);
+		STRUCT_MEMBER(float, float_val, 5.5f);
+		STRUCT_LAYOUT(TestStruct, BasicStruct, struct int_val, struct float_val);
 		BasicStruct() {};
 	};
 	struct BasicStructLookalike {
 		STRUCT_DECLARE(BasicStructLookalike);
-		STRUCT_MEMBER_PRIMITIVE(int, int_val, 4);
-		STRUCT_MEMBER_PRIMITIVE(float, float_val, 5.5f);
-		STRUCT_LAYOUT(BasicStructLookalike, struct int_val, struct float_val);
+		STRUCT_MEMBER(int, int_val, 4);
+		STRUCT_MEMBER(float, float_val, 5.5f);
+		STRUCT_LAYOUT(TestStruct, BasicStructLookalike, struct int_val, struct float_val);
 	};
 	struct NestedStruct {
 		STRUCT_DECLARE(NestedStruct);
 		STRUCT_MEMBER_CLASS_POINTER(Node, node, nullptr);
 		STRUCT_MEMBER_STRUCT(BasicStruct, value, BasicStruct());
-		STRUCT_LAYOUT(NestedStruct, struct node, struct value);
+		STRUCT_LAYOUT(TestStruct, NestedStruct, struct node, struct value);
 	};
 
 	REQUIRE_EQ(NestedStruct::Layout::struct_member_count, 2);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -105,6 +105,7 @@
 #include "tests/core/variant/test_array.h"
 #include "tests/core/variant/test_callable.h"
 #include "tests/core/variant/test_dictionary.h"
+#include "tests/core/variant/test_struct.h"
 #include "tests/core/variant/test_variant.h"
 #include "tests/core/variant/test_variant_utility.h"
 #include "tests/scene/test_animation.h"


### PR DESCRIPTION
I am in the process of implementing the proposal https://github.com/godotengine/godot-proposals/issues/7329 of @reduz on adding structs to GDScript. This work is still very much in it's early stages and many features still have yet to be implemented. Nevertheless, I'm making the draft public now so I can get continual feedback on this highly requested feature.

Edit 2023-Oct-18 22:50: Added list of structable methods

I've gone through Godot's API and made a list of about 130 methods that might benefit from structification: https://gist.github.com/nlupugla/01d59094d5fa31230e15bd991b63d33f.

- [x] Add struct attributes to the `Array` class.
- [x] Create `Struct<T>` class as a child of `Array`.
- [x] Create `STRUCT_LAYOUT` and related macros to facilitate creating `Struct<T>` specializations from actual C++ structs.
- [x] Proof of concept: create a struct that is equivalent to the `PropertyInfo` used in `Object::get_property_list`.
- [x] Implement type validation.
- [x] Find a way to return a typed array of structs (Godot does not yet support `TypedArray<TypedArray<T>>`).
- [x] Register structs with `ClassDB`.
- [x] Proof of concept: expose a struct to GDScript.
- [ ] Comprehensive unit tests.
- [ ] Performance profiling.
- [ ] Performance optimizations.
- [ ] Probably a million other things I'm forgetting.
- [x] Implement struct syntax in GDScript.
- [x] Implement static analysis for structs in GDScript.
- [ ] Figure out how structs will interoperate with C# and GDExtension.
- [ ] User testing.