### PR TITLE
Add compatibility rename of `(v)align` properties of `Label`

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -673,6 +673,19 @@ Size2 Label::get_minimum_size() const {
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
+bool Label::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == SNAME("valign")) {
+		set_vertical_alignment((VerticalAlignment)p_value.operator int());
+		return true;
+	} else if (p_name == SNAME("align")) {
+		set_horizontal_alignment((HorizontalAlignment)p_value.operator int());
+		return true;
+	}
+	return false;
+}
+#endif
+
 int Label::get_line_count() const {
 	if (!is_inside_tree()) {
 		return 1;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -90,6 +90,9 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	bool _set(const StringName &p_name, const Variant &p_value);
+#endif
 
 public:
 	virtual Size2 get_minimum_size() const override;


### PR DESCRIPTION
Fixes #74493 

Now when converting a project from 3 to 4, it is also renamed the `align` and `valign` properties to `horizontal_align` and `vertical_align`.