### PR TITLE
POC: open Pinned Debugger Tab on project run

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -237,7 +237,9 @@ Error EditorDebuggerNode::start(const String &p_uri) {
 	}
 	stop(true);
 	current_uri = p_uri;
-	if (EDITOR_GET("run/output/always_open_output_on_play")) {
+
+	int debugger_tab_pin_idx = EditorDebuggerNode::get_singleton()->get_current_debugger()->get_debugger_tab_pin_idx();
+	if (EDITOR_GET("run/output/always_open_output_on_play") && debugger_tab_pin_idx == -1) {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
 	} else {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -151,6 +151,18 @@ void ScriptEditorDebugger::update_tabs() {
 			tabs->set_tab_icon(tabs->get_tab_idx_from_control(errors_tab), get_editor_theme_icon(SNAME("Warning")));
 		}
 	}
+	if (tab_pin_button_idx != tabs->get_tab_count() - 1) {
+		// Ensure pin button is last in debugger tabs.
+		Control *pin_button = tabs->get_tab_control(tab_pin_button_idx);
+		tabs->remove_child(pin_button);
+		tabs->add_child(pin_button);
+		tab_pin_button_idx = tabs->get_tab_count() - 1;
+		if (tab_pin_idx == -1 || tabs->get_current_tab() != tab_pin_idx) {
+			_tab_pin_button_enable_pin();
+		} else {
+			_tab_pin_button_enable_unpin();
+		}
+	}
 }
 
 void ScriptEditorDebugger::clear_style() {
@@ -1006,7 +1018,11 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	set_process(true);
 	camera_override = CameraOverride::OVERRIDE_NONE;
 
-	tabs->set_current_tab(0);
+	if (tab_pin_idx >= 0) {
+		tabs->set_current_tab(tab_pin_idx);
+	} else {
+		tabs->set_current_tab(0);
+	}
 	_set_reason_text(TTR("Debug session started."), MESSAGE_SUCCESS);
 	_update_buttons_state();
 	emit_signal(SNAME("started"));
@@ -1723,6 +1739,66 @@ void ScriptEditorDebugger::_tab_changed(int p_tab) {
 		// "Video RAM" tab was clicked, refresh the data it's displaying when entering the tab.
 		_video_mem_request();
 	}
+	if (p_tab == tab_pin_button_idx) {
+		// This tab acts as a button, so always send user back to previous tab.
+		tabs->set_current_tab(tabs->get_previous_tab());
+		_tab_button_pressed(tab_pin_button_idx);
+		return;
+	}
+	// Update context of tab pin button.
+	if (p_tab == tab_pin_idx) {
+		_tab_pin_button_enable_unpin();
+	} else {
+		_tab_pin_button_enable_pin();
+	}
+
+}
+
+void ScriptEditorDebugger::_tab_button_pressed(int p_tab) {
+	{ //pinned tabs
+		if (p_tab == tab_pin_button_idx) {
+			if (tabs->get_tab_icon(tab_pin_button_idx) == get_editor_theme_icon(SNAME("PinJoint3D"))) {
+				// Unpin a tab.
+				tabs->set_tab_button_icon(tab_pin_idx, nullptr);
+				tab_pin_idx = -1;
+				_tab_pin_button_enable_pin();
+			} else if (tab_pin_idx == -1) {
+				// Pin a tab.
+				tab_pin_idx = tabs->get_current_tab();
+				tabs->set_tab_button_icon(tab_pin_idx, get_editor_theme_icon(SNAME("PinJoint2D")));
+				_tab_pin_button_enable_unpin();
+			} else {
+				// Shift pin from an already pinned tab.
+				tabs->set_tab_button_icon(tab_pin_idx, nullptr);
+				tab_pin_idx = tabs->get_current_tab();
+				tabs->set_tab_button_icon(tab_pin_idx, get_editor_theme_icon(SNAME("PinJoint2D")));
+				_tab_pin_button_enable_unpin();
+			}
+			return;
+		}
+		if (tabs->get_tab_button_icon(p_tab) == nullptr) {
+			// For some reason tabs without a texture can still emit tab_button_pressed, so ignore.
+			return;
+		}
+		// Unpin a tab with its button.
+		tabs->set_tab_button_icon(p_tab, nullptr);
+		tab_pin_idx = -1;
+		_tab_pin_button_enable_pin();
+	}
+}
+
+void ScriptEditorDebugger::_tab_pin_button_enable_pin() {
+	if (tab_pin_idx == -1) {
+		tabs->set_tab_title(tab_pin_button_idx, TTR("Pin Tab"));
+	} else {
+		tabs->set_tab_title(tab_pin_button_idx, TTR("Shift Pin"));
+	}
+	tabs->set_tab_icon(tab_pin_button_idx, get_editor_theme_icon(SNAME("PinJoint2D")));
+}
+
+void ScriptEditorDebugger::_tab_pin_button_enable_unpin() {
+	tabs->set_tab_title(tab_pin_button_idx, TTR("Unpin"));
+	tabs->set_tab_icon(tab_pin_button_idx, get_editor_theme_icon(SNAME("PinJoint3D")));
 }
 
 void ScriptEditorDebugger::_bind_methods() {
@@ -1773,6 +1849,10 @@ int ScriptEditorDebugger::get_current_debugger_tab() const {
 	return tabs->get_current_tab();
 }
 
+int ScriptEditorDebugger::get_debugger_tab_pin_idx() const {
+	return tab_pin_idx;
+}
+
 void ScriptEditorDebugger::switch_to_debugger(int p_debugger_tab_idx) {
 	tabs->set_current_tab(p_debugger_tab_idx);
 }
@@ -1792,6 +1872,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 	tabs = memnew(TabContainer);
 	add_child(tabs);
 	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
+	tabs->connect("tab_button_pressed", callable_mp(this, &ScriptEditorDebugger::_tab_button_pressed));
 
 	InspectorDock::get_inspector_singleton()->connect("object_id_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
 
@@ -2110,6 +2191,12 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 
 		misc->add_child(buttons);
 	}
+
+	Button *pin_button = memnew(Button);
+	tabs->add_child(pin_button);
+	tab_pin_idx = -1;
+	tab_pin_button_idx = tabs->get_tab_count() - 1;
+	_tab_pin_button_enable_pin();
 
 	msgdialog = memnew(AcceptDialog);
 	add_child(msgdialog);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -117,6 +117,8 @@ private:
 	Ref<Script> stack_script;
 
 	TabContainer *tabs = nullptr;
+	int tab_pin_idx;
+	int tab_pin_button_idx;
 
 	Label *reason = nullptr;
 
@@ -221,6 +223,9 @@ private:
 	void _error_tree_item_rmb_selected(const Vector2 &p_pos, MouseButton p_button);
 	void _item_menu_id_pressed(int p_option);
 	void _tab_changed(int p_tab);
+	void _tab_button_pressed(int p_tab);
+	void _tab_pin_button_enable_pin();
+	void _tab_pin_button_enable_unpin();
 
 	void _put_msg(String p_message, Array p_data, uint64_t p_thread_id = Thread::MAIN_ID);
 	void _export_csv();
@@ -309,6 +314,7 @@ public:
 	void add_debugger_tab(Control *p_control);
 	void remove_debugger_tab(Control *p_control);
 	int get_current_debugger_tab() const;
+	int get_debugger_tab_pin_idx() const;
 	void switch_to_debugger(int p_debugger_tab_idx);
 
 	void send_message(const String &p_message, const Array &p_args);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4147,7 +4147,10 @@ void EditorNode::_project_run_started() {
 		log->clear();
 	}
 
-	if (bool(EDITOR_GET("run/output/always_open_output_on_play"))) {
+	int debugger_tab_pin_idx = EditorDebuggerNode::get_singleton()->get_current_debugger()->get_debugger_tab_pin_idx();
+	if (debugger_tab_pin_idx >= 0) {
+		make_bottom_panel_item_visible(EditorDebuggerNode::get_singleton()->get_current_debugger());
+	} else if (bool(EDITOR_GET("run/output/always_open_output_on_play"))) {
 		make_bottom_panel_item_visible(log);
 	}
 }

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -67,6 +67,7 @@ void EditorDebuggerSession::add_session_tab(Control *p_tab) {
 	ERR_FAIL_COND(!p_tab || !debugger);
 	debugger->add_debugger_tab(p_tab);
 	tabs.insert(p_tab);
+	debugger->update_tabs();
 }
 
 void EditorDebuggerSession::remove_session_tab(Control *p_tab) {


### PR DESCRIPTION
Implements proof of concept shown off in:
https://github.com/godotengine/godot-proposals/issues/7848

I'll make note that for some reason the logic for auto opening Output on project run, due to editor setting `run/output/always_open_output_on_play`, is done twice, once in editor_node.cpp @`EditorNode::_project_run_started()`, and again in script_editor_debugger.cpp  @`ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer)`. Unsure if that's nescessary for some reason or if it's an oversight.

Added Pin Tab button gui to tab bar of Debugger bottom panel. Includes two private variables to track the pinned tab index(and a public method to get that variable), and the pin button index. Added several private methods to update the logic. The button forces a tab open upon project start and overrides related editor settings. The button is updated to always be the last tab on the Debugger's tab bar.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
