### PR TITLE
Error handling for `FileAccess.get_file_as_*`

### DIFF
--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -223,8 +223,8 @@ public:
 	static Vector<uint8_t> get_file_as_bytes(const String &p_path, Error *r_error = nullptr);
 	static String get_file_as_string(const String &p_path, Error *r_error = nullptr);
 
-	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path); }
-	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path); };
+	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
+	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
 	template <class T>
 	static void make_default(AccessType p_access) {

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -155,6 +155,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns the whole [param path] file contents as a [PackedByteArray] without any decoding.
+				Returns an empty [PackedByteArray] if an error occurred while opening the file. You can use [method get_open_error] to check the error that occurred.
 			</description>
 		</method>
 		<method name="get_file_as_string" qualifiers="static">
@@ -162,6 +163,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns the whole [param path] file contents as a [String]. Text is interpreted as being UTF-8 encoded.
+				Returns an empty [String] if an error occurred while opening the file. You can use [method get_open_error] to check the error that occurred.
 			</description>
 		</method>
 		<method name="get_float" qualifiers="const">


### PR DESCRIPTION
What happens on errors in `FileAccess.get_file_as_bytes` and `FileAccess.get_file_as_string` is currently undocumented. It's also impossible to retrieve the actual error that happened.

---

- Assign last error in said `FileAccess.get_file_as_bytes` and `FileAccess.get_file_as_string`
- Document error handling for said methods
