### PR TITLE
[3.x] BVH - fix not refitting upward from leaf nodes

### DIFF
--- a/core/math/bvh_refit.inc
+++ b/core/math/bvh_refit.inc
@@ -134,7 +134,7 @@ void refit_branch(uint32_t p_node_id) {
 			TLeaf &leaf = _node_get_leaf(tnode);
 			if (leaf.is_dirty()) {
 				leaf.set_dirty(false);
-				refit_upward(p_node_id);
+				refit_upward(rp.node_id);
 			}
 		}
 	} // while more nodes to pop

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -71,7 +71,7 @@ public:
 
 	void clear() {
 		num_items = 0;
-		set_dirty(true);
+		set_dirty(false);
 	}
 	bool is_full() const { return num_items >= MAX_ITEMS; }
 


### PR DESCRIPTION
Fix leaf node possibly not updating aabb due to wrong node id.

Additionally, when requesting a new leaf, mark `dirty` as `false` in `clear()`.

Backport of #82482.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
