### PR TITLE
Only perform modelview transform on tangent and binormal when vertex shader is in local space

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -417,13 +417,12 @@ void main() {
 	normal = modelview_normal * normal;
 #endif
 
-#endif
-
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
 #endif
+#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 	// Using world coordinates
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -411,13 +411,12 @@ void vertex_shader(vec3 vertex_input,
 	normal = modelview_normal * normal;
 #endif
 
-#endif
-
 #ifdef TANGENT_USED
 
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
 #endif
+#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 //using world coordinates
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -408,13 +408,12 @@ void main() {
 	normal = modelview_normal * normal;
 #endif
 
-#endif
-
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
 #endif
+#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 //using world coordinates
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)


### PR DESCRIPTION
This doesn't fix a reported issue. Most likely because world_vertex_coords is totally unusable right now (until https://github.com/godotengine/godot/pull/82886 is merged). 

In master when tangents are used, the tangents and binormals go through a model-to-view space transformation regardless of what space they are in. Therefore, when using skip_vertex_transform, or world_vertex_coords the tangent and binormal will end up in a completely wrong coordinate space and will look totally wrong. 

This appears to have come from a typo in the early days of rewriting the renderer for Godot 4.0 https://github.com/godotengine/godot/commit/8cee7703a6673f9505332de1581055c821b756f0#diff-ab6440873ccc60605b6c0f0bbc3e3bc2d94b7c8238824321a579fb868aebf5cb