### PR TITLE
Optimizing glow behavior

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -103,12 +103,13 @@ void main() {
 #ifdef MODE_GLOW
 	if (bool(params.flags & FLAG_GLOW_FIRST_PASS)) {
 		// Tonemap initial samples to reduce weight of fireflies: https://graphicrants.blogspot.com/2013/12/tone-mapping.html
-		local_cache[dest_index] /= 1.0 + dot(local_cache[dest_index].rgb, vec3(0.299, 0.587, 0.114));
-		local_cache[dest_index + 1] /= 1.0 + dot(local_cache[dest_index + 1].rgb, vec3(0.299, 0.587, 0.114));
-		local_cache[dest_index + 16] /= 1.0 + dot(local_cache[dest_index + 16].rgb, vec3(0.299, 0.587, 0.114));
-		local_cache[dest_index + 16 + 1] /= 1.0 + dot(local_cache[dest_index + 16 + 1].rgb, vec3(0.299, 0.587, 0.114));
+		vec3 tonemap_col = vec3(0.299, 0.587, 0.114) / max(params.glow_luminance_cap, 6.0);
+		local_cache[dest_index] /= 1.0 + dot(local_cache[dest_index].rgb, tonemap_col);
+		local_cache[dest_index + 1] /= 1.0 + dot(local_cache[dest_index + 1].rgb, tonemap_col);
+		local_cache[dest_index + 16] /= 1.0 + dot(local_cache[dest_index + 16].rgb, tonemap_col);
+		local_cache[dest_index + 16 + 1] /= 1.0 + dot(local_cache[dest_index + 16 + 1].rgb, tonemap_col);
 	}
-	const float kernel[4] = { 0.174938, 0.165569, 0.140367, 0.106595 };
+	const float kernel[5] = { 0.2024, 0.1790, 0.1240, 0.0672, 0.0285 };
 #else
 	// Simpler blur uses SIGMA2 for the gaussian kernel for a stronger effect.
 	const float kernel[4] = { 0.214607, 0.189879, 0.131514, 0.071303 };
@@ -126,6 +127,10 @@ void main() {
 	color_top += local_cache[read_index - 1] * kernel[1];
 	color_top += local_cache[read_index - 2] * kernel[2];
 	color_top += local_cache[read_index - 3] * kernel[3];
+#ifdef MODE_GLOW
+	color_top += local_cache[read_index + 4] * kernel[4];
+	color_top += local_cache[read_index - 4] * kernel[4];
+#endif // MODE_GLOW
 
 	vec4 color_bottom = vec4(0.0);
 	color_bottom += local_cache[read_index + 16] * kernel[0];
@@ -135,6 +140,10 @@ void main() {
 	color_bottom += local_cache[read_index - 1 + 16] * kernel[1];
 	color_bottom += local_cache[read_index - 2 + 16] * kernel[2];
 	color_bottom += local_cache[read_index - 3 + 16] * kernel[3];
+#ifdef MODE_GLOW
+	color_bottom += local_cache[read_index + 4 + 16] * kernel[4];
+	color_bottom += local_cache[read_index - 4 + 16] * kernel[4];
+#endif // MODE_GLOW
 
 	// rotate samples to take advantage of cache coherency
 	uint write_index = gl_LocalInvocationID.y * 2 + gl_LocalInvocationID.x * 16;
@@ -161,11 +170,15 @@ void main() {
 	color += temp_cache[index - 1] * kernel[1];
 	color += temp_cache[index - 2] * kernel[2];
 	color += temp_cache[index - 3] * kernel[3];
+#ifdef MODE_GLOW
+	color += temp_cache[index + 4] * kernel[4];
+	color += temp_cache[index - 4] * kernel[4];
+#endif // MODE_GLOW
 
 #ifdef MODE_GLOW
 	if (bool(params.flags & FLAG_GLOW_FIRST_PASS)) {
 		// Undo tonemap to restore range: https://graphicrants.blogspot.com/2013/12/tone-mapping.html
-		color /= 1.0 - dot(color.rgb, vec3(0.299, 0.587, 0.114));
+		color /= 1.0 - dot(color.rgb, vec3(0.299, 0.587, 0.114) / max(params.glow_luminance_cap, 6.0));
 	}
 
 	color *= params.glow_strength;


### PR DESCRIPTION
This should fix #56452 and fix #57693
I was working on this with @clayjohn who contributed a lot of the code and knowledge, thanks for that!

The current glow shader implementation was lacking a bit in comparison to the high-quality glow in Godot 3.
This PR fixes this by giving the glow one more sample level and also fixes the boxiness with improved sigma values.

Current glow in a test scene (Small glow missing and box shape):
![image](https://github.com/godotengine/godot/assets/9423774/317973f1-fe02-429a-99bd-9f2c19debec9)

This PR:
![image](https://github.com/godotengine/godot/assets/9423774/6163087f-f974-42f1-a51f-ba7a12d2b1a5)

We also checked against fireflies and with this implementation, no fireflies are to be found.
On very strongly glowing objects that are very small, a kinda similar effect can be noticed - But this can be "fixed" by changing the `glow_luminance_cap`.