### PR TITLE
Fix missing dependency warning popup

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -230,7 +230,11 @@ public:
 	// Loaders can safely use this regardless which thread they are running on.
 	static void notify_dependency_error(const String &p_path, const String &p_dependency, const String &p_type) {
 		if (dep_err_notify) {
-			callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type).call_deferred();
+			if (Thread::get_caller_id() == Thread::get_main_id()) {
+				dep_err_notify(p_path, p_dependency, p_type);
+			} else {
+				callable_mp_static(dep_err_notify).bind(p_path, p_dependency, p_type).call_deferred();
+			}
 		}
 	}
 	static void set_dependency_error_notify_func(DependencyErrorNotify p_err_notify) {


### PR DESCRIPTION
Closes #82243

In older versions of Godot, a popup would appear when a scene was loaded which contained broken dependencies and would give the user an oppertunity to either cancel loading the scene or attempt to fix the dependencies. This seems may have been broken for a while due to changes the ResourceLoader. Since the ResourceLoader is now multithreaded, the callback for broken dependencies now uses a deferred call, but the load_scene function used by the EditorNode only ever requests that loading be done from the main thread. Immediately after the loading is performed, it would check for any dependency_errors list. However, since the callback is now deferred, the updates to the dependency_errors list would not be performed until the end of the frame, skipping the check entirely.

This PR attempts to fix this bug by making it so that if a broken dependency is detected, but the loading is being done on the main thread, it will do a direct callback rather than a deferred call. This fixes the bug and allows the warning popup to be seen again in the event of a broken scene.

![godot windows editor dev x86_64_UWiLWOV8SJ](https://github.com/godotengine/godot/assets/12756047/33e06fe2-d823-478d-8aa3-792215960191)
