### PR TITLE
[MP] Various performance optimizations

### DIFF
--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -239,8 +239,8 @@ void MultiplayerDebugger::RPCProfiler::tick(double p_frame_time, double p_proces
 MultiplayerDebugger::SyncInfo::SyncInfo(MultiplayerSynchronizer *p_sync) {
 	ERR_FAIL_NULL(p_sync);
 	synchronizer = p_sync->get_instance_id();
-	if (p_sync->get_replication_config().is_valid()) {
-		config = p_sync->get_replication_config()->get_instance_id();
+	if (p_sync->get_replication_config_ptr()) {
+		config = p_sync->get_replication_config_ptr()->get_instance_id();
 	}
 	if (p_sync->get_root_node()) {
 		root_node = p_sync->get_root_node()->get_instance_id();

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -441,6 +441,10 @@ List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes)
 	return out;
 }
 
+SceneReplicationConfig *MultiplayerSynchronizer::get_replication_config_ptr() const {
+	return replication_config.ptr();
+}
+
 MultiplayerSynchronizer::MultiplayerSynchronizer() {
 	// Publicly visible by default.
 	peer_visibility.insert(0);

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -118,6 +118,7 @@ public:
 
 	List<Variant> get_delta_state(uint64_t p_cur_usec, uint64_t p_last_usec, uint64_t &r_indexes);
 	List<NodePath> get_delta_properties(uint64_t p_indexes);
+	SceneReplicationConfig *get_replication_config_ptr() const;
 
 	MultiplayerSynchronizer();
 };

--- a/modules/multiplayer/scene_cache_interface.h
+++ b/modules/multiplayer/scene_cache_interface.h
@@ -58,12 +58,12 @@ private:
 		HashMap<int, NodeInfo> nodes;
 	};
 
-	HashMap<NodePath, PathSentCache> path_send_cache;
+	HashMap<ObjectID, PathSentCache> path_send_cache;
 	HashMap<int, PathGetCache> path_get_cache;
 	int last_send_cache_id = 1;
 
 protected:
-	Error _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, const List<int> &p_peers);
+	Error _send_confirm_path(Node *p_node, PathSentCache *psc, const List<int> &p_peers);
 
 public:
 	void clear();
@@ -75,7 +75,7 @@ public:
 	bool send_object_cache(Object *p_obj, int p_target, int &p_id);
 	int make_object_cache(Object *p_obj);
 	Object *get_cached_object(int p_from, uint32_t p_cache_id);
-	bool is_cache_confirmed(NodePath p_path, int p_peer);
+	bool is_cache_confirmed(Node *p_path, int p_peer);
 
 	SceneCacheInterface(SceneMultiplayer *p_multiplayer) { multiplayer = p_multiplayer; }
 };

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -680,12 +680,16 @@ void SceneMultiplayer::_bind_methods() {
 
 SceneMultiplayer::SceneMultiplayer() {
 	relay_buffer.instantiate();
-	replicator = Ref<SceneReplicationInterface>(memnew(SceneReplicationInterface(this)));
-	rpc = Ref<SceneRPCInterface>(memnew(SceneRPCInterface(this)));
 	cache = Ref<SceneCacheInterface>(memnew(SceneCacheInterface(this)));
+	replicator = Ref<SceneReplicationInterface>(memnew(SceneReplicationInterface(this, cache.ptr())));
+	rpc = Ref<SceneRPCInterface>(memnew(SceneRPCInterface(this, cache.ptr(), replicator.ptr())));
 	set_multiplayer_peer(Ref<OfflineMultiplayerPeer>(memnew(OfflineMultiplayerPeer)));
 }
 
 SceneMultiplayer::~SceneMultiplayer() {
 	clear();
+	// Ensure unref in reverse order for safety (we shouldn't use those pointers in the deconstructors anyway).
+	rpc.unref();
+	replicator.unref();
+	cache.unref();
 }

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -201,9 +201,6 @@ public:
 	void set_max_delta_packet_size(int p_size);
 	int get_max_delta_packet_size() const;
 
-	Ref<SceneCacheInterface> get_path_cache() { return cache; }
-	Ref<SceneReplicationInterface> get_replicator() { return replicator; }
-
 	SceneMultiplayer();
 	~SceneMultiplayer();
 };

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -37,6 +37,7 @@
 #include "core/object/ref_counted.h"
 
 class SceneMultiplayer;
