### PR TITLE
[3.x] Deprecate `NOTIFICATION_MOVED_IN_PARENT`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -797,6 +797,11 @@
 				When this signal is received, the child [code]node[/code] is still in the tree and valid. This signal is emitted [i]after[/i] the child node's own [signal tree_exiting] and [constant NOTIFICATION_EXIT_TREE].
 			</description>
 		</signal>
+		<signal name="child_order_changed">
+			<description>
+				Emitted when the list of children is changed. This happens when child nodes are added, moved, or removed.
+			</description>
+		</signal>
 		<signal name="ready">
 			<description>
 				Emitted when the node is ready.
@@ -835,7 +840,7 @@
 			This notification is emitted [i]after[/i] the related [signal tree_exiting].
 		</constant>
 		<constant name="NOTIFICATION_MOVED_IN_PARENT" value="12">
-			Notification received when the node is moved in the parent.
+			[i]Deprecated.[/i] This notification is no longer emitted. Use [constant NOTIFICATION_CHILD_ORDER_CHANGED] instead.
 		</constant>
 		<constant name="NOTIFICATION_READY" value="13">
 			Notification received when the node is ready. See [method _ready].
@@ -873,6 +878,9 @@
 		</constant>
 		<constant name="NOTIFICATION_PATH_CHANGED" value="23">
 			Notification received when the node's [NodePath] changed.
+		</constant>
+		<constant name="NOTIFICATION_CHILD_ORDER_CHANGED" value="24">
+			Notification received when the list of children is changed. This happens when child nodes are added, moved, or removed.
 		</constant>
 		<constant name="NOTIFICATION_INTERNAL_PROCESS" value="25">
 			Notification received every frame when the internal process flag is set (see [method set_process_internal]).

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2399,6 +2399,12 @@ bool Main::iteration() {
 		exit = true;
 	}
 	visual_server_callbacks->flush();
+
+	// Ensure that VisualServer is kept up to date at least once with any ordering changes
+	// of canvas items before a render.
+	// This ensures this will be done at least once in apps that create their own MainLoop.
+	Viewport::flush_canvas_parents_dirty_order();
+
 	message_queue->flush();
 
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -611,20 +611,6 @@ void CanvasItem::_notification(int p_what) {
 				notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 			}
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			if (!is_inside_tree()) {
-				break;
-			}
-
-			if (canvas_group != "") {
-				get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
-			} else {
-				CanvasItem *p = get_parent_item();
-				ERR_FAIL_COND(!p);
-				VisualServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
-			}
-
-		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
@@ -661,6 +647,20 @@ void CanvasItem::_name_changed_notify() {
 #endif
 }
 #endif
