### PR TITLE
Fixes to allow object-less callables throughout Godot

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1211,8 +1211,7 @@ void Thread::_start_func(void *ud) {
 	Ref<Thread> t = *tud;
 	memdelete(tud);
 
-	Object *target_instance = t->target_callable.get_object();
-	if (!target_instance) {
+	if (!t->target_callable.is_valid()) {
 		t->running.clear();
 		ERR_FAIL_MSG(vformat("Could not call function '%s' on previously freed instance to start thread %s.", t->target_callable.get_method(), t->get_id()));
 	}

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -136,17 +136,22 @@ void UndoRedo::add_do_method(const Callable &p_callable) {
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 
-	Object *object = p_callable.get_object();
-	ERR_FAIL_NULL(object);
+	ObjectID object_id = p_callable.get_object_id();
+	Object *object = ObjectDB::get_instance(object_id);
+	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
 
 	Operation do_op;
 	do_op.callable = p_callable;
-	do_op.object = p_callable.get_object_id();
+	do_op.object = object_id;
 	if (Object::cast_to<RefCounted>(object)) {
 		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
 	}
 	do_op.type = Operation::TYPE_METHOD;
 	do_op.name = p_callable.get_method();
+	if (do_op.name == StringName()) {
+		// There's no `get_method()` for custom callables, so use `operator String()` instead.
+		do_op.name = static_cast<String>(p_callable);
+	}
 
 	actions.write[current_action + 1].do_ops.push_back(do_op);
 }
@@ -161,18 +166,23 @@ void UndoRedo::add_undo_method(const Callable &p_callable) {
 		return;
 	}
 
-	Object *object = p_callable.get_object();
-	ERR_FAIL_NULL(object);
+	ObjectID object_id = p_callable.get_object_id();
+	Object *object = ObjectDB::get_instance(object_id);
+	ERR_FAIL_COND(object_id.is_valid() && object == nullptr);
 
 	Operation undo_op;
 	undo_op.callable = p_callable;
-	undo_op.object = p_callable.get_object_id();
+	undo_op.object = object_id;
 	if (Object::cast_to<RefCounted>(object)) {
 		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
 	}
 	undo_op.type = Operation::TYPE_METHOD;
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
 	undo_op.name = p_callable.get_method();
+	if (undo_op.name == StringName()) {
+		// There's no `get_method()` for custom callables, so use `operator String()` instead.
+		undo_op.name = static_cast<String>(p_callable);
+	}
 
 	actions.write[current_action + 1].undo_ops.push_back(undo_op);
 }

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -47,6 +47,13 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 		r_call_error.expected = 0;
 		r_return_value = Variant();
 	} else if (is_custom()) {
+		if (!is_valid()) {
+			r_call_error.error = CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			r_call_error.argument = 0;
+			r_call_error.expected = 0;
+			r_return_value = Variant();
+			return;
+		}
 		custom->call(p_arguments, p_argcount, r_return_value, r_call_error);
 	} else {
 		Object *obj = ObjectDB::get_instance(ObjectID(object));

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -675,7 +675,7 @@ bool CallbackTweener::step(double &r_delta) {
 		return false;
 	}
 
-	if (!callback.get_object()) {
+	if (!callback.is_valid()) {
 		return false;
 	}
 
@@ -740,7 +740,7 @@ bool MethodTweener::step(double &r_delta) {
 		return false;
 	}
 
-	if (!callback.get_object()) {
+	if (!callback.is_valid()) {
 		return false;
 	}
 

--- a/servers/physics_2d/godot_area_2d.cpp
+++ b/servers/physics_2d/godot_area_2d.cpp
@@ -78,13 +78,6 @@ void GodotArea2D::set_space(GodotSpace2D *p_space) {
 }
 
 void GodotArea2D::set_monitor_callback(const Callable &p_callback) {
-	ObjectID id = p_callback.get_object_id();
-
-	if (id == monitor_callback.get_object_id()) {
-		monitor_callback = p_callback;
-		return;
-	}
-
 	_unregister_shapes();
 
 	monitor_callback = p_callback;
@@ -100,13 +93,6 @@ void GodotArea2D::set_monitor_callback(const Callable &p_callback) {
 }
 
 void GodotArea2D::set_area_monitor_callback(const Callable &p_callback) {
-	ObjectID id = p_callback.get_object_id();
-
-	if (id == area_monitor_callback.get_object_id()) {
-		area_monitor_callback = p_callback;
-		return;
-	}
-
 	_unregister_shapes();
 
 	area_monitor_callback = p_callback;

--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -615,7 +615,7 @@ void GodotBody2D::integrate_velocities(real_t p_step) {
 		return;
 	}
 
-	if (fi_callback_data || body_state_callback.get_object()) {
+	if (fi_callback_data || body_state_callback.is_valid()) {
 		get_space()->body_add_to_state_query_list(&direct_state_query_list);
 	}
 
@@ -676,7 +676,7 @@ void GodotBody2D::call_queries() {
 	Variant direct_state_variant = get_direct_state();
 
 	if (fi_callback_data) {
-		if (!fi_callback_data->callable.get_object()) {
+		if (!fi_callback_data->callable.is_valid()) {
 			set_force_integration_callback(Callable());
 		} else {
 			const Variant *vp[2] = { &direct_state_variant, &fi_callback_data->udata };
@@ -692,7 +692,7 @@ void GodotBody2D::call_queries() {
 		}
 	}
 
-	if (body_state_callback.get_object()) {
+	if (body_state_callback.is_valid()) {
 		body_state_callback.call(direct_state_variant);
 	}
 }
@@ -719,7 +719,7 @@ void GodotBody2D::set_state_sync_callback(const Callable &p_callable) {
 }
 
 void GodotBody2D::set_force_integration_callback(const Callable &p_callable, const Variant &p_udata) {
-	if (p_callable.get_object()) {
+	if (p_callable.is_valid()) {
 		if (!fi_callback_data) {
 			fi_callback_data = memnew(ForceIntegrationCallbackData);
 		}

--- a/servers/physics_3d/godot_area_3d.cpp
+++ b/servers/physics_3d/godot_area_3d.cpp
@@ -87,12 +87,6 @@ void GodotArea3D::set_space(GodotSpace3D *p_space) {
 }
 
 void GodotArea3D::set_monitor_callback(const Callable &p_callback) {
-	ObjectID id = p_callback.get_object_id();
-	if (id == monitor_callback.get_object_id()) {
-		monitor_callback = p_callback;
-		return;
-	}
-
 	_unregister_shapes();
 
 	monitor_callback = p_callback;
@@ -108,12 +102,6 @@ void GodotArea3D::set_monitor_callback(const Callable &p_callback) {
 }
 
 void GodotArea3D::set_area_monitor_callback(const Callable &p_callback) {
-	ObjectID id = p_callback.get_object_id();
-	if (id == area_monitor_callback.get_object_id()) {
-		area_monitor_callback = p_callback;
-		return;
-	}
-
 	_unregister_shapes();
 
 	area_monitor_callback = p_callback;

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -674,7 +674,7 @@ void GodotBody3D::integrate_velocities(real_t p_step) {
 		return;
 	}
 
-	if (fi_callback_data || body_state_callback.get_object()) {
+	if (fi_callback_data || body_state_callback.is_valid()) {
 		get_space()->body_add_to_state_query_list(&direct_state_query_list);
 	}
 
@@ -759,7 +759,7 @@ void GodotBody3D::call_queries() {
 	Variant direct_state_variant = get_direct_state();
 
 	if (fi_callback_data) {
-		if (!fi_callback_data->callable.get_object()) {
+		if (!fi_callback_data->callable.is_valid()) {
 			set_force_integration_callback(Callable());
 		} else {
 			const Variant *vp[2] = { &direct_state_variant, &fi_callback_data->udata };
@@ -771,7 +771,7 @@ void GodotBody3D::call_queries() {
 		}
 	}
 
-	if (body_state_callback.get_object()) {
+	if (body_state_callback.is_valid()) {
 		body_state_callback.call(direct_state_variant);
 	}
 }
@@ -798,7 +798,7 @@ void GodotBody3D::set_state_sync_callback(const Callable &p_callable) {
 }
 
 void GodotBody3D::set_force_integration_callback(const Callable &p_callable, const Variant &p_udata) {
-	if (p_callable.get_object()) {
+	if (p_callable.is_valid()) {
 		if (!fi_callback_data) {
 			fi_callback_data = memnew(ForceIntegrationCallbackData);
 		}


### PR DESCRIPTION
This fixes #81887

I searched the entire Godot source code for `Callable` methods `get_object()`, `get_object_id()` and `get_method()`, which could potentially be used to detect if a callable is associated with an object. Several places in the code used these methods to check callable validity instead of using `Callable::is_valid()`, causing object-less callables to be rejected. I then carefully and selectively updated the code to use the correct methods.

A few places remain where object-less callables may not be handled correctly. These files use `get_object()` and `get_method()` for various purposes:

- `scene/main/node.cpp`: serialization
- `editor/editor_node.cpp`: serialization
- `scene/resources/packed_scene.cpp`: serialization
- `core/core_bind.cpp`: error messages
- `core/variant/callable.cpp`: custom callable `get_method()`
- `core/variant/variant.cpp`: error messages

While I was quite thorough, its possible I may have missed things. I also left gdscript and mono alone.