### PR TITLE
[macOS] Check all exclusive fullscreen windows before setting presentation mode.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -245,6 +245,7 @@ public:
 	WindowID _get_focused_window_or_popup() const;
 	void mouse_enter_window(WindowID p_window);
 	void mouse_exit_window(WindowID p_window);
+	void update_presentation_mode();
 
 	void window_destroy(WindowID p_window);
 	void window_resize(WindowID p_window, int p_width, int p_height);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -749,6 +749,7 @@ void DisplayServerMacOS::window_destroy(WindowID p_window) {
 	}
 #endif
 	windows.erase(p_window);
+	update_presentation_mode();
 }
 
 void DisplayServerMacOS::window_resize(WindowID p_window, int p_width, int p_height) {
@@ -2868,6 +2869,15 @@ Size2i DisplayServerMacOS::window_get_max_size(WindowID p_window) const {
 	return wd.max_size;
 }
 
+void DisplayServerMacOS::update_presentation_mode() {
+	for (const KeyValue<WindowID, WindowData> &wd : windows) {
+		if (wd.value.fullscreen && wd.value.exclusive_fullscreen) {
+			return;
+		}
+	}
+	[NSApp setPresentationOptions:NSApplicationPresentationDefault];
+}
+
 void DisplayServerMacOS::window_set_min_size(const Size2i p_size, WindowID p_window) {
 	_THREAD_SAFE_METHOD_
 
@@ -2978,7 +2988,7 @@ void DisplayServerMacOS::window_set_mode(WindowMode p_mode, WindowID p_window) {
 			[wd.window_object toggleFullScreen:nil];
 
 			if (old_mode == WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
-				[NSApp setPresentationOptions:NSApplicationPresentationDefault];
+				update_presentation_mode();
 			}
 
 			wd.fullscreen = false;

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -157,7 +157,7 @@
 
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	if (wd.exclusive_fullscreen) {
-		[NSApp setPresentationOptions:NSApplicationPresentationDefault];
+		ds->update_presentation_mode();
 	}
 
 	wd.fullscreen = false;


### PR DESCRIPTION
Improves exiting from the exclusive full-screen when there are multiple exclusive full-screen windows on the different screens (previously, exclusive mode was disabled for all windows after closing the first one).