### PR TITLE
Improve SeparationRayShape docs

### DIFF
--- a/doc/classes/SeparationRayShape2D.xml
+++ b/doc/classes/SeparationRayShape2D.xml
@@ -4,7 +4,7 @@
 		A 2D ray shape used for physics collision that tries to separate itself from any collider.
 	</brief_description>
 	<description>
-		A 2D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape2D]. When a [SeparationRayShape2D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. It can for example be used for spears falling from the sky.
+		A 2D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape2D]. When a [SeparationRayShape2D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape2D] next to a character can allow it to instantly move up when touching stairs.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SeparationRayShape3D.xml
+++ b/doc/classes/SeparationRayShape3D.xml
@@ -4,7 +4,7 @@
 		A 3D ray shape used for physics collision that tries to separate itself from any collider.
 	</brief_description>
 	<description>
-		A 3D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. When a [SeparationRayShape3D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. It can for example be used for spears falling from the sky.
+		A 3D ray shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. When a [SeparationRayShape3D] collides with an object, it tries to separate itself from it by moving its endpoint to the collision point. For example, a [SeparationRayShape3D] next to a character can allow it to instantly move up when touching stairs.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/8087

How did the "spears falling from the skies" come to be?

Well, I was making this massive PR refactoring physics classes' documentation, and this was a class I hadn't used before.  I noticed a few issues in this page. The first was that the documentation said "SeparationRayShape is useful for characters" which seemed so broad. You can use everything for characters except for stuff like worldboundaries and heightmaps. So I started thinking about how to give a more obvious example.

The second issue in the old documentation page, and it was a reoccuring issue, was a performance remark along the lines of "SeparationRayShape is fast, but CircleShape is faster". Again, why would you mention this? It's not like the two shapes are similar to any capacity, no one will replace their SeparationRayShapes for CircleShapes for performance reasons.

Wanting to make these performance remarks more useful, I made a test project and started spawning a lot of physics shapes. Spawning 1000 SeparationRayShapes looked like a "Rain of spears" sorta spell, so it gave me the idea to put this as an example in the docs. I didn't even look into its common use cases :sweat: 