### PR TITLE
Use theme icon size when calculating category minimum size

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1188,7 +1188,8 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	Size2 ms;
 	ms.height = font->get_height(font_size);
 	if (icon.is_valid()) {
-		ms.height = MAX(icon->get_height(), ms.height);
+		int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+		ms.height = MAX(icon_size, ms.height);
 	}
 	ms.height += get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 


### PR DESCRIPTION
This previously used the underlying size of the icon, causing the category to grow incorrectly when re-rendered (e.g. via switching tabs at the top of the inspector):

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/godotengine/godot/assets/1843197/be01f216-f31a-4d6f-91b8-4ff91cffe5c1"></td>
<td><img src="https://github.com/godotengine/godot/assets/1843197/1e2f4b4b-e30c-4340-a050-bb05e5a04c7a"></td>
</tr>
</tbody>
</table>

Fixes #82527

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
