### PR TITLE
Pass `*.translation` files in the project settings in conversion 3 to 4

### DIFF
--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -36,6 +36,7 @@
 
 #ifdef MODULE_REGEX_ENABLED
 
+#include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
@@ -523,6 +524,7 @@ bool ProjectConverter3To4::convert() {
 	print_line(vformat("Conversion ended - all files(%d), converted files: (%d), not converted files: (%d).", collected_files.size(), converted_files, collected_files.size() - converted_files));
 	uint64_t conversion_end_time = Time::get_singleton()->get_ticks_msec();
 	print_line(vformat("Conversion of all files took %10.3f seconds.", (conversion_end_time - conversion_start_time) / 1000.0));
+	update_translations_path();
 	return true;
 }
 
@@ -730,6 +732,15 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 		}
 	}
 	return collected_files;
+}
+
+// Updates the path for *.localization files added in the project settings
+void ProjectConverter3To4::update_translations_path() {
+	if (ProjectSettings::get_singleton()->has_setting("locale/translations")) {
+		PackedStringArray old_path_translations = ProjectSettings::get_singleton()->get("locale/translations");
+		ProjectSettings::get_singleton()->set("internationalization/locale/translations", old_path_translations);
+		ProjectSettings::get_singleton()->save();
+	}
 }
 
 Vector<SourceLine> ProjectConverter3To4::split_lines(const String &text) {

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -734,7 +734,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 	return collected_files;
 }
 
-// Updates the path for *.localization files added in the project settings
+// Updates the path for *.localization files added in the project settings.
 void ProjectConverter3To4::update_translations_path() {
 	if (ProjectSettings::get_singleton()->has_setting("locale/translations")) {
 		PackedStringArray old_path_translations = ProjectSettings::get_singleton()->get("locale/translations");

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -108,7 +108,7 @@ class ProjectConverter3To4 {
 	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
 
 	Vector<String> check_for_files();
-	
+
 	void update_translations_path();
 
 	Vector<String> parse_arguments(const String &line);

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -108,6 +108,8 @@ class ProjectConverter3To4 {
 	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);
 
 	Vector<String> check_for_files();
+	
+	void update_translations_path();
 
 	Vector<String> parse_arguments(const String &line);
 	int get_end_parenthesis(const String &line) const;


### PR DESCRIPTION
Fixes #78595 

Added a method in the ProjectConverter3To4 for passing the content stored in the path used in previous versions to the newest path.