### PR TITLE
Copy network authority when instancing placeholders

### DIFF
--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -93,6 +93,7 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		return nullptr;
 	}
 	scene->set_name(get_name());
+	scene->set_multiplayer_authority(get_multiplayer_authority());
 	int pos = get_index();
 
 	for (const PropSet &E : stored_values) {


### PR DESCRIPTION
This changes the behaviour of the InstancePlaceholder so that the instanced node retains the same network authority ID as the placeholder node. This is important for some workflows which use placeholders to efficently dummy out unnessecary composition of player scenes when they are instanced for other players who they client does not have authority for if branches are contained in the nodes' _ready method.