### PR TITLE
Replace String.substr() with simpler functions where possible

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -197,7 +197,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 			return "res://" + path;
 		}
 
-		String parent = path.substr(0, sep);
+		String parent = path.left(sep);
 
 		String plocal = localize_path(parent);
 		if (plocal.is_empty()) {
@@ -426,9 +426,8 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	for (const _VCSort &E : vclist) {
 		String prop_info_name = E.name;
-		int dot = prop_info_name.find(".");
-		if (dot != -1 && !custom_prop_info.has(prop_info_name)) {
-			prop_info_name = prop_info_name.substr(0, dot);
+		if (!custom_prop_info.has(prop_info_name)) {
+			prop_info_name = prop_info_name.get_slice(".", 0);
 		}
 
 		if (custom_prop_info.has(prop_info_name)) {
@@ -522,9 +521,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		// OS will call ProjectSettings->get_resource_path which will be empty if not overridden!
 		// If the OS would rather use a specific location, then it will not be empty.
 		resource_path = OS::get_singleton()->get_resource_dir().replace("\\", "/");
-		if (!resource_path.is_empty() && resource_path[resource_path.length() - 1] == '/') {
-			resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
-		}
+		resource_path = resource_path.trim_suffix("/");
 	}
 
 	// Attempt with a user-defined main pack first
@@ -645,9 +642,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		return err;
 	}
 
-	if (resource_path.length() && resource_path[resource_path.length() - 1] == '/') {
-		resource_path = resource_path.substr(0, resource_path.length() - 1); // Chop end.
-	}
+	resource_path = resource_path.trim_suffix("/");
 
 	return OK;
 }
@@ -1060,7 +1055,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		if (div < 0) {
 			category = "";
 		} else {
-			category = category.substr(0, div);
+			category = category.left(div);
 			name = name.substr(div + 1, name.size());
 		}
 		save_props[category].push_back(name);

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -138,7 +138,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, Ve
 		// Tell the OS that we want to handle termination signals.
 		OS::get_singleton()->initialize_debugging();
 	} else if (p_uri.find("://") >= 0) {
-		const String proto = p_uri.substr(0, p_uri.find("://") + 3);
+		const String proto = p_uri.left(p_uri.find("://") + 3);
 		if (!protocols.has(proto)) {
 			return;
 		}

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -141,7 +141,7 @@ void RemoteDebugger::_print_handler(void *p_this, const String &p_string, bool p
 	}
 
 	if (allowed_chars < s.length()) {
-		s = s.substr(0, allowed_chars);
+		s = s.left(allowed_chars);
 	}
 
 	MutexLock lock(rd->mutex);
@@ -341,7 +341,7 @@ Error RemoteDebugger::_try_capture(const String &p_msg, const Array &p_data, boo
 	if (idx < 0) { // No prefix, unknown message.
 		return OK;
 	}
-	const String cap = p_msg.substr(0, idx);
+	const String cap = p_msg.left(idx);
 	if (!has_capture(cap)) {
 		return ERR_UNAVAILABLE; // Unknown message...
 	}
@@ -581,7 +581,7 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 			continue;
 		}
 
-		const String cap = cmd.substr(0, idx);
+		const String cap = cmd.left(idx);
 		if (!has_capture(cap)) {
 			continue; // Unknown message...
 		}

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -227,7 +227,7 @@ RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create(const String &p_uri) {
 	if (debug_host.contains(":")) {
 		int sep_pos = debug_host.rfind(":");
 		debug_port = debug_host.substr(sep_pos + 1).to_int();
-		debug_host = debug_host.substr(0, sep_pos);
+		debug_host = debug_host.left(sep_pos);
 	}
 
 	RemoteDebuggerPeerTCP *peer = memnew(RemoteDebuggerPeerTCP);

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -159,11 +159,11 @@ Error DirAccess::make_dir_recursive(String p_dir) {
 		ERR_FAIL_COND_V(pos < 0, ERR_INVALID_PARAMETER);
 		pos = full_dir.find("/", pos + 1);
 		ERR_FAIL_COND_V(pos < 0, ERR_INVALID_PARAMETER);
-		base = full_dir.substr(0, pos + 1);
+		base = full_dir.left(pos + 1);
 	} else if (full_dir.begins_with("/")) {
 		base = "/";
 	} else if (full_dir.contains(":/")) {
-		base = full_dir.substr(0, full_dir.find(":/") + 2);
+		base = full_dir.left(full_dir.find(":/") + 2);
 	} else {
 		ERR_FAIL_V(ERR_INVALID_PARAMETER);
 	}

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -417,7 +417,7 @@ Vector<String> FileAccess::get_csv_line(const String &p_delim) const {
 	} while (qc % 2);
 
 	// Remove the extraneous newline we've added above.
-	line = line.substr(0, line.length() - 1);
+	line = line.left(-1);
 
 	Vector<String> strings;
 

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -34,7 +34,7 @@
 
 void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
-	magic = (magic + "    ").substr(0, 4);
+	magic = magic.rpad(4, " ");
 
 	cmode = p_mode;
 	block_size = p_block_size;

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -117,7 +117,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 		if (sp == -1) {
 			continue;
 		}
-		String key = s.substr(0, sp).strip_edges();
+		String key = s.left(sp).strip_edges();
 		String value = s.substr(sp + 1, s.length()).strip_edges();
 		ret[key] = value;
 	}

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -286,7 +286,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 
 			ERR_FAIL_COND_V_MSG(end_pos == -1, Ref<Resource>(), "Expected '\"' at end of message while parsing: " + path + ":" + itos(line));
 
-			l = l.substr(0, end_pos);
+			l = l.left(end_pos);
 			l = l.c_unescape();
 
 			if (status == STATUS_READING_ID) {
@@ -329,7 +329,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 		if (p == -1) {
 			continue;
 		}
-		String prop = c.substr(0, p).strip_edges();
+		String prop = c.left(p).strip_edges();
 		String value = c.substr(p + 1, c.length()).strip_edges();
 
 		if (prop == "X-Language" || prop == "Language") {

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -362,7 +362,7 @@ NodePath::NodePath(const NodePath &p_path) {
 }
 
 NodePath::NodePath(const String &p_path) {
-	if (p_path.length() == 0) {
+	if (p_path.is_empty()) {
 		return;
 	}
 
@@ -393,7 +393,7 @@ NodePath::NodePath(const String &p_path) {
 			}
 		}
 
-		path = path.substr(0, subpath_pos);
+		path = path.left(subpath_pos);
 	}
 
 	for (int i = (int)absolute; i < path.length(); i++) {

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -1016,9 +1016,9 @@ void TranslationServer::_bind_methods() {
 
 void TranslationServer::load_translations() {
 	_load_translations("internationalization/locale/translations"); //all
-	_load_translations("internationalization/locale/translations_" + locale.substr(0, 2));
+	_load_translations("internationalization/locale/translations_" + locale.left(2));
 
-	if (locale.substr(0, 2) != locale) {
+	if (locale.left(2) != locale) {
 		_load_translations("internationalization/locale/translations_" + locale);
 	}
 }

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -172,7 +172,7 @@ void TranslationPO::_cache_plural_tests(const String &p_plural_rule) {
 		return;
 	}
 
-	String equi_test = p_plural_rule.substr(0, first_ques_mark).strip_edges();
+	String equi_test = p_plural_rule.left(first_ques_mark).strip_edges();
 	equi_tests.push_back(equi_test);
 
 	String after_colon = p_plural_rule.substr(p_plural_rule.find(":") + 1, p_plural_rule.length());

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -79,11 +79,7 @@ Error AudioDriverALSA::init_output_device() {
 	if (output_device_name == "Default") {
 		status = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK);
 	} else {
-		String device = output_device_name;
-		int pos = device.find(";");
-		if (pos != -1) {
-			device = device.substr(0, pos);
-		}
+		String device = output_device_name.get_slice(";", 0);
 		status = snd_pcm_open(&pcm_handle, device.utf8().get_data(), SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK);
 	}
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -619,12 +619,7 @@ String OS_Unix::get_locale() const {
 		return "en";
 	}
 
-	String locale = get_environment("LANG");
-	int tp = locale.find(".");
-	if (tp != -1) {
-		locale = locale.substr(0, tp);
-	}
-	return locale;
+	return get_environment("LANG").get_slice(".", 0);
 }
 
 Error OS_Unix::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -314,7 +314,7 @@ String DirAccessWindows::get_filesystem_type() const {
 
 	int unit_end = path.find(":");
 	ERR_FAIL_COND_V(unit_end == -1, String());
-	String unit = path.substr(0, unit_end + 1) + "\\";
+	String unit = path.left(unit_end + 1) + "\\";
 
 	if (path.is_network_share_path()) {
 		return "Network Share";

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -60,12 +60,7 @@ void FileAccessWindows::check_errors() const {
 
 bool FileAccessWindows::is_path_invalid(const String &p_path) {
 	// Check for invalid operating system file.
-	String fname = p_path;
-	int dot = fname.find(".");
-	if (dot != -1) {
-		fname = fname.substr(0, dot);
-	}
-	fname = fname.to_lower();
+	String fname = p_path.get_slice(".", 0).to_lower();
 	return invalid_files.has(fname);
 }
 
@@ -362,8 +357,8 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 	}
 
 	String file = fix_path(p_file);
-	if (file.ends_with("/") && file != "/") {
-		file = file.substr(0, file.length() - 1);
+	if (file != "/") {
+		file = file.trim_suffix("/");
 	}
 
 	struct _stat st;

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -281,7 +281,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 				int end = base_path.find(":");
 				if (end != -1) {
-					base_path = base_path.substr(0, end + 1);
+					base_path = base_path.left(end + 1);
 				}
 				Vector<int> indices = track_indices.has(base_path) ? track_indices[base_path] : Vector<int>();
 				indices.push_back(i);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3861,7 +3861,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			} else {
 				int sep = track_path.rfind(":");
 				if (sep != -1) {
-					String base_path = track_path.substr(0, sep);
+					String base_path = track_path.left(sep);
 					if (base_path == np) {
 						String value_name = track_path.substr(sep + 1);
 						value = p_value.get(value_name);
@@ -3959,7 +3959,7 @@ void AnimationTrackEditor::insert_value_key(const String &p_property, const Vari
 			} else {
 				String tpath = animation->track_get_path(i);
 				int index = tpath.rfind(":");
-				if (NodePath(tpath.substr(0, index + 1)) == np) {
+				if (NodePath(tpath.left(index + 1)) == np) {
 					String subindex = tpath.substr(index + 1, tpath.length() - index);
 					value = p_value.get(subindex);
 				} else {
@@ -4329,7 +4329,7 @@ void AnimationTrackEditor::_update_tracks() {
 	if (!animation->get_path().is_resource_file()) {
 		int srpos = animation->get_path().find("::");
 		if (srpos != -1) {
-			String base = animation->get_path().substr(0, srpos);
+			String base = animation->get_path().left(srpos);
 			if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 				if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 					file_read_only = true;

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1113,7 +1113,7 @@ void CodeTextEditor::trim_trailing_whitespace() {
 					break;
 				}
 			}
-			text_editor->set_line(i, line.substr(0, end));
+			text_editor->set_line(i, line.left(end));
 		}
 	}
 

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -340,10 +340,10 @@ Dictionary DebugAdapterParser::req_setBreakpoints(const Dictionary &p_params) co
 		return prepare_error_response(p_params, DAP::ErrorType::WRONG_PATH, variables);
 	}
 
-	// If path contains \, it's a Windows path, so we need to convert it to /, and make the drive letter uppercase
+	// If path contains \, it's a Windows path, so we need to convert it to /, and make the drive letter uppercase.
 	if (source.path.find("\\") != -1) {
 		source.path = source.path.replace("\\", "/");
-		source.path = source.path.substr(0, 1).to_upper() + source.path.substr(1);
+		source.path = source.path.left(1).to_upper() + source.path.substr(1);
 	}
 
 	Array breakpoints = args["breakpoints"], lines;

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -242,7 +242,7 @@ Error EditorDebuggerNode::start(const String &p_uri) {
 	} else {
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 	}
-	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));
+	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.left(p_uri.find("://") + 3)));
 	const Error err = server->start(p_uri);
 	if (err != OK) {
 		return err;
@@ -764,7 +764,7 @@ bool EditorDebuggerNode::plugins_capture(ScriptEditorDebugger *p_debugger, const
 	int colon_index = p_message.find_char(':');
 	ERR_FAIL_COND_V_MSG(colon_index < 1, false, "Invalid message received.");
 
-	const String cap = p_message.substr(0, colon_index);
+	const String cap = p_message.left(colon_index);
 	bool parsed = false;
 	for (Ref<EditorDebuggerPlugin> plugin : debugger_plugins) {
 		if (plugin->has_capture(cap)) {

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1035,7 +1035,7 @@ void DocTools::generate(bool p_basic_types) {
 
 static Error _parse_methods(Ref<XMLParser> &parser, Vector<DocData::MethodDoc> &methods) {
 	String section = parser->get_node_name();
-	String element = section.substr(0, section.length() - 1);
+	String element = section.left(-1);
 
 	while (parser->read() == OK) {
 		if (parser->get_node_type() == XMLParser::NODE_ELEMENT) {

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -104,7 +104,7 @@ void EditorAssetInstaller::open_asset(const String &p_path, bool p_autoskip_topl
 		// We are only interested in subfolders, so skip the root slash.
 		int separator = source_name.find("/", 1);
 		while (separator != -1) {
-			String dir_name = source_name.substr(0, separator + 1);
+			String dir_name = source_name.left(separator + 1);
 			if (!dir_name.is_empty() && !asset_files.has(dir_name)) {
 				asset_files.insert(dir_name);
 			}
@@ -190,7 +190,7 @@ void EditorAssetInstaller::_rebuild_source_tree() {
 		if (separator == -1) {
 			parent_item = root;
 		} else {
-			String parent_path = path.substr(0, separator);
+			String parent_path = path.left(separator);
 			HashMap<String, TreeItem *>::Iterator I = directory_item_map.find(parent_path);
 			ERR_CONTINUE(!I);
 			parent_item = I->value;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -124,10 +124,8 @@ Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {
 
 	for (int i = 0; i < files[p_idx]->deps.size(); i++) {
 		String dep = files[p_idx]->deps[i];
-		int sep_idx = dep.find("::"); //may contain type information, unwanted
-		if (sep_idx != -1) {
-			dep = dep.substr(0, sep_idx);
-		}
+		dep = dep.get_slice("::", 0); // May contain type information, unwanted.
+
 		ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(dep);
 		if (uid != ResourceUID::INVALID_ID) {
 			//return proper dependency resource from uid
@@ -1464,9 +1462,7 @@ EditorFileSystemDirectory *EditorFileSystem::get_filesystem_path(const String &p
 		return filesystem;
 	}
 
-	if (f.ends_with("/")) {
-		f = f.substr(0, f.length() - 1);
-	}
+	f = f.trim_suffix("/");
 
 	Vector<String> path = f.split("/");
 

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -233,10 +233,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, HashSet<Ref<Resource>> 
 		}
 		if (E.usage & PROPERTY_USAGE_GROUP) {
 			group = E.name;
-			group_base = E.hint_string;
-			if (group_base.ends_with("_")) {
-				group_base = group_base.substr(0, group_base.length() - 1);
-			}
+			group_base = E.hint_string.trim_suffix("_");
 		}
 
 		//can unfold
@@ -253,7 +250,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, HashSet<Ref<Resource>> 
 				if (last != -1) {
 					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {
-						unfold_group.insert(E.name.substr(0, last));
+						unfold_group.insert(E.name.left(last));
 					}
 				}
 			}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -194,7 +194,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		String class_name;
 		int rfind = select.rfind(".");
 		if (rfind != -1) {
-			class_name = select.substr(0, rfind);
+			class_name = select.left(rfind);
 			select = select.substr(rfind + 1);
 		} else {
 			class_name = "@GlobalScope";
@@ -273,7 +273,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 
 			if (link.contains(".")) {
 				int class_end = link.find(".");
-				emit_signal(SNAME("go_to_help"), topic + ":" + link.substr(0, class_end) + ":" + link.substr(class_end + 1, link.length()));
+				emit_signal(SNAME("go_to_help"), topic + ":" + link.left(class_end) + ":" + link.substr(class_end + 1, link.length()));
 			}
 		}
 	} else if (p_select.begins_with("http")) {
@@ -610,10 +610,10 @@ void EditorHelp::_update_method_list(const Vector<DocData::MethodDoc> p_methods)
 
 		String group_prefix;
 		for (int i = 0; i < m.size(); i++) {
-			const String new_prefix = m[i].name.substr(0, 3);
+			const String new_prefix = m[i].name.left(3);
 			bool is_new_group = false;
 
-			if (i < m.size() - 1 && new_prefix == m[i + 1].name.substr(0, 3) && new_prefix != group_prefix) {
+			if (i < m.size() - 1 && new_prefix == m[i + 1].name.left(3) && new_prefix != group_prefix) {
 				is_new_group = i > 0;
 				group_prefix = new_prefix;
 			} else if (!group_prefix.is_empty() && new_prefix != group_prefix) {
@@ -2116,7 +2116,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 
 		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("annotation ") || tag.begins_with("theme_item ")) {
 			const int tag_end = tag.find(" ");
-			const String link_tag = tag.substr(0, tag_end);
+			const String link_tag = tag.left(tag_end);
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
 			// Use monospace font to make clickable references
@@ -2601,7 +2601,7 @@ void EditorHelpBit::_meta_clicked(String p_select) {
 		String class_name;
 		int rfind = select.rfind(".");
 		if (rfind != -1) {
-			class_name = select.substr(0, rfind);
+			class_name = select.left(rfind);
 			select = select.substr(rfind + 1);
 		} else {
 			class_name = "@GlobalScope";

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3013,7 +3013,7 @@ void EditorInspector::update_tree() {
 			const int dot = name_override.find(".");
 			if (dot != -1) {
 				feature_tag = name_override.substr(dot);
-				name_override = name_override.substr(0, dot);
+				name_override = name_override.left(dot);
 			}
 		}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -211,7 +211,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				// then slash_idx is the second '/', so that we select just "folder", and
 				// append that to yield "folder/foo.tscn".
 				if (difference > 0) {
-					String parent = full_path.substr(0, difference);
+					String parent = full_path.left(difference);
 					int slash_idx = parent.rfind("/");
 					slash_idx = parent.rfind("/", slash_idx - 1);
 					parent = (slash_idx >= 0 && parent.length() > 1) ? parent.substr(slash_idx + 1) : parent;
@@ -1263,7 +1263,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 		if (!path.is_resource_file()) {
 			int srpos = path.find("::");
 			if (srpos != -1) {
-				String base = path.substr(0, srpos);
+				String base = path.left(srpos);
 				if (!get_edited_scene() || get_edited_scene()->get_scene_file_path() != base) {
 					show_warning(TTR("This resource can't be saved because it does not belong to the edited scene. Make it unique first."));
 					return;
@@ -1671,13 +1671,7 @@ int EditorNode::_save_external_resources() {
 
 		String path = res->get_path();
 		if (path.begins_with("res://")) {
-			int subres_pos = path.find("::");
-			if (subres_pos == -1) {
-				// Actual resource.
-				edited_resources.insert(path);
-			} else {
-				edited_resources.insert(path.substr(0, subres_pos));
-			}
+			edited_resources.insert(path.get_slice("::", 0));
 		}
 
 		res->set_edited(false);
@@ -2300,7 +2294,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
-			String base_path = current_res->get_path().substr(0, subr_idx);
+			String base_path = current_res->get_path().left(subr_idx);
 			if (!base_path.is_resource_file()) {
 				if (FileAccess::exists(base_path + ".import")) {
 					if (get_edited_scene() && get_edited_scene()->get_scene_file_path() == base_path) {
@@ -3994,7 +3988,7 @@ bool EditorNode::is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_
 		// If the resource name contains '::', that means it is a subresource embedded in another resource.
 		int srpos = path.find("::");
 		if (srpos != -1) {
-			String base = path.substr(0, srpos);
+			String base = path.left(srpos);
 			// If the base resource is a packed scene, we treat it as read-only if it is not the currently edited scene.
 			if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 				if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
@@ -5883,7 +5877,7 @@ Variant EditorNode::drag_files_and_dirs(const Vector<String> &p_paths, Control *
 		Label *label = memnew(Label);
 
 		if (p_paths[i].ends_with("/")) {
-			label->set_text(p_paths[i].substr(0, p_paths[i].length() - 1).get_file());
+			label->set_text(p_paths[i].left(-1).get_file());
 			icon->set_texture(theme->get_icon(SNAME("Folder"), EditorStringName(EditorIcons)));
 		} else {
 			label->set_text(p_paths[i].get_file());

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -601,11 +601,11 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 	if (!p_hint_string.is_empty()) {
 		int hint_subtype_separator = p_hint_string.find(":");
 		if (hint_subtype_separator >= 0) {
-			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
+			String subtype_string = p_hint_string.left(hint_subtype_separator);
 			int slash_pos = subtype_string.find("/");
 			if (slash_pos >= 0) {
 				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1, subtype_string.size() - slash_pos - 1).to_int());
-				subtype_string = subtype_string.substr(0, slash_pos);
+				subtype_string = subtype_string.left(slash_pos);
 			}
 
 			subtype_hint_string = p_hint_string.substr(hint_subtype_separator + 1, p_hint_string.size() - hint_subtype_separator - 1);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -271,7 +271,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		if (placeholder_pos != -1) {
 			// Prepend executable-specific custom arguments.
 			// If nothing is placed before `%command%`, behave as if no placeholder was specified.
-			Vector<String> exec_args = _split_cmdline_args(raw_custom_args.substr(0, placeholder_pos));
+			Vector<String> exec_args = _split_cmdline_args(raw_custom_args.left(placeholder_pos));
 			if (exec_args.size() >= 1) {
 				exec = exec_args[0];
 				exec_args.remove_at(0);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1363,7 +1363,7 @@ bool EditorSettings::save_text_editor_theme_as(String p_file) {
 	if (_save_text_editor_theme(p_file)) {
 		// switch to theme is saved in the theme directory
 		list_text_editor_themes();
-		String theme_name = p_file.substr(0, p_file.length() - 4).get_file();
+		String theme_name = p_file.left(-4).get_file();
 
 		if (p_file.get_base_dir() == EditorPaths::get_singleton()->get_text_editor_themes_dir()) {
 			_initial_set("text_editor/theme/color_theme", theme_name);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -400,7 +400,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 			icon = folder_icon;
 			color = default_folder_color;
 		} else if (favorite.ends_with("/")) {
-			text = favorite.substr(0, favorite.length() - 1).get_file();
+			text = favorite.left(-1).get_file();
 			icon = folder_icon;
 			color = assigned_folder_colors.has(favorite) ? folder_colors[assigned_folder_colors[favorite]] : default_folder_color;
 		} else {
@@ -698,11 +698,8 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 	if (p_path == "Favorites") {
 		current_path = p_path;
 	} else {
-		String target_path = p_path;
 		// If the path is a file, do not only go to the directory in the tree, also select the file in the file list.
-		if (target_path.ends_with("/")) {
-			target_path = target_path.substr(0, target_path.length() - 1);
-		}
+		String target_path = p_path.trim_suffix("/");
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->file_exists(p_path)) {
 			current_path = target_path;
@@ -959,7 +956,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 					files->set_item_metadata(-1, favorite);
 				}
 			} else if (favorite.ends_with("/")) {
-				text = favorite.substr(0, favorite.length() - 1).get_file();
+				text = favorite.left(-1).get_file();
 				icon = folder_icon;
 				if (searched_string.length() == 0 || text.to_lower().find(searched_string) >= 0) {
 					files->add_item(text, icon, true);
@@ -989,8 +986,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		}
 	} else {
 		// Get infos on the directory + file.
-		if (directory.ends_with("/") && directory != "res://") {
-			directory = directory.substr(0, directory.length() - 1);
+		if (directory != "res://") {
+			directory = directory.trim_suffix("/");
 		}
 		EditorFileSystemDirectory *efd = EditorFileSystem::get_singleton()->get_filesystem_path(directory);
 		if (!efd) {
@@ -1147,7 +1144,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 	String fpath = p_path;
 	if (fpath.ends_with("/")) {
 		if (fpath != "res://") {
-			fpath = fpath.substr(0, fpath.length() - 1);
+			fpath = fpath.left(-1);
 		}
 	} else if (fpath != "Favorites") {
 		if (FileAccess::exists(fpath + ".import")) {
@@ -1440,7 +1437,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
 			p_folder_renames[folder_changed_paths[i]] = folder_changed_paths[i].replace_first(old_path, new_path);
-			emit_signal(SNAME("folder_moved"), folder_changed_paths[i], p_folder_renames[folder_changed_paths[i]].substr(0, p_folder_renames[folder_changed_paths[i]].length() - 1));
+			emit_signal(SNAME("folder_moved"), folder_changed_paths[i], p_folder_renames[folder_changed_paths[i]].left(-1));
 		}
 	} else {
 		EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + "\n");
@@ -1551,7 +1548,7 @@ void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, Str
 		int sep_pos = r->get_path().find("::");
 		if (sep_pos >= 0) {
 			extra_path = base_path.substr(sep_pos, base_path.length());
-			base_path = base_path.substr(0, sep_pos);
+			base_path = base_path.left(sep_pos);
 		}
 
 		if (p_renames.has(base_path)) {
@@ -2251,7 +2248,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 					duplicate_dialog_text->set_text(name);
 					duplicate_dialog_text->select(0, name.rfind("."));
 				} else {
-					String name = to_duplicate.path.substr(0, to_duplicate.path.length() - 1).get_file();
+					String name = to_duplicate.path.left(-1).get_file();
 					duplicate_dialog->set_title(TTR("Duplicating folder:") + " " + name);
 					duplicate_dialog_text->set_text(name);
 					duplicate_dialog_text->select(0, name.length());
@@ -2757,9 +2754,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 						// Not in the favorite section.
 						if (fpath != "res://") {
 							// We drop between two files
-							if (fpath.ends_with("/")) {
-								fpath = fpath.substr(0, fpath.length() - 1);
-							}
+							fpath = fpath.trim_suffix("/");
 							target = fpath.get_base_dir();
 							return;
 						}

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1072,7 +1072,7 @@ void EditorFileDialog::set_current_path(const String &p_path) {
 	if (pos == -1) {
 		set_current_file(p_path);
 	} else {
-		String path_dir = p_path.substr(0, pos);
+		String path_dir = p_path.left(pos);
 		String path_file = p_path.substr(pos + 1, p_path.length());
 		set_current_dir(path_dir);
 		set_current_file(path_file);
@@ -1418,7 +1418,7 @@ void EditorFileDialog::_update_favorites() {
 			if (name == current || name == current + "/") {
 				current_favorite = favorited_paths.size();
 			}
-			name = name.substr(0, name.length() - 1);
+			name = name.left(-1);
 			name = name.get_file();
 			favorited_paths.append(favorited[i]);
 			favorited_names.append(name);
@@ -1505,10 +1505,7 @@ void EditorFileDialog::_update_recent() {
 		if (res && name == "res://") {
 			name = "/";
 		} else {
-			if (name.ends_with("/")) {
-				name = name.substr(0, name.length() - 1);
-			}
-			name = name.get_file();
+			name = name.trim_suffix("/").get_file();
 		}
 		recentd_paths.append(recentd[i]);
 		recentd_names.append(name);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1079,7 +1079,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 		}
 	}
 	if (sample.is_empty()) {
-		sample = font_preview->get_supported_chars().substr(0, 6);
+		sample = font_preview->get_supported_chars().left(6);
 	}
 	font_preview_label->set_text(sample);
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -317,7 +317,7 @@ static bool _teststr(const String &p_what, const String &p_str) {
 	// Remove trailing spaces and numbers, some apps like blender add ".number" to duplicates
 	// (dot is replaced with _ as invalid character) so also compensate for this.
 	while (what.length() && (is_digit(what[what.length() - 1]) || what[what.length() - 1] <= 32 || what[what.length() - 1] == '_')) {
-		what = what.substr(0, what.length() - 1);
+		what = what.left(-1);
 	}
 
 	if (what.findn("$" + p_str) != -1) { //blender and other stuff
@@ -338,7 +338,7 @@ static String _fixstr(const String &p_what, const String &p_str) {
 	// Remove trailing spaces and numbers, some apps like blender add ".number" to duplicates
 	// (dot is replaced with _ as invalid character) so also compensate for this.
 	while (what.length() && (is_digit(what[what.length() - 1]) || what[what.length() - 1] <= 32 || what[what.length() - 1] == '_')) {
-		what = what.substr(0, what.length() - 1);
+		what = what.left(-1);
 	}
 
 	String end = p_what.substr(what.length(), p_what.length() - what.length());
@@ -347,10 +347,10 @@ static String _fixstr(const String &p_what, const String &p_str) {
 		return what.replace("$" + p_str, "") + end;
 	}
 	if (what.to_lower().ends_with("-" + p_str)) { //collada only supports "_" and "-" besides letters
-		return what.substr(0, what.length() - (p_str.length() + 1)) + end;
+		return what.left(-p_str.length() - 1) + end;
 	}
 	if (what.to_lower().ends_with("_" + p_str)) { //collada only supports "_" and "-" besides letters
-		return what.substr(0, what.length() - (p_str.length() + 1)) + end;
+		return what.left(-p_str.length() - 1) + end;
 	}
 	return what;
 }

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -165,7 +165,7 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 				if (!al_path.is_resource_file()) {
 					int srpos = al_path.find("::");
 					if (srpos != -1) {
-						String base = al_path.substr(0, srpos);
+						String base = al_path.left(srpos);
 						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 							error_dialog->set_text(TTR("This animation library can't be saved because it does not belong to the edited scene. Make it unique first."));
 							error_dialog->popup_centered();
@@ -243,7 +243,7 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 				if (!anim_path.is_resource_file()) {
 					int srpos = anim_path.find("::");
 					if (srpos != -1) {
-						String base = anim_path.substr(0, srpos);
+						String base = anim_path.left(srpos);
 						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 							error_dialog->set_text(TTR("This animation can't be saved because it does not belong to the edited scene. Make it unique first."));
 							error_dialog->popup_centered();
@@ -646,7 +646,7 @@ void AnimationLibraryEditor::update_tree() {
 			libitem->set_tooltip_text(1, al_path);
 			int srpos = al_path.find("::");
 			if (srpos != -1) {
-				String base = al_path.substr(0, srpos);
+				String base = al_path.left(srpos);
 				if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 					if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 						animation_library_is_foreign = true;
@@ -698,7 +698,7 @@ void AnimationLibraryEditor::update_tree() {
 				anitem->set_tooltip_text(1, anim_path);
 				int srpos = anim_path.find("::");
 				if (srpos != -1) {
-					String base = anim_path.substr(0, srpos);
+					String base = anim_path.left(srpos);
 					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 							anitem->set_text(1, TTR("[foreign]"));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -965,7 +965,7 @@ void EditorAssetLibrary::_search(int p_page) {
 		}
 	}
 	if (!support_list.is_empty()) {
-		args += "&support=" + support_list.substr(0, support_list.length() - 1);
+		args += "&support=" + support_list.left(-1);
 	}
 
 	if (categories->get_selected() > 0) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5844,7 +5844,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 		for (int i = 0; i < error_files.size(); i++) {
 			files_str += error_files[i].get_file().get_basename() + ",";
 		}
-		files_str = files_str.substr(0, files_str.length() - 1);
+		files_str = files_str.left(-1);
 		accept->set_text(vformat(TTR("Error instantiating scene from %s"), files_str.get_data()));
 		accept->popup_centered();
 	}

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -814,7 +814,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 		}
 	}
 	if (sample.is_empty()) {
-		sample = sampled_font->get_supported_chars().substr(0, 6);
+		sample = sampled_font->get_supported_chars().left(6);
 	}
 	Vector2 size = sampled_font->get_string_size(sample, HORIZONTAL_ALIGNMENT_LEFT, -1, 50);
 

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -929,7 +929,7 @@ void FontPreview::_notification(int p_what) {
 						}
 					}
 					if (sample.is_empty()) {
-						sample = prev_font->get_supported_chars().substr(0, 6);
+						sample = prev_font->get_supported_chars().left(6);
 					}
 					if (sample.is_empty()) {
 						prev_ok = false;

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -46,7 +46,7 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 				if (!path.is_resource_file()) {
 					int srpos = path.find("::");
 					if (srpos != -1) {
-						String base = path.substr(0, srpos);
+						String base = path.left(srpos);
 						if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 							if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 								err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -310,7 +310,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 			String path = mesh2->get_path();
 			int srpos = path.find("::");
 			if (srpos != -1) {
-				String base = path.substr(0, srpos);
+				String base = path.left(srpos);
 				if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 					if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 						err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it does not belong to the edited scene. Make it unique first."));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4421,7 +4421,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 		for (int i = 0; i < error_files.size(); i++) {
 			files_str += error_files[i].get_file().get_basename() + ",";
 		}
-		files_str = files_str.substr(0, files_str.length() - 1);
+		files_str = files_str.left(-1);
 		accept->set_text(vformat(TTR("Error instantiating scene from %s"), files_str.get_data()));
 		accept->popup_centered();
 	}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -705,7 +705,7 @@ void ScriptTextEditor::_update_bookmark_list() {
 
 		// Limit the size of the line if too big.
 		if (line.length() > 50) {
-			line = line.substr(0, 50);
+			line = line.left(50);
 		}
 
 		bookmarks_menu->add_item(String::num((int)bookmark_list[i] + 1) + " - `" + line + "`");
@@ -858,7 +858,7 @@ void ScriptTextEditor::_update_breakpoint_list() {
 
 		// Limit the size of the line if too big.
 		if (line.length() > 50) {
-			line = line.substr(0, 50);
+			line = line.left(50);
 		}
 
 		breakpoints_menu->add_item(String::num((int)breakpoint_list[i] + 1) + " - `" + line + "`");
@@ -1397,7 +1397,7 @@ void ScriptTextEditor::_edit_option(int p_op) {
 
 				for (int i = 0; i < lines.size(); i++) {
 					String line = lines[i];
-					String whitespace = line.substr(0, line.size() - line.strip_edges(true, false).size()); // Extract the whitespace at the beginning.
+					String whitespace = line.left(line.size() - line.strip_edges(true, false).size()); // Extract the whitespace at the beginning.
 					if (expression.parse(line) == OK) {
 						Variant result = expression.execute(Array(), Variant(), false, true);
 						if (expression.get_error_text().is_empty()) {

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -222,7 +222,7 @@ void TextEditor::_update_bookmark_list() {
 		String line = code_editor->get_text_editor()->get_line(bookmark_list[i]).strip_edges();
 		// Limit the size of the line if too big.
 		if (line.length() > 50) {
-			line = line.substr(0, 50);
+			line = line.left(50);
 		}
 
 		bookmarks_menu->add_item(String::num((int)bookmark_list[i] + 1) + " - \"" + line + "\"");

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -1033,7 +1033,7 @@ void TextShaderEditor::_update_bookmark_list() {
 		String line = shader_editor->get_text_editor()->get_line(bookmark_list[i]).strip_edges();
 		// Limit the size of the line if too big.
 		if (line.length() > 50) {
-			line = line.substr(0, 50);
+			line = line.left(50);
 		}
 
 		bookmarks_menu->add_item(String::num((int)bookmark_list[i] + 1) + " - \"" + line + "\"");

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -55,7 +55,7 @@ void VoxelGIEditorPlugin::_bake() {
 			if (!path.is_resource_file()) {
 				int srpos = path.find("::");
 				if (srpos != -1) {
-					String base = path.substr(0, srpos);
+					String base = path.left(srpos);
 					if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 						if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 							EditorNode::get_singleton()->show_warning(TTR("Voxel GI data is not local to the scene."));

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1800,7 +1800,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int start = line.find("move_and_slide(");
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
-			String base_obj = get_object_of_execution(line.substr(0, start));
+			String base_obj = get_object_of_execution(line.left(start));
 			String starting_space = get_starting_space(line);
 
 			Vector<String> parts = parse_arguments(line.substr(start, end));
@@ -1838,7 +1838,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 				line_new += starting_space + base_obj + "move_and_slide()";
 
 				if (!line.begins_with(starting_space + "move_and_slide")) {
-					line = line_new + "\n" + line.substr(0, start) + "velocity" + line.substr(end + start);
+					line = line_new + "\n" + line.left(start) + "velocity" + line.substr(end + start);
 				} else {
 					line = line_new + line.substr(end + start);
 				}
@@ -1851,7 +1851,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int start = line.find("move_and_slide_with_snap(");
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
-			String base_obj = get_object_of_execution(line.substr(0, start));
+			String base_obj = get_object_of_execution(line.left(start));
 			String starting_space = get_starting_space(line);
 
 			Vector<String> parts = parse_arguments(line.substr(start, end));
@@ -1894,7 +1894,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 				line_new += starting_space + base_obj + "move_and_slide()";
 
 				if (!line.begins_with(starting_space + "move_and_slide_with_snap")) {
-					line = line_new + "\n" + line.substr(0, start) + "velocity" + line.substr(end + start);
+					line = line_new + "\n" + line.left(start) + "velocity" + line.substr(end + start);
 				} else {
 					line = line_new + line.substr(end + start);
 				}
@@ -1909,7 +1909,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
-				line = line.substr(0, start) + "sort_custom(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
+				line = line.left(start) + "sort_custom(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -1919,7 +1919,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int start = line.find("list_dir_begin(");
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
-			line = line.substr(0, start) + "list_dir_begin() " + line.substr(end + start) + "# TODOConverter3To4 fill missing arguments https://github.com/godotengine/godot/pull/40547";
+			line = line.left(start) + "list_dir_begin() " + line.substr(end + start) + "# TODOConverter3To4 fill missing arguments https://github.com/godotengine/godot/pull/40547";
 		}
 	}
 
@@ -1930,7 +1930,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
-				line = line.substr(0, start) + "draw_line(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")" + line.substr(end + start);
+				line = line.left(start) + "draw_line(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -1943,7 +1943,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 
-			String start_string = line.substr(0, start) + "(";
+			String start_string = line.left(start) + "(";
 			for (int i = 0; i < parts.size(); i++) {
 				start_string += parts[i].strip_edges().trim_prefix("var ");
 				if (i != parts.size() - 1) {
@@ -1962,9 +1962,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
 				if (builtin) {
-					line = line.substr(0, start) + "await " + parts[0] + "." + parts[1].replace("\\\"", "").replace("\\'", "").replace(" ", "") + line.substr(end + start);
+					line = line.left(start) + "await " + parts[0] + "." + parts[1].replace("\\\"", "").replace("\\'", "").replace(" ", "") + line.substr(end + start);
 				} else {
-					line = line.substr(0, start) + "await " + parts[0] + "." + parts[1].replace("\"", "").replace("\'", "").replace(" ", "") + line.substr(end + start);
+					line = line.left(start) + "await " + parts[0] + "." + parts[1].replace("\"", "").replace("\'", "").replace(" ", "") + line.substr(end + start);
 				}
 			}
 		}
@@ -1976,7 +1976,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
-			line = line.substr(0, start) + "JSON.new().stringify(" + connect_arguments(parts, 0) + ")" + line.substr(end + start);
+			line = line.left(start) + "JSON.new().stringify(" + connect_arguments(parts, 0) + ")" + line.substr(end + start);
 		}
 	}
 
@@ -1987,7 +1987,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 1) {
-				line = line.substr(0, start) + " * (" + parts[0] + ")" + line.substr(end + start);
+				line = line.left(start) + " * (" + parts[0] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -1997,12 +1997,12 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int start = line.find(".xform_inv(");
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
-			String object_exec = get_object_of_execution(line.substr(0, start));
+			String object_exec = get_object_of_execution(line.left(start));
 			if (line.contains(object_exec + ".xform")) {
 				int start2 = line.find(object_exec + ".xform");
 				Vector<String> parts = parse_arguments(line.substr(start, end));
 				if (parts.size() == 1) {
-					line = line.substr(0, start2) + "(" + parts[0] + ") * " + object_exec + line.substr(end + start);
+					line = line.left(start2) + "(" + parts[0] + ") * " + object_exec + line.substr(end + start);
 				}
 			}
 		}
@@ -2015,9 +2015,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "connect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "connect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			} else if (parts.size() >= 4) {
-				line = line.substr(0, start) + "connect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + ").bind(" + parts[3].lstrip(" [").rstrip("] ") + ")" + connect_arguments(parts, 4) + ")" + line.substr(end + start);
+				line = line.left(start) + "connect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + ").bind(" + parts[3].lstrip(" [").rstrip("] ") + ")" + connect_arguments(parts, 4) + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2028,7 +2028,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "disconnect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "disconnect(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2039,7 +2039,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "is_connected(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "is_connected(" + parts[0] + ", Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2051,9 +2051,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
-				line = line.substr(0, start) + "tween_method(Callable(" + parts[0] + ", " + parts[1] + "), " + parts[2] + ", " + parts[3] + ", " + parts[4] + ")" + line.substr(end + start);
+				line = line.left(start) + "tween_method(Callable(" + parts[0] + ", " + parts[1] + "), " + parts[2] + ", " + parts[3] + ", " + parts[4] + ")" + line.substr(end + start);
 			} else if (parts.size() >= 6) {
-				line = line.substr(0, start) + "tween_method(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + connect_arguments(parts, 5).substr(1).lstrip(" [").rstrip("] ") + "), " + parts[2] + ", " + parts[3] + ", " + parts[4] + ")" + line.substr(end + start);
+				line = line.left(start) + "tween_method(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + connect_arguments(parts, 5).substr(1).lstrip(" [").rstrip("] ") + "), " + parts[2] + ", " + parts[3] + ", " + parts[4] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2064,9 +2064,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
-				line = line.substr(0, start) + "tween_callback(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
+				line = line.left(start) + "tween_callback(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
 			} else if (parts.size() >= 3) {
-				line = line.substr(0, start) + "tween_callback(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + connect_arguments(parts, 2).substr(1).lstrip(" [").rstrip("] ") + "))" + line.substr(end + start);
+				line = line.left(start) + "tween_callback(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + connect_arguments(parts, 2).substr(1).lstrip(" [").rstrip("] ") + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2080,9 +2080,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			if (end > -1) {
 				Vector<String> parts = parse_arguments(line.substr(start, end));
 				if (parts.size() == 2) {
-					line = line.substr(0, start) + "start(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
+					line = line.left(start) + "start(Callable(" + parts[0] + ", " + parts[1] + "))" + line.substr(end + start);
 				} else if (parts.size() >= 3) {
-					line = line.substr(0, start) + "start(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + parts[2] + ")" + connect_arguments(parts, 3) + ")" + line.substr(end + start);
+					line = line.left(start) + "start(Callable(" + parts[0] + ", " + parts[1] + ").bind(" + parts[2] + ")" + connect_arguments(parts, 3) + ")" + line.substr(end + start);
 				}
 			}
 		}
@@ -2095,7 +2095,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		int super_start = line.find(".(");
 		int super_end = line.rfind(")");
 		if (super_start > 0 && super_end > super_start) {
-			line = line.substr(0, super_start) + line.substr(super_end + 1) + "\n" + String("\t").repeat(indent + 1) + "super" + line.substr(super_start + 1, super_end - super_start);
+			line = line.left(super_start) + line.substr(super_end + 1) + "\n" + String("\t").repeat(indent + 1) + "super" + line.substr(super_start + 1, super_end - super_start);
 		}
 	}
 
@@ -2106,7 +2106,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
-				line = line.substr(0, start) + "create_from_image(" + parts[0] + ") " + "#," + parts[1] + line.substr(end + start);
+				line = line.left(start) + "create_from_image(" + parts[0] + ") " + "#," + parts[1] + line.substr(end + start);
 			}
 		}
 	}
@@ -2117,7 +2117,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() > 2) {
-				line = line.substr(0, start) + "set_cell_item(Vector3(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ")" + connect_arguments(parts, 3).lstrip(" ") + ")" + line.substr(end + start);
+				line = line.left(start) + "set_cell_item(Vector3(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ")" + connect_arguments(parts, 3).lstrip(" ") + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2128,7 +2128,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "get_cell_item(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "get_cell_item(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2139,7 +2139,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "get_cell_item_orientation(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "get_cell_item_orientation(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2150,7 +2150,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
-				line = line.substr(0, start) + "apply_impulse(" + parts[1] + ", " + parts[0] + ")" + line.substr(end + start);
+				line = line.left(start) + "apply_impulse(" + parts[1] + ", " + parts[0] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2161,7 +2161,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 2) {
-				line = line.substr(0, start) + "apply_force(" + parts[1] + ", " + parts[0] + ")" + line.substr(end + start);
+				line = line.left(start) + "apply_force(" + parts[1] + ", " + parts[0] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2172,9 +2172,9 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "map_to_local(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "map_to_local(Vector3i(" + parts[0] + ", " + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			} else if (parts.size() == 1) {
-				line = line.substr(0, start) + "map_to_local(" + parts[0] + ")" + line.substr(end + start);
+				line = line.left(start) + "map_to_local(" + parts[0] + ")" + line.substr(end + start);
 			}
 		}
 	}
@@ -2187,7 +2187,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 1) {
 				String opposite = parts[0] == "true" ? "false" : "true";
-				line = line.substr(0, start) + "set_ignore_rotation(" + opposite + ")";
+				line = line.left(start) + "set_ignore_rotation(" + opposite + ")";
 			}
 		}
 	}
@@ -2199,7 +2199,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 0) {
-				line = line.substr(0, start) + "DisplayServer.get_display_safe_area()" + line.substr(end + start);
+				line = line.left(start) + "DisplayServer.get_display_safe_area()" + line.substr(end + start);
 			}
 		}
 	}
@@ -2210,7 +2210,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 5) {
-				line = line.substr(0, start) + "draw_rect(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")" + line.substr(end + start) + "# " + parts[4] + ") TODOConverter3To4 Antialiasing argument is missing";
+				line = line.left(start) + "draw_rect(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")" + line.substr(end + start) + "# " + parts[4] + ") TODOConverter3To4 Antialiasing argument is missing";
 			}
 		}
 	}
@@ -2235,7 +2235,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			}
 		}
 		if (foundNextEqual) {
-			line = line.substr(0, start) + ".button_pressed" + line.substr(start + String(".pressed").length());
+			line = line.left(start) + ".button_pressed" + line.substr(start + String(".pressed").length());
 		}
 	}
 
@@ -2259,7 +2259,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 			}
 		}
 		if (foundNextEqual) {
-			line = line.substr(0, start) + "ignore_rotation = " + assigned_value + " # reversed \"rotating\" for Camera2D";
+			line = line.left(start) + "ignore_rotation = " + assigned_value + " # reversed \"rotating\" for Camera2D";
 		}
 	}
 
@@ -2368,7 +2368,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 			if (end > -1) {
 				Vector<String> parts = parse_arguments(line.substr(start, end));
 				if (parts.size() >= 3) {
-					line = line.substr(0, start) + "Connect(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + ")" + connect_arguments(parts, 3) + ")" + line.substr(end + start);
+					line = line.left(start) + "Connect(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + ")" + connect_arguments(parts, 3) + ")" + line.substr(end + start);
 				}
 			}
 		}
@@ -2380,7 +2380,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "Disconnect(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "Disconnect(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2391,7 +2391,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
 			if (parts.size() == 3) {
-				line = line.substr(0, start) + "IsConnected(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
+				line = line.left(start) + "IsConnected(" + parts[0] + ", new Callable(" + parts[1] + ", " + parts[2] + "))" + line.substr(end + start);
 			}
 		}
 	}
@@ -2881,13 +2881,13 @@ Vector<String> ProjectConverter3To4::check_for_rename_common(const char *array[]
 // Line (67) remove -> remove_at  -  LINE """ doubler._blacklist.remove(0) """
 String ProjectConverter3To4::line_formatter(int current_line, String from, String to, String line) {
 	if (from.size() > 200) {
-		from = from.substr(0, 197) + "...";
+		from = from.left(197) + "...";
 	}
 	if (to.size() > 200) {
-		to = to.substr(0, 197) + "...";
+		to = to.left(197) + "...";
 	}
 	if (line.size() > 400) {
-		line = line.substr(0, 397) + "...";
+		line = line.left(397) + "...";
 	}
 
 	from = from.strip_escapes();
@@ -2901,10 +2901,10 @@ String ProjectConverter3To4::line_formatter(int current_line, String from, Strin
 // Line (1) - FULL LINES - """yield(get_tree().create_timer(3), 'timeout')"""  =====>  """ await get_tree().create_timer(3).timeout """
 String ProjectConverter3To4::simple_line_formatter(int current_line, String old_line, String new_line) {
 	if (old_line.size() > 1000) {
-		old_line = old_line.substr(0, 997) + "...";
+		old_line = old_line.left(997) + "...";
 	}
 	if (new_line.size() > 1000) {
-		new_line = new_line.substr(0, 997) + "...";
+		new_line = new_line.left(997) + "...";
 	}
 
 	old_line = old_line.replace("\r", "").replace("\n", "").strip_edges();

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -556,7 +556,7 @@ void ProjectDialog::ok_pressed() {
 
 					String name = String::utf8(fname);
 					if (name.ends_with("project.godot")) {
-						zip_root = name.substr(0, name.rfind("project.godot"));
+						zip_root = name.trim_suffix("project.godot");
 						break;
 					}
 
@@ -581,7 +581,7 @@ void ProjectDialog::ok_pressed() {
 					if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
 						//
 					} else if (path.ends_with("/")) { // a dir
-						path = path.substr(0, path.length() - 1);
+						path = path.left(-1);
 						String rel_path = path.substr(zip_root.length());
 
 						Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
@@ -630,10 +630,7 @@ void ProjectDialog::ok_pressed() {
 			}
 		}
 
-		dir = dir.replace("\\", "/");
-		if (dir.ends_with("/")) {
-			dir = dir.substr(0, dir.length() - 1);
-		}
+		dir = dir.replace("\\", "/").trim_suffix("/");
 
 		hide();
 		emit_signal(SNAME("project_created"), dir);
@@ -1059,7 +1056,7 @@ void ProjectListItemControl::set_project_icon(const Ref<Texture2D> &p_icon) {
 }
 
 bool _project_feature_looks_like_version(const String &p_feature) {
-	return p_feature.contains(".") && p_feature.substr(0, 3).is_numeric();
+	return p_feature.contains(".") && p_feature.left(3).is_numeric();
 }
 
 void ProjectListItemControl::set_unsupported_features(PackedStringArray p_features) {
@@ -2653,7 +2650,7 @@ void ProjectManager::_install_project(const String &p_zip_path, const String &p_
 void ProjectManager::_files_dropped(PackedStringArray p_files) {
 	if (p_files.size() == 1 && p_files[0].ends_with(".zip")) {
 		const String file = p_files[0].get_file();
-		_install_project(p_files[0], file.substr(0, file.length() - 4).capitalize());
+		_install_project(p_files[0], file.left(-4).capitalize());
 		return;
 	}
 	HashSet<String> folders_set;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1383,7 +1383,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (sep == -1) {
 				path = ".";
 			} else {
-				path = file.substr(0, sep);
+				path = file.left(sep);
 			}
 			if (OS::get_singleton()->set_cwd(path) == OK) {
 				// path already specified, don't override
@@ -3321,7 +3321,7 @@ bool Main::start() {
 
 							local_game_path = da->get_current_dir().path_join(local_game_path);
 						} else {
-							Ref<DirAccess> da = DirAccess::open(local_game_path.substr(0, sep));
+							Ref<DirAccess> da = DirAccess::open(local_game_path.left(sep));
 							if (da.is_valid()) {
 								local_game_path = da->get_current_dir().path_join(
 										local_game_path.substr(sep + 1, local_game_path.length()));

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3065,21 +3065,14 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			}
 
 			for (const MethodInfo &mi : virtual_methods) {
-				String method_hint = mi.name;
-				if (method_hint.contains(":")) {
-					method_hint = method_hint.get_slice(":", 0);
-				}
-				method_hint += "(";
+				String method_hint = mi.name.get_slice(":", 0) + "(";
 
 				if (mi.arguments.size()) {
 					for (int i = 0; i < mi.arguments.size(); i++) {
 						if (i > 0) {
 							method_hint += ", ";
 						}
-						String arg = mi.arguments[i].name;
-						if (arg.contains(":")) {
-							arg = arg.substr(0, arg.find(":"));
-						}
+						String arg = mi.arguments[i].name.get_slice(":", 0);
 						method_hint += arg;
 						if (use_type_hint) {
 							method_hint += ": " + _get_visual_datatype(mi.arguments[i], true, class_name);

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -625,7 +625,7 @@ String ExtendGDScriptParser::get_text_for_completion(const lsp::Position &p_curs
 	int len = lines.size();
 	for (int i = 0; i < len; i++) {
 		if (i == p_cursor.line) {
-			longthing += lines[i].substr(0, p_cursor.character);
+			longthing += lines[i].left(p_cursor.character);
 			longthing += String::chr(0xFFFF); // Not unicode, represents the cursor.
 			longthing += lines[i].substr(p_cursor.character, lines[i].size());
 		} else {
@@ -646,14 +646,14 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const lsp::Position &p_c
 	for (int i = 0; i < len; i++) {
 		if (i == p_cursor.line) {
 			String line = lines[i];
-			String first_part = line.substr(0, p_cursor.character);
+			String first_part = line.left(p_cursor.character);
 			String last_part = line.substr(p_cursor.character, lines[i].length());
 			if (!p_symbol.is_empty()) {
 				String left_cursor_text;
 				for (int c = p_cursor.character - 1; c >= 0; c--) {
 					left_cursor_text = line.substr(c, p_cursor.character - c);
 					if (p_symbol.begins_with(left_cursor_text)) {
-						first_part = line.substr(0, c);
+						first_part = line.left(c);
 						first_part += p_symbol;
 						break;
 					}

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -71,9 +71,9 @@ void GDScriptWorkspace::apply_new_signal(Object *obj, String function, PackedStr
 	int first_class = source.find("\nclass ");
 	int start_line = 0;
 	if (first_class != -1) {
-		start_line = source.substr(0, first_class).split("\n").size();
+		start_line = source.left(first_class).get_slice_count("\n");
 	} else {
-		start_line = source.split("\n").size();
+		start_line = source.get_slice_count("\n");
 	}
 
 	String function_body = "\n\n" + function_signature + "(";

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -314,7 +314,7 @@ static bool _test_blender_path(const String &p_path, String *r_err = nullptr) {
 		}
 		return false;
 	}
-	String v = pipe.substr(0, pp);
+	String v = pipe.left(pp);
 	int version = v.to_int();
 	if (version < 3) {
 		if (r_err) {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -266,7 +266,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			pos = brk_pos + 1;
 		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ") || tag.begins_with("param ")) {
 			const int tag_end = tag.find(" ");
-			const String link_tag = tag.substr(0, tag_end);
+			const String link_tag = tag.left(tag_end);
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
 			const Vector<String> link_target_parts = link_target.split(".");
@@ -2157,7 +2157,7 @@ Error BindingsGenerator::_generate_cs_method(const BindingsGenerator::TypeInterf
 
 			String cs_type = arg_cs_type;
 			if (cs_type.ends_with("[]")) {
-				cs_type = cs_type.substr(0, cs_type.length() - 2);
+				cs_type = cs_type.left(-2);
 			}
 
 			String def_arg = sformat(iarg.default_argument, cs_type);

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -213,7 +213,7 @@ String relative_to_impl(const String &p_path, const String &p_relative_to) {
 String get_drive_letter(const String &p_norm_path) {
 	int idx = p_norm_path.find(":/");
 	if (idx != -1 && idx < p_norm_path.find("/")) {
-		return p_norm_path.substr(0, idx + 1);
+		return p_norm_path.left(idx + 1);
 	}
 	return String();
 }

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -139,7 +139,7 @@ void EditorNetworkProfiler::refresh_replication_data() {
 		int cfg_idx = cfg_info.path.find("::");
 		if (cfg_info.path.begins_with("res://") && ResourceLoader::exists(cfg_info.path) && cfg_idx > 0) {
 			String res_idstr = cfg_info.path.substr(cfg_idx + 2).replace("SceneReplicationConfig_", "");
-			String scene_path = cfg_info.path.substr(0, cfg_idx);
+			String scene_path = cfg_info.path.left(cfg_idx);
 			node->set_text(2, vformat("%s (%s)", res_idstr, scene_path.get_file()));
 			node->add_button(2, theme_cache.instance_options_icon);
 			node->set_tooltip_text(2, cfg_info.path);

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -566,7 +566,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 	Node *root_node = current && !current->get_root_path().is_empty() ? current->get_node(current->get_root_path()) : nullptr;
 	Ref<Texture2D> icon = _get_class_icon(root_node);
 	if (root_node) {
-		String path = prop.substr(0, prop.find(":"));
+		String path = prop.get_slice(":", 0);
 		String subpath = prop.substr(path.size());
 		Node *node = root_node->get_node_or_null(path);
 		if (!node) {

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -76,7 +76,7 @@ void NavigationMeshEditor::_bake_pressed() {
 	if (!path.is_resource_file()) {
 		int srpos = path.find("::");
 		if (srpos != -1) {
-			String base = path.substr(0, srpos);
+			String base = path.left(srpos);
 			if (ResourceLoader::get_resource_type(base) == "PackedScene") {
 				if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 					err_dialog->set_text(TTR("Cannot generate navigation mesh because it does not belong to the edited scene. Make it unique first."));

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1054,7 +1054,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	// Assumes that the file name length limit is 255 characters.
 	String file_name = path.get_file();
 	if (file_name.length() > 240) {
-		file_name = file_name.substr(0, file_name.length() - 15);
+		file_name = file_name.left(-15);
 	}
 
 	String dest_path = trash_path + "/files/" + file_name;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -2106,7 +2106,7 @@ void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<A
 			activity.push_back(a);
 		}
 		input_activity_map[p_base_path] = activity;
-		input_activity_map_get[String(p_base_path).substr(0, String(p_base_path).length() - 1)] = &input_activity_map[p_base_path];
+		input_activity_map_get[String(p_base_path).left(-1)] = &input_activity_map[p_base_path];
 	}
 
 	List<PropertyInfo> plist;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -145,7 +145,7 @@ void CodeEdit::_notification(int p_what) {
 
 					for (int j = 0; j < code_completion_options[l].matches.size(); j++) {
 						Pair<int, int> match_segment = code_completion_options[l].matches[j];
-						int match_offset = theme_cache.font->get_string_size(code_completion_options[l].display.substr(0, match_segment.first), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width;
+						int match_offset = theme_cache.font->get_string_size(code_completion_options[l].display.left(match_segment.first), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width;
 						int match_len = theme_cache.font->get_string_size(code_completion_options[l].display.substr(match_segment.first, match_segment.second), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).width;
 
 						draw_rect(Rect2(match_pos + Point2(match_offset, 0), Size2(match_len, row_height)), theme_cache.code_completion_existing_color);
@@ -176,7 +176,7 @@ void CodeEdit::_notification(int p_what) {
 				}
 				Size2 minsize = theme_cache.code_hint_style->get_minimum_size() + Size2(max_width, line_count * font_height + (theme_cache.line_spacing * line_count - 1));
 
-				int offset = theme_cache.font->get_string_size(code_hint_lines[0].substr(0, code_hint_lines[0].find(String::chr(0xFFFF))), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
+				int offset = theme_cache.font->get_string_size(code_hint_lines[0].get_slice(String::chr(0xFFFF), 0), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
 				if (code_hint_xpos == -0xFFFF) {
 					code_hint_xpos = get_caret_draw_pos().x - offset;
 				}
@@ -196,8 +196,8 @@ void CodeEdit::_notification(int p_what) {
 					int begin = 0;
 					int end = 0;
 					if (line.contains(String::chr(0xFFFF))) {
-						begin = theme_cache.font->get_string_size(line.substr(0, line.find(String::chr(0xFFFF))), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
-						end = theme_cache.font->get_string_size(line.substr(0, line.rfind(String::chr(0xFFFF))), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
+						begin = theme_cache.font->get_string_size(line.get_slice(String::chr(0xFFFF), 0), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
+						end = theme_cache.font->get_string_size(line.get_slice(String::chr(0xFFFF), 0), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
 					}
 
 					Point2 round_ofs = hint_ofs + theme_cache.code_hint_style->get_offset() + Vector2(0, theme_cache.font->get_ascent(theme_cache.font_size) + font_height * i + yofs);
@@ -2078,7 +2078,7 @@ String CodeEdit::get_text_for_code_completion() const {
 		String line = get_line(i);
 
 		if (i == get_caret_line()) {
-			completion_text += line.substr(0, get_caret_column());
+			completion_text += line.left(get_caret_column());
 			/* Not unicode, represents the caret. */
 			completion_text += String::chr(0xFFFF);
 			completion_text += line.substr(get_caret_column(), line.size());
@@ -2273,7 +2273,7 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 			set_caret_column(get_caret_column(i) - code_completion_base.length(), false, i);
 
 			// Merge with text.
-			insert_text_at_caret(insert_text.substr(0, code_completion_base.length()), i);
+			insert_text_at_caret(insert_text.left(code_completion_base.length()), i);
 			set_caret_column(caret_col, false, i);
 			insert_text_at_caret(insert_text.substr(matching_chars), i);
 		}
@@ -2375,7 +2375,7 @@ String CodeEdit::get_text_with_cursor_char(int p_line, int p_column) const {
 	for (int i = 0; i < text_size; i++) {
 		String line_text = get_line(i);
 		if (i == p_line && p_column >= 0 && p_column <= line_text.size()) {
-			result += line_text.substr(0, p_column);
+			result += line_text.left(p_column);
 			/* Not unicode, represents the cursor. */
 			result += String::chr(0xFFFF);
 			result += line_text.substr(p_column, line_text.size());

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -766,7 +766,7 @@ void FileDialog::set_current_path(const String &p_path) {
 	if (pos == -1) {
 		set_current_file(p_path);
 	} else {
-		String path_dir = p_path.substr(0, pos);
+		String path_dir = p_path.left(pos);
 		String path_file = p_path.substr(pos + 1, p_path.length());
 		set_current_dir(path_dir);
 		set_current_file(path_file);

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -117,7 +117,7 @@ void Label::_shape() {
 		ERR_FAIL_COND(font.is_null());
 		String txt = (uppercase) ? TS->string_to_upper(xl_text, language) : xl_text;
 		if (visible_chars >= 0 && visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
-			txt = txt.substr(0, visible_chars);
+			txt = txt.left(visible_chars);
 		}
 		if (dirty) {
 			TS->shaped_text_add_string(text_rid, txt, font->get_rids(), font_size, font->get_opentype_features(), language);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -141,7 +141,7 @@ void LineEdit::_backspace(bool p_word, bool p_all_to_left) {
 
 	if (p_all_to_left) {
 		deselect();
-		text = text.substr(0, caret_column);
+		text = text.left(caret_column);
 		_text_changed();
 		return;
 	}
@@ -1738,10 +1738,10 @@ void LineEdit::insert_text_at_caret(String p_text) {
 		int available_chars = max_length - text.length();
 		if (p_text.length() > available_chars) {
 			emit_signal(SNAME("text_change_rejected"), p_text.substr(available_chars));
-			p_text = p_text.substr(0, available_chars);
+			p_text = p_text.left(available_chars);
 		}
 	}
-	String pre = text.substr(0, caret_column);
+	String pre = text.left(caret_column);
 	String post = text.substr(caret_column, text.length() - caret_column);
 	text = pre + p_text + post;
 	_shape();
@@ -2283,7 +2283,7 @@ void LineEdit::_shape() {
 		t = secret_character.repeat(text.length() + ime_text.length());
 	} else {
 		if (ime_text.length() > 0) {
-			t = text.substr(0, caret_column) + ime_text + text.substr(caret_column, text.length());
+			t = text.left(caret_column) + ime_text + text.substr(caret_column, text.length());
 		} else {
 			t = text;
 		}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -574,7 +574,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				String lang = _find_language(it);
 				String tx = t->text;
 				if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING && visible_characters >= 0 && remaining_characters >= 0) {
-					tx = tx.substr(0, remaining_characters);
+					tx = tx.left(remaining_characters);
 				}
 				remaining_characters -= tx.length();
 
@@ -4019,7 +4019,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				const String &expr = split_tag_block[i];
 				int value_pos = expr.find("=");
 				if (value_pos > -1) {
-					bbcode_options[expr.substr(0, value_pos)] = expr.substr(value_pos + 1).unquote();
+					bbcode_options[expr.left(value_pos)] = expr.substr(value_pos + 1).unquote();
 				}
 			}
 		} else {
@@ -4031,7 +4031,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 		int main_value_pos = bbcode_name.find("=");
 		if (main_value_pos > -1) {
 			bbcode_value = bbcode_name.substr(main_value_pos + 1);
-			bbcode_name = bbcode_name.substr(0, main_value_pos);
+			bbcode_name = bbcode_name.left(main_value_pos);
 		}
 
 		if (tag.begins_with("/") && tag_stack.size()) {
@@ -4598,7 +4598,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 					if (sep == -1) {
 						width = bbcode_value.to_int();
 					} else {
-						width = bbcode_value.substr(0, sep).to_int();
+						width = bbcode_value.left(sep).to_int();
 						height = bbcode_value.substr(sep + 1).to_int();
 					}
 				} else {
@@ -5384,7 +5384,7 @@ String RichTextLabel::_get_line_text(ItemFrame *p_frame, int p_line, Selection p
 		}
 	}
 	if ((l.from != nullptr) && (p_frame == p_selection.to_frame) && (p_selection.to_item != nullptr) && (p_selection.to_item->index >= l.from->index) && (p_selection.to_item->index < end_idx)) {
-		txt = txt.substr(0, p_selection.to_char);
+		txt = txt.left(p_selection.to_char);
 	}
 	if ((l.from != nullptr) && (p_frame == p_selection.from_frame) && (p_selection.from_item != nullptr) && (p_selection.from_item->index >= l.from->index) && (p_selection.from_item->index < end_idx)) {
 		txt = txt.substr(p_selection.from_char, -1);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1575,7 +1575,7 @@ void TextEdit::_notification(int p_what) {
 				for (int i = 0; i < carets.size(); i++) {
 					String t;
 					if (get_caret_column(i) >= 0) {
-						t = text[get_caret_line(i)].substr(0, get_caret_column(i)) + ime_text + text[get_caret_line(i)].substr(get_caret_column(i), text[get_caret_line(i)].length());
+						t = text[get_caret_line(i)].left(get_caret_column(i)) + ime_text + text[get_caret_line(i)].substr(get_caret_column(i), text[get_caret_line(i)].length());
 					} else {
 						t = ime_text;
 					}
@@ -3571,7 +3571,7 @@ void TextEdit::insert_text_at_caret(const String &p_text, int p_caret) {
 		for (int i = 0; i < carets.size(); i++) {
 			String t;
 			if (get_caret_column(i) >= 0) {
-				t = text[get_caret_line(i)].substr(0, get_caret_column(i)) + ime_text + text[get_caret_line(i)].substr(get_caret_column(i), text[get_caret_line(i)].length());
+				t = text[get_caret_line(i)].left(get_caret_column(i)) + ime_text + text[get_caret_line(i)].substr(get_caret_column(i), text[get_caret_line(i)].length());
 			} else {
 				t = ime_text;
 			}
@@ -7787,7 +7787,7 @@ void TextEdit::_base_insert_text(int p_line, int p_char, const String &p_text, i
 	/* STEP 3: Separate dest string in pre and post text. */
 	String postinsert_text = text[p_line].substr(p_char, text[p_line].size());
 
-	substrings.write[0] = text[p_line].substr(0, p_char) + substrings[0];
+	substrings.write[0] = text[p_line].left(p_char) + substrings[0];
 	substrings.write[substrings.size() - 1] += postinsert_text;
 
 	Vector<Array> bidi_override;
@@ -7853,7 +7853,7 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 	ERR_FAIL_COND(p_to_line < p_from_line); // 'from > to'.
 	ERR_FAIL_COND(p_to_line == p_from_line && p_to_column < p_from_column); // 'from > to'.
 
-	String pre_text = text[p_from_line].substr(0, p_from_column);
+	String pre_text = text[p_from_line].left(p_from_column);
 	String post_text = text[p_to_line].substr(p_to_column, text[p_to_line].length());
 
 	text.remove_range(p_from_line, p_to_line);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1319,7 +1319,7 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 	for (int i = name_string.length() - 1; i >= 0; i--) {
 		char32_t n = name_string[i];
 		if (is_digit(n)) {
-			nums = String::chr(name_string[i]) + nums;
+			nums = String::chr(n) + nums;
 		} else {
 			break;
 		}
@@ -1328,9 +1328,9 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 	String nnsep = _get_name_num_separator();
 	int name_last_index = name_string.length() - nnsep.length() - nums.length();
 
-	// Assign the base name + separator to name if we have numbers preceded by a separator
+	// Assign the base name + separator to name if we have numbers preceded by a separator.
 	if (nums.length() > 0 && name_string.substr(name_last_index, nnsep.length()) == nnsep) {
-		name_string = name_string.substr(0, name_last_index + nnsep.length());
+		name_string = name_string.left(name_last_index + nnsep.length());
 	} else {
 		nums = "";
 	}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -699,12 +699,12 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		} else if (E.type == Variant::ARRAY && E.hint == PROPERTY_HINT_TYPE_STRING) {
 			int hint_subtype_separator = E.hint_string.find(":");
 			if (hint_subtype_separator >= 0) {
-				String subtype_string = E.hint_string.substr(0, hint_subtype_separator);
+				String subtype_string = E.hint_string.left(hint_subtype_separator);
 				int slash_pos = subtype_string.find("/");
 				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (slash_pos >= 0) {
 					subtype_hint = PropertyHint(subtype_string.get_slice("/", 1).to_int());
-					subtype_string = subtype_string.substr(0, slash_pos);
+					subtype_string = subtype_string.left(slash_pos);
 				}
 				Variant::Type subtype = Variant::Type(subtype_string.to_int());
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2027,7 +2027,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		if (cached_id.is_empty() || cached_ids_found.has(cached_id)) {
 			int sep_pos = E.value.find("_");
 			if (sep_pos != -1) {
-				E.value = E.value.substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
+				E.value = E.value.left(sep_pos + 1); // Keep the order found, for improved thread loading performance.
 			} else {
 				E.value = "";
 			}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1391,7 +1391,7 @@ String VisualShader::validate_parameter_name(const String &p_name, const Ref<Vis
 			//remove numbers, put new and try again
 			attempt++;
 			while (param_name.length() && is_digit(param_name[param_name.length() - 1])) {
-				param_name = param_name.substr(0, param_name.length() - 1);
+				param_name = param_name.left(-1);
 			}
 			ERR_FAIL_COND_V(param_name.is_empty(), String());
 			param_name += itos(attempt);
@@ -4242,10 +4242,10 @@ void VisualShaderNodeGroupBase::remove_input_port(int p_id) {
 	inputs = inputs.left(index) + inputs.substr(index + count);
 
 	inputs_strings = inputs.split(";", false);
-	inputs = inputs.substr(0, index);
+	inputs = inputs.left(index);
 
 	for (int i = p_id; i < inputs_strings.size(); i++) {
-		inputs += inputs_strings[i].replace_first(inputs_strings[i].split(",")[0], itos(i)) + ";";
+		inputs += inputs_strings[i].replace_first(inputs_strings[i].get_slice(",", 0), itos(i)) + ";";
 	}
 
 	_apply_port_changes();
@@ -4317,10 +4317,10 @@ void VisualShaderNodeGroupBase::remove_output_port(int p_id) {
 	outputs = outputs.left(index) + outputs.substr(index + count);
 
 	outputs_strings = outputs.split(";", false);
-	outputs = outputs.substr(0, index);
+	outputs = outputs.left(index);
 
 	for (int i = p_id; i < outputs_strings.size(); i++) {
-		outputs += outputs_strings[i].replace_first(outputs_strings[i].split(",")[0], itos(i)) + ";";
+		outputs += outputs_strings[i].replace_first(outputs_strings[i].get_slice(",", 0), itos(i)) + ";";
 	}
 
 	_apply_port_changes();

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -674,7 +674,7 @@ void ShaderPreprocessor::process_include(Tokenizer *p_tokenizer) {
 			break;
 		}
 	}
-	path = path.substr(0, path.length() - 1);
+	path = path.left(-1);
 
 	if (path.is_empty() || !p_tokenizer->consume_empty_line()) {
 		set_error(RTR("Invalid path."), line);
@@ -956,7 +956,7 @@ Error ShaderPreprocessor::expand_condition(const String &p_string, int p_line, S
 			String body = state->defines.has(vector_to_string(text)) ? "true" : "false";
 			String temp = result;
 
-			result = result.substr(0, index) + body;
+			result = result.left(index) + body;
 			index_start = result.length();
 			if (index_end > 0) {
 				result += temp.substr(index_end);
@@ -1074,7 +1074,7 @@ bool ShaderPreprocessor::expand_macros_once(const String &p_line, int p_line_num
 				int arg_index_start = 0;
 				int arg_index = 0;
 				while (find_match(body, arg_name, arg_index, arg_index_start)) {
-					body = body.substr(0, arg_index) + args[i] + body.substr(arg_index + arg_name.length(), body.length() - (arg_index + arg_name.length()));
+					body = body.left(arg_index) + args[i] + body.substr(arg_index + arg_name.length(), body.length() - (arg_index + arg_name.length()));
 					// Manually reset arg_index_start to where the arg value of the define finishes.
 					// This ensures we don't skip the other args of this macro in the string.
 					arg_index_start = arg_index + args[i].length() + 1;
@@ -1083,11 +1083,11 @@ bool ShaderPreprocessor::expand_macros_once(const String &p_line, int p_line_num
 
 			concatenate_macro_body(body);
 
-			result = result.substr(0, index) + " " + body + " " + result.substr(args_end + 1, result.length());
+			result = result.left(index) + " " + body + " " + result.substr(args_end + 1, result.length());
 		} else {
 			concatenate_macro_body(body);
 
-			result = result.substr(0, index) + " " + body + " " + result.substr(index + key.length(), result.length() - (index + key.length()));
+			result = result.left(index) + " " + body + " " + result.substr(index + key.length(), result.length() - (index + key.length()));
 		}
 
 		r_expanded = result;
@@ -1154,7 +1154,7 @@ void ShaderPreprocessor::concatenate_macro_body(String &r_body) {
 			index_start--;
 		}
 
-		r_body = r_body.substr(0, index_start) + r_body.substr(index_end, r_body.length() - index_end);
+		r_body = r_body.left(index_start) + r_body.substr(index_end, r_body.length() - index_end);
 
 		index_start = r_body.find("##", index_start);
 	}


### PR DESCRIPTION
`substr(0, len)` can be simplified to `left(len)` if `len >= 0`. In fact, this alternative is 10% faster.

While this is mostly about code style, I expect the performance improvement to be subtle, but non-negligible. Since String also used `substr()` in a few places when it could use `left()`, this should optimize other String functions too, and those are used all over the codebase, too.

And a couple of other code simplifications.