### PR TITLE
Web: Catch using GDExtensions in a non-dlink build

### DIFF
--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -164,6 +164,10 @@ const Engine = (function () {
 
 					// Preload GDExtension libraries.
 					const libs = [];
+					if (me.config.gdextensionLibs.length > 0 && !me.rtenv['loadDynamicLibrary']) {
+						return Promise.reject(new Error('GDExtension libraries are not supported by this engine version. '
+							+ 'Enable "Extensions Support" for your export preset and/or build your custom template with "dlink_enabled=yes".'));
+					}
 					me.config.gdextensionLibs.forEach(function (lib) {
 						libs.push(me.rtenv['loadDynamicLibrary'](lib, { 'loadAsync': true }));
 					});


### PR DESCRIPTION
Previously, if one would try to use GDExtensions with a web build that doesn't have dynamic loading enabled, this would simply fail with a cryptic `me.rtenv.loadDynamicLibrary is not a function` error message.

If it's attempted again, it will now instead error out with `GDExtension libraries are not supported by this engine version`.