### PR TITLE
Avoid trying to free null RIDs in FSR2 teardown

### DIFF
--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -804,7 +804,9 @@ FSR2Effect::~FSR2Effect() {
 	RD::get_singleton()->free(device.linear_clamp_sampler);
 
 	for (uint32_t i = 0; i < FFX_FSR2_PASS_COUNT; i++) {
-		RD::get_singleton()->free(device.passes[i].pipeline.pipeline_rid);
+		if (device.passes[i].pipeline.pipeline_rid.is_valid()) {
+			RD::get_singleton()->free(device.passes[i].pipeline.pipeline_rid);
+		}
 		device.passes[i].shader->version_free(device.passes[i].shader_version);
 	}
 }


### PR DESCRIPTION
On shutdown, removes nine of these from happening:
```
ERROR: Attempted to free invalid ID: 0 
   at: RenderingDeviceVulkan::_free_internal (drivers\vulkan\rendering_device_vulkan.cpp:8557)
drivers\vulkan\rendering_device_vulkan.cpp:8557 - Attempted to free invalid ID: 0 
```

CC @DarioSamo