### PR TITLE
Workaround crash due to null shader when running XR project with `--xr-mode` off

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -5054,6 +5054,7 @@ RID RenderingDeviceVulkan::shader_create_from_bytecode(const Vector<uint8_t> &p_
 	}
 
 	Shader *shader = shader_owner.get_or_null(id);
+	ERR_FAIL_NULL_V(shader, RID());
 
 	shader->vertex_input_mask = vertex_input_mask;
 	shader->fragment_output_mask = fragment_output_mask;


### PR DESCRIPTION
Steps to reproduce:
1. use official openxr test project
2. make sure OpenXR is enabled in project setting; and enable OpenXR Shaders.
3. In Project Settings, enable Advanced Settings, and go to the Run category under Editor, not the Run category under Application. In the text box, type `--xr-mode off`
4. Press run.
5. Without this patch, it will crash with Nasal Demons and/or Undefined Behavior due to dereference of null pointer. On windows MSVC, this undefined behavior is compiled as an illegal instruction (flow off the end of a function into FF / ??? instructions), but other possibilities may also happen.

This is not a complete fix, since it still prints error due to null shader RID, but at least it won't crash. I was able to play the game with --xr-mode off.
Other people also hit this issue in 4.2 dev