### PR TITLE
GDScript: Fix unresolved datatype for incomplete binary operator

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2800,6 +2800,9 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 	}
 
 	if (!left_type.is_set() || !right_type.is_set()) {
+		GDScriptParser::DataType dummy;
+		dummy.kind = GDScriptParser::DataType::VARIANT;
+		p_binary_op->set_datatype(dummy);
 		return;
 	}
 


### PR DESCRIPTION
* Fixes #82765.
