### PR TITLE
Fix compiler detection.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1021,7 +1021,7 @@ def get_compiler_version(env):
         # Not using -dumpversion as some GCC distros only return major, and
         # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
         try:
-            version = subprocess.check_output([env.subst(env["CXX"]), "--version"], shell=True).strip().decode("utf-8")
+            version = subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip().decode("utf-8")
         except (subprocess.CalledProcessError, OSError):
             print("Couldn't parse CXX environment variable to infer compiler version.")
             return ret


### PR DESCRIPTION
Fixes compiler detection broken by https://github.com/godotengine/godot/pull/82325

With `shell=true`, if two arguments are used, the second (`--version`) is not passed to clang (like: `zsh -c clang --version`), if only one is used it is passed (like: `zsh -c "clang --version"`).

*Bugsquad edit:*
- Fixes #82350