### PR TITLE
Set default indent size for *.{cpp,hpp,c,h,mm} to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,8 @@ insert_final_newline = true
 
 [*.{cpp,hpp,c,h,mm}]
 trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4
 
 [{*.gradle,AndroidManifest.xml}]
 indent_style = space


### PR DESCRIPTION
[GitHub respect the indent size set by an .editorconfig file in the repository.](https://stackoverflow.com/a/33831598) This will make working with diffs a little bit easier for the majority of the PRs, as tabs will no longer be set to their default value of tabs of 8 spaces.

I set the style to tabs, and spaces to 4, which is currently the standard for the project for those files.

Here's an example of the tabs in diff currently (set as 8 spaces), it actively hinders the ability to review well PRs as so much whitespace is added.

Here's how it currently look on Chrome:

![Capture d’écran du 2023-10-04 11-33-15](https://github.com/godotengine/godot/assets/270928/d9b75aa2-f505-4364-b333-6a0352a3eabc)

There's a bug on Firefox that makes it 16 characters!

![image](https://github.com/godotengine/godot/assets/270928/52d4ee06-0b54-4322-bd63-bb883b840875)
