### PR TITLE
Linux/OpenGL: Don't force vsync in the editor

### DIFF
--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -290,12 +290,6 @@ void EGLManager::window_make_current(DisplayServer::WindowID p_window_id) {
 }
 
 void EGLManager::set_use_vsync(bool p_use) {
-	// Force vsync in the editor for now, as a safety measure.
-	bool is_editor = Engine::get_singleton()->is_editor_hint();
-	if (is_editor) {
-		p_use = true;
-	}
-
 	// We need an active window to get a display to set the vsync.
 	if (!current_window) {
 		return;

--- a/platform/linuxbsd/x11/gl_manager_x11.cpp
+++ b/platform/linuxbsd/x11/gl_manager_x11.cpp
@@ -347,12 +347,6 @@ Error GLManager_X11::initialize(Display *p_display) {
 }
 
 void GLManager_X11::set_use_vsync(bool p_use) {
-	// force vsync in the editor for now, as a safety measure
-	bool is_editor = Engine::get_singleton()->is_editor_hint();
-	if (is_editor) {
-		p_use = true;
-	}
-
 	// we need an active window to get a display to set the vsync
 	if (!_current_window) {
 		return;


### PR DESCRIPTION
I couldn't tell whether this has an actual purpose and it feels more like a debug remnant.

We also need to be able to disable vsync in the editor for the WIP Wayland backend (in the EGL driver) as it does manual frame throttling.

CC @lawnjelly which seems the original author of this code.

Note that I haven't tested the X11 part and I've tested the EGL change only with the Wayland branch, so some further testing would be a good idea.