### PR TITLE
Update README.md adding license link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The best way to get in touch with the core engine developers is to join the
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 
+## License
+
+This project is licensed under the [MIT License](https://github.com/godotengine/godot/blob/master/LICENSE.txt).
+
 ## Documentation and demos
 
 The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This change adds the license to the README. This can be overlooked if not added, and companies such as Google have also added them to their READMEs, for example.