### PR TITLE
Expose `Object::free_instance_binding()` to GDExtension

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1152,6 +1152,11 @@ static void gdextension_object_set_instance_binding(GDExtensionObjectPtr p_objec
 	o->set_instance_binding(p_token, p_binding, p_callbacks);
 }
 
+static void gdextension_object_free_instance_binding(GDExtensionObjectPtr p_object, void *p_token) {
+	Object *o = (Object *)p_object;
+	o->free_instance_binding(p_token);
+}
+
 static void gdextension_object_set_instance(GDExtensionObjectPtr p_object, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance) {
 	const StringName classname = *reinterpret_cast<const StringName *>(p_classname);
 	Object *o = (Object *)p_object;
@@ -1491,6 +1496,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(global_get_singleton);
 	REGISTER_INTERFACE_FUNC(object_get_instance_binding);
 	REGISTER_INTERFACE_FUNC(object_set_instance_binding);
+	REGISTER_INTERFACE_FUNC(object_free_instance_binding);
 	REGISTER_INTERFACE_FUNC(object_set_instance);
 	REGISTER_INTERFACE_FUNC(object_get_class_name);
 	REGISTER_INTERFACE_FUNC(object_cast_to);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -2192,6 +2192,17 @@ typedef void *(*GDExtensionInterfaceObjectGetInstanceBinding)(GDExtensionObjectP
 typedef void (*GDExtensionInterfaceObjectSetInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
 
 /**
+ * @name object_free_instance_binding
+ * @since 4.2
+ *
+ * Free an Object's instance binding.
+ *
+ * @param p_o A pointer to the Object.
+ * @param p_library A token the library received by the GDExtension's entry point function.
+ */
+typedef void (*GDExtensionInterfaceObjectFreeInstanceBinding)(GDExtensionObjectPtr p_o, void *p_token);
+
+/**
  * @name object_set_instance
  * @since 4.1
  *

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1863,7 +1863,6 @@ bool Object::has_instance_binding(void *p_token) {
 	return found;
 }
 
-#ifdef TOOLS_ENABLED
 void Object::free_instance_binding(void *p_token) {
 	bool found = false;
 	_instance_binding_mutex.lock();
@@ -1888,6 +1887,7 @@ void Object::free_instance_binding(void *p_token) {
 	_instance_binding_mutex.unlock();
 }
 
+#ifdef TOOLS_ENABLED
 void Object::clear_internal_extension() {
 	ERR_FAIL_NULL(_extension);
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -970,9 +970,9 @@ public:
 	// Used on creation by binding only.
 	void set_instance_binding(void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
 	bool has_instance_binding(void *p_token);
+	void free_instance_binding(void *p_token);
 
 #ifdef TOOLS_ENABLED
-	void free_instance_binding(void *p_token);
 	void clear_internal_extension();
 	void reset_internal_extension(ObjectGDExtension *p_extension);
 #endif


### PR DESCRIPTION
I noticed that the latest Godot 4.2 beta added a new free_instance_binding function to Object. 
It is only exposed to the Editor but it has uses for regular GDExtension memory management.

We would welcome that change for our Godot Kotlin binding as it makes some memory management operations easier. 
One of the use cases is for example to free the JVM instance used to wrap the native object pointer when it's no longer used in the managed side of the memory. That way we don't have to wait for the native object freed to release the Kotlin wrapper as our instance binding hold a reference to the JVM instance (so far we had to convert it to a weak reference instead of removing the binding).
