### PR TITLE
[3.x] Deprecate NOTIFICATION_MOVED_IN_PARENT

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -828,7 +828,7 @@
 			This notification is emitted [i]after[/i] the related [signal tree_exiting].
 		</constant>
 		<constant name="NOTIFICATION_MOVED_IN_PARENT" value="12">
-			Notification received when the node is moved in the parent.
+			This notification is deprecated and is no longer emitted. Use [constant NOTIFICATION_CHILD_ORDER_CHANGED] instead.
 		</constant>
 		<constant name="NOTIFICATION_READY" value="13">
 			Notification received when the node is ready. See [method _ready].
@@ -866,6 +866,9 @@
 		</constant>
 		<constant name="NOTIFICATION_PATH_CHANGED" value="23">
 			Notification received when the node's [NodePath] changed.
+		</constant>
+		<constant name="NOTIFICATION_CHILD_ORDER_CHANGED" value="24">
+			Notification received when the list of children is changed. This happens when child nodes are added, moved or removed.
 		</constant>
 		<constant name="NOTIFICATION_INTERNAL_PROCESS" value="25">
 			Notification received every frame when the internal process flag is set (see [method set_process_internal]).

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -611,20 +611,6 @@ void CanvasItem::_notification(int p_what) {
 				notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 			}
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			if (!is_inside_tree()) {
-				break;
-			}
-
-			if (canvas_group != "") {
-				get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
-			} else {
-				CanvasItem *p = get_parent_item();
-				ERR_FAIL_COND(!p);
-				VisualServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
-			}
-
-		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
@@ -661,6 +647,20 @@ void CanvasItem::_name_changed_notify() {
 #endif
 }
 #endif
