### PR TITLE
Fix typos in documentation: `than/then` and `loose/lose`

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -125,7 +125,7 @@
 			<return type="void" />
 			<param index="0" name="replace" type="bool" default="false" />
 			<description>
-				Inserts the selected entry into the text. If [param replace] is true, any existing text is replaced rather then merged.
+				Inserts the selected entry into the text. If [param replace] is true, any existing text is replaced rather than merged.
 			</description>
 		</method>
 		<method name="convert_indent">
@@ -676,7 +676,7 @@
 			Max number of options to display in the code completion popup at any one time.
 		</theme_item>
 		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
-			Max width of options in the code completion popup. Options longer then this will be cut off.
+			Max width of options in the code completion popup. Options longer than this will be cut off.
 		</theme_item>
 		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="6">
 			Width of the scrollbar in the code completion popup.

--- a/doc/classes/TLSOptions.xml
+++ b/doc/classes/TLSOptions.xml
@@ -28,7 +28,7 @@
 			<param index="1" name="common_name_override" type="String" default="&quot;&quot;" />
 			<description>
 				Creates a TLS client configuration which validates certificates and their common names (fully qualified domain names).
-				You can specify a custom [param trusted_chain] of certification authorities (the default CA list will be used if [code]null[/code]), and optionally provide a [param common_name_override] if you expect the certificate to have a common name other then the server FQDN.
+				You can specify a custom [param trusted_chain] of certification authorities (the default CA list will be used if [code]null[/code]), and optionally provide a [param common_name_override] if you expect the certificate to have a common name other than the server FQDN.
 				[b]Note:[/b] On the Web platform, TLS verification is always enforced against the CA list of the web browser. This is considered a security feature.
 			</description>
 		</method>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1169,7 +1169,7 @@
 			Allow scrolling past the last line into "virtual" space.
 		</member>
 		<member name="scroll_smooth" type="bool" setter="set_smooth_scroll_enabled" getter="is_smooth_scroll_enabled" default="false">
-			Scroll smoothly over the text rather then jumping to the next location.
+			Scroll smoothly over the text rather than jumping to the next location.
 		</member>
 		<member name="scroll_v_scroll_speed" type="float" setter="set_v_scroll_speed" getter="get_v_scroll_speed" default="80.0">
 			Sets the scroll speed with the minimap or when [member scroll_smooth] is enabled.

--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -37,7 +37,7 @@
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
-				Marks this pose as invalid, we don't clear the last reported state but it allows users to decide if trackers need to be hidden if we loose tracking or just remain at their last known position.
+				Marks this pose as invalid, we don't clear the last reported state but it allows users to decide if trackers need to be hidden if we lose tracking or just remain at their last known position.
 			</description>
 		</method>
 		<method name="set_input">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
