### PR TITLE
C#: Add checks to Android export

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -23,10 +23,14 @@ namespace GodotTools.ProjectEditor
 
             var mainGroup = root.AddPropertyGroup();
             mainGroup.AddProperty("TargetFramework", "net6.0");
-            mainGroup.AddProperty("EnableDynamicLoading", "true");
+
+            var net7 = mainGroup.AddProperty("TargetFramework", "net7.0");
+            net7.Condition = " '$(GodotTargetPlatform)' == 'android' ";
 
             var net8 = mainGroup.AddProperty("TargetFramework", "net8.0");
             net8.Condition = " '$(GodotTargetPlatform)' == 'ios' ";
+
+            mainGroup.AddProperty("EnableDynamicLoading", "true");
 
             string sanitizedName = IdentifierUtils.SanitizeQualifiedIdentifier(name, allowEmptyIdentifiers: true);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -187,7 +187,7 @@ namespace GodotTools.Export
 
             List<string> outputPaths = new();
 
-            bool embedBuildResults = (bool)GetOption("dotnet/embed_build_outputs") || features.Contains("android");
+            bool embedBuildResults = (bool)GetOption("dotnet/embed_build_outputs") || platform == OS.Platforms.Android;
 
             foreach (PublishConfig config in targets)
             {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2238,6 +2238,19 @@ bool EditorExportPlatformAndroid::has_valid_export_configuration(const Ref<Edito
 #ifdef MODULE_MONO_ENABLED
 	// Android export is still a work in progress, keep a message as a warning.
 	err += TTR("Exporting to Android when using C#/.NET is experimental.") + "\n";
+
+	bool unsupported_arch = false;
+	Vector<ABI> enabled_abis = get_enabled_abis(p_preset);
+	for (ABI abi : enabled_abis) {
+		if (abi.arch != "arm64" && abi.arch != "x86_64") {
+			err += vformat(TTR("Android architecture %s not supported in C# projects."), abi.arch) + "\n";
+			unsupported_arch = true;
+		}
+	}
+	if (unsupported_arch) {
+		r_error = err;
+		return false;
+	}
 #endif
 
 	// Look for export templates (first official, and if defined custom templates).


### PR DESCRIPTION
- Add .NET 7.0 TFM when the platform is Anroid to the created csproj.
- Prevent exporting to Android when the architecture is not supported.
- Fixes https://github.com/godotengine/godot/issues/82013.

The intention is to communicate the limitations of the current experimental Android exports to users and hopefully simplify the process.