### PR TITLE
Support saving packed scene's metadata 

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -291,6 +291,9 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 				if (!assign.is_empty()) {
 					StringName assign_name = assign;
+					if (parent == -1 && assign.begins_with("metadata/")) {
+						packed_scene->set(assign, value);
+					}
 					int nameidx = packed_scene->get_state()->add_name(assign_name);
 					int valueidx = packed_scene->get_state()->add_value(value);
 					packed_scene->get_state()->add_node_property(node_id, nameidx, valueidx, path_properties.has(assign_name));
@@ -2270,11 +2273,32 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			f->store_line("]");
 
+			HashSet<String> stored_metadatas;
+			if (i == 0) {
+				// Store scene metadata as the first node's metadata.
+				List<PropertyInfo> property_list;
+				packed_scene->get_property_list(&property_list);
+				for (List<PropertyInfo>::Element *PE = property_list.front(); PE; PE = PE->next()) {
+					String property_name = PE->get().name;
+					if ((PE->get().usage & PROPERTY_USAGE_STORAGE) && property_name.begins_with("metadata/")) {
+						Variant value = packed_scene->get(property_name);
+						String vars;
+						VariantWriter::write_to_string(value, vars, _write_resources, this);
+						f->store_string(property_name.property_name_encode() + " = " + vars + "\n");
+						stored_metadatas.insert(property_name);
+					}
+				}
+			}
+
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
+				String property_name = String(state->get_node_property_name(i, j)).property_name_encode();
+				if (i == 0 && stored_metadatas.has(property_name)) {
+					continue;
+				}
 				String vars;
 				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this);
 
-				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
+				f->store_string(property_name + " = " + vars + "\n");
 			}
 
 			if (i < state->get_node_count() - 1) {


### PR DESCRIPTION
Fixes #76366

This is the initial version, I guess it can be improved a lot. Maybe we can merge some metadata saving code shared between common resource and packedscene, or just leave it like this is fine. 

Also there might still many corner cases I did not test. I would appreciate any feedback or alternative suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
