### PR TITLE
Fix `godot_js_wrapper_create_cb` regression

### DIFF
--- a/platform/web/js/libs/library_godot_javascript_singleton.js
+++ b/platform/web/js/libs/library_godot_javascript_singleton.js
@@ -210,7 +210,7 @@ const GodotJSWrapper = {
 			// This is safe! JavaScript is single threaded (and using it in threads is not a good idea anyway).
 			GodotJSWrapper.cb_ret = null;
 			const args = Array.from(arguments);
-			const argsProxy = GodotJSWrapper.MyProxy(args);
+			const argsProxy = new GodotJSWrapper.MyProxy(args);
 			func(p_ref, argsProxy.get_id(), args.length);
 			argsProxy.unref();
 			const ret = GodotJSWrapper.cb_ret;


### PR DESCRIPTION
Fix a regression caused by #81105.

Currently, calling `GodotJSWrapper.MyProxy(args)` without the `new` keyword returns `undefined`, which make the following calls fail.

This PR adds the missing `new` keyword to the expression.

Fixes #82734