### PR TITLE
Fix cluster artifacts and negative light

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -576,8 +576,9 @@ void main() {
 						float attenuation = get_omni_attenuation(d, spot_lights.data[light_index].inv_radius, spot_lights.data[light_index].attenuation);
 
 						vec3 spot_dir = spot_lights.data[light_index].direction;
-						float scos = max(dot(-normalize(light_rel_vec), spot_dir), spot_lights.data[light_index].cone_angle);
-						float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - spot_lights.data[light_index].cone_angle));
+						highp float cone_angle = spot_lights.data[light_index].cone_angle;
+						float scos = max(dot(-normalize(light_rel_vec), spot_dir), cone_angle);
+						float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - cone_angle));
 						attenuation *= 1.0 - pow(spot_rim, spot_lights.data[light_index].cone_attenuation);
 
 						vec3 light = spot_lights.data[light_index].color;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/78500

Instructions:
Definitely should be merged on top of this PR: https://github.com/godotengine/godot/pull/80992

Details:
Just added the same shader adjustment for the cone angle as in this PR: https://github.com/godotengine/godot/pull/71832 it might have been just forgotten?


EDIT:
There's one more place which also uses the cone angle, but this time in gles3 shader, which doesn't use the `highp` for the cone angle in case it matters (?), the original author did not rework that one, it might not be an issue but I'm keeping this note here in case in future there's a similar clustered artifact issue with spotlight in gles3 in some other areas, it might not be need to make a change there at all but let's try not to foget it.