### PR TITLE
Fix not refitting upward from leaf nodes

### DIFF
--- a/core/math/bvh_refit.inc
+++ b/core/math/bvh_refit.inc
@@ -134,7 +134,7 @@ void refit_branch(uint32_t p_node_id) {
 			TLeaf &leaf = _node_get_leaf(tnode);
 			if (leaf.is_dirty()) {
 				leaf.set_dirty(false);
-				refit_upward(p_node_id);
+				refit_upward(rp.node_id);
 			}
 		}
 	} // while more nodes to pop

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -83,7 +83,7 @@ public:
 
 	void clear() {
 		num_items = 0;
-		set_dirty(true);
+		set_dirty(false);
 	}
 	bool is_full() const { return num_items >= MAX_ITEMS; }
 


### PR DESCRIPTION
Previously, the wrong node id (the root node id) was used. Dirty leaf nodes do not actually recalculate aabb.

Additionally, when requesting a new leaf, mark `dirty` as `false` in `clear()`.

Make sure to only mark the leaf as **dirty** when shrinking the border of the leaf when removing items.

In other cases, the leaf node's aabb will get the correct result immediately.
1. When adding an item, the leaf nodes will be calculated immediately.
2. Removing the item within the border of the leaf node has no effect on the original aabb.

Fix https://github.com/godotengine/godot/pull/82436#issuecomment-1738966251.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
