### PR TITLE
Fix `AudioStreamRandomizer.random_volume_offset_db` not working

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -810,7 +810,11 @@ void AudioStreamPlaybackRandomizer::tag_used_streams() {
 
 int AudioStreamPlaybackRandomizer::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) {
 	if (playing.is_valid()) {
-		return playing->mix(p_buffer, p_rate_scale * pitch_scale, p_frames);
+		int mixed_samples = playing->mix(p_buffer, p_rate_scale * pitch_scale, p_frames);
+		for (int samp = 0; samp < mixed_samples; samp++) {
+			p_buffer[samp] *= volume_scale;
+		}
+		return mixed_samples;
 	} else {
 		for (int i = 0; i < p_frames; i++) {
 			p_buffer[i] = AudioFrame(0, 0);


### PR DESCRIPTION
Fixes #82469

Note：I did not quite obey the rule of OOP here but I think it's fine. Add a dedicated virtual method for getting the volume seems a little overkill.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
