### PR TITLE
Fix axis getting mixed up when split leaf

### DIFF
--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -20,8 +20,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		group_b[num_b++] = ind;
 
 		// remove from a
-		group_a[0] = group_a[num_a - 1];
 		num_a--;
+		group_a[0] = group_a[num_a];
 		return;
 	}
 
@@ -30,15 +30,15 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 
 	int order[POINT::AXIS_COUNT];
 
-	order[0] = size.min_axis_index();
-	order[POINT::AXIS_COUNT - 1] = size.max_axis_index();
+	order[0] = size.max_axis_index(); // The longest axis.
+	order[POINT::AXIS_COUNT - 1] = size.min_axis_index(); // The shortest axis.
 
 	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
 	if constexpr (POINT::AXIS_COUNT == 3) {
 		order[1] = 3 - (order[0] + order[2]);
 	}
 
-	// simplest case, split on the longest axis
+	// Simplest case, split on the longest axis.
 	int split_axis = order[0];
 	for (int a = 0; a < num_a; a++) {
 		uint32_t ind = group_a[a];
@@ -48,8 +48,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 			group_b[num_b++] = ind;
 
 			// remove from a
-			group_a[a] = group_a[num_a - 1];
 			num_a--;
+			group_a[a] = group_a[num_a];
 
 			// do this one again, as it has been replaced
 			a--;
@@ -67,7 +67,7 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		}
 		num_b = 0;
 
-		// now calculate the best split
+		// Now calculate the best split.
 		for (int axis = 1; axis < POINT::AXIS_COUNT; axis++) {
 			split_axis = order[axis];
 			int count = 0;
@@ -105,8 +105,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 					group_b[num_b++] = ind;
 
 					// remove from a
-					group_a[a] = group_a[num_a - 1];
 					num_a--;
+					group_a[a] = group_a[num_a];
 
 					// do this one again, as it has been replaced
 					a--;
@@ -123,8 +123,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		group_b[num_b++] = ind;
 
 		// remove from a
-		group_a[0] = group_a[num_a - 1];
 		num_a--;
+		group_a[0] = group_a[num_a];
 	}
 	// opposite problem! :)
 	if (!num_a) {
@@ -134,8 +134,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		group_a[num_a++] = ind;
 
 		// remove from b
-		group_b[0] = group_b[num_b - 1];
 		num_b--;
+		group_b[0] = group_b[num_b];
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
`order[0]` should hold the **longest** axis (`max_axis_index()`), while `order[POINT::AXIS_COUNT - 1]` should hold the **shortest** axis (`min_axis_index()`).

