### PR TITLE
Fix export mesh lib break due to imported gltf has a redundant Node3D

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -84,9 +84,16 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 			if (child->get_child_count() > 0) {
 				child = child->get_child(0);
 				if (!Object::cast_to<MeshInstance3D>(child)) {
-					continue;
+					// Some imported gltf will generate an empty parent.
+					if (child->get_child_count() > 0) {
+						child = child->get_child(0);
+						if (!Object::cast_to<MeshInstance3D>(child)) {
+							continue;
+						}
+					} else {
+						continue;
+					}
 				}
-
 			} else {
 				continue;
 			}


### PR DESCRIPTION
Fixes #81850

The code is a little messy this way, but imho it's better to change the mesh lib export code than change the gltf import code. I would appreciate any feedback or alternative suggestions.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
