### PR TITLE
Fix `RefCounted.unreference()` documentation providing wrong info.

### DIFF
--- a/doc/classes/RefCounted.xml
+++ b/doc/classes/RefCounted.xml
@@ -37,7 +37,7 @@
 			<return type="bool" />
 			<description>
 				Decrements the internal reference counter. Use this only if you really know what you are doing.
-				Returns [code]true[/code] if the decrement was successful, [code]false[/code] otherwise.
+				Returns [code]true[/code] if the object should be freed after the decrement, [code]false[/code] otherwise.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
