### PR TITLE
Fog shader: Fix undeclared identifier `global_variables`

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -228,7 +228,7 @@ void Fog::init_fog_shader(uint32_t p_max_directional_lights, int p_roughness_lay
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_DISABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 
 		volumetric_fog.compiler.initialize(actions);
 	}


### PR DESCRIPTION
If user try to use a global shader variable in a fog type shader we are getting shader error. The reason of this there is a typo in the fog.cpp. In other well working shaders types like sky, the "action.global_buffer_array_variable" is "global_shader_uniforms.data".  The investigation tracked is here:
https://discord.com/channels/212250894228652034/1158918161337434172
