### PR TITLE
Fix NavigationObstacle3D debug being affected by rotation and scale

### DIFF
--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -148,10 +148,14 @@ void NavigationObstacle3D::_notification(int p_what) {
 				}
 #ifdef DEBUG_ENABLED
 				if (fake_agent_radius_debug_instance.is_valid() && radius > 0.0) {
-					RS::get_singleton()->instance_set_transform(fake_agent_radius_debug_instance, get_global_transform());
+					Transform3D debug_transform;
+					debug_transform.origin = get_global_position();
+					RS::get_singleton()->instance_set_transform(fake_agent_radius_debug_instance, debug_transform);
 				}
 				if (static_obstacle_debug_instance.is_valid() && get_vertices().size() > 0) {
-					RS::get_singleton()->instance_set_transform(static_obstacle_debug_instance, get_global_transform());
+					Transform3D debug_transform;
+					debug_transform.origin = get_global_position();
+					RS::get_singleton()->instance_set_transform(static_obstacle_debug_instance, debug_transform);
 				}
 #endif // DEBUG_ENABLED
 			}


### PR DESCRIPTION
Fixes NavigationObstacle3D debug being affected by rotation and scale.

An avoidance obstacle has no full transform, it only has a position. The late change from Node to Node3D brought with it that all the Node3D properties are inherited so now the debug visuals can end up rotated or at the wrong size due to scale changes.

No property of obstacles or agents, e.g. radius, is affected by node transform except the position. While xforming radius and vertices now is debatable it would break compatiblity so fixing the debug is the better option for now.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
