### PR TITLE
Search terms are now highlighted when the bar opens with a selection.

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -141,6 +141,20 @@ void FindReplaceBar::_focus_lost() {
 	}
 }
 
+void FindReplaceBar::_update_flags(bool p_direction_backwards) {
+	flags = 0;
+
+	if (is_whole_words()) {
+		flags |= TextEdit::SEARCH_WHOLE_WORDS;
+	}
+	if (is_case_sensitive()) {
+		flags |= TextEdit::SEARCH_MATCH_CASE;
+	}
+	if (p_direction_backwards) {
+		flags |= TextEdit::SEARCH_BACKWARDS;
+	}
+}
+
 bool FindReplaceBar::_search(uint32_t p_flags, int p_from_line, int p_from_col) {
 	if (!preserve_cursor) {
 		text_editor->remove_secondary_carets();
@@ -431,14 +445,7 @@ void FindReplaceBar::_update_matches_label() {
 }
 
 bool FindReplaceBar::search_current() {
-	flags = 0;
-
-	if (is_whole_words()) {
-		flags |= TextEdit::SEARCH_WHOLE_WORDS;
-	}
-	if (is_case_sensitive()) {
-		flags |= TextEdit::SEARCH_MATCH_CASE;
-	}
+	_update_flags(false);
 
 	int line, col;
 	_get_search_from(line, col);
@@ -455,17 +462,9 @@ bool FindReplaceBar::search_prev() {
 		popup_search(true);
 	}
 
-	flags = 0;
 	String text = get_search_text();
 
-	if (is_whole_words()) {
-		flags |= TextEdit::SEARCH_WHOLE_WORDS;
-	}
-	if (is_case_sensitive()) {
-		flags |= TextEdit::SEARCH_MATCH_CASE;
-	}
-
-	flags |= TextEdit::SEARCH_BACKWARDS;
+	_update_flags(true);
 
 	int line, col;
 	_get_search_from(line, col);
@@ -491,14 +490,7 @@ bool FindReplaceBar::search_next() {
 		popup_search(true);
 	}
 
-	flags = 0;
-
-	if (is_whole_words()) {
-		flags |= TextEdit::SEARCH_WHOLE_WORDS;
-	}
-	if (is_case_sensitive()) {
-		flags |= TextEdit::SEARCH_MATCH_CASE;
-	}
+	_update_flags(false);
 
 	int line, col;
 	_get_search_from(line, col, true);
@@ -546,11 +538,9 @@ void FindReplaceBar::_show_search(bool p_focus_replace, bool p_show_only) {
 			search_text->set_caret_column(search_text->get_text().length());
 		}
 
-		results_count = -1;
-		results_count_to_current = -1;
-		needs_to_count_results = true;
-		_update_results_count();
-		_update_matches_label();
+		preserve_cursor = true;
+		_search_text_changed(get_search_text());
+		preserve_cursor = false;
 	}
 }
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -110,6 +110,8 @@ protected:
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 	void _focus_lost();
 
+	void _update_flags(bool p_direction_backwards);
+
 	bool _search(uint32_t p_flags, int p_from_line, int p_from_col);
 
 	void _replace();


### PR DESCRIPTION
Previously, the code editor only updated the text highlights when a search was made, but opening the search bar with a selection does not go through that code path because the first result is already selected.

This is a fix for #82706.

*Bugsquad edit:*
- Fixes #82706.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
