### PR TITLE
Re-add optional OIDN denoise as an external dynamic library.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -500,6 +500,9 @@
 			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
 			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
 		</member>
+		<member name="filesystem/tools/oidn/oidn_library_path" type="String" setter="" getter="">
+			The path to the directory containing the OIDN denoise dynamic library.
+		</member>
 		<member name="interface/editor/accept_dialog_cancel_ok_buttons" type="int" setter="" getter="">
 			How to position the Cancel and OK buttons in the editor's [AcceptDialog]s. Different platforms have different standard behaviors for this, which can be overridden using this setting. This is useful if you use Godot both on Windows and macOS/Linux and your Godot muscle memory is stronger than your OS specific one.
 			- [b]Auto[/b] follows the platform convention: Cancel first on macOS and Linux, OK first on Windows.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -519,6 +519,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "filesystem/import/blender/rpc_server_uptime", 5, "0,300,1,or_greater,suffix:s", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "filesystem/import/fbx/fbx2gltf_path", "", "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
+	// Tools (denoise)
+	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_DIR, "filesystem/tools/oidn/oidn_library_path", "", "", PROPERTY_USAGE_DEFAULT)
+
 	/* Docks */
 
 	// SceneTree

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -36,9 +36,69 @@
 #include "scene/resources/mesh.h"
 #include "servers/rendering/rendering_device.h"
 
+typedef enum {
+	OIDN_DEVICE_TYPE_DEFAULT = 0, // select device automatically
+
+	OIDN_DEVICE_TYPE_CPU = 1, // CPU device
+	OIDN_DEVICE_TYPE_SYCL = 2, // SYCL device
+	OIDN_DEVICE_TYPE_CUDA = 3, // CUDA device
+	OIDN_DEVICE_TYPE_HIP = 4, // HIP device
+} OIDNDeviceType;
+
+typedef enum {
+	OIDN_FORMAT_UNDEFINED = 0,
+
+	// 32-bit single-precision floating-point scalar and vector formats
+	OIDN_FORMAT_FLOAT = 1,
+	OIDN_FORMAT_FLOAT2,
+	OIDN_FORMAT_FLOAT3,
+	OIDN_FORMAT_FLOAT4,
+
+	// 16-bit half-precision floating-point scalar and vector formats
+	OIDN_FORMAT_HALF = 257,
+	OIDN_FORMAT_HALF2,
+	OIDN_FORMAT_HALF3,
+	OIDN_FORMAT_HALF4,
+} OIDNFormat;
+
+typedef enum {
+	OIDN_ERROR_NONE = 0, // no error occurred
+	OIDN_ERROR_UNKNOWN = 1, // an unknown error occurred
+	OIDN_ERROR_INVALID_ARGUMENT = 2, // an invalid argument was specified
+	OIDN_ERROR_INVALID_OPERATION = 3, // the operation is not allowed
+	OIDN_ERROR_OUT_OF_MEMORY = 4, // not enough memory to execute the operation
+	OIDN_ERROR_UNSUPPORTED_HARDWARE = 5, // the hardware (e.g. CPU) is not supported
+	OIDN_ERROR_CANCELLED = 6, // the operation was cancelled by the user
+} OIDNError;
+
+typedef void *(*oidnNewDevicePtr)(OIDNDeviceType type);
+typedef void (*oidnCommitDevicePtr)(void *device);
+typedef void *(*oidnNewFilterPtr)(void *device, const char *type);
+typedef void (*oidnSetSharedFilterImagePtr)(void *filter, const char *name, void *devPtr, OIDNFormat format, size_t width, size_t height, size_t byteOffset, size_t pixelByteStride, size_t rowByteStride);
+typedef void (*oidnSetFilterBoolPtr)(void *filter, const char *name, bool value);
+typedef void (*oidnCommitFilterPtr)(void *filter);
+typedef void (*oidnExecuteFilterPtr)(void *filter);
+typedef OIDNError (*oidnGetDeviceErrorPtr)(void *device, const char **outMessage);
+typedef void (*oidnReleaseFilterPtr)(void *filter);
+typedef void (*oidnReleaseDevicePtr)(void *device);
+
 class RDShaderFile;
 class LightmapperRD : public Lightmapper {
 	GDCLASS(LightmapperRD, Lightmapper)
+
+	String oidn_lib_path;
+	void *oidn_lib_handle = nullptr;
+	void *oidn_device = nullptr;
+	oidnNewDevicePtr oidnNewDevice = nullptr;
+	oidnCommitDevicePtr oidnCommitDevice = nullptr;
+	oidnNewFilterPtr oidnNewFilter = nullptr;
+	oidnSetSharedFilterImagePtr oidnSetSharedFilterImage = nullptr;
+	oidnSetFilterBoolPtr oidnSetFilterBool = nullptr;
+	oidnCommitFilterPtr oidnCommitFilter = nullptr;
+	oidnExecuteFilterPtr oidnExecuteFilter = nullptr;
+	oidnGetDeviceErrorPtr oidnGetDeviceError = nullptr;
+	oidnReleaseFilterPtr oidnReleaseFilter = nullptr;
+	oidnReleaseDevicePtr oidnReleaseDevice = nullptr;
 
 	struct MeshInstance {
 		MeshData data;
@@ -246,6 +306,10 @@ class LightmapperRD : public Lightmapper {
 	BakeError _dilate(RenderingDevice *rd, Ref<RDShaderFile> &compute_shader, RID &compute_base_uniform_set, PushConstant &push_constant, RID &source_light_tex, RID &dest_light_tex, const Size2i &atlas_size, int atlas_slices);
 	BakeError _denoise(RenderingDevice *p_rd, Ref<RDShaderFile> &p_compute_shader, const RID &p_compute_base_uniform_set, PushConstant &p_push_constant, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, float p_denoiser_strength, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh, BakeStepFunc p_step_function);
 
+	bool _load_oidn(const String &p_library_path);
+	void _unload_oidn();
+	BakeError _denoise_oidn(RenderingDevice *p_rd, RID p_source_light_tex, RID p_source_normal_tex, RID p_dest_light_tex, const Size2i &p_atlas_size, int p_atlas_slices, bool p_bake_sh);
+
 public:
 	virtual void add_mesh(const MeshData &p_mesh) override;
 	virtual void add_directional_light(bool p_static, const Vector3 &p_direction, const Color &p_color, float p_energy, float p_angular_distance, float p_shadow_blur) override;
@@ -265,6 +329,7 @@ public:
 	Vector<Color> get_bake_probe_sh(int p_probe) const override;
 
 	LightmapperRD();
+	~LightmapperRD();
 };
 
 #endif // LIGHTMAPPER_RD_H


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/7640

Alternative variant https://github.com/godotengine/godot/pull/82832 (uses executable).

Pros: more stable API, no writing/reading to disk.
Cons: library should be the same architecture as executable (and there's no ARM64 prebuild library for macOS in official releases), might have issues with dependency loading paths.

TODO: ensure correct library lookup paths are set on all platforms.