### PR TITLE
SCons: Change `check_c_headers` from tuple array to dictionary

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -987,9 +987,10 @@ if selected_platform in platform_list:
     # Check for the existence of headers
     conf = Configure(env)
     if "check_c_headers" in env:
-        for header in env["check_c_headers"]:
-            if conf.CheckCHeader(header[0]):
-                env.AppendUnique(CPPDEFINES=[header[1]])
+        headers = env["check_c_headers"]
+        for header in headers:
+            if conf.CheckCHeader(header):
+                env.AppendUnique(CPPDEFINES=[headers[header]])
 
 elif selected_platform != "":
     if selected_platform == "list":

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -4,4 +4,4 @@ Import("env")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 
-env["check_c_headers"] = [["mntent.h", "HAVE_MNTENT"]]
+env["check_c_headers"] = {"mntent.h": "HAVE_MNTENT"}


### PR DESCRIPTION
Minor alteration to one of the SCons checks. It's largely identical to the old method, but a dictionary is more scalable & the formatting becomes in-line with the rest of the SCons files