### PR TITLE
Corrected `exposure_shutter_speed` description to match reality and engine functionality.

### DIFF
--- a/doc/classes/CameraAttributesPhysical.xml
+++ b/doc/classes/CameraAttributesPhysical.xml
@@ -32,7 +32,8 @@
 			Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled.
 		</member>
 		<member name="exposure_shutter_speed" type="float" setter="set_shutter_speed" getter="get_shutter_speed" default="100.0">
-			Time for shutter to open and close, measured in seconds. A higher value will let in more light leading to a brighter image, while a lower amount will let in less light leading to a darker image.
+			Time for shutter to open and close, evaluated as [code]1 / shutter_speed[/code] seconds. A higher value will allow less light, leading to a darker image, while a lower amount will allow more light leading to a brighter image.
+
 			Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled.
 		</member>
 		<member name="frustum_far" type="float" setter="set_far" getter="get_far" default="4000.0">

--- a/doc/classes/CameraAttributesPhysical.xml
+++ b/doc/classes/CameraAttributesPhysical.xml
@@ -33,7 +33,6 @@
 		</member>
 		<member name="exposure_shutter_speed" type="float" setter="set_shutter_speed" getter="get_shutter_speed" default="100.0">
 			Time for shutter to open and close, evaluated as [code]1 / shutter_speed[/code] seconds. A higher value will allow less light, leading to a darker image, while a lower amount will allow more light leading to a brighter image.
-
 			Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled.
 		</member>
 		<member name="frustum_far" type="float" setter="set_far" getter="get_far" default="4000.0">

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -271,8 +271,8 @@ void Camera3D::clear_current(bool p_enable_next) {
 
 	if (get_viewport()->get_camera_3d() == this) {
 		get_viewport()->_camera_3d_set(nullptr);
-
-		if (p_enable_next) {
+		
+		if (p_enable_next && !Engine::get_singleton()->is_editor_hint()) {
 			get_viewport()->_camera_3d_make_next_current(this);
 		}
 	}

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -271,8 +271,8 @@ void Camera3D::clear_current(bool p_enable_next) {
 
 	if (get_viewport()->get_camera_3d() == this) {
 		get_viewport()->_camera_3d_set(nullptr);
-		
-		if (p_enable_next && !Engine::get_singleton()->is_editor_hint()) {
+
+		if (p_enable_next) {
 			get_viewport()->_camera_3d_make_next_current(this);
 		}
 	}


### PR DESCRIPTION
Due to shutter speed being inversely proportional, higher values correspond to a faster shutter, causing less light to be collected. This behavior is present in-engine, but the documentation had things switched around.