### PR TITLE
Fix tooltips behaving incorrectly on `Tree` nodes

### DIFF
--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -368,6 +368,7 @@ private:
 		Control *tooltip_control = nullptr;
 		Window *tooltip_popup = nullptr;
 		Label *tooltip_label = nullptr;
+		String tooltip_text;
 		Point2 tooltip_pos;
 		Point2 last_mouse_pos;
 		Point2 drag_accum;


### PR DESCRIPTION
Tooltips within `Tree` nodes behave awkwardly on Godot 4. Normal ones don't disappear when switching to another item, and custom ones don't even update at all. This PR fixes both cases.