### PR TITLE
Color match editor log toggles and flat pressed buttons

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -442,6 +442,9 @@ EditorLog::EditorLog() {
 	copy_button->connect("pressed", callable_mp(this, &EditorLog::_copy_request));
 	hb_tools->add_child(copy_button);
 
+	// Separate toggle buttons from normal buttons.
+	vb_right->add_child(memnew(HSeparator));
+
 	// A second hbox to make a 2x2 grid of buttons.
 	HBoxContainer *hb_tools2 = memnew(HBoxContainer);
 	hb_tools2->set_h_size_flags(SIZE_SHRINK_CENTER);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1030,9 +1030,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	}
 
 	Ref<StyleBoxFlat> style_flat_button_pressed = style_widget_pressed->duplicate();
-	Color flat_pressed_color = dark_color_1.lerp(accent_color, 0.2) * Color(0.8, 0.8, 0.8, 0.85);
+	Color flat_pressed_color = dark_color_1.lightened(0.24).lerp(accent_color, 0.2) * Color(0.8, 0.8, 0.8, 0.85);
 	if (dark_theme) {
-		flat_pressed_color = dark_color_1.lerp(accent_color, 0.2) * Color(0.6, 0.6, 0.6, 0.85);
+		flat_pressed_color = dark_color_1.lerp(accent_color, 0.12) * Color(0.6, 0.6, 0.6, 0.85);
 	}
 	style_flat_button_pressed->set_bg_color(flat_pressed_color);
 
@@ -1074,7 +1074,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_normal_color", "EditorLogFilterButton", icon_disabled_color);
 	// When pressed, add a small bottom border to the buttons to better show their active state,
 	// similar to active tabs.
-	Ref<StyleBoxFlat> editor_log_button_pressed = style_widget_pressed->duplicate();
+
+	Ref<StyleBoxFlat> editor_log_button_pressed = style_flat_button_pressed->duplicate();
 	editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
 	editor_log_button_pressed->set_border_color(accent_color);
 	theme->set_stylebox("pressed", "EditorLogFilterButton", editor_log_button_pressed);


### PR DESCRIPTION
One thing that I didn't account for in https://github.com/godotengine/godot/pull/81939 was that we have these special-style toggle buttons in the editor log, and right next to them we have flat toggle buttons. With the new style it looks pretty meh together.

<img width="168" alt="godot windows editor dev x86_64_2023-09-26_14-00-03" src="https://github.com/godotengine/godot/assets/11782833/1767bc12-14c3-4aee-9b4b-1ac7edd4c41e">

So I've adjusted the colors of the new flat buttons and made sure that the editor log filters also use the same colors. I also added a separator to the editor log sidebar to separate buttons which do immediate actions from buttons which have toggle behavior.

<img width="890" alt="godot windows editor dev x86_64_2023-09-26_14-14-57" src="https://github.com/godotengine/godot/assets/11782833/5b26c1d2-ada6-47d1-8555-82c7477c37fb">
<img width="890" alt="godot windows editor dev x86_64_2023-09-26_14-15-33" src="https://github.com/godotengine/godot/assets/11782833/7cd2199d-42ea-4fe3-bff7-061ef30a6105">

I've debated a bit if we should completely match the style of the editor log filters with flat buttons, but decided to avoid drowning in bikeshedding on this one. There was a reason to add borders, but these borders don't work well if applied to every flat button. Also making filters flat makes them less clear in the disabled state. So I kept them as is, with their unique features. Just made sure that pressed colors are the same.