### PR TITLE
OpenXR: Properly skip frame render when the XR runtime is not yet ready

### DIFF
--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -139,6 +139,7 @@ private:
 		void *swapchain_graphics_data = nullptr;
 		uint32_t image_index = 0;
 		bool image_acquired = false;
+		bool skip_acquire_swapchain = false;
 	};
 
 	OpenXRSwapChainInfo swapchains[OPENXR_SWAPCHAIN_MAX];


### PR DESCRIPTION
This PR essentially recreates the workaround found here: https://github.com/GodotVR/godot_openxr/commit/484b1a87bd43726620914ba582f590ea189994f7 to recover when swapchains can't be released.

As mentioned, this is a workaround, but in my opinion is a pretty important one because the issue it fixes prevents people from recording videos of the game among other things, and worst of all, it happens seemingly randomly, which can frustrate players.

I just tried my best to adapt the previous code to the new OpenXR API, so please let me know if something could be done a better way!

Closes https://github.com/godotengine/godot/issues/82751