### PR TITLE
fix stackoverflow in `TabBar` when hover style has diff size

### DIFF
--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -105,6 +105,7 @@ private:
 	bool drag_to_rearrange_enabled = false;
 	bool dragging_valid_tab = false;
 	bool scroll_to_selected = true;
+	bool hover_has_diff_size = false;
 	int tabs_rearrange_group = -1;
 
 	struct ThemeCache {


### PR DESCRIPTION
Fix #81836

Problem: When an unselected tab changes size between unselected and hover, it can cause a stackoverflow because _update_cache and _update_hover call each other.
When hover is changed, all tabs positions and sizes are recomputed in _update_cache. When thats done, _update_hover is called and can make the cursor change tab, causing an infinite loop.

Preventing any stackoverflow by never calling _update_hover from _update_cache. Didn't find any case where this was usefull. If you find a case please tell me.
Checking that the cursor is inside the smaller zone before switching hover. Always first check if the cursor changed tab before going through the whole list.

@YeldhamDev