### PR TITLE
GDExtension: Don't deprecate old method of getting script category

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -510,7 +510,7 @@ typedef struct {
 	GDExtensionScriptInstanceGet get_func;
 	GDExtensionScriptInstanceGetPropertyList get_property_list_func;
 	GDExtensionScriptInstanceFreePropertyList free_property_list_func;
-	GDExtensionScriptInstanceGetClassCategory get_class_category_func;
+	GDExtensionScriptInstanceGetClassCategory get_class_category_func; // Optional. Set to NULL for the default behavior.
 
 	GDExtensionScriptInstancePropertyCanRevert property_can_revert_func;
 	GDExtensionScriptInstancePropertyGetRevert property_get_revert_func;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -676,13 +676,11 @@ public:
 					if (native_info->get_class_category_func(instance, &gdext_class_category)) {
 						p_list->push_back(PropertyInfo(gdext_class_category));
 					}
-#ifndef DISABLE_DEPRECATED
 				} else {
 					Ref<Script> script = get_script();
 					if (script.is_valid()) {
 						p_list->push_back(script->get_class_category());
 					}
-#endif // DISABLE_DEPRECATED
 				}
 			}
 #endif // TOOLS_ENABLED


### PR DESCRIPTION
This is a follow up to PR https://github.com/godotengine/godot/pull/78995

That PR allows GDExtensions to take control over the class category used for script instances (when you're adding a scripting language from a GDExtension). However, in many (most?) cases, GDExtensions don't need this extra control and the old, default method is just fine.

So, rather than deprecating the old behavior, I think this should just be a case where there's two ways to handle this: (1) provide a `get_class_category_func` if you want the extra control, or (2) provide `nullptr` if the default behavior is fine.

This PR just removes the `#ifndef DISABLE_DEPRECATED` that wraps the old behavior, and adds a comment to the `gdextension_interface.h`.