### PR TITLE
Disable the blend file import setting support by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -915,7 +915,7 @@
 		</member>
 		<member name="editor/version_control/plugin_name" type="String" setter="" getter="" default="&quot;&quot;">
 		</member>
-		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="true">
+		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blender/blender3_path[/code]. Blender 3.0 or later is required.
 		</member>

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -137,7 +137,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 
 		// Project settings defined here so doctool finds them.
-		GLOBAL_DEF_RST_BASIC("filesystem/import/blender/enabled", true);
+		GLOBAL_DEF_RST_BASIC("filesystem/import/blender/enabled", false);
 		GLOBAL_DEF_RST_BASIC("filesystem/import/fbx/enabled", true);
 		GDREGISTER_CLASS(EditorSceneFormatImporterBlend);
 		GDREGISTER_CLASS(EditorSceneFormatImporterFBX);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Resolves https://github.com/godotengine/godot-proposals/issues/7827

_Edit by the production team: [Added the right keyword for GitHub to link it with the issue.](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)_