### PR TITLE
[WIP]Use get dynamic time zone information to get no localized time zone name

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -576,9 +576,9 @@ OS::DateTime OS_Windows::get_datetime(bool p_utc) const {
 }
 
 OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
-	TIME_ZONE_INFORMATION info;
+	DYNAMIC_TIME_ZONE_INFORMATION info;
 	bool is_daylight = false;
-	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
+	if (GetDynamicTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
 		is_daylight = true;
 	}
 
@@ -588,7 +588,7 @@ OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
 		ret.name = info.DaylightName;
 		ret.bias = info.Bias + info.DaylightBias;
 	} else {
-		ret.name = info.StandardName;
+		ret.name = info.TimeZoneKeyName;
 		ret.bias = info.Bias + info.StandardBias;
 	}
 


### PR DESCRIPTION
Fix part of #82361

This is a small breaking change that might have other impacts.
To be honest this pr doesn't take care of `DaylightName` and the value returned is not the abbrev. Maybe we can use a translation map for this. But I doubt if the issue worth the effort or not.

Update:
I find a complex implementation of the function that may solve this issue in `wintz.cpp`, in module `icu4c`. Maybe we can find a way to use this function or port it to suit our needs.



<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
