### PR TITLE
Fix Texture icon update mechanism

### DIFF
--- a/doc/classes/EditorResourcePreview.xml
+++ b/doc/classes/EditorResourcePreview.xml
@@ -55,6 +55,12 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="preview_changed">
+			<param index="0" name="path" type="String" />
+			<description>
+				Emitted if a resource preview has changed. [param path] corresponds to the path of the preview.
+			</description>
+		</signal>
 		<signal name="preview_invalidated">
 			<param index="0" name="path" type="String" />
 			<description>

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -47,6 +47,19 @@
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
 
+void EditorResourcePicker::_preview_changed(const String &p_path) {
+	String resource_path;
+	if (edited_resource.is_valid() && edited_resource->get_path().is_resource_file()) {
+		resource_path = edited_resource->get_path();
+	}
+
+	if (resource_path != p_path) {
+		return;
+	}
+
+	EditorResourcePreview::get_singleton()->queue_edited_resource_preview_changed(edited_resource, this, "_update_resource_preview", edited_resource->get_instance_id());
+}
+
 void EditorResourcePicker::_update_resource() {
 	String resource_path;
 	if (edited_resource.is_valid() && edited_resource->get_path().is_resource_file()) {
@@ -804,6 +817,7 @@ void EditorResourcePicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_resource();
+			EditorResourcePreview::get_singleton()->connect("preview_changed", callable_mp(this, &EditorResourcePicker::_preview_changed));
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -109,6 +109,7 @@ class EditorResourcePicker : public HBoxContainer {
 	void _duplicate_selected_resources();
 
 protected:
+	virtual void _preview_changed(const String &p_path);
 	virtual void _update_resource();
 
 	Button *get_assign_button() { return assign_button; }

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -96,7 +96,7 @@ class EditorResourcePreview : public Node {
 
 	HashMap<String, Item> cache;
 
-	void _preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, ObjectID id, const StringName &p_func, const Variant &p_ud, const Dictionary &p_metadata);
+	void _preview_ready(const String &p_path, const Ref<Resource> &p_resource, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, ObjectID id, const StringName &p_func, const Variant &p_ud, const Dictionary &p_metadata);
 	void _generate_preview(Ref<ImageTexture> &r_texture, Ref<ImageTexture> &r_small_texture, const QueueItem &p_item, const String &cache_base, Dictionary &p_metadata);
 
 	int small_thumbnail_size = -1;
@@ -122,6 +122,7 @@ public:
 	// p_preview will be null if there was an error
 	void queue_resource_preview(const String &p_path, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
 	void queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
+	void queue_edited_resource_preview_changed(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
 	const Dictionary get_preview_metadata(const String &p_path) const;
 
 	void add_preview_generator(const Ref<EditorResourcePreviewGenerator> &p_generator);


### PR DESCRIPTION
close #82229 

The reason why this icon is not updated, I found out, is that when the file changes, all the cache will be updated normally, but the texture icon is special, it is an instance object, and is not associated with the source file.

So I try to update it after a file change if the currently selected object is also associated. Then, for instance, the object's Item.modified_time, is used to store the modified_time of the source file, which is used to handle the judgment basis for updating the cache when other files are selected.