+
+void CanvasItem::update_draw_order() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	if (canvas_group != "") {
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
+	} else {
+		CanvasItem *p = get_parent_item();
+		ERR_FAIL_COND(!p);
+		VisualServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
+	}
+}
 
 void CanvasItem::update() {
 	if (!is_inside_tree()) {

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -295,6 +295,8 @@ public:
 	virtual Transform2D _edit_get_transform() const;
 #endif
 
+	void update_draw_order();
+
 	/* VISIBILITY */
 
 	void set_visible(bool p_visible);

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -30,9 +30,20 @@
 
 #include "skeleton_2d.h"
 
+void Bone2D::_order_changed_in_parent() {
+	if (skeleton) {
+		skeleton->_make_transform_dirty();
+	}
+}
+
 void Bone2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		Node *parent = get_parent();
+
+		if (parent) {
+			parent->connect("child_order_changed", this, "_order_changed_in_parent");
+		}
+
 		parent_bone = Object::cast_to<Bone2D>(parent);
 		skeleton = nullptr;
 		while (parent) {
@@ -59,13 +70,12 @@ void Bone2D::_notification(int p_what) {
 			skeleton->_make_transform_dirty();
 		}
 	}
-	if (p_what == NOTIFICATION_MOVED_IN_PARENT) {
-		if (skeleton) {
-			skeleton->_make_bone_setup_dirty();
-		}
-	}
-
 	if (p_what == NOTIFICATION_EXIT_TREE) {
+		Node *parent = get_parent();
+		if (parent) {
+			parent->disconnect("child_order_changed", this, "_order_changed_in_parent");
+		}
+
 		if (skeleton) {
 			for (int i = 0; i < skeleton->bones.size(); i++) {
 				if (skeleton->bones[i].bone == this) {

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -53,6 +53,7 @@ class Bone2D : public Node2D {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _order_changed_in_parent();
 
 public:
 	void set_rest(const Transform2D &p_rest);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -593,22 +593,6 @@ void Control::_notification(int p_notification) {
 			*/
 
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			// some parents need to know the order of the children to draw (like TabContainer)
-			// update if necessary
-			if (data.parent) {
-				data.parent->update();
-			}
-			update();
-
-			if (data.SI) {
-				get_viewport()->_gui_set_subwindow_order_dirty();
-			}
-			if (data.RI) {
-				get_viewport()->_gui_set_root_order_dirty();
-			}
-
-		} break;
 		case NOTIFICATION_RESIZED: {
 			emit_signal(SceneStringNames::get_singleton()->resized);
 		} break;
@@ -2663,6 +2647,15 @@ void Control::set_v_grow_direction(GrowDirection p_direction) {
 
 Control::GrowDirection Control::get_v_grow_direction() const {
 	return data.v_grow;
+}
+
+void Control::_query_order_update(bool &r_subwindow_order_dirty, bool &r_root_order_dirty) const {
+	if (data.SI) {
+		r_subwindow_order_dirty = true;
+	}
+	if (data.RI) {
+		r_root_order_dirty = true;
+	}
 }
 
 void Control::_bind_methods() {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -508,6 +508,8 @@ public:
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 	virtual String get_configuration_warning() const;
 
+	void _query_order_update(bool &r_subwindow_order_dirty, bool &r_root_order_dirty) const;
+
 	Control();
 	~Control();
 };

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -228,13 +228,14 @@ void CanvasLayer::_notification(int p_what) {
 			viewport = RID();
 			_update_follow_viewport(false);
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			// Note: As this step requires traversing the entire scene tree, it is thus expensive
-			// to move the canvas layer multiple times. Take special care when deleting / moving
-			// multiple nodes to prevent multiple NOTIFICATION_MOVED_IN_PARENT occurring.
-			_update_layer_orders();
-		} break;
 	}
+}
+
+void CanvasLayer::update_draw_order() {
+	// Note: As this step requires traversing the entire scene tree, it is thus expensive
+	// to move the canvas layer multiple times. Take special care when deleting / moving
+	// multiple nodes to prevent this happening multiple times.
+	_update_layer_orders();
 }
 
 Size2 CanvasLayer::get_viewport_size() const {

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -70,6 +70,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void update_draw_order();
+
 	void set_layer(int p_xform);
 	int get_layer() const;
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -134,6 +134,11 @@ private:
 
 		int process_priority;
 
+		// If canvas item children of a node change child order,
+		// we store this information in the scenetree in a temporary structure
+		// allocated on demand per node.
+		uint32_t canvas_parent_id = UINT32_MAX;
+
 		// Keep bitpacked values together to get better packing
 		PauseMode pause_mode : 2;
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
@@ -279,7 +284,7 @@ public:
 		NOTIFICATION_DRAG_BEGIN = 21,
 		NOTIFICATION_DRAG_END = 22,
 		NOTIFICATION_PATH_CHANGED = 23,
-		//NOTIFICATION_TRANSLATION_CHANGED = 24, moved below
+		NOTIFICATION_CHILD_ORDER_CHANGED = 24,
 		NOTIFICATION_INTERNAL_PROCESS = 25,
 		NOTIFICATION_INTERNAL_PHYSICS_PROCESS = 26,
 		NOTIFICATION_POST_ENTER_TREE = 27,
@@ -454,6 +459,9 @@ public:
 	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
 	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();
+
+	uint32_t get_canvas_parent_id() const { return data.canvas_parent_id; }
+	void set_canvas_parent_id(uint32_t p_id) { data.canvas_parent_id = p_id; }
 
 	void request_ready();
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -280,9 +280,19 @@ private:
 	static int idle_callback_count;
 	void _call_idle_callbacks();
 
+	struct CanvasParent {
+		ObjectID id;
+		uint32_t first_child_moved = UINT32_MAX;
+		uint32_t last_child_moved_plus_one = 0;
+	};
+
+	LocalVector<CanvasParent> _canvas_parents_dirty_order;
+
 protected:
 	void _notification(int p_notification);
 	static void _bind_methods();
+
+	void flush_canvas_parents_dirty_order();
 
 public:
 	enum {
@@ -436,6 +446,9 @@ public:
 
 	void client_physics_interpolation_add_spatial(SelfList<Spatial> *p_elem);
 	void client_physics_interpolation_remove_spatial(SelfList<Spatial> *p_elem);
+
+	void notify_canvas_parent_children_moved(Node &p_parent, uint32_t p_first_child, uint32_t p_last_child_plus_one);
+	void notify_canvas_parent_child_count_reduced(Node &p_parent);
 
 	static void add_idle_callback(IdleCallback p_callback);
 	SceneTree();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -354,6 +354,7 @@ private:
 	Ref<InputEvent> _make_input_local(const Ref<InputEvent> &ev);
 
 	friend class Control;
+	friend class SceneTree;
 
 	List<Control *>::Element *_gui_add_root_control(Control *p_control);
 	List<Control *>::Element *_gui_add_subwindow_control(Control *p_control);


### PR DESCRIPTION
* NOTIFICATION_MOVED_IN_PARENT makes node children management very inefficient.
* Replaced by a NOTIFICATION_CHILD_ORDER_CHANGED (and children_changed signal).
* Most of the previous tasks carried out by NOTIFICATION_MOVED_IN_PARENT are now done not more than a single time per frame by SceneTree.

This PR breaks compatibility (although this notification was very rarely used, even within the engine), but provides an alternate way to do the same.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
