### PR TITLE
Fix unintended dev-only assignment in mesh baking

### DIFF
--- a/modules/navigation/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/nav_mesh_generator_2d.cpp
@@ -92,7 +92,7 @@ void NavMeshGenerator2D::sync() {
 			finished_task_ids.push_back(E.key);
 
 			NavMeshGeneratorTask2D *generator_task = E.value;
-			DEV_ASSERT(generator_task->status = NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
+			DEV_ASSERT(generator_task->status == NavMeshGeneratorTask2D::TaskStatus::BAKING_FINISHED);
 
 			baking_navmeshes.erase(generator_task->navigation_mesh);
 			if (generator_task->callback.is_valid()) {


### PR DESCRIPTION
I wouldn't even call this a bug, but looks like the best fitting label...