### PR TITLE
Use internal texture at internal resolution for calculating luminance (FSR2).

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -418,7 +418,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		double step = RSG::camera_attributes->camera_attributes_get_auto_exposure_adjust_speed(p_render_data->camera_attributes) * time_step;
 		float auto_exposure_min_sensitivity = RSG::camera_attributes->camera_attributes_get_auto_exposure_min_sensitivity(p_render_data->camera_attributes);
 		float auto_exposure_max_sensitivity = RSG::camera_attributes->camera_attributes_get_auto_exposure_max_sensitivity(p_render_data->camera_attributes);
-		luminance->luminance_reduction(color_texture, color_size, luminance_buffers, auto_exposure_min_sensitivity, auto_exposure_max_sensitivity, step, set_immediate);
+		luminance->luminance_reduction(rb->get_internal_texture(), rb->get_internal_size(), luminance_buffers, auto_exposure_min_sensitivity, auto_exposure_max_sensitivity, step, set_immediate);
 
 		// Swap final reduce with prev luminance.
 


### PR DESCRIPTION
Fixes an error where the exposure was calculated incorrectly if a lower resolution scale was used while using FSR2. Now the behavior is consistent regardless of the resolution scale since it uses the internal texture as it should instead.

Master 0.5
![image](https://github.com/godotengine/godot/assets/538504/2217ef58-5769-4955-908c-262fd7f914c7)

Master 1.0
![image](https://github.com/godotengine/godot/assets/538504/6b86c1d7-045f-49ad-838f-0c2b06517df1)

PR 0.5
![image](https://github.com/godotengine/godot/assets/538504/f8491b91-65a9-419b-aefb-07df3d44f835)

PR 1.0
![image](https://github.com/godotengine/godot/assets/538504/ac63a563-ddb0-4a26-bb87-0300dcec1fa4)

This is a low risk change and only affected results when auto-exposure was enabled on the camera properties.