### PR TITLE
Remove the separator from ItemList's thumbnails mode

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1082,14 +1082,16 @@ void ItemList::_notification(int p_what) {
 				first_visible_separator = lo;
 			}
 
-			// Draw visible separators.
-			for (int i = first_visible_separator; i < separators.size(); i++) {
-				if (separators[i] > clip.position.y + clip.size.y) {
-					break; // done
-				}
+			// If not in thumbnails mode, draw visible separators.
+			if (icon_mode != ICON_MODE_TOP) {
+				for (int i = first_visible_separator; i < separators.size(); i++) {
+					if (separators[i] > clip.position.y + clip.size.y) {
+						break; // done
+					}
 
-				const int y = base_ofs.y + separators[i];
-				draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT), y), Vector2(width, y), theme_cache.guide_color);
+					const int y = base_ofs.y + separators[i];
+					draw_line(Vector2(theme_cache.panel_style->get_margin(SIDE_LEFT), y), Vector2(width, y), theme_cache.guide_color);
+				}
 			}
 
 			// Do a binary search to find the first item whose rect reaches below clip.position.y.


### PR DESCRIPTION
Fixes #81787.

This pull request removes separators which appear when ItemList's `icon_mode` is set to `ICON_MODE_TOP` (thumbnails mode).

See the mentioned issue to see how things were before; after fix:

![godot_separator](https://github.com/godotengine/godot/assets/37378746/c7430fe0-efa0-4a4c-919f-50c727e38799)
