### PR TITLE
[3.x] BVH - fix axis getting mixed up when split leaf

### DIFF
--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -30,8 +30,8 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 
 	int order[POINT::AXIS_COUNT];
 
-	order[0] = size.min_axis();
-	order[POINT::AXIS_COUNT - 1] = size.max_axis();
+	order[0] = size.max_axis();
+	order[POINT::AXIS_COUNT - 1] = size.min_axis();
 
 	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
 	if (POINT::AXIS_COUNT == 3) {


### PR DESCRIPTION
Split preferentially on longest axis, rather than shortest axis.

Backport of #82436.

Replaces #82447... for quick merging.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
