### PR TITLE
Allow to remove signal connections using `Delete`

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -252,7 +252,7 @@ class ConnectionsDock : public VBoxContainer {
 	void _signal_menu_about_to_popup();
 	void _handle_slot_menu_option(int p_option);
 	void _slot_menu_about_to_popup();
-	void _rmb_pressed(const Ref<InputEvent> &p_event);
+	void _tree_gui_input(const Ref<InputEvent> &p_event);
 	void _close();
 
 protected:


### PR DESCRIPTION
This pull request improves usability with the Node connection panel, to allow the user to quickly delete connections by pressing the DEL key.

The `_rmb_pressed` method in the `ConnectionsDock` class has been renamed to `_gui_input` to reflect the new handling of other inputs.

This fixes the usability issue outlined in [#82616](https://github.com/godotengine/godot/issues/82616).

* *Bugsquad edit, closes: #82616*