### PR TITLE
Fix `SkeletonIK3D` editor preview when changing active node

### DIFF
--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -48,24 +48,17 @@ void SkeletonIK3DEditorPlugin::_play() {
 		skeleton_ik->start();
 	} else {
 		skeleton_ik->stop();
-		skeleton_ik->get_parent_skeleton()->clear_bones_global_pose_override();
 	}
 }
 
 void SkeletonIK3DEditorPlugin::edit(Object *p_object) {
-	if (p_object != skeleton_ik) {
-		if (skeleton_ik) {
-			play_btn->set_pressed(false);
-			_play();
-		}
-	}
-
 	SkeletonIK3D *s = Object::cast_to<SkeletonIK3D>(p_object);
 	if (!s) {
 		return;
 	}
 
 	skeleton_ik = s;
+	play_btn->set_pressed(skeleton_ik->is_running());
 }
 
 bool SkeletonIK3DEditorPlugin::handles(Object *p_object) const {

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -414,7 +414,7 @@ void SkeletonIK3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			reload_chain();
+			stop();
 		} break;
 	}
 }


### PR DESCRIPTION
Fixed an issue where "Play IK" would stop playing IK in editor when changing from one node to another. This issue made basically SkeletonIK3D node useless since you couldn't preview how it looked like or you could but it would have involved going back and forth between ik and target node. 

Now you can:

- preview ik without going back and forth between ik and target node.
- turn on multiple SkeletonIK3D nodes.

 

https://github.com/godotengine/godot/assets/33091666/a59c4c8c-587c-4f03-b4e3-d6268c3a0b39

Fixes: https://github.com/godotengine/godot/issues/72945