### PR TITLE
Update script editors on global class list changes

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1262,6 +1262,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
+	ADD_SIGNAL(MethodInfo("global_script_classes_changed"));
 }
 
 void ProjectSettings::_add_builtin_input_map() {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -381,6 +381,8 @@ void ScriptServer::save_global_classes() {
 		gcarr.push_back(d);
 	}
 	ProjectSettings::get_singleton()->store_global_class_list(gcarr);
+	// Workaround for ScriptServer not being able to emit signals.
+	ProjectSettings::get_singleton()->emit_signal(SNAME("global_script_classes_changed"));
 }
 
 String ScriptServer::get_global_class_cache_file_path() {

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2757,6 +2757,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="global_script_classes_changed">
+			<description>
+				Emitted right after ScriptServer saves the newly updated global class list.
+			</description>
+		</signal>
 		<signal name="settings_changed">
 			<description>
 				Emitted when any setting is changed, up to once per process frame.

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "code_editor.h"
 
+#include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
@@ -1972,6 +1973,8 @@ void CodeTextEditor::update_toggle_scripts_button() {
 }
 
 CodeTextEditor::CodeTextEditor() {
+	ProjectSettings::get_singleton()->connect("global_script_classes_changed", callable_mp(this, &CodeTextEditor::_text_changed_idle_timeout));
+
 	code_complete_func = nullptr;
 	ED_SHORTCUT("script_editor/zoom_in", TTR("Zoom In"), KeyModifierMask::CMD_OR_CTRL | Key::EQUAL);
 	ED_SHORTCUT("script_editor/zoom_out", TTR("Zoom Out"), KeyModifierMask::CMD_OR_CTRL | Key::MINUS);


### PR DESCRIPTION
Partially addresses #75388

From what I tested, the bug only happens when global class cache does not exist, but `.godot` folder exists. If you delete `.godot` folder, the project loads without a fail.
Even if we somehow ensured global class cache, this doesn't solve the problem of addons. Global classes are only scanned once, every further update needs to be done manually. I think we could scan the enabled addon's folder to check for new classes.

As for what this PR fixes, whenever your class can't be detected for any reason (e.g. script error), the other script using that class will have an error until you fix the class and then manually trigger script validation. After these changes, the last step is done automatically:

https://github.com/godotengine/godot/assets/2223172/c50b6ba0-ac2b-4c3b-98a9-50af6d0356a4

(here renaming the script makes it re-parsed and added to class cache, fixing the error immediately)

Not sure how much it improves the situation though. It should make it easier to fix class-related errors. I also noticed that after these changes in the case where `.godot` exists, but not global class cache, some classes may randomly get cached on startup and the script will be less broken.