### PR TITLE
Add a function to get all tile atlas coordinates in a TileSetAtlasSource

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -36,6 +36,12 @@
 				Creates a new tile at coordinates [param atlas_coords] with the given [param size].
 			</description>
 		</method>
+		<method name="get_all_tile_coords" qualifiers="const">
+			<return type="Vector2i[]" />
+			<description>
+				Returns an array of all tile atlas coordinates.
+			</description>
+		</method>
 		<method name="get_atlas_grid_size" qualifiers="const">
 			<return type="Vector2i" />
 			<description>

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -3892,6 +3892,16 @@ bool TileSetAtlasSource::get_use_texture_padding() const {
 	return use_texture_padding;
 }
 
+TypedArray<Vector2i> TileSetAtlasSource::get_all_tile_coords() const {
+	TypedArray<Vector2i> r_typed_tile_coords;
+
+	for (Vector2i tile_coords : tiles_ids) {
+		r_typed_tile_coords.append(tile_coords);
+	}
+
+	return r_typed_tile_coords;
+}
+
 Vector2i TileSetAtlasSource::get_atlas_grid_size() const {
 	Ref<Texture2D> txt = get_texture();
 	if (!txt.is_valid()) {
@@ -4665,6 +4675,7 @@ void TileSetAtlasSource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tile_data", "atlas_coords", "alternative_tile"), &TileSetAtlasSource::get_tile_data);
 
 	// Helpers.
+	ClassDB::bind_method(D_METHOD("get_all_tile_coords"), &TileSetAtlasSource::get_all_tile_coords);
 	ClassDB::bind_method(D_METHOD("get_atlas_grid_size"), &TileSetAtlasSource::get_atlas_grid_size);
 	ClassDB::bind_method(D_METHOD("get_tile_texture_region", "atlas_coords", "frame"), &TileSetAtlasSource::get_tile_texture_region, DEFVAL(0));
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -739,6 +739,7 @@ public:
 	TileData *get_tile_data(const Vector2i p_atlas_coords, int p_alternative_tile) const;
 
 	// Helpers.
+	TypedArray<Vector2i> get_all_tile_coords() const;
 	Vector2i get_atlas_grid_size() const;
 	Rect2i get_tile_texture_region(Vector2i p_atlas_coords, int p_frame = 0) const;
 	bool is_position_in_tile_texture_region(const Vector2i p_atlas_coords, int p_alternative_tile, Vector2 p_position) const;


### PR DESCRIPTION
This PR adds a function to `TileSetAtlasSource` to get all tile coordinates (internally already exposed as `tile_coords`). This is mainly for conistency among other tilemap related resources and performance reasons (because looping through potentially thousand of tiles is more perfomance heavy than just returning an already existing variable).