### PR TITLE
Windows: Remove `MSVC` define redundant with `_MSC_VER`

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -39,18 +39,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#if defined(UNIX_ENABLED)
 #include <unistd.h>
-#endif
-
-#ifdef MSVC
-#define S_ISREG(m) ((m)&_S_IFREG)
-#include <io.h>
-#endif
-#ifndef S_ISREG
-#define S_ISREG(m) ((m)&S_IFREG)
-#endif
 
 void FileAccessUnix::check_errors() const {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
@@ -279,16 +268,10 @@ bool FileAccessUnix::file_exists(const String &p_path) {
 		return false;
 	}
 
-#ifdef UNIX_ENABLED
 	// See if we have access to the file
 	if (access(filename.utf8().get_data(), F_OK)) {
 		return false;
 	}
-#else
-	if (_access(filename.utf8().get_data(), 4) == -1) {
-		return false;
-	}
-#endif
 
 	// See if this is a regular file
 	switch (st.st_mode & S_IFMT) {

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -34,6 +34,7 @@
 
 #include "core/os/os.h"
 #include "core/string/print_string.h"
+
 #include <share.h> // _SH_DENYNO
 #include <shlwapi.h>
 #define WIN32_LEAN_AND_MEAN

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -35,7 +35,7 @@
 #include <windows.h>
 
 // Crash handler exception only enabled with MSVC
-#if defined(DEBUG_ENABLED) && defined(MSVC)
+#if defined(DEBUG_ENABLED) && defined(_MSC_VER)
 #define CRASH_HANDLER_EXCEPTION 1
 
 extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -385,7 +385,6 @@ def configure_msvc(env, vcvars_msvc_config):
             "WINMIDI_ENABLED",
             "TYPED_METHOD_BIND",
             "WIN32",
-            "MSVC",
             "WINVER=%s" % env["target_win_version"],
             "_WIN32_WINNT=%s" % env["target_win_version"],
         ]


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/81200#discussion_r1335783464.