### PR TITLE
Make the lightmapper not dilate before denoising.

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1493,14 +1493,6 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 #endif
 
-	{
-		SWAP(light_accum_tex, light_accum_tex2);
-		BakeError error = _dilate(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, light_accum_tex, atlas_size, atlas_slices * (p_bake_sh ? 4 : 1));
-		if (unlikely(error != BAKE_OK)) {
-			return error;
-		}
-	}
-
 	/* DENOISE */
 
 	if (p_use_denoiser) {
@@ -1515,13 +1507,13 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				return error;
 			}
 		}
+	}
 
-		{
-			SWAP(light_accum_tex, light_accum_tex2);
-			BakeError error = _dilate(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, light_accum_tex, atlas_size, atlas_slices * (p_bake_sh ? 4 : 1));
-			if (unlikely(error != BAKE_OK)) {
-				return error;
-			}
+	{
+		SWAP(light_accum_tex, light_accum_tex2);
+		BakeError error = _dilate(rd, compute_shader, compute_base_uniform_set, push_constant, light_accum_tex2, light_accum_tex, atlas_size, atlas_slices * (p_bake_sh ? 4 : 1));
+		if (unlikely(error != BAKE_OK)) {
+			return error;
 		}
 	}
 


### PR DESCRIPTION
Dilating noisy data caused issues for the denoiser. Fixes #82526.

Upon merging the new denoiser, which filters out invalid pixels from being part of the algorithm, there was a problem where noisy pixels would be dilated first and the denoiser wouldn't be able to fix it.

In retrospect, the fix is fairly obvious and it makes sense: denoise valid data first, and then do the dilation with the valid data only, not the noisy pixels.

This fixes the noise present in seams that made its way in once the half pixel offset started being used in the denoiser branch.

### Before

![MASTER](https://github.com/godotengine/godot/assets/538504/2260d188-cff9-4d70-a734-7d6dd9c56d9c)

### After
![DILATE_FIX](https://github.com/godotengine/godot/assets/538504/c29657c6-fa20-4e8e-9de3-2300efce191f)