### PR TITLE
Fix transform calculations for drag-moving CanvasItems in editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2062,8 +2062,8 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			drag_to = transform.affine_inverse().xform(m->get_position());
 			Point2 previous_pos;
 			if (drag_selection.size() == 1) {
-				Transform2D xform = drag_selection[0]->get_global_transform_with_canvas() * drag_selection[0]->get_transform().affine_inverse();
-				previous_pos = xform.xform(drag_selection[0]->_edit_get_position());
+				Transform2D parent_xform = drag_selection[0]->get_global_transform_with_canvas() * drag_selection[0]->get_transform().affine_inverse();
+				previous_pos = parent_xform.xform(drag_selection[0]->_edit_get_position());
 			} else {
 				previous_pos = _get_encompassing_rect_from_list(drag_selection).position;
 			}
@@ -2071,14 +2071,17 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			Point2 drag_delta = drag_to - drag_from;
 			if (drag_selection.size() == 1 && (drag_type == DRAG_MOVE_X || drag_type == DRAG_MOVE_Y)) {
 				const CanvasItem *selected = drag_selection.front()->get();
-				drag_delta = selected->get_transform().affine_inverse().basis_xform(drag_delta);
+				Transform2D parent_xform = selected->get_global_transform_with_canvas() * selected->get_transform().affine_inverse();
+				Transform2D unscaled_transform = (transform * parent_xform * selected->_edit_get_transform()).orthonormalized();
+				Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 
+				drag_delta = simple_xform.affine_inverse().basis_xform(drag_delta);
 				if (drag_type == DRAG_MOVE_X) {
 					drag_delta.y = 0;
 				} else {
 					drag_delta.x = 0;
 				}
-				drag_delta = selected->get_transform().basis_xform(drag_delta);
+				drag_delta = simple_xform.basis_xform(drag_delta);
 			}
 			Point2 new_pos = snap_point(previous_pos + drag_delta, SNAP_GRID | SNAP_GUIDES | SNAP_PIXEL | SNAP_NODE_PARENT | SNAP_NODE_ANCHORS | SNAP_OTHER_NODES, 0, nullptr, drag_selection);
 
@@ -2092,8 +2095,8 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 			}
 
 			for (CanvasItem *ci : drag_selection) {
-				Transform2D xform = ci->get_global_transform_with_canvas().affine_inverse() * ci->get_transform();
-				ci->_edit_set_position(ci->_edit_get_position() + xform.xform(new_pos) - xform.xform(previous_pos));
+				Transform2D parent_xform_inv = ci->get_transform() * ci->get_global_transform_with_canvas().affine_inverse();
+				ci->_edit_set_position(ci->_edit_get_position() + parent_xform_inv.basis_xform(new_pos - previous_pos));
 			}
 			return true;
 		}


### PR DESCRIPTION
Fixes #82643.

Lately these calculations were tweaked in #81735 but we must have tested only some simple cases. In https://github.com/godotengine/godot/pull/81735#discussion_r1327973174 I deduced the `drag_from`/`drag_to` are in the parent coordinate space, but I've deduced it only based on the new code in that PR (which seemed to work). This was a wrong a conclusion. Now I've properly taken a look at a bigger chunk of code and `drag_from`/`drag_to` seem to be in the Viewport's global canvas coordinate space (viewport space transformed by inverse of its `global_canvas_transform`). Updated the calculations accordingly, now things seem to work just fine.
(To be clear things were broken for "non-standard" transforms even before #81735.)

| Before | After |
|--------|--------|
|![foegTIB6X3](https://github.com/godotengine/godot/assets/9283098/7e2e0cba-a67d-47ce-8886-fc7561e56ee4)|![o1aB4FdPB8](https://github.com/godotengine/godot/assets/9283098/87420431-6791-4916-8a04-b44b9dfa95a6)|
