### PR TITLE
Improve thread safety of `ScriptServer`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -54,8 +54,9 @@ class ScriptServer {
 	static int _language_count;
 	static bool scripting_enabled;
 	static bool reload_scripts_on_save;
-	static bool languages_finished; // Used until GH-76581 is fixed properly.
-	static SafeFlag languages_initialized;
+	static bool languages_finished;
+	static bool languages_initialized;
+	static Mutex languages_lock;
 
 	struct GlobalScriptClass {
 		StringName language;
@@ -72,7 +73,10 @@ public:
 
 	static void set_scripting_enabled(bool p_enabled);
 	static bool is_scripting_enabled();
-	_FORCE_INLINE_ static int get_language_count() { return _language_count; }
+	_FORCE_INLINE_ static int get_language_count() {
+		MutexLock lock(languages_lock);
+		return _language_count;
+	}
 	static ScriptLanguage *get_language(int p_idx);
 	static Error register_language(ScriptLanguage *p_language);
 	static Error unregister_language(const ScriptLanguage *p_language);
@@ -100,7 +104,10 @@ public:
 	static void init_languages();
 	static void finish_languages();
 
-	static bool are_languages_finished() { return languages_finished; }
+	static bool are_languages_finished() {
+		MutexLock lock(languages_lock);
+		return languages_finished;
+	}
 };
 
 class PlaceHolderScriptInstance;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -54,7 +54,8 @@ class ScriptServer {
 	static int _language_count;
 	static bool scripting_enabled;
 	static bool reload_scripts_on_save;
-	static SafeFlag languages_finished; // Used until GH-76581 is fixed properly.
+	static bool languages_finished; // Used until GH-76581 is fixed properly.
+	static SafeFlag languages_initialized;
 
 	struct GlobalScriptClass {
 		StringName language;
@@ -99,7 +100,7 @@ public:
 	static void init_languages();
 	static void finish_languages();
 
-	static bool are_languages_finished() { return languages_finished.is_set(); }
+	static bool are_languages_finished() { return languages_finished; }
 };
 
 class PlaceHolderScriptInstance;


### PR DESCRIPTION
When working on [godot-jvm](https://github.com/utopia-rise/godot-kotlin-jvm) multi-threading, we implemented `ScriptLanguage::thread_enter` and `ScriptLanguage::thread_exit` to attach and detach JVM according to thread lifecycle.  
Those implementations were not called. So after looking to `ScriptServer` code I found those methods:

```cpp
void ScriptServer::finish_languages() {
	for (int i = 0; i < _language_count; i++) {
		_languages[i]->finish();
	}
	global_classes_clear();
	languages_finished.set();
}

void ScriptServer::thread_enter() {
	if (!languages_finished.is_set()) {
		return;
	}
	for (int i = 0; i < _language_count; i++) {
		_languages[i]->thread_enter();
	}
}

void ScriptServer::thread_exit() {
	if (!languages_finished.is_set()) {
		return;
	}
	for (int i = 0; i < _language_count; i++) {
		_languages[i]->thread_exit();
	}
}
```

The problem here is that `languages_finished` is set only when killing languages (C# is using `ScriptLanguage::finish` to kill language too).

So the problem here is the condition inversion on 
```cpp
	if (!languages_finished.is_set()) {
		return;
	}
```

This PR fixes this by inverting the condition.  
It also adds a pre-processor on this if, as when engine runs language servers are up most of the time.