### PR TITLE
Avoid import dock cleanup for non-loadable assets

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -499,9 +499,12 @@ void ImportDock::_reimport_attempt() {
 
 		String imported_with = config->get_value("remap", "importer");
 		if (imported_with != importer_name) {
-			need_cleanup.push_back(params->paths[i]);
-			if (_find_owners(EditorFileSystem::get_singleton()->get_filesystem(), params->paths[i])) {
-				used_in_resources = true;
+			Ref<Resource> resource = ResourceLoader::load(params->paths[i]);
+			if (resource.is_valid()) {
+				need_cleanup.push_back(params->paths[i]);
+				if (_find_owners(EditorFileSystem::get_singleton()->get_filesystem(), params->paths[i])) {
+					used_in_resources = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes a crash when changing the type of a file that is not loadable (e.g a CSV or file with the "keep file" option) and reimporting. Not all files in the editor return a valid file from Resource::load. If these are added to the `need_cleanup` list, it'll crash when attempting to load the resource during cleanup [here](https://github.com/godotengine/godot/blob/4c3dc26367518e006f8555c12f5d2df0b8a28192/editor/import_dock.cpp#L524).

Technically the cleanup code could also be updated to better handle non loadable resources, but I think it's simpler to just ensure `need_cleanup` doesn't contain these files.

One small problem that remains is that objects that reference the updated resource aren't auto saved, so if a user quits before saving, the next project load will still be referencing the old object. Out of scope for this PR though.

Project for reproducing the crash (on latest code, this bug is not in 4.1.1): [reimport_crash.zip](https://github.com/godotengine/godot/files/12752120/reimport_crash.zip)

Project for testing the fix: [change_type_crash_test.zip](https://github.com/godotengine/godot/files/12752126/change_type_crash_test.zip). To test, set the sprite's texture to the image. Then update the image to "keep file" and reimport.

I think there are some potential improvements that could be made to handle files that don't actually load resources. There's currently no easy way to determine if a given path can be loaded into a resource without calling `ResourceLoader::load` and checking the result. ResourceLoader will always find a loader that "recognizes" the path, because ResourceFormatImporter technically recognizes all paths that can be imported. This logic is what allows the remapping of a file to it's imported file to work, but makes it more difficult to gracefully handle cases like CSV files or resources with "keep file" selected.