### PR TITLE
Fix `AnimationPlayer::play()` process unwanted start between the same animations

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -415,9 +415,16 @@ void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, floa
 	}
 
 	c.current.from = &animation_set[name];
+	c.current.speed_scale = p_custom_scale;
+
+	if (!end_reached) {
+		playback_queue.clear();
+	}
 
 	if (c.assigned != name) { // Reset.
 		c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
+		c.assigned = name;
+		emit_signal(SNAME("current_animation_changed"), c.assigned);
 	} else {
 		if (p_from_end && c.current.pos == 0) {
 			// Animation reset but played backwards, set position to the end.
@@ -425,18 +432,14 @@ void AnimationPlayer::play(const StringName &p_name, double p_custom_blend, floa
 		} else if (!p_from_end && c.current.pos == c.current.from->animation->get_length()) {
 			// Animation resumed but already ended, set position to the beginning.
 			c.current.pos = 0;
+		} else if (playing) {
+			return;
 		}
 	}
 
-	c.current.speed_scale = p_custom_scale;
-	c.assigned = name;
-	emit_signal(SNAME("current_animation_changed"), c.assigned);
 	c.seeked = false;
 	c.started = true;
 
-	if (!end_reached) {
-		playback_queue.clear();
-	}
 	_set_process(true); // Always process when starting an animation.
 	playing = true;
 


### PR DESCRIPTION
Fixes #82828.

Even when the same animation was played, the `started` flag was set. This was probably the old behavior.

The rework in #80813 forces the AnimationPlayer to set its internal delta to `0` immediately after start in order to process the first frame (to follow AnimationTree/Mixer blending process), so the problem in #82828 is that this caused the delta to be `0` every frame.

Test project:
[animtest.zip](https://github.com/godotengine/godot/files/12827850/animtest.zip)
