### PR TITLE
Fix GLTF importer forcing vertex colors on all materials

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3877,7 +3877,6 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 		} else {
 			material->set_name(vformat("material_%s", itos(i)));
 		}
-		material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 		Dictionary material_extensions;
 		if (material_dict.has("extensions")) {
 			material_extensions = material_dict["extensions"];


### PR DESCRIPTION
The importer already checks if a mesh has vertex colors and enables vertex colors on the material using it.

Before this fix, GLTF importer would force shader generation to use vertex colors even if the scene did not have vertex colors at all, or did not need them for some of its meshes; causing inefficient shader and PSO generation.
