### PR TITLE
GDExtension: Convert `validated_call()` to `ptrcall()` (rather than `call()`)

### DIFF
--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -418,7 +418,7 @@ public:
 			case Variant::PACKED_COLOR_ARRAY:
 				return get_color_array(v);
 			case Variant::OBJECT:
-				return v->_get_obj().obj;
+				return get_object(v);
 			case Variant::VARIANT_MAX:
 				ERR_FAIL_V(nullptr);
 		}


### PR DESCRIPTION
Presently, if you do a `validated_call()` to a GDExtension method, and the GDExtension doesn't provide special support for validated calls (very unlikely), then it will convert that to a `call()`. This will be much slower than necessary, since we know all the argument types match - it would be better to do a `ptrcall()`.

Right now, this isn't that important, because GDScript will do `ptrcall()`s directly (when possible), but PR https://github.com/godotengine/godot/pull/79893 would switch GDScript to doing `validated_call()`.

So, this PR changes `validated_call()` to GDExtension methods to use `ptrcall()`.

I've tested this PR, in combination with PR https://github.com/godotengine/godot/pull/79893, and it seems to be working fine (the automated godot-cpp tests pass).

It also fixes an issue in `Object::get_opaque_pointer()` that was missed in PR https://github.com/godotengine/godot/pull/77410. That PR made the same change to the const version of `Object::get_opaque_pointer()`, but missed it for the non-const version. We didn't notice, because we were only using it for function arguments (which are const), and in this PR we start using it for function return values as well (which are non-const).