### PR TITLE
[FileDialog] Make `set_visible` compatible with native dialogs.

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -63,6 +63,16 @@ void FileDialog::popup(const Rect2i &p_rect) {
 	}
 }
 
+void FileDialog::set_visible(bool p_visible) {
+	if (access == ACCESS_FILESYSTEM && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG) && (use_native_dialog || OS::get_singleton()->is_sandboxed())) {
+		if (p_visible) {
+			DisplayServer::get_singleton()->file_dialog_show(get_title(), dir->get_text(), file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), filters, callable_mp(this, &FileDialog::_native_dialog_cb));
+		}
+	} else {
+		ConfirmationDialog::set_visible(p_visible);
+	}
+}
+
 void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files) {
 	if (p_ok) {
 		if (p_files.size() > 0) {

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -171,6 +171,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual void set_visible(bool p_visible) override;
 	virtual void popup(const Rect2i &p_rect = Rect2i()) override;
 
 	void popup_file_dialog();

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -293,7 +293,7 @@ public:
 	void request_attention();
 	void move_to_foreground();
 
-	void set_visible(bool p_visible);
+	virtual void set_visible(bool p_visible);
 	bool is_visible() const;
 
 	void update_mouse_cursor_state() override;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82531