### PR TITLE
C#: Remove compat method that is now generated

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
@@ -83,13 +83,6 @@ partial class RenderingDevice
 
 partial class RichTextLabel
 {
-    /// <inheritdoc cref="AddImage(Texture2D, int, int, Nullable{Color}, InlineAlignment, Nullable{Rect2}, Variant, bool, string, bool)"/>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public void AddImage(Texture2D image, int width, int height, Nullable<Color> color, InlineAlignment inlineAlign, Nullable<Rect2> region)
-    {
-        AddImage(image, width, height, color, inlineAlign, region, key: default, pad: false, tooltip: "", sizeInPercent: false);
-    }
-
     /// <inheritdoc cref="PushList(int, ListType, bool, string)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void PushList(int level, ListType type, bool capitalize)


### PR DESCRIPTION
- Follow-up to #80410 and #80527.

With #80527 we're now generating compat methods for C# from the ones registered in ClassDB, so it's not needed to add them manually to the `Compat.cs` file.

PRs that modify `Compat.cs` should be rebased, so that CI can fail if there are conflicts with the generated compat methods. But going forward there should be no need to modify `Compat.cs` manually except for cases unsupported by ClassDB (e.g.: compatibility properties).