### PR TITLE
Add device info to GLES3 shader cache key hash

### DIFF
--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -140,6 +140,14 @@ void ShaderGLES3::_setup(const char *p_vertex_code, const char *p_fragment_code,
 	tohash.append("[Fragment]");
 	tohash.append(p_fragment_code ? p_fragment_code : "");
 
+	tohash.append("[gl_implementation]");
+	const char *vendor = (const char *)glGetString(GL_VENDOR);
+	tohash.append(vendor ? vendor : "unknown");
+	const char *renderer = (const char *)glGetString(GL_RENDERER);
+	tohash.append(renderer ? renderer : "unknown");
+	const char *version = (const char *)glGetString(GL_VERSION);
+	tohash.append(version ? version : "unknown");
+
 	base_sha256 = tohash.as_string().sha256_text();
 }
 


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/81150

Adds some extra device info to the shader base cache key hash so that toggling between two different GPU's gives each device their own cache files. I also added the driver version, so driver updates will now also invalidate the cache. On my device, these values are:

```
GL_VENDOR: NVIDIA Corporation
GL_RENDERER: NVIDIA GeForce GTX 970/PCIe/SSE2
GL_VERSION: 3.3.0 NVIDIA 536.23
```