### PR TITLE
Automatically ensure correct normals in Compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2921,6 +2921,8 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				}
 			}
 
+			material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::MODEL_FLAGS, inst->flags_cache, shader->version, instance_variant, spec_constants);
+
 			// Can be index count or vertex count
 			uint32_t count = 0;
 			if (surf->lod_index > 0) {

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -139,6 +139,8 @@ layout(location = 14) in highp vec4 instance_xform2;
 layout(location = 15) in highp uvec4 instance_color_custom_data; // Color packed into xy, Custom data into zw.
 #endif
 
+#define FLAGS_NON_UNIFORM_SCALE (1 << 4)
+
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
@@ -242,6 +244,8 @@ uniform highp vec3 compressed_aabb_position;
 uniform highp vec3 compressed_aabb_size;
 uniform highp vec4 uv_scale;
 
+uniform highp uint model_flags;
+
 /* Varyings */
 
 out highp vec3 vertex_interp;
@@ -310,7 +314,14 @@ void main() {
 #ifdef NORMAL_USED
 	vec3 normal = oct_to_vec3(axis_tangent_attrib.xy * 2.0 - 1.0);
 #endif
-	highp mat3 model_normal_matrix = mat3(model_matrix);
+
+	highp mat3 model_normal_matrix;
+
+	if (bool(model_flags & uint(FLAGS_NON_UNIFORM_SCALE))) {
+		model_normal_matrix = transpose(inverse(mat3(model_matrix)));
+	} else {
+		model_normal_matrix = mat3(model_matrix);
+	}
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 


### PR DESCRIPTION
Fixes #82763

The `ensure_correct_normals` define is redundant in the Forward+ and Mobile renderers, as they check whether individual instances are uniform or not. ~Due to the way instancing is done in the Compatibility renderer, however, the `ENSURE_CORRECT_NORMALS` shader define has to be used instead.~

This PR changes the shader's logic to automatically figure out which objects have a non-uniform scale.

Results (Compatibility):

![aaa](https://github.com/godotengine/godot/assets/53150244/67488623-bb4c-44cd-b5cc-cadfd8f35dfa)

Progress:
- [x] Implementation for non-instanced rendering