### PR TITLE
Fix storing invalid item height values in `ItemList`

### DIFF
--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1431,11 +1431,11 @@ void ItemList::force_update_list_size() {
 			}
 		}
 
-		for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
-			items.write[j].rect_cache.size.y = max_h;
-		}
-
 		if (all_fit) {
+			for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
+				items.write[j].rect_cache.size.y = max_h;
+			}
+
 			float page = MAX(0, size.height - theme_cache.panel_style->get_minimum_size().height);
 			float max = MAX(page, ofs.y + max_h);
 			if (auto_height) {


### PR DESCRIPTION
fixes #80793

Last n items' height is incorrectly overwritten with the max height of first row (n = number of columns). This happens in the first iteration of the while loop. Moving this code inside if (all_fit) makes sure the last rows height is only updated at the last iteration of the while loop when max height (max_h) is calculated for the last row.

after
![image](https://github.com/godotengine/godot/assets/122149176/7cb1cc62-6048-4f21-8d99-e1474cd3c444)

before
![image](https://github.com/godotengine/godot/assets/122149176/811976ec-582c-4f4e-90db-3b75eea2f79d)


The 3rd last item has incorrect height because it is using the first rows height. the last 3 items correct height was lost.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
