### PR TITLE
Fix grid snapping for box shape gizmos

### DIFF
--- a/editor/plugins/gizmos/gizmo_3d_helper.cpp
+++ b/editor/plugins/gizmos/gizmo_3d_helper.cpp
@@ -77,36 +77,46 @@ String Gizmo3DHelper::box_get_handle_name(int p_id) const {
 }
 
 void Gizmo3DHelper::box_set_handle(const Vector3 p_segment[2], int p_id, Vector3 &r_box_size, Vector3 &r_box_position) {
-	Vector3 axis;
-	axis[p_id / 2] = 1.0;
-	Vector3 ra, rb;
+	int axis = p_id / 2;
 	int sign = p_id % 2 * -2 + 1;
+
 	Vector3 initial_size = initial_value;
+	float neg_end = initial_size[axis] * -0.5;
+	float pos_end = initial_size[axis] * 0.5;
 
-	Geometry3D::get_closest_points_between_segments(Vector3(), axis * 4096 * sign, p_segment[0], p_segment[1], ra, rb);
-	if (ra[p_id / 2] == 0) {
-		// Point before half of the shape. Needs to be calculated in opposite direction.
-		Geometry3D::get_closest_points_between_segments(Vector3(), axis * 4096 * -sign, p_segment[0], p_segment[1], ra, rb);
-	}
+	Vector3 axis_segment[2] = { Vector3(), Vector3() };
+	axis_segment[0][axis] = 4096.0;
+	axis_segment[1][axis] = -4096.0;
+	Vector3 ra, rb;
+	Geometry3D::get_closest_points_between_segments(axis_segment[0], axis_segment[1], p_segment[0], p_segment[1], ra, rb);
 
-	float d = ra[p_id / 2] * sign;
-
-	Vector3 he = r_box_size;
-	he[p_id / 2] = d * 2;
-	if (Node3DEditor::get_singleton()->is_snap_enabled()) {
-		he[p_id / 2] = Math::snapped(he[p_id / 2], Node3DEditor::get_singleton()->get_translate_snap());
-	}
-
+	// Calculate new size.
+	r_box_size = initial_size;
 	if (Input::get_singleton()->is_key_pressed(Key::ALT)) {
-		he[p_id / 2] = MAX(he[p_id / 2], 0.001);
-		r_box_size = he;
+		r_box_size[axis] = ra[axis] * sign * 2;
+	} else {
+		r_box_size[axis] = sign > 0 ? ra[axis] - neg_end : pos_end - ra[axis];
+	}
+
+	// Snap to grid.
+	if (Node3DEditor::get_singleton()->is_snap_enabled()) {
+		r_box_size[axis] = Math::snapped(r_box_size[axis], Node3DEditor::get_singleton()->get_translate_snap());
+	}
+	r_box_size[axis] = MAX(r_box_size[axis], 0.001);
+
+	// Adjust position.
+	if (Input::get_singleton()->is_key_pressed(Key::ALT)) {
 		r_box_position = initial_transform.get_origin();
 	} else {
-		he[p_id / 2] = MAX(he[p_id / 2], -initial_size[p_id / 2] + 0.002);
-		r_box_size = (initial_size + (he - initial_size) * 0.5).abs();
-		Vector3 pos = initial_transform.affine_inverse().xform(initial_transform.get_origin());
-		pos += (r_box_size - initial_size) * 0.5 * sign;
-		r_box_position = initial_transform.xform(pos);
+		if (sign > 0) {
+			pos_end = neg_end + r_box_size[axis];
+		} else {
+			neg_end = pos_end - r_box_size[axis];
+		}
+
+		Vector3 offset;
+		offset[axis] = (pos_end + neg_end) * 0.5;
+		r_box_position = initial_transform.xform(offset);
 	}
 }
 


### PR DESCRIPTION
Fixes #81916 

I've rewritten Gizmo3DHelper logic for its box "extrusion" mode. In this version it applies snapping directly to box size and then adjusts box position by ensuring that opposite end of the box doesn't move as result of the operation. This way box size doesn't deviate from the snap grid.

Position (origin) adjustment logic is thus:
1. Calculate initial offsets of box sides on selected axis.
2. Adjust offset of the side we're extruding to accommodate new box size.
3. Adjust box position to be in the middle between unmoved side and extruded side.