### PR TITLE
Fix can't unset exported typed array element when the type is set to Node

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2818,7 +2818,7 @@ void EditorPropertyNodePath::_node_assign() {
 }
 
 void EditorPropertyNodePath::_node_clear() {
-	emit_changed(get_edited_property(), NodePath());
+	emit_changed(get_edited_property(), Variant());
 	update_property();
 }
 


### PR DESCRIPTION
Fixes #82034

The code failed at `ERR_FAIL_COND(!_p->typed.validate(value, "set"))` , NodePath can't be set to a TypedArray of type 'Object'.

I guess the easy way to fix this is what this pr did,  make `_node_clear` emit an empty variant instead of an empty node_path. But it might has unexpected impacts, I would appreciate any feedback or alternative suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
