### PR TITLE
Add helpful error message when using old type hint in shader language

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8640,7 +8640,11 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							completion_line = tk.line;
 
 							if (!is_token_hint(tk.type)) {
-								_set_error(RTR("Expected valid type hint after ':'."));
+								if (tk.text == "hint_color") {
+									_set_error(vformat(RTR("`%s` is no longer supported, use `%s` instead."), "hint_color", "source_color"));
+								} else {
+									_set_error(RTR("Expected valid type hint after ':'."));
+								}
 								return ERR_PARSE_ERROR;
 							}
 


### PR DESCRIPTION
- Adds an error message telling users to use source_color if they used hint_color in their code