### PR TITLE
Fix crash when deleting the player in `AnimationPlayerEditorPlugin`

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -2203,9 +2203,6 @@ AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {
 	if (dummy_player) {
 		memdelete(dummy_player);
 	}
-	if (player) {
-		memdelete(player);
-	}
 }
 
 // AnimationTrackKeyEditEditorPlugin


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/82549

The player is just a weak pointer, which doesn't allocate and shouldn't free in this class:

```
player = Object::cast_to<AnimationPlayer>(p_object);
```