### PR TITLE
Implement optional path for patching spec constants into the SPIR-V during pipeline creation.

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -643,13 +643,17 @@ class RenderingDeviceVulkan : public RenderingDevice {
 		Vector<uint32_t> set_formats;
 		Vector<VkPipelineShaderStageCreateInfo> pipeline_stages;
 		Vector<SpecializationConstant> specialization_constants;
+		Vector<SpirvSpecializationData> spirv_specializations;
 		VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
 		String name; // Used for debug.
 	};
 
 	String _shader_uniform_debug(RID p_shader, int p_set = -1);
+	void _shader_specialization_constants_to_pipeline_constants(const Vector<Shader::SpecializationConstant> &p_shader_specialization_constants, LocalVector<PipelineSpecializationConstant> &p_pipeline_specialization_constants);
+	VkShaderModule _create_patched_shader_module(const SpirvSpecializationData &p_spirv_spec_data, const Vector<Shader::SpecializationConstant> &p_shader_specialization_constants, const Vector<PipelineSpecializationConstant> &p_pipeline_specialization_constants);
 
 	RID_Owner<Shader, true> shader_owner;
+	bool patch_spirv_spec_constants = false;
 
 	/******************/
 	/**** UNIFORMS ****/

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1400,7 +1400,18 @@ protected:
 		Vector<SpecializationConstant> specialization_constants;
 	};
 
+	struct SpirvSpecializationData {
+		LocalVector<uint32_t> spirv_words;
+		LocalVector<uint32_t> constant_locations;
+	};
+
+	enum {
+		SPIRV_STARTING_WORD_INDEX = 5
+	};
+
 	Error _reflect_spirv(const Vector<ShaderStageSPIRVData> &p_spirv, SpirvReflectionData &r_reflection_data);
+	void _create_specialization_data_spirv(const Vector<uint8_t> &p_spirv_data, const Vector<PipelineSpecializationConstant> &p_shader_specialization_constants, SpirvSpecializationData &p_spirv_spec_data);
+	void _specialize_spirv(const SpirvSpecializationData &p_spirv_spec_data, const Vector<PipelineSpecializationConstant> &p_shader_specialization_constants, const Vector<PipelineSpecializationConstant> &p_pipeline_specialization_constants, LocalVector<uint32_t> &r_patched_spirv_words);
 
 #ifndef DISABLE_DEPRECATED
 	BitField<BarrierMask> _convert_barrier_mask_81356(BitField<BarrierMask> p_old_barrier);


### PR DESCRIPTION
Credit to @darksylinc first and foremost for identifying that when hard-coding specialization constants he managed to get substantial performance improvements on the mobile hardware he was testing on.

### Background

This is a very weird experiment that common sense would dictate it shouldn't be necessary, but we've found a reason to believe specialization constants are just not implemented correctly across some vendors, particularly in platforms like Android where the drivers can get pretty outdated due to how the distribution works.

To work around that, the PR implements a SPIR-V parser that will search for the specialization constant instructions and replace them with the instructions and values they should be according to what the pipeline has specified. This is very much not a standard process and it shouldn't be necessary at all, but it seems to have some actual results.

After some experimentation, we found a very substantial improvement **of ~30% extra FPS in Redmi 4X, Adreno 504** in a simple test scene.

I've not been able to replicate any substantial improvements in desktop with NVIDIA hardware (as expected), but we figure the best target would be platforms that have fairly outdated drivers or just plain don't implement these as we expect them to.

While the process is not free, it adds a very minimal cost during pipeline creation (around 100us). However, I would advise against enabling this unless we detect that it should be done on a platform that warrants it (e.g. Android).

While I've done the replacement for the instructions Godot uses, I've avoided modifying "OpSpecConstantOp", as it requires some much more complex logic that I haven't done (unless I misunderstood how it works). However, the specification doesn't mention that this instruction can't take inputs that aren't specialization constants, so I'm not sure if it's necessary to perform a replacement at all.

### What we are looking for

**This experiment will only apply to the Vulkan-based renderers (Forward+ and Mobile).**

We're mostly interested in people trying out this PR on platforms they suspect might not have the most up to date drivers and see if they can get any actual performance improvement. So far we got some substantial results on **Adreno 504 (2018)** so we suspect we might find improvements elsewhere.

There should also be no noticeable regressions from doing this and it'd be good to know if that holds true.

If you're interested in turning this on and off, the boolean that controls it can be found here. It is enabled by default at the moment on the branch.

https://github.com/DarioSamo/godot/blob/31a0f95b075575e50e5ae10a38ed34b247b00cd0/drivers/vulkan/rendering_device_vulkan.cpp#L5250
```cpp
bool patch_spirv_spec_constants = true;
```