### PR TITLE
Add a recommendation to turn on type hints with untyped declaration warning

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -556,6 +556,7 @@
 		</member>
 		<member name="debug/gdscript/warnings/untyped_declaration" type="int" setter="" getter="" default="0">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a variable or parameter has no static type, or if a function has no static return type.
+			[b]Note:[/b] This warning is recommended together with [member EditorSettings.text_editor/completion/add_type_hints] to help achieve type safety.
 		</member>
 		<member name="debug/gdscript/warnings/unused_local_constant" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a local constant is never used.


### PR DESCRIPTION
Fixes #82587 by improving usability of the untyped_declaration warning. This adds a note to the documentation that recommends turning on EditorSettings.text_editor/completion/add_type_hints when the untyped declaration warning is set to warn or error. This new text echos the recommendation proposed in the [docs PR](https://github.com/godotengine/godot-docs/pull/8130)