### PR TITLE
Fix the Advanced Import Settings window's 3D camera

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -550,7 +550,7 @@ void SceneImportSettings::_update_camera() {
 	camera->set_orthogonal(camera_size * zoom, 0.0001, camera_size * 2);
 
 	Transform3D xf;
-	xf.basis = Basis(Vector3(1, 0, 0), rot_x) * Basis(Vector3(0, 1, 0), rot_y);
+	xf.basis = Basis(Vector3(0, 1, 0), rot_y) * Basis(Vector3(1, 0, 0), rot_x);
 	xf.origin = center;
 	xf.translate_local(0, 0, camera_size);
 


### PR DESCRIPTION
The viewport preview of the Advanced Import Settings window doesn't feel very intuitive in terms of how mouse movement changes the camera.  Mainly, it doesn't match the main 3D viewport in the editor's rotation where by default it keeps the Y axis pointing up.

Example:

https://github.com/godotengine/godot-proposals/assets/22860318/814adf47-fa0d-48b4-84dc-3b60d94e172a

Fixed:

https://github.com/godotengine/godot-proposals/assets/22860318/9ee5ec03-92e5-4245-8922-ad8872eba0d2


<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
