### PR TITLE
Reduce minimum capsule/cylinder mesh rings to 0

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -552,7 +552,7 @@ void CapsuleMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_radius", "get_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_rings", "get_rings");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_rings", "get_rings");
 
 	ADD_LINKED_PROPERTY("radius", "height");
 	ADD_LINKED_PROPERTY("height", "radius");
@@ -594,7 +594,8 @@ int CapsuleMesh::get_radial_segments() const {
 }
 
 void CapsuleMesh::set_rings(const int p_rings) {
-	rings = p_rings > 1 ? p_rings : 1;
+	ERR_FAIL_COND(p_rings < 0);
+	rings = p_rings;
 	_request_update();
 }
 
@@ -1161,7 +1162,7 @@ void CylinderMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bottom_radius", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater,suffix:m"), "set_bottom_radius", "get_bottom_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_rings", "get_rings");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_rings", "get_rings");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cap_top"), "set_cap_top", "is_cap_top");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cap_bottom"), "set_cap_bottom", "is_cap_bottom");
 }
@@ -1206,7 +1207,8 @@ int CylinderMesh::get_radial_segments() const {
 }
 
 void CylinderMesh::set_rings(const int p_rings) {
-	rings = p_rings > 0 ? p_rings : 0;
+	ERR_FAIL_COND(p_rings < 0);
+	rings = p_rings;
 	_request_update();
 }
 
@@ -1919,7 +1921,8 @@ int SphereMesh::get_radial_segments() const {
 }
 
 void SphereMesh::set_rings(const int p_rings) {
-	rings = p_rings > 1 ? p_rings : 1;
+	ERR_FAIL_COND(p_rings < 1);
+	rings = p_rings;
 	_request_update();
 }
 

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -232,7 +232,7 @@ TEST_CASE("[SceneTree][Primitive][Cylinder] Cylinder Primitive") {
 		CHECK(cylinder->get_bottom_radius() > 0);
 		CHECK(cylinder->get_height() > 0);
 		CHECK(cylinder->get_radial_segments() > 0);
-		CHECK(cylinder->get_rings() > 0);
+		CHECK(cylinder->get_rings() >= 0);
 	}
 
 	SUBCASE("[SceneTree][Primitive][Cylinder] Set properties and get them") {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82850

* Reduce the minimum amount of capsule/cylinder mesh rings to 0. I checked that both work fine with 0. The code for cylinder already supported 0, but the range hint was wrong, so the editor didn't allow less. Allowing a capsule to have 0 rings is new behavior, but I tested that it still works fine.
* Change the ring amount setter methods to use `ERR_FAIL_COND` like `TorusMesh::set_rings` already does.