### PR TITLE
Fix performance regression in RigidBody2D/3D and PhysicalBone3D

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -447,9 +447,12 @@ void RigidBody2D::_body_state_changed(PhysicsDirectBodyState2D *p_state) {
 	lock_callback();
 
 	set_block_transform_notify(true); // don't want notify (would feedback loop)
-	_sync_body_state(p_state);
 
-	GDVIRTUAL_CALL(_integrate_forces, p_state);
+	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+		_sync_body_state(p_state);
+
+		GDVIRTUAL_CALL(_integrate_forces, p_state);
+	}
 
 	_sync_body_state(p_state);
 	set_block_transform_notify(false); // want it back

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -502,9 +502,12 @@ void RigidBody3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	lock_callback();
 
 	set_ignore_transform_notification(true);
-	_sync_body_state(p_state);
 
-	GDVIRTUAL_CALL(_integrate_forces, p_state);
+	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+		_sync_body_state(p_state);
+
+		GDVIRTUAL_CALL(_integrate_forces, p_state);
+	}
 
 	_sync_body_state(p_state);
 	set_ignore_transform_notification(false);
@@ -2935,9 +2938,12 @@ void PhysicalBone3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	}
 
 	set_ignore_transform_notification(true);
-	_sync_body_state(p_state);
 
-	GDVIRTUAL_CALL(_integrate_forces, p_state);
+	if (GDVIRTUAL_IS_OVERRIDDEN(_integrate_forces)) {
+		_sync_body_state(p_state);
+
+		GDVIRTUAL_CALL(_integrate_forces, p_state);
+	}
 
 	_sync_body_state(p_state);
 	set_ignore_transform_notification(false);


### PR DESCRIPTION
After change https://github.com/godotengine/godot/pull/79977 the body state is synched 2x per frame, but this is only needed if _integrate_forces is overridden.

Adding this extra if increases the FPS by 2.5% in a heavy physics scene, see discussion at: https://github.com/godot-jolt/godot-jolt/discussions/611
