### PR TITLE
Clamp ReflectionProbe Max Distance to 262,144 to fix rendering issues

### DIFF
--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -68,8 +68,9 @@ Color ReflectionProbe::get_ambient_color() const {
 }
 
 void ReflectionProbe::set_max_distance(float p_distance) {
-	max_distance = p_distance;
-	RS::get_singleton()->reflection_probe_set_max_distance(probe, p_distance);
+	max_distance = CLAMP(p_distance, 0.0, 262'144.0);
+	// Reflection rendering breaks if distance exceeds 262,144 units (due to floating-point precision with the near plane being 0.01).
+	RS::get_singleton()->reflection_probe_set_max_distance(probe, max_distance);
 }
 
 float ReflectionProbe::get_max_distance() const {


### PR DESCRIPTION
I have an [alternative solution](https://github.com/Calinou/godot/tree/reflectionprobe-fix-high-max-distance-rendering) that automatically sets near clip above 0.01 if needed, but it may be less robust (and I doubt there are many use cases for reflection probes that large anyway).

- This closes https://github.com/godotengine/godot/issues/79448.
