### PR TITLE
Fix `RBMap`'s, iterator-based, `remove()`

### DIFF
--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -96,6 +96,8 @@ public:
 	typedef KeyValue<K, V> ValueType;
 
 	struct Iterator {
+		friend class RBMap<K, V, C, A>;
+
 		_FORCE_INLINE_ KeyValue<K, V> &operator*() const {
 			return E->key_value();
 		}


### PR DESCRIPTION
`RBMap::remove()` needs to access private members of its `Iterator`, but there's no friendship between them, so it's broken.

This PR is here to save the day.

---

Test code:
```C++
	RBMap<int, int> rb_map;
	decltype(rb_map)::Iterator rb_it;
	rb_map.remove(rb_it);
```
MSVC error:
> `core/templates/rb_map.h(166): error C2248: 'RBMap<int,int,Comparator<K>,DefaultAllocator>::Iterator::E': cannot access private member declared in class 'RBMap<int,int,Comparator<K>,DefaultAllocator>::Iterator'`
