### PR TITLE
Make the search bars in the "Project Settings" dialog grab focus when they appear

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -532,7 +532,7 @@ ActionMapEditor::ActionMapEditor() {
 
 	action_list_search = memnew(LineEdit);
 	action_list_search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	action_list_search->set_placeholder(TTR("Filter by name..."));
+	action_list_search->set_placeholder(TTR("Filter by Name"));
 	action_list_search->set_clear_button_enabled(true);
 	action_list_search->connect("text_changed", callable_mp(this, &ActionMapEditor::_search_term_updated));
 	top_hbox->add_child(action_list_search);

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -891,7 +891,7 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	export_profile->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 
 	force_detect_classes = memnew(LineEdit);
-	main_vbc->add_margin_child(TTR("Forced classes on detect:"), force_detect_classes);
+	main_vbc->add_margin_child(TTR("Forced Classes on Detect:"), force_detect_classes);
 	force_detect_classes->connect("text_changed", callable_mp(this, &EditorBuildProfileManager::_force_detect_classes_changed));
 
 	set_title(TTR("Edit Build Configuration Profile"));

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -92,9 +92,6 @@ void EditorSettingsDialog::popup_edit_settings() {
 	inspector->edit(EditorSettings::get_singleton());
 	inspector->get_inspector()->update_tree();
 
-	search_box->select_all();
-	search_box->grab_focus();
-
 	_update_shortcuts();
 	set_process_shortcut_input(true);
 
@@ -762,7 +759,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	tab_shortcuts->add_child(top_hbox);
 
 	shortcut_search_box = memnew(LineEdit);
-	shortcut_search_box->set_placeholder(TTR("Filter by name..."));
+	shortcut_search_box->set_placeholder(TTR("Filter by Name"));
 	shortcut_search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	top_hbox->add_child(shortcut_search_box);
 	shortcut_search_box->connect("text_changed", callable_mp(this, &EditorSettingsDialog::_filter_shortcuts));

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -175,12 +175,12 @@ void EventListenerLineEdit::_on_text_changed(const String &p_text) {
 }
 
 void EventListenerLineEdit::_on_focus() {
-	set_placeholder(TTR("Listening for input..."));
+	set_placeholder(TTR("Listening for Input"));
 }
 
 void EventListenerLineEdit::_on_unfocus() {
 	ignore_next_event = true;
-	set_placeholder(TTR("Filter by event..."));
+	set_placeholder(TTR("Filter by Event"));
 }
 
 Ref<InputEvent> EventListenerLineEdit::get_event() const {
@@ -227,5 +227,5 @@ void EventListenerLineEdit::_bind_methods() {
 
 EventListenerLineEdit::EventListenerLineEdit() {
 	set_caret_blink_enabled(false);
-	set_placeholder(TTR("Filter by event..."));
+	set_placeholder(TTR("Filter by Event"));
 }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -68,6 +68,8 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	if (p_clear_filter) {
 		search_box->clear();
 	}
+
+	_focus_current_search_box();
 }
 
 void ProjectSettingsEditor::queue_save() {
@@ -253,8 +255,7 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (k->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F))) {
-			search_box->grab_focus();
-			search_box->select_all();
+			_focus_current_search_box();
 			handled = true;
 		}
 
@@ -323,6 +324,25 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	int id = 1;
 	for (const String &E : presets) {
 		feature_box->add_item(E, id++);
+	}
+}
+
+void ProjectSettingsEditor::_tabs_tab_changed(int p_tab) {
+	_focus_current_search_box();
+}
+
+void ProjectSettingsEditor::_focus_current_search_box() {
+	Control *tab = tab_container->get_current_tab_control();
+	LineEdit *current_search_box = nullptr;
+	if (tab == general_editor) {
+		current_search_box = search_box;
+	} else if (tab == action_map_editor) {
+		current_search_box = action_map_editor->get_search_box();
+	}
+
+	if (current_search_box) {
+		current_search_box->grab_focus();
+		current_search_box->select_all();
 	}
 }
 
@@ -596,6 +616,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container = memnew(TabContainer);
 	tab_container->set_use_hidden_tabs_for_min_size(true);
 	tab_container->set_theme_type_variation("TabContainerOdd");
+	tab_container->connect("tab_changed", callable_mp(this, &ProjectSettingsEditor::_tabs_tab_changed));
 	add_child(tab_container);
 
 	general_editor = memnew(VBoxContainer);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -93,6 +93,9 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _add_setting();
 	void _delete_setting();
 
+	void _tabs_tab_changed(int p_tab);
+	void _focus_current_search_box();
+
 	void _editor_restart_request();
 	void _editor_restart();
 	void _editor_restart_close();


### PR DESCRIPTION
This behavior is already present in the "Editor Settings" dialog, now this PR introduces it to the "Project Settings" one as well.