### PR TITLE
GDScript: Fix `UNSAFE_CALL_ARGUMENT` warning for `Variant` constructors

### DIFF
--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -107,8 +107,8 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The value is cast to "%s" but has an unknown type.)", symbols[0]);
 		case UNSAFE_CALL_ARGUMENT:
-			CHECK_SYMBOLS(4);
-			return vformat(R"*(The argument %s of the function "%s()" requires the subtype "%s" but the supertype "%s" was provided.)*", symbols[0], symbols[1], symbols[2], symbols[3]);
+			CHECK_SYMBOLS(5);
+			return vformat(R"*(The argument %s of the %s "%s()" requires the subtype "%s" but the supertype "%s" was provided.)*", symbols[0], symbols[1], symbols[2], symbols[3], symbols[4]);
 		case UNSAFE_VOID_RETURN:
 			CHECK_SYMBOLS(2);
 			return vformat(R"*(The method "%s()" returns "void" but it's trying to return a call to "%s()" that can't be ensured to also be "void".)*", symbols[0], symbols[1]);

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.gd
@@ -7,8 +7,12 @@ func int_func(x: int) -> void:
 func float_func(x: float) -> void:
 	print(x)
 
+func node_func(x: Node) -> void:
+	print(x)
+
 # We don't want to execute it because of errors, just analyze.
 func no_exec_test():
+	var variant: Variant = null
 	var untyped_int = 42
 	var untyped_string = "abc"
 	var variant_int: Variant = 42
@@ -32,6 +36,19 @@ func no_exec_test():
 	float_func(variant_int)
 	float_func(variant_string)
 	float_func(typed_int) # No warning.
+
+	node_func(variant)
+	node_func(Object.new())
+	node_func(Node.new()) # No warning.
+	node_func(Node2D.new()) # No warning.
+
+	# GH-82529
+	print(Callable(self, "test")) # No warning.
+	print(Callable(variant, "test"))
+
+	print(Dictionary(variant))
+	print(Vector2(variant))
+	print(int(variant))
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unsafe_call_argument.out
@@ -1,33 +1,57 @@
 GDTEST_OK
 >> WARNING
->> Line: 24
+>> Line: 28
 >> UNSAFE_CALL_ARGUMENT
 >> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
 >> WARNING
->> Line: 25
->> UNSAFE_CALL_ARGUMENT
->> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
->> WARNING
->> Line: 26
->> UNSAFE_CALL_ARGUMENT
->> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
->> WARNING
->> Line: 27
+>> Line: 29
 >> UNSAFE_CALL_ARGUMENT
 >> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
 >> WARNING
 >> Line: 30
 >> UNSAFE_CALL_ARGUMENT
->> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
+>> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
 >> WARNING
 >> Line: 31
 >> UNSAFE_CALL_ARGUMENT
->> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
+>> The argument 1 of the function "int_func()" requires the subtype "int" but the supertype "Variant" was provided.
 >> WARNING
->> Line: 32
+>> Line: 34
 >> UNSAFE_CALL_ARGUMENT
 >> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
 >> WARNING
->> Line: 33
+>> Line: 35
 >> UNSAFE_CALL_ARGUMENT
 >> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 36
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 37
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the function "float_func()" requires the subtype "float" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 40
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the function "node_func()" requires the subtype "Node" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 41
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the function "node_func()" requires the subtype "Node" but the supertype "Object" was provided.
+>> WARNING
+>> Line: 47
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the constructor "Callable()" requires the subtype "Object" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 49
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the constructor "Dictionary()" requires the subtype "Dictionary" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 50
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the constructor "Vector2()" requires the subtype "Vector2" or "Vector2i" but the supertype "Variant" was provided.
+>> WARNING
+>> Line: 51
+>> UNSAFE_CALL_ARGUMENT
+>> The argument 1 of the constructor "int()" requires the subtype "int", "bool", or "float" but the supertype "Variant" was provided.

--- a/modules/gdscript/tests/scripts/runtime/features/stringify.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/stringify.gd
@@ -24,7 +24,6 @@ func test():
 	print(StringName("hello"))
 	print(NodePath("hello/world"))
 	var node := Node.new()
-	@warning_ignore("unsafe_call_argument")
 	print(RID(node)) # TODO: Why is the constructor (or implicit cast) not documented?
 	print(node.get_name)
 	print(node.property_list_changed)


### PR DESCRIPTION
* Fixes #82529.
* Improves warning message for Variant constructors, particularly copy/convert constructors.