### PR TITLE
Allow editing editor settings from project manager

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1870,7 +1870,7 @@ void MaterialStorage::global_shader_parameter_remove(const StringName &p_name) {
 }
 
 Vector<StringName> MaterialStorage::global_shader_parameter_get_list() const {
-	if (!Engine::get_singleton()->is_editor_hint()) {
+	if (!Engine::get_singleton()->is_editor_hint() && !Engine::get_singleton()->is_project_manager_hint()) {
 		ERR_FAIL_V_MSG(Vector<StringName>(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8300,6 +8300,7 @@ EditorNode::EditorNode() {
 
 	editor_settings_dialog = memnew(EditorSettingsDialog);
 	gui_base->add_child(editor_settings_dialog);
+	editor_settings_dialog->connect("restart_requested", callable_mp(this, &EditorNode::_restart_editor).bind(false));
 
 	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
 	gui_base->add_child(project_settings_editor);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3782,6 +3782,10 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, EditorIn
 }
 
 bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName &p_property) {
+	if (!EditorFeatureProfileManager::get_singleton()) {
+		return false;
+	}
+
 	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
 	if (profile.is_null()) {
 		return false;
@@ -3872,7 +3876,7 @@ void EditorInspector::update_tree() {
 	// or if the whole object should be considered read-only.
 	bool draw_warning = false;
 	bool all_read_only = false;
-	if (is_inside_tree()) {
+	if (is_inside_tree() && EditorNode::get_singleton()) {
 		if (object->has_method("_is_read_only")) {
 			all_read_only = object->call("_is_read_only");
 		}
@@ -5153,7 +5157,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	if (bool(object->call("_dont_undo_redo"))) {
+	if (!undo_redo || bool(object->call("_dont_undo_redo"))) {
 		object->set(p_name, p_value);
 		if (p_refresh_all) {
 			_edit_request_change(object, "");
@@ -5664,8 +5668,9 @@ void EditorInspector::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			ERR_FAIL_NULL(EditorFeatureProfileManager::get_singleton());
-			EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
+			if (EditorFeatureProfileManager::get_singleton()) {
+				EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &EditorInspector::_feature_profile_changed));
+			}
 			set_process(is_visible_in_tree());
 			if (!is_sub_inspector()) {
 				get_tree()->connect("node_removed", callable_mp(this, &EditorInspector::_node_removed));

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2801,7 +2801,9 @@ void EditorPropertyColor::_picker_created() {
 }
 
 void EditorPropertyColor::_popup_opening() {
-	EditorNode::get_singleton()->setup_color_picker(picker->get_picker());
+	if (EditorNode::get_singleton()) {
+		EditorNode::get_singleton()->setup_color_picker(picker->get_picker());
+	}
 	last_color = picker->get_pick_color();
 	was_checked = !is_checkable() || is_checked();
 }

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -31,8 +31,11 @@
 #include "quick_settings_dialog.h"
 
 #include "core/string/translation_server.h"
+#include "editor/doc/editor_help.h"
 #include "editor/editor_string_names.h"
+#include "editor/inspector/editor_properties.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/settings/editor_settings_dialog.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -228,6 +231,25 @@ void QuickSettingsDialog::_set_setting_value(const String &p_setting, const Vari
 	}
 }
 
+void QuickSettingsDialog::_show_full_settings() {
+	if (!editor_settings_dialog) {
+		EditorHelp::generate_doc();
+
+		Ref<EditorInspectorDefaultPlugin> eidp;
+		eidp.instantiate();
+		EditorInspector::add_inspector_plugin(eidp);
+
+		EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
+		add_child(epnp);
+
+		editor_settings_dialog = memnew(EditorSettingsDialog);
+		get_parent()->add_child(editor_settings_dialog);
+		editor_settings_dialog->connect("restart_requested", callable_mp(this, &QuickSettingsDialog::_request_restart));
+	}
+	hide();
+	editor_settings_dialog->popup_edit_settings();
+}
+
 void QuickSettingsDialog::_request_restart() {
 	emit_signal("restart_required");
 }
@@ -376,6 +398,15 @@ QuickSettingsDialog::QuickSettingsDialog() {
 		}
 
 		_update_current_values();
+	}
+
+	// Full settings button.
+	{
+		Button *open_full_settings = memnew(Button);
+		open_full_settings->set_text(TTRC("Edit All Settings"));
+		open_full_settings->set_h_size_flags(Control::SIZE_SHRINK_END);
+		settings_list->add_child(open_full_settings);
+		open_full_settings->connect(SceneStringName(pressed), callable_mp(this, &QuickSettingsDialog::_show_full_settings));
 	}
 
 	// Restart required panel.

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -33,6 +33,7 @@
 #include "scene/gui/dialogs.h"
 
 class Button;
+class EditorSettingsDialog;
 class Label;
 class MarginContainer;
 class OptionButton;
@@ -71,6 +72,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	OptionButton *directory_naming_convention_button = nullptr;
 
 	Label *custom_theme_label = nullptr;
+	EditorSettingsDialog *editor_settings_dialog = nullptr;
 
 #ifndef ANDROID_ENABLED
 	void _language_selected(int p_id);
@@ -81,6 +83,7 @@ class QuickSettingsDialog : public AcceptDialog {
 	void _check_for_update_selected(int p_id);
 	void _directory_naming_convention_selected(int p_id);
 	void _set_setting_value(const String &p_setting, const Variant &p_value, bool p_restart_required = false);
+	void _show_full_settings();
 
 	Label *restart_required_label = nullptr;
 	Button *restart_required_button = nullptr;

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -89,6 +89,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	void _update_icons();
 
 	void _event_config_confirmed();
+	bool _is_in_project_manager() const;
 
 	TreeItem *_create_shortcut_treeitem(TreeItem *p_parent, const String &p_shortcut_identifier, const String &p_display, Array &p_events, bool p_allow_revert, bool p_is_common, bool p_is_collapsed);
 	Array _event_list_to_array_helper(const List<Ref<InputEvent>> &p_events);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1602

https://github.com/user-attachments/assets/c576f515-fb21-4296-8466-ef3267bd05d9

I had to add a couple random ifs to decouple EditorSettingsDialog and related controls from EditorNode. Also the dialog requires a few singletons. They are initialized when opening it for the first time, so there is a short freeze.