### PR TITLE
Updated compiler version detection

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -106,7 +106,7 @@ def configure(env: "Environment"):
         print("Using linker program: " + env["linker"])
         if env["linker"] == "mold" and using_gcc(env):  # GCC < 12.1 doesn't support -fuse-ld=mold.
             cc_version = get_compiler_version(env)
-            cc_semver = (int(cc_version["major"]), int(cc_version["minor"]))
+            cc_semver = (cc_version["major"], cc_version["minor"])
             if cc_semver < (12, 1):
                 found_wrapper = False
                 for path in ["/usr/libexec", "/usr/local/libexec", "/usr/lib", "/usr/local/lib"]:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -120,16 +120,9 @@ def configure(env: "Environment"):
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
-    cc_version = get_compiler_version(env) or {
-        "major": None,
-        "minor": None,
-        "patch": None,
-        "metadata1": None,
-        "metadata2": None,
-        "date": None,
-    }
-    cc_version_major = int(cc_version["major"] or -1)
-    cc_version_minor = int(cc_version["minor"] or -1)
+    cc_version = get_compiler_version(env)
+    cc_version_major = cc_version["major"]
+    cc_version_minor = cc_version["minor"]
     vanilla = is_vanilla_clang(env)
 
     # Workaround for Xcode 15 linker bug.

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -203,7 +203,7 @@ def configure(env: "Environment"):
 
     # Get version info for checks below.
     cc_version = get_compiler_version(env)
-    cc_semver = (int(cc_version["major"]), int(cc_version["minor"]), int(cc_version["patch"]))
+    cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
 
     if env["lto"] != "none":
         # Workaround https://github.com/emscripten-core/emscripten/issues/19781.


### PR DESCRIPTION
This fixes multiple issues/inconsistencies around  `get_compiler_version()`:
* With no shell allocated, launching the compiler could fail even with proper paths being set.
* The return value was described as "an array of version numbers as ints", but the function actually returned a `Dictionary` (or `None`).
* Not all calls were properly handling a `None` return value in case of errors. On Windows this broke compiling for me since #81869 with default settings.
* Some calls defined inconsistent defaults/fallbacks (`0` or `-1`).

While I verified these changes under Windows, I currently don't have a build environment for Linux or MacOS ready.