### PR TITLE
Disable `lightmapper_rd` module in non-editor builds (and in Android editor)

### DIFF
--- a/modules/lightmapper_rd/config.py
+++ b/modules/lightmapper_rd/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return True
+    return env.editor_build and platform not in ["android", "ios"]
 
 
 def configure(env):

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -58,7 +58,6 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 	GLOBAL_DEF("rendering/lightmapping/bake_quality/high_quality_probe_ray_count", 512);
 	GLOBAL_DEF("rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", 2048);
 	GLOBAL_DEF("rendering/lightmapping/bake_performance/max_rays_per_probe_pass", 64);
-	GLOBAL_DEF("rendering/lightmapping/primitive_meshes/texel_size", 0.2);
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(LightmapperRD);
 	Lightmapper::create_gpu = create_lightmapper_rd;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2983,6 +2983,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/limits/global_shader_variables/buffer_size", 65536);
 
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/lightmapping/probe_capture/update_speed", PROPERTY_HINT_RANGE, "0.001,256,0.001"), 15);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/lightmapping/primitive_meshes/texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.2);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/probe_ray_count", PROPERTY_HINT_ENUM, "8 (Fastest),16,32,64,96,128 (Slowest)"), 1);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/sdfgi/frames_to_converge", PROPERTY_HINT_ENUM, "5 (Less Latency but Lower Quality),10,15,20,25,30 (More Latency but Higher Quality)"), 5);


### PR DESCRIPTION
This is consistent with `xatlas_unwrap`, which isn't enabled in non-editor builds and the Android editor either. There is currently no way to use the lightmapper in a non-editor build anyway, as it doesn't expose any methods (and even if there was, there would be no way to perform UV2 unwrapping in the exported project).

This reduces binary size of a stripped Linux x86_64 export template build by ~164 KB (compared against fe8a58b9d7ca5b85348b3a984eeb16371a097481).

- Before: 61,254,808 bytes
- After: 61,091,000 bytes (-0.26%)

This also moves the PrimitiveMesh texel size project setting so that it's defined when the module is disabled, and adds a property hint to it.

In the future, if we decide to make this functionality available in non-editor builds, it should also be made available with `xatlas_unwrap` as a build-time option (similar to https://github.com/godotengine/godot/pull/73003).

I tested this PR in a project with existing baked lightmaps and it works as expected (no errors, it renders correctly).

- This closes https://github.com/godotengine/godot/issues/72544.