### PR TITLE
Restore UNIQUE_SCENE_NAME toggle to foreign scenes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3066,23 +3066,13 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	}
 
 	if (profile_allow_editing) {
-		// Allow multi-toggling scene unique names but only if all selected nodes are owned by the edited scene root.
-		bool all_owned = true;
-		for (Node *node : full_selection) {
-			if (node->get_owner() != EditorNode::get_singleton()->get_edited_scene()) {
-				all_owned = false;
-				break;
-			}
+		// Group "toggle_unique_name" with "copy_node_path", if it is available.
+		if (menu->get_item_index(TOOL_COPY_NODE_PATH) == -1) {
+			menu->add_separator();
 		}
-		if (all_owned) {
-			// Group "toggle_unique_name" with "copy_node_path", if it is available.
-			if (menu->get_item_index(TOOL_COPY_NODE_PATH) == -1) {
-				menu->add_separator();
-			}
-			Node *node = full_selection[0];
-			menu->add_icon_shortcut(get_editor_theme_icon(SNAME("SceneUniqueName")), ED_GET_SHORTCUT("scene_tree/toggle_unique_name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
-			menu->set_item_text(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), node->is_unique_name_in_owner() ? TTR("Revoke Unique Name") : TTR("Access as Unique Name"));
-		}
+		Node *node = full_selection[0];
+		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("SceneUniqueName")), ED_GET_SHORTCUT("scene_tree/toggle_unique_name"), TOOL_TOGGLE_SCENE_UNIQUE_NAME);
+		menu->set_item_text(menu->get_item_index(TOOL_TOGGLE_SCENE_UNIQUE_NAME), node->is_unique_name_in_owner() ? TTR("Revoke Unique Name") : TTR("Access as Unique Name"));
 	}
 
 	if (selection.size() == 1) {


### PR DESCRIPTION
This PR restores the ability to toggle the unique name flag on nodes which are the children of instanced or inherited scenes, which should be permissible as this flag is treated as singular property for nodes. I haven't checked the history, but this mistake was likely done when I was conforming the editor to restrict editing operations in foreign scenes. It's still possible to toggle the unique scene flag off, but not turn it back on, so this make the behaviour consistent once again.