+class SceneCacheInterface;
 
 class SceneReplicationInterface : public RefCounted {
 	GDCLASS(SceneReplicationInterface, RefCounted);
@@ -87,6 +88,7 @@ private:
 
 	// Replicator config.
 	SceneMultiplayer *multiplayer = nullptr;
+	SceneCacheInterface *multiplayer_cache = nullptr;
 	PackedByteArray packet_cache;
 	int sync_mtu = 1350; // Highly dependent on underlying protocol.
 	int delta_mtu = 65535;
@@ -144,8 +146,9 @@ public:
 	void set_max_delta_packet_size(int p_size);
 	int get_max_delta_packet_size() const;
 
-	SceneReplicationInterface(SceneMultiplayer *p_multiplayer) {
+	SceneReplicationInterface(SceneMultiplayer *p_multiplayer, SceneCacheInterface *p_cache) {
 		multiplayer = p_multiplayer;
+		multiplayer_cache = p_cache;
 	}
 };
 

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -95,6 +95,7 @@ private:
 	void _untrack(const ObjectID &p_id);
 	void _node_ready(const ObjectID &p_oid);
 
+	bool _has_authority(const Node *p_node);
 	bool _verify_synchronizer(int p_peer, MultiplayerSynchronizer *p_sync, uint32_t &r_net_id);
 	MultiplayerSynchronizer *_find_synchronizer(int p_peer, uint32_t p_net_ida);
 

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -443,15 +443,14 @@ void SceneRPCInterface::_send_rpc(Node *p_node, int p_to, uint16_t p_rpc_id, con
 		// Not all verified path, so send one by one.
 
 		// Append path at the end, since we will need it for some packets.
-		NodePath from_path = multiplayer->get_root_path().rel_path_to(p_node->get_path());
-		CharString pname = String(from_path).utf8();
+		CharString pname = String(multiplayer->get_root_path().rel_path_to(p_node->get_path())).utf8();
 		int path_len = encode_cstring(pname.get_data(), nullptr);
 		MAKE_ROOM(ofs + path_len);
 		encode_cstring(pname.get_data(), &(packet_cache.write[ofs]));
 
 		// Not all verified path, so check which needs the longer packet.
 		for (const int P : targets) {
-			bool confirmed = multiplayer->get_path_cache()->is_cache_confirmed(from_path, P);
+			bool confirmed = multiplayer->get_path_cache()->is_cache_confirmed(p_node, P);
 			if (confirmed) {
 				// This one confirmed path, so use id.
 				encode_uint32(psc_id, &(packet_cache.write[1]));

--- a/modules/multiplayer/scene_rpc_interface.h
+++ b/modules/multiplayer/scene_rpc_interface.h
@@ -35,6 +35,8 @@
 #include "scene/main/multiplayer_api.h"
 
 class SceneMultiplayer;
+class SceneCacheInterface;
+class SceneReplicationInterface;
 class Node;
 
 class SceneRPCInterface : public RefCounted {
@@ -77,6 +79,9 @@ private:
 	};
 
 	SceneMultiplayer *multiplayer = nullptr;
+	SceneCacheInterface *multiplayer_cache = nullptr;
+	SceneReplicationInterface *multiplayer_replicator = nullptr;
+
 	Vector<uint8_t> packet_cache;
 
 	HashMap<ObjectID, RPCConfigCache> rpc_cache;
@@ -99,7 +104,11 @@ public:
 	void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len);
 	String get_rpc_md5(const Object *p_obj);
 
-	SceneRPCInterface(SceneMultiplayer *p_multiplayer) { multiplayer = p_multiplayer; }
+	SceneRPCInterface(SceneMultiplayer *p_multiplayer, SceneCacheInterface *p_cache, SceneReplicationInterface *p_replicator) {
+		multiplayer = p_multiplayer;
+		multiplayer_cache = p_cache;
+		multiplayer_replicator = p_replicator;
+	}
 };
 
 #endif // SCENE_RPC_INTERFACE_H


### PR DESCRIPTION
As pointed out in #81593 , watched/on change variables are quite heavy on the CPU side, mostly due to the way network IDs are exchanged and stored for non-spawned node.

This PR introduce a series of optimizations to reduce the computational cost of the replication system:

- Optimize the data structures used by the network IDs cache (using `ObjectID`s locally, while still transferring relative paths).
- Optimize internal authority checks to avoid going through the SceneTree (searching the appropriate MultiplayerAPI as we already know the correct one)
- Avoid unnecessary ref/unrefs between the various internal components (Replication/Cache/RPC)
- Optimize internal SceneReplicationConfig access (using direct pointers instead of refs)

![flamegraph](https://github.com/godotengine/godot/assets/1687918/c3e60d50-f69f-4455-aab7-15fef84b2ff9)

Closes #81593 , might need some more testing.