### PR TITLE
Fix typo causing `C4606` warning

### DIFF
--- a/modules/navigation/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/nav_mesh_generator_2d.cpp
@@ -92,7 +92,7 @@ void NavMeshGenerator2D::sync() {
 			finished_task_ids.push_back(E.key);
 
 			NavMeshGeneratorTask2D *generator_task = E.value;
-			DEV_ASSERT(generator_task->status = NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
+			DEV_ASSERT(generator_task->status == NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
 
 			baking_navmeshes.erase(generator_task->navigation_mesh);
 			if (generator_task->callback.is_valid()) {


### PR DESCRIPTION
Small change fixing a typo in the navigation module, where a 2d mesh generator dev assertion was erroneously assigning a value instead of comparing values