### PR TITLE
Blender importer: allow Blender 4 executables

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -322,7 +322,7 @@ static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {
 		}
 		return false;
 	}
-	if (version > 3) {
+	if (version > 4) {
 		if (r_err) {
 			*r_err = TTR("This Blender installation is too new for this importer (not 3.x).");
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

[Blender 4 is currently scheduled to release in ~6 weeks](https://projects.blender.org/blender/blender/milestone/7), so it'd be nice to be able to already test the importer with the new version.