+
+void CanvasItem::update_draw_order() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	if (canvas_group != "") {
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, canvas_group, "_toplevel_raise_self");
+	} else {
+		CanvasItem *p = get_parent_item();
+		ERR_FAIL_NULL(p);
+		VisualServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
+	}
+}
 
 void CanvasItem::update() {
 	if (!is_inside_tree()) {

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -296,6 +296,8 @@ public:
 	virtual Transform2D _edit_get_transform() const;
 #endif
 
+	void update_draw_order();
+
 	/* VISIBILITY */
 
 	void set_visible(bool p_visible);

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -30,9 +30,20 @@
 
 #include "skeleton_2d.h"
 
+void Bone2D::_order_changed_in_parent() {
+	if (skeleton) {
+		skeleton->_make_bone_setup_dirty();
+	}
+}
+
 void Bone2D::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		Node *parent = get_parent();
+
+		if (parent) {
+			parent->connect("child_order_changed", this, "_order_changed_in_parent");
+		}
+
 		parent_bone = Object::cast_to<Bone2D>(parent);
 		skeleton = nullptr;
 		while (parent) {
@@ -59,13 +70,13 @@ void Bone2D::_notification(int p_what) {
 			skeleton->_make_transform_dirty();
 		}
 	}
-	if (p_what == NOTIFICATION_MOVED_IN_PARENT) {
-		if (skeleton) {
-			skeleton->_make_bone_setup_dirty();
-		}
-	}
 
 	if (p_what == NOTIFICATION_EXIT_TREE) {
+		Node *parent = get_parent();
+		if (parent) {
+			parent->disconnect("child_order_changed", this, "_order_changed_in_parent");
+		}
+
 		if (skeleton) {
 			for (int i = 0; i < skeleton->bones.size(); i++) {
 				if (skeleton->bones[i].bone == this) {
@@ -88,6 +99,8 @@ void Bone2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_default_length", "default_length"), &Bone2D::set_default_length);
 	ClassDB::bind_method(D_METHOD("get_default_length"), &Bone2D::get_default_length);
+
+	ClassDB::bind_method(D_METHOD("_order_changed_in_parent"), &Bone2D::_order_changed_in_parent);
 
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "rest"), "set_rest", "get_rest");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "default_length", PROPERTY_HINT_RANGE, "1,1024,1"), "set_default_length", "get_default_length");

--- a/scene/2d/skeleton_2d.h
+++ b/scene/2d/skeleton_2d.h
@@ -53,6 +53,7 @@ class Bone2D : public Node2D {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	void _order_changed_in_parent();
 
 public:
 	void set_rest(const Transform2D &p_rest);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -593,22 +593,6 @@ void Control::_notification(int p_notification) {
 			*/
 
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			// some parents need to know the order of the children to draw (like TabContainer)
-			// update if necessary
-			if (data.parent) {
-				data.parent->update();
-			}
-			update();
-
-			if (data.SI) {
-				get_viewport()->_gui_set_subwindow_order_dirty();
-			}
-			if (data.RI) {
-				get_viewport()->_gui_set_root_order_dirty();
-			}
-
-		} break;
 		case NOTIFICATION_RESIZED: {
 			emit_signal(SceneStringNames::get_singleton()->resized);
 		} break;
@@ -2663,6 +2647,15 @@ void Control::set_v_grow_direction(GrowDirection p_direction) {
 
 Control::GrowDirection Control::get_v_grow_direction() const {
 	return data.v_grow;
+}
+
+void Control::_query_order_update(bool &r_subwindow_order_dirty, bool &r_root_order_dirty) const {
+	if (data.SI) {
+		r_subwindow_order_dirty = true;
+	}
+	if (data.RI) {
+		r_root_order_dirty = true;
+	}
 }
 
 void Control::_bind_methods() {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -508,6 +508,8 @@ public:
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const;
 	virtual String get_configuration_warning() const;
 
+	void _query_order_update(bool &r_subwindow_order_dirty, bool &r_root_order_dirty) const;
+
 	Control();
 	~Control();
 };

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -228,13 +228,14 @@ void CanvasLayer::_notification(int p_what) {
 			viewport = RID();
 			_update_follow_viewport(false);
 		} break;
-		case NOTIFICATION_MOVED_IN_PARENT: {
-			// Note: As this step requires traversing the entire scene tree, it is thus expensive
-			// to move the canvas layer multiple times. Take special care when deleting / moving
-			// multiple nodes to prevent multiple NOTIFICATION_MOVED_IN_PARENT occurring.
-			_update_layer_orders();
-		} break;
 	}
+}
+
+void CanvasLayer::update_draw_order() {
+	// Note: As this step requires traversing the entire scene tree, it is thus expensive
+	// to move the canvas layer multiple times. Take special care when deleting / moving
+	// multiple nodes to prevent this happening multiple times.
+	_update_layer_orders();
 }
 
 Size2 CanvasLayer::get_viewport_size() const {

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -70,6 +70,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	void update_draw_order();
+
 	void set_layer(int p_xform);
 	int get_layer() const;
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -426,9 +426,8 @@ void Node::move_child(Node *p_child, int p_pos) {
 	}
 	// notification second
 	move_child_notify(p_child);
-	for (int i = motion_from; i <= motion_to; i++) {
-		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
-	}
+	Viewport::notify_canvas_parent_children_moved(*this, motion_from, motion_to + 1);
+
 	p_child->_propagate_groups_dirty();
 
 	data.blocked--;
@@ -1364,8 +1363,10 @@ void Node::remove_child(Node *p_child) {
 
 	for (int i = idx; i < child_count; i++) {
 		children[i]->data.pos = i;
-		children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
 	}
+
+	Viewport::notify_canvas_parent_children_moved(*this, idx, child_count);
+	Viewport::notify_canvas_parent_child_count_reduced(*this);
 
 	p_child->data.parent = nullptr;
 	p_child->data.pos = -1;
@@ -3193,6 +3194,7 @@ void Node::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_DRAG_BEGIN);
 	BIND_CONSTANT(NOTIFICATION_DRAG_END);
 	BIND_CONSTANT(NOTIFICATION_PATH_CHANGED);
+	BIND_CONSTANT(NOTIFICATION_CHILD_ORDER_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_INTERNAL_PROCESS);
 	BIND_CONSTANT(NOTIFICATION_INTERNAL_PHYSICS_PROCESS);
 	BIND_CONSTANT(NOTIFICATION_POST_ENTER_TREE);
@@ -3233,6 +3235,7 @@ void Node::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_exited"));
 	ADD_SIGNAL(MethodInfo("child_entered_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
 	ADD_SIGNAL(MethodInfo("child_exiting_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
+	ADD_SIGNAL(MethodInfo("child_order_changed"));
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "pause_mode", PROPERTY_HINT_ENUM, "Inherit,Stop,Process"), "set_pause_mode", "get_pause_mode");
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -134,6 +134,11 @@ private:
 
 		int process_priority;
 
+		// If canvas item children of a node change child order,
+		// we store this information in the scenetree in a temporary structure
+		// allocated on demand per node.
+		uint32_t canvas_parent_id = UINT32_MAX;
+
 		// Keep bitpacked values together to get better packing
 		PauseMode pause_mode : 2;
 		PhysicsInterpolationMode physics_interpolation_mode : 2;
@@ -279,7 +284,7 @@ public:
 		NOTIFICATION_DRAG_BEGIN = 21,
 		NOTIFICATION_DRAG_END = 22,
 		NOTIFICATION_PATH_CHANGED = 23,
-		//NOTIFICATION_TRANSLATION_CHANGED = 24, moved below
+		NOTIFICATION_CHILD_ORDER_CHANGED = 24,
 		NOTIFICATION_INTERNAL_PROCESS = 25,
 		NOTIFICATION_INTERNAL_PHYSICS_PROCESS = 26,
 		NOTIFICATION_POST_ENTER_TREE = 27,
@@ -454,6 +459,9 @@ public:
 	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
 	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();
+
+	uint32_t get_canvas_parent_id() const { return data.canvas_parent_id; }
+	void set_canvas_parent_id(uint32_t p_id) { data.canvas_parent_id = p_id; }
 
 	bool is_node_ready() const;
 	void request_ready();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -326,6 +326,14 @@ private:
 		bool dragging;
 		bool drag_successful;
 
+		struct CanvasParent {
+			ObjectID id;
+			uint32_t first_child_moved = UINT32_MAX;
+			uint32_t last_child_moved_plus_one = 0;
+		};
+
+		static LocalVector<CanvasParent> canvas_parents_dirty_order;
+
 		GUI();
 	} gui;
 
@@ -587,6 +595,10 @@ public:
 
 	bool gui_is_dragging() const;
 	bool gui_is_drag_successful() const;
+
+	static void notify_canvas_parent_children_moved(Node &r_parent, uint32_t p_first_child, uint32_t p_last_child_plus_one);
+	static void notify_canvas_parent_child_count_reduced(const Node &p_parent);
+	static void flush_canvas_parents_dirty_order();
 
 	Viewport();
 	~Viewport();


### PR DESCRIPTION
* NOTIFICATION_MOVED_IN_PARENT makes node children management very inefficient.
* Replaced by a NOTIFICATION_CHILD_ORDER_CHANGED (and children_changed signal).
* Most of the previous tasks carried out by NOTIFICATION_MOVED_IN_PARENT are now done not more than a single time per frame.

This PR strictly speaking breaks compatibility, however this notification was very rarely used, even within the engine, and provides an alternate way to do the same. The need to fix this design issue was deemed more important than the likelihood of any breaking in master, and the same applies in 3.x.

Alternative to #74672
Backport of #75701

## Example Project
Run before and after PR:
[ChildOrderChangedBenchmark.zip](https://github.com/godotengine/godot/files/12762158/ChildOrderChangedBenchmark.zip)
_before_ 9069 milliseconds, _after_ 894 milliseconds (approx 10x faster)

The example project stress tests moving sprite children, which causes large numbers of `NOTIFICATION_MOVED_IN_PARENT`. After the PR, these are reduced to once per frame, and the notification is replaced with a cheaper direct function call.

## Explanation
The exponential notification problem remains one of the biggest inefficiencies / achilles heel in the engine in 3.x, so it makes sense to solve it properly, even if there may require some beta testing to iron out any regressions.

This is not a straight backport of #75701 (as 3.x works in a slightly different way) but is inspired to work in a similar(ish) way. There are some significant differences:

* The storage of the dirty parent nodes in `Viewport::GUI` becomes a static rather than _per viewport_. This single list allows storing an ID within the list on the `canvas_item`, which gives O(1) behaviour rather than relying on a `HashSet` and slower lookup as in the 4.x version. It also allows easy flushing once per frame, rather than also flushing on each tick (which is unnecessary and potentially greatly increases the cost).
* As with #74672, the dirty nodes store a minimum and maximum child to update. This makes the processing significantly more efficient when only a small subset of the children are moved. This optimization is not so readily available in master, due to the new way the children are stored.

## Notes
* Like the version in master, this is (strictly speaking) compatibility breaking, because it avoids sending the `NOTIFICATION_MOVED_IN_PARENT` completely. This notification is no longer required in core, but there is the possibility that third parties may rely on it, and need to switch to the new `NOTIFICATION_CHILD_ORDER_CHANGED`. This is however unlikely to be widely used.
* We could still send the old notification if breaking compatibility was a major concern, however this would lose a lot of efficiency. This could for instance be switched on by means of a project setting. However this may be best to avoid unless there are regressions requiring it.  
* Inspired by #75701 this uses simple casting during iteration to determine whether a child needs an update, rather than marking nodes with a flag (the approach used in #74672).
* This potentially makes the `CanvasLayer` updates more efficient because it ensures only a single canvas layer order update per frame.

## Follow up
After we decide whether an approach such as this or the alternative PR is desired, there is another significant optimization which can be made in a followup PR, and possibly also applied in master. Much of the remaining inefficiency is in multiple calls to `VisualServer::canvas_item_set_draw_index()`, where in some cases hundreds or thousands of calls may take place. It seems to make sense to replace this by a single call to an extended version of the function which can change the draw indices of all the items in a single batch.

## Discussion
Personally overall I would be tempted to go with this approach over #74672 . This is now closer to master, and is more efficient because it calls `update_draw_order()` directly instead of going through the heavyweight notifications.
Although it technically breaks compatibility, this is likely to be a rare case, which can either be worked around with the new notification, or we can add an optional legacy mode to call the old notification.
Additionally it should be significantly faster than the version in master because it only updates the range of children changed, rather than _all_ the children every time.

## Update
Due to concerns over applications using custom `MainLoop`, I moved the storage of the dirty list from the `SceneTree` to statics within `Viewport`. This also makes more sense architecturally as the 2D is more localized with other GUI data, and `SceneTree` is not associated with any particular node type.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
