### PR TITLE
Web: Clarify that `OS.get_unique_id` is not supported

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -355,7 +355,7 @@ void OS::set_cmdline(const char *p_execpath, const List<String> &p_args, const L
 }
 
 String OS::get_unique_id() const {
-	ERR_FAIL_V("");
+	return "";
 }
 
 int OS::get_processor_count() const {

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -449,7 +449,7 @@
 			<description>
 				Returns a string that is unique to the device.
 				[b]Note:[/b] This string may change without notice if the user reinstalls/upgrades their operating system or changes their hardware. This means it should generally not be used to encrypt persistent data as the data saved before an unexpected ID change would become inaccessible. The returned string may also be falsified using external programs, so do not rely on the string returned by [method get_unique_id] for security purposes.
-				[b]Note:[/b] Returns an empty string on Web, as this method isn't implemented on this platform yet.
+				[b]Note:[/b] Returns an empty string and prints an error on Web, as this method cannot be implemented on this platform.
 			</description>
 		</method>
 		<method name="get_user_data_dir" qualifiers="const">

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -132,6 +132,10 @@ int OS_Web::get_processor_count() const {
 	return godot_js_os_hw_concurrency_get();
 }
 
+String OS_Web::get_unique_id() const {
+	ERR_FAIL_V_MSG("", "OS::get_unique_id() is not available on the Web platform.");
+}
+
 bool OS_Web::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "web") {
 		return true;

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -83,6 +83,7 @@ public:
 	int get_process_id() const override;
 	bool is_process_running(const ProcessID &p_pid) const override;
 	int get_processor_count() const override;
+	String get_unique_id() const override;
 	int get_default_thread_pool_size() const override { return 1; }
 
 	String get_executable_path() const override;


### PR DESCRIPTION
Remove the base error message in `OS`, we no longer really error out this way for not implemented methods. Instead, each platform should override them to provide the context they want.

Fixes #82439.