### PR TITLE
Fix extensions loading/initializing even when entry point fails

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -743,6 +743,7 @@ Error GDExtension::open_library(const String &p_path, const String &p_entry_symb
 		return OK;
 	} else {
 		ERR_PRINT("GDExtension initialization function '" + p_entry_symbol + "' returned an error.");
+		OS::get_singleton()->close_dynamic_library(library);
 		return FAILED;
 	}
 }
@@ -928,6 +929,10 @@ Error GDExtensionResourceLoader::load_gdextension_resource(const String &p_path,
 			DirAccess::remove_absolute(p_extension->get_temp_library_path());
 		}
 #endif
+
+		// Unreference the extension so that this loading can be considered a failure.
+		p_extension.unref();
+
 		// Errors already logged in open_library()
 		return err;
 	}


### PR DESCRIPTION
This fixes an apparent bug with the loading of extensions, where even if `false` is returned from the extension's entry point ([here](https://github.com/godotengine/godot/blob/d31794c4a26e5e10fc30c34a1ae9722fd9f50123/core/extension/gdextension.cpp#L739)) the extension will still be considered successfully loaded by `GDExtensionManager` ([here](https://github.com/godotengine/godot/blob/d31794c4a26e5e10fc30c34a1ae9722fd9f50123/core/extension/gdextension_manager.cpp#L76-L78)) due to the `p_extension` parameter pointing to a valid instance even after the entry point has reported a failure. This also results in it calling the extension module initalizer function even after its entry point has failed, which doesn't seem right.

This also has the unfortunate side effect of preventing any actual error messages from being emitted to the editor log as a result of the failure in the extension entry point, since `EditorLog` is initialized as part of `Main::start()`, rather than `Main::setup()` where all the extension initialization happens. Currently you're able to see editor logs/errors for things like `compatibility_minimum` due to the fact that any loading of extensions gets retried as part of `EditorFileSystem::_scan_extensions`, but this will only ever actually be retried if the loading failed in the first place, which it doesn't without the change in this PR.

CC: @dsnopek