### PR TITLE
Add viewport handle for `Area2D::gravity_point_center`

### DIFF
--- a/editor/plugins/area_2d_editor_plugin.cpp
+++ b/editor/plugins/area_2d_editor_plugin.cpp
@@ -1,0 +1,158 @@
+/**************************************************************************/
+/*  area_2d_editor_plugin.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "area_2d_editor_plugin.h"
+
+#include "editor/editor_interface.h"
+#include "editor/editor_settings.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/inspector_dock.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
+#include "scene/2d/area_2d.h"
+
+bool Area2DEditorPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
+	if (!node || !node->is_visible_in_tree() || !node->is_gravity_a_point() || node->get_gravity_space_override_mode() == Area2D::SpaceOverride::SPACE_OVERRIDE_DISABLED) {
+		return false;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (action == Action::ACTION_MOVING_POINT && mb->get_button_index() == MouseButton::RIGHT) {
+			return true;
+		}
+
+		Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
+
+		Vector2 mpos = mb->get_position();
+		Vector2 point = xform.xform(node->get_gravity_point_center());
+		Vector2 mposxd = xform.affine_inverse().xform(mpos);
+
+		real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		grab_threshold = grab_threshold * grab_threshold;
+
+		// Check for gravity point movement start.
+		if (action == ACTION_NONE && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+			real_t dist_to_p = mpos.distance_squared_to(point);
+			if (dist_to_p < grab_threshold) {
+				action = ACTION_MOVING_POINT;
+				moving_from = node->get_gravity_point_center();
+				moving_mouse_from = mposxd;
+
+				canvas_item_editor->update_viewport();
+				return true;
+			}
+		}
+
+		// Check for gravity point movement completion.
+		if (action == ACTION_MOVING_POINT && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			Vector2 new_pos = moving_from + mposxd - moving_mouse_from;
+
+			undo_redo->create_action(TTR("Move Gravity Point Center"));
+			undo_redo->add_do_method(node, "set_gravity_point_center", new_pos);
+			undo_redo->add_undo_method(node, "set_gravity_point_center", moving_from);
+			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->commit_action();
+
+			action = ACTION_NONE;
+			return true;
+		}
+	}
+
+	// Handle movement.
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid() && action == ACTION_MOVING_POINT) {
+		Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
+		Vector2 new_pos = moving_from + xform.affine_inverse().xform(mm->get_position()) - moving_mouse_from;
+
+		node->set_gravity_point_center(new_pos);
+
+		canvas_item_editor->update_viewport();
+		return true;
+	}
+
+	return false;
+}
+
+void Area2DEditorPlugin::forward_canvas_draw_over_viewport(Control *p_overlay) {
+	if (!node || !node->is_visible_in_tree() || !node->is_gravity_a_point() || node->get_gravity_space_override_mode() == Area2D::SpaceOverride::SPACE_OVERRIDE_DISABLED) {
+		return;
+	}
+
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
+	const Ref<Texture2D> gravity_point_handle = canvas_item_editor->get_editor_theme_icon(SNAME("EditorHandle"));
+	const Size2 handle_size = gravity_point_handle->get_size();
+	Vector2 point = xform.xform(node->get_gravity_point_center());
+
+	if (node->get_gravity_point_unit_distance() > 0) {
+		float gdist = xform.get_scale().x * node->get_gravity_point_unit_distance();
+		p_overlay->draw_circle(point, gdist, Color(0.92f, 1.0f, 0.6f, 0.3f));
+	} else {
+		p_overlay->draw_circle(point, 20.0f, Color(0.5f, 0.5f, 0.5f, 0.3f));
+	}
+
+	p_overlay->draw_texture_rect(gravity_point_handle, Rect2(point - handle_size * 0.5, handle_size));
+}
+
+void Area2DEditorPlugin::_property_edited(const StringName &p_prop) {
+	if (((String)p_prop).begins_with("gravity_")) {
+		canvas_item_editor->update_viewport();
+	}
+}
+
+void Area2DEditorPlugin::edit(Object *p_object) {
+	if (!canvas_item_editor) {
+		canvas_item_editor = CanvasItemEditor::get_singleton();
+	}
+	action = Action::ACTION_NONE;
+
+	node = Object::cast_to<Area2D>(p_object);
+	EditorInspector *insp = get_editor_interface()->get_inspector();
+	const Callable property_edited_callable = callable_mp(this, &Area2DEditorPlugin::_property_edited);
+
+	if (node) {
+		if (!insp->is_connected("property_edited", property_edited_callable)) {
+			insp->connect("property_edited", property_edited_callable);
+		}
+		canvas_item_editor->update_viewport();
+	} else {
+		if (insp->is_connected("property_edited", property_edited_callable)) {
+			insp->disconnect("property_edited", property_edited_callable);
+		}
+		canvas_item_editor->update_viewport();
+	}
+}
+
+void Area2DEditorPlugin::make_visible(bool p_visible) {
+	if (!p_visible) {
+		edit(nullptr);
+	}
+}

--- a/editor/plugins/area_2d_editor_plugin.h
+++ b/editor/plugins/area_2d_editor_plugin.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  area_2d_editor_plugin.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef AREA_2D_EDITOR_PLUGIN_H
+#define AREA_2D_EDITOR_PLUGIN_H
+
+#include "editor/editor_plugin.h"
+
+class Area2D;
+class CanvasItemEditor;
+
+class Area2DEditorPlugin : public EditorPlugin {
+	GDCLASS(Area2DEditorPlugin, EditorPlugin)
+
+	CanvasItemEditor *canvas_item_editor = nullptr;
+	Area2D *node = nullptr;
+
+	enum Action {
+		ACTION_NONE,
+		ACTION_MOVING_POINT,
+	};
+
+	Action action = Action::ACTION_NONE;
+	Point2 moving_from;
+	Point2 moving_mouse_from;
+
+	void _property_edited(const StringName &p_prop);
+
+public:
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override;
+
+	virtual String get_name() const override { return "Area2D"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override { return p_object->is_class("Area2D"); }
+	virtual void make_visible(bool p_visible) override;
+};
+
+#endif // AREA_2D_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -65,6 +65,7 @@
 #include "editor/import/resource_importer_texture_atlas.h"
 #include "editor/import/resource_importer_wav.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
+#include "editor/plugins/area_2d_editor_plugin.h"
 #include "editor/plugins/audio_stream_editor_plugin.h"
 #include "editor/plugins/audio_stream_randomizer_editor_plugin.h"
 #include "editor/plugins/bit_map_editor_plugin.h"
@@ -243,6 +244,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
 
 	// 2D
+	EditorPlugins::add_by_type<Area2DEditorPlugin>();
 	EditorPlugins::add_by_type<CollisionPolygon2DEditorPlugin>();
 	EditorPlugins::add_by_type<CollisionShape2DEditorPlugin>();
 	EditorPlugins::add_by_type<CPUParticles2DEditorPlugin>();


### PR DESCRIPTION
also add visualizer for Area2D::gravity_point_unit_distance

Implements: [#7876](https://github.com/godotengine/godot-proposals/issues/7876), but only the 2D portion.

Usage: Add an Area2D. Set gravity_space_override to anything other than Disabled. Set gravity_point=true. A handle should appear over the Area2D transform position. Dragging the handle corresponds with gravity_point_center.

Increase the gravity_point_unit_distance in the inspector and note that the transparent circle around the handle becomes colored and grows to the size of gravity_point_unit_distance.

Feedback greatly appreciated!

Please let me know if you believe anything could use improving functionally, aesthetically, or to better adhere to style/standards. Thanks!
