### PR TITLE
Document, cleanup and fix some theme properties

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -132,6 +132,7 @@
 			Font size of the [Button]'s text.
 		</theme_item>
 		<theme_item name="icon" data_type="icon" type="Texture2D">
+			Default icon for the [Button]. Appears only if [member icon] is not assigned.
 		</theme_item>
 		<theme_item name="disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is disabled.

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -214,7 +214,7 @@
 			<param index="3" name="to_port" type="int" />
 			<param index="4" name="amount" type="float" />
 			<description>
-				Sets the coloration of the connection between [param from_node]'s [param from_port] and [param to_node]'s [param to_port] with the color provided in the [theme_item activity] theme property.
+				Sets the coloration of the connection between [param from_node]'s [param from_port] and [param to_node]'s [param to_port] with the color provided in the [theme_item activity] theme property. The color is linearly interpolated between the connection color and the activity color using [param amount] as weight.
 			</description>
 		</method>
 		<method name="set_selected">
@@ -396,6 +396,7 @@
 	</constants>
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Color of the connection's activity (see [method set_connection_activity]).
 		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines.

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -49,8 +49,6 @@
 		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
 			Used when the grabber is being dragged.
 		</theme_item>
-		<theme_item name="hscroll" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].
 		</theme_item>

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1402,7 +1402,7 @@ void GraphEdit::_zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputE
 void GraphEdit::set_connection_activity(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port, float p_activity) {
 	for (Connection &E : connections) {
 		if (E.from_node == p_from && E.from_port == p_from_port && E.to_node == p_to && E.to_port == p_to_port) {
-			if (Math::is_equal_approx(E.activity, p_activity)) {
+			if (!Math::is_equal_approx(E.activity, p_activity)) {
 				// Update only if changed.
 				top_layer->queue_redraw();
 				minimap->queue_redraw();

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -468,22 +468,6 @@ double ScrollBar::get_area_size() const {
 	}
 }
 
-double ScrollBar::get_area_offset() const {
-	double ofs = 0.0;
-
-	if (orientation == VERTICAL) {
-		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_TOP);
-		ofs += theme_cache.decrement_icon->get_height();
-	}
-
-	if (orientation == HORIZONTAL) {
-		ofs += theme_cache.scroll_offset_style->get_margin(SIDE_LEFT);
-		ofs += theme_cache.decrement_icon->get_width();
-	}
-
-	return ofs;
-}
-
 double ScrollBar::get_grabber_offset() const {
 	return (get_area_size()) * get_as_ratio();
 }
@@ -639,7 +623,6 @@ void ScrollBar::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, scroll_style, "scroll");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, scroll_focus_style, "scroll_focus");
-	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, scroll_offset_style, "hscroll");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, grabber_style, "grabber");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, grabber_hl_style, "grabber_highlight");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollBar, grabber_pressed_style, "grabber_pressed");

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -63,7 +63,6 @@ class ScrollBar : public Range {
 	double get_grabber_size() const;
 	double get_grabber_min_size() const;
 	double get_area_size() const;
-	double get_area_offset() const;
 	double get_grabber_offset() const;
 
 	static void set_can_focus_by_default(bool p_can_focus);


### PR DESCRIPTION
Somewhat follow-up to #81573

I wanted to add descriptions to the 3 newly "exposed" theme items, but found some obstacles along the way.
- Adds description for Button's `icon`
- Removes `hscroll` theme property from ScrollBar and the related `get_area_offset()` method (it was unused)
- Documents and fixes GraphEdit's `activity` theme property