### PR TITLE
Avoid crash when generating LODs on meshes with non-finite vertices.

### DIFF
--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -506,6 +506,10 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 					const Vector3 &v2 = vertices_ptr[new_indices_ptr[j + 2]];
 					Vector3 face_normal = vec3_cross(v0 - v2, v0 - v1);
 					float face_area = face_normal.length(); // Actually twice the face area, since it's the same error_factor on all faces, we don't care
+					if (!Math::is_finite(face_area) || face_area == 0) {
+						WARN_PRINT_ONCE("Ignoring face with non-finite normal in LOD generation.");
+						continue;
+					}
 
 					Vector3 dir = face_normal / face_area;
 					int ray_count = CLAMP(5.0 * face_area * error_factor, 16, 64);


### PR DESCRIPTION
Basically just a finite check. I threw in `== 0` as well since that would cause a division by zero if it would happen, but I'm not sure if that is possible.

I originally thought #80467 might address this type of issue but it does not: what happens is a nan in a vertex position propagates to the `face_area` variable which gets cast to `int ray_count` and this becomes negative. I think this symptom is possibly related to the one aaron fixed (which was likely an integer overflow in that case), but the cause is different.

Fixes https://github.com/V-Sekai/unidot_importer/issues/20
In the case of this fbx mesh, it had three vertices in a face all set to nan. FBX2glTF helpfully preserved these nans in the gltf model. Unfortunately this test model could not be redistributed, so I never filed a Godot issue for this model.