### PR TITLE
Typed array equality operator update

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1277,11 +1277,13 @@ static GDExtensionVariantPtr gdextension_array_operator_index_const(GDExtensionC
 	return (GDExtensionVariantPtr)&self->operator[](p_index);
 }
 
+#ifndef DISABLE_DEPRECATED
 void gdextension_array_ref(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from) {
 	Array *self = (Array *)p_self;
 	const Array *from = (const Array *)p_from;
-	self->_ref(*from);
+	self->Array::operator=(*from);
 }
+#endif // DISABLE_DEPRECATED
 
 void gdextension_array_set_typed(GDExtensionTypePtr p_self, GDExtensionVariantType p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script) {
 	Array *self = reinterpret_cast<Array *>(p_self);
@@ -1798,7 +1800,9 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(packed_vector4_array_operator_index_const);
 	REGISTER_INTERFACE_FUNC(array_operator_index);
 	REGISTER_INTERFACE_FUNC(array_operator_index_const);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(array_ref);
+#endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(array_set_typed);
 	REGISTER_INTERFACE_FUNC(dictionary_operator_index);
 	REGISTER_INTERFACE_FUNC(dictionary_operator_index_const);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2386,6 +2386,7 @@ typedef GDExtensionVariantPtr (*GDExtensionInterfaceArrayOperatorIndexConst)(GDE
 /**
  * @name array_ref
  * @since 4.1
+ * @deprecated in Godot 4.5. use `Array::operator=` instead.
  *
  * Sets an Array to be a reference to another Array object.
  *

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -44,6 +44,7 @@ struct ContainerType;
 
 class Array {
 	mutable ArrayPrivate *_p;
+	void _ref(const Array &p_from) const;
 	void _unref() const;
 
 public:
@@ -108,8 +109,6 @@ public:
 
 	ConstIterator begin() const;
 	ConstIterator end() const;
-
-	void _ref(const Array &p_from) const;
 
 	Variant &operator[](int p_idx);
 	const Variant &operator[](int p_idx) const;

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -42,7 +42,7 @@ class TypedArray : public Array {
 public:
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
-		_ref(p_array);
+		Array::operator=(p_array);
 	}
 	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
 			TypedArray(Array(p_variant)) {
@@ -50,7 +50,7 @@ public:
 	_FORCE_INLINE_ TypedArray(const Array &p_array) {
 		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
 		if (is_same_typed(p_array)) {
-			_ref(p_array);
+			Array::operator=(p_array);
 		} else {
 			assign(p_array);
 		}
@@ -81,7 +81,7 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 	public:                                                                                                      \
 		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
 			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			_ref(p_array);                                                                                       \
+			Array::operator=(p_array);                                                                           \
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :                                       \
 				Array(Array(p_init), m_variant_type, StringName(), Variant()) {                                  \
@@ -92,7 +92,7 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
 			set_typed(m_variant_type, StringName(), Variant());                                                  \
 			if (is_same_typed(p_array)) {                                                                        \
-				_ref(p_array);                                                                                   \
+				Array::operator=(p_array);                                                                       \
 			} else {                                                                                             \
 				assign(p_array);                                                                                 \
 			}                                                                                                    \


### PR DESCRIPTION
After being asked about the significance of `_ref` being exposed to in gdextension on [#78656](https://github.com/godotengine/godot/pull/78656#discussion_r1338138231), I tried looking into why it needed to be exposed for typed arrays. But after looking, I'm convinced that it actually **doesn't** need to be exposed in the way it is now. It appears that the same effect can be achieved by changing the typed array call from `_ref` to `Array::operator=`

Consequently, this removes the need for `_ref` to be exposed in the first place. Not only can that return to being a private function, but the `gdextension_interface` references can be ~~safely removed~~ deprecated as well, as binding tools can simply reference the operator instead