### PR TITLE
[TextServer] Store font extra spacing variations without making a full copy of font.

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -15,6 +15,13 @@
 				Creates a new, empty font cache entry resource. To free the resulting resource, use the [method free_rid] method.
 			</description>
 		</method>
+		<method name="create_font_linked_variation">
+			<return type="RID" />
+			<param index="0" name="font_rid" type="RID" />
+			<description>
+				Creates a new variation existing font which is reusing the same glyph cache and font data. To free the resulting resource, use the [method free_rid] method.
+			</description>
+		</method>
 		<method name="create_shaped_text">
 			<return type="RID" />
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" default="0" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -19,6 +19,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_create_font_linked_variation" qualifiers="virtual">
+			<return type="RID" />
+			<param index="0" name="font_rid" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_create_shaped_text" qualifiers="virtual">
 			<return type="RID" />
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" />

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -293,6 +293,11 @@ class TextServerAdvanced : public TextServerExtension {
 		}
 	};
 
+	struct FontAdvancedLinkedVariation {
+		RID base_font;
+		int extra_spacing[4] = { 0, 0, 0, 0 };
+	};
+
 	struct FontAdvanced {
 		Mutex mutex;
 
@@ -534,8 +539,18 @@ class TextServerAdvanced : public TextServerExtension {
 	// Common data.
 
 	double oversampling = 1.0;
+	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
+
+	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
+		RID rid = p_font_rid;
+		FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(rid);
+		if (unlikely(fdv)) {
+			rid = fdv->base_font;
+		}
+		return font_owner.get_or_null(rid);
+	}
 
 	struct SystemFontKey {
 		String font_name;
@@ -704,6 +719,7 @@ public:
 	/* Font interface */
 
 	MODBIND0R(RID, create_font);
+	MODBIND1R(RID, create_font_linked_variation, const RID &);
 
 	MODBIND2(font_set_data, const RID &, const PackedByteArray &);
 	MODBIND3(font_set_data_ptr, const RID &, const uint8_t *, int64_t);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -123,6 +123,14 @@ void TextServerFallback::_free_rid(const RID &p_rid) {
 			font_owner.free(p_rid);
 		}
 		memdelete(fd);
+	} else if (font_var_owner.owns(p_rid)) {
+		MutexLock ftlock(ft_mutex);
+
+		FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_rid);
+		{
+			font_var_owner.free(p_rid);
+		}
+		memdelete(fdv);
 	} else if (shaped_owner.owns(p_rid)) {
 		ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_rid);
 		{
@@ -935,8 +943,24 @@ RID TextServerFallback::_create_font() {
 	return font_owner.make_rid(fd);
 }
 
+RID TextServerFallback::_create_font_linked_variation(const RID &p_font_rid) {
+	_THREAD_SAFE_METHOD_
+
+	RID rid = p_font_rid;
+	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(rid);
+	if (unlikely(fdv)) {
+		rid = fdv->base_font;
+	}
+	ERR_FAIL_COND_V(!font_owner.owns(rid), RID());
+
+	FontFallbackLinkedVariation *new_fdv = memnew(FontFallbackLinkedVariation);
+	new_fdv->base_font = rid;
+
+	return font_var_owner.make_rid(new_fdv);
+}
+
 void TextServerFallback::_font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -947,7 +971,7 @@ void TextServerFallback::_font_set_data(const RID &p_font_rid, const PackedByteA
 }
 
 void TextServerFallback::_font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -958,7 +982,7 @@ void TextServerFallback::_font_set_data_ptr(const RID &p_font_rid, const uint8_t
 }
 
 void TextServerFallback::_font_set_style(const RID &p_font_rid, BitField<FontStyle> p_style) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -971,7 +995,7 @@ void TextServerFallback::_font_set_face_index(const RID &p_font_rid, int64_t p_f
 	ERR_FAIL_COND(p_face_index < 0);
 	ERR_FAIL_COND(p_face_index >= 0x7FFF);
 
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -982,7 +1006,7 @@ void TextServerFallback::_font_set_face_index(const RID &p_font_rid, int64_t p_f
 }
 
 int64_t TextServerFallback::_font_get_face_index(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -990,7 +1014,7 @@ int64_t TextServerFallback::_font_get_face_index(const RID &p_font_rid) const {
 }
 
 int64_t TextServerFallback::_font_get_face_count(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1036,7 +1060,7 @@ int64_t TextServerFallback::_font_get_face_count(const RID &p_font_rid) const {
 }
 
 BitField<TextServer::FontStyle> TextServerFallback::_font_get_style(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1046,7 +1070,7 @@ BitField<TextServer::FontStyle> TextServerFallback::_font_get_style(const RID &p
 }
 
 void TextServerFallback::_font_set_style_name(const RID &p_font_rid, const String &p_name) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1056,7 +1080,7 @@ void TextServerFallback::_font_set_style_name(const RID &p_font_rid, const Strin
 }
 
 String TextServerFallback::_font_get_style_name(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -1066,7 +1090,7 @@ String TextServerFallback::_font_get_style_name(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_weight(const RID &p_font_rid, int64_t p_weight) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1076,7 +1100,7 @@ void TextServerFallback::_font_set_weight(const RID &p_font_rid, int64_t p_weigh
 }
 
 int64_t TextServerFallback::_font_get_weight(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 400);
 
 	MutexLock lock(fd->mutex);
@@ -1086,7 +1110,7 @@ int64_t TextServerFallback::_font_get_weight(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_stretch(const RID &p_font_rid, int64_t p_stretch) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1096,7 +1120,7 @@ void TextServerFallback::_font_set_stretch(const RID &p_font_rid, int64_t p_stre
 }
 
 int64_t TextServerFallback::_font_get_stretch(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 100);
 
 	MutexLock lock(fd->mutex);
@@ -1106,7 +1130,7 @@ int64_t TextServerFallback::_font_get_stretch(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_name(const RID &p_font_rid, const String &p_name) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1116,7 +1140,7 @@ void TextServerFallback::_font_set_name(const RID &p_font_rid, const String &p_n
 }
 
 String TextServerFallback::_font_get_name(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -1126,7 +1150,7 @@ String TextServerFallback::_font_get_name(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_antialiasing(const RID &p_font_rid, TextServer::FontAntialiasing p_antialiasing) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1137,7 +1161,7 @@ void TextServerFallback::_font_set_antialiasing(const RID &p_font_rid, TextServe
 }
 
 TextServer::FontAntialiasing TextServerFallback::_font_get_antialiasing(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TextServer::FONT_ANTIALIASING_NONE);
 
 	MutexLock lock(fd->mutex);
@@ -1145,7 +1169,7 @@ TextServer::FontAntialiasing TextServerFallback::_font_get_antialiasing(const RI
 }
 
 void TextServerFallback::_font_set_generate_mipmaps(const RID &p_font_rid, bool p_generate_mipmaps) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1161,7 +1185,7 @@ void TextServerFallback::_font_set_generate_mipmaps(const RID &p_font_rid, bool 
 }
 
 bool TextServerFallback::_font_get_generate_mipmaps(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1169,7 +1193,7 @@ bool TextServerFallback::_font_get_generate_mipmaps(const RID &p_font_rid) const
 }
 
 void TextServerFallback::_font_set_multichannel_signed_distance_field(const RID &p_font_rid, bool p_msdf) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1180,7 +1204,7 @@ void TextServerFallback::_font_set_multichannel_signed_distance_field(const RID 
 }
 
 bool TextServerFallback::_font_is_multichannel_signed_distance_field(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1188,7 +1212,7 @@ bool TextServerFallback::_font_is_multichannel_signed_distance_field(const RID &
 }
 
 void TextServerFallback::_font_set_msdf_pixel_range(const RID &p_font_rid, int64_t p_msdf_pixel_range) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1199,7 +1223,7 @@ void TextServerFallback::_font_set_msdf_pixel_range(const RID &p_font_rid, int64
 }
 
 int64_t TextServerFallback::_font_get_msdf_pixel_range(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1207,7 +1231,7 @@ int64_t TextServerFallback::_font_get_msdf_pixel_range(const RID &p_font_rid) co
 }
 
 void TextServerFallback::_font_set_msdf_size(const RID &p_font_rid, int64_t p_msdf_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1218,7 +1242,7 @@ void TextServerFallback::_font_set_msdf_size(const RID &p_font_rid, int64_t p_ms
 }
 
 int64_t TextServerFallback::_font_get_msdf_size(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1226,7 +1250,7 @@ int64_t TextServerFallback::_font_get_msdf_size(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1234,7 +1258,7 @@ void TextServerFallback::_font_set_fixed_size(const RID &p_font_rid, int64_t p_f
 }
 
 int64_t TextServerFallback::_font_get_fixed_size(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1242,7 +1266,7 @@ int64_t TextServerFallback::_font_get_fixed_size(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_allow_system_fallback(const RID &p_font_rid, bool p_allow_system_fallback) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1250,7 +1274,7 @@ void TextServerFallback::_font_set_allow_system_fallback(const RID &p_font_rid, 
 }
 
 bool TextServerFallback::_font_is_allow_system_fallback(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1258,7 +1282,7 @@ bool TextServerFallback::_font_is_allow_system_fallback(const RID &p_font_rid) c
 }
 
 void TextServerFallback::_font_set_force_autohinter(const RID &p_font_rid, bool p_force_autohinter) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1269,7 +1293,7 @@ void TextServerFallback::_font_set_force_autohinter(const RID &p_font_rid, bool 
 }
 
 bool TextServerFallback::_font_is_force_autohinter(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -1277,7 +1301,7 @@ bool TextServerFallback::_font_is_force_autohinter(const RID &p_font_rid) const 
 }
 
 void TextServerFallback::_font_set_hinting(const RID &p_font_rid, TextServer::Hinting p_hinting) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1288,7 +1312,7 @@ void TextServerFallback::_font_set_hinting(const RID &p_font_rid, TextServer::Hi
 }
 
 TextServer::Hinting TextServerFallback::_font_get_hinting(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, HINTING_NONE);
 
 	MutexLock lock(fd->mutex);
@@ -1296,7 +1320,7 @@ TextServer::Hinting TextServerFallback::_font_get_hinting(const RID &p_font_rid)
 }
 
 void TextServerFallback::_font_set_subpixel_positioning(const RID &p_font_rid, TextServer::SubpixelPositioning p_subpixel) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1304,7 +1328,7 @@ void TextServerFallback::_font_set_subpixel_positioning(const RID &p_font_rid, T
 }
 
 TextServer::SubpixelPositioning TextServerFallback::_font_get_subpixel_positioning(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, SUBPIXEL_POSITIONING_DISABLED);
 
 	MutexLock lock(fd->mutex);
@@ -1312,7 +1336,7 @@ TextServer::SubpixelPositioning TextServerFallback::_font_get_subpixel_positioni
 }
 
 void TextServerFallback::_font_set_embolden(const RID &p_font_rid, double p_strength) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1323,7 +1347,7 @@ void TextServerFallback::_font_set_embolden(const RID &p_font_rid, double p_stre
 }
 
 double TextServerFallback::_font_get_embolden(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1332,28 +1356,39 @@ double TextServerFallback::_font_get_embolden(const RID &p_font_rid) const {
 
 void TextServerFallback::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
 	ERR_FAIL_INDEX((int)p_spacing, 4);
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_NULL(fd);
+	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
+	if (fdv) {
+		if (fdv->extra_spacing[p_spacing] != p_value) {
+			fdv->extra_spacing[p_spacing] = p_value;
+		}
+	} else {
+		FontFallback *fd = font_owner.get_or_null(p_font_rid);
+		ERR_FAIL_NULL(fd);
 
-	MutexLock lock(fd->mutex);
-	if (fd->extra_spacing[p_spacing] != p_value) {
-		_font_clear_cache(fd);
-		fd->extra_spacing[p_spacing] = p_value;
+		MutexLock lock(fd->mutex);
+		if (fd->extra_spacing[p_spacing] != p_value) {
+			_font_clear_cache(fd);
+			fd->extra_spacing[p_spacing] = p_value;
+		}
 	}
 }
 
 int64_t TextServerFallback::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
 	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
+	if (fdv) {
+		return fdv->extra_spacing[p_spacing];
+	} else {
+		FontFallback *fd = font_owner.get_or_null(p_font_rid);
+		ERR_FAIL_NULL_V(fd, 0);
 
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
-	ERR_FAIL_NULL_V(fd, 0);
-
-	MutexLock lock(fd->mutex);
-	return fd->extra_spacing[p_spacing];
+		MutexLock lock(fd->mutex);
+		return fd->extra_spacing[p_spacing];
+	}
 }
 
 void TextServerFallback::_font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1364,7 +1399,7 @@ void TextServerFallback::_font_set_transform(const RID &p_font_rid, const Transf
 }
 
 Transform2D TextServerFallback::_font_get_transform(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Transform2D());
 
 	MutexLock lock(fd->mutex);
@@ -1372,7 +1407,7 @@ Transform2D TextServerFallback::_font_get_transform(const RID &p_font_rid) const
 }
 
 void TextServerFallback::_font_set_variation_coordinates(const RID &p_font_rid, const Dictionary &p_variation_coordinates) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1383,7 +1418,7 @@ void TextServerFallback::_font_set_variation_coordinates(const RID &p_font_rid, 
 }
 
 Dictionary TextServerFallback::_font_get_variation_coordinates(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -1391,7 +1426,7 @@ Dictionary TextServerFallback::_font_get_variation_coordinates(const RID &p_font
 }
 
 void TextServerFallback::_font_set_oversampling(const RID &p_font_rid, double p_oversampling) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1402,7 +1437,7 @@ void TextServerFallback::_font_set_oversampling(const RID &p_font_rid, double p_
 }
 
 double TextServerFallback::_font_get_oversampling(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1410,7 +1445,7 @@ double TextServerFallback::_font_get_oversampling(const RID &p_font_rid) const {
 }
 
 TypedArray<Vector2i> TextServerFallback::_font_get_size_cache_list(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
@@ -1422,7 +1457,7 @@ TypedArray<Vector2i> TextServerFallback::_font_get_size_cache_list(const RID &p_
 }
 
 void TextServerFallback::_font_clear_size_cache(const RID &p_font_rid) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1434,7 +1469,7 @@ void TextServerFallback::_font_clear_size_cache(const RID &p_font_rid) {
 }
 
 void TextServerFallback::_font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1446,7 +1481,7 @@ void TextServerFallback::_font_remove_size_cache(const RID &p_font_rid, const Ve
 }
 
 void TextServerFallback::_font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1457,7 +1492,7 @@ void TextServerFallback::_font_set_ascent(const RID &p_font_rid, int64_t p_size,
 }
 
 double TextServerFallback::_font_get_ascent(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1473,7 +1508,7 @@ double TextServerFallback::_font_get_ascent(const RID &p_font_rid, int64_t p_siz
 }
 
 void TextServerFallback::_font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	Vector2i size = _get_size(fd, p_size);
@@ -1483,7 +1518,7 @@ void TextServerFallback::_font_set_descent(const RID &p_font_rid, int64_t p_size
 }
 
 double TextServerFallback::_font_get_descent(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1499,7 +1534,7 @@ double TextServerFallback::_font_get_descent(const RID &p_font_rid, int64_t p_si
 }
 
 void TextServerFallback::_font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1510,7 +1545,7 @@ void TextServerFallback::_font_set_underline_position(const RID &p_font_rid, int
 }
 
 double TextServerFallback::_font_get_underline_position(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1526,7 +1561,7 @@ double TextServerFallback::_font_get_underline_position(const RID &p_font_rid, i
 }
 
 void TextServerFallback::_font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1537,7 +1572,7 @@ void TextServerFallback::_font_set_underline_thickness(const RID &p_font_rid, in
 }
 
 double TextServerFallback::_font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1553,7 +1588,7 @@ double TextServerFallback::_font_get_underline_thickness(const RID &p_font_rid, 
 }
 
 void TextServerFallback::_font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1569,7 +1604,7 @@ void TextServerFallback::_font_set_scale(const RID &p_font_rid, int64_t p_size, 
 }
 
 double TextServerFallback::_font_get_scale(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0.0);
 
 	MutexLock lock(fd->mutex);
@@ -1585,7 +1620,7 @@ double TextServerFallback::_font_get_scale(const RID &p_font_rid, int64_t p_size
 }
 
 int64_t TextServerFallback::_font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);
 
 	MutexLock lock(fd->mutex);
@@ -1597,7 +1632,7 @@ int64_t TextServerFallback::_font_get_texture_count(const RID &p_font_rid, const
 }
 
 void TextServerFallback::_font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	MutexLock lock(fd->mutex);
 	Vector2i size = _get_size_outline(fd, p_size);
@@ -1607,7 +1642,7 @@ void TextServerFallback::_font_clear_textures(const RID &p_font_rid, const Vecto
 }
 
 void TextServerFallback::_font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1619,7 +1654,7 @@ void TextServerFallback::_font_remove_texture(const RID &p_font_rid, const Vecto
 }
 
 void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	ERR_FAIL_COND(p_image.is_null());
 
@@ -1648,7 +1683,7 @@ void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Ve
 }
 
 Ref<Image> TextServerFallback::_font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Ref<Image>());
 
 	MutexLock lock(fd->mutex);
@@ -1662,7 +1697,7 @@ Ref<Image> TextServerFallback::_font_get_texture_image(const RID &p_font_rid, co
 
 void TextServerFallback::_font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offsets) {
 	ERR_FAIL_COND(p_offsets.size() % 4 != 0);
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1681,7 +1716,7 @@ void TextServerFallback::_font_set_texture_offsets(const RID &p_font_rid, const 
 }
 
 PackedInt32Array TextServerFallback::_font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
@@ -1706,7 +1741,7 @@ PackedInt32Array TextServerFallback::_font_get_texture_offsets(const RID &p_font
 }
 
 PackedInt32Array TextServerFallback::_font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedInt32Array());
 
 	MutexLock lock(fd->mutex);
@@ -1722,7 +1757,7 @@ PackedInt32Array TextServerFallback::_font_get_glyph_list(const RID &p_font_rid,
 }
 
 void TextServerFallback::_font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1733,7 +1768,7 @@ void TextServerFallback::_font_clear_glyphs(const RID &p_font_rid, const Vector2
 }
 
 void TextServerFallback::_font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1744,7 +1779,7 @@ void TextServerFallback::_font_remove_glyph(const RID &p_font_rid, const Vector2
 }
 
 Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -1782,7 +1817,7 @@ Vector2 TextServerFallback::_font_get_glyph_advance(const RID &p_font_rid, int64
 }
 
 void TextServerFallback::_font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1797,7 +1832,7 @@ void TextServerFallback::_font_set_glyph_advance(const RID &p_font_rid, int64_t 
 }
 
 Vector2 TextServerFallback::_font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -1827,7 +1862,7 @@ Vector2 TextServerFallback::_font_get_glyph_offset(const RID &p_font_rid, const 
 }
 
 void TextServerFallback::_font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1842,7 +1877,7 @@ void TextServerFallback::_font_set_glyph_offset(const RID &p_font_rid, const Vec
 }
 
 Vector2 TextServerFallback::_font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -1872,7 +1907,7 @@ Vector2 TextServerFallback::_font_get_glyph_size(const RID &p_font_rid, const Ve
 }
 
 void TextServerFallback::_font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1887,7 +1922,7 @@ void TextServerFallback::_font_set_glyph_size(const RID &p_font_rid, const Vecto
 }
 
 Rect2 TextServerFallback::_font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Rect2());
 
 	MutexLock lock(fd->mutex);
@@ -1912,7 +1947,7 @@ Rect2 TextServerFallback::_font_get_glyph_uv_rect(const RID &p_font_rid, const V
 }
 
 void TextServerFallback::_font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1927,7 +1962,7 @@ void TextServerFallback::_font_set_glyph_uv_rect(const RID &p_font_rid, const Ve
 }
 
 int64_t TextServerFallback::_font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, -1);
 
 	MutexLock lock(fd->mutex);
@@ -1952,7 +1987,7 @@ int64_t TextServerFallback::_font_get_glyph_texture_idx(const RID &p_font_rid, c
 }
 
 void TextServerFallback::_font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -1967,7 +2002,7 @@ void TextServerFallback::_font_set_glyph_texture_idx(const RID &p_font_rid, cons
 }
 
 RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, RID());
 
 	MutexLock lock(fd->mutex);
@@ -2013,7 +2048,7 @@ RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 }
 
 Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Size2());
 
 	MutexLock lock(fd->mutex);
@@ -2059,7 +2094,7 @@ Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, co
 }
 
 Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, int64_t p_size, int64_t p_index) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -2109,7 +2144,7 @@ Dictionary TextServerFallback::_font_get_glyph_contours(const RID &p_font_rid, i
 }
 
 TypedArray<Vector2i> TextServerFallback::_font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, TypedArray<Vector2i>());
 
 	MutexLock lock(fd->mutex);
@@ -2125,7 +2160,7 @@ TypedArray<Vector2i> TextServerFallback::_font_get_kerning_list(const RID &p_fon
 }
 
 void TextServerFallback::_font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2136,7 +2171,7 @@ void TextServerFallback::_font_clear_kerning_map(const RID &p_font_rid, int64_t 
 }
 
 void TextServerFallback::_font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2147,7 +2182,7 @@ void TextServerFallback::_font_remove_kerning(const RID &p_font_rid, int64_t p_s
 }
 
 void TextServerFallback::_font_set_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair, const Vector2 &p_kerning) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2158,7 +2193,7 @@ void TextServerFallback::_font_set_kerning(const RID &p_font_rid, int64_t p_size
 }
 
 Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Vector2());
 
 	MutexLock lock(fd->mutex);
@@ -2202,7 +2237,7 @@ int64_t TextServerFallback::_font_get_char_from_glyph_index(const RID &p_font_ri
 }
 
 bool TextServerFallback::_font_has_char(const RID &p_font_rid, int64_t p_char) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_COND_V_MSG((p_char >= 0xd800 && p_char <= 0xdfff) || (p_char > 0x10ffff), false, "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_char, 16) + ".");
 	if (!fd) {
 		return false;
@@ -2223,7 +2258,7 @@ bool TextServerFallback::_font_has_char(const RID &p_font_rid, int64_t p_char) c
 }
 
 String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, String());
 
 	MutexLock lock(fd->mutex);
@@ -2256,7 +2291,7 @@ String TextServerFallback::_font_get_supported_chars(const RID &p_font_rid) cons
 }
 
 void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2i &p_size, int64_t p_start, int64_t p_end) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 	ERR_FAIL_COND_MSG((p_start >= 0xd800 && p_start <= 0xdfff) || (p_start > 0x10ffff), "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_start, 16) + ".");
 	ERR_FAIL_COND_MSG((p_end >= 0xd800 && p_end <= 0xdfff) || (p_end > 0x10ffff), "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_end, 16) + ".");
@@ -2291,7 +2326,7 @@ void TextServerFallback::_font_render_range(const RID &p_font_rid, const Vector2
 }
 
 void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2322,7 +2357,7 @@ void TextServerFallback::_font_render_glyph(const RID &p_font_rid, const Vector2
 }
 
 void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2414,7 +2449,7 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 }
 
 void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2506,7 +2541,7 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 }
 
 bool TextServerFallback::_font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2518,7 +2553,7 @@ bool TextServerFallback::_font_is_language_supported(const RID &p_font_rid, cons
 }
 
 void TextServerFallback::_font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2526,7 +2561,7 @@ void TextServerFallback::_font_set_language_support_override(const RID &p_font_r
 }
 
 bool TextServerFallback::_font_get_language_support_override(const RID &p_font_rid, const String &p_language) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2534,7 +2569,7 @@ bool TextServerFallback::_font_get_language_support_override(const RID &p_font_r
 }
 
 void TextServerFallback::_font_remove_language_support_override(const RID &p_font_rid, const String &p_language) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2542,7 +2577,7 @@ void TextServerFallback::_font_remove_language_support_override(const RID &p_fon
 }
 
 PackedStringArray TextServerFallback::_font_get_language_support_overrides(const RID &p_font_rid) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedStringArray());
 
 	MutexLock lock(fd->mutex);
@@ -2554,7 +2589,7 @@ PackedStringArray TextServerFallback::_font_get_language_support_overrides(const
 }
 
 bool TextServerFallback::_font_is_script_supported(const RID &p_font_rid, const String &p_script) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2566,7 +2601,7 @@ bool TextServerFallback::_font_is_script_supported(const RID &p_font_rid, const 
 }
 
 void TextServerFallback::_font_set_script_support_override(const RID &p_font_rid, const String &p_script, bool p_supported) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2574,7 +2609,7 @@ void TextServerFallback::_font_set_script_support_override(const RID &p_font_rid
 }
 
 bool TextServerFallback::_font_get_script_support_override(const RID &p_font_rid, const String &p_script) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, false);
 
 	MutexLock lock(fd->mutex);
@@ -2582,7 +2617,7 @@ bool TextServerFallback::_font_get_script_support_override(const RID &p_font_rid
 }
 
 void TextServerFallback::_font_remove_script_support_override(const RID &p_font_rid, const String &p_script) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2592,7 +2627,7 @@ void TextServerFallback::_font_remove_script_support_override(const RID &p_font_
 }
 
 PackedStringArray TextServerFallback::_font_get_script_support_overrides(const RID &p_font_rid) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, PackedStringArray());
 
 	MutexLock lock(fd->mutex);
@@ -2604,7 +2639,7 @@ PackedStringArray TextServerFallback::_font_get_script_support_overrides(const R
 }
 
 void TextServerFallback::_font_set_opentype_feature_overrides(const RID &p_font_rid, const Dictionary &p_overrides) {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -2614,7 +2649,7 @@ void TextServerFallback::_font_set_opentype_feature_overrides(const RID &p_font_
 }
 
 Dictionary TextServerFallback::_font_get_opentype_feature_overrides(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -2626,7 +2661,7 @@ Dictionary TextServerFallback::_font_supported_feature_list(const RID &p_font_ri
 }
 
 Dictionary TextServerFallback::_font_supported_variation_list(const RID &p_font_rid) const {
-	FontFallback *fd = font_owner.get_or_null(p_font_rid);
+	FontFallback *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, Dictionary());
 
 	MutexLock lock(fd->mutex);
@@ -2904,7 +2939,7 @@ bool TextServerFallback::_shaped_text_add_string(const RID &p_shaped, const Stri
 	ERR_FAIL_COND_V(p_size <= 0, false);
 
 	for (int i = 0; i < p_fonts.size(); i++) {
-		ERR_FAIL_COND_V(!font_owner.get_or_null(p_fonts[i]), false);
+		ERR_FAIL_COND_V(!_get_font_data(p_fonts[i]), false);
 	}
 
 	if (p_text.is_empty()) {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -245,6 +245,11 @@ class TextServerFallback : public TextServerExtension {
 		}
 	};
 
+	struct FontFallbackLinkedVariation {
+		RID base_font;
+		int extra_spacing[4] = { 0, 0, 0, 0 };
+	};
+
 	struct FontFallback {
 		Mutex mutex;
 
@@ -451,8 +456,18 @@ class TextServerFallback : public TextServerExtension {
 	// Common data.
 
 	double oversampling = 1.0;
+	mutable RID_PtrOwner<FontFallbackLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontFallback> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
+
+	_FORCE_INLINE_ FontFallback *_get_font_data(const RID &p_font_rid) const {
+		RID rid = p_font_rid;
+		FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(rid);
+		if (unlikely(fdv)) {
+			rid = fdv->base_font;
+		}
+		return font_owner.get_or_null(rid);
+	}
 
 	struct SystemFontKey {
 		String font_name;
@@ -569,6 +584,7 @@ public:
 	/* Font interface */
 
 	MODBIND0R(RID, create_font);
+	MODBIND1R(RID, create_font_linked_variation, const RID &);
 
 	MODBIND2(font_set_data, const RID &, const PackedByteArray &);
 	MODBIND3(font_set_data_ptr, const RID &, const uint8_t *, int64_t);

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -205,7 +205,7 @@ class FontFile : public Font {
 	mutable Vector<RID> cache;
 
 	_FORCE_INLINE_ void _clear_cache();
-	_FORCE_INLINE_ void _ensure_rid(int p_cache_index) const;
+	_FORCE_INLINE_ void _ensure_rid(int p_cache_index, int p_make_linked_from = -1) const;
 
 	void _convert_packed_8bit(Ref<Image> &p_source, int p_page, int p_sz);
 	void _convert_packed_4bit(Ref<Image> &p_source, int p_page, int p_sz);

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -51,6 +51,7 @@ void TextServerExtension::_bind_methods() {
 	/* Font interface */
 
 	GDVIRTUAL_BIND(_create_font);
+	GDVIRTUAL_BIND(_create_font_linked_variation, "font_rid");
 
 	GDVIRTUAL_BIND(_font_set_data, "font_rid", "data");
 	GDVIRTUAL_BIND(_font_set_data_ptr, "font_rid", "data_ptr", "data_size");
@@ -409,6 +410,12 @@ String TextServerExtension::tag_to_name(int64_t p_tag) const {
 RID TextServerExtension::create_font() {
 	RID ret;
 	GDVIRTUAL_CALL(_create_font, ret);
+	return ret;
+}
+
+RID TextServerExtension::create_font_linked_variation(const RID &p_font_rid) {
+	RID ret;
+	GDVIRTUAL_CALL(_create_font_linked_variation, p_font_rid, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -80,6 +80,9 @@ public:
 	virtual RID create_font() override;
 	GDVIRTUAL0R(RID, _create_font);
 
+	virtual RID create_font_linked_variation(const RID &p_font_rid) override;
+	GDVIRTUAL1R(RID, _create_font_linked_variation, RID);
+
 	virtual void font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) override;
 	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &);

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -206,6 +206,7 @@ void TextServer::_bind_methods() {
 	/* Font Interface */
 
 	ClassDB::bind_method(D_METHOD("create_font"), &TextServer::create_font);
+	ClassDB::bind_method(D_METHOD("create_font_linked_variation", "font_rid"), &TextServer::create_font_linked_variation);
 
 	ClassDB::bind_method(D_METHOD("font_set_data", "font_rid", "data"), &TextServer::font_set_data);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -237,6 +237,7 @@ public:
 	/* Font interface */
 
 	virtual RID create_font() = 0;
+	virtual RID create_font_linked_variation(const RID &p_font_rid) = 0;
 
 	virtual void font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) = 0;
 	virtual void font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) = 0;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/81455 and prevents excessive glyph cache copies.