### PR TITLE
Specify the behavior of `get_tree()` when the node is not in the scene tree

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -444,7 +444,7 @@
 		<method name="get_tree" qualifiers="const">
 			<return type="SceneTree" />
 			<description>
-				Returns the [SceneTree] that contains this node.
+				Returns the [SceneTree] that contains this node. Returns [code]null[/code] and prints an error if this node is not inside the scene tree. See also [method is_inside_tree].
 			</description>
 		</method>
 		<method name="get_tree_string">


### PR DESCRIPTION
Specify in the docs of `Node` that `get_tree()` returns `null` if it is called on a node that is not inside the scene tree.