### PR TITLE
Fix errors when freeing GPUParticles

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -94,13 +94,15 @@ RID ParticlesStorage::particles_allocate() {
 }
 
 void ParticlesStorage::particles_initialize(RID p_rid) {
-	particles_owner.initialize_rid(p_rid, Particles());
+	particles_owner.initialize_rid(p_rid);
 }
 
 void ParticlesStorage::particles_free(RID p_rid) {
-	update_particles();
 	Particles *particles = particles_owner.get_or_null(p_rid);
+
 	particles->dependency.deleted_notify(p_rid);
+	particles->update_list.remove_from_list();
+
 	_particles_free_data(particles);
 	particles_owner.free(p_rid);
 }
@@ -355,8 +357,10 @@ void ParticlesStorage::particles_request_process(RID p_particles) {
 
 	if (!particles->dirty) {
 		particles->dirty = true;
-		particles->update_list = particle_update_list;
-		particle_update_list = particles;
+
+		if (!particles->update_list.in_list()) {
+			particle_update_list.add(&particles->update_list);
+		}
 	}
 }
 
@@ -978,13 +982,12 @@ void ParticlesStorage::update_particles() {
 	glBindBufferBase(GL_UNIFORM_BUFFER, PARTICLES_GLOBALS_UNIFORM_LOCATION, global_buffer);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-	while (particle_update_list) {
+	while (particle_update_list.first()) {
 		// Use transform feedback to process particles.
 
-		Particles *particles = particle_update_list;
+		Particles *particles = particle_update_list.first()->self();
 
-		particle_update_list = particles->update_list;
-		particles->update_list = nullptr;
+		particles->update_list.remove_from_list();
 		particles->dirty = false;
 
 		_particles_update_buffers(particles);

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -209,7 +209,7 @@ private:
 		uint32_t userdata_count = 0;
 
 		bool dirty = false;
-		Particles *update_list = nullptr;
+		SelfList<Particles> update_list;
 
 		double phase = 0.0;
 		double prev_phase = 0.0;
@@ -237,7 +237,8 @@ private:
 		double trail_length = 1.0;
 		bool trails_enabled = false;
 
-		Particles() {
+		Particles() :
+				update_list(this) {
 		}
 	};
 
@@ -259,7 +260,7 @@ private:
 		RID copy_shader_version;
 	} particles_shader;
 
-	Particles *particle_update_list = nullptr;
+	SelfList<Particles>::List particle_update_list;
 
 	mutable RID_Owner<Particles, true> particles_owner;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -221,13 +221,15 @@ RID ParticlesStorage::particles_allocate() {
 }
 
 void ParticlesStorage::particles_initialize(RID p_rid) {
-	particles_owner.initialize_rid(p_rid, Particles());
+	particles_owner.initialize_rid(p_rid);
 }
 
 void ParticlesStorage::particles_free(RID p_rid) {
-	update_particles();
 	Particles *particles = particles_owner.get_or_null(p_rid);
+
 	particles->dependency.deleted_notify(p_rid);
+	particles->update_list.remove_from_list();
+
 	_particles_free_data(particles);
 	particles_owner.free(p_rid);
 }
@@ -577,8 +579,10 @@ void ParticlesStorage::particles_request_process(RID p_particles) {
 
 	if (!particles->dirty) {
 		particles->dirty = true;
-		particles->update_list = particle_update_list;
-		particle_update_list = particles;
+
+		if (!particles->update_list.in_list()) {
+			particle_update_list.add(&particles->update_list);
+		}
 	}
 }
 
@@ -1345,14 +1349,12 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 void ParticlesStorage::update_particles() {
 	uint32_t frame = RSG::rasterizer->get_frame_number();
 	bool uses_motion_vectors = RSG::viewport->get_num_viewports_with_motion_vectors() > 0;
-	while (particle_update_list) {
+	while (particle_update_list.first()) {
 		//use transform feedback to process particles
 
-		Particles *particles = particle_update_list;
+		Particles *particles = particle_update_list.first()->self();
 
-		//take and remove
-		particle_update_list = particles->update_list;
-		particles->update_list = nullptr;
+		particles->update_list.remove_from_list();
 		particles->dirty = false;
 
 		_particles_update_buffers(particles);

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -206,7 +206,7 @@ private:
 		RID particles_sort_uniform_set;
 
 		bool dirty = false;
-		Particles *update_list = nullptr;
+		SelfList<Particles> update_list;
 
 		RID sub_emitter;
 
@@ -250,7 +250,8 @@ private:
 		LocalVector<ParticlesFrameParams> frame_history;
 		LocalVector<ParticlesFrameParams> trail_params;
 
-		Particles() {
+		Particles() :
+				update_list(this) {
 		}
 	};
 
@@ -322,7 +323,7 @@ private:
 
 	} particles_shader;
 
-	Particles *particle_update_list = nullptr;
+	SelfList<Particles>::List particle_update_list;
 
 	mutable RID_Owner<Particles, true> particles_owner;
 


### PR DESCRIPTION
* Fixes https://github.com/godotengine/godot/issues/82257
* Probably fixes https://github.com/godotengine/godot/issues/82489. This issue is most likely a duplicate of the previous one, but there is no good test project so hard to say for sure.
* Maybe fixes https://github.com/godotengine/godot/issues/78898. I didn't manage to repro the MRP glitching before or after this PR, so it might not manifest on my system or it has been already fixed by the other PR discussed there.

The fundamental reason for the first linked bug seems to be that when a GPUParticles2D or GPUParticles3D is freed and destroyed, they eventually call `ParticlesStorage::particles_free()`. This in turn has a somewhat unusual call to `ParticlesStorage::update_particles()`. So deleting a single particle system can force update all other currently processing particles systems. I looked around and I think the main reason for this call is that this "update all" has a side effect of removing the currently deleted particle system from the `particle_update_list` so that it doesn't point to invalid memory after the particle system is freed soon after. However, there might be more subtler reason too, but I didn't notice anything suspicious. Indirectly sending the `Dependency::DEPENDENCY_CHANGED_AABB` is in theory something that could matter, but I don't think that is needed as the particle system is being deleted anyway. I replaced the simple update list management with a `SelfList`, so there is now a more standard mechanism for tracking updates and we avoid the wasteful updates.

Now, this update call can also invalidate some particle system material uniform sets. Normally, this doesn't seem to be a problem because they will be re-created when needed, but on some occasions this can happen during a particle system destructor. When this matters depends on many variables, including active particle system count, Material "Local to Scene" flag and even where and when the `queue_free()` is called as the event flushing and destructor call can happen in several places during the main loop iteration. A different particle system might be updated immediately, but if the material uniform set was invalidated (here is where that "Local to Scene" flag seems to matter) and has not been re-created yet the update will cause the bug and error message with potential for visual glitches. Every time you see that error message in the MRP, the debugger stack trace will point to a particle system queued destructor being run and calling `update_particles()`.

Another hint that calling `update_particles()` at random times is not a good idea is the comment in `RenderingServerDefault::draw()`, suggesting that the update order is important:

https://github.com/godotengine/godot/blob/fba341ce44427d9515a581c19a8c98b522cef02b/servers/rendering/rendering_server_default.cpp#L87

The exact circumstances where this bug can happen are pretty complex and I don't claim I understand them all, but simply avoiding these potentially troublesome updates in `ParticlesStorage::particles_free()` seems to fix the fundamental problem. Another alternative one-liner fix is to simply change the branch condition in `ParticlesStorage::_particles_process()
`
```cpp
ParticleProcessMaterialData *m = static_cast<ParticleProcessMaterialData *>(material_storage->material_get_data(p_particles->process_material, MaterialStorage::SHADER_TYPE_PARTICLES));
if (!m) {
    m = static_cast<ParticleProcessMaterialData *>(material_storage->material_get_data(particles_shader.default_material, MaterialStorage::SHADER_TYPE_PARTICLES));
}
```

to

```cpp
if (!m || m->uniform_set.is_null()) {
```

However, I think changing that might just hide the issue and could still cause some visual glitches. Still, in case more bug reports like these appear in the future, adding that extra check might be useful.

Again, this is a pretty tricky issue, so getting another opinion of this will be useful.