### PR TITLE
Make Nodes with disabled processing appear selectable if their type matches in the exported node menu

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -504,6 +504,8 @@ void SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent) {
 		if (!valid) {
 			_set_item_custom_color(item, get_theme_color(SNAME("disabled_font_color"), EditorStringName(Editor)));
 			item->set_selectable(0, false);
+		} else {
+			_set_item_custom_color(item, get_theme_color(SNAME("font_color"), EditorStringName(Editor)));
 		}
 	}
 }


### PR DESCRIPTION
Fixes #82631