### PR TITLE
Fix directional light soft shadow excessive blur far from origin

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2284,7 +2284,7 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 			cull.shadows[p_shadow_index].cascades[i].split = distances[i + 1];
 			cull.shadows[p_shadow_index].cascades[i].shadow_texel_size = radius * 2.0 / texture_size;
 			cull.shadows[p_shadow_index].cascades[i].bias_scale = (z_max - z_min_cam);
-			cull.shadows[p_shadow_index].cascades[i].range_begin = z_max;
+			cull.shadows[p_shadow_index].cascades[i].range_begin = pancake_size;
 			cull.shadows[p_shadow_index].cascades[i].uv_scale = uv_scale;
 		}
 	}


### PR DESCRIPTION
I'm not 100% sure about this fix, but it seems to work in my basic test case.

Using `z_max` for `range_begin` lead to completely wrong calculations in the soft shadow shader code. Using `pancake_size` results in `(range_pos - range_begin) = 2.0 * radius`, which might be wrong, but it's at least a lot closer to what it should be.
https://github.com/godotengine/godot/blob/fcbc50ec144df458aee75db94cdbf6396bd408ed/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl#L1649

Maybe related to #63610

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

---

comparison showing [shadowdistrepr.zip](https://github.com/godotengine/godot/files/12719328/shadowdistrepr.zip)
left: camera near origin
right: camera very far from origin

|  |  |
| ------------- | ------------- |
| <video src="https://github.com/godotengine/godot/assets/6376721/0b672503-3236-4bd8-a4ff-a11dd44cdcae"> | <video src="https://github.com/godotengine/godot/assets/6376721/b6d9cc2f-94c4-46b4-a73a-bb66e1812919"> |
| <video src="https://github.com/godotengine/godot/assets/6376721/de36675f-a1e3-4d73-8b8f-bee32382733a"> | <video src="https://github.com/godotengine/godot/assets/6376721/b10b1c87-72fe-48f1-90be-11f23d3601e2"> |
