### PR TITLE
Tweak AnimationPlayer speed scale property hint to make dragging more useful

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -768,7 +768,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_GROUP("Playback Options", "playback_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:s"), "set_default_blend_time", "get_default_blend_time");
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-64,64,0.01"), "set_speed_scale", "get_speed_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
 
 	ADD_SIGNAL(MethodInfo(SNAME("current_animation_changed"), PropertyInfo(Variant::STRING, "name")));


### PR DESCRIPTION
The animation speed scale is most commonly used with values less than 2, and often less than 1. The current slider goes to 64 which is very high, so it's not very useful as-is. This PR changes the slider extent to 4.

The finer precision isn't really necessary, but I don't see a reason to prevent using a step smaller than 0.01.