### PR TITLE
Add editor setting to make tab always indent the line

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -587,6 +587,9 @@
 		<member name="symbol_lookup_on_click" type="bool" setter="set_symbol_lookup_on_click_enabled" getter="is_symbol_lookup_on_click_enabled" default="false">
 			Set when a validated word from [signal symbol_validate] is clicked, the [signal symbol_lookup] should be emitted.
 		</member>
+		<member name="tab_always_indents" type="bool" setter="set_tab_always_indents" getter="is_tab_always_indents" default="false">
+			Sets if pressing [kbd]Tab[/kbd] should indent the current line instead of inserting a tab.
+		</member>
 		<member name="text_direction" type="int" setter="set_text_direction" getter="get_text_direction" overrides="TextEdit" enum="Control.TextDirection" default="1" />
 	</members>
 	<signals>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1024,6 +1024,11 @@
 		<member name="text_editor/behavior/indent/size" type="int" setter="" getter="">
 			When using tab indentation, determines the length of each tab. When using space indentation, determines how many spaces are inserted when pressing [kbd]Tab[/kbd] and when automatic indentation is performed.
 		</member>
+		<member name="text_editor/behavior/indent/tab_action" type="int" setter="" getter="">
+			What happens when pressing [kbd]Tab[/kbd] in the code editor.
+			- [b]Insert:[/b] Pressing [kbd]Tab[/kbd] will insert a tab character or a number of spaces until the next tab is reached (depending on [member text_editor/behavior/indent/type])
+			- [b]Indent:[/b] Pressing [kbd]Tab[/kbd] will increase the indentation of the line regardless of where the cursor is.
+		</member>
 		<member name="text_editor/behavior/indent/type" type="int" setter="" getter="">
 			The indentation style to use (tabs or spaces).
 			[b]Note:[/b] The [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_styleguide.html]GDScript style guide[/url] recommends using tabs for indentation. It is advised to change this setting only if you need to work on a project that currently uses spaces for indentation.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1054,6 +1054,7 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_indent_size(EDITOR_GET("text_editor/behavior/indent/size"));
 	text_editor->set_auto_indent_enabled(EDITOR_GET("text_editor/behavior/indent/auto_indent"));
 	text_editor->set_indent_wrapped_lines(EDITOR_GET("text_editor/behavior/indent/indent_wrapped_lines"));
