### PR TITLE
Register RenderingServer class and singleton with scene types

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1227,6 +1227,8 @@ void unregister_scene_types() {
 
 void register_scene_singletons() {
 	GDREGISTER_CLASS(ThemeDB);
+	GDREGISTER_ABSTRACT_CLASS(RenderingServer);
 
+	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ThemeDB", ThemeDB::get_singleton()));
 }

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -132,7 +132,6 @@ void register_server_types() {
 	OS::get_singleton()->set_has_server_feature_callback(has_server_feature_callback);
 
 	GDREGISTER_ABSTRACT_CLASS(DisplayServer);
-	GDREGISTER_ABSTRACT_CLASS(RenderingServer);
 	GDREGISTER_CLASS(AudioServer);
 
 	GDREGISTER_CLASS(PhysicsServer2DManager);
@@ -304,7 +303,6 @@ void unregister_server_types() {
 
 void register_server_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer2D", PhysicsServer2D::get_singleton(), "PhysicsServer2D"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3D", PhysicsServer3D::get_singleton(), "PhysicsServer3D"));


### PR DESCRIPTION
The rendering server singleton is created very early on but is not able to be accessed via the Engine singleton methods until server classes are registered. This change moves the registration further up. This change is primarily to partially address https://github.com/godotengine/godot-cpp/issues/1180.

I'm not too familiar with the internals of the engine, so edits and feedback are welcome.