### PR TITLE
Namespace Templating for C# Scripts

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -237,7 +237,7 @@ public:
 	virtual bool is_control_flow_keyword(String p_string) const = 0;
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const = 0;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const = 0;
-	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const { return Ref<Script>(); }
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name, const String &p_script_path) const { return Ref<Script>(); }
 	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) { return Vector<ScriptTemplate>(); }
 	virtual bool is_using_templates() { return false; }
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const = 0;

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -92,7 +92,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_is_control_flow_keyword, "keyword");
 	GDVIRTUAL_BIND(_get_comment_delimiters);
 	GDVIRTUAL_BIND(_get_string_delimiters);
-	GDVIRTUAL_BIND(_make_template, "template", "class_name", "base_class_name");
+	GDVIRTUAL_BIND(_make_template, "template", "class_name", "base_class_name", "script_path");
 	GDVIRTUAL_BIND(_get_built_in_templates, "object");
 	GDVIRTUAL_BIND(_is_using_templates);
 	GDVIRTUAL_BIND(_validate, "script", "path", "validate_functions", "validate_errors", "validate_warnings", "validate_safe_lines");

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -250,7 +250,7 @@ public:
 		}
 	}
 
-	EXBIND3RC(Ref<Script>, make_template, const String &, const String &, const String &)
+	EXBIND4RC(Ref<Script>, make_template, const String &, const String &, const String &, const String &)
 
 	GDVIRTUAL1RC(TypedArray<Dictionary>, _get_built_in_templates, StringName)
 

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -83,7 +83,7 @@ void PluginConfigDialog::_on_confirmed() {
 		if (!templates.is_empty()) {
 			template_content = templates[0].content;
 		}
-		Ref<Script> scr = ScriptServer::get_language(lang_idx)->make_template(template_content, class_name, "EditorPlugin");
+		Ref<Script> scr = ScriptServer::get_language(lang_idx)->make_template(template_content, class_name, "EditorPlugin", script_path);
 		scr->set_path(script_path, true);
 		ResourceSaver::save(scr);
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -345,14 +345,14 @@ void ScriptCreateDialog::_create_new() {
 	}
 
 	String class_name = file_path->get_text().get_file().get_basename();
-	scr = ScriptServer::get_language(language_menu->get_selected())->make_template(sinfo.content, class_name, parent_class);
+	String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
+	scr = ScriptServer::get_language(language_menu->get_selected())->make_template(sinfo.content, class_name, parent_class, lpath);
 
 	if (is_built_in) {
 		scr->set_name(built_in_name->get_text());
 		// Make sure the script is compiled to make its type recognizable.
 		scr->reload();
 	} else {
-		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		scr->set_path(lpath);
 		Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 		if (err != OK) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -498,7 +498,7 @@ public:
 	virtual void get_comment_delimiters(List<String> *p_delimiters) const override;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const override;
 	virtual bool is_using_templates() override;
-	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name, const String &p_script_path) const override;
 	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) override;
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override;
 	virtual Script *create_script() const override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -66,7 +66,7 @@ bool GDScriptLanguage::is_using_templates() {
 	return true;
 }
 
-Ref<Script> GDScriptLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const {
+Ref<Script> GDScriptLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name, const String &p_script_path) const {
 	Ref<GDScript> scr;
 	scr.instantiate();
 	String processed_template = p_template;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -354,10 +354,12 @@ Ref<Script> CSharpLanguage::make_template(const String &p_template, const String
 	String class_name_no_spaces = p_class_name.replace(" ", "_");
 	String base_class_name = get_base_class_name(p_base_class_name, class_name_no_spaces);
 	String processed_template = p_template;
+	String root_namespace = GLOBAL_GET("application/config/name");
 	processed_template = processed_template.replace("_BINDINGS_NAMESPACE_", BINDINGS_NAMESPACE)
 								 .replace("_BASE_", base_class_name)
 								 .replace("_CLASS_", class_name_no_spaces)
-								 .replace("_TS_", _get_indentation());
+								 .replace("_TS_", _get_indentation())
+								 .replace("_ROOT_NAMESPACE_");
 	scr->set_source_code(processed_template);
 	return scr;
 }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -347,7 +347,7 @@ bool CSharpLanguage::is_using_templates() {
 	return true;
 }
 
-Ref<Script> CSharpLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const {
+Ref<Script> CSharpLanguage::make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name, const String &p_script_path) const {
 	Ref<CSharpScript> scr;
 	scr.instantiate();
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -421,7 +421,7 @@ public:
 	void get_comment_delimiters(List<String> *p_delimiters) const override;
 	void get_string_delimiters(List<String> *p_delimiters) const override;
 	bool is_using_templates() override;
-	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
+	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name, const String &p_script_path) const override;
 	virtual Vector<ScriptTemplate> get_built_in_templates(StringName p_object) override;
 	/* TODO */ bool validate(const String &p_script, const String &p_path, List<String> *r_functions,
 			List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Added 2 new Templating Keywords:

- `_ROOT_NAMESPACE_`: The Project's root namespace, substituted with the Project's Name
- `_SCRIPT_NAMESPACE_`: The Script's namespace, substituted with the root Namespace followed by the Script's Path, with the following characteristic:
  - Any Folders named `Script` or `Scripts` will not be included in the Namespace, as it's redundant
  
Namespaces are capitalized according to PascalCasing

Works with `master` and `4.1`, haven't tested other versions