### PR TITLE
Fix not being able to set Node process priority in certain cases

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -968,7 +968,11 @@ void Node::set_process_priority(int p_priority) {
 
 	if (_is_any_processing()) {
 		_remove_from_process_thread_group();
-		data.process_priority = p_priority;
+	}
+
+	data.process_priority = p_priority;
+
+	if (_is_any_processing()) {
 		_add_to_process_thread_group();
 	}
 }
@@ -990,7 +994,11 @@ void Node::set_physics_process_priority(int p_priority) {
 
 	if (_is_any_processing()) {
 		_remove_from_process_thread_group();
-		data.physics_process_priority = p_priority;
+	}
+
+	data.physics_process_priority = p_priority;
+
+	if (_is_any_processing()) {
 		_add_to_process_thread_group();
 	}
 }


### PR DESCRIPTION
Should fix #82339

I guess we can hide the process priority UI or just set the value without touching the thread_group part when `_is_any_processing` is false. This pr goes with the second option. 

`process_priority` is only used in `ComparatorWithPriority` now so I guess this commit is safe to some extent. I would appreciate any feedback or alternative suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
