### PR TITLE
Escape `+/- key` in constant descriptions to avoid issues when generating RST

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2077,6 +2077,24 @@ def escape_rst(text: str, until_pos: int = -1) -> str:
         text = f"{text[:pos]}\*{text[pos + 1 :]}"
         pos += 2
 
+    # Escape + character in key enumerations to avoid interpreting it as a bullet list
+    pos = 0
+    while True:
+        pos = text.find("+ key", pos, until_pos)
+        if pos == -1:
+            break
+        text = f"{text[:pos]}\+ key{text[pos + 5 :]}"
+        pos += 6
+
+    # Escape - character in key enumerations to avoid interpreting it as a bullet list
+    pos = 0
+    while True:
+        pos = text.find("- key", pos, until_pos)
+        if pos == -1:
+            break
+        text = f"{text[:pos]}\- key{text[pos + 5 :]}"
+        pos += 6
+
     # Escape _ character at the end of a word to avoid interpreting it as an inline hyperlink
     pos = 0
     while True:


### PR DESCRIPTION
Hey all, this is my first pull request here.

## Problem Description

This PR fixes the problems raised in [#8127](https://github.com/godotengine/godot-docs/issues/8127). The issues stem from the _+_ and _-_ characters used in the `KEY_PLUS` and `KEY_MINUS` enumeration descriptions not being escaped after the _make_rst.py_ script is run. This results in the _+_ and _-_ characters being interpreted as bullet lists, rather than characters, as can be seen [here](https://docs.godotengine.org/en/4.1/classes/class_%40globalscope.html#enum-globalscope-key).

## Problem Solution

The cleanest solution that I can think of is to add additional escape logic to the `escape_rst` method in _make_rst.py_ for the _+_ and _-_ characters by searching for the strings `"+ key"` and `"- key"`. This will allow the `KEY_PLUS` and `KEY_MINUS` enumeration descriptions to display correctly after generating a _.rst_ file from _@GlobalScope.xml_. This solution will be transparent to all of the other _.xml_ files in the project.

I looked at trying to escape these characters in the same way that the _*_ is handled, but found that this can break bullet lists in _.rst_ files generated from other _.xml_ files, such as _EditorCommandPalatte.xml_. As a result, the proposed solution is the cleanest way that I can think of to fix the problem.

## Results
Upon diffing the generated `_build/rst` folders before and after applying the fix, only `class_@globalscope.rst` is modified:
![image](https://github.com/godotengine/godot/assets/46616290/faf83f23-fb9e-4a5d-bb61-c7ff4422aab6)

 
Please let me know if someone has a cleaner solution! 

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
