### PR TITLE
Option to put TabContainer tabs at bottom

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -193,6 +193,9 @@
 		<member name="tab_focus_mode" type="int" setter="set_tab_focus_mode" getter="get_tab_focus_mode" enum="Control.FocusMode" default="2">
 			The focus access mode for the internal [TabBar] node.
 		</member>
+		<member name="tabs_position" type="int" setter="set_tabs_position" getter="get_tabs_position" enum="TabContainer.TabPosition" default="0">
+			Sets the position of the tab bar. See [enum TabPosition] for details.
+		</member>
 		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
 			[TabContainer]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].
 			Setting this to [code]-1[/code] will disable rearranging between [TabContainer]s.
@@ -247,6 +250,17 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="POSITION_TOP" value="0" enum="TabPosition">
+			Places the tab bar at the top.
+		</constant>
+		<constant name="POSITION_BOTTOM" value="1" enum="TabPosition">
+			Places the tab bar at the bottom. The tab bar's [StyleBox] will be flipped vertically.
+		</constant>
+		<constant name="POSITION_MAX" value="2" enum="TabPosition">
+			Represents the size of the [enum TabPosition] enum.
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="drop_mark_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Modulation color for the [theme_item drop_mark] icon.

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -516,7 +516,13 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 	bool rtl = is_layout_rtl();
 
 	Rect2 sb_rect = Rect2(p_x, 0, tabs[p_index].size_cache, get_size().height);
+	if (tab_style_v_flip) {
+		draw_set_transform(Point2(0.0, p_tab_style->get_draw_rect(sb_rect).size.y), 0.0, Size2(1.0, -1.0));
+	}
 	p_tab_style->draw(ci, sb_rect);
+	if (tab_style_v_flip) {
+		draw_set_transform(Point2(), 0.0, Size2(1.0, 1.0));
+	}
 	if (p_focus) {
 		Ref<StyleBox> focus_style = theme_cache.tab_focus_style;
 		focus_style->draw(ci, sb_rect);
@@ -1365,6 +1371,10 @@ void TabBar::set_clip_tabs(bool p_clip_tabs) {
 
 bool TabBar::get_clip_tabs() const {
 	return clip_tabs;
+}
+
+void TabBar::set_tab_style_v_flip(bool p_tab_style_v_flip) {
+	tab_style_v_flip = p_tab_style_v_flip;
 }
 
 void TabBar::move_tab(int p_from, int p_to) {

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -91,6 +91,7 @@ private:
 	bool clip_tabs = true;
 	int rb_hover = -1;
 	bool rb_pressing = false;
+	bool tab_style_v_flip = false;
 
 	bool select_with_rmb = false;
 
@@ -209,6 +210,8 @@ public:
 
 	void set_clip_tabs(bool p_clip_tabs);
 	bool get_clip_tabs() const;
+
+	void set_tab_style_v_flip(bool p_tab_style_v_flip);
 
 	void move_tab(int p_from, int p_to);
 

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -38,9 +38,18 @@
 class TabContainer : public Container {
 	GDCLASS(TabContainer, Container);
 
+public:
+	enum TabPosition {
+		POSITION_TOP,
+		POSITION_BOTTOM,
+		POSITION_MAX,
+	};
+
+private:
 	TabBar *tab_bar = nullptr;
 	bool tabs_visible = true;
 	bool all_tabs_in_front = false;
+	TabPosition tabs_position = POSITION_TOP;
 	bool menu_hovered = false;
 	mutable ObjectID popup_obj_id;
 	bool use_hidden_tabs_for_min_size = false;
@@ -86,7 +95,7 @@ class TabContainer : public Container {
 		int tab_font_size;
 	} theme_cache;
 
-	int _get_top_margin() const;
+	int _get_tab_height() const;
 	Vector<Control *> _get_tab_controls() const;
 	void _on_theme_changed();
 	void _repaint();
@@ -123,6 +132,9 @@ public:
 
 	void set_tab_alignment(TabBar::AlignmentMode p_alignment);
 	TabBar::AlignmentMode get_tab_alignment() const;
+
+	void set_tabs_position(TabPosition p_tab_position);
+	TabPosition get_tabs_position() const;
 
 	void set_tab_focus_mode(FocusMode p_focus_mode);
 	FocusMode get_tab_focus_mode() const;
@@ -184,5 +196,7 @@ public:
 
 	TabContainer();
 };
+
+VARIANT_ENUM_CAST(TabContainer::TabPosition);
 
 #endif // TAB_CONTAINER_H


### PR DESCRIPTION
part of: https://github.com/godotengine/godot-proposals/issues/1986
salvaged: https://github.com/godotengine/godot/pull/44420

Adds `tabs_at_bottom` to TabContainer.
Enabling will move the tab bar to the bottom.

![image](https://github.com/godotengine/godot/assets/10054226/dd758bce-a59c-4ab5-8647-43e138d59f25)
