### PR TITLE
Improve `NavigationAgent3D.target_position` documentation readability

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -202,7 +202,7 @@
 			The distance threshold before the final target point is considered to be reached. This allows agents to not have to hit the point of the final target exactly, but only to reach its general area. If this value is set too low, the NavigationAgent will be stuck in a repath loop because it will constantly overshoot or undershoot the distance to the final target point on each physics frame update.
 		</member>
 		<member name="target_position" type="Vector2" setter="set_target_position" getter="get_target_position" default="Vector2(0, 0)">
-			If set a new navigation path from the current agent position to the [member target_position] is requested from the NavigationServer.
+			If set, a new navigation path from the current agent position to the [member target_position] is requested from the NavigationServer.
 		</member>
 		<member name="time_horizon_agents" type="float" setter="set_time_horizon_agents" getter="get_time_horizon_agents" default="1.0">
 			The minimal amount of time for which this agent's velocities, that are computed with the collision avoidance algorithm, are safe with respect to other agents. The larger the number, the sooner the agent will respond to other agents, but less freedom in choosing its velocities. A too high value will slow down agents movement considerably. Must be positive.

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -205,7 +205,7 @@
 			The distance threshold before the final target point is considered to be reached. This allows agents to not have to hit the point of the final target exactly, but only to reach its general area. If this value is set too low, the NavigationAgent will be stuck in a repath loop because it will constantly overshoot or undershoot the distance to the final target point on each physics frame update.
 		</member>
 		<member name="target_position" type="Vector3" setter="set_target_position" getter="get_target_position" default="Vector3(0, 0, 0)">
-			If set a new navigation path from the current agent position to the [member target_position] is requested from the NavigationServer.
+			If set, a new navigation path from the current agent position to the [member target_position] is requested from the NavigationServer.
 		</member>
 		<member name="time_horizon_agents" type="float" setter="set_time_horizon_agents" getter="get_time_horizon_agents" default="1.0">
 			The minimal amount of time for which this agent's velocities, that are computed with the collision avoidance algorithm, are safe with respect to other agents. The larger the number, the sooner the agent will respond to other agents, but less freedom in choosing its velocities. A too high value will slow down agents movement considerably. Must be positive.


### PR DESCRIPTION
I know this is a tiny commit but I had to read this sentence 4 times before I figured out what it was trying to say. The comma is important here.

Examples of where the same type of documentation has the comma are [here](https://github.com/godotengine/godot/blob/0ca8542329888e8dccba89d59d3b728090c29991/doc/classes/Environment.xml#L86), [here](https://github.com/godotengine/godot/blob/0ca8542329888e8dccba89d59d3b728090c29991/doc/classes/Environment.xml#L112), [here](https://github.com/godotengine/godot/blob/0ca8542329888e8dccba89d59d3b728090c29991/doc/classes/FontFile.xml#L580) amongst many other instances.