### PR TITLE
Document worker thread pool project settings and `TreeItem.uncollapse_tree()`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2764,6 +2764,7 @@
 			[/codeblock]
 		</member>
 		<member name="threading/worker_pool/low_priority_thread_ratio" type="float" setter="" getter="" default="0.3">
+			The ratio of [WorkerThreadPool]'s threads that will be reserved for low-priority tasks. For example, if 10 threads are available and this value is set to [code]0.3[/code], 3 of the worker threads will be reserved for low-priority tasks. The actual value won't exceed the number of CPU cores minus one, and if possible, at least one worker thread will be dedicated to low-priority tasks.
 		</member>
 		<member name="threading/worker_pool/max_threads" type="int" setter="" getter="" default="-1">
 			Maximum number of threads to be used by [WorkerThreadPool]. Value of [code]-1[/code] means no limit.
@@ -2772,7 +2773,7 @@
 			Action map configuration to load by default.
 		</member>
 		<member name="xr/openxr/enabled" type="bool" setter="" getter="" default="false">
-			If [code]true[/code] Godot will setup and initialize OpenXR on startup.
+			If [code]true[/code], Godot will setup and initialize OpenXR on startup.
 		</member>
 		<member name="xr/openxr/environment_blend_mode" type="int" setter="" getter="" default="&quot;0&quot;">
 			Specify how OpenXR should blend in the environment. This is specific to certain AR and passthrough devices where camera images are blended in by the XR compositor.

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -754,6 +754,7 @@
 		<method name="uncollapse_tree">
 			<return type="void" />
 			<description>
+				Uncollapses all [TreeItem]s necessary to reveal this [TreeItem], i.e. all ancestor [TreeItem]s.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Adds some missing docs.

https://github.com/godotengine/godot/pull/76525#issuecomment-1545474260