### PR TITLE
Bugfix UI Mirroring

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -715,14 +715,14 @@ String TranslationServer::get_tool_locale() {
 		if (TranslationServer::get_singleton()->get_tool_translation().is_valid()) {
 			return tool_translation->get_locale();
 		} else {
-			return "en";
+			return locale;
 		}
 	} else {
 #else
 	{
 #endif
 		// Look for best matching loaded translation.
-		String best_locale = "en";
+		String best_locale = locale;
 		int best_score = 0;
 
 		for (const Ref<Translation> &E : translations) {


### PR DESCRIPTION
with this small adjustment `UI Mirroring Demo` works like before with the version `Godot.4.0-rc6`

@bruvzg: do you see any problems when `en` is no longer hardcoded? 
(Note: in the header file `locale` is initialized with 'en'. )

https://github.com/godotengine/godot-demo-projects/tree/master/gui/ui_mirroring


**original gscript**

https://github.com/godotengine/godot/assets/41921395/b91a0c47-228a-452e-8a69-1feab8bfdb04




