### PR TITLE
Fix GroupedStateMachine reset

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -690,9 +690,9 @@ double AnimationNodeStateMachinePlayback::_process(const String &p_base_path, An
 			if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 				path.clear();
 				_clear_path_children(tree, p_state_machine, p_test_only);
+				_start(p_state_machine);
 			}
 			reset_request = true;
-			_start(p_state_machine);
 		} else {
 			// Reset current state.
 			reset_request = true;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82566. Follow up https://github.com/godotengine/godot/pull/80813.

https://github.com/godotengine/godot/assets/61938263/8b38e41d-2c47-4589-8650-00e1a295f8d7

Due to a process change, the GroupedStateMachine reset is not working properly with travel. (I didn't think I had made any changes that would affect it...)

For now, GroupedStateMachine should not be reset by seek. Actually, if you specify a move or seek to a Grouped StateMachine in the parent StateMachine, the GroupedStateMachine will be forced to transition to Start state, so this explicit restart should be not necessary.