### PR TITLE
[Web] Fix `dlink_enabled` build

### DIFF
--- a/platform/web/audio_driver_web.h
+++ b/platform/web/audio_driver_web.h
@@ -32,6 +32,7 @@
 #define AUDIO_DRIVER_WEB_H
 
 #include "godot_audio.h"
+#include "godot_js.h"
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
@@ -55,8 +56,8 @@ private:
 	int mix_rate = 0;
 	int channel_count = 0;
 
-	static void _state_change_callback(int p_state);
-	static void _latency_update_callback(float p_latency);
+	WASM_EXPORT static void _state_change_callback(int p_state);
+	WASM_EXPORT static void _latency_update_callback(float p_latency);
 
 	static AudioDriverWeb *singleton;
 

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -33,6 +33,8 @@
 
 #include "servers/display_server.h"
 
+#include "godot_js.h"
+
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
@@ -88,28 +90,28 @@ private:
 	static const char *godot2dom_cursor(DisplayServer::CursorShape p_shape);
 
 	// events
-	static void fullscreen_change_callback(int p_fullscreen);
-	static int mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
-	static void mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers);
-	static int mouse_wheel_callback(double p_delta_x, double p_delta_y);
-	static void touch_callback(int p_type, int p_count);
-	static void key_callback(int p_pressed, int p_repeat, int p_modifiers);
-	static void vk_input_text_callback(const char *p_text, int p_cursor);
-	static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
+	WASM_EXPORT static void fullscreen_change_callback(int p_fullscreen);
+	WASM_EXPORT static int mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
+	WASM_EXPORT static void mouse_move_callback(double p_x, double p_y, double p_rel_x, double p_rel_y, int p_modifiers);
+	WASM_EXPORT static int mouse_wheel_callback(double p_delta_x, double p_delta_y);
+	WASM_EXPORT static void touch_callback(int p_type, int p_count);
+	WASM_EXPORT static void key_callback(int p_pressed, int p_repeat, int p_modifiers);
+	WASM_EXPORT static void vk_input_text_callback(const char *p_text, int p_cursor);
+	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
 	void process_joypads();
-	static void _js_utterance_callback(int p_event, int p_id, int p_pos);
+	WASM_EXPORT static void _js_utterance_callback(int p_event, int p_id, int p_pos);
 
 	static Vector<String> get_rendering_drivers_func();
 	static DisplayServer *create_func(const String &p_rendering_driver, WindowMode p_window_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Error &r_error);
 
 	static void _dispatch_input_event(const Ref<InputEvent> &p_event);
 
-	static void request_quit_callback();
-	static void window_blur_callback();
-	static void update_voices_callback(int p_size, const char **p_voice);
-	static void update_clipboard_callback(const char *p_text);
-	static void send_window_event_callback(int p_notification);
-	static void drop_files_js_callback(char **p_filev, int p_filec);
+	WASM_EXPORT static void request_quit_callback();
+	WASM_EXPORT static void window_blur_callback();
+	WASM_EXPORT static void update_voices_callback(int p_size, const char **p_voice);
+	WASM_EXPORT static void update_clipboard_callback(const char *p_text);
+	WASM_EXPORT static void send_window_event_callback(int p_notification);
+	WASM_EXPORT static void drop_files_js_callback(char **p_filev, int p_filec);
 
 protected:
 	int get_current_video_driver() const;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -31,6 +31,8 @@
 #ifndef GODOT_JS_H
 #define GODOT_JS_H
 
+#define WASM_EXPORT __attribute__((visibility("default")))
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/platform/web/javascript_bridge_singleton.cpp
+++ b/platform/web/javascript_bridge_singleton.cpp
@@ -68,11 +68,11 @@ private:
 	int _js_id = 0;
 	Callable _callable;
 
-	static int _variant2js(const void **p_args, int p_pos, godot_js_wrapper_ex *r_val, void **p_lock);
-	static void _free_lock(void **p_lock, int p_type);
-	static Variant _js2variant(int p_type, godot_js_wrapper_ex *p_val);
-	static void *_alloc_variants(int p_size);
-	static void _callback(void *p_ref, int p_arg_id, int p_argc);
+	WASM_EXPORT static int _variant2js(const void **p_args, int p_pos, godot_js_wrapper_ex *r_val, void **p_lock);
+	WASM_EXPORT static void _free_lock(void **p_lock, int p_type);
+	WASM_EXPORT static Variant _js2variant(int p_type, godot_js_wrapper_ex *p_val);
+	WASM_EXPORT static void *_alloc_variants(int p_size);
+	WASM_EXPORT static void _callback(void *p_ref, int p_arg_id, int p_argc);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value) override;

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -33,6 +33,8 @@
 
 #include "audio_driver_web.h"
 
+#include "godot_js.h"
+
 #include "core/input/input.h"
 #include "drivers/unix/os_unix.h"
 #include "servers/audio_server.h"
@@ -48,11 +50,11 @@ class OS_Web : public OS_Unix {
 	bool idb_needs_sync = false;
 	bool pwa_is_waiting = false;
 
-	static void main_loop_callback();
+	WASM_EXPORT static void main_loop_callback();
 
-	static void file_access_close_callback(const String &p_file, int p_flags);
-	static void fs_sync_callback();
-	static void update_pwa_state_callback();
+	WASM_EXPORT static void file_access_close_callback(const String &p_file, int p_flags);
+	WASM_EXPORT static void fs_sync_callback();
+	WASM_EXPORT static void update_pwa_state_callback();
 
 protected:
 	void initialize() override;


### PR DESCRIPTION
After changing the default visibility to hidden to avoid generating thousands of import/export symbols (browsers have a hard limit of 10k), explicitly setting visibility for "boundary functions" (i.e. wasm callbacks called by JS via pointer) is required to ensure the function can be retrieved via pointer from the function table.


Fixup after #79578 , which mischaracterized the resulting error as https://github.com/emscripten-core/emscripten/issues/19425 (we do start threads from the fat side module, but apparently that does work for us :eyes: ).