### PR TITLE
Fix Decal clamping to positive values not being applied to RenderingServer

### DIFF
--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -32,7 +32,7 @@
 
 void Decal::set_size(const Vector3 &p_size) {
 	size = Vector3(MAX(0.001, p_size.x), MAX(0.001, p_size.y), MAX(0.001, p_size.z));
-	RS::get_singleton()->decal_set_size(decal, p_size);
+	RS::get_singleton()->decal_set_size(decal, size);
 	update_gizmos();
 }
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/61492.

This means the Decal editor gizmo could be incorrect compared to the actual rendering if you enter a negative value in the inspector.
