### PR TITLE
OpenXR - add access to hand joint validity flags

### DIFF
--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -31,6 +31,14 @@
 				If handtracking is enabled, returns the angular velocity of a joint ([param joint]) of a hand ([param hand]) as provided by OpenXR. This is relative to [XROrigin3D]!
 			</description>
 		</method>
+		<method name="get_hand_joint_flags" qualifiers="const">
+			<return type="int" enum="OpenXRInterface.HandJointFlags" is_bitfield="true" />
+			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
+			<param index="1" name="joint" type="int" enum="OpenXRInterface.HandJoints" />
+			<description>
+				If handtracking is enabled, returns flags that inform us of the validity of the tracking data.
+			</description>
+		</method>
 		<method name="get_hand_joint_linear_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
@@ -89,6 +97,13 @@
 			<description>
 				Returns [code]true[/code] if OpenXRs foveation extension is supported, the interface must be initialised before this returns a valid value.
 				[b]Note:[/b] This feature is only available on the compatibility renderer and currently only available on some stand alone headsets. For Vulkan set [member Viewport.vrs_mode] to [code]VRS_XR[/code] on desktop.
+			</description>
+		</method>
+		<method name="is_hand_tracking_supported">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if OpenXRs hand tracking is supported and enabled.
+				[b]Note:[/b] This only returns a valid value after OpenXR has been initialized.
 			</description>
 		</method>
 		<method name="set_action_set_active">
@@ -245,6 +260,27 @@
 		</constant>
 		<constant name="HAND_JOINT_MAX" value="26" enum="HandJoints">
 			Maximum value for the hand joint enum.
+		</constant>
+		<constant name="HAND_JOINT_NONE" value="0" enum="HandJointFlags" is_bitfield="true">
+			No flags are set.
+		</constant>
+		<constant name="HAND_JOINT_ORIENTATION_VALID" value="1" enum="HandJointFlags" is_bitfield="true">
+			If set, the orientation data is valid, otherwise, the orientation data is unreliable and should not be used.
+		</constant>
+		<constant name="HAND_JOINT_ORIENTATION_TRACKED" value="2" enum="HandJointFlags" is_bitfield="true">
+			If set, the orientation data comes from tracking data, otherwise, the orientation data contains predicted data.
+		</constant>
+		<constant name="HAND_JOINT_POSITION_VALID" value="4" enum="HandJointFlags" is_bitfield="true">
+			If set, the positional data is valid, otherwise, the positional data is unreliable and should not be used.
+		</constant>
+		<constant name="HAND_JOINT_POSITION_TRACKED" value="8" enum="HandJointFlags" is_bitfield="true">
+			If set, the positional data comes from tracking data, otherwise, the positional data contains predicted data.
+		</constant>
+		<constant name="HAND_JOINT_LINEAR_VELOCITY_VALID" value="16" enum="HandJointFlags" is_bitfield="true">
+			If set, our linear velocity data is valid, otherwise, the linear velocity data is unreliable and should not be used.
+		</constant>
+		<constant name="HAND_JOINT_ANGULAR_VELOCITY_VALID" value="32" enum="HandJointFlags" is_bitfield="true">
+			If set, our angular velocity data is valid, otherwise, the angular velocity data is unreliable and should not be used.
 		</constant>
 	</constants>
 </class>

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -245,6 +245,18 @@ void OpenXRHandTrackingExtension::set_motion_range(HandTrackedHands p_hand, XrHa
 	hand_trackers[p_hand].motion_range = p_motion_range;
 }
 
+XrSpaceLocationFlags OpenXRHandTrackingExtension::get_hand_joint_location_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceLocationFlags(0));
+	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceLocationFlags(0));
+
+	if (!hand_trackers[p_hand].is_initialized) {
+		return XrSpaceLocationFlags(0);
+	}
+
+	const XrHandJointLocationEXT &location = hand_trackers[p_hand].joint_locations[p_joint];
+	return location.locationFlags;
+}
+
 Quaternion OpenXRHandTrackingExtension::get_hand_joint_rotation(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
 	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Quaternion());
 	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Quaternion());
@@ -278,6 +290,18 @@ float OpenXRHandTrackingExtension::get_hand_joint_radius(HandTrackedHands p_hand
 	}
 
 	return hand_trackers[p_hand].joint_locations[p_joint].radius;
+}
+
+XrSpaceVelocityFlags OpenXRHandTrackingExtension::get_hand_joint_velocity_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceVelocityFlags(0));
+	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceVelocityFlags(0));
+
+	if (!hand_trackers[p_hand].is_initialized) {
+		return XrSpaceVelocityFlags(0);
+	}
+
+	const XrHandJointVelocityEXT &velocity = hand_trackers[p_hand].joint_velocities[p_joint];
+	return velocity.velocityFlags;
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_linear_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.h
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.h
@@ -77,10 +77,12 @@ public:
 	XrHandJointsMotionRangeEXT get_motion_range(HandTrackedHands p_hand) const;
 	void set_motion_range(HandTrackedHands p_hand, XrHandJointsMotionRangeEXT p_motion_range);
 
+	XrSpaceLocationFlags get_hand_joint_location_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 	Quaternion get_hand_joint_rotation(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 	Vector3 get_hand_joint_position(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 	float get_hand_joint_radius(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 
+	XrSpaceVelocityFlags get_hand_joint_velocity_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 	Vector3 get_hand_joint_linear_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 	Vector3 get_hand_joint_angular_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const;
 

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -111,6 +111,7 @@ public:
 	virtual PackedStringArray get_suggested_tracker_names() const override;
 	virtual TrackingStatus get_tracking_status() const override;
 
+	bool is_hand_tracking_supported();
 	bool is_eye_gaze_interaction_supported();
 
 	bool initialize_on_startup() const;
@@ -222,6 +223,17 @@ public:
 		HAND_JOINT_MAX = 26,
 	};
 
+	enum HandJointFlags {
+		HAND_JOINT_NONE = 0,
+		HAND_JOINT_ORIENTATION_VALID = 1,
+		HAND_JOINT_ORIENTATION_TRACKED = 2,
+		HAND_JOINT_POSITION_VALID = 4,
+		HAND_JOINT_POSITION_TRACKED = 8,
+		HAND_JOINT_LINEAR_VELOCITY_VALID = 16,
+		HAND_JOINT_ANGULAR_VELOCITY_VALID = 32,
+	};
+
+	BitField<HandJointFlags> get_hand_joint_flags(Hand p_hand, HandJoints p_joint) const;
 	Quaternion get_hand_joint_rotation(Hand p_hand, HandJoints p_joint) const;
 	Vector3 get_hand_joint_position(Hand p_hand, HandJoints p_joint) const;
 	float get_hand_joint_radius(Hand p_hand, HandJoints p_joint) const;
@@ -236,5 +248,6 @@ public:
 VARIANT_ENUM_CAST(OpenXRInterface::Hand)
 VARIANT_ENUM_CAST(OpenXRInterface::HandMotionRange)
 VARIANT_ENUM_CAST(OpenXRInterface::HandJoints)
+VARIANT_BITFIELD_CAST(OpenXRInterface::HandJointFlags)
 
 #endif // OPENXR_INTERFACE_H


### PR DESCRIPTION
This PR adds access to the validity flags in OpenXR hand tracking data.
This is a follow up to #78032, we missed exposing these flags.