+	text_editor->set_tab_always_indents(EDITOR_GET("text_editor/behavior/indent/tab_action"));
 
 	// Completion
 	text_editor->set_auto_brace_completion_enabled(EDITOR_GET("text_editor/completion/auto_brace_complete"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -644,6 +644,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/indent/size", 4, "1,64,1") // size of 0 crashes.
 	_initial_set("text_editor/behavior/indent/auto_indent", true);
 	_initial_set("text_editor/behavior/indent/indent_wrapped_lines", true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/tab_action", 0, "Insert,Indent")
 
 	// Behavior: Files
 	_initial_set("text_editor/behavior/files/trim_trailing_whitespace_on_save", false);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -836,6 +836,14 @@ bool CodeEdit::is_auto_indent_enabled() const {
 	return auto_indent;
 }
 
+void CodeEdit::set_tab_always_indents(bool p_tab_always_indents) {
+	tab_always_indents = p_tab_always_indents;
+}
+
+bool CodeEdit::is_tab_always_indents() const {
+	return tab_always_indents;
+}
+
 void CodeEdit::set_auto_indent_prefixes(const TypedArray<String> &p_prefixes) {
 	auto_indent_prefixes.clear();
 	for (int i = 0; i < p_prefixes.size(); i++) {
@@ -857,7 +865,7 @@ void CodeEdit::do_indent() {
 		return;
 	}
 
-	if (has_selection()) {
+	if (has_selection() || tab_always_indents) {
 		indent_lines();
 		return;
 	}
@@ -2490,6 +2498,9 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_auto_indent_enabled", "enable"), &CodeEdit::set_auto_indent_enabled);
 	ClassDB::bind_method(D_METHOD("is_auto_indent_enabled"), &CodeEdit::is_auto_indent_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_tab_always_indents", "tab_always_indents"), &CodeEdit::set_tab_always_indents);
+	ClassDB::bind_method(D_METHOD("is_tab_always_indents"), &CodeEdit::is_tab_always_indents);
+
 	ClassDB::bind_method(D_METHOD("set_auto_indent_prefixes", "prefixes"), &CodeEdit::set_auto_indent_prefixes);
 	ClassDB::bind_method(D_METHOD("get_auto_indent_prefixes"), &CodeEdit::get_auto_indent_prefixes);
 
@@ -2703,6 +2714,7 @@ void CodeEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "indent_size"), "set_indent_size", "get_indent_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_use_spaces"), "set_indent_using_spaces", "is_indent_using_spaces");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_automatic"), "set_auto_indent_enabled", "is_auto_indent_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tab_always_indents"), "set_tab_always_indents", "is_tab_always_indents");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "indent_automatic_prefixes"), "set_auto_indent_prefixes", "get_auto_indent_prefixes");
 
 	ADD_GROUP("Auto Brace Completion", "auto_brace_completion_");

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -73,6 +73,8 @@ private:
 	int _calculate_spaces_till_next_left_indent(int p_column) const;
 	int _calculate_spaces_till_next_right_indent(int p_column) const;
 
+	bool tab_always_indents = false;
+
 	void _new_line(bool p_split_current_line = true, bool p_above = false);
 
 	/* Auto brace completion */
@@ -336,6 +338,9 @@ public:
 
 	void set_auto_indent_enabled(bool p_enabled);
 	bool is_auto_indent_enabled() const;
+
+	void set_tab_always_indents(bool p_tab_always_indents);
+	bool is_tab_always_indents() const;
 
 	void set_auto_indent_prefixes(const TypedArray<String> &p_prefixes);
 	TypedArray<String> get_auto_indent_prefixes() const;

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -1770,6 +1770,12 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_indent_using_spaces(true);
 		CHECK(code_edit->is_indent_using_spaces());
 
+		code_edit->set_tab_always_indents(false);
+		CHECK_FALSE(code_edit->is_tab_always_indents());
+
+		code_edit->set_tab_always_indents(true);
+		CHECK(code_edit->is_tab_always_indents());
+
 		/* Only the first char is registered. */
 		TypedArray<String> auto_indent_prefixes;
 		auto_indent_prefixes.push_back("::");
@@ -1787,6 +1793,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_indent_size(4);
 		code_edit->set_auto_indent_enabled(true);
 		code_edit->set_indent_using_spaces(false);
+		code_edit->set_tab_always_indents(false);
 
 		/* Do nothing if not editable. */
 		code_edit->set_editable(false);
@@ -1826,7 +1833,15 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->get_caret_column(2) == 3);
 		code_edit->remove_secondary_carets();
 
-		// Indent lines does entire line and works without selection.
+		/* Indents when tab_always_indents is set. */
+		code_edit->set_tab_always_indents(true);
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("test");
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "\ttest");
+		code_edit->set_tab_always_indents(false);
+
+		/* Indent lines does entire line and works without selection. */
 		code_edit->set_text("");
 		code_edit->insert_text_at_caret("test");
 		code_edit->indent_lines();
@@ -1938,6 +1953,7 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		code_edit->set_indent_size(4);
 		code_edit->set_auto_indent_enabled(true);
 		code_edit->set_indent_using_spaces(true);
+		code_edit->set_tab_always_indents(false);
 
 		/* Do nothing if not editable. */
 		code_edit->set_editable(false);
@@ -1977,7 +1993,15 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 		CHECK(code_edit->get_caret_column(2) == 4);
 		code_edit->remove_secondary_carets();
 
-		// Indent lines does entire line and works without selection.
+		/* Indents when tab_always_indents is set. */
+		code_edit->set_tab_always_indents(true);
+		code_edit->set_text("");
+		code_edit->insert_text_at_caret("test");
+		code_edit->do_indent();
+		CHECK(code_edit->get_line(0) == "    test");
+		code_edit->set_tab_always_indents(false);
+
+		/* Indent lines does entire line and works without selection. */
 		code_edit->set_text("");
 		code_edit->insert_text_at_caret("test");
 		code_edit->indent_lines();


### PR DESCRIPTION
See https://github.com/godotengine/godot-proposals/issues/7816

This add a setting to always make the tab key indent the current line in a code editor

![godot_editor_settings_tab_action_description2](https://github.com/godotengine/godot/assets/7968950/ee3c5ded-09c7-4711-b4fa-ca92b45b5e9f)


* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/7816*