### PR TITLE
Color: Expose OKHSL properties

### DIFF
--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -139,6 +139,10 @@ void register_named_setters_getters() {
 	REGISTER_MEMBER(Color, h);
 	REGISTER_MEMBER(Color, s);
 	REGISTER_MEMBER(Color, v);
+
+	REGISTER_MEMBER(Color, ok_hsl_h);
+	REGISTER_MEMBER(Color, ok_hsl_s);
+	REGISTER_MEMBER(Color, ok_hsl_l);
 }
 
 void unregister_named_setters_getters() {

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -493,6 +493,15 @@
 		<member name="h" type="float" setter="" getter="" default="0.0">
 			The HSV hue of this color, on the range 0 to 1.
 		</member>
+		<member name="ok_hsl_h" type="float" setter="" getter="" default="0.0">
+			The OKHSL hue of this color, on the range 0 to 1.
+		</member>
+		<member name="ok_hsl_l" type="float" setter="" getter="" default="0.0">
+			The OKHSL lightness of this color, on the range 0 to 1.
+		</member>
+		<member name="ok_hsl_s" type="float" setter="" getter="" default="0.0">
+			The OKHSL saturation of this color, on the range 0 to 1.
+		</member>
 		<member name="r" type="float" setter="" getter="" default="0.0">
 			The color's red component, typically on the range of 0 to 1.
 		</member>


### PR DESCRIPTION
I’m proposing a solution to enhance the `Color` class by adding an `OkHSL` lightness attribute. This attribute will facilitate the creation of colour palettes based on predefined colour stops. Currently, this PR exposes a previously private function to public gdscript. I’m unsure how to extend this functionality to C#, and would appreciate any help on this matter.

This PR is an implementation of my [feature proposal](https://github.com/godotengine/godot-proposals/issues/7954), just aiming to expose pre-existing infrastructure to the user.

I’ve tested these changes locally and everything appears to be working correctly, but I welcome any feedback or suggestions on my PR’s implementation.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/7954_