### PR TITLE
Fixed an error in `Vector3.BezierDerivative` in mono module

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -265,7 +265,7 @@ namespace Godot
             return new Vector3(
                 Mathf.BezierDerivative(X, control1.X, control2.X, end.X, t),
                 Mathf.BezierDerivative(Y, control1.Y, control2.Y, end.Y, t),
-                Mathf.BezierDerivative(Z, control1.Z, control2.Z, end.Y, t)
+                Mathf.BezierDerivative(Z, control1.Z, control2.Z, end.Z, t)
             );
         }
 


### PR DESCRIPTION
Fixed a bug in Vector3.BezierDerivative in mono module. In Vector3.BezierDerivative, the last line does not look right, end.Y is used instead of end.Z, from what I understand, this is probably a bug.
