### PR TITLE
Moved `face_index` field in 3D `RayResult` to end of struct

### DIFF
--- a/misc/extension_api_validation/4.1-stable.expected
+++ b/misc/extension_api_validation/4.1-stable.expected
@@ -198,3 +198,10 @@ GH-80410
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 6 to 10.
 
 Added optional argument. Compatibility method registered.
+
+
+GH-82403
+--------
+Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionRayResult': format changed value in new API, from "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape" to "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape;int face_index".
+
+Added/moved face_index field (introduced in GH-71233) to end of struct. Should still be compatible with 4.1.

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -150,11 +150,11 @@ public:
 	struct RayResult {
 		Vector3 position;
 		Vector3 normal;
-		int face_index = -1;
 		RID rid;
 		ObjectID collider_id;
 		Object *collider = nullptr;
 		int shape = 0;
+		int face_index = -1;
 	};
 
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -157,7 +157,7 @@ void register_server_types() {
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState3DExtension)
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DRenderingServerHandler)
 
-	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionRayResult, "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionRayResult, "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape;int face_index");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionShapeResult, "RID rid;ObjectID collider_id;Object *collider;int shape");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionShapeRestInfo, "Vector3 point;Vector3 normal;RID rid;ObjectID collider_id;int shape;Vector3 linear_velocity");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionCollision, "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape");


### PR DESCRIPTION
Fixes #80444.

This moves the new `face_index` field found in `PhysicsDirectSpaceState3D::RayResult`, also known/bound as `PhysicsServer3DExtensionRayResult`, which was introduced in #71233, to the end of the struct, thereby "fixing" the accidental GDExtension compatibility breakage that happened as a result of it being added in the middle of the struct.

Note that while this is still technically a breaking change, since it still changes the size/layout of `RayResult`, the only part of the GDExtension API that actually uses this is `PhysicsDirectSpaceState3DExtension::_intersect_ray`, which has you writing to that struct through a pointer, meaning only the field offsets have to be preserved between versions, which this PR should satisfy.