### PR TITLE
Fix `get_pos_at_line_column` will give incorrect Vector2 if column = 1

### DIFF
--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1396,7 +1396,7 @@ Vector2 TextServer::shaped_text_get_grapheme_bounds(const RID &p_shaped, int64_t
 	real_t off = 0.0f;
 	for (int i = 0; i < v_size; i++) {
 		if ((glyphs[i].count > 0) && ((glyphs[i].index != 0) || ((glyphs[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE))) {
-			if (glyphs[i].start <= p_pos && glyphs[i].end >= p_pos) {
+			if (glyphs[i].start <= p_pos && glyphs[i].end > p_pos) {
 				real_t advance = 0.f;
 				for (int j = 0; j < glyphs[i].count; j++) {
 					advance += glyphs[i + j].advance;


### PR DESCRIPTION
FIxes #82280

The `col_bounds` in `get_rect_at_line_column` is the same for column 0 and 1, I changed the if condition but it might have unexpected impacts. I would appreciate any feedback or alternative suggestions.  cc @YuriSizov 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
