### PR TITLE
Fix exported script variables in remote object inspector.

### DIFF
--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -74,6 +74,7 @@ private:
 
 	void _object_selected(ObjectID p_object);
 	void _object_edited(ObjectID p_id, const String &p_prop, const Variant &p_value);
+	void _inspector_property_edited(const String &p_name);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
Currently, if you have exported script variables, they will always show up as their default values if viewed in the remote object inspector. This is due to the fact that the getter/setter only gets the properties from the locally assigned PlaceholderScriptInstance, completely bypassing the native object and proxy logic.

Since this is quite a deeply embedded problem, I worked around it by having the EditorDebuggerInspector::add_object update any script instance values which makes the inspector display property. To allow setting them, I connect a signal 'property_edited' callback to the default inspector and if the object being edited is a remote object, check if property matches any in the script, and if it does, set the corresponding member value.

This solution on the whole is a bit hacky, but it feels the cleanest approach I could come up with without introducing lots of changes, and as far as I can tell, seems to work as intended now.