### PR TITLE
Fix buffered key events not marked as echo events on Linux

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -270,6 +270,17 @@ bool Input::is_mouse_button_pressed(MouseButton p_button) const {
 	return mouse_button_mask.has_flag(mouse_button_to_mask(p_button));
 }
 
+bool Input::is_buffered_key_pressed(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+	for (Ref<InputEvent> event : buffered_events) {
+		Ref<InputEventKey> k = event;
+		if (k.is_valid() && k->get_keycode() == p_keycode && k->is_pressed()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static JoyAxis _combine_device(JoyAxis p_value, int p_device) {
 	return JoyAxis((int)p_value | (p_device << 20));
 }

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -262,6 +262,7 @@ public:
 	bool is_physical_key_pressed(Key p_keycode) const;
 	bool is_key_label_pressed(Key p_keycode) const;
 	bool is_mouse_button_pressed(MouseButton p_button) const;
+	bool is_buffered_key_pressed(Key p_keycode) const;
 	bool is_joy_button_pressed(int p_device, JoyButton p_button) const;
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3448,8 +3448,9 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	}
 
 	bool last_is_pressed = Input::get_singleton()->is_key_pressed(k->get_keycode());
+	bool last_is_pressed_buffered = Input::get_singleton()->is_buffered_key_pressed(k->get_keycode());
 	if (k->is_pressed()) {
-		if (last_is_pressed) {
+		if (last_is_pressed || last_is_pressed_buffered) {
 			k->set_echo(true);
 		}
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes https://github.com/godotengine/godot/issues/82262

Key echo events on Linux are being manually detected (X11 doesn't report this info, really? :no_mouth:). However, events that get buffered have their echo field already calculated before input processing, and thus never get marked as echo events.

This wasn't a problem when an action's `pressed` field was a boolean, but now that it's a counter (https://github.com/godotengine/godot/pull/80859), buffered events kept incrementing it. This made the action then impossible to "release" because the counter was stuck on high values.

This fix takes into account the presence of pressed events of the buffer in order to set the echo field appropriately, preventing further increments.

Windows, macOS and Web already get this information natively, and are not affected. iOS also seems to have echo fields hardcoded to `false` from what I gather. However I couldn't figure out how this info is obtained for Android, so if it's also done manually, then it likely needs this fix as well.
