### PR TITLE
Fix C# editor dialogs

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -206,17 +206,19 @@ namespace GodotTools.Build
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to build.
 
-            using var pr = new EditorProgress("dotnet_build_project", "Building .NET project...", 1);
-
-            pr.Step("Building project", 0);
-
-            if (!Build(buildInfo))
+            bool success;
+            using (var pr = new EditorProgress("dotnet_build_project", "Building .NET project...", 1))
             {
-                ShowBuildErrorDialog("Failed to build project");
-                return false;
+                pr.Step("Building project", 0);
+                success = Build(buildInfo);
             }
 
-            return true;
+            if (!success)
+            {
+                ShowBuildErrorDialog("Failed to build project");
+            }
+
+            return success;
         }
 
         private static bool CleanProjectBlocking(BuildInfo buildInfo)
@@ -224,32 +226,36 @@ namespace GodotTools.Build
             if (!File.Exists(buildInfo.Project))
                 return true; // No project to clean.
 
-            using var pr = new EditorProgress("dotnet_clean_project", "Cleaning .NET project...", 1);
-
-            pr.Step("Cleaning project", 0);
-
-            if (!Build(buildInfo))
+            bool success;
+            using (var pr = new EditorProgress("dotnet_clean_project", "Cleaning .NET project...", 1))
             {
-                ShowBuildErrorDialog("Failed to clean project");
-                return false;
+                pr.Step("Cleaning project", 0);
+                success = Build(buildInfo);
             }
 
-            return true;
+            if (!success)
+            {
+                ShowBuildErrorDialog("Failed to clean project");
+            }
+
+            return success;
         }
 
         private static bool PublishProjectBlocking(BuildInfo buildInfo)
         {
-            using var pr = new EditorProgress("dotnet_publish_project", "Publishing .NET project...", 1);
-
-            pr.Step("Running dotnet publish", 0);
-
-            if (!Publish(buildInfo))
+            bool success;
+            using (var pr = new EditorProgress("dotnet_publish_project", "Publishing .NET project...", 1))
             {
-                ShowBuildErrorDialog("Failed to publish .NET project");
-                return false;
+                pr.Step("Running dotnet publish", 0);
+                success = Publish(buildInfo);
             }
 
-            return true;
+            if (!success)
+            {
+                ShowBuildErrorDialog("Failed to publish .NET project");
+            }
+
+            return success;
         }
 
         private static BuildInfo CreateBuildInfo(

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -65,6 +65,7 @@ namespace GodotTools
 
         private bool CreateProjectSolution()
         {
+            string errorMessage = null;
             using (var pr = new EditorProgress("create_csharp_solution", "Generating solution...".TTR(), 2))
             {
                 pr.Step("Generating C# project...".TTR());
@@ -96,22 +97,23 @@ namespace GodotTools
                     }
                     catch (IOException e)
                     {
-                        ShowErrorDialog("Failed to save solution. Exception message: ".TTR() + e.Message);
-                        return false;
+                        errorMessage = "Failed to save solution. Exception message: ".TTR() + e.Message;
                     }
-
-                    pr.Step("Done".TTR());
-
-                    // Here, after all calls to progress_task_step
-                    CallDeferred(nameof(_ShowDotnetFeatures));
                 }
                 else
                 {
-                    ShowErrorDialog("Failed to create C# project.".TTR());
+                    errorMessage = "Failed to create C# project.".TTR();
                 }
-
-                return true;
             }
+
+            if (!string.IsNullOrEmpty(errorMessage))
+            {
+                ShowErrorDialog(errorMessage);
+                return false;
+            }
+
+            _ShowDotnetFeatures();
+            return true;
         }
 
         private void _ShowDotnetFeatures()
@@ -161,14 +163,14 @@ namespace GodotTools
         {
             _errorDialog.Title = title;
             _errorDialog.DialogText = message;
-            _errorDialog.PopupCentered();
+            EditorInterface.Singleton.PopupDialogCentered(_errorDialog);
         }
 
         public void ShowConfirmCreateSlnDialog()
         {
             _confirmCreateSlnDialog.Title = "C# solution already exists. This will override the existing C# project file, any manual changes will be lost.".TTR();
             _confirmCreateSlnDialog.DialogText = "Create C# solution".TTR();
-            _confirmCreateSlnDialog.PopupCentered();
+            EditorInterface.Singleton.PopupDialogCentered(_confirmCreateSlnDialog);
         }
 
         private static string _vsCodePath = string.Empty;
@@ -483,11 +485,11 @@ namespace GodotTools
             _editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             _errorDialog = new AcceptDialog();
-            editorBaseControl.AddChild(_errorDialog);
+            _errorDialog.SetUnparentWhenInvisible(true);
 
             _confirmCreateSlnDialog = new ConfirmationDialog();
+            _confirmCreateSlnDialog.SetUnparentWhenInvisible(true);
             _confirmCreateSlnDialog.Confirmed += () => CreateProjectSolution();
-            editorBaseControl.AddChild(_confirmCreateSlnDialog);
 
             MSBuildPanel = new MSBuildPanel();
             MSBuildPanel.BuildStateChanged += BuildStateChanged;


### PR DESCRIPTION
- Use `EditorInterface` to open C# editor dialogs.
- Ensure C# editor dialogs are open after `EditorProgress` finishes.

Fixes the error about dialogs mentioned in https://github.com/godotengine/godot/pull/80260#issuecomment-1